### PR TITLE
fix(checker): resolve lazy refs in TS2344 constraint before evaluation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -797,6 +797,14 @@ impl<'a> CheckerState<'a> {
                         // before checking. E.g., `WeakKeyTypes[keyof WeakKeyTypes]`
                         // must be reduced to `object | symbol` for the assignability
                         // check to work correctly.
+                        //
+                        // Ensure lazy refs inside the constraint are resolved in the
+                        // type environment BEFORE evaluation. Without this, constraints
+                        // like `WeakKeyTypes[keyof WeakKeyTypes]` (where WeakKeyTypes is
+                        // a Lazy(DefId) from a lib file) remain unevaluated because the
+                        // evaluator's `ensure_relation_input_ready` may be skipped due
+                        // to depth guards during nested evaluation.
+                        self.ensure_refs_resolved(inst_constraint);
                         let inst_constraint = self.evaluate_type_for_assignability(inst_constraint);
                         let mut is_satisfied = self.is_assignable_to(base, inst_constraint)
                             || self.satisfies_array_like_constraint(base, inst_constraint);

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -25397,3 +25397,46 @@ enum ENUM1 { A, B, C }
         "Should NOT emit TS2356 for valid enum member type. Got: {diagnostics:?}"
     );
 }
+
+/// TS2344 false positive: when a type parameter `K extends object` is used
+/// in a class member type annotation (not a `new` expression) referencing a
+/// generic with an indexed-access-type constraint like `WeakKey`, the Lazy
+/// refs inside the constraint (e.g., `WeakKeyTypes[keyof WeakKeyTypes]`) must
+/// be resolved before the assignability check. Without resolving them,
+/// `evaluate_type_for_assignability` returns the unevaluated IndexAccess and
+/// the check incorrectly fails.
+///
+/// Regression test for esNextWeakRefs_IterableWeakMap conformance failure.
+#[test]
+fn test_ts2344_indexed_access_constraint_lazy_refs_resolved_in_class_member() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+interface MyWeakKeyTypes {
+    object: object;
+    symbol: symbol;
+}
+type MyWeakKey = MyWeakKeyTypes[keyof MyWeakKeyTypes];
+
+declare class MyWeakRef<T extends MyWeakKey> { deref(): T | undefined; }
+declare class MyWeakMap<K extends MyWeakKey, V> { }
+
+class Foo<K extends object, V> {
+    // Type references in class member positions (field type annotation,
+    // method return type) go through validate_type_reference_type_arguments,
+    // NOT validate_new_expression_type_arguments. This path must also
+    // resolve Lazy refs in constraints.
+    weakMap: MyWeakMap<K, V> = null as any;
+    ref: MyWeakRef<K> = null as any;
+    getRef(): MyWeakRef<K> { return null as any; }
+}
+        "#,
+    );
+
+    let ts2344: Vec<_> = diagnostics.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(
+        ts2344.is_empty(),
+        "Should NOT get TS2344: K extends object satisfies MyWeakKey (= object | symbol).\n\
+         The indexed access constraint must be fully evaluated before the check.\n\
+         Got: {ts2344:#?}"
+    );
+}


### PR DESCRIPTION
When checking if a bare type parameter (e.g., `K extends object`) satisfies a generic constraint like `WeakKey` (= `WeakKeyTypes[keyof WeakKeyTypes]`), the constraint's IndexAccess type contains Lazy(DefId) references to lib-defined interfaces. These Lazy refs must be resolved in the type environment before `evaluate_type_for_assignability` can reduce the IndexAccess to its concrete form (e.g., `object | symbol`).

Previously, the evaluator's `ensure_relation_input_ready` could be skipped due to eval_depth or symbol_resolution_depth guards during nested evaluation, leaving the IndexAccess unevaluated. The assignability check then compared `object` against the raw `IndexAccess(Lazy(DefId), KeyOf(Lazy(DefId)))` and incorrectly failed.

The fix adds an explicit `ensure_refs_resolved(inst_constraint)` call before evaluation, guaranteeing the Lazy types are materialized in the type environment regardless of nesting depth.

This affected class member type annotations (fields, method return types) but not `new` expressions or function/interface contexts, because class member type references go through validate_type_reference_type_arguments which resolves constraints at a different nesting depth.

Fixes: esNextWeakRefs_IterableWeakMap conformance test (false positive TS2344 on `K extends object` used as `WeakMap<K, V>` / `WeakRef<K>` in class members).

https://claude.ai/code/session_01BF9tp1z3Hxg63SfzjuybHA