### PR TITLE
fix(solver): handle index signatures in recursive reverse-mapped type…

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -212,3 +212,28 @@ const store2 = configureStore({
         "Expected no TS2322 for reducer-pattern reverse mapped inference, got: {codes:?}"
     );
 }
+
+#[test]
+fn reverse_mapped_recursive_with_index_signature() {
+    // Regression test: recursive mapped type `Deep<T> = { [K in keyof T]: Deep<T[K]> }`
+    // inferred against an interface with only an index signature `{ [s: string]: B }`
+    // should produce T = B (coinductively), NOT T = unknown.
+    //
+    // Before the fix, reverse_infer_through_template's Case 6 (Mapped template)
+    // only iterated named properties, skipping index signatures entirely.
+    // For `interface B { [s: string]: B }` with no named properties, the
+    // reversal loop never ran, producing no candidate for T → T = unknown.
+    let code = r#"
+interface B { [s: string]: B }
+declare let b: B;
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+declare function foo<T>(deep: Deep<T>): T;
+const oub = foo(b);
+oub.b;
+"#;
+    let codes = check_and_get_codes(code);
+    assert!(
+        !codes.contains(&18046),
+        "Expected no TS18046 ('is of type unknown') for index-signature reverse mapped inference, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -505,6 +505,32 @@ impl<'a> InferenceContext<'a> {
         let mapped = self.interner.mapped_type(mapped_id);
         let source = self.interner.object_shape(source_shape);
 
+        // Detect homomorphic mapped type: constraint is `keyof T` where T
+        // is an inference parameter. For these, we use reverse-mapped inference
+        // to construct a candidate for T from the source type's structure.
+        // This detection is shared across named-property and index-signature paths.
+        let homomorphic_var = if let Some(TypeData::KeyOf(inner)) =
+            self.interner.lookup(mapped.constraint)
+        {
+            // Resolve Lazy wrappers — type parameters may be stored as
+            // Lazy(DefId) rather than TypeParameter directly.
+            let resolved_inner = if let Some(TypeData::Lazy(def_id)) = self.interner.lookup(inner) {
+                self.resolve_lazy_for_inference(def_id, inner)
+                    .unwrap_or(inner)
+            } else {
+                inner
+            };
+            if let Some(TypeData::TypeParameter(ref param_info)) =
+                self.interner.lookup(resolved_inner)
+            {
+                self.find_type_param(param_info.name)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         if !source.properties.is_empty() {
             // Infer the constraint type (K) from the union of source property names
             // e.g., for { foo: string, bar: number }, K = "foo" | "bar"
@@ -526,32 +552,6 @@ impl<'a> InferenceContext<'a> {
             // which includes MappedTypeConstraint: when multiple properties each
             // contribute a different type for T, the result should be their union
             // (e.g., Box<number> | Box<string> | Box<boolean>), not a single "best" type.
-            // Detect homomorphic mapped type: constraint is `keyof T` where T
-            // is an inference parameter. For these, we collect reverse-mapped
-            // properties during template inference and add a single object
-            // candidate for T after the loop.
-            let homomorphic_var =
-                if let Some(TypeData::KeyOf(inner)) = self.interner.lookup(mapped.constraint) {
-                    // Resolve Lazy wrappers — type parameters may be stored as
-                    // Lazy(DefId) rather than TypeParameter directly.
-                    let resolved_inner =
-                        if let Some(TypeData::Lazy(def_id)) = self.interner.lookup(inner) {
-                            self.resolve_lazy_for_inference(def_id, inner)
-                                .unwrap_or(inner)
-                        } else {
-                            inner
-                        };
-                    if let Some(TypeData::TypeParameter(ref param_info)) =
-                        self.interner.lookup(resolved_inner)
-                    {
-                        self.find_type_param(param_info.name)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
             let template_priority = InferencePriority::MappedType;
             for prop in &source.properties {
                 let key_literal = self.interner.literal_string_atom(prop.name);
@@ -596,6 +596,21 @@ impl<'a> InferenceContext<'a> {
                 mapped.template,
                 InferencePriority::MappedType,
             )?;
+
+            // For homomorphic mapped types (constraint is `keyof T`), the source
+            // type with its index signature structure is the reverse-mapped candidate
+            // for T. This matches tsc's getReverseMappedType which, for sources with
+            // only index signatures matched against `{ [K in keyof T]: Template<T[K]> }`,
+            // produces a type structurally equivalent to the source as the candidate.
+            // This is critical for recursive mapped types like `Deep<T>` where the
+            // template wraps `T[K]` — the coinductive equivalence between the source
+            // and the mapped result means the source itself is a valid candidate for T.
+            if let Some(var) = homomorphic_var {
+                let source_type = self
+                    .interner
+                    .object_with_index_type_from_shape(source_shape);
+                self.add_candidate(var, source_type, InferencePriority::HomomorphicMappedType);
+            }
         } else if let Some(ref number_index) = source.number_index {
             // Source has a number index signature (e.g., `{ [index: number]: V }`).
             self.infer_from_types(TypeId::NUMBER, mapped.constraint, priority)?;
@@ -604,6 +619,14 @@ impl<'a> InferenceContext<'a> {
                 mapped.template,
                 InferencePriority::MappedType,
             )?;
+
+            // Same homomorphic reverse-mapping for number index signatures.
+            if let Some(var) = homomorphic_var {
+                let source_type = self
+                    .interner
+                    .object_with_index_type_from_shape(source_shape);
+                self.add_candidate(var, source_type, InferencePriority::HomomorphicMappedType);
+            }
         }
 
         Ok(())

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -725,6 +725,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
                 let source_obj = self.interner.object_shape(source_shape_id);
                 let source_props = source_obj.properties.clone();
+                let source_string_idx = source_obj.string_index.clone();
+                let source_number_idx = source_obj.number_index.clone();
                 let mut reverse_properties = Vec::new();
                 let mut any_reversed = false;
 
@@ -779,9 +781,68 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     });
                 }
 
+                // Also reverse index signatures from the source.
+                // For sources with only index signatures (e.g., `{ [s: string]: B }`),
+                // the named property loop above doesn't run. We must reverse the index
+                // signature value through the template to reconstruct T's index signature.
+                // This handles recursive mapped types like `Deep<T>` matched against
+                // dictionary-like sources.
+                let mut reverse_string_index = None;
+                let mut reverse_number_index = None;
+
+                if let Some(ref sig) = source_string_idx {
+                    if let Some(reversed_value) = self.reverse_infer_through_template(
+                        sig.value_type,
+                        mapped.template,
+                        inner_placeholder,
+                    ) {
+                        any_reversed = true;
+                        let readonly = match mapped.readonly_modifier {
+                            Some(MappedModifier::Add) => false,
+                            Some(MappedModifier::Remove) => true,
+                            None => sig.readonly,
+                        };
+                        reverse_string_index = Some(crate::types::IndexSignature {
+                            key_type: sig.key_type,
+                            value_type: reversed_value,
+                            readonly,
+                            param_name: sig.param_name,
+                        });
+                    }
+                }
+                if let Some(ref sig) = source_number_idx {
+                    if let Some(reversed_value) = self.reverse_infer_through_template(
+                        sig.value_type,
+                        mapped.template,
+                        inner_placeholder,
+                    ) {
+                        any_reversed = true;
+                        let readonly = match mapped.readonly_modifier {
+                            Some(MappedModifier::Add) => false,
+                            Some(MappedModifier::Remove) => true,
+                            None => sig.readonly,
+                        };
+                        reverse_number_index = Some(crate::types::IndexSignature {
+                            key_type: sig.key_type,
+                            value_type: reversed_value,
+                            readonly,
+                            param_name: sig.param_name,
+                        });
+                    }
+                }
+
                 self.reverse_mapped_depth.set(depth);
 
                 if any_reversed {
+                    if reverse_string_index.is_some() || reverse_number_index.is_some() {
+                        return Some(self.interner.object_with_index(ObjectShape {
+                            flags: crate::types::ObjectFlags::empty(),
+                            properties: reverse_properties,
+                            string_index: reverse_string_index,
+                            number_index: reverse_number_index,
+                            symbol: None,
+                        }));
+                    }
                     return Some(self.interner.object(reverse_properties));
                 }
             }


### PR DESCRIPTION
… inference

When inferring type parameters through homomorphic mapped types like `Deep<T> = { [K in keyof T]: Deep<T[K]> }`, the reverse-mapped inference in `reverse_infer_through_template` Case 6 (Mapped template) only iterated named properties from the source object, completely skipping index signatures.

For a source like `interface B { [s: string]: B }` with no named properties, the property loop never ran, producing no inference candidate for T, causing T to resolve to `unknown`. This led to false TS18046 errors ("'x' is of type 'unknown'") when accessing properties on the result.

The fix adds index signature reversal to Case 6, mirroring the existing logic in `constrain_reverse_mapped_type` (outer level). For recursive mapped types, the depth guard at depth > 0 returns `Some(source_value)` (coinductive convergence), correctly producing T = B for the example above.

Also lifts homomorphic detection in `infer_from_mapped_type` (infer_matching.rs) before the properties/index-signature split, and adds HomomorphicMappedType candidates for sources with index signatures as a secondary inference path.

Conformance: +8 tests passing (net +7 with 1 unrelated transient regression). Tests flipped PASS: arrayLiterals3, instanceofOperatorWithInvalidOperands (x2), instantiatedModule, checkJsxChildrenCanBeTupleType, invalidMultipleVariableDeclarations, forStatementsMultipleInvalidDecl, conditionalTypes2.

https://claude.ai/code/session_01CgTMnGMq4yhFcV3f4Jhab6