### PR TITLE
fix(checker): prevent false TS2448/TS2454 from cross-binder SymbolId …

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -50,6 +50,18 @@ impl<'a> CheckerState<'a> {
             return declared_type;
         }
 
+        // Skip flow analysis for cross-file symbols.
+        // The SymbolId belongs to a different binder's arena, so looking it up
+        // in the local binder hits a different symbol (cross-binder SymbolId
+        // collision). This causes false TS2454 for UMD globals and other
+        // cross-file bindings.
+        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id) {
+            if file_idx != self.ctx.current_file_idx {
+                trace!("Cross-file symbol, skipping flow analysis");
+                return declared_type;
+            }
+        }
+
         // Const object/array literal bindings have a stable type shape and do not
         // benefit from control-flow narrowing. Skipping CFG traversal for these
         // bindings avoids O(N²) reference matching on large call-heavy files.

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -73,6 +73,17 @@ impl<'a> CheckerState<'a> {
         if self.ctx.is_declaration_file() {
             return false;
         }
+        // Skip TDZ for cross-file symbols (resolved from another binder).
+        // The SymbolId belongs to a different binder's arena, so looking it up
+        // in the local binder would hit a different symbol at the same numeric
+        // ID, causing false TS2448/TS2454 (cross-binder SymbolId collision).
+        // Cross-file symbols (e.g., UMD global aliases from `export as namespace`)
+        // have no same-file TDZ — they are evaluated when their origin file loads.
+        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id) {
+            if file_idx != self.ctx.current_file_idx {
+                return false;
+            }
+        }
         let is_tdz_in_static_block =
             self.is_variable_used_before_declaration_in_static_block(sym_id, idx);
         let is_tdz_in_property_initializer =

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -13517,6 +13517,61 @@ const p: string = Alpha.x;
         !diagnostics.iter().any(|(code, _)| *code == 2339),
         "Expected first UMD namespace export to win for Alpha.x without TS2339. Actual diagnostics: {diagnostics:#?}"
     );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics for umdGlobalConflict. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+/// Regression test: cross-binder SymbolId collision must not cause false
+/// TS2448 ("used before declaration") or TS2454 ("used before assignment")
+/// for UMD globals resolved from another file's binder.
+///
+/// When `resolve_identifier_symbol_from_all_binders` returns a SymbolId from
+/// another file, subsequent code that looks up that numeric ID in the local
+/// binder finds a *different* symbol. If that local symbol is a block-scoped
+/// variable, TDZ/DAA checks fire incorrectly.
+#[test]
+fn test_umd_global_no_false_tdz_or_daa_cross_binder() {
+    let files = [
+        (
+            "/lib/index.d.ts",
+            r#"
+export as namespace Lib;
+export var value: string;
+"#,
+        ),
+        (
+            "/app.ts",
+            r#"
+const result: string = Lib.value;
+"#,
+        ),
+    ];
+
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &files,
+        "/app.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            target: ScriptTarget::ES2015,
+            no_lib: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2448),
+        "Should not emit TS2448 for cross-file UMD global. Diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2454),
+        "Should not emit TS2454 for cross-file UMD global. Diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics. Actual: {diagnostics:#?}"
+    );
 }
 
 fn compile_two_global_files_get_diagnostics_with_options(


### PR DESCRIPTION
…collision

When `resolve_identifier_symbol_from_all_binders` returns a SymbolId from another file's binder, subsequent code that looks up that numeric ID in the local binder finds a *different* symbol at the same numeric slot. If that local symbol is a block-scoped variable, TDZ checks (TS2448) and definite assignment analysis (TS2454) fire incorrectly.

This manifests with UMD globals (`export as namespace Foo`): the cross-file alias SymbolId collides with a local `const` variable in the entry file, causing false "used before declaration" and "used before assignment" errors.

Fix: add cross-file symbol guards in both `check_tdz_violation` and `check_flow_usage`. When a symbol's registered file index differs from the current file, skip TDZ/DAA checks since:
1. The SymbolId would resolve to a wrong symbol in the local binder
2. Cross-file symbols have no same-file TDZ — they are evaluated when their origin file loads

Also strengthens the existing UMD global conflict test to assert zero diagnostics (not just no TS2339), and adds a focused regression test for the cross-binder SymbolId collision scenario.

https://claude.ai/code/session_01Kemt61WhS2MRT4Da5s9FmJ