### PR TITLE
fix(checker): suppress false TS2346 on super() with forward-reference…

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_super.rs
+++ b/crates/tsz-checker/src/types/computation/access_super.rs
@@ -72,7 +72,40 @@ impl<'a> CheckerState<'a> {
                     extends_type_args.as_ref(),
                 )
             {
-                return ctor_type;
+                // For super() calls without explicit type arguments, verify
+                // the resolved type has construct signatures. When the base
+                // class is forward-referenced (used before its declaration),
+                // identifier resolution may return a stale symbol type (a
+                // Callable with static properties but missing construct
+                // signatures) even though the direct class constructor type
+                // computation produces the correct type. In that case, fall
+                // through to get_class_constructor_type which builds the
+                // constructor type from the AST and always includes construct
+                // signatures (including default constructors).
+                //
+                // When type arguments ARE present, missing construct sigs may
+                // be intentional (e.g., `extends Base<any>` where Base is not
+                // generic — apply_type_arguments_to_constructor_type_for_extends
+                // deliberately strips construct sigs so TS2346 fires). In that
+                // case, return the type as-is.
+                if is_super_call && extends_type_args.is_none() {
+                    let has_construct_sigs =
+                        crate::query_boundaries::common::construct_signatures_for_type(
+                            self.ctx.types,
+                            ctor_type,
+                        )
+                        .is_some_and(|sigs| !sigs.is_empty());
+
+                    if !has_construct_sigs {
+                        // Fall through: super() target lacks construct
+                        // signatures without type args — likely a forward
+                        // reference. Try direct class constructor type lookup.
+                    } else {
+                        return ctor_type;
+                    }
+                } else {
+                    return ctor_type;
+                }
             }
 
             let Some(base_class_idx) = self.get_base_class_idx(class_info.class_idx) else {

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -35693,3 +35693,154 @@ export const myVar: number = 42;
         mappings.len()
     );
 }
+
+/// Test that super() in a class extending a class with private static fields
+/// does NOT emit false TS2346 ("Call target does not contain any signatures").
+/// Regression test for conformance: privateNamesAndStaticFields.ts
+#[test]
+fn test_super_call_no_false_ts2346_with_private_static_fields() {
+    use crate::parser::ParserState;
+
+    let source = r#"
+class A {
+    static #foo: number;
+    static #bar: number;
+    constructor () {
+    }
+}
+
+class B extends A {
+    static #foo: string;
+    constructor () {
+        super();
+        B.#foo = "some string";
+    }
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "Parse errors: {:?}",
+        parser.get_diagnostics()
+    );
+
+    let mut binder = BinderState::new();
+    merge_shared_lib_symbols(&mut binder);
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        crate::checker::context::CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+    setup_lib_contexts(&mut checker);
+    checker.check_source_file(root);
+
+    println!("=== super() with private static fields ===");
+    for diag in &checker.ctx.diagnostics {
+        println!(
+            "  TS{}: {} (pos={})",
+            diag.code, diag.message_text, diag.start
+        );
+    }
+
+    let has_2346 = checker.ctx.diagnostics.iter().any(|d| d.code == 2346);
+    assert!(
+        !has_2346,
+        "Should NOT emit TS2346 for super() in class with private static fields. Diagnostics: {:?}",
+        checker
+            .ctx
+            .diagnostics
+            .iter()
+            .map(|d| format!("TS{}: {}", d.code, d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Test that super() in a class extending a forward-declared class
+/// does NOT emit false TS2346. tsc emits TS2449 for the forward reference
+/// but NOT TS2346 for the super() call.
+/// Regression test for conformance: classSideInheritance2.ts
+#[test]
+fn test_super_call_no_false_ts2346_with_forward_reference() {
+    use crate::parser::ParserState;
+
+    let source = r#"
+interface IText {
+    foo: number;
+}
+
+interface TextSpan {}
+
+class SubText extends TextBase {
+    constructor(text: IText, span: TextSpan) {
+        super();
+    }
+}
+
+class TextBase implements IText {
+    public foo: number;
+    public subText(span: TextSpan): IText {
+        return new SubText(this, span);
+    }
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "Parse errors: {:?}",
+        parser.get_diagnostics()
+    );
+
+    let mut binder = BinderState::new();
+    merge_shared_lib_symbols(&mut binder);
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        crate::checker::context::CheckerOptions::default(),
+    );
+    setup_lib_contexts(&mut checker);
+    checker.check_source_file(root);
+
+    println!("=== super() with forward reference ===");
+    for diag in &checker.ctx.diagnostics {
+        println!(
+            "  TS{}: {} (pos={})",
+            diag.code, diag.message_text, diag.start
+        );
+    }
+
+    let has_2346 = checker.ctx.diagnostics.iter().any(|d| d.code == 2346);
+    assert!(
+        !has_2346,
+        "Should NOT emit TS2346 for super() in class with forward-referenced base. Diagnostics: {:?}",
+        checker
+            .ctx
+            .diagnostics
+            .iter()
+            .map(|d| format!("TS{}: {}", d.code, d.message_text))
+            .collect::<Vec<_>>()
+    );
+
+    // TS2449 (forward reference) should still be emitted
+    let has_2449 = checker.ctx.diagnostics.iter().any(|d| d.code == 2449);
+    assert!(
+        has_2449,
+        "Should still emit TS2449 for class used before its declaration"
+    );
+}


### PR DESCRIPTION
…d base class

When a class is used before its declaration (forward reference), the super() call in the derived class constructor would incorrectly emit TS2346 ("Call target does not contain any signatures") alongside the correct TS2449 ("Class used before its declaration").

Root cause: For forward-referenced classes, identifier resolution returns a stale symbol type — a Callable with static properties but missing construct signatures — even though get_class_constructor_type produces the correct type with construct signatures. The super() call resolution used the stale type from base_constructor_type_from_expression, which lacked construct signatures, causing the solver to return NotCallable.

Fix: In get_type_of_super_keyword, when the base constructor type from expression resolution has no construct signatures AND no type arguments are present, fall through to the direct get_class_constructor_type path which builds the constructor type from the AST and always includes construct signatures (including default constructors).

When type arguments ARE present (e.g., `extends Base<any>` where Base is not generic), the missing construct signatures may be intentional — apply_type_arguments_to_constructor_type_for_extends deliberately strips them so TS2346 fires correctly.

Conformance impact: +7 improvements, 0 regressions
  + classSideInheritance2.ts
  + privateNamesAndStaticFields.ts
  + arrayAssignmentTest1.ts
  + interfaceExtendsClassWithPrivate1.ts
  + ramdaToolsNoInfinite.ts
  + ramdaToolsNoInfinite2.ts
  + dependentDestructuredVariables.ts

https://claude.ai/code/session_014ZbzUopcbV5EGjdL2QhXSj