### PR TITLE
fix(checker): improve TS2344 constraint validation for conditional ty…

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -758,12 +758,22 @@ impl<'a> CheckerState<'a> {
                             }
                             continue;
                         }
-                        // If the base constraint is a union, skip. Union-constrained type
-                        // params often appear in conditional types where the true branch
-                        // narrows to a specific union member. Checking the full union
-                        // against the narrowed constraint would produce false positives.
+                        // When the base constraint is a union, only skip if the type
+                        // arg is inside a conditional type's FALSE branch where it
+                        // could be narrowed by exclusion (Exclude<T, extends>). In
+                        // true branches and non-conditional contexts, proceed with
+                        // the constraint check.
                         if query::has_union_members(self.ctx.types.as_type_database(), base) {
-                            continue;
+                            let defer_for_conditional =
+                                type_args_list.nodes.get(i).is_some_and(|&arg_idx| {
+                                    self.type_arg_is_in_conditional_false_branch_of_check_type(
+                                        arg_idx,
+                                    )
+                                });
+                            if defer_for_conditional {
+                                continue;
+                            }
+                            // Fall through to perform the constraint check
                         }
                         if query::contains_type_parameters(self.ctx.types, base) {
                             // Base constraint itself contains type parameters

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -163,24 +163,23 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // Case 2: The type arg is derived from the check type (e.g.,
-                // `T extends O ? X<ReturnType<T['m']>> : never`). In the true branch,
-                // TSC wraps the check type with a substitute type carrying the extends
-                // constraint. Any use of the check type in the true branch benefits
-                // from this constraint, so TS2344 checks are deferred to instantiation
-                // time. Suppress when the arg contains a syntactic reference to the
-                // conditional's check type.
-                if self.type_node_contains_reference(arg_idx, cond.check_type) {
+                // Case 2: The type arg is derived from (but not identical to) the
+                // check type (e.g., `T extends O ? X<ReturnType<T['m']>> : never`).
+                // Only suppress when the arg is DERIVED from the check type — if the
+                // arg IS the check type, Case 1 already handled it and correctly
+                // didn't suppress when extends doesn't satisfy the constraint.
+                if !self.type_nodes_structurally_equal(arg_idx, cond.check_type)
+                    && self.type_node_contains_reference(arg_idx, cond.check_type)
+                {
                     return true;
                 }
 
                 // Case 3: The check type wraps the type argument (e.g.,
-                // `[T] extends [{ a: string }] ? ... : ...`). In non-distributive
-                // conditionals, the check type contains T in a wrapper. In the true
-                // branch, T is narrowed by the corresponding component of the extends
-                // type. Since constraint satisfaction depends on the narrowing, defer
-                // to instantiation time.
-                if self.type_node_contains_reference(cond.check_type, arg_idx) {
+                // `[T] extends [{ a: string }] ? ... : ...`). Only trigger when
+                // the check type WRAPS the arg (not when they're identical).
+                if !self.type_nodes_structurally_equal(cond.check_type, arg_idx)
+                    && self.type_node_contains_reference(cond.check_type, arg_idx)
+                {
                     return true;
                 }
             }
@@ -218,6 +217,31 @@ impl<'a> CheckerState<'a> {
             if self.type_node_contains_reference(child_idx, target_type_node) {
                 return true;
             }
+        }
+        false
+    }
+
+    /// Check if a type argument is inside the FALSE branch of a conditional type
+    /// where the check type is (or contains) the same type parameter.
+    fn type_arg_is_in_conditional_false_branch_of_check_type(&self, arg_idx: NodeIndex) -> bool {
+        let mut current = self.ctx.arena.get_extended(arg_idx).map(|ext| ext.parent);
+        while let Some(parent_idx) = current {
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                break;
+            };
+            if let Some(cond) = self.ctx.arena.get_conditional_type(parent_node)
+                && self.is_descendant_type_node(arg_idx, cond.false_type)
+                && (self.type_nodes_structurally_equal(arg_idx, cond.check_type)
+                    || self.type_node_contains_reference(cond.check_type, arg_idx)
+                    || self.type_node_contains_reference(arg_idx, cond.check_type))
+            {
+                return true;
+            }
+            current = self
+                .ctx
+                .arena
+                .get_extended(parent_idx)
+                .map(|ext| ext.parent);
         }
         false
     }

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -25631,3 +25631,44 @@ x7 = importInst;
          `typeof instantiated` to `typeof Outer`. Got diagnostics: {diagnostics:#?}"
     );
 }
+
+#[test]
+fn test_ts2344_conditional_true_branch_unsatisfied_extends() {
+    // When a type parameter appears in a conditional type's true branch and
+    // the extends type does NOT satisfy the required constraint, TS2344 should
+    // still be emitted. Previously, Case 2 in
+    // `type_argument_is_narrowed_by_conditional_true_branch` would suppress the
+    // error even when the arg was the check type itself.
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+interface Array<T> {}
+interface Boolean {}
+interface Function {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+
+interface ComponentType<P> { (props: P): any; }
+
+type Wrapper = { __brand: any };
+type AnyWrapper = Wrapper | { __brand2: any };
+
+type Inner<C extends ComponentType<any>> = C;
+
+type PropsWithRef<C extends ComponentType<any>> = { ref: C };
+
+// In the true branch, C is narrowed to AnyWrapper & C.
+// But AnyWrapper does NOT satisfy ComponentType<any>.
+// TS2344 should be emitted for the C in Inner<C>.
+type TestType<C extends string | ComponentType<any>> =
+    C extends AnyWrapper ? PropsWithRef<Inner<C>> : PropsWithRef<C>;
+        ",
+    );
+    assert!(
+        has_error(&diagnostics, 2344),
+        "Expected TS2344 for type arg in conditional true branch where extends type \
+         doesn't satisfy the constraint. Got diagnostics: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
…pe narrowing

Fix three issues in the TS2344 (type argument constraint) validation:

1. Union guard: The unconditional skip for union base constraints prevented TS2344 from being emitted even when the union genuinely doesn't satisfy the required constraint. Now only defers when the type arg is in a conditional type's FALSE branch (where Exclude narrowing applies).

2. Case 2 over-suppression: type_argument_is_narrowed_by_conditional_true_branch Case 2 (type_node_contains_reference) fired when the arg was identical to the check type. This incorrectly suppressed TS2344 when the extends type didn't satisfy the constraint. Now only triggers for DERIVED references (T['m'] from T).

3. Case 3 over-suppression: Same issue as Case 2 but for the reverse direction (check type wraps the arg). Now only triggers for genuine wrappers ([T]).

Adds type_arg_is_in_conditional_false_branch_of_check_type helper for the union guard's conditional deferral logic.

Fixes 3 conformance tests: exportDefaultAsyncFunction2, readonlyTupleAndArrayElaboration, iterableArrayPattern23.

https://claude.ai/code/session_01NpQqtVKtUiUp5CxJCY27LH