### PR TITLE
Fix solver tests and add missing intrinsic type lookups

### DIFF
--- a/src/solver/intern.rs
+++ b/src/solver/intern.rs
@@ -556,6 +556,10 @@ impl TypeInterner {
             TypeId::BIGINT => Some(TypeKey::Intrinsic(IntrinsicKind::Bigint)),
             TypeId::SYMBOL => Some(TypeKey::Intrinsic(IntrinsicKind::Symbol)),
             TypeId::OBJECT => Some(TypeKey::Intrinsic(IntrinsicKind::Object)),
+            TypeId::BOOLEAN_TRUE => Some(TypeKey::Literal(LiteralValue::Boolean(true))),
+            TypeId::BOOLEAN_FALSE => Some(TypeKey::Literal(LiteralValue::Boolean(false))),
+            TypeId::FUNCTION => Some(TypeKey::Intrinsic(IntrinsicKind::Function)),
+            TypeId::PROMISE_BASE => Some(TypeKey::Intrinsic(IntrinsicKind::Object)), // Promise base treated as object
             _ => None,
         }
     }


### PR DESCRIPTION
- Add missing intrinsic type lookups for BOOLEAN_TRUE, BOOLEAN_FALSE,
  FUNCTION, and PROMISE_BASE in get_intrinsic_key() - this was causing
  Function intrinsic type assignability checks to fail

- Fix template literal keyof tests - keyof template_literal should
  return apparent keys of string (same as keyof string), not string itself

- Fix keyof union contravariance test - when A and B have disjoint keys,
  keyof (A | B) = keyof A & keyof B = never, not a union of both keys

- Fix strict_function_types test - Animal and Dog must be structurally
  different types (Dog is subtype of Animal) for variance testing to work

- Fix compat_tests.rs compilation error - use interner.is_subtype_of()
  instead of ctx.is_subtype_of() since QueryDatabase trait method
  is on the interner, not InferenceContext