### PR TITLE
ci: install binaryen in gh-pages wasm job

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
+      - name: Install wasm-opt (via binaryen)
+        run: sudo apt-get install -y binaryen
+
       - name: Build WASM (web target)
         run: |
           cp LICENSE.txt crates/tsz-wasm/LICENSE.txt


### PR DESCRIPTION
## Summary
- install `binaryen` in the gh-pages workflow wasm job
- ensure `wasm-pack` can use local `wasm-opt` instead of downloading Binaryen at runtime

## Why
The Deploy Website workflow run 24611035791 failed in job 71965393571 while downloading Binaryen for wasm-opt. Installing binaryen ahead of time makes this step deterministic and prevents that download failure from breaking deploys.

## Validation
- workflow diff reviewed locally
