### PR TITLE
fix(checker): use strict sensitivity check for block-body return expr…

### DIFF
--- a/crates/tsz-checker/src/types/computation/contextual.rs
+++ b/crates/tsz-checker/src/types/computation/contextual.rs
@@ -230,6 +230,21 @@ fn function_body_needs_contextual_return_type(state: &CheckerState, body_idx: No
         return expression_needs_contextual_return_type(state, body_idx);
     }
 
+    // For block bodies, use the stricter `is_contextually_sensitive` check on return
+    // expressions rather than the broader `expression_needs_contextual_return_type`.
+    //
+    // tsc's `hasContextSensitiveReturnExpression` returns false for all block bodies.
+    // We can't go that far because our inference pipeline needs the two-pass flow
+    // for block-bodied functions returning context-sensitive expressions (e.g.,
+    // `() => { return a => a + 1 }` where `a` needs contextual type from outer generic).
+    //
+    // But `expression_needs_contextual_return_type` is too broad — it flags ALL object
+    // literals, array literals, and call expressions, even non-sensitive ones. This
+    // incorrectly makes methods like `state() { return { bar2: 1 }; }` context-sensitive,
+    // preventing them from contributing to Round 1 generic inference.
+    //
+    // The stricter check only flags truly context-sensitive return expressions
+    // (those with unannotated params, sensitive nested objects, etc.).
     let Some(block) = state.ctx.arena.get_block(body_node) else {
         return false;
     };
@@ -246,8 +261,7 @@ fn function_body_needs_contextual_return_type(state: &CheckerState, body_idx: No
             .arena
             .get_return_statement(stmt_node)
             .is_some_and(|ret| {
-                ret.expression.is_some()
-                    && expression_needs_contextual_return_type(state, ret.expression)
+                ret.expression.is_some() && is_contextually_sensitive(state, ret.expression)
             })
     })
 }

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -22231,6 +22231,46 @@ repro({
 }
 
 #[test]
+fn test_thisless_method_not_context_sensitive_for_inference() {
+    // Block-bodied methods with no parameters should NOT be considered context-sensitive
+    // even when they return an object literal. This matches tsc's behavior where
+    // hasContextSensitiveReturnExpression returns false for block bodies.
+    //
+    // Without this, state() is flagged as context-sensitive because it returns an object
+    // literal, and gets deferred to Round 2. This prevents State type parameter from
+    // being inferred from state()'s return type in Round 1, leaving mutations callback
+    // with unknown parameter type.
+    let source = r#"
+// @strict: true
+type StateFunction<State> = (s: State, ...args: any[]) => any;
+
+type StoreOptions<State> = {
+  state?: State | (() => State) | { (): State };
+  mutations?: Record<string, StateFunction<State>>;
+};
+
+declare function createStore<State extends Record<string, unknown>>(
+  options: StoreOptions<State>,
+): void;
+
+createStore({
+  state() {
+    return { bar2: 1 };
+  },
+  mutations: { inc: (state123) => state123.bar2++ },
+});
+"#;
+    let diagnostics = compile_and_get_diagnostics(source);
+    let ts18046: Vec<_> = diagnostics.iter().filter(|d| d.0 == 18046).collect();
+    assert!(
+        ts18046.is_empty(),
+        "state() method with block body returning object literal should not be context-sensitive. \
+         state123 should be inferred as {{ bar2: number }}, not unknown. \
+         Got false TS18046: {ts18046:#?}"
+    );
+}
+
+#[test]
 fn test_jsdoc_constructor_overload_tags_emit_ts2394_for_incompatible_overload() {
     let diagnostics = compile_and_get_diagnostics_named(
         "overloadTag2.js",


### PR DESCRIPTION
…essions

In function_body_needs_contextual_return_type, block body return expressions were checked with expression_needs_contextual_return_type, which flags ALL object/array/call expressions as needing contextual types. This made methods like `state() { return { bar2: 1 }; }` incorrectly context-sensitive, preventing them from contributing to Round 1 generic inference.

tsc's hasContextSensitiveReturnExpression returns false for all block bodies. We can't go that far because our inference pipeline needs two-pass flow for functions returning truly sensitive expressions (e.g., `() => { return a => a + 1 }`). Instead, use the stricter is_contextually_sensitive check which only flags expressions with unannotated parameters or nested sensitive objects.

This fixes false TS18046 errors in patterns like VuexStoreOptions where a zero-param method's return type should infer a type parameter for sibling callback properties. Also fixes tsxDynamicTagName7 conformance test (FAIL -> PASS).

Invariant: block-bodied functions/methods with no parameters are context-sensitive only if their return expressions contain truly sensitive sub-expressions (unannotated params), not merely because they return object/array/call expressions.

https://claude.ai/code/session_01LYXCQZts7QsJsb3q5aysFD