### PR TITLE
AI: Update PROJECT_DIRECTION.md references

### DIFF
--- a/PROJECT_DIRECTION.md
+++ b/PROJECT_DIRECTION.md
@@ -107,7 +107,7 @@ Finish implementing the unified test runner to handle `compiler/` and `projects/
 
 ### 5. Improve code hygiene
 
-- Move all scripts to `scripts/` directory. no scripts in root. Including test.sh, build-wasm.sh, etc.
+- Move all scripts to `scripts/` directory. no scripts in root.
 - Update AGENTS.md so agents do not produce .md files for results of their work.
 - Update .gitignore to not allow any new files in root.
 - Revisit scripts/ and conformance/ scripts and clean up as needed.


### PR DESCRIPTION
## Task
Update PROJECT_DIRECTION.md line 110 to remove build-wasm.sh from the list of scripts to move (since it will be moved). Line 167 already shows the correct target path ./scripts/build-wasm.sh so no change needed there.

---
*Automated by AI Orchestrator*