### PR TITLE
fix(checker): propagate const assertion context for const type parame…

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -1258,10 +1258,42 @@ impl<'a> CheckerState<'a> {
             // tuple/object, causing a false TS2322.
             let prev_const_assertion = self.ctx.in_const_assertion;
             if !self.ctx.in_const_assertion {
+                let mut should_enable_const = false;
                 if let Some(et) = expected_type {
                     if Self::type_references_const_type_param(self.ctx.types, et) {
-                        self.ctx.in_const_assertion = true;
+                        should_enable_const = true;
                     }
+                }
+                // When the expected type doesn't directly reference a const type
+                // param (e.g., it's an already-instantiated type from Round 2 of
+                // generic inference), also check the callable's ORIGINAL parameter
+                // type. Only enable const assertion when the parameter IS directly
+                // a const type param (e.g., `x: T` where T is const), not when it
+                // merely contains one (e.g., `obj: [T, T]`). For container types
+                // like tuples, const assertion flows through contextual typing of
+                // each element, not globally at the argument level.
+                if !should_enable_const {
+                    if let Some(callable_type) = callable_ctx.callable_type {
+                        let ctx = tsz_solver::ContextualTypeContext::with_expected(
+                            self.ctx.types,
+                            callable_type,
+                        );
+                        if let Some(param_type) =
+                            ctx.get_parameter_type_for_call(effective_index, expanded_count)
+                        {
+                            if crate::query_boundaries::common::type_param_info(
+                                self.ctx.types,
+                                param_type,
+                            )
+                            .is_some_and(|info| info.is_const)
+                            {
+                                should_enable_const = true;
+                            }
+                        }
+                    }
+                }
+                if should_enable_const {
+                    self.ctx.in_const_assertion = true;
                 }
             }
             let arg_snap = self.ctx.snapshot_diagnostics();

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -812,6 +812,18 @@ impl<'a> CheckerState<'a> {
                 self.ctx.node_types = Default::default();
                 refresh_all_args(self);
 
+                // Restore const-assertion and literal-preservation context for the
+                // contextual retry pass. These flags were cleared at the end of the
+                // preinference rounds (above), but the retry still needs them so that
+                // nested array/object literals in arguments of `const` type parameter
+                // functions are correctly inferred as readonly tuples / readonly objects.
+                let prev_preserve_literals_retry = self.ctx.preserve_literal_types;
+                let prev_in_const_assertion_retry = self.ctx.in_const_assertion;
+                self.ctx.preserve_literal_types = true;
+                if has_const_type_params {
+                    self.ctx.in_const_assertion = true;
+                }
+
                 let retry_callable_ctx = CallableContext::new(func_type);
                 let refreshed_contextual_types = if !return_sub_for_retry.is_empty() {
                     (0..args.len())
@@ -844,6 +856,9 @@ impl<'a> CheckerState<'a> {
                     None,
                     retry_callable_ctx,
                 );
+
+                self.ctx.preserve_literal_types = prev_preserve_literals_retry;
+                self.ctx.in_const_assertion = prev_in_const_assertion_retry;
 
                 let (retry_result, _retry_predicate, _retry_instantiated_params) = self
                     .resolve_call_with_checker_adapter(

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -214,6 +214,13 @@ impl<'a> CheckerState<'a> {
         };
 
         if array.elements.nodes.is_empty() {
+            // In const assertion context (e.g., `[] as const` or inside a `const T`
+            // type parameter call), empty arrays become empty readonly tuples, not
+            // `never[]`. This matches tsc's behavior for `[] as const` → `readonly []`.
+            if self.ctx.in_const_assertion {
+                return factory.tuple(vec![]);
+            }
+
             // Empty array literal: always never[] in strict mode, any[] otherwise.
             // This matches tsc's checkArrayLiteral which unconditionally uses
             // implicitNeverType for empty arrays in strict mode, regardless of

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -1374,3 +1374,52 @@ const x = pipe(es, filter(exists((n) => n > 0)));
         "pipe(es, filter(exists(...))) should not produce TS2345. Got: {diags:#?}"
     );
 }
+
+// ─── Const type parameter inference ─────────────────────────────────
+
+#[test]
+fn const_type_param_nested_array_in_object_no_false_ts2322() {
+    // When a function has `const T` and multiple parameters, nested array
+    // literals inside object literal arguments must be inferred as readonly
+    // tuples, not plain arrays. Without const assertion flowing into nested
+    // expressions, [1, 2] is typed as `number[]` which is not assignable to
+    // the inferred `readonly [1, 2]`, producing a false TS2322.
+    let source = r#"
+declare function f<const T>(x: T, y?: string): T;
+const a = f({ d: [1, 2] });
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "const type param with multi-param function should not produce false TS2322. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn const_type_param_single_param_nested_array_no_false_ts2322() {
+    // Baseline: single-param const type param function should also work.
+    let source = r#"
+declare function f<const T>(x: T): T;
+const a = f({ d: [1, 2] });
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "const type param with single-param function should not produce TS2322. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn const_type_param_empty_array_in_object_no_false_ts2322() {
+    // Empty arrays inside object literals with const type params should be
+    // typed as empty readonly tuples, not `never[]`.
+    let source = r#"
+declare function f<const T>(x: T, y?: string): T;
+const a = f({ d: [] });
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "const type param with empty array should not produce false TS2322. Got: {diags:#?}"
+    );
+}


### PR DESCRIPTION
…ter calls

When a generic function has `const` type parameters and is called with object literal arguments containing nested array literals, the const assertion context was not flowing into the nested expressions during argument type collection. This caused nested arrays like `[1, 2]` in `f<const T>({d: [1, 2]}, y)` to be typed as `number[]` instead of `readonly [1, 2]`, producing false TS2322 diagnostics.

Root cause: The per-argument const assertion logic in collect_call_argument_types_with_context only checked if the `expected_type` directly references a const type param. But during Round 2 of generic inference, the expected type is the already-instantiated type (e.g., `{ readonly d: readonly [1, 2] }`) which no longer references a type parameter. The original callable's parameter type (`T`) was not consulted.

Fix: When the expected type doesn't reference a const type param, also check the callable's original parameter type at that position. If the original param IS directly a const type param, enable const assertion for the argument. Additionally, empty array literals in const assertion context now produce empty tuples instead of `never[]`.

This also adds preserve_literal_types + in_const_assertion restoration for the contextual retry pass in overload resolution, ensuring the retry pass uses the same literal/const context as the initial passes.

Fixes conformance: jsdocTemplateTag6.ts (FAIL → PASS)

https://claude.ai/code/session_016cCrZryX2iwxxiSri9HHzy