### PR TITLE
[codex] split missing lib diagnostics and hide duplicate _default aliases

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -252,6 +252,10 @@ name = "promise_constructor_capability_tests"
 path = "tests/promise_constructor_capability_tests.rs"
 
 [[test]]
+name = "missing_global_type_diagnostics_tests"
+path = "tests/missing_global_type_diagnostics_tests.rs"
+
+[[test]]
 name = "import_attributes_resolution_mode_tests"
 path = "tests/import_attributes_resolution_mode_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -117,7 +117,7 @@ impl<'a> CheckerState<'a> {
             .heritage_name_text(expr_idx)
             .unwrap_or_else(|| "<expression>".to_string());
         if (self.ctx.has_lib_loaded() && self.ctx.symbol_is_from_lib(heritage_sym))
-            || self.ctx.is_known_global_type(&name)
+            || self.is_well_known_lib_type_name(&name)
             || self
                 .get_cross_file_symbol(heritage_sym)
                 .is_some_and(|symbol| (symbol.flags & symbol_flags::VARIABLE) != 0)

--- a/crates/tsz-checker/src/context/lib_queries.rs
+++ b/crates/tsz-checker/src/context/lib_queries.rs
@@ -1,8 +1,7 @@
 //! Library and global type availability queries for `CheckerContext`.
 //!
 //! These methods check whether specific types (Promise, Symbol, etc.) are
-//! available in lib files or global scope, and classify known global types
-//! for diagnostic selection (TS2304 vs TS2318 vs TS2583).
+//! available in lib files or global scope.
 
 use std::sync::Arc;
 
@@ -123,50 +122,5 @@ impl<'a> CheckerContext<'a> {
         self.lib_contexts
             .iter()
             .any(|lib_ctx| Arc::ptr_eq(&lib_ctx.arena, symbol_arena))
-    }
-
-    /// Check if a name is a known global type that should emit TS2318/TS2583 when missing.
-    /// This helps distinguish between "unknown name" (TS2304) and "missing global type" (TS2318/TS2583).
-    pub fn is_known_global_type(&self, name: &str) -> bool {
-        use tsz_binder::lib_loader;
-
-        // ES2015+ types
-        if lib_loader::is_es2015_plus_type(name) {
-            return true;
-        }
-
-        // Pre-ES2015 global types that are commonly used
-        // These are always available in lib.d.ts but should emit TS2318 when @noLib is enabled
-        matches!(
-            name,
-            "Object"
-                | "Function"
-                | "Array"
-                | "String"
-                | "Number"
-                | "Boolean"
-                | "Date"
-                | "RegExp"
-                | "Error"
-                | "Math"
-                | "JSON"
-                | "console"
-                | "window"
-                | "document"
-                | "ArrayBuffer"
-                | "DataView"
-                | "Int8Array"
-                | "Uint8Array"
-                | "Uint8ClampedArray"
-                | "Int16Array"
-                | "Uint16Array"
-                | "Int32Array"
-                | "Uint32Array"
-                | "Float32Array"
-                | "Float64Array"
-                | "this"
-                | "globalThis"
-                | "IArguments"
-        )
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -671,7 +671,15 @@ impl<'a> CheckerState<'a> {
                         request.idx,
                     );
                 } else {
-                    self.error_cannot_find_name_at(request.name, request.idx);
+                    if matches!(request.kind, NameLookupKind::Type) {
+                        self.error_at_node_msg(
+                            request.idx,
+                            crate::diagnostics::diagnostic_codes::CANNOT_FIND_NAME,
+                            &[request.name],
+                        );
+                    } else {
+                        self.error_cannot_find_name_at(request.name, request.idx);
+                    }
                 }
             }
             ResolutionFailureKind::WrongMeaning { actual_meaning, .. } => {

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -1082,11 +1082,11 @@ impl<'a> CheckerState<'a> {
                             ) {
                                 continue;
                             }
-                            if self.is_known_global_type_name(&name) {
+                            if self.has_special_missing_lib_type_diagnostic(&name) {
                                 // Check if the global type is actually available in lib contexts
                                 if !self.ctx.has_name_in_lib(&name) {
                                     // TS2318/TS2583: Emit error for missing global type
-                                    self.error_cannot_find_global_type(&name, expr_idx);
+                                    self.report_missing_lib_type_name(&name, expr_idx);
                                 }
                                 continue;
                             }

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -373,7 +373,7 @@ impl<'a> CheckerState<'a> {
         {
             let name = ident.escaped_text.as_str();
             let has_libs = self.ctx.has_lib_loaded();
-            let is_known_global = self.is_known_global_type_name(name);
+            let is_known_global = self.is_well_known_lib_type_name(name);
 
             if has_type_args {
                 let is_builtin_array =
@@ -551,8 +551,7 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                     // When has_lib_loaded() is false (noLib is true), the above block is skipped
-                    // and falls through to the is_known_global_type_name check below,
-                    // which emits TS2318 via error_cannot_find_global_type
+                    // and falls through to the well-known-lib-type recovery path below.
                     if is_known_global {
                         return self.handle_missing_global_type_with_args(
                             name,
@@ -1041,7 +1040,7 @@ impl<'a> CheckerState<'a> {
             return TypeId::ANY;
         }
 
-        self.error_cannot_find_global_type(name, type_name_idx);
+        self.report_missing_lib_type_name(name, type_name_idx);
 
         if self.is_promise_like_name(name)
             && let Some(args) = &type_ref.type_arguments

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -293,8 +293,8 @@ impl<'a> CheckerState<'a> {
             self.error_cannot_find_name_did_you_mean_at(name, "Awaited", type_name_idx);
             return TypeId::ERROR;
         }
-        if self.is_known_global_type_name(name) {
-            self.error_cannot_find_global_type(name, type_name_idx);
+        if self.has_special_missing_lib_type_diagnostic(name) {
+            self.report_missing_lib_type_name(name, type_name_idx);
             return TypeId::ERROR;
         }
         if self.is_unresolved_import_symbol(type_name_idx) {

--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -239,16 +239,12 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
-        if self.ctx.is_known_global_type(name) {
-            self.error_cannot_find_global_type(name, idx);
-        } else {
-            // Route through boundary for TS2304/TS2552 with suggestion collection
-            self.report_not_found_at_boundary(
-                name,
-                idx,
-                crate::query_boundaries::name_resolution::NameLookupKind::Value,
-            );
-        }
+        // Route through boundary for TS2304/TS2552 with suggestion collection
+        self.report_not_found_at_boundary(
+            name,
+            idx,
+            crate::query_boundaries::name_resolution::NameLookupKind::Value,
+        );
         TypeId::ERROR
     }
 

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -283,20 +283,13 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    /// Check if a type name is a known global type.
+    /// Check if a missing type name is a well-known lib-provided type/interface.
     ///
-    /// Known global types include built-in JavaScript/TypeScript types
-    /// like Object, Array, Promise, Map, etc.
-    ///
-    /// ## Parameters
-    /// - `name`: The type name to check
-    ///
-    /// Returns true if the name is a known global type.
-    pub(crate) fn is_known_global_type_name(&self, name: &str) -> bool {
-        if self.ctx.is_known_global_type(name) {
-            return true;
-        }
-
+    /// This is intentionally broader than the set of names that get TS2318/TS2583.
+    /// Callers use it when they want fallback behavior for familiar lib types
+    /// (for example, `PromiseLike<T>` recovery), not when choosing the diagnostic
+    /// family for a missing type reference.
+    pub(crate) fn is_well_known_lib_type_name(&self, name: &str) -> bool {
         matches!(
             name,
             // Core built-in objects
@@ -393,13 +386,8 @@ impl<'a> CheckerState<'a> {
                 | "ReferenceError"
                 | "SyntaxError"
                 | "AggregateError"
-                // Math and JSON
-                | "Math"
-                | "JSON"
-                // Proxy and Reflect
-                | "Proxy"
+                // Proxy types
                 | "ProxyHandler"
-                | "Reflect"
                 // BigInt
                 | "BigInt"
                 | "BigIntConstructor"
@@ -415,21 +403,61 @@ impl<'a> CheckerState<'a> {
                 | "NodeList"
                 | "NodeListOf"
                 | "Console"
-                | "Atomics"
-                // Primitive types (lowercase)
-                | "number"
-                | "string"
-                | "boolean"
-                | "void"
-                | "null"
-                | "undefined"
-                | "never"
-                | "unknown"
-                | "any"
-                | "object"
-                | "bigint"
-                | "symbol"
+                | "PromiseLike"
         )
+    }
+
+    /// Check if a missing type-position name should emit TS2318/TS2583 instead of TS2304.
+    ///
+    /// This is intentionally narrower than `is_well_known_lib_type_name`: many
+    /// lib types such as `Document`, `ArrayLike`, `PromiseLike`, and
+    /// `TypedPropertyDescriptor` still get ordinary TS2304 when referenced
+    /// directly without the relevant libs.
+    pub(crate) fn has_special_missing_lib_type_diagnostic(&self, name: &str) -> bool {
+        matches!(
+            name,
+            // Core global types that tsc treats as missing-global-type diagnostics.
+            "Array"
+                | "Boolean"
+                | "CallableFunction"
+                | "Function"
+                | "IArguments"
+                | "NewableFunction"
+                | "Number"
+                | "Object"
+                | "RegExp"
+                | "String"
+                // ES lib names that tsc upgrades to TS2583 in type position.
+                | "Promise"
+                | "Map"
+                | "Set"
+                | "Symbol"
+                | "WeakMap"
+                | "WeakSet"
+                | "Reflect"
+                | "Iterator"
+                | "AsyncIterator"
+                | "AsyncIterable"
+                | "AsyncIterableIterator"
+                | "SharedArrayBuffer"
+                | "Atomics"
+                | "BigInt"
+                | "BigInt64Array"
+                | "BigUint64Array"
+        )
+    }
+
+    /// Emit the correct missing-type diagnostic for a well-known lib name.
+    ///
+    /// Some missing lib names use TS2318/TS2583, while others still use the
+    /// ordinary type-position "Cannot find name" path.
+    pub(crate) fn report_missing_lib_type_name(&mut self, name: &str, idx: NodeIndex) {
+        if self.has_special_missing_lib_type_diagnostic(name) {
+            self.error_cannot_find_global_type(name, idx);
+            return;
+        }
+
+        let _ = self.resolve_type_name_or_report(name, idx);
     }
 
     /// Check if a type is a constructor type.

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -249,7 +249,7 @@ impl<'a> CheckerState<'a> {
                 }
 
                 if !is_builtin_array && type_param.is_none() && sym_id.is_none() {
-                    if self.is_known_global_type_name(name) {
+                    if self.has_special_missing_lib_type_diagnostic(name) {
                         // TS2318/TS2583: Emit error for missing global type
                         // Process type arguments for validation first
                         if let Some(args) = &type_ref.type_arguments {
@@ -257,8 +257,7 @@ impl<'a> CheckerState<'a> {
                                 let _ = self.get_type_from_type_node_in_type_literal(arg_idx);
                             }
                         }
-                        // Emit the appropriate error
-                        self.error_cannot_find_global_type(name, type_name_idx);
+                        self.report_missing_lib_type_name(name, type_name_idx);
                         return TypeId::ERROR;
                     }
                     if name == "await" {
@@ -428,9 +427,9 @@ impl<'a> CheckerState<'a> {
                 self.error_cannot_find_name_did_you_mean_at(name, "Awaited", type_name_idx);
                 return TypeId::ERROR;
             }
-            if self.is_known_global_type_name(name) {
+            if self.has_special_missing_lib_type_diagnostic(name) {
                 // TS2318/TS2583: Emit error for missing global type
-                self.error_cannot_find_global_type(name, type_name_idx);
+                self.report_missing_lib_type_name(name, type_name_idx);
                 return TypeId::ERROR;
             }
             // Suppress TS2304 if this is an unresolved import (TS2307 was already emitted)

--- a/crates/tsz-checker/tests/conformance_issues.rs
+++ b/crates/tsz-checker/tests/conformance_issues.rs
@@ -13504,6 +13504,10 @@ fn test_divergent_accessor_read_keeps_getter_surface_without_ts2339() {
         r#"
 export {};
 
+interface CSSStyleDeclaration {
+    animationTimingFunction: string;
+}
+
 interface Element {
     get style(): CSSStyleDeclaration;
     set style(cssText: string);

--- a/crates/tsz-checker/tests/global_type_tests.rs
+++ b/crates/tsz-checker/tests/global_type_tests.rs
@@ -56,6 +56,41 @@ fn check_without_lib_with_options(
     checker.ctx.diagnostics.clone()
 }
 
+const MINIMAL_CORE_GLOBAL_DECLS: &[(&str, &str)] = &[
+    ("Array", "interface Array<T> {}"),
+    ("Boolean", "interface Boolean {}"),
+    ("CallableFunction", "interface CallableFunction {}"),
+    ("Function", "interface Function {}"),
+    ("IArguments", "interface IArguments {}"),
+    ("NewableFunction", "interface NewableFunction {}"),
+    ("Number", "interface Number {}"),
+    ("Object", "interface Object {}"),
+    ("RegExp", "interface RegExp {}"),
+    ("String", "interface String {}"),
+];
+
+fn check_without_lib_with_minimal_core_globals(
+    source: &str,
+) -> Vec<crate::checker::diagnostics::Diagnostic> {
+    check_without_lib_with_minimal_core_globals_except(&[], source)
+}
+
+fn check_without_lib_with_minimal_core_globals_except(
+    omitted: &[&str],
+    source: &str,
+) -> Vec<crate::checker::diagnostics::Diagnostic> {
+    let mut full_source = String::new();
+    for &(name, decl) in MINIMAL_CORE_GLOBAL_DECLS {
+        if omitted.iter().any(|omitted_name| omitted_name == &name) {
+            continue;
+        }
+        full_source.push_str(decl);
+        full_source.push('\n');
+    }
+    full_source.push_str(source);
+    check_without_lib(&full_source)
+}
+
 #[test]
 fn test_missing_promise_emits_ts2583_without_lib() {
     // Without lib.d.ts, Promise should emit TS2583 (Cannot find name - change lib)
@@ -198,6 +233,135 @@ fn test_console_emits_ts2304_without_lib() {
     assert!(
         !ts2584_errors.is_empty(),
         "Expected TS2584 error for console without lib.d.ts, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_document_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Document;");
+    let ts2304_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2304 && d.message_text.contains("'Document'"))
+        .collect();
+
+    assert!(
+        !ts2304_errors.is_empty(),
+        "Expected TS2304 for Document type reference without DOM libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_arraylike_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: ArrayLike<number>;");
+    let ts2304_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2304 && d.message_text.contains("'ArrayLike'"))
+        .collect();
+
+    assert!(
+        !ts2304_errors.is_empty(),
+        "Expected TS2304 for ArrayLike type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_promise_constructor_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: PromiseConstructor;");
+    let ts2304_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2304 && d.message_text.contains("'PromiseConstructor'"))
+        .collect();
+
+    assert!(
+        !ts2304_errors.is_empty(),
+        "Expected TS2304 for PromiseConstructor type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_promise_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Promise<number>;");
+    let ts2583_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2583 && d.message_text.contains("'Promise'"))
+        .collect();
+
+    assert!(
+        !ts2583_errors.is_empty(),
+        "Expected TS2583 for Promise type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_reflect_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Reflect;");
+    let ts2583_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2583 && d.message_text.contains("'Reflect'"))
+        .collect();
+
+    assert!(
+        !ts2583_errors.is_empty(),
+        "Expected TS2583 for Reflect in type position without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_async_iterable_iterator_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals("let x: AsyncIterableIterator<number>;");
+    let ts2583_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2583 && d.message_text.contains("'AsyncIterableIterator'"))
+        .collect();
+
+    assert!(
+        !ts2583_errors.is_empty(),
+        "Expected TS2583 for AsyncIterableIterator without ES2018 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_regexp_type_reference_emits_ts2318_when_core_global_missing() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals_except(&["RegExp"], "let x: RegExp;");
+    let ts2318_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2318 && d.message_text.contains("'RegExp'"))
+        .collect();
+
+    assert!(
+        !ts2318_errors.is_empty(),
+        "Expected TS2318 for missing RegExp global type, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_iarguments_type_reference_emits_ts2318_when_core_global_missing() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals_except(&["IArguments"], "let x: IArguments;");
+    let ts2318_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2318 && d.message_text.contains("'IArguments'"))
+        .collect();
+
+    assert!(
+        !ts2318_errors.is_empty(),
+        "Expected TS2318 for missing IArguments global type, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_promise_like_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: PromiseLike<number>;");
+    let ts2304_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2304 && d.message_text.contains("'PromiseLike'"))
+        .collect();
+
+    assert!(
+        !ts2304_errors.is_empty(),
+        "Expected TS2304 for PromiseLike type reference without libs, got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/missing_global_type_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/missing_global_type_diagnostics_tests.rs
@@ -1,0 +1,167 @@
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn check_without_lib(source: &str) -> Vec<Diagnostic> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "Parse errors: {:?}",
+        parser.get_diagnostics()
+    );
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.clone()
+}
+
+const MINIMAL_CORE_GLOBAL_DECLS: &[(&str, &str)] = &[
+    ("Array", "interface Array<T> {}"),
+    ("Boolean", "interface Boolean {}"),
+    ("CallableFunction", "interface CallableFunction {}"),
+    ("Function", "interface Function {}"),
+    ("IArguments", "interface IArguments {}"),
+    ("NewableFunction", "interface NewableFunction {}"),
+    ("Number", "interface Number {}"),
+    ("Object", "interface Object {}"),
+    ("RegExp", "interface RegExp {}"),
+    ("String", "interface String {}"),
+];
+
+fn check_without_lib_with_minimal_core_globals(source: &str) -> Vec<Diagnostic> {
+    check_without_lib_with_minimal_core_globals_except(&[], source)
+}
+
+fn check_without_lib_with_minimal_core_globals_except(
+    omitted: &[&str],
+    source: &str,
+) -> Vec<Diagnostic> {
+    let mut full_source = String::new();
+    for &(name, decl) in MINIMAL_CORE_GLOBAL_DECLS {
+        if omitted.iter().any(|omitted_name| omitted_name == &name) {
+            continue;
+        }
+        full_source.push_str(decl);
+        full_source.push('\n');
+    }
+    full_source.push_str(source);
+    check_without_lib(&full_source)
+}
+
+#[test]
+fn document_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Document;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2304 && d.message_text.contains("'Document'")),
+        "Expected TS2304 for Document type reference without DOM libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn arraylike_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: ArrayLike<number>;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2304 && d.message_text.contains("'ArrayLike'")),
+        "Expected TS2304 for ArrayLike type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn promise_constructor_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: PromiseConstructor;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2304 && d.message_text.contains("'PromiseConstructor'")),
+        "Expected TS2304 for PromiseConstructor type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn promise_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Promise<number>;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2583 && d.message_text.contains("'Promise'")),
+        "Expected TS2583 for Promise type reference without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn reflect_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: Reflect;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2583 && d.message_text.contains("'Reflect'")),
+        "Expected TS2583 for Reflect in type position without ES2015 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn async_iterable_iterator_type_reference_emits_ts2583_with_minimal_core_globals() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals("let x: AsyncIterableIterator<number>;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2583 && d.message_text.contains("'AsyncIterableIterator'")),
+        "Expected TS2583 for AsyncIterableIterator without ES2018 libs, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn regexp_type_reference_emits_ts2318_when_core_global_missing() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals_except(&["RegExp"], "let x: RegExp;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2318 && d.message_text.contains("'RegExp'")),
+        "Expected TS2318 for missing RegExp global type, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn iarguments_type_reference_emits_ts2318_when_core_global_missing() {
+    let diagnostics =
+        check_without_lib_with_minimal_core_globals_except(&["IArguments"], "let x: IArguments;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2318 && d.message_text.contains("'IArguments'")),
+        "Expected TS2318 for missing IArguments global type, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn promise_like_type_reference_emits_ts2304_with_minimal_core_globals() {
+    let diagnostics = check_without_lib_with_minimal_core_globals("let x: PromiseLike<number>;");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 2304 && d.message_text.contains("'PromiseLike'")),
+        "Expected TS2304 for PromiseLike type reference without libs, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/tests/signature_assignability_regression_tests.rs
+++ b/crates/tsz-checker/tests/signature_assignability_regression_tests.rs
@@ -38,6 +38,7 @@ class Base { foo: string; }
 class Derived extends Base { bar: string; }
 class Derived2 extends Derived { baz: string; }
 class OtherDerived extends Base { bing: string; }
+declare class Date {}
 
 declare var a6: (x: (arg: Base) => Derived) => Base;
 declare var a7: (x: (arg: Base) => Derived) => (r: Base) => Derived;

--- a/crates/tsz-cli/build.rs
+++ b/crates/tsz-cli/build.rs
@@ -59,9 +59,9 @@ fn main() {
         .unwrap()
         .join("scripts/conformance/typescript-versions.json");
 
-    let version = detect_tsc_version_from_local_scripts(&manifest_dir)
+    let version = detect_tsc_version_from_path()
+        .or_else(|| detect_tsc_version_from_local_scripts(&manifest_dir))
         .or_else(|| detect_tsc_version_from_versions_file(&versions_path))
-        .or_else(detect_tsc_version_from_path)
         .unwrap_or_else(|| {
             if versions_path.exists() {
                 let content = std::fs::read_to_string(&versions_path).unwrap();

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -52,7 +52,7 @@ use clap::Parser;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Read as IoRead, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -573,7 +573,7 @@ pub(crate) enum ServerMode {
 impl Server {
     fn new(args: &ServerArgs) -> Result<Self> {
         let lib_dir = Self::find_lib_dir()?;
-        let tests_lib_dir = PathBuf::from("TypeScript/tests/lib");
+        let tests_lib_dir = Self::find_tests_lib_dir(&lib_dir);
         info!("Using lib directory: {}", lib_dir.display());
 
         let server_mode = if args.syntax_only {
@@ -783,47 +783,60 @@ impl Server {
         result
     }
 
-    fn find_lib_dir() -> Result<PathBuf> {
-        let cwd = std::env::current_dir().context("Failed to get CWD")?;
+    fn canonicalize_or_owned(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
 
-        // Allow override via environment variable
-        if let Ok(dir) = std::env::var("TSZ_LIB_DIR") {
+    fn find_lib_dir() -> Result<PathBuf> {
+        tsz_cli::config::default_lib_dir().with_context(|| {
+            let cwd = std::env::current_dir()
+                .map(|dir| dir.display().to_string())
+                .unwrap_or_else(|_| "<unknown>".to_string());
+            format!("TypeScript lib directory not found for tsz-server (cwd: {cwd})")
+        })
+    }
+
+    fn find_tests_lib_dir(lib_dir: &Path) -> PathBuf {
+        if let Ok(dir) = std::env::var("TSZ_TESTS_LIB_DIR") {
             let path = PathBuf::from(&dir);
             let path = if path.is_absolute() {
                 path
             } else {
-                cwd.join(&path)
+                std::env::current_dir()
+                    .map(|cwd| cwd.join(&path))
+                    .unwrap_or(path)
             };
-            if path.exists() {
-                return Ok(path);
+            if path.is_dir() {
+                return Self::canonicalize_or_owned(&path);
             }
         }
 
-        let lib_path = cwd.join("TypeScript/src/lib");
-        if lib_path.exists() {
-            return Ok(lib_path);
-        }
-
-        let mut current = cwd.clone();
-        for _ in 0..10 {
-            let candidate = current.join("TypeScript/src/lib");
-            if candidate.exists() {
-                return Ok(candidate);
+        let mut roots = Vec::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            let mut current: Option<&Path> = Some(cwd.as_path());
+            while let Some(dir) = current {
+                roots.push(dir.to_path_buf());
+                current = dir.parent();
             }
-            current = match current.parent() {
-                Some(p) => p.to_path_buf(),
-                None => break,
-            };
         }
 
-        anyhow::bail!(
-            "TypeScript lib directory not found. \
-             CWD: {}. \
-             Checked: TypeScript/src/lib (relative to CWD), TSZ_LIB_DIR env var, \
-             and walked up 10 directories looking for TypeScript/src/lib. \
-             Run from project root or set TSZ_LIB_DIR to an absolute path.",
-            cwd.display()
-        )
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut current: Option<&Path> = Some(manifest_dir);
+        while let Some(dir) = current {
+            if !roots.iter().any(|existing| existing == dir) {
+                roots.push(dir.to_path_buf());
+            }
+            current = dir.parent();
+        }
+
+        for root in roots {
+            let candidate = root.join("TypeScript/tests/lib");
+            if candidate.is_dir() {
+                return Self::canonicalize_or_owned(&candidate);
+            }
+        }
+
+        lib_dir.to_path_buf()
     }
 
     // =========================================================================

--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -40,11 +40,29 @@ fn make_server() -> Server {
 fn make_server_with_real_libs() -> Server {
     let mut server = make_server();
     server.lib_dir = Server::find_lib_dir().expect("lib dir should be discoverable in tests");
-    server.tests_lib_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../TypeScript/tests/lib")
-        .canonicalize()
-        .expect("TypeScript tests lib dir should exist");
+    server.tests_lib_dir = Server::find_tests_lib_dir(&server.lib_dir);
     server
+}
+
+#[test]
+fn test_find_lib_dir_finds_workspace_libs() {
+    let lib_dir = Server::find_lib_dir().expect("lib dir should be discoverable in tests");
+    assert!(
+        lib_dir.join("lib.es5.d.ts").exists() || lib_dir.join("es5.d.ts").exists(),
+        "expected lib.es5.d.ts or es5.d.ts in {}",
+        lib_dir.display()
+    );
+}
+
+#[test]
+fn test_find_tests_lib_dir_returns_existing_directory() {
+    let lib_dir = Server::find_lib_dir().expect("lib dir should be discoverable in tests");
+    let tests_lib_dir = Server::find_tests_lib_dir(&lib_dir);
+    assert!(
+        tests_lib_dir.exists(),
+        "expected tests lib dir fallback to exist, got {}",
+        tests_lib_dir.display()
+    );
 }
 
 fn make_request(command: &str, arguments: serde_json::Value) -> TsServerRequest {

--- a/crates/tsz-core/src/config.rs
+++ b/crates/tsz-core/src/config.rs
@@ -3633,6 +3633,11 @@ fn lib_dir_from_root(root: &Path) -> Option<PathBuf> {
             .join("node_modules")
             .join("typescript")
             .join("lib"),
+        // Bundled lib snapshot committed with tsz for standalone and test environments.
+        root.join("crates")
+            .join("tsz-website")
+            .join("src")
+            .join("lib"),
         root.join("TypeScript").join("src").join("lib"),
         root.join("TypeScript")
             .join("node_modules")

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -22872,7 +22872,7 @@ declare let x: Recurse;
 }
 
 #[test]
-fn test_builtin_types_no_ts2304_errors() {
+fn test_builtin_type_references_only_emit_ts2304_for_missing_dom_globals() {
     // Regression test: Global types like Promise, Array, Map should not cause
     // TS2304 "Cannot find name" errors when lib.d.ts is not loaded.
     use crate::parser::ParserState;
@@ -22944,27 +22944,72 @@ interface MyError extends Error {
     setup_lib_contexts(&mut checker);
     checker.check_source_file(root);
 
-    // Filter for TS2304 errors (Cannot find name)
-    let ts2304_errors: Vec<_> = checker
+    let ts2304_messages: Vec<String> = checker
         .ctx
         .diagnostics
         .iter()
         .filter(|d| d.code == 2304)
+        .map(|d| d.message_text.clone())
         .collect();
 
+    let missing_dom_globals = [
+        "Element",
+        "HTMLElement",
+        "Document",
+        "Window",
+        "Event",
+        "NodeList",
+    ];
+    for name in missing_dom_globals {
+        assert!(
+            ts2304_messages
+                .iter()
+                .any(|message| message.contains(&format!("'{name}'"))),
+            "expected TS2304 for missing DOM global {name}, got: {ts2304_messages:?}"
+        );
+    }
+
+    let builtin_non_dom_types = [
+        "Promise",
+        "PromiseLike",
+        "Map",
+        "Set",
+        "Array",
+        "ReadonlyArray",
+        "Partial",
+        "Required",
+        "Readonly",
+        "Record",
+        "Iterator",
+        "Date",
+        "RegExp",
+        "RegExpExecArray",
+        "PropertyKey",
+        "PropertyDescriptor",
+        "NonNullable",
+        "Extract",
+        "ThisType",
+        "Error",
+    ];
+    for name in builtin_non_dom_types {
+        assert!(
+            !ts2304_messages
+                .iter()
+                .any(|message| message.contains(&format!("'{name}'"))),
+            "did not expect TS2304 for builtin lib type {name}, got: {ts2304_messages:?}"
+        );
+    }
+
     assert!(
-        ts2304_errors.is_empty(),
-        "Should not emit TS2304 errors for builtin types, got: {:?}",
-        ts2304_errors
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2304_messages.len() == 6,
+        "expected TS2304 only for missing DOM globals, got: {ts2304_messages:?}"
     );
 }
 
 #[test]
-fn test_builtin_types_in_type_literal_no_ts2304() {
-    // Ensure builtin generics used inside type literals don't emit TS2304 when lib is absent.
+fn test_builtin_types_in_type_literal_only_emit_ts2304_for_missing_dom_globals() {
+    // Ensure true lib types still resolve in type literals while missing DOM globals
+    // continue to route through plain TS2304.
     use crate::parser::ParserState;
 
     let source = r#"
@@ -23002,20 +23047,37 @@ type Foo = {
     setup_lib_contexts(&mut checker);
     checker.check_source_file(root);
 
-    let ts2304_errors: Vec<_> = checker
+    let ts2304_messages: Vec<String> = checker
         .ctx
         .diagnostics
         .iter()
         .filter(|d| d.code == 2304)
+        .map(|d| d.message_text.clone())
         .collect();
 
     assert!(
-        ts2304_errors.is_empty(),
-        "Unexpected TS2304 for builtin types in type literals, got: {:?}",
-        ts2304_errors
+        ts2304_messages
             .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+            .any(|message| message.contains("'NodeList'")),
+        "expected TS2304 for missing NodeList, got: {ts2304_messages:?}"
+    );
+    assert!(
+        ts2304_messages
+            .iter()
+            .any(|message| message.contains("'Document'")),
+        "expected TS2304 for missing Document, got: {ts2304_messages:?}"
+    );
+    for name in ["Promise", "Map", "ReadonlyArray", "Partial"] {
+        assert!(
+            !ts2304_messages
+                .iter()
+                .any(|message| message.contains(&format!("'{name}'"))),
+            "did not expect TS2304 for builtin type literal member {name}, got: {ts2304_messages:?}"
+        );
+    }
+    assert!(
+        ts2304_messages.len() == 2,
+        "expected only missing DOM globals to produce TS2304 in type literals, got: {ts2304_messages:?}"
     );
 }
 

--- a/crates/tsz-lsp/src/project/imports.rs
+++ b/crates/tsz-lsp/src/project/imports.rs
@@ -113,8 +113,12 @@ impl Project {
             .cloned()
             .collect();
 
-        let files_to_check =
-            self.files_to_check_for_symbol(missing_name, &all_files, &wildcard_reexport_files);
+        let files_to_check = self.files_to_check_for_symbol(
+            missing_name,
+            from_file.file_name(),
+            &all_files,
+            &wildcard_reexport_files,
+        );
 
         for file_name in files_to_check {
             if file_name == from_file.file_name() {
@@ -288,7 +292,12 @@ impl Project {
             let files_to_check = if supplemental_symbol_set.contains(&symbol_name) {
                 all_files.clone()
             } else {
-                self.files_to_check_for_symbol(&symbol_name, &all_files, &wildcard_reexport_files)
+                self.files_to_check_for_symbol(
+                    &symbol_name,
+                    from_file.file_name(),
+                    &all_files,
+                    &wildcard_reexport_files,
+                )
             };
 
             for file_name in files_to_check {
@@ -401,11 +410,15 @@ impl Project {
     fn files_to_check_for_symbol(
         &self,
         symbol_name: &str,
+        from_file_name: &str,
         all_files: &[String],
         wildcard_reexport_files: &[String],
     ) -> Vec<String> {
         let candidate_files = self.symbol_index.get_files_with_symbol(symbol_name);
-        if candidate_files.is_empty() {
+        let has_external_candidates = candidate_files
+            .iter()
+            .any(|file_name| file_name != from_file_name);
+        if candidate_files.is_empty() || !has_external_candidates {
             return all_files.to_vec();
         }
 
@@ -443,7 +456,16 @@ impl Project {
             let Some(export) = arena.get_export_decl(stmt_node) else {
                 return false;
             };
-            export.module_specifier.is_some() && export.export_clause.is_none()
+            let is_namespace_reexport = if export.export_clause.is_none() {
+                false
+            } else if let Some(clause_node) = arena.get(export.export_clause) {
+                clause_node.kind == SyntaxKind::Identifier as u16
+                    || clause_node.kind == SyntaxKind::StringLiteral as u16
+            } else {
+                false
+            };
+            export.module_specifier.is_some()
+                && (export.export_clause.is_none() || is_namespace_reexport)
         })
     }
 
@@ -1421,11 +1443,14 @@ impl Project {
                 continue;
             }
             let clause_node = arena.get(export.export_clause)?;
-            if clause_node.kind != SyntaxKind::Identifier as u16 {
-                continue;
-            }
-            let export_text = arena.get_identifier_text(export.export_clause)?;
-            if export_text == "default" {
+            let export_text = if clause_node.kind == SyntaxKind::Identifier as u16 {
+                arena.get_identifier_text(export.export_clause)
+            } else if clause_node.kind == SyntaxKind::StringLiteral as u16 {
+                arena.get_literal_text(export.export_clause)
+            } else {
+                None
+            };
+            if export_text == Some("default") {
                 return Some(export.is_type_only);
             }
         }

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -713,28 +713,50 @@ impl ParserState {
                 if !self.is_js_file() && self.is_token(SyntaxKind::LessThanSlashToken) {
                     let snapshot = self.scanner.save_state();
                     let current = self.current_token;
+
                     self.next_token();
                     let malformed = !self.is_token(SyntaxKind::GreaterThanToken);
+                    let diagnostic_anchor = if malformed {
+                        let expected_start = self.token_pos();
+                        let expected_length = self.token_end().saturating_sub(expected_start);
+
+                        if self.is_identifier_or_keyword() {
+                            self.next_token();
+                        }
+                        let fragment_unclosed_pos = if self.is_token(SyntaxKind::GreaterThanToken)
+                        {
+                            let end = self.token_end();
+                            self.next_token();
+                            end
+                        } else {
+                            self.token_end()
+                        };
+
+                        Some((expected_start, expected_length, fragment_unclosed_pos))
+                    } else {
+                        None
+                    };
+
                     self.scanner.restore_state(snapshot);
                     self.current_token = current;
-                    malformed
+                    diagnostic_anchor
                 } else {
-                    false
+                    None
                 };
 
-            if malformed_named_closing_fragment {
+            if let Some((expected_start, expected_length, fragment_unclosed_pos)) =
+                malformed_named_closing_fragment
+            {
                 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
-                if let Some(open_fragment) = self.arena.get(opening) {
-                    self.parse_error_at(
-                        open_fragment.pos,
-                        open_fragment.end.saturating_sub(open_fragment.pos),
-                        diagnostic_messages::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT,
-                        diagnostic_codes::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT,
-                    );
-                }
                 self.parse_error_at(
-                    self.token_pos(),
-                    self.token_end().saturating_sub(self.token_pos()),
+                    expected_start,
+                    expected_length,
+                    diagnostic_messages::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT,
+                    diagnostic_codes::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT,
+                );
+                self.parse_error_at(
+                    fragment_unclosed_pos,
+                    0,
                     diagnostic_messages::JSX_FRAGMENT_HAS_NO_CORRESPONDING_CLOSING_TAG,
                     diagnostic_codes::JSX_FRAGMENT_HAS_NO_CORRESPONDING_CLOSING_TAG,
                 );

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::parser::ParserState;
 use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
 
 #[test]
 fn test_index_signature_with_modifier_emits_ts1071() {
@@ -3412,6 +3413,60 @@ fn test_tsx_fragment_errors_actual_conformance_file_matches_expected_codes() {
             diagnostic_codes::EXPECTED,
         ],
         "Expected TS17015/TS17014/TS1005 on actual tsxFragmentErrors conformance file, got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_tsx_fragment_errors_stripped_source_matches_expected_positions() {
+    let source = r#"
+declare namespace JSX {
+	interface Element { }
+	interface IntrinsicElements {
+		[s: string]: any;
+	}
+}
+declare var React: any;
+
+<>hi</div> // Error
+
+<>eof   // Error
+"#
+    .to_string();
+    let line_map = LineMap::build(&source);
+    let mut parser = ParserState::new("file.tsx".to_string(), source.clone());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let actual: Vec<(u32, u32, u32)> = diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                diag.code,
+                diagnostic_codes::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT
+                    | diagnostic_codes::JSX_FRAGMENT_HAS_NO_CORRESPONDING_CLOSING_TAG
+            )
+        })
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, &source);
+            (diag.code, pos.line + 1, pos.character + 1)
+        })
+        .collect();
+
+    assert_eq!(
+        actual,
+        vec![
+            (
+                diagnostic_codes::EXPECTED_CORRESPONDING_CLOSING_TAG_FOR_JSX_FRAGMENT,
+                10,
+                7,
+            ),
+            (
+                diagnostic_codes::JSX_FRAGMENT_HAS_NO_CORRESPONDING_CLOSING_TAG,
+                10,
+                11,
+            ),
+        ],
+        "Expected JSX fragment recovery positions to match tsc for tsxFragmentErrors.tsx, got {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -85,6 +85,33 @@ impl<'a> TypeFormatter<'a> {
         format!("{{ {}; }}", display_parts.join("; "))
     }
 
+    fn visible_object_properties<'b>(&self, props: &'b [PropertyInfo]) -> Vec<&'b PropertyInfo> {
+        let default_name = self.interner.intern_string("default");
+        let internal_default_name = self.interner.intern_string("_default");
+        let default_prop = props.iter().find(|prop| prop.name == default_name);
+
+        props
+            .iter()
+            .filter(|prop| {
+                if prop.name != internal_default_name {
+                    return true;
+                }
+                let Some(default_prop) = default_prop else {
+                    return true;
+                };
+
+                // Some module export surfaces retain the local `_default` binding
+                // alongside the real `default` export. tsc hides that duplicate
+                // implementation detail in object displays.
+                prop.type_id != default_prop.type_id
+                    || prop.write_type != default_prop.write_type
+                    || prop.optional != default_prop.optional
+                    || prop.readonly != default_prop.readonly
+                    || prop.is_method != default_prop.is_method
+            })
+            .collect()
+    }
+
     pub(super) fn format_literal(&mut self, lit: &LiteralValue) -> String {
         match lit {
             LiteralValue::String(s) => {
@@ -119,7 +146,7 @@ impl<'a> TypeFormatter<'a> {
         if props.is_empty() {
             return "{}".to_string();
         }
-        let mut display_props: Vec<&PropertyInfo> = props.iter().collect();
+        let mut display_props = self.visible_object_properties(props);
         // Sort properties for display. Use declaration_order as primary key when
         // available, with tsc-compatible tiebreaking: numeric keys in numeric order,
         // then string keys in existing order (stable sort preserves Atom ID order).
@@ -431,7 +458,7 @@ impl<'a> TypeFormatter<'a> {
             ));
         }
         // Sort properties by declaration_order for display (preserves source order)
-        let mut display_props: Vec<&PropertyInfo> = shape.properties.iter().collect();
+        let mut display_props = self.visible_object_properties(shape.properties.as_slice());
         let has_decl_order = display_props.iter().any(|p| p.declaration_order > 0);
         if has_decl_order {
             display_props.sort_by_key(|p| p.declaration_order);

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -567,6 +567,50 @@ fn format_object_many_properties_truncated() {
 }
 
 #[test]
+fn format_object_hides_duplicate_internal_default_alias() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+
+    let shared = TypeId::NUMBER;
+    let obj = db.object(vec![
+        PropertyInfo::new(db.intern_string("default"), shared),
+        PropertyInfo::new(db.intern_string("_default"), shared),
+        PropertyInfo::new(db.intern_string("value"), TypeId::STRING),
+    ]);
+    let result = fmt.format(obj);
+
+    assert!(
+        result.contains("default: number"),
+        "Expected real default export to remain visible, got: {result}"
+    );
+    assert!(
+        !result.contains("_default"),
+        "Expected duplicate internal `_default` alias to be hidden, got: {result}"
+    );
+    assert!(
+        result.contains("value: string"),
+        "Expected unrelated properties to remain visible, got: {result}"
+    );
+}
+
+#[test]
+fn format_object_keeps_distinct_internal_default_alias() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+
+    let obj = db.object(vec![
+        PropertyInfo::new(db.intern_string("default"), TypeId::NUMBER),
+        PropertyInfo::new(db.intern_string("_default"), TypeId::STRING),
+    ]);
+    let result = fmt.format(obj);
+
+    assert!(
+        result.contains("_default: string"),
+        "Expected `_default` to remain when it is not a duplicate of `default`, got: {result}"
+    );
+}
+
+#[test]
 fn format_object_with_string_index_signature() {
     let db = TypeInterner::new();
     let mut fmt = TypeFormatter::new(&db);
@@ -588,6 +632,43 @@ fn format_object_with_string_index_signature() {
     assert!(
         result.contains("[x: string]: number"),
         "Expected string index signature with default param name 'x', got: {result}"
+    );
+}
+
+#[test]
+fn format_object_with_index_hides_duplicate_internal_default_alias() {
+    let db = TypeInterner::new();
+    let mut fmt = TypeFormatter::new(&db);
+
+    let shape = crate::types::ObjectShape {
+        properties: vec![
+            PropertyInfo::new(db.intern_string("default"), TypeId::NUMBER),
+            PropertyInfo::new(db.intern_string("_default"), TypeId::NUMBER),
+        ],
+        string_index: Some(crate::types::IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol: None,
+        flags: Default::default(),
+    };
+    let obj = db.object_with_index(shape);
+    let result = fmt.format(obj);
+
+    assert!(
+        result.contains("[x: string]: number"),
+        "Expected index signature to remain visible, got: {result}"
+    );
+    assert!(
+        result.contains("default: number"),
+        "Expected real default export to remain visible, got: {result}"
+    );
+    assert!(
+        !result.contains("_default"),
+        "Expected duplicate internal `_default` alias to be hidden in object-with-index display, got: {result}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Split missing-lib diagnostic classification so core global types like `IArguments` are handled separately from other known global names.
- Align JSX fragment recovery and follow-on checker/LSP/CLI adjustments needed by the conformance work on this branch.
- Hide duplicate internal `_default` aliases from diagnostic object formatting when they only mirror the real `default` export.

## Why

The previous builtin-name handling mixed type-space and value-space globals into one path, which made the model misleading and the diagnostics harder to evolve. Separately, some namespace/export surfaces were leaking an internal `_default` alias into displayed object types even when TypeScript hides it.

## Impact

- Improves missing-global diagnostics and test coverage for core/global/lib name handling.
- Keeps diagnostic object displays closer to `tsc` by suppressing duplicate implementation-detail aliases.
- Leaves the branch ready for continued work from this PR.

## Validation

- `cargo nextest run -p tsz-solver format_object_hides_duplicate_internal_default_alias format_object_keeps_distinct_internal_default_alias format_object_with_index_hides_duplicate_internal_default_alias`
- `cargo nextest run -p tsz-checker test_export_equals_typeof_import_namespace_import_exposes_referenced_named_exports`

## Notes

- This PR is draft on purpose so work can continue from the published branch.
- Full `scripts/session/verify-all.sh` is not included here; on the current latest `origin/main`, representative checker failures already reproduce for `checked_js_default_type_import_reports_ts18042` and `test_typeof_import_nested_export_equals_qualifier_includes_cross_file_path`.
