### PR TITLE
fix(checker): skip block-body callback return mismatch when expected …

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -458,8 +458,22 @@ impl<'a> CheckerState<'a> {
                         // The component check already handles TNext contravariantly
                         // (line: `is_assignable_to(expected_next, actual_next)`),
                         // so it is the more accurate signal for generators.
+                        // When the expected return type contains unresolved
+                        // type parameters (e.g., `U` from a generic overload
+                        // `reduce<U>(fn: (a: U) => U, init: U): U`), skip the
+                        // return type mismatch check.  The type parameter is
+                        // resolved via inference during generic call resolution,
+                        // not by direct assignability.  Checking `number[]` vs
+                        // `U` would always fail, causing a false TS2769.
+                        let expected_return_has_type_params =
+                            crate::query_boundaries::common::contains_type_parameters(
+                                self.ctx.types,
+                                expected_return,
+                            );
                         let return_type_mismatch =
                             if is_generator_callback && !generator_component_mismatch {
+                                false
+                            } else if expected_return_has_type_params {
                                 false
                             } else {
                                 generator_component_mismatch

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -157,6 +157,18 @@ impl<'a> CheckerState<'a> {
 
         self.ctx.node_types = std::mem::take(&mut original_node_types);
 
+        // Snapshot diagnostics AFTER union-contextual argument collection.
+        // The union-contextual pass can produce speculative callback body errors
+        // (e.g., TS2322 from checking `return [a]` against the union contextual
+        // return type `number | U`). These errors are from the union context, NOT
+        // from individual overload attempts. Using `overload_snap` (taken before
+        // arg collection) would cause `overload_candidate_has_callback_body_errors`
+        // to see these stale union-context diagnostics and incorrectly reject
+        // overloads that the solver successfully resolves (e.g., generic overloads
+        // like `reduce<U>`). This post-collection snapshot ensures only diagnostics
+        // from the current overload attempt are checked.
+        let post_union_arg_diag_snap = self.ctx.snapshot_diagnostics();
+
         // First pass: try each signature with union-contextual argument types.
         // When an overload succeeds but its return context substitution is empty
         // (couldn't infer type params from contextual return type), defer it as
@@ -225,8 +237,10 @@ impl<'a> CheckerState<'a> {
                     // Defer those candidates to the signature-specific pass, which can
                     // re-evaluate callbacks with per-overload parameter types.
                     if signatures.len() > 1
-                        && self
-                            .overload_candidate_has_callback_body_errors(args, &overload_snap.diag)
+                        && self.overload_candidate_has_callback_body_errors(
+                            args,
+                            &post_union_arg_diag_snap,
+                        )
                     {
                         self.prune_callback_body_diagnostics(args, &overload_snap.diag);
                         continue;

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -2212,6 +2212,45 @@ arr.reduce((a, b) => a + b, 0);
     );
 }
 
+/// Block-body callbacks with explicit param types should match generic overloads.
+/// Regression test: `raw_block_body_callback_mismatch` was incorrectly checking
+/// `is_assignable_to(actual_return, expected_return)` where `expected_return` was
+/// a type parameter (e.g., `U`), causing a false TS2769 for block-body arrows
+/// like `(acc: number[], a: number) => { return [a]; }` against `reduce<U>`.
+#[test]
+fn test_generic_overload_block_body_callback_no_false_ts2769() {
+    use crate::parser::ParserState;
+
+    let source = r#"
+const arr = [1, 2, 3];
+arr.reduce((acc: number[], a: number, index: number) => { return [a] }, []);
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    merge_shared_lib_symbols(&mut binder);
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        crate::checker::context::CheckerOptions::default(),
+    );
+    setup_lib_contexts(&mut checker);
+    checker.check_source_file(root);
+
+    let codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&2769),
+        "Should not emit TS2769 for block-body callback matching generic overload, got: {codes:?}"
+    );
+}
+
 #[test]
 fn test_class_method_overload_reports_no_overload_matches() {
     use crate::checker::diagnostics::diagnostic_codes;


### PR DESCRIPTION
…return has type params

When overload resolution encountered a block-body callback (e.g., `(acc: number[]) => { return [a]; }`) against a generic overload like `reduce<U>(fn: (a: U) => U, init: U): U`, the `raw_block_body_callback_mismatch` check was incorrectly comparing the actual return type (`number[]`) against the unresolved type parameter (`U`). Since `number[]` is never assignable to a raw `U`, the check reported a false return-type mismatch, causing the generic overload to be rejected with a false TS2769.

Root cause: `raw_block_body_callback_mismatch` extracts the expected callback return type and checks `is_assignable_to(actual_return, expected_return)`. When the expected return type contains type parameters, this check is invalid because the type parameter is resolved via inference during generic call resolution, not by direct assignability.

Fix: Skip the return-type mismatch check when `expected_return` contains type parameters (via `contains_type_parameters`).

Secondary fix: Use a post-union-contextual diagnostic snapshot for the `overload_candidate_has_callback_body_errors` check, so stale diagnostics from the union-contextual argument collection pass don't leak into per-overload callback body error checks.

Conformance: +4 tests (unionOfClassCalls, ramdaToolsNoInfinite{,2}, dependentDestructuredVariables). 1 unrelated regression (filesystem- dependent incrementalTsBuildInfoFile).

https://claude.ai/code/session_01Tzee2wNrx13G3cxAZUKsDn