### PR TITLE
fix(checker): emit TS2364 for direct assignment to import.meta

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -263,5 +263,9 @@ path = "tests/fresh_intersection_display_tests.rs"
 name = "intersection_signatures"
 path = "tests/intersection_signatures.rs"
 
+[[test]]
+name = "ts2364_import_meta_assignment_tests"
+path = "tests/ts2364_import_meta_assignment_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -59,6 +59,18 @@ impl<'a> CheckerState<'a> {
             k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                 || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
             {
+                // `import.meta` is parsed as PROPERTY_ACCESS_EXPRESSION with
+                // ImportKeyword as the expression. It is NOT a valid assignment
+                // target — assigning to `import.meta` itself must emit TS2364.
+                // (Assigning to `import.meta.foo` is fine — that's a real
+                // property access on the meta object, not `import.meta` itself.)
+                if let Some(access) = self.ctx.arena.get_access_expr(node) {
+                    if let Some(expr_node) = self.ctx.arena.get(access.expression) {
+                        if expr_node.kind == SyntaxKind::ImportKeyword as u16 {
+                            return false;
+                        }
+                    }
+                }
                 true
             }
             k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN

--- a/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
+++ b/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
@@ -1,0 +1,81 @@
+//! Tests for TS2364: The left-hand side of an assignment expression must be a
+//! variable or a property access.
+//!
+//! Specifically tests that `import.meta = ...` is rejected (TS2364) while
+//! `import.meta.prop = ...` is allowed (it's a real property access).
+
+use tsz_binder::BinderState;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn get_error_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        tsz_checker::context::CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn has_error_with_code(source: &str, code: u32) -> bool {
+    get_error_codes(source).contains(&code)
+}
+
+#[test]
+fn test_import_meta_direct_assignment_is_invalid() {
+    // `import.meta = foo` must emit TS2364 because import.meta itself
+    // is not a valid assignment target (it's a meta-property, not a variable
+    // or property access).
+    let source = r#"
+const foo: any = {};
+import.meta = foo;
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Should emit TS2364 for direct assignment to import.meta"
+    );
+}
+
+#[test]
+fn test_import_meta_property_assignment_is_valid() {
+    // `import.meta.foo = value` is fine — it's a property access on import.meta
+    let source = r#"
+import.meta.foo = 42;
+"#;
+    let codes = get_error_codes(source);
+    assert!(
+        !codes.contains(&2364),
+        "Should NOT emit TS2364 for assignment to import.meta.foo; got codes: {:?}",
+        codes
+    );
+}
+
+#[test]
+fn test_import_meta_compound_assignment_is_invalid() {
+    // `import.meta += foo` must also emit TS2364
+    let source = r#"
+import.meta += 1;
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Should emit TS2364 for compound assignment to import.meta"
+    );
+}


### PR DESCRIPTION
In tsz, `import.meta` is parsed as a PROPERTY_ACCESS_EXPRESSION (with ImportKeyword as the base expression), rather than using the META_PROPERTY node kind. This caused `is_valid_assignment_target` to incorrectly return true for `import.meta`, allowing `import.meta = foo;` without emitting TS2364 ("The left-hand side of an assignment expression must be a variable or a property access").

The fix detects when a PROPERTY_ACCESS_EXPRESSION has ImportKeyword as its base expression and rejects it as an assignment target, matching tsc's behavior where MetaProperty is never a valid LHS.

Note: `import.meta.prop = value` remains valid — that's a real property access on the meta object, not import.meta itself.

Fixes conformance test: importMeta.ts (was missing TS2364)

https://claude.ai/code/session_013SrFdDpDRJWcVxcPX8kyB9