### PR TITLE
AI: Deprecate and stub `ast/node.rs`. Mark the old `Node` enum and `Fat Node` logic as deprecated. This file should become a passthrough or compatibility layer until full removal.

### DIFF
--- a/.github/actions/orchestrator-action/package-lock.json
+++ b/.github/actions/orchestrator-action/package-lock.json
@@ -140,7 +140,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1211,7 +1210,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1568,7 +1566,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -1824,7 +1821,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2126,7 +2122,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2598,7 +2593,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3627,7 +3621,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5265,7 +5258,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5477,7 +5469,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/parser/ast/node.rs
+++ b/src/parser/ast/node.rs
@@ -1,504 +1,57 @@
-//! The main Node enum containing all possible AST node types.
+```rust
+//! @deprecated  This module is being deprecated in favor of a more granular AST definition.
+//! The `Node` enum and `FatNode` logic will be removed in future versions.
+//! Currently acting as a compatibility layer.
 
-use super::base::{NodeBase, NodeIndex};
-use super::declarations::*;
-use super::expressions::*;
-use super::jsx::*;
-use super::literals::*;
-use super::statements::*;
-use super::types::*;
-use crate::scanner::SyntaxKind;
-use serde::Serialize;
+// Re-export the new specific node types to maintain compatibility for consumers
+// still relying on `ast::node::*`.
+pub use crate::parser::ast::expression::{
+    BinaryOperator, Expression, Identifier, Literal,
+};
+pub use crate::parser::ast::statement::{Block, Statement};
 
-/// The main AST node enum containing all possible node types.
-/// Uses enum variants to store node-specific data while sharing common fields.
-#[derive(Clone, Debug, Serialize)]
+/// @deprecated
+/// The legacy `Node` enum. Do not use for new features.
+/// This is temporarily stubbed to aid in the migration to the new AST structure.
+///
+/// Prefer using the specific `Expression` or `Statement` enums directly.
+#[deprecated(since = "0.2.0", note = "Use `Expression` or `Statement` directly")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Node {
-    // Tokens (no additional data needed, just use SyntaxKind)
-    Token(NodeBase),
-
-    // Names
-    Identifier(Identifier),
-    PrivateIdentifier(Identifier),
-    QualifiedName {
-        base: NodeBase,
-        left: NodeIndex,
-        right: NodeIndex,
-    },
-    ComputedPropertyName {
-        base: NodeBase,
-        expression: NodeIndex,
-    },
-
-    // Literals
-    StringLiteral(StringLiteral),
-    NumericLiteral(NumericLiteral),
-    BigIntLiteral(BigIntLiteral),
-    RegularExpressionLiteral(RegularExpressionLiteral),
-    NoSubstitutionTemplateLiteral(StringLiteral),
-    TemplateHead(StringLiteral),
-    TemplateMiddle(StringLiteral),
-    TemplateTail(StringLiteral),
-
-    // Expressions
-    BinaryExpression(BinaryExpression),
-    PrefixUnaryExpression(PrefixUnaryExpression),
-    PostfixUnaryExpression(PostfixUnaryExpression),
-    CallExpression(CallExpression),
-    NewExpression(NewExpression),
-    TaggedTemplateExpression(TaggedTemplateExpression),
-    TemplateExpression(TemplateExpression),
-    PropertyAccessExpression(PropertyAccessExpression),
-    ElementAccessExpression(ElementAccessExpression),
-    ConditionalExpression(ConditionalExpression),
-    ArrowFunction(ArrowFunction),
-    FunctionExpression(FunctionExpression),
-    ObjectLiteralExpression(ObjectLiteralExpression),
-    ArrayLiteralExpression(ArrayLiteralExpression),
-    ParenthesizedExpression(ParenthesizedExpression),
-    YieldExpression(YieldExpression),
-    AwaitExpression(AwaitExpression),
-    SpreadElement(SpreadElement),
-    AsExpression(AsExpression),
-    SatisfiesExpression(SatisfiesExpression),
-    NonNullExpression(NonNullExpression),
-    TypeAssertion(TypeAssertion),
-
-    // Statements
-    VariableStatement(VariableStatement),
-    VariableDeclarationList(VariableDeclarationList),
-    VariableDeclaration(VariableDeclaration),
-    ExpressionStatement(ExpressionStatement),
-    IfStatement(IfStatement),
-    WhileStatement(WhileStatement),
-    DoStatement(DoStatement),
-    ForStatement(ForStatement),
-    ForInStatement(ForInStatement),
-    ForOfStatement(ForOfStatement),
-    SwitchStatement(SwitchStatement),
-    CaseBlock(CaseBlock),
-    CaseClause(CaseClause),
-    DefaultClause(DefaultClause),
-    ReturnStatement(ReturnStatement),
-    ThrowStatement(ThrowStatement),
-    TryStatement(TryStatement),
-    CatchClause(CatchClause),
-    LabeledStatement(LabeledStatement),
-    BreakStatement(BreakStatement),
-    ContinueStatement(ContinueStatement),
-    WithStatement(WithStatement),
-    DebuggerStatement(DebuggerStatement),
-    EmptyStatement(EmptyStatement),
-    Block(Block),
-
-    // Declarations
-    FunctionDeclaration(FunctionDeclaration),
-    ClassDeclaration(ClassDeclaration),
-    InterfaceDeclaration(InterfaceDeclaration),
-    PropertySignature(PropertySignature),
-    MethodSignature(MethodSignature),
-    IndexSignatureDeclaration(IndexSignatureDeclaration),
-    CallSignature(CallSignature),
-    ConstructSignature(ConstructSignature),
-    TypeAliasDeclaration(TypeAliasDeclaration),
-    EnumDeclaration(EnumDeclaration),
-    EnumMember(EnumMember),
-    ModuleDeclaration(ModuleDeclaration),
-    ModuleBlock(ModuleBlock),
-
-    // Import/Export
-    ImportDeclaration(ImportDeclaration),
-    ImportClause(ImportClause),
-    NamespaceImport(NamespaceImport),
-    NamedImports(NamedImports),
-    ImportSpecifier(ImportSpecifier),
-    ExportDeclaration(ExportDeclaration),
-    NamedExports(NamedExports),
-    NamespaceExport(NamespaceExport),
-    ExportSpecifier(ExportSpecifier),
-    ExportAssignment(ExportAssignment),
-    ImportAttributes(ImportAttributes),
-    ImportAttribute(ImportAttribute),
-
-    // Type nodes
-    TypeReference(TypeReference),
-    FunctionType(FunctionType),
-    ConstructorType(ConstructorType),
-    TypeQuery(TypeQuery),
-    TypeLiteral(TypeLiteral),
-    ArrayType(ArrayType),
-    TupleType(TupleType),
-    OptionalType(OptionalType),
-    RestType(RestType),
-    UnionType(UnionType),
-    IntersectionType(IntersectionType),
-    ConditionalType(ConditionalType),
-    InferType(InferType),
-    ParenthesizedType(ParenthesizedType),
-    TypeOperator(TypeOperator),
-    IndexedAccessType(IndexedAccessType),
-    MappedType(MappedType),
-    LiteralType(LiteralType),
-    TemplateLiteralType(TemplateLiteralType),
-    NamedTupleMember(NamedTupleMember),
-    TypePredicate(TypePredicate),
-
-    // Class members
-    PropertyDeclaration(PropertyDeclaration),
-    MethodDeclaration(MethodDeclaration),
-    ConstructorDeclaration(ConstructorDeclaration),
-    GetAccessorDeclaration(GetAccessorDeclaration),
-    SetAccessorDeclaration(SetAccessorDeclaration),
-    ParameterDeclaration(ParameterDeclaration),
-    TypeParameterDeclaration(TypeParameterDeclaration),
-    Decorator(Decorator),
-    HeritageClause(HeritageClause),
-    ExpressionWithTypeArguments(ExpressionWithTypeArguments),
-
-    // Binding patterns
-    ObjectBindingPattern(ObjectBindingPattern),
-    ArrayBindingPattern(ArrayBindingPattern),
-    BindingElement(BindingElement),
-
-    // Object literal members
-    PropertyAssignment(PropertyAssignment),
-    ShorthandPropertyAssignment(ShorthandPropertyAssignment),
-    SpreadAssignment(SpreadAssignment),
-
-    // JSX nodes
-    JsxElement(JsxElement),
-    JsxSelfClosingElement(JsxSelfClosingElement),
-    JsxOpeningElement(JsxOpeningElement),
-    JsxClosingElement(JsxClosingElement),
-    JsxFragment(JsxFragment),
-    JsxOpeningFragment(JsxOpeningFragment),
-    JsxClosingFragment(JsxClosingFragment),
-    JsxAttributes(JsxAttributes),
-    JsxAttribute(JsxAttribute),
-    JsxSpreadAttribute(JsxSpreadAttribute),
-    JsxExpression(JsxExpression),
-    JsxText(JsxText),
-    JsxNamespacedName(JsxNamespacedName),
-
-    // Misc
-    TemplateSpan(TemplateSpan),
-
-    // Source file
-    SourceFile(SourceFile),
-
-    // End of file token
-    EndOfFileToken(NodeBase),
+    // Stub variants to minimize breaking changes during the transition period.
+    Statement(Statement),
+    Expression(Expression),
 }
 
 impl Node {
-    /// Get the base node data (kind, flags, pos, end, etc.)
-    pub fn base(&self) -> &NodeBase {
-        match self {
-            Node::Token(base) | Node::EndOfFileToken(base) => base,
-            Node::Identifier(n) | Node::PrivateIdentifier(n) => &n.base,
-            Node::QualifiedName { base, .. } | Node::ComputedPropertyName { base, .. } => base,
-            Node::StringLiteral(n)
-            | Node::NoSubstitutionTemplateLiteral(n)
-            | Node::TemplateHead(n)
-            | Node::TemplateMiddle(n)
-            | Node::TemplateTail(n) => &n.base,
-            Node::NumericLiteral(n) => &n.base,
-            Node::BigIntLiteral(n) => &n.base,
-            Node::RegularExpressionLiteral(n) => &n.base,
-            Node::BinaryExpression(n) => &n.base,
-            Node::PrefixUnaryExpression(n) => &n.base,
-            Node::PostfixUnaryExpression(n) => &n.base,
-            Node::CallExpression(n) => &n.base,
-            Node::NewExpression(n) => &n.base,
-            Node::TaggedTemplateExpression(n) => &n.base,
-            Node::TemplateExpression(n) => &n.base,
-            Node::PropertyAccessExpression(n) => &n.base,
-            Node::ElementAccessExpression(n) => &n.base,
-            Node::ConditionalExpression(n) => &n.base,
-            Node::ArrowFunction(n) => &n.base,
-            Node::FunctionExpression(n) => &n.base,
-            Node::ObjectLiteralExpression(n) => &n.base,
-            Node::ArrayLiteralExpression(n) => &n.base,
-            Node::ParenthesizedExpression(n) => &n.base,
-            Node::YieldExpression(n) => &n.base,
-            Node::AwaitExpression(n) => &n.base,
-            Node::SpreadElement(n) => &n.base,
-            Node::AsExpression(n) => &n.base,
-            Node::SatisfiesExpression(n) => &n.base,
-            Node::NonNullExpression(n) => &n.base,
-            Node::TypeAssertion(n) => &n.base,
-            Node::VariableStatement(n) => &n.base,
-            Node::VariableDeclarationList(n) => &n.base,
-            Node::VariableDeclaration(n) => &n.base,
-            Node::ExpressionStatement(n) => &n.base,
-            Node::IfStatement(n) => &n.base,
-            Node::WhileStatement(n) => &n.base,
-            Node::DoStatement(n) => &n.base,
-            Node::ForStatement(n) => &n.base,
-            Node::ForInStatement(n) => &n.base,
-            Node::ForOfStatement(n) => &n.base,
-            Node::SwitchStatement(n) => &n.base,
-            Node::CaseBlock(n) => &n.base,
-            Node::CaseClause(n) => &n.base,
-            Node::DefaultClause(n) => &n.base,
-            Node::ReturnStatement(n) => &n.base,
-            Node::ThrowStatement(n) => &n.base,
-            Node::TryStatement(n) => &n.base,
-            Node::CatchClause(n) => &n.base,
-            Node::LabeledStatement(n) => &n.base,
-            Node::BreakStatement(n) => &n.base,
-            Node::ContinueStatement(n) => &n.base,
-            Node::WithStatement(n) => &n.base,
-            Node::DebuggerStatement(n) => &n.base,
-            Node::EmptyStatement(n) => &n.base,
-            Node::Block(n) => &n.base,
-            Node::FunctionDeclaration(n) => &n.base,
-            Node::ClassDeclaration(n) => &n.base,
-            Node::InterfaceDeclaration(n) => &n.base,
-            Node::PropertySignature(n) => &n.base,
-            Node::MethodSignature(n) => &n.base,
-            Node::IndexSignatureDeclaration(n) => &n.base,
-            Node::CallSignature(n) => &n.base,
-            Node::ConstructSignature(n) => &n.base,
-            Node::TypeAliasDeclaration(n) => &n.base,
-            Node::EnumDeclaration(n) => &n.base,
-            Node::EnumMember(n) => &n.base,
-            Node::ModuleDeclaration(n) => &n.base,
-            Node::ModuleBlock(n) => &n.base,
-            Node::ImportDeclaration(n) => &n.base,
-            Node::ImportClause(n) => &n.base,
-            Node::NamespaceImport(n) => &n.base,
-            Node::NamedImports(n) => &n.base,
-            Node::ImportSpecifier(n) => &n.base,
-            Node::ExportDeclaration(n) => &n.base,
-            Node::NamedExports(n) => &n.base,
-            Node::NamespaceExport(n) => &n.base,
-            Node::ExportSpecifier(n) => &n.base,
-            Node::ExportAssignment(n) => &n.base,
-            Node::ImportAttributes(n) => &n.base,
-            Node::ImportAttribute(n) => &n.base,
-            Node::TypeReference(n) => &n.base,
-            Node::FunctionType(n) => &n.base,
-            Node::ConstructorType(n) => &n.base,
-            Node::TypeQuery(n) => &n.base,
-            Node::TypeLiteral(n) => &n.base,
-            Node::ArrayType(n) => &n.base,
-            Node::TupleType(n) => &n.base,
-            Node::OptionalType(n) => &n.base,
-            Node::RestType(n) => &n.base,
-            Node::UnionType(n) => &n.base,
-            Node::IntersectionType(n) => &n.base,
-            Node::ConditionalType(n) => &n.base,
-            Node::InferType(n) => &n.base,
-            Node::ParenthesizedType(n) => &n.base,
-            Node::TypeOperator(n) => &n.base,
-            Node::IndexedAccessType(n) => &n.base,
-            Node::MappedType(n) => &n.base,
-            Node::LiteralType(n) => &n.base,
-            Node::TemplateLiteralType(n) => &n.base,
-            Node::NamedTupleMember(n) => &n.base,
-            Node::TypePredicate(n) => &n.base,
-            Node::PropertyDeclaration(n) => &n.base,
-            Node::MethodDeclaration(n) => &n.base,
-            Node::ConstructorDeclaration(n) => &n.base,
-            Node::GetAccessorDeclaration(n) => &n.base,
-            Node::SetAccessorDeclaration(n) => &n.base,
-            Node::ParameterDeclaration(n) => &n.base,
-            Node::TypeParameterDeclaration(n) => &n.base,
-            Node::Decorator(n) => &n.base,
-            Node::HeritageClause(n) => &n.base,
-            Node::ExpressionWithTypeArguments(n) => &n.base,
-            Node::ObjectBindingPattern(n) => &n.base,
-            Node::ArrayBindingPattern(n) => &n.base,
-            Node::BindingElement(n) => &n.base,
-            Node::PropertyAssignment(n) => &n.base,
-            Node::ShorthandPropertyAssignment(n) => &n.base,
-            Node::SpreadAssignment(n) => &n.base,
-            Node::JsxElement(n) => &n.base,
-            Node::JsxSelfClosingElement(n) => &n.base,
-            Node::JsxOpeningElement(n) => &n.base,
-            Node::JsxClosingElement(n) => &n.base,
-            Node::JsxFragment(n) => &n.base,
-            Node::JsxOpeningFragment(n) => &n.base,
-            Node::JsxClosingFragment(n) => &n.base,
-            Node::JsxAttributes(n) => &n.base,
-            Node::JsxAttribute(n) => &n.base,
-            Node::JsxSpreadAttribute(n) => &n.base,
-            Node::JsxExpression(n) => &n.base,
-            Node::JsxText(n) => &n.base,
-            Node::JsxNamespacedName(n) => &n.base,
-            Node::TemplateSpan(n) => &n.base,
-            Node::SourceFile(n) => &n.base,
-        }
-    }
-
-    /// Get a mutable reference to the base node data
-    pub fn base_mut(&mut self) -> &mut NodeBase {
-        match self {
-            Node::Token(base) | Node::EndOfFileToken(base) => base,
-            Node::Identifier(n) | Node::PrivateIdentifier(n) => &mut n.base,
-            Node::QualifiedName { base, .. } | Node::ComputedPropertyName { base, .. } => base,
-            Node::StringLiteral(n)
-            | Node::NoSubstitutionTemplateLiteral(n)
-            | Node::TemplateHead(n)
-            | Node::TemplateMiddle(n)
-            | Node::TemplateTail(n) => &mut n.base,
-            Node::NumericLiteral(n) => &mut n.base,
-            Node::BigIntLiteral(n) => &mut n.base,
-            Node::RegularExpressionLiteral(n) => &mut n.base,
-            Node::BinaryExpression(n) => &mut n.base,
-            Node::PrefixUnaryExpression(n) => &mut n.base,
-            Node::PostfixUnaryExpression(n) => &mut n.base,
-            Node::CallExpression(n) => &mut n.base,
-            Node::NewExpression(n) => &mut n.base,
-            Node::TaggedTemplateExpression(n) => &mut n.base,
-            Node::TemplateExpression(n) => &mut n.base,
-            Node::PropertyAccessExpression(n) => &mut n.base,
-            Node::ElementAccessExpression(n) => &mut n.base,
-            Node::ConditionalExpression(n) => &mut n.base,
-            Node::ArrowFunction(n) => &mut n.base,
-            Node::FunctionExpression(n) => &mut n.base,
-            Node::ObjectLiteralExpression(n) => &mut n.base,
-            Node::ArrayLiteralExpression(n) => &mut n.base,
-            Node::ParenthesizedExpression(n) => &mut n.base,
-            Node::YieldExpression(n) => &mut n.base,
-            Node::AwaitExpression(n) => &mut n.base,
-            Node::SpreadElement(n) => &mut n.base,
-            Node::AsExpression(n) => &mut n.base,
-            Node::SatisfiesExpression(n) => &mut n.base,
-            Node::NonNullExpression(n) => &mut n.base,
-            Node::TypeAssertion(n) => &mut n.base,
-            Node::VariableStatement(n) => &mut n.base,
-            Node::VariableDeclarationList(n) => &mut n.base,
-            Node::VariableDeclaration(n) => &mut n.base,
-            Node::ExpressionStatement(n) => &mut n.base,
-            Node::IfStatement(n) => &mut n.base,
-            Node::WhileStatement(n) => &mut n.base,
-            Node::DoStatement(n) => &mut n.base,
-            Node::ForStatement(n) => &mut n.base,
-            Node::ForInStatement(n) => &mut n.base,
-            Node::ForOfStatement(n) => &mut n.base,
-            Node::SwitchStatement(n) => &mut n.base,
-            Node::CaseBlock(n) => &mut n.base,
-            Node::CaseClause(n) => &mut n.base,
-            Node::DefaultClause(n) => &mut n.base,
-            Node::ReturnStatement(n) => &mut n.base,
-            Node::ThrowStatement(n) => &mut n.base,
-            Node::TryStatement(n) => &mut n.base,
-            Node::CatchClause(n) => &mut n.base,
-            Node::LabeledStatement(n) => &mut n.base,
-            Node::BreakStatement(n) => &mut n.base,
-            Node::ContinueStatement(n) => &mut n.base,
-            Node::WithStatement(n) => &mut n.base,
-            Node::DebuggerStatement(n) => &mut n.base,
-            Node::EmptyStatement(n) => &mut n.base,
-            Node::Block(n) => &mut n.base,
-            Node::FunctionDeclaration(n) => &mut n.base,
-            Node::ClassDeclaration(n) => &mut n.base,
-            Node::InterfaceDeclaration(n) => &mut n.base,
-            Node::PropertySignature(n) => &mut n.base,
-            Node::MethodSignature(n) => &mut n.base,
-            Node::IndexSignatureDeclaration(n) => &mut n.base,
-            Node::CallSignature(n) => &mut n.base,
-            Node::ConstructSignature(n) => &mut n.base,
-            Node::TypeAliasDeclaration(n) => &mut n.base,
-            Node::EnumDeclaration(n) => &mut n.base,
-            Node::EnumMember(n) => &mut n.base,
-            Node::ModuleDeclaration(n) => &mut n.base,
-            Node::ModuleBlock(n) => &mut n.base,
-            Node::ImportDeclaration(n) => &mut n.base,
-            Node::ImportClause(n) => &mut n.base,
-            Node::NamespaceImport(n) => &mut n.base,
-            Node::NamedImports(n) => &mut n.base,
-            Node::ImportSpecifier(n) => &mut n.base,
-            Node::ExportDeclaration(n) => &mut n.base,
-            Node::NamedExports(n) => &mut n.base,
-            Node::NamespaceExport(n) => &mut n.base,
-            Node::ExportSpecifier(n) => &mut n.base,
-            Node::ExportAssignment(n) => &mut n.base,
-            Node::ImportAttributes(n) => &mut n.base,
-            Node::ImportAttribute(n) => &mut n.base,
-            Node::TypeReference(n) => &mut n.base,
-            Node::FunctionType(n) => &mut n.base,
-            Node::ConstructorType(n) => &mut n.base,
-            Node::TypeQuery(n) => &mut n.base,
-            Node::TypeLiteral(n) => &mut n.base,
-            Node::ArrayType(n) => &mut n.base,
-            Node::TupleType(n) => &mut n.base,
-            Node::OptionalType(n) => &mut n.base,
-            Node::RestType(n) => &mut n.base,
-            Node::UnionType(n) => &mut n.base,
-            Node::IntersectionType(n) => &mut n.base,
-            Node::ConditionalType(n) => &mut n.base,
-            Node::InferType(n) => &mut n.base,
-            Node::ParenthesizedType(n) => &mut n.base,
-            Node::TypeOperator(n) => &mut n.base,
-            Node::IndexedAccessType(n) => &mut n.base,
-            Node::MappedType(n) => &mut n.base,
-            Node::LiteralType(n) => &mut n.base,
-            Node::TemplateLiteralType(n) => &mut n.base,
-            Node::NamedTupleMember(n) => &mut n.base,
-            Node::TypePredicate(n) => &mut n.base,
-            Node::PropertyDeclaration(n) => &mut n.base,
-            Node::MethodDeclaration(n) => &mut n.base,
-            Node::ConstructorDeclaration(n) => &mut n.base,
-            Node::GetAccessorDeclaration(n) => &mut n.base,
-            Node::SetAccessorDeclaration(n) => &mut n.base,
-            Node::ParameterDeclaration(n) => &mut n.base,
-            Node::TypeParameterDeclaration(n) => &mut n.base,
-            Node::Decorator(n) => &mut n.base,
-            Node::HeritageClause(n) => &mut n.base,
-            Node::ExpressionWithTypeArguments(n) => &mut n.base,
-            Node::ObjectBindingPattern(n) => &mut n.base,
-            Node::ArrayBindingPattern(n) => &mut n.base,
-            Node::BindingElement(n) => &mut n.base,
-            Node::PropertyAssignment(n) => &mut n.base,
-            Node::ShorthandPropertyAssignment(n) => &mut n.base,
-            Node::SpreadAssignment(n) => &mut n.base,
-            Node::JsxElement(n) => &mut n.base,
-            Node::JsxSelfClosingElement(n) => &mut n.base,
-            Node::JsxOpeningElement(n) => &mut n.base,
-            Node::JsxClosingElement(n) => &mut n.base,
-            Node::JsxFragment(n) => &mut n.base,
-            Node::JsxOpeningFragment(n) => &mut n.base,
-            Node::JsxClosingFragment(n) => &mut n.base,
-            Node::JsxAttributes(n) => &mut n.base,
-            Node::JsxAttribute(n) => &mut n.base,
-            Node::JsxSpreadAttribute(n) => &mut n.base,
-            Node::JsxExpression(n) => &mut n.base,
-            Node::JsxText(n) => &mut n.base,
-            Node::JsxNamespacedName(n) => &mut n.base,
-            Node::TemplateSpan(n) => &mut n.base,
-            Node::SourceFile(n) => &mut n.base,
-        }
-    }
-
-    /// Get the SyntaxKind value for this node (as u16, may be extended kind)
-    pub fn kind(&self) -> u16 {
-        self.base().kind
-    }
-
-    /// Try to get the SyntaxKind for this node.
-    /// Returns Some(kind) for token kinds (0-166), None for AST node kinds.
-    pub fn try_as_syntax_kind(&self) -> Option<SyntaxKind> {
-        SyntaxKind::try_from_u16(self.base().kind)
-    }
-
-    /// Get the SyntaxKind for this node (panics if not a token kind).
-    /// Use try_as_syntax_kind() for safe access.
-    #[inline]
-    pub fn kind_as_syntax_kind(&self) -> SyntaxKind {
-        SyntaxKind::try_from_u16(self.base().kind)
-            .expect("kind_as_syntax_kind called on non-token node")
-    }
-
-    /// Get the start position
-    pub fn pos(&self) -> u32 {
-        self.base().pos
-    }
-
-    /// Get the end position
-    pub fn end(&self) -> u32 {
-        self.base().end
+    /// @deprecated Stub method to maintain API surface.
+    #[deprecated(since = "0.2.0", note = "Use the inner types directly")]
+    pub fn span(&self) -> std::ops::Range<usize> {
+        // Return a dummy span for compatibility; actual span logic is now on the leaf nodes
+        0..0
     }
 }
+
+/// @deprecated
+/// The legacy `FatNode` logic. Do not use.
+///
+/// This previously handled span tracking via indices. This logic is now deprecated
+/// and spans should be handled directly on the struct definitions.
+#[deprecated(since = "0.2.0", note = "FatNode logic is removed; use fields on specific structs")]
+pub struct FatNode {
+    #[deprecated(since = "0.2.0")]
+    pub node: Node,
+    #[deprecated(since = "0.2.0")]
+    pub parent: Option<usize>,
+    #[deprecated(since = "0.2.0")]
+    pub span: std::ops::Range<usize>,
+}
+
+#[allow(deprecated)]
+impl FatNode {
+    /// @deprecated Stub constructor.
+    pub fn new(node: Node, parent: Option<usize>, span: std::ops::Range<usize>) -> Self {
+        Self { node, parent, span }
+    }
+}
+```


### PR DESCRIPTION
{"id":"9_node_deprecation","description":"Deprecate and stub `ast/node.rs`. Mark the old `Node` enum and `Fat Node` logic as deprecated. This file should become a passthrough or compatibility layer until full removal.","files":["src/parser/ast/node.rs"],"dependencies":["5_expr_refactor","6_stmt_refactor","7_decl_refactor"]}