### PR TITLE
fix(checker): emit TS1064 for async functions with JSDoc @type {funct…

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params.rs
+++ b/crates/tsz-checker/src/jsdoc/params.rs
@@ -1861,6 +1861,97 @@ impl<'a> CheckerState<'a> {
         Some(comment_pos + (tag_pos + "@type".len() + fn_rel) as u32)
     }
 
+    /// Extract the return type string from `@type {function(): ReturnType}`.
+    /// Returns `Some(return_type_str)` if the JSDoc `@type` is a function type
+    /// with an explicit return type annotation.
+    pub(crate) fn jsdoc_type_tag_function_return_type(jsdoc: &str) -> Option<String> {
+        let expr = Self::jsdoc_extract_type_tag_expr_braceless(jsdoc)?;
+        let expr = expr.trim();
+        let rest = expr.strip_prefix("function")?;
+        let rest = rest.trim_start();
+        if !rest.starts_with('(') {
+            return None;
+        }
+        let rest = &rest[1..];
+        let mut depth = 1u32;
+        let mut close_idx = None;
+        for (i, ch) in rest.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close_idx = Some(i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close_idx = close_idx?;
+        let after_close = rest[close_idx + 1..].trim_start();
+        let ret_str = after_close.strip_prefix(':')?;
+        let ret_str = ret_str.trim();
+        if ret_str.is_empty() {
+            return None;
+        }
+        Some(ret_str.to_string())
+    }
+
+    /// Find the source position and length of the return type in
+    /// `@type {function(): ReturnType}` within the comment starting at `comment_pos`.
+    pub(crate) fn jsdoc_type_tag_function_return_type_span_in_source(
+        source_text: &str,
+        comment_pos: u32,
+    ) -> Option<(u32, u32)> {
+        let comment_start = comment_pos as usize;
+        let comment_text = source_text.get(comment_start..)?;
+        let comment_end = comment_text.find("*/")?;
+        let comment_text = &comment_text[..comment_end];
+        let tag_pos = comment_text.find("@type")?;
+        let rest = &comment_text[tag_pos + "@type".len()..];
+        let fn_rel = rest.find("function")?;
+        let after_fn = &rest[fn_rel + "function".len()..];
+        let paren_start = after_fn.find('(')?;
+        let after_paren = &after_fn[paren_start + 1..];
+        let mut depth = 1u32;
+        let mut close_idx = None;
+        for (i, ch) in after_paren.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close_idx = Some(i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close_idx = close_idx?;
+        let after_close = &after_paren[close_idx + 1..];
+        let colon_rel = after_close.find(':')?;
+        let ret_part = &after_close[colon_rel + 1..];
+        let leading_ws = ret_part.len() - ret_part.trim_start().len();
+        let ret_trimmed = ret_part.trim();
+        let ret_end = ret_trimmed.find('}').unwrap_or(ret_trimmed.len());
+        let ret_type_str = ret_trimmed[..ret_end].trim_end();
+        let abs_start = comment_start
+            + tag_pos
+            + "@type".len()
+            + fn_rel
+            + "function".len()
+            + paren_start
+            + 1
+            + close_idx
+            + 1
+            + colon_rel
+            + 1
+            + leading_ws;
+        Some((abs_start as u32, ret_type_str.len() as u32))
+    }
+
     pub(crate) fn jsdoc_extract_type_tag_expr_braceless(jsdoc: &str) -> Option<String> {
         for raw_line in jsdoc.lines() {
             let trimmed = raw_line.trim().trim_start_matches('*').trim();

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1674,6 +1674,15 @@ impl<'a> CheckerState<'a> {
                 type_annotation,
             );
 
+            // TS1064 for JSDoc `@type {function(): ReturnType}` on async functions.
+            // When a JS file uses `@type {function(): string}` on an async arrow/function,
+            // tsc emits TS1064 because `string` is not `Promise<string>`. The check above
+            // only fires when `has_type_annotation` (AST-level return type) is true, so
+            // we need a separate path for JSDoc-derived return types.
+            if !has_type_annotation && is_async && !is_generator && self.is_js_file() {
+                self.check_async_return_type_from_jsdoc_type(idx, &func_jsdoc);
+            }
+
             // TS2366/TS2355/TS7030: Check return completeness
             self.check_function_return_completeness(
                 is_function_declaration,

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -598,6 +598,103 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// TS1064 for async functions in JS files with `@type {function(): ReturnType}`.
+    ///
+    /// When a variable in a JS file has `/** @type {function(): string} */` and the
+    /// initializer is an async function, tsc emits TS1064 because `string` is not
+    /// `Promise<string>`. The main `check_async_return_type_is_promise` only fires
+    /// when there's an AST-level return type annotation, so this method handles the
+    /// JSDoc-only case.
+    pub(crate) fn check_async_return_type_from_jsdoc_type(
+        &mut self,
+        func_idx: NodeIndex,
+        func_jsdoc: &Option<String>,
+    ) {
+        let Some(jsdoc) = func_jsdoc else {
+            return;
+        };
+        let Some(ret_type_str) = Self::jsdoc_type_tag_function_return_type(jsdoc) else {
+            return;
+        };
+        let trimmed = ret_type_str.trim();
+        if trimmed.starts_with("Promise") || trimmed.starts_with("PromiseLike") {
+            return;
+        }
+
+        let inner_type_name = trimmed;
+        let sf = self.source_file_data_for_node(func_idx);
+        let span = sf.and_then(|sf| {
+            let source_text: &str = &sf.text;
+            let comments = &sf.comments;
+            let func_node = self.ctx.arena.get(func_idx)?;
+            for comment in comments.iter().rev() {
+                if comment.end <= func_node.pos as u32 {
+                    if tsz_common::comments::is_jsdoc_comment(comment, source_text) {
+                        return Self::jsdoc_type_tag_function_return_type_span_in_source(
+                            source_text,
+                            comment.pos,
+                        );
+                    }
+                    break;
+                }
+            }
+            self.try_jsdoc_with_ancestor_walk(func_idx, comments, source_text)
+                .and_then(|_jsdoc_text| {
+                    let mut current = func_idx;
+                    for _ in 0..4 {
+                        if let Some(ext) = self.ctx.arena.get_extended(current) {
+                            let parent = ext.parent;
+                            if parent.is_none() {
+                                break;
+                            }
+                            if let Some(parent_node) = self.ctx.arena.get(parent) {
+                                for comment in comments.iter().rev() {
+                                    if comment.end <= parent_node.pos as u32
+                                        || (comment.pos <= parent_node.pos as u32
+                                            && comment.end <= parent_node.end as u32)
+                                    {
+                                        if tsz_common::comments::is_jsdoc_comment(
+                                            comment,
+                                            source_text,
+                                        ) {
+                                            return Self::jsdoc_type_tag_function_return_type_span_in_source(
+                                                source_text,
+                                                comment.pos,
+                                            );
+                                        }
+                                    }
+                                }
+                                current = parent;
+                            } else {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    None
+                })
+        });
+        let msg = format_message(
+            diagnostic_messages::THE_RETURN_TYPE_OF_AN_ASYNC_FUNCTION_OR_METHOD_MUST_BE_THE_GLOBAL_PROMISE_T_TYPE,
+            &[&inner_type_name],
+        );
+        if let Some((start, length)) = span {
+            self.error_at_position(
+                start,
+                length,
+                &msg,
+                diagnostic_codes::THE_RETURN_TYPE_OF_AN_ASYNC_FUNCTION_OR_METHOD_MUST_BE_THE_GLOBAL_PROMISE_T_TYPE,
+            );
+        } else {
+            self.error_at_node(
+                func_idx,
+                &msg,
+                diagnostic_codes::THE_RETURN_TYPE_OF_AN_ASYNC_FUNCTION_OR_METHOD_MUST_BE_THE_GLOBAL_PROMISE_T_TYPE,
+            );
+        }
+    }
+
     /// Check if a type is a type alias application that resolves to Promise.
     ///
     /// For example, `type PromiseAlias<T> = Promise<T>; async function f(): PromiseAlias<void>`

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -28154,6 +28154,71 @@ const arrowPromise = async (): Promise<string> => "test";
     );
 }
 
+/// TS1064 fires for async functions in JS files with `@type {function(): string}`.
+/// When a variable in a JS file has a JSDoc `@type` annotation declaring a function
+/// type with a non-Promise return type, and the initializer is async, tsc emits TS1064.
+#[test]
+fn test_ts1064_jsdoc_type_function_async() {
+    use crate::parser::ParserState;
+
+    let source = r#"
+interface Promise<T> {}
+
+/** @type {function(): string} */
+const a = async () => 0
+
+/** @type {function(): string} */
+const b = async () => {
+    return 0
+}
+"#;
+
+    let mut parser = ParserState::new("file.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "Parse errors: {:?}",
+        parser.get_diagnostics()
+    );
+
+    let mut binder = BinderState::new();
+    merge_shared_lib_symbols(&mut binder);
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "file.js".to_string(),
+        crate::checker::context::CheckerOptions {
+            target: tsz_common::common::ScriptTarget::ES2017,
+            allow_js: true,
+            check_js: true,
+            ..crate::checker::context::CheckerOptions::default()
+        },
+    );
+    setup_lib_contexts(&mut checker);
+    checker.check_source_file(root);
+
+    let ts1064_count = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1064)
+        .count();
+    assert!(
+        ts1064_count >= 2,
+        "Expected at least 2 TS1064 errors for async functions with JSDoc @type {{function(): string}}, got {ts1064_count}. Diagnostics: {:?}",
+        checker
+            .ctx
+            .diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn test_duplicate_class_members() {
     use crate::parser::ParserState;


### PR DESCRIPTION
…ion(): ReturnType}

When a JS file uses `/** @type {function(): string} */` on a variable initialized with an async arrow/function, tsc emits TS1064 because `string` is not `Promise<string>`. The existing check_async_return_type_is_promise only fires when there's an AST-level return type annotation (has_type_annotation), so JSDoc-only return types were skipped.

Added check_async_return_type_from_jsdoc_type which:
- Extracts the return type from @type {function(): ReturnType} JSDoc annotations
- Checks if the return type is Promise/PromiseLike
- Emits TS1064 at the correct position (the return type in the JSDoc comment)

Also added helper functions for extracting and locating the return type within JSDoc function type annotations.

Fixes asyncArrowFunction_allowJs.ts (was missing=[TS1064], now fingerprint-only). Conformance: 11921 -> 11922 (+1), zero regressions from this change.

https://claude.ai/code/session_018TCx3k2sgTHeRjoVSuGqTV