### PR TITLE
[EM-1] Solver Evaluate: Fix solver evaluate tests (27 failures) - conditio

### DIFF
--- a/src/solver/instantiate.rs
+++ b/src/solver/instantiate.rs
@@ -429,11 +429,6 @@ impl<'a> TypeInstantiator<'a> {
                     {
                         if !self.is_shadowed(info.name) {
                             if let Some(substituted) = self.substitution.get(info.name) {
-                                // When substituting a type parameter with `any` in a distributive conditional,
-                                // the result is `any` (not a union of branches)
-                                if substituted == crate::solver::types::TypeId::ANY {
-                                    return substituted;
-                                }
                                 // When substituting with `never`, the result is `never`
                                 if substituted == crate::solver::types::TypeId::NEVER {
                                     return substituted;


### PR DESCRIPTION
## EM-1: Solver Evaluate

**Task:** Fix solver evaluate tests (27 failures) - conditional type inference, distributive types, object property access, and keyof operations on intersections. Focus on conditional type resolution logic and union distribution behavior.

**Workers:** 3 (2 merged)

---
*Automated by Claude Code Orchestrator*