### PR TITLE
fix(solver): restore this-binding in union property access for polymo…

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1134,7 +1134,7 @@ impl<'a> CheckerState<'a> {
         let method = self.ctx.arena.get_method_decl(member_node)?;
         let name = self.get_member_name_text(method.name)?;
         let (type_params, type_param_updates) = self.push_type_parameters(&method.type_parameters);
-        let (params, _this_type) = self.extract_params_from_parameter_list(&method.parameters);
+        let (params, this_type) = self.extract_params_from_parameter_list(&method.parameters);
         let return_type = if method.type_annotation.is_some() {
             self.get_type_from_type_node(method.type_annotation)
         } else if method.body.is_some() {
@@ -1151,7 +1151,7 @@ impl<'a> CheckerState<'a> {
             .function(tsz_solver::FunctionShape {
                 type_params,
                 params,
-                this_type: None,
+                this_type,
                 return_type,
                 type_predicate: None,
                 is_constructor: false,

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -1290,6 +1290,31 @@ let x = a.equalsShallow(b);
     );
 }
 
+#[test]
+fn union_this_type_in_functions_emits_ts2684() {
+    // unionThisTypeInFunctions conformance test: calling a method with `this: this`
+    // on a union type where members have incompatible `data` properties.
+    // The `this` context is Real | Fake, but the method requires Real & Fake.
+    let source = r#"
+interface Real {
+    method(this: this, n: number): void;
+    data: string;
+}
+interface Fake {
+    method(this: this, n: number): void;
+    data: number;
+}
+function test(r: Real | Fake) {
+    r.method(12);
+}
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2684),
+        "Should emit TS2684 for union this type mismatch. Got: {diags:#?}"
+    );
+}
+
 // ─── Higher-order generic contextual types (compose/flip patterns) ──────
 
 #[test]

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -205,6 +205,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
         self.skip_this_binding.set(skip);
     }
 
+    /// Returns the current state of the `skip_this_binding` flag.
+    pub(crate) fn is_skip_this_binding(&self) -> bool {
+        self.skip_this_binding.get()
+    }
+
     /// Helper to access the underlying `TypeDatabase`
     pub(crate) fn interner(&self) -> &dyn TypeDatabase {
         self.db.as_type_database()
@@ -413,8 +418,12 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
                 for prop in &shape.properties {
                     if prop.name == prop_atom {
-                        let read_type = self.optional_property_type(prop);
-                        let write_type = self.optional_property_write_type(prop);
+                        let read_type = self
+                            .bind_object_receiver_this(obj_type, self.optional_property_type(prop));
+                        let write_type = self.bind_object_receiver_this(
+                            obj_type,
+                            self.optional_property_write_type(prop),
+                        );
                         let write = (write_type != read_type).then_some(write_type);
                         return PropertyAccessResult::Success {
                             type_id: read_type,

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -374,9 +374,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
         };
 
         let shape = self.interner().object_shape(ObjectShapeId(shape_id));
-        // PERF: Reuse existing interned type for this shape instead of cloning
-        // the entire property list and re-interning. The shape is already interned,
-        // so this is an O(1) cache hit.
         let obj_type = self
             .interner()
             .object_type_from_shape(ObjectShapeId(shape_id));
@@ -537,6 +534,16 @@ impl<'a> PropertyAccessEvaluator<'a> {
         prop_atom: Option<Atom>,
     ) -> Option<PropertyAccessResult> {
         use crate::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+
+        // Re-enable `this` binding for union member resolution. When a union is
+        // nested inside an intersection (e.g., `(A & B) | (C & D)`), the
+        // intersection handler sets `skip_this_binding = true` to prevent
+        // per-member binding within the intersection. But each union member is a
+        // distinct receiver type and needs its own `this` substitution — otherwise
+        // polymorphic `this: this` methods on different interfaces collapse to the
+        // same unsubstituted function type, breaking TS2684 detection.
+        let prev_skip = self.is_skip_this_binding();
+        self.set_skip_this_binding(false);
 
         let members = self.interner().type_list(crate::types::TypeListId(list_id));
 
@@ -726,6 +733,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 }
             }
         }
+
+        // Restore the `this` binding flag after processing all union members.
+        self.set_skip_this_binding(prev_skip);
 
         // If all non-nullable, non-unknown members had no results and some were unknown,
         // then the union is effectively unknown for property access purposes.


### PR DESCRIPTION
…rphic this

When resolving property access on a union type nested inside an intersection, the intersection handler sets skip_this_binding=true to defer this-substitution to the checker. However, this flag was inherited by nested union member resolution, causing polymorphic `this: this` method types from different interfaces to collapse into the same unsubstituted function type. This prevented TS2684 detection for calls like `(Real | Fake).method()` where Real and Fake have incompatible `data` properties.

The fix resets skip_this_binding=false at the start of visit_union_impl, since each union member is a distinct receiver type and needs its own `this` substitution. The flag is restored after member processing.

Additionally:
- Callable property access now calls bind_object_receiver_this (matching the Object handler behavior) so `this: this` is properly substituted when interface types are stored as Callable shapes.
- interface_checks.rs now passes the extracted this_type to FunctionShape instead of hardcoding None.

Fixes conformance test: unionThisTypeInFunctions.ts (wrong-code → fingerprint-only)

https://claude.ai/code/session_01NjZjak6sbkKEdz52BadL4P