### PR TITLE
fix(checker): emit TS2739 instead of TS2322 for function-to-callable-…

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -457,6 +457,21 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
+        // When the target is a callable type with additional properties (e.g.,
+        // `ArrayConstructor` with `isArray`, `from`, `of`), the primary failure
+        // is missing properties (TS2739), not return type mismatch (TS2322).
+        // Skip function body elaboration so the standard `diagnose_assignment_failure`
+        // path produces TS2739 instead. tsc does the same: it reports missing
+        // properties on the callable, not return type mismatches on the function body.
+        if let Some(callable) = tsz_solver::type_queries::get_callable_shape(
+            self.ctx.types.as_type_database(),
+            param_type,
+        ) {
+            if !callable.properties.is_empty() {
+                return false;
+            }
+        }
+
         // For generator function callbacks, the callable return type is
         // Generator<Y, R, N> or AsyncGenerator<Y, R, N>, but the body's
         // `return` statements produce TReturn (R), not the full Generator type.

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1260,12 +1260,28 @@ impl<'a> CheckerState<'a> {
                         }
                         // Symbol found but not local - fall through to IArguments check below
                     } else {
-                        // Not "arguments" or not in function - use the symbol
+                        // Not "arguments" or not in function - use the symbol.
+                        // For merged interface+value symbols (e.g., `Array`, `Error`,
+                        // `Promise`) `get_type_of_symbol` returns the INTERFACE type
+                        // which is correct for type position but wrong for assignment
+                        // targets. Route through `get_type_of_node` which invokes
+                        // `get_type_of_identifier_with_request` and picks the value-
+                        // side type (e.g., ArrayConstructor, ErrorConstructor).
+                        if (sym_flags & tsz_binder::symbol_flags::INTERFACE) != 0
+                            && (sym_flags & tsz_binder::symbol_flags::VALUE) != 0
+                        {
+                            return self.get_type_of_node(idx);
+                        }
                         let declared_type = self.get_type_of_symbol(sym_id);
                         return declared_type;
                     }
                 } else {
                     // Use the resolved symbol
+                    if (sym_flags & tsz_binder::symbol_flags::INTERFACE) != 0
+                        && (sym_flags & tsz_binder::symbol_flags::VALUE) != 0
+                    {
+                        return self.get_type_of_node(idx);
+                    }
                     let declared_type = self.get_type_of_symbol(sym_id);
                     return declared_type;
                 }

--- a/crates/tsz-solver/tests/compat_tests.rs
+++ b/crates/tsz-solver/tests/compat_tests.rs
@@ -5855,3 +5855,93 @@ fn test_intersection_with_primitive_weak_type_check_not_suppressed() {
         "intersection with conflicting optional literal properties should not be assignable"
     );
 }
+
+#[test]
+fn test_explain_function_to_callable_with_properties_produces_missing_properties() {
+    // When a function type is assigned to a callable type with additional properties
+    // (like ArrayConstructor with isArray, from, of), the failure should be
+    // MissingProperties, not TypeMismatch. This matches tsc's behavior of emitting
+    // TS2739 instead of TS2322 for `Array = function(n, s) { return n; }`.
+    let interner = TypeInterner::new();
+
+    let is_array = interner.intern_string("isArray");
+    let from = interner.intern_string("from");
+    let of = interner.intern_string("of");
+
+    // Source: (n: number, s: string) => number (a simple function type)
+    let source = interner.function(FunctionShape {
+        params: vec![
+            ParamInfo::unnamed(TypeId::NUMBER),
+            ParamInfo::unnamed(TypeId::STRING),
+        ],
+        this_type: None,
+        return_type: TypeId::NUMBER,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    // Target: callable with properties (like ArrayConstructor)
+    // Has call signatures and properties: isArray, from, of
+    let target = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature {
+            params: vec![],
+            type_params: Vec::new(),
+            return_type: TypeId::ANY,
+            this_type: None,
+            type_predicate: None,
+            is_method: false,
+        }],
+        construct_signatures: vec![CallSignature {
+            params: vec![],
+            type_params: Vec::new(),
+            return_type: TypeId::ANY,
+            this_type: None,
+            type_predicate: None,
+            is_method: false,
+        }],
+        properties: vec![
+            PropertyInfo::new(is_array, TypeId::BOOLEAN),
+            PropertyInfo::new(from, TypeId::NUMBER),
+            PropertyInfo::new(of, TypeId::NUMBER),
+        ],
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    });
+
+    let mut checker = CompatChecker::new(&interner);
+    let reason = checker.explain_failure(source, target);
+
+    match reason {
+        Some(SubtypeFailureReason::MissingProperties { property_names, .. }) => {
+            assert!(
+                property_names.contains(&is_array),
+                "Expected isArray in missing properties, got: {property_names:?}"
+            );
+            assert!(
+                property_names.contains(&from),
+                "Expected from in missing properties, got: {property_names:?}"
+            );
+            assert!(
+                property_names.contains(&of),
+                "Expected of in missing properties, got: {property_names:?}"
+            );
+        }
+        Some(SubtypeFailureReason::MissingProperty { property_name, .. }) => {
+            // If only one property is reported, that's also acceptable
+            assert!(
+                property_name == is_array || property_name == from || property_name == of,
+                "Expected a constructor property in MissingProperty, got: {property_name:?}"
+            );
+        }
+        other => {
+            panic!(
+                "Expected MissingProperties or MissingProperty for function assigned to \
+                 callable with properties, got: {other:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
…with-properties assignment

Two root causes fixed:

1. `get_type_of_assignment_target` used `get_type_of_symbol` for merged interface+value symbols (e.g., global `Array`), which returns the INTERFACE type (Array<T>) instead of the VALUE type (ArrayConstructor). Now routes through `get_type_of_node` for these symbols, which correctly resolves to the value-side constructor type.

2. `try_elaborate_function_arg_return_error` would drill into function body return statements and emit TS2322 for return type mismatches, short-circuiting before `diagnose_assignment_failure` could produce TS2739 for missing properties. Now skips function body elaboration when the target is a callable with additional properties, matching tsc's behavior of reporting missing properties as the primary error.

Test: `Array = function(n, s) { return n; }` now emits:
  TS2739: Type '...' is missing the following properties from type
  'ArrayConstructor': isArray, prototype, from, of

instead of:
  TS2322: Type '...' is not assignable to type 'Array'.

Adds solver unit test verifying explain_failure produces MissingProperties for function-to-callable-with-properties comparisons.

https://claude.ai/code/session_01JZRZ6yE6Yx5wwAVqHHLbFB