### PR TITLE
[EM-3/W-2] Refactor class_es5.rs to separate AST transformation from st

### DIFF
--- a/.orchestrator/state.json
+++ b/.orchestrator/state.json
@@ -9,7 +9,7 @@
     "owner": "mohsen1",
     "name": "tsz"
   },
-  "phase": "em_assignment",
+  "phase": "worker_review",
   "workBranch": "cco/57-improve-typescript-conformance-test-pass-rate-to-5",
   "baseBranch": "main",
   "ems": [
@@ -18,28 +18,127 @@
       "task": "Implement missing error diagnostics to reduce top missing errors: TS2318 (global type not found), TS2583 (ES2015+ lib support), TS2304 (cannot find name), TS2307 (module resolution), and TS7006 (implicit any type). Focus on type checker and binder integration.",
       "focusArea": "Error Diagnostics - Missing Errors",
       "branch": "cco/issue-57-em-1",
-      "status": "pending",
+      "status": "pr_created",
       "workers": [],
       "reviewsAddressed": 0,
-      "startedAt": "2026-01-20T05:50:26.802Z"
+      "startedAt": "2026-01-20T05:50:26.802Z",
+      "error": "No workers merged - all had conflicts"
     },
     {
       "id": 2,
       "task": "Eliminate top extra errors: fix remaining TS2300 (duplicate identifier) edge cases, resolve TS1005 parser expectations, fix TS2339 property existence checks, handle TS1202 ESM import assignments, and resolve TS2454 variable usage analysis.",
       "focusArea": "Error Diagnostics - Extra Errors & Parser",
       "branch": "cco/issue-57-em-2",
-      "status": "pending",
-      "workers": [],
+      "status": "pr_created",
+      "workers": [
+        {
+          "id": 1,
+          "task": "Fix TS2300 duplicate identifier edge cases in symbol binding - analyze static/instance member conflicts, enum member naming, and type parameter declarations to resolve remaining false positives",
+          "files": [
+            "src/thin_binder.rs",
+            "src/symbols.rs"
+          ],
+          "branch": "cco/issue-57-em-2-w-1",
+          "status": "merged",
+          "reviewsAddressed": 0,
+          "startedAt": "2026-01-20T06:44:05.929Z",
+          "prNumber": 62,
+          "prUrl": "https://github.com/mohsen1/tsz/pull/62",
+          "completedAt": "2026-01-20T07:17:55.863Z"
+        },
+        {
+          "id": 2,
+          "task": "Fix TS1005 parser expectations and TS2339 property existence - improve token lookahead for expression statements, object literal parsing, and implement proper property existence resolution on unknown types",
+          "files": [
+            "src/thin_parser.rs",
+            "src/checker/property_resolver.rs"
+          ],
+          "branch": "cco/issue-57-em-2-w-2",
+          "status": "merged",
+          "reviewsAddressed": 0,
+          "startedAt": "2026-01-20T07:17:57.014Z",
+          "prNumber": 64,
+          "prUrl": "https://github.com/mohsen1/tsz/pull/64",
+          "completedAt": "2026-01-20T07:52:12.194Z"
+        },
+        {
+          "id": 3,
+          "task": "Handle TS1202 ESM import assignments and TS2454 variable usage analysis - implement proper import assignment detection for ES modules and definite assignment analysis for block-scoped variables",
+          "files": [
+            "src/checker/definite_assignment.rs",
+            "src/checker/module_checker.rs"
+          ],
+          "branch": "cco/issue-57-em-2-w-3",
+          "status": "merged",
+          "reviewsAddressed": 0,
+          "startedAt": "2026-01-20T07:52:13.717Z",
+          "prNumber": 65,
+          "prUrl": "https://github.com/mohsen1/tsz/pull/65",
+          "completedAt": "2026-01-20T08:19:26.998Z"
+        }
+      ],
       "reviewsAddressed": 0,
-      "startedAt": "2026-01-20T05:50:26.802Z"
+      "startedAt": "2026-01-20T05:50:26.802Z",
+      "prNumber": 63,
+      "prUrl": "https://github.com/mohsen1/tsz/pull/63"
     },
     {
       "id": 3,
       "task": "Rewrite flow analyzer from recursive to iterative worklist algorithm to prevent stack overflow on deeply nested control flow. Also address transform pipeline architecture by separating AST manipulation from string emission.",
       "focusArea": "Flow Analysis & Architecture",
       "branch": "cco/issue-57-em-3",
-      "status": "pending",
-      "workers": [],
+      "status": "workers_running",
+      "workers": [
+        {
+          "id": 1,
+          "task": "Rewrite flow analyzer from recursive to iterative worklist algorithm. The check_flow function in flow_analyzer.rs is recursive and will cause stack overflow on deeply nested control flow. Implement an iterative worklist algorithm with explicit stack. File src/checker/flow_analyzer.rs is completely isolated with no overlap with other checker modules.",
+          "files": [
+            "src/checker/flow_analyzer.rs"
+          ],
+          "branch": "cco/issue-57-em-3-w-1",
+          "status": "pr_created",
+          "reviewsAddressed": 0,
+          "startedAt": "2026-01-20T08:26:46.166Z",
+          "prNumber": 66,
+          "prUrl": "https://github.com/mohsen1/tsz/pull/66",
+          "completedAt": "2026-01-20T08:47:30.602Z"
+        },
+        {
+          "id": 2,
+          "task": "Separate AST manipulation from string emission in expression transforms. Refactor es5.rs, class_es5.rs, async_es5.rs, arrow_es5.rs, generators.rs, and private_fields_es5.rs to ensure all transforms produce IR nodes only, with string emission delegated entirely to ir_printer.rs. Create new IR node types in ir.rs if needed. These files handle expression and function-related transformations.",
+          "files": [
+            "src/transforms/es5.rs",
+            "src/transforms/class_es5.rs",
+            "src/transforms/async_es5.rs",
+            "src/transforms/arrow_es5.rs",
+            "src/transforms/generators.rs",
+            "src/transforms/private_fields_es5.rs",
+            "src/transforms/ir.rs"
+          ],
+          "branch": "cco/issue-57-em-3-w-2",
+          "status": "in_progress",
+          "reviewsAddressed": 0,
+          "startedAt": "2026-01-20T08:47:31.903Z"
+        },
+        {
+          "id": 3,
+          "task": "Separate AST manipulation from string emission in statement and module transforms. Refactor block_scoping_es5.rs, destructuring_es5.rs, spread_es5.rs, namespace_es5.rs, enum_es5.rs, decorators.rs, and module_commonjs.rs to ensure all transforms produce IR nodes only. Update ir_printer.rs and emit_utils.rs for any new emission patterns. These files handle statement, declaration, and module-related transformations - completely separate from Worker-2's expression transforms.",
+          "files": [
+            "src/transforms/block_scoping_es5.rs",
+            "src/transforms/destructuring_es5.rs",
+            "src/transforms/spread_es5.rs",
+            "src/transforms/namespace_es5.rs",
+            "src/transforms/enum_es5.rs",
+            "src/transforms/decorators.rs",
+            "src/transforms/module_commonjs.rs",
+            "src/transforms/ir_printer.rs",
+            "src/transforms/emit_utils.rs"
+          ],
+          "branch": "cco/issue-57-em-3-w-3",
+          "status": "pending",
+          "reviewsAddressed": 0
+        }
+      ],
       "reviewsAddressed": 0,
       "startedAt": "2026-01-20T05:50:26.802Z"
     }
@@ -51,6 +150,6 @@
     "prLabel": "cco"
   },
   "createdAt": "2026-01-20T05:50:00.445Z",
-  "updatedAt": "2026-01-20T07:49:13.484Z",
+  "updatedAt": "2026-01-20T08:47:31.903Z",
   "analysisSummary": "Improve TypeScript conformance test pass rate from 30% to 50%+ by implementing missing error diagnostics (TS2318, TS2583, TS2304, TS2307, TS7006), eliminating extra errors, and fixing the flow analyzer stack overflow issue through iterative worklist algorithm."
 }

--- a/src/transforms/ir.rs
+++ b/src/transforms/ir.rs
@@ -239,9 +239,9 @@ pub enum IRNode {
         base_class: Option<Box<IRNode>>,
         body: Vec<IRNode>,
         /// WeakMap declarations for private fields (before the IIFE)
-        weakmap_decls: Vec<String>,
+        weakmap_decls: Vec<IRNode>,
         /// WeakMap instantiations (after the IIFE)
-        weakmap_inits: Vec<String>,
+        weakmap_inits: Vec<IRNode>,
     },
 
     /// __extends helper call: `__extends(ClassName, _super);`
@@ -275,6 +275,22 @@ pub enum IRNode {
     AwaiterCall {
         this_arg: Box<IRNode>,
         generator_body: Box<IRNode>,
+    },
+
+    /// Generator function (standalone or expression)
+    GeneratorFunction {
+        name: Option<String>,
+        parameters: Vec<String>,
+        generator_body: Box<IRNode>,
+    },
+
+    /// Generator method (class method)
+    GeneratorMethod {
+        class_name: String,
+        method_name: String,
+        parameters: Vec<String>,
+        generator_body: Box<IRNode>,
+        is_static: bool,
     },
 
     /// __generator helper body


### PR DESCRIPTION
## Worker Implementation

**Task:** Refactor class_es5.rs to separate AST transformation from string emission. Move all string emission logic (write, emit_class, emit_statement methods with output.push_str/write calls) into ir_printer.rs. Create new IR node types in ir.rs for ES5ClassIIFE, ExtendsHelper, and any class-specific constructs. Update class_es5.rs to only return IRNode trees, never emit strings directly.

---
*Automated by Claude Code Orchestrator*