### PR TITLE
fix(checker): resolve inherited constructor through definition store …

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -255,5 +255,9 @@ path = "tests/infer_extends_constraint_substitution_tests.rs"
 name = "fresh_intersection_display_tests"
 path = "tests/fresh_intersection_display_tests.rs"
 
+[[test]]
+name = "intersection_signatures"
+path = "tests/intersection_signatures.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -166,11 +166,6 @@ impl<'a> CheckerState<'a> {
         {
             return cached;
         }
-        let can_use_cache = apply_module_augmentations
-            && request.is_empty()
-            && current_sym
-                .map(|sym_id| !self.ctx.class_constructor_resolution_set.contains(&sym_id))
-                .unwrap_or(true);
 
         // Cycle detection: prevent infinite recursion on circular class hierarchies
         // (e.g. class C extends C {}, or A extends B extends A)
@@ -191,6 +186,12 @@ impl<'a> CheckerState<'a> {
         } else {
             false
         };
+
+        let can_use_cache = apply_module_augmentations
+            && request.is_empty()
+            && current_sym
+                .map(|sym_id| !self.ctx.class_constructor_resolution_set.contains(&sym_id))
+                .unwrap_or(true);
 
         // Check fuel to prevent timeout on pathological inheritance hierarchies
         if !self.ctx.consume_fuel() {
@@ -1690,6 +1691,38 @@ impl<'a> CheckerState<'a> {
             // If there's a base class with construct signatures, inherit them
             if let Some(inherited) = inherited_construct_signatures {
                 construct_signatures = inherited;
+            } else if class.heritage_clauses.is_some() {
+                // The class has a heritage clause but we couldn't resolve
+                // inherited construct signatures. This can happen in cross-file
+                // delegation contexts where heritage call expressions (e.g.,
+                // mixin patterns like `MyMixin(Base)<string>`) fail to resolve
+                // because imports aren't available in the delegation checker.
+                //
+                // Fall back to the shared definition store: if the original
+                // file's checker already computed this class's constructor type,
+                // extract construct signatures from it instead of using the
+                // default 0-param constructor.
+                let def_store_sigs = current_sym
+                    .and_then(|sym_id| self.ctx.symbol_to_def.borrow().get(&sym_id).copied())
+                    .and_then(|class_def| self.ctx.definition_store.get_constructor_def(class_def))
+                    .and_then(|ctor_def| self.ctx.definition_store.get_body(ctor_def))
+                    .filter(|&body| body != TypeId::ERROR)
+                    .and_then(|body| construct_signatures_for_type(self.ctx.types, body))
+                    .filter(|sigs| !sigs.is_empty());
+
+                if let Some(sigs) = def_store_sigs {
+                    construct_signatures = sigs;
+                } else {
+                    // No base class or base class has no explicit constructor - use default
+                    construct_signatures.push(CallSignature {
+                        type_params: class_type_params,
+                        params: Vec::new(),
+                        this_type: None,
+                        return_type: instance_type,
+                        type_predicate: None,
+                        is_method: false,
+                    });
+                }
             } else {
                 // No base class or base class has no explicit constructor - use default
                 construct_signatures.push(CallSignature {

--- a/crates/tsz-checker/tests/intersection_signatures.rs
+++ b/crates/tsz-checker/tests/intersection_signatures.rs
@@ -4,8 +4,9 @@
 //! intersection type members, enabling mixin patterns and similar TypeScript
 //! idioms where an intersection of callable types should be callable.
 
-use crate::state::CheckerState;
 use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
 use tsz_parser::parser::ParserState;
 use tsz_solver::TypeInterner;
 
@@ -22,7 +23,7 @@ fn has_error_code(source: &str, code: u32) -> bool {
         &binder,
         &types,
         "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
+        CheckerOptions::default(),
     );
 
     checker.check_source_file(root);


### PR DESCRIPTION
…for cross-file mixin patterns

When a class extends a mixin call expression (e.g., `class C extends Mixin(Base)<string>`), the constructor type resolution fails in cross-file delegation contexts because the delegation checker cannot resolve imports from the heritage expression. This caused a default 0-param constructor to be used, producing false TS2554 errors.

The fix adds a targeted fallback: when a class has a heritage clause but inherited construct signatures couldn't be resolved, check the shared definition store for a previously-computed constructor type from the original file's checker. This only activates for the specific failure case (heritage clause present, no inherited signatures found), avoiding any impact on classes that resolve correctly.

Root cause: In multi-file parallel checking, each file gets its own CheckerState. When Main.ts imports MyExtendedClass from FinalClass.ts, a delegation checker is created for FinalClass.ts. This delegation checker has a fresh node_types cache and can't resolve the call expression MyMixin(MyBaseClass) in the heritage clause because the imports (MyMixin from MixinClass.ts, MyBaseClass from BaseClass.ts) fail to resolve in the delegation context, returning TypeId::Error.

Also fixes broken imports in intersection_signatures.rs test file (crate:: -> tsz_checker::) and registers it in Cargo.toml.

Fixes: exportClassExtendingIntersection conformance test Also fixes: defaultPropsEmptyCurlyBecomesAnyForJs,
  declarationEmitPrivateSymbolCausesVarDeclarationEmit2,
  typeReferenceRelatedFiles, typesVersionsDeclarationEmit.ambient

https://claude.ai/code/session_01L4tAJyf1u6yZY3WYT5vS1A