### PR TITLE
fix(checker): suppress false TS2558 when constructor has no construct…

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -813,6 +813,10 @@ impl<'a> CheckerState<'a> {
         let got = type_args_list.nodes.len();
         let type_arg_error_anchor = type_args_list.nodes.first().copied().unwrap_or(call_idx);
 
+        if shape.construct_signatures.is_empty() {
+            return;
+        }
+
         // For callable types with overloaded construct signatures, prefer
         // a signature whose type parameter arity matches the provided args.
         let type_params = {

--- a/crates/tsz-checker/tests/ts2558_new_type_args_tests.rs
+++ b/crates/tsz-checker/tests/ts2558_new_type_args_tests.rs
@@ -97,3 +97,39 @@ let a: Foo<string>;
         "Should emit TS2314 for too few type args in type reference, got: {codes:?}"
     );
 }
+
+#[test]
+fn test_new_generic_class_in_static_method_no_false_ts2558() {
+    let codes = get_error_codes(
+        r#"
+class Foo<T> {
+    value!: T;
+    static create(): Foo<number> {
+        return new Foo<number>();
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2558),
+        "Should not emit TS2558 for new Foo<number>() inside static method, got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_new_generic_class_in_generic_static_method_no_false_ts2558() {
+    let codes = get_error_codes(
+        r#"
+class Foo<T> {
+    value!: T;
+    static create<T>(): Foo<T> {
+        return new Foo<T>();
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2558),
+        "Should not emit TS2558 for new Foo<T>() inside generic static method, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -91,8 +91,12 @@ pub fn extract_type_params_for_call(
         }
         Some(TypeData::Callable(shape_id)) => {
             let shape = db.callable_shape(shape_id);
-            let matching: Vec<_> = shape
+            let all_sigs: Vec<_> = shape
                 .call_signatures
+                .iter()
+                .chain(shape.construct_signatures.iter())
+                .collect();
+            let matching: Vec<_> = all_sigs
                 .iter()
                 .filter(|sig| {
                     let max = sig.type_params.len();
@@ -104,17 +108,14 @@ pub fn extract_type_params_for_call(
                     type_arg_count >= min && type_arg_count <= max
                 })
                 .collect();
-            // Multiple overloads match → skip (overload resolution handles it)
             if matching.len() > 1 {
                 return None;
             }
             if let Some(sig) = matching.first() {
                 Some(sig.type_params.clone())
             } else {
-                // Fall back to first signature for diagnostics
                 Some(
-                    shape
-                        .call_signatures
+                    all_sigs
                         .first()
                         .map(|sig| sig.type_params.clone())
                         .unwrap_or_default(),


### PR DESCRIPTION
… signatures

When a generic class like `Foo<T>` is instantiated with `new Foo<T>()` inside its own static method, the constructor type resolves to a Callable with empty construct signatures (likely due to circular reference during type-building). The validate_new_expression_type_arguments function treated "no signatures" as "0 type params expected" and incorrectly emitted TS2558 ("Expected 0 type arguments, but got 1").

Fix: bail out early when construct_signatures is empty, since we cannot validate type arguments without signature information.

Also updated extract_type_params_for_call to consider both call and construct signatures when matching type parameter arity for Callable types.

Flips 8 conformance tests (net +8, 0 regressions):
  - symbolLinkDeclarationEmitModuleNames.ts
  - bluebirdStaticThis.ts
  - declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
  - internalAliasInterfaceInsideLocalModuleWithoutExportAccessError.ts
  - isolatedDeclarationErrorsAugmentation.ts
  - optionalFunctionArgAssignability.ts
  - typeGuardConstructorDerivedClass.ts
  - chained.ts

https://claude.ai/code/session_01T4pNmUrK8RemuGhVvgqJoX