### PR TITLE
fix(solver,checker): correct enum type display in assignment diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1281,8 +1281,21 @@ impl<'a> CheckerState<'a> {
                 {
                     return self.format_annotation_like_type(&display);
                 }
+                // When the target is an enum type, format_type() may resolve to
+                // an unrelated type name (e.g., a DOM interface that shares the
+                // same structural shape). Use the assignability formatter which
+                // correctly produces namespace-qualified enum names.
+                if tsz_solver::type_queries::get_enum_def_id(self.ctx.types, target).is_some() {
+                    return self.format_assignability_type_for_message(target, source);
+                }
                 return fallback;
             }
+        }
+
+        // When the target is an enum type without annotation text, use the
+        // assignability formatter for correct qualified enum name display.
+        if tsz_solver::type_queries::get_enum_def_id(self.ctx.types, display_target).is_some() {
+            return self.format_assignability_type_for_message(display_target, source);
         }
 
         if self.target_preserves_literal_surface(source) {

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -24829,3 +24829,59 @@ fn test_ts7060_not_emitted_with_constraint() {
         "Expected 0 TS7060 with constraint. Got: {diagnostics:#?}"
     );
 }
+
+/// Enum types from different namespaces with the same name should produce
+/// TS2322 with namespace-qualified type names in the diagnostic message, not
+/// TS2719 ("Two different types with this name exist").
+///
+/// tsc displays the target as the qualified enum name (e.g.,
+/// "numerics.DiagnosticCategory") rather than a structural type alias.
+/// Previously, the target formatter lacked an enum-specific path, causing
+/// it to resolve enum types to unrelated display aliases.
+#[test]
+fn test_enum_assignment_compat_uses_qualified_names_not_ts2719() {
+    let code = r#"
+namespace numerics {
+    export enum DiagnosticCategory {
+        Warning,
+        Error,
+        Suggestion,
+        Message,
+    }
+}
+namespace strings {
+    export enum DiagnosticCategory {
+        Warning = "Warning",
+        Error = "Error",
+        Suggestion = "Suggestion",
+        Message = "Message",
+    }
+}
+function f(x: numerics.DiagnosticCategory, y: strings.DiagnosticCategory) {
+    x = y;
+    y = x;
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics(code);
+    assert!(
+        has_error(&diagnostics, 2322),
+        "Expected TS2322 for incompatible enum assignment, got: {diagnostics:?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 2719),
+        "Should NOT emit TS2719 for enums from different namespaces, got: {diagnostics:?}"
+    );
+    // Verify the message uses qualified names
+    let ts2322_messages: Vec<&str> = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2322)
+        .map(|(_, msg)| msg.as_str())
+        .collect();
+    for msg in &ts2322_messages {
+        assert!(
+            msg.contains("strings.DiagnosticCategory")
+                || msg.contains("numerics.DiagnosticCategory"),
+            "TS2322 message should use qualified enum names, got: {msg}"
+        );
+    }
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -459,6 +459,7 @@ impl<'a> TypeFormatter<'a> {
                 | TypeData::Tuple(_)
                 | TypeData::Union(_)
                 | TypeData::Function(_)
+                | TypeData::Enum(_, _)
         );
         if !is_simple_type
             && let Some(alias_origin) = self.interner.get_display_alias(type_id)


### PR DESCRIPTION
Enum types from different namespaces (e.g., numerics.DiagnosticCategory vs strings.DiagnosticCategory) were displaying incorrect target type names in TS2322 diagnostics. Two root causes:

1. Solver: TypeData::Enum was not in the is_simple_type guard for display alias resolution, causing enum types to follow display_alias chains to unrelated DOM interface types (e.g., "StorageManager" instead of "DiagnosticCategory").

2. Checker: format_assignment_target_type_for_diagnostic lacked an enum-specific path (unlike the source formatter), falling through to format_type() which produced wrong names. Added enum detection that routes to format_assignability_type_for_message for correct namespace-qualified display.

Fixes 5 enumAssignmentCompat conformance tests. Net +11 tests overall with zero regressions.

https://claude.ai/code/session_01YXuBjpjk3TGeSN49AyF8sv