### PR TITLE
fix(checker): display correct overload parameter type with explicit t…

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -482,6 +482,20 @@ impl<'a> CheckerState<'a> {
             .iter()
             .position(|&n| n == arg_idx)?;
 
+        // When explicit type arguments are provided (e.g., `_.map<number, string, Date>(...)`),
+        // the annotation-based display cannot fully substitute type parameters that are only
+        // determined by the explicit type args (not inferable from call arguments). For example,
+        // in `map<T, U, V>(c: Collection<T, U>, f: (x: T, y: U) => V)`, V is only known from
+        // the explicit type arg `Date`, not from any call argument. Returning None lets the
+        // general type display format the correctly instantiated param_type TypeId directly.
+        if call
+            .type_arguments
+            .as_ref()
+            .is_some_and(|ta| !ta.nodes.is_empty())
+        {
+            return None;
+        }
+
         let raw_callee_type = self
             .resolve_qualified_symbol(call.expression)
             .or_else(|| self.resolve_identifier_symbol(call.expression))

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -733,3 +733,47 @@ foo({ e: 1, m: 1 });
         diag.message_text
     );
 }
+
+#[test]
+fn ts2345_explicit_type_args_display_uses_correct_overload() {
+    // When calling an overloaded method with explicit type arguments, the error
+    // message should display the parameter type from the overload whose type
+    // parameter count matches the explicit type arguments, not the first overload.
+    // Bug: `_.map<number, string, Date>(c2, rf1)` showed `=> any` (from the 2-param
+    // overload) instead of `=> Date` (from the 3-param overload).
+    let source = r#"
+interface Pair<A, B> { first: A; second: B; }
+
+interface Combinators {
+    map<T, U>(c: Pair<T, U>, f: (x: T, y: U) => any): Pair<any, any>;
+    map<T, U, V>(c: Pair<T, U>, f: (x: T, y: U) => V): Pair<T, V>;
+}
+
+declare var _: Combinators;
+declare var c2: Pair<number, string>;
+var rf1 = (x: number, y: string): string => { return "hello" };
+var r5b = _.map<number, string, boolean>(c2, rf1);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let codes: Vec<(u32, &str)> = diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.as_str()))
+        .collect();
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .unwrap_or_else(|| panic!("expected TS2345, got: {:?}", codes));
+
+    assert!(
+        diag.message_text
+            .contains("parameter of type '(x: number, y: string) => boolean'"),
+        "Expected the 3-param overload's parameter type with boolean, got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("=> any"),
+        "Should not show => any from the wrong overload, got: {}",
+        diag.message_text
+    );
+}


### PR DESCRIPTION
…ype args

When calling an overloaded method with explicit type arguments (e.g., `_.map<number, string, Date>(c2, rf1)`), the TS2345 error message was displaying the parameter type from the wrong overload.

Root cause: `property_access_call_parameter_annotation_display` iterates through interface method declarations in declaration order and uses the first matching overload's annotation for the error message. With explicit type args, the correct overload (e.g., `map<T, U, V>` with 3 params) was skipped in favor of the first overload (`map<T, U>` with 2 params), and `instantiated_property_access_annotation_display` couldn't substitute type params only known from explicit args (like V=Date), resulting in `=> any` instead of `=> Date`.

Fix: return None from the annotation-based display when explicit type arguments are present, letting the general type display format the correctly instantiated param_type TypeId directly. The solver already correctly resolves the overload — only the display was wrong.

Fixes genericCombinators2.ts conformance test.

https://claude.ai/code/session_01PF49DGqTbCyt4q23dBDau5