### PR TITLE
fix(checker): suppress false TS2451 from type-root ambient module imp…

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -199,7 +199,17 @@ impl<'a> CheckerState<'a> {
                 // Function declarations merge across files via module augmentation.
                 let is_function_merge = (symbol.flags & symbol_flags::FUNCTION) != 0
                     && !module_augmentation_declarations.is_empty();
-                if !is_interface_merge && !is_var_merge && !is_function_merge {
+                // Import aliases referencing remote declarations are valid merges.
+                let is_alias_import_merge = (symbol.flags & symbol_flags::ALIAS) != 0
+                    && symbol
+                        .declarations
+                        .iter()
+                        .any(|&d| self.is_import_alias_node(d));
+                if !is_interface_merge
+                    && !is_var_merge
+                    && !is_function_merge
+                    && !is_alias_import_merge
+                {
                     cross_file_conflicts.push(symbol.escaped_name.clone());
                 }
             }
@@ -1065,6 +1075,20 @@ impl<'a> CheckerState<'a> {
                         let decl_is_reexport = self.is_reexport_specifier(decl_idx);
                         let other_is_reexport = self.is_reexport_specifier(other_idx);
                         if decl_is_reexport || other_is_reexport {
+                            continue;
+                        }
+                    }
+
+                    // Import alias referencing a remote non-alias declaration
+                    // is not a conflict — suppress the false duplicate.
+                    if !same_source_file {
+                        let decl_is_import_alias = (decl_flags & symbol_flags::ALIAS) != 0
+                            && self.is_import_alias_node(decl_idx);
+                        let other_is_import_alias = (other_flags & symbol_flags::ALIAS) != 0
+                            && self.is_import_alias_node(other_idx);
+                        if (decl_is_import_alias && (other_flags & symbol_flags::ALIAS) == 0)
+                            || (other_is_import_alias && (decl_flags & symbol_flags::ALIAS) == 0)
+                        {
                             continue;
                         }
                     }

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -1553,6 +1553,23 @@ impl<'a> CheckerState<'a> {
             .get_export_decl(export_decl_node)
             .is_some_and(|data| data.module_specifier.is_some())
     }
+
+    /// Check if a declaration node is an import alias (import specifier,
+    /// import clause, or namespace import). These create ALIAS symbols
+    /// that reference a declaration in another file. In tsc, import
+    /// aliases are separate symbols and never conflict with the original
+    /// declaration. Our binder sometimes merges them, so we use this
+    /// check to suppress false duplicate diagnostics.
+    pub(super) fn is_import_alias_node(&self, decl_idx: NodeIndex) -> bool {
+        self.ctx.arena.get(decl_idx).is_some_and(|node| {
+            matches!(
+                node.kind,
+                syntax_kind_ext::IMPORT_SPECIFIER
+                    | syntax_kind_ext::IMPORT_CLAUSE
+                    | syntax_kind_ext::NAMESPACE_IMPORT
+            )
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1809,14 +1809,12 @@ pub(super) fn collect_diagnostics(
         base_dir,
         &file_is_esm_map,
     ));
-    diagnostics.extend(
-        collect_type_root_ambient_module_import_conflict_diagnostics(
-            program,
-            options,
-            base_dir,
-            &resolved_module_paths,
-        ),
-    );
+    // NOTE: collect_type_root_ambient_module_import_conflict_diagnostics was
+    // disabled because it produces false TS2451 ("Cannot redeclare block-scoped
+    // variable") for every exported value declaration in type-root ambient
+    // modules when the module is imported by another file. Importing a module
+    // is NOT a redeclaration — tsc does not emit TS2451 in this scenario.
+    // See conformance test: moduleResolutionAsTypeReferenceDirectiveAmbient.ts
 
     // Use the aggregated query-cache statistics. In the parallel path, these
     // are merged from all per-file caches. In the sequential path, they come


### PR DESCRIPTION
…orts

The driver-level `collect_type_root_ambient_module_import_conflict_diagnostics` function was incorrectly emitting TS2451 ("Cannot redeclare block-scoped variable") for every exported value declaration in type-root ambient modules when the module was imported by another file. Importing from a module is NOT a redeclaration — tsc does not emit TS2451 in this scenario.

Root cause: the function treated `import { a2 } from "phaser"` as a redeclaration conflict with `declare module "phaser" { export const a2; }`, but these are reference relationships, not conflicts.

Fix:
1. Disabled the buggy driver-level function that generated false positives
2. Added defensive checks in the checker's duplicate identifier detection to suppress false conflicts between import aliases (ALIAS) and their original declarations from different files
3. Added `is_import_alias_node` helper to distinguish import specifiers from other ALIAS node kinds (export specifiers, namespace exports)

Conformance: +8 net (10 improvements, 2 flaky regressions unrelated to change) Tests fixed: moduleResolutionAsTypeReferenceDirectiveAmbient,
  assertionFunctionWildcardImport2, unionOfClassCalls, spreadObjectOrFalsy,
  typeOfThisInInstanceMember, typeOfThisInInstanceMember2,
  decrementOperatorWithEnumType, esmModeDeclarationFileWithExportAssignment,
  functionVariableInReturnTypeAnnotation, parameterNamesInTypeParameterList

https://claude.ai/code/session_01WaEBJrDqnmSC9t3Gt13oEF