### PR TITLE
[codex] WIP checker cleanup helper extraction

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -8,6 +8,7 @@
 //! - JS namespace enum rebind assignments
 
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -237,25 +238,6 @@ impl<'a> CheckerState<'a> {
         // the member symbol but binder metadata still records the assignment
         // (`var X = {}; X.Y = function(){}` style). This should behave like a
         // constructor declaration write in TS.
-        fn property_access_chain(
-            arena: &tsz_parser::parser::node::NodeArena,
-            idx: NodeIndex,
-        ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
-            }
-            if node.kind == tsz_parser::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                let access = arena.get_access_expr(node)?;
-                let left = property_access_chain(arena, access.expression)?;
-                let right = arena
-                    .get_identifier_at(access.name_or_argument)?
-                    .escaped_text
-                    .clone();
-                return Some(format!("{left}.{right}"));
-            }
-            None
-        }
         fn root_identifier(
             arena: &tsz_parser::parser::node::NodeArena,
             idx: NodeIndex,
@@ -274,7 +256,9 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let Some(object_key) = property_access_chain(self.ctx.arena, access.expression) else {
+        let Some(object_key) =
+            property_access_chain_text_in_arena(self.ctx.arena, access.expression)
+        else {
             return false;
         };
         let mut has_expando_property = self
@@ -517,30 +501,9 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         use tsz_binder::symbol_flags;
         use tsz_parser::parser::syntax_kind_ext;
-        use tsz_scanner::SyntaxKind;
 
         if !self.is_js_file() || !self.ctx.compiler_options.check_js {
             return false;
-        }
-
-        fn property_access_chain(
-            arena: &tsz_parser::parser::node::NodeArena,
-            idx: NodeIndex,
-        ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
-            }
-            if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                return None;
-            }
-            let access = arena.get_access_expr(node)?;
-            let left = property_access_chain(arena, access.expression)?;
-            let right = arena
-                .get_identifier_at(access.name_or_argument)?
-                .escaped_text
-                .clone();
-            Some(format!("{left}.{right}"))
         }
 
         let target_idx = self.ctx.arena.skip_parenthesized(target_idx);
@@ -614,7 +577,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let Some(object_key) = property_access_chain(self.ctx.arena, access.expression) else {
+        let Some(object_key) =
+            property_access_chain_text_in_arena(self.ctx.arena, access.expression)
+        else {
             return false;
         };
 

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -3,6 +3,7 @@
 
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::entity_name_text_in_arena;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
@@ -1150,23 +1151,7 @@ impl<'a> CheckerState<'a> {
         arena: &NodeArena,
         idx: NodeIndex,
     ) -> Option<String> {
-        let node = arena.get(idx)?;
-        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
-            return arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
-            let qn = arena.get_qualified_name(node)?;
-            let left = Self::entity_name_text_in_arena(arena, qn.left)?;
-            let right = Self::entity_name_text_in_arena(arena, qn.right)?;
-            let mut combined = String::with_capacity(left.len() + 1 + right.len());
-            combined.push_str(&left);
-            combined.push('.');
-            combined.push_str(&right);
-            return Some(combined);
-        }
-        None
+        entity_name_text_in_arena(arena, idx)
     }
 
     // JSX Intrinsic Elements Type

--- a/crates/tsz-checker/src/flow/flow_analysis/core.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/core.rs
@@ -1,4 +1,5 @@
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -954,25 +955,7 @@ impl<'a> CheckerState<'a> {
 
     /// Extract a qualified name from a property access expression.
     fn qualified_name_from_property_access(&self, access_idx: NodeIndex) -> Option<String> {
-        let node = self.ctx.arena.get(access_idx)?;
-        let access = self.ctx.arena.get_access_expr(node)?;
-
-        let base_name = if let Some(base_node) = self.ctx.arena.get(access.expression) {
-            if let Some(ident) = self.ctx.arena.get_identifier(base_node) {
-                Some(ident.escaped_text.clone())
-            } else if base_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                self.qualified_name_from_property_access(access.expression)
-            } else {
-                None
-            }
-        } else {
-            None
-        }?;
-
-        let name_node = self.ctx.arena.get(access.name_or_argument)?;
-        let ident = self.ctx.arena.get_identifier(name_node)?;
-
-        Some(format!("{}.{}", base_name, ident.escaped_text))
+        property_access_chain_text_in_arena(self.ctx.arena, access_idx)
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -4,6 +4,9 @@
 //! architectural limit.
 
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::{
+    is_zero_arg_call_like_expr_in_arena, simple_computed_name_expr_text_in_arena,
+};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -712,61 +715,11 @@ impl<'a> CheckerState<'a> {
     }
 
     fn get_simple_computed_name_expr_text(&self, expr_idx: NodeIndex) -> Option<String> {
-        let expr_node = self.ctx.arena.get(expr_idx)?;
-        match expr_node.kind {
-            k if k == tsz_scanner::SyntaxKind::Identifier as u16 => self
-                .ctx
-                .arena
-                .get_identifier(expr_node)
-                .map(|ident| ident.escaped_text.clone()),
-            k if k == tsz_parser::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
-                let access = self.ctx.arena.get_access_expr(expr_node)?;
-                let left = self.get_simple_computed_name_expr_text(access.expression)?;
-                let right = self
-                    .ctx
-                    .arena
-                    .get_identifier_text(access.name_or_argument)?;
-                Some(format!("{left}.{right}"))
-            }
-            k if k == tsz_parser::parser::syntax_kind_ext::CALL_EXPRESSION => {
-                let call = self.ctx.arena.get_call_expr(expr_node)?;
-                let callee = self.get_simple_computed_name_expr_text(call.expression)?;
-                let args = call.arguments.as_ref()?;
-                if !args.nodes.is_empty() {
-                    return None;
-                }
-                Some(format!("{callee}()"))
-            }
-            k if k == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
-                let paren = self.ctx.arena.get_parenthesized(expr_node)?;
-                self.get_simple_computed_name_expr_text(paren.expression)
-            }
-            _ => None,
-        }
+        simple_computed_name_expr_text_in_arena(self.ctx.arena, expr_idx)
     }
 
     fn is_zero_arg_call_like_expr(&self, expr_idx: NodeIndex) -> bool {
-        let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        match expr_node.kind {
-            k if k == tsz_parser::parser::syntax_kind_ext::CALL_EXPRESSION => {
-                self.ctx.arena.get_call_expr(expr_node).is_some_and(|call| {
-                    call.arguments
-                        .as_ref()
-                        .is_some_and(|args| args.nodes.is_empty())
-                        && self
-                            .get_simple_computed_name_expr_text(call.expression)
-                            .is_some()
-                })
-            }
-            k if k == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION => self
-                .ctx
-                .arena
-                .get_parenthesized(expr_node)
-                .is_some_and(|paren| self.is_zero_arg_call_like_expr(paren.expression)),
-            _ => false,
-        }
+        is_zero_arg_call_like_expr_in_arena(self.ctx.arena, expr_idx)
     }
 
     fn should_check_late_bound_class_property_name(&mut self, name_idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -1,6 +1,7 @@
 //! Helpers for computing type aliases in `compute_type_of_symbol`.
 
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::expression_name_text_in_arena;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::node::{NodeAccess, NodeArena, TypeAliasData};
@@ -309,36 +310,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn cross_arena_expression_name_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-        let node = arena.get(idx)?;
-
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-
-        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
-            let qn = arena.get_qualified_name(node)?;
-            let left = Self::cross_arena_expression_name_text(arena, qn.left)?;
-            let right = Self::cross_arena_expression_name_text(arena, qn.right)?;
-            return Some(format!("{left}.{right}"));
-        }
-
-        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-            let paren = arena.get_parenthesized(node)?;
-            return Self::cross_arena_expression_name_text(arena, paren.expression);
-        }
-
-        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            && let Some(access) = arena.get_access_expr(node)
-        {
-            let left = Self::cross_arena_expression_name_text(arena, access.expression)?;
-            let right_node = arena.get(access.name_or_argument)?;
-            let right = arena.get_identifier(right_node)?;
-            return Some(format!("{left}.{}", right.escaped_text));
-        }
-
-        None
+        expression_name_text_in_arena(arena, idx)
     }
 
     fn cross_arena_symbol_is_unique(&self, sym_id: SymbolId) -> bool {

--- a/crates/tsz-checker/src/symbols/mod.rs
+++ b/crates/tsz-checker/src/symbols/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod name_text;
 pub mod scope_finder;
 pub(crate) mod scope_finder_contexts;
 pub mod symbol_resolver;

--- a/crates/tsz-checker/src/symbols/name_text.rs
+++ b/crates/tsz-checker/src/symbols/name_text.rs
@@ -1,0 +1,124 @@
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+pub(crate) fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    let node = arena.get(idx)?;
+    if node.kind == SyntaxKind::Identifier as u16 {
+        return arena
+            .get_identifier(node)
+            .map(|ident| ident.escaped_text.clone());
+    }
+
+    if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+        let qn = arena.get_qualified_name(node)?;
+        let left = entity_name_text_in_arena(arena, qn.left)?;
+        let right = entity_name_text_in_arena(arena, qn.right)?;
+        let mut combined = String::with_capacity(left.len() + 1 + right.len());
+        combined.push_str(&left);
+        combined.push('.');
+        combined.push_str(&right);
+        return Some(combined);
+    }
+
+    None
+}
+
+pub(crate) fn expression_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    let node = arena.get(idx)?;
+
+    if node.kind == SyntaxKind::Identifier as u16 || node.kind == syntax_kind_ext::QUALIFIED_NAME {
+        return entity_name_text_in_arena(arena, idx);
+    }
+
+    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+        let paren = arena.get_parenthesized(node)?;
+        return expression_name_text_in_arena(arena, paren.expression);
+    }
+
+    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        && let Some(access) = arena.get_access_expr(node)
+    {
+        let left = expression_name_text_in_arena(arena, access.expression)?;
+        let right_node = arena.get(access.name_or_argument)?;
+        let right = arena.get_identifier(right_node)?;
+        return Some(format!("{left}.{}", right.escaped_text));
+    }
+
+    None
+}
+
+pub(crate) fn property_access_chain_text_in_arena(
+    arena: &NodeArena,
+    idx: NodeIndex,
+) -> Option<String> {
+    let node = arena.get(idx)?;
+    if node.kind == SyntaxKind::Identifier as u16 {
+        return arena
+            .get_identifier(node)
+            .map(|ident| ident.escaped_text.clone());
+    }
+
+    if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+        return None;
+    }
+
+    let access = arena.get_access_expr(node)?;
+    let left = property_access_chain_text_in_arena(arena, access.expression)?;
+    let right = arena.get_identifier_at(access.name_or_argument)?;
+    Some(format!("{left}.{}", right.escaped_text))
+}
+
+pub(crate) fn simple_computed_name_expr_text_in_arena(
+    arena: &NodeArena,
+    idx: NodeIndex,
+) -> Option<String> {
+    let node = arena.get(idx)?;
+    match node.kind {
+        k if k == SyntaxKind::Identifier as u16 => arena
+            .get_identifier(node)
+            .map(|ident| ident.escaped_text.clone()),
+        k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+            let access = arena.get_access_expr(node)?;
+            let left = simple_computed_name_expr_text_in_arena(arena, access.expression)?;
+            let right = arena.get_identifier_text(access.name_or_argument)?;
+            Some(format!("{left}.{right}"))
+        }
+        k if k == syntax_kind_ext::CALL_EXPRESSION => {
+            let call = arena.get_call_expr(node)?;
+            let callee = simple_computed_name_expr_text_in_arena(arena, call.expression)?;
+            let args = call.arguments.as_ref()?;
+            if !args.nodes.is_empty() {
+                return None;
+            }
+            Some(format!("{callee}()"))
+        }
+        k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+            let paren = arena.get_parenthesized(node)?;
+            simple_computed_name_expr_text_in_arena(arena, paren.expression)
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn is_zero_arg_call_like_expr_in_arena(arena: &NodeArena, idx: NodeIndex) -> bool {
+    let Some(node) = arena.get(idx) else {
+        return false;
+    };
+
+    match node.kind {
+        k if k == syntax_kind_ext::CALL_EXPRESSION => {
+            arena.get_call_expr(node).is_some_and(|call| {
+                call.arguments
+                    .as_ref()
+                    .is_some_and(|args| args.nodes.is_empty())
+                    && simple_computed_name_expr_text_in_arena(arena, call.expression).is_some()
+            })
+        }
+        k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => arena
+            .get_parenthesized(node)
+            .is_some_and(|paren| is_zero_arg_call_like_expr_in_arena(arena, paren.expression)),
+        _ => false,
+    }
+}

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -9,6 +9,7 @@
 //! operations, providing cleaner APIs for common patterns.
 
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::entity_name_text_in_arena;
 use std::sync::Arc;
 use tracing::trace;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -1178,25 +1179,7 @@ impl<'a> CheckerState<'a> {
     /// Entity names can be simple identifiers or qualified names (e.g., `A.B.C`).
     /// This function recursively builds the full text representation.
     pub(crate) fn entity_name_text(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.ctx.arena.get(idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return self
-                .ctx
-                .arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
-            let qn = self.ctx.arena.get_qualified_name(node)?;
-            let left = self.entity_name_text(qn.left)?;
-            let right = self.entity_name_text(qn.right)?;
-            let mut combined = String::with_capacity(left.len() + 1 + right.len());
-            combined.push_str(&left);
-            combined.push('.');
-            combined.push_str(&right);
-            return Some(combined);
-        }
-        None
+        entity_name_text_in_arena(self.ctx.arena, idx)
     }
 
     /// Resolve a simple or qualified type name through the merged checker binder.

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -6,6 +6,7 @@
 
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
@@ -148,22 +149,8 @@ impl<'a> CheckerState<'a> {
         object_expr_idx: NodeIndex,
         key_expr_idx: NodeIndex,
     ) -> bool {
-        fn property_access_chain(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
-            }
-            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                let access = arena.get_access_expr(node)?;
-                let left = property_access_chain(arena, access.expression)?;
-                let right_node = arena.get(access.name_or_argument)?;
-                let right = arena.get_identifier(right_node)?.escaped_text.clone();
-                return Some(format!("{left}.{right}"));
-            }
-            None
-        }
-
-        let Some(obj_key) = property_access_chain(self.ctx.arena, object_expr_idx) else {
+        let Some(obj_key) = property_access_chain_text_in_arena(self.ctx.arena, object_expr_idx)
+        else {
             return false;
         };
         let Some(prop_key) = self.expando_element_key_name(key_expr_idx) else {
@@ -260,30 +247,8 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_identifier_at(access.name_or_argument)
                     .is_some_and(|member_ident| {
-                        fn property_access_chain(
-                            arena: &tsz_parser::parser::node::NodeArena,
-                            idx: NodeIndex,
-                        ) -> Option<String> {
-                            let node = arena.get(idx)?;
-                            if node.kind == SyntaxKind::Identifier as u16 {
-                                return arena
-                                    .get_identifier(node)
-                                    .map(|id| id.escaped_text.clone());
-                            }
-                            if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                                return None;
-                            }
-                            let access = arena.get_access_expr(node)?;
-                            let left = property_access_chain(arena, access.expression)?;
-                            let right = arena
-                                .get_identifier_at(access.name_or_argument)?
-                                .escaped_text
-                                .clone();
-                            Some(format!("{left}.{right}"))
-                        }
-
-                        property_access_chain(self.ctx.arena, access.expression).is_some_and(
-                            |object_key| {
+                        property_access_chain_text_in_arena(self.ctx.arena, access.expression)
+                            .is_some_and(|object_key| {
                                 self.collect_expando_properties_for_root(&object_key)
                                     .contains(&member_ident.escaped_text)
                                     || object_key.rsplit_once('.').is_some_and(
@@ -292,8 +257,7 @@ impl<'a> CheckerState<'a> {
                                                 .contains(&member_ident.escaped_text)
                                         },
                                     )
-                            },
-                        )
+                            })
                     });
             let can_use_no_flow = if let Some(name) = literal_string.as_deref() {
                 !matches!(

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -8,6 +8,7 @@ use crate::query_boundaries::type_computation::core::{
     self as expr_ops, evaluate_contextual_structure_with,
 };
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
@@ -1348,26 +1349,6 @@ impl<'a> CheckerState<'a> {
         // properties. Return `any` to match this behavior.
         // Note: class declarations are NOT included here — class static property
         // assignments DO check assignability in tsc.
-        fn property_access_chain(
-            arena: &tsz_parser::parser::node::NodeArena,
-            idx: NodeIndex,
-        ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
-            }
-            if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                return None;
-            }
-            let access = arena.get_access_expr(node)?;
-            let left = property_access_chain(arena, access.expression)?;
-            let right = arena
-                .get_identifier_at(access.name_or_argument)?
-                .escaped_text
-                .clone();
-            Some(format!("{left}.{right}"))
-        }
-
         if let Some(node) = self.ctx.arena.get(idx)
             && node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
             && let Some(access) = self.ctx.arena.get_access_expr(node)
@@ -1380,7 +1361,8 @@ impl<'a> CheckerState<'a> {
                 .map(|ident| ident.escaped_text.clone())
         {
             let has_expando_property = {
-                let object_key = property_access_chain(self.ctx.arena, access.expression);
+                let object_key =
+                    property_access_chain_text_in_arena(self.ctx.arena, access.expression);
                 object_key.is_some_and(|object_key| {
                     let has_expando_property = self
                         .collect_expando_properties_for_root(&object_key)

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -7,6 +7,9 @@ use super::super::object_literal_context::ContextualPropertyPresence;
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationGuard;
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::{
+    is_zero_arg_call_like_expr_in_arena, simple_computed_name_expr_text_in_arena,
+};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -47,63 +50,11 @@ impl<'a> CheckerState<'a> {
     }
 
     fn simple_computed_name_expr_text_for_duplicates(&self, expr_idx: NodeIndex) -> Option<String> {
-        let expr_node = self.ctx.arena.get(expr_idx)?;
-        match expr_node.kind {
-            k if k == tsz_scanner::SyntaxKind::Identifier as u16 => self
-                .ctx
-                .arena
-                .get_identifier(expr_node)
-                .map(|ident| ident.escaped_text.clone()),
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
-                let access = self.ctx.arena.get_access_expr(expr_node)?;
-                let left = self.simple_computed_name_expr_text_for_duplicates(access.expression)?;
-                let right = self
-                    .ctx
-                    .arena
-                    .get_identifier_text(access.name_or_argument)?;
-                Some(format!("{left}.{right}"))
-            }
-            k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                let call = self.ctx.arena.get_call_expr(expr_node)?;
-                let callee = self.simple_computed_name_expr_text_for_duplicates(call.expression)?;
-                let args = call.arguments.as_ref()?;
-                if !args.nodes.is_empty() {
-                    return None;
-                }
-                Some(format!("{callee}()"))
-            }
-            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
-                let paren = self.ctx.arena.get_parenthesized(expr_node)?;
-                self.simple_computed_name_expr_text_for_duplicates(paren.expression)
-            }
-            _ => None,
-        }
+        simple_computed_name_expr_text_in_arena(self.ctx.arena, expr_idx)
     }
 
     fn is_zero_arg_call_like_expr_for_duplicates(&self, expr_idx: NodeIndex) -> bool {
-        let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        match expr_node.kind {
-            k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                self.ctx.arena.get_call_expr(expr_node).is_some_and(|call| {
-                    call.arguments
-                        .as_ref()
-                        .is_some_and(|args| args.nodes.is_empty())
-                        && self
-                            .simple_computed_name_expr_text_for_duplicates(call.expression)
-                            .is_some()
-                })
-            }
-            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => self
-                .ctx
-                .arena
-                .get_parenthesized(expr_node)
-                .is_some_and(|paren| {
-                    self.is_zero_arg_call_like_expr_for_duplicates(paren.expression)
-                }),
-            _ => false,
-        }
+        is_zero_arg_call_like_expr_in_arena(self.ctx.arena, expr_idx)
     }
 
     fn simple_computed_call_name_for_duplicates(&self, name_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -5,6 +5,7 @@
 
 use crate::FlowAnalyzer;
 use crate::state::CheckerState;
+use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1132,25 +1133,8 @@ impl<'a> CheckerState<'a> {
     /// Check if the object expression has any unique-symbol-keyed expando properties
     /// recorded by the binder (i.e., any `__unique_*` entry in `expando_properties`).
     pub(crate) fn object_has_unique_symbol_expandos(&self, object_expr_idx: NodeIndex) -> bool {
-        fn property_access_chain(
-            arena: &tsz_parser::parser::node::NodeArena,
-            idx: NodeIndex,
-        ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
-            }
-            if node.kind == tsz_parser::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                let access = arena.get_access_expr(node)?;
-                let left = property_access_chain(arena, access.expression)?;
-                let right_node = arena.get(access.name_or_argument)?;
-                let right = arena.get_identifier(right_node)?.escaped_text.clone();
-                return Some(format!("{left}.{right}"));
-            }
-            None
-        }
-
-        let Some(obj_key) = property_access_chain(self.ctx.arena, object_expr_idx) else {
+        let Some(obj_key) = property_access_chain_text_in_arena(self.ctx.arena, object_expr_idx)
+        else {
             return false;
         };
 

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -9,6 +9,9 @@ use super::lib_resolution::{
     resolve_lib_node_in_lib_contexts,
 };
 use crate::state::{CheckerState, MemberAccessLevel};
+use crate::symbols_domain::name_text::{
+    entity_name_text_in_arena, property_access_chain_text_in_arena,
+};
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::syntax_kind_ext;
@@ -540,22 +543,11 @@ impl<'a> CheckerState<'a> {
         }
 
         if node.kind == syntax_kind_ext::QUALIFIED_NAME {
-            return self.entity_name_text(idx);
+            return entity_name_text_in_arena(self.ctx.arena, idx);
         }
 
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-            let access = self.ctx.arena.get_access_expr(node)?;
-            let left = self.heritage_name_text(access.expression)?;
-            let right = self
-                .ctx
-                .arena
-                .get_identifier_at(access.name_or_argument)
-                .map(|ident| ident.escaped_text.clone())?;
-            let mut combined = String::with_capacity(left.len() + 1 + right.len());
-            combined.push_str(&left);
-            combined.push('.');
-            combined.push_str(&right);
-            return Some(combined);
+            return property_access_chain_text_in_arena(self.ctx.arena, idx);
         }
 
         // Handle keyword literals in heritage clauses (e.g., extends null, extends true)

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -10,6 +10,7 @@ use super::type_node_helpers::{
     check_duplicate_parameters_in_type, check_parameter_initializers_in_type,
 };
 use crate::context::CheckerContext;
+use crate::symbols_domain::name_text::expression_name_text_in_arena;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -1776,35 +1777,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     }
 
     fn expression_name_text(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.ctx.arena.get(idx)?;
-
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return self
-                .ctx
-                .arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-
-        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
-            return self.entity_name_text(idx);
-        }
-
-        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-            let paren = self.ctx.arena.get_parenthesized(node)?;
-            return self.expression_name_text(paren.expression);
-        }
-
-        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            && let Some(access) = self.ctx.arena.get_access_expr(node)
-        {
-            let left = self.expression_name_text(access.expression)?;
-            let right_node = self.ctx.arena.get(access.name_or_argument)?;
-            let right = self.ctx.arena.get_identifier(right_node)?;
-            return Some(format!("{left}.{}", right.escaped_text));
-        }
-
-        None
+        expression_name_text_in_arena(self.ctx.arena, idx)
     }
 
     fn symbol_refers_to_unique_symbol(&self, sym_id: SymbolId) -> bool {

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -4,6 +4,7 @@
 //! Contains methods for ensuring type alias bodies are registered in the
 //! type environment and for resolving `DefIds` from qualified names.
 
+use crate::symbols_domain::name_text::{entity_name_text_in_arena, expression_name_text_in_arena};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_solver::TypeId;
@@ -13,27 +14,7 @@ use super::type_node::TypeNodeChecker;
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     pub(super) fn entity_name_text(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.ctx.arena.get(idx)?;
-        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
-            return self
-                .ctx
-                .arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-
-        if node.kind == tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME {
-            let qn = self.ctx.arena.get_qualified_name(node)?;
-            let left = self.entity_name_text(qn.left)?;
-            let right = self.entity_name_text(qn.right)?;
-            let mut combined = String::with_capacity(left.len() + 1 + right.len());
-            combined.push_str(&left);
-            combined.push('.');
-            combined.push_str(&right);
-            return Some(combined);
-        }
-
-        None
+        entity_name_text_in_arena(self.ctx.arena, idx)
     }
 
     pub(super) fn resolve_entity_name_text_symbol(
@@ -410,36 +391,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     }
 
     fn expression_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-        let node = arena.get(idx)?;
-
-        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
-            return arena
-                .get_identifier(node)
-                .map(|ident| ident.escaped_text.clone());
-        }
-
-        if node.kind == tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME {
-            let qn = arena.get_qualified_name(node)?;
-            let left = Self::expression_name_text_in_arena(arena, qn.left)?;
-            let right = Self::expression_name_text_in_arena(arena, qn.right)?;
-            return Some(format!("{left}.{right}"));
-        }
-
-        if node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-            let paren = arena.get_parenthesized(node)?;
-            return Self::expression_name_text_in_arena(arena, paren.expression);
-        }
-
-        if node.kind == tsz_parser::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            && let Some(access) = arena.get_access_expr(node)
-        {
-            let left = Self::expression_name_text_in_arena(arena, access.expression)?;
-            let right_node = arena.get(access.name_or_argument)?;
-            let right = arena.get_identifier(right_node)?;
-            return Some(format!("{left}.{}", right.escaped_text));
-        }
-
-        None
+        expression_name_text_in_arena(arena, idx)
     }
 
     pub(super) fn symbol_refers_to_unique_symbol_anywhere(


### PR DESCRIPTION
## What changed

This WIP extracts repeated checker-side AST name rendering into shared helpers in `crates/tsz-checker/src/symbols/name_text.rs` and rewires exact-match call sites to use those helpers.

## Why

The checker had several near-identical recursive walkers for entity names, property access chains, and simple computed-name formatting. This pass is intended to reduce duplication and drift, not to change behavior.

## Validation

Ran targeted checks only:
- `cargo fmt --all --check`
- `cargo check -p tsz-checker --lib`
- `cargo test -p tsz-checker --test lib_resolution_identity_tests test_lib_ref_iterable_iterator_heritage_chain -- --nocapture`
- `cargo test -p tsz-checker --test type_alias_namespace_merge_tests -- --nocapture`

## Notes

- Local Cargo `target` and `.target` worktree artifacts were cleaned up to reclaim disk space.
- `scripts/session/verify-all.sh` was not run for this WIP PR.