### PR TITLE
refactor(arch): clear TEMPORARILY_ALLOWED bypass list (ceiling 41 → 0)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1,6 +1,7 @@
 //! Type assignability and excess property checking.
 //! Subtype, identity, and redeclaration compatibility live in `subtype_identity_checker`.
 
+use crate::query_boundaries::assignability::RelationCacheKey;
 use crate::query_boundaries::assignability::{
     AssignabilityEvalKind, AssignabilityQueryInputs, are_types_overlapping_with_env,
     check_application_variance_assignability, classify_for_assignability_eval,
@@ -18,7 +19,6 @@ use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::NarrowingContext;
-use tsz_solver::RelationCacheKey;
 use tsz_solver::TypeId;
 use tsz_solver::visitor::{collect_lazy_def_ids, collect_type_queries};
 

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -616,7 +616,7 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
         source_idx: NodeIndex,
     ) -> Option<bool> {
-        use tsz_solver::TypeResolver;
+        use crate::query_boundaries::common::TypeResolver;
         let target = self.evaluate_type_for_assignability(target);
         let target_def_id = tsz_solver::type_queries::get_enum_def_id(self.ctx.types, target)?;
         if !self.ctx.is_numeric_enum(target_def_id) {

--- a/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
@@ -17,7 +17,7 @@ impl<'a> CheckerState<'a> {
     /// Returns true if the type is number, bigint, any, or an enum type.
     /// This is used to validate operands for TS2362/TS2363 errors.
     fn is_arithmetic_operand(&self, type_id: TypeId) -> bool {
-        use tsz_solver::BinaryOpEvaluator;
+        use crate::query_boundaries::common::BinaryOpEvaluator;
 
         // Check if this is an enum type (Lazy/DefId to an enum symbol)
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -1013,7 +1013,7 @@ impl<'a> CheckerState<'a> {
     /// this returns the boxed wrapper type (e.g., `number` -> `Number`).
     /// For other types, returns the type as-is.
     fn get_apparent_type_for_index_check(&self, type_id: TypeId) -> TypeId {
-        use tsz_solver::IntrinsicKind;
+        use crate::query_boundaries::common::IntrinsicKind;
         let kind = match type_id {
             TypeId::NUMBER => Some(IntrinsicKind::Number),
             TypeId::STRING => Some(IntrinsicKind::String),

--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -428,8 +428,8 @@ impl<'a> CheckerState<'a> {
         right_type: TypeId,
         operator: u16,
     ) -> TypeId {
+        use crate::query_boundaries::common::BinaryOpEvaluator;
         use crate::query_boundaries::type_computation::core::BinaryOpResult;
-        use tsz_solver::BinaryOpEvaluator;
 
         let evaluator = BinaryOpEvaluator::new(self.ctx.types);
         let op_str = match operator {

--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -5,11 +5,11 @@
 //! - `is_subtype_of`
 //! - `are_var_decl_types_compatible` (TS2403)
 
+use crate::query_boundaries::assignability::RelationCacheKey;
 use crate::query_boundaries::assignability::{
     is_redeclaration_identical_with_resolver, is_relation_cacheable, is_subtype_with_resolver,
 };
 use crate::state::CheckerState;
-use tsz_solver::RelationCacheKey;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -11,10 +11,11 @@ use crate::query_boundaries::checkers::call::{
     array_element_type_for_type, is_type_parameter_type, resolve_call, resolve_new,
     stable_call_recovery_return_type, tuple_elements_for_type,
 };
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{AssignabilityChecker, CallResult, ContextualTypeContext, TupleElement, TypeId};
+use tsz_solver::{AssignabilityChecker, CallResult, TupleElement, TypeId};
 
 /// Call-local context carrying the callable type during argument collection.
 ///
@@ -1207,7 +1208,6 @@ impl<'a> CheckerState<'a> {
                 .get(self.ctx.arena.skip_parenthesized_and_assertions(arg_idx))
                 .is_some_and(|node| node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
             let pushed_this_type = if is_object_literal_arg && let Some(et) = expected_type {
-                use tsz_solver::ContextualTypeContext;
                 let ctx_helper = ContextualTypeContext::with_expected_and_options(
                     self.ctx.types,
                     et,

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -11,11 +11,12 @@ use crate::query_boundaries::checkers::call::{
     array_element_type_for_type, is_type_parameter_type, resolve_call, resolve_new,
     stable_call_recovery_return_type, tuple_elements_for_type,
 };
+use crate::query_boundaries::common::CallResult;
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{AssignabilityChecker, CallResult, TupleElement, TypeId};
+use tsz_solver::{AssignabilityChecker, TupleElement, TypeId};
 
 /// Call-local context carrying the callable type during argument collection.
 ///

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -11,12 +11,13 @@ use crate::query_boundaries::checkers::call::{
     array_element_type_for_type, is_type_parameter_type, resolve_call, resolve_new,
     stable_call_recovery_return_type, tuple_elements_for_type,
 };
+use crate::query_boundaries::common::AssignabilityChecker;
 use crate::query_boundaries::common::CallResult;
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{AssignabilityChecker, TupleElement, TypeId};
+use tsz_solver::{TupleElement, TypeId};
 
 /// Call-local context carrying the callable type during argument collection.
 ///

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -3,10 +3,11 @@
 //! Split from the parent `call_checker` module — pure code motion.
 
 use crate::query_boundaries::checkers::call::lazy_def_id_for_type;
+use crate::query_boundaries::common::{ContextualTypeContext, PendingDiagnosticBuilder};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{ContextualTypeContext, PendingDiagnosticBuilder, TypeId};
+use tsz_solver::TypeId;
 
 use super::{CallableContext, OverloadResolution};
 

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -32,8 +32,7 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
     ) -> Option<OverloadResolution> {
-        use tsz_solver::FunctionShape;
-        use tsz_solver::operations::CallResult;
+        use crate::query_boundaries::common::{CallResult, FunctionShape};
 
         tracing::debug!(
             "resolve_overloaded_call_with_signatures: signatures = {:?}, args = {:?}",

--- a/crates/tsz-checker/src/context/compiler_options.rs
+++ b/crates/tsz-checker/src/context/compiler_options.rs
@@ -3,8 +3,8 @@
 //! These methods provide convenient access to the `CheckerOptions` flags
 //! and derive solver configuration (`JudgeConfig`, `CompatChecker`) from them.
 
+use crate::query_boundaries::common::JudgeConfig;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::judge::JudgeConfig;
 
 use super::CheckerContext;
 

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -12,11 +12,11 @@ use std::sync::Arc;
 
 use crate::context::{CheckerContext, TypeCache};
 use crate::control_flow::FlowGraph;
+use crate::query_boundaries::common::{QueryDatabase, TypeEnvironment};
 use tsz_binder::BinderState;
 use tsz_common::checker_options::CheckerOptions;
 use tsz_parser::parser::node::NodeArena;
 use tsz_solver::def::DefinitionStore;
-use tsz_solver::{QueryDatabase, TypeEnvironment};
 
 impl<'a> CheckerContext<'a> {
     fn normalize_options(

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -785,8 +785,8 @@ impl<'a> CheckerContext<'a> {
     /// let formatter = self.create_type_formatter();
     /// let type_str = formatter.format(type_id);  // Shows "List<number>" not "Lazy(1)<number>"
     /// ```
-    pub fn create_type_formatter(&self) -> tsz_solver::TypeFormatter<'_> {
-        use tsz_solver::TypeFormatter;
+    pub fn create_type_formatter(&self) -> crate::query_boundaries::common::TypeFormatter<'_> {
+        use crate::query_boundaries::common::TypeFormatter;
 
         TypeFormatter::with_symbols(self.types, &self.binder.symbols)
             .with_def_store(&self.definition_store)
@@ -799,7 +799,9 @@ impl<'a> CheckerContext<'a> {
     /// Create a type formatter configured for diagnostic error messages.
     /// Skips union optionalization (synthetic `?: undefined` members) that
     /// tsc only uses in hover/quickinfo, not in error messages.
-    pub fn create_diagnostic_type_formatter(&self) -> tsz_solver::TypeFormatter<'_> {
+    pub fn create_diagnostic_type_formatter(
+        &self,
+    ) -> crate::query_boundaries::common::TypeFormatter<'_> {
         self.create_type_formatter()
             .with_diagnostic_mode()
             .with_strict_null_checks(self.compiler_options.strict_null_checks)

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -459,7 +459,7 @@ impl<'a> CheckerContext<'a> {
     /// updates the class-instance type. Otherwise, preserves existing type
     /// parameters (if any) when re-inserting the definition body.
     pub fn register_augmented_def_in_envs(&self, def_id: DefId, augmented: TypeId, is_class: bool) {
-        use tsz_solver::TypeEnvironment;
+        use crate::query_boundaries::common::TypeEnvironment;
 
         // Helper that applies the augmentation logic to a single env.
         fn apply(env: &mut TypeEnvironment, def_id: DefId, augmented: TypeId, is_class: bool) {

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -38,10 +38,11 @@ use tsz_common::interner::Atom;
 
 use crate::control_flow::FlowGraph;
 use crate::diagnostics::Diagnostic;
+use crate::query_boundaries::common::{QueryDatabase, TypeEnvironment};
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
 use tsz_solver::def::{DefId, DefinitionStore};
-use tsz_solver::{QueryDatabase, TypeEnvironment, TypeId};
 
 // Re-export CheckerOptions and ScriptTarget from tsz-common
 use tsz_binder::{BinderState, ModuleAugmentation};

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -960,8 +960,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             &request.read().normal_origin().contextual_opt(None),
                         );
                         self.checker.ctx.in_const_assertion = prev_in_const_assertion;
-                        use tsz_solver::widening::apply_const_assertion;
-                        apply_const_assertion(self.checker.ctx.types, expr_type)
+                        crate::query_boundaries::common::apply_const_assertion(
+                            self.checker.ctx.types,
+                            expr_type,
+                        )
                     } else {
                         // Check for duplicate properties in type literal nodes (TS2300)
                         self.checker

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -359,7 +359,7 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> Option<Vec<tsz_common::interner::Atom>> {
-        use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
 
         if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, source) {
             return None;

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -269,7 +269,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        use tsz_solver::PendingDiagnostic;
+        use crate::query_boundaries::common::PendingDiagnostic;
 
         let argument_failures: Vec<_> = failures
             .iter()

--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -275,8 +275,8 @@ impl<'a> CheckerState<'a> {
         arg_idx: NodeIndex,
         param_type: TypeId,
     ) -> Option<NodeIndex> {
+        use crate::query_boundaries::common::SubtypeFailureReason;
         use tsz_parser::parser::syntax_kind_ext;
-        use tsz_solver::SubtypeFailureReason;
 
         let source_type = self.get_type_of_node(arg_idx);
         let effective_param_type = if let (Some(non_nullish), Some(_nullish_cause)) =

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -233,7 +233,7 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
         anchor_idx: NodeIndex,
     ) -> Option<Vec<DiagnosticRelatedInformation>> {
-        use tsz_solver::SubtypeFailureReason;
+        use crate::query_boundaries::common::SubtypeFailureReason;
 
         let anchor = self.resolve_diagnostic_anchor(anchor_idx, DiagnosticAnchorKind::Exact)?;
         let start = anchor.start;
@@ -590,7 +590,7 @@ impl<'a> CheckerState<'a> {
         source_type: TypeId,
         target_type: TypeId,
     ) -> bool {
-        use tsz_solver::SubtypeFailureReason;
+        use crate::query_boundaries::common::SubtypeFailureReason;
 
         let analysis = self.analyze_assignability_failure(source_type, target_type);
         let Some(reason) = analysis.failure_reason else {

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -293,7 +293,7 @@ impl<'a> CheckerState<'a> {
                 | ">="
         );
 
-        use tsz_solver::BinaryOpEvaluator;
+        use crate::query_boundaries::common::BinaryOpEvaluator;
 
         let evaluator = BinaryOpEvaluator::new(self.ctx.types);
 

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -28,7 +28,7 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         depth: u32,
     ) -> Diagnostic {
-        use tsz_solver::SubtypeFailureReason;
+        use crate::query_boundaries::common::SubtypeFailureReason;
 
         let source = self.recover_unknown_array_source_type_for_display(source, idx, depth);
         let (start, length) = self
@@ -718,7 +718,7 @@ impl<'a> CheckerState<'a> {
         // from the Array interface and ARE named properties even though the array also has
         // a numeric index signature.
         {
-            use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+            use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
             let resolver = IndexSignatureResolver::new(self.ctx.types);
             let target_is_array_or_tuple =
                 tsz_solver::visitor::array_element_type(self.ctx.types, target).is_some()
@@ -765,7 +765,7 @@ impl<'a> CheckerState<'a> {
         // is preferred over specific missing property errors.
         // Skip for array/tuple targets — their numeric index is implicit and missing named
         // properties (like `length`) should still produce TS2741.
-        use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
         let resolver = IndexSignatureResolver::new(self.ctx.types);
         // Check both original and evaluated types (needed for generic class instances)
         let source_evaluated = self.evaluate_type_with_env(source);
@@ -1263,7 +1263,7 @@ impl<'a> CheckerState<'a> {
         // target has no explicit named properties (i.e., it's purely an index-signature
         // type like `{ [x: number]: T }`). Named interfaces that happen to have number
         // index signatures (like String, Array) should still get TS2739/TS2740.
-        use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
         let resolver = IndexSignatureResolver::new(self.ctx.types);
         // Check both original and evaluated types (needed for generic class instances)
         let source_evaluated = self.evaluate_type_with_env(source);

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -182,7 +182,7 @@ impl<'a> CheckerState<'a> {
     /// Map a primitive type to its boxed interface type for property name collection.
     /// Returns `None` if the type is not a primitive or no boxed type is registered.
     fn resolve_primitive_to_boxed_type(&self, type_id: TypeId) -> Option<TypeId> {
-        use tsz_solver::IntrinsicKind;
+        use crate::query_boundaries::common::IntrinsicKind;
         use tsz_solver::def::resolver::TypeResolver;
 
         let kind = if tsz_solver::type_queries::is_string_type(self.ctx.types, type_id)

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -183,7 +183,7 @@ impl<'a> CheckerState<'a> {
     /// Returns `None` if the type is not a primitive or no boxed type is registered.
     fn resolve_primitive_to_boxed_type(&self, type_id: TypeId) -> Option<TypeId> {
         use crate::query_boundaries::common::IntrinsicKind;
-        use tsz_solver::def::resolver::TypeResolver;
+        use crate::query_boundaries::common::TypeResolver;
 
         let kind = if tsz_solver::type_queries::is_string_type(self.ctx.types, type_id)
             || tsz_solver::type_queries::is_string_literal(self.ctx.types, type_id)

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -176,8 +176,8 @@ impl<'a> FlowAnalyzer<'a> {
                     if self.is_access_reference(target) {
                         return None;
                     }
+                    use crate::query_boundaries::common::BinaryOpEvaluator;
                     use crate::query_boundaries::type_computation::core::BinaryOpResult;
-                    use tsz_solver::BinaryOpEvaluator;
 
                     // When node_types is not available, use heuristics for flow narrowing
                     if self.node_types.is_none() {

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -15,7 +15,7 @@ use crate::query_boundaries::flow_analysis::{
 use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{CallSignature, CallableShape, PropertyInfo, TypeId, types::ParamInfo};
+use tsz_solver::{CallSignature, CallableShape, ParamInfo, PropertyInfo, TypeId};
 
 impl<'a> FlowAnalyzer<'a> {
     pub(super) fn assigned_type_for_await_rhs(

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::common::QueryDatabase;
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::flow_analysis as query;
 use crate::query_boundaries::flow_analysis::{tuple_elements_for_type, union_members_for_type};
@@ -12,7 +13,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{GuardSense, ParamInfo, QueryDatabase, TupleElement, TypeId, TypePredicate};
+use tsz_solver::{GuardSense, ParamInfo, TupleElement, TypeId, TypePredicate};
 
 type FlowCache = FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>;
 type ReferenceMatchCache = RefCell<FxHashMap<(u32, u32), bool>>;

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -1,10 +1,11 @@
 //! Type guard extraction for flow-based narrowing (typeof, instanceof,
 //! discriminants, type predicates, Array.isArray, array.every).
 
+use crate::query_boundaries::common::TypeResolver;
 use tsz_parser::parser::node::CallExprData;
 use tsz_parser::parser::{NodeIndex, node_flags, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{SymbolRef, TypeGuard, TypeId, TypeResolver, TypeofKind};
+use tsz_solver::{SymbolRef, TypeGuard, TypeId, TypeofKind};
 
 use crate::state::MAX_TREE_WALK_ITERATIONS;
 

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -470,9 +470,10 @@ impl<'a> CheckerState<'a> {
                             let t_name = &expr[in_idx + "inkeyof".len()..close_bracket];
                             let k_atom = self.ctx.types.intern_string(k_name);
                             if let Some(&t_id) = self.ctx.type_parameter_scope.get(t_name) {
-                                use tsz_solver::{
-                                    FunctionShape, MappedType, ParamInfo, TypeParamInfo,
+                                use crate::query_boundaries::common::{
+                                    FunctionShape, MappedType, ParamInfo,
                                 };
+                                use tsz_solver::TypeParamInfo;
                                 let keyof_t_id = factory.keyof(t_id);
                                 let k_param = TypeParamInfo {
                                     name: k_atom,

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -565,7 +565,7 @@ impl<'a> CheckerState<'a> {
                 return Some(body_type);
             }
 
-            use tsz_solver::instantiate_generic;
+            use crate::query_boundaries::common::instantiate_generic;
             let instantiated =
                 instantiate_generic(self.ctx.types, body_type, &type_params, &type_args);
             return Some(instantiated);
@@ -612,7 +612,7 @@ impl<'a> CheckerState<'a> {
         // Do NOT evaluate here — the caller (jsdoc_satisfies_annotation_with_pos)
         // calls judge_evaluate, which will expand mapped types while preserving
         // Lazy(DefId) references in value positions for correct type name display.
-        use tsz_solver::instantiate_generic;
+        use crate::query_boundaries::common::instantiate_generic;
         let instantiated = instantiate_generic(self.ctx.types, body_type, &type_params, &type_args);
         Some(instantiated)
     }
@@ -1492,7 +1492,7 @@ impl<'a> CheckerState<'a> {
             return Some(body_type);
         }
 
-        use tsz_solver::instantiate_generic;
+        use crate::query_boundaries::common::instantiate_generic;
         let instantiated = instantiate_generic(self.ctx.types, body_type, &type_params, type_args);
         let args_display = type_args
             .iter()

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -140,6 +140,12 @@ impl RelationFlags {
     pub const DISABLE_METHOD_BIVARIANCE: u16 =
         tsz_solver::RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE;
 }
+
+/// Re-export of the solver's relation cache key type.
+///
+/// Used by the assignability checker to construct cache keys for memoizing
+/// subtype and assignability relation results.
+pub(crate) use tsz_solver::RelationCacheKey;
 pub(crate) use tsz_solver::type_queries::{
     AssignabilityEvalKind, ExcessPropertiesKind, get_allowed_keys, get_keyof_type,
     get_string_literal_value, get_union_members, is_keyof_type, is_type_parameter_like,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -492,6 +492,12 @@ pub(crate) fn unwrap_readonly_or_noinfer(db: &dyn TypeDatabase, type_id: TypeId)
     tsz_solver::unwrap_readonly_or_noinfer(db, type_id)
 }
 
+/// Apply a `const` assertion to a type, recursively converting mutable literals
+/// to their `readonly` / literal-preserving forms (e.g. `string[]` → `readonly ["a"]`).
+pub(crate) fn apply_const_assertion(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::widening::apply_const_assertion(db, type_id)
+}
+
 /// Widen a literal type to its base primitive (e.g. `"hello"` → `string`).
 pub(crate) fn widen_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     tsz_solver::widen_type(db, type_id)

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -643,6 +643,23 @@ pub(crate) fn enum_def_id(
     tsz_solver::type_queries::get_enum_def_id(db, type_id)
 }
 
+/// Check whether a mapped type has a `readonly` modifier applied.
+pub(crate) fn is_mapped_type_with_readonly_modifier(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    tsz_solver::operations::property::is_mapped_type_with_readonly_modifier(db, type_id)
+}
+
+/// Check whether a tuple element at a fixed position is readonly.
+pub(crate) fn is_readonly_tuple_fixed_element(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    prop_name: &str,
+) -> bool {
+    tsz_solver::operations::property::is_readonly_tuple_fixed_element(db, type_id, prop_name)
+}
+
 /// Check if a type is a plain object type (properties only, no index signatures).
 ///
 /// Returns `true` for `TypeData::Object` but not `TypeData::ObjectWithIndex`.

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -605,6 +605,12 @@ pub(crate) fn find_property_in_object(
     tsz_solver::type_queries::find_property_in_object(db, type_id, name)
 }
 
+/// Extract the inner type of a `keyof T` type, returning `None` if the type is
+/// not a keyof type.
+pub(crate) fn keyof_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    tsz_solver::keyof_inner_type(db, type_id)
+}
+
 /// Get the enum `DefId` for an enum type.
 pub(crate) fn enum_def_id(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -607,6 +607,14 @@ pub(crate) fn enum_def_id(
     tsz_solver::type_queries::get_enum_def_id(db, type_id)
 }
 
+/// Check if a type is a plain object type (properties only, no index signatures).
+///
+/// Returns `true` for `TypeData::Object` but not `TypeData::ObjectWithIndex`.
+/// Used to choose between `factory.object()` and `factory.object_with_index()`.
+pub(crate) fn is_plain_object_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::object_shape_id(db, type_id).is_some()
+}
+
 /// Get application info (base type + type arguments) for a type application.
 pub(crate) fn application_info(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -611,6 +611,15 @@ pub(crate) fn keyof_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option
     tsz_solver::keyof_inner_type(db, type_id)
 }
 
+/// Substitute `this` type references in `type_id` with `this_type`.
+pub(crate) fn substitute_this_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    this_type: TypeId,
+) -> TypeId {
+    tsz_solver::substitute_this_type(db, type_id, this_type)
+}
+
 /// Get the enum `DefId` for an enum type.
 pub(crate) fn enum_def_id(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -13,6 +13,7 @@ use tsz_solver::{
 // Re-export solver value types used by checker call computation.
 pub(crate) use tsz_solver::ContextualTypeContext;
 pub(crate) use tsz_solver::FunctionShape;
+pub(crate) use tsz_solver::MappedType;
 pub(crate) use tsz_solver::ObjectFlags;
 pub(crate) use tsz_solver::ParamInfo;
 #[allow(unused_imports)]
@@ -609,6 +610,16 @@ pub(crate) fn find_property_in_object(
 /// not a keyof type.
 pub(crate) fn keyof_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::keyof_inner_type(db, type_id)
+}
+
+/// Instantiate a type, returning the result and a flag indicating whether the
+/// depth limit was exceeded during instantiation.
+pub(crate) fn instantiate_type_with_depth_status(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    substitution: &TypeSubstitution,
+) -> (TypeId, bool) {
+    tsz_solver::instantiate_type_with_depth_status(db, type_id, substitution)
 }
 
 /// Substitute `this` type references in `type_id` with `this_type`.

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -13,6 +13,7 @@ use tsz_solver::{
 // Re-export solver value types used by checker call computation.
 pub(crate) use tsz_solver::ContextualTypeContext;
 pub(crate) use tsz_solver::FunctionShape;
+pub(crate) use tsz_solver::IntrinsicKind;
 pub(crate) use tsz_solver::MappedType;
 pub(crate) use tsz_solver::ObjectFlags;
 pub(crate) use tsz_solver::ParamInfo;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -25,6 +25,12 @@ pub(crate) use tsz_solver::TypeInstantiator;
 #[allow(unused_imports)]
 pub(crate) use tsz_solver::TypeInterner;
 
+pub(crate) use tsz_solver::AssignabilityChecker;
+pub(crate) use tsz_solver::IndexKind;
+pub(crate) use tsz_solver::IndexSignatureResolver;
+pub(crate) use tsz_solver::SubtypeFailureReason;
+pub(crate) use tsz_solver::instantiate_generic;
+pub(crate) use tsz_solver::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::type_queries::TypeTraversalKind;
 
 /// Re-export of the solver's property access result type.

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -26,9 +26,13 @@ pub(crate) use tsz_solver::TypeInstantiator;
 pub(crate) use tsz_solver::TypeInterner;
 
 pub(crate) use tsz_solver::AssignabilityChecker;
+pub(crate) use tsz_solver::BinaryOpEvaluator;
 pub(crate) use tsz_solver::IndexKind;
 pub(crate) use tsz_solver::IndexSignatureResolver;
+pub(crate) use tsz_solver::QueryDatabase;
 pub(crate) use tsz_solver::SubtypeFailureReason;
+pub(crate) use tsz_solver::TypeEnvironment;
+pub(crate) use tsz_solver::TypeResolver;
 pub(crate) use tsz_solver::instantiate_generic;
 pub(crate) use tsz_solver::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::type_queries::TypeTraversalKind;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -17,6 +17,7 @@ pub(crate) use tsz_solver::IntrinsicKind;
 pub(crate) use tsz_solver::MappedType;
 pub(crate) use tsz_solver::ObjectFlags;
 pub(crate) use tsz_solver::ParamInfo;
+pub(crate) use tsz_solver::PendingDiagnostic;
 pub(crate) use tsz_solver::PendingDiagnosticBuilder;
 pub(crate) use tsz_solver::SourceLocation;
 pub(crate) use tsz_solver::TypeFormatter;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -16,6 +16,10 @@ pub(crate) use tsz_solver::FunctionShape;
 pub(crate) use tsz_solver::MappedType;
 pub(crate) use tsz_solver::ObjectFlags;
 pub(crate) use tsz_solver::ParamInfo;
+pub(crate) use tsz_solver::PendingDiagnosticBuilder;
+pub(crate) use tsz_solver::SourceLocation;
+pub(crate) use tsz_solver::TypeFormatter;
+pub(crate) use tsz_solver::TypeInstantiator;
 #[allow(unused_imports)]
 pub(crate) use tsz_solver::TypeInterner;
 

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -92,12 +92,13 @@
 
 use crate::CheckerContext;
 use crate::context::{CheckerOptions, RequestCacheKey, TypingRequest};
+use crate::query_boundaries::common::QueryDatabase;
 use tsz_binder::BinderState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{QueryDatabase, TypeId};
+use tsz_solver::TypeId;
 
 thread_local! {
     /// Shared depth counter for all cross-arena delegation points.

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -97,7 +97,7 @@ use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{QueryDatabase, TypeId, substitute_this_type};
+use tsz_solver::{QueryDatabase, TypeId};
 
 thread_local! {
     /// Shared depth counter for all cross-arena delegation points.
@@ -620,12 +620,20 @@ impl<'a> CheckerState<'a> {
         if let Some(access) = self.ctx.arena.get_access_expr(node) {
             let receiver_type = self.get_type_of_node(access.expression);
             if receiver_type != TypeId::ERROR && receiver_type != TypeId::ANY {
-                return substitute_this_type(self.ctx.types, return_type, receiver_type);
+                return crate::query_boundaries::common::substitute_this_type(
+                    self.ctx.types,
+                    return_type,
+                    receiver_type,
+                );
             }
             if let Some(receiver_sym) = self.resolve_identifier_symbol(access.expression) {
                 let receiver_type = self.get_type_of_symbol(receiver_sym);
                 if receiver_type != TypeId::ERROR && receiver_type != TypeId::ANY {
-                    return substitute_this_type(self.ctx.types, return_type, receiver_type);
+                    return crate::query_boundaries::common::substitute_this_type(
+                        self.ctx.types,
+                        return_type,
+                        receiver_type,
+                    );
                 }
             }
         }

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
                         index_type,
                     ) {
                         use crate::query_boundaries::common::PropertyAccessResult;
-                        use tsz_solver::operations::property::is_readonly_tuple_fixed_element;
+                        use crate::query_boundaries::common::is_readonly_tuple_fixed_element;
                         let from_idx_sig = if name == "index signature" {
                             true
                         } else if is_readonly_tuple_fixed_element(
@@ -327,7 +327,7 @@ impl<'a> CheckerState<'a> {
                         // `readonly [number, number, ...number[]]`) are named properties
                         // even though resolve_array_property reports from_index_signature.
                         use crate::query_boundaries::common::PropertyAccessResult;
-                        use tsz_solver::operations::property::is_readonly_tuple_fixed_element;
+                        use crate::query_boundaries::common::is_readonly_tuple_fixed_element;
                         let from_idx_sig = if name == "index signature" {
                             true
                         } else if is_readonly_tuple_fixed_element(
@@ -1118,7 +1118,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn is_readonly_mapped_type(&mut self, type_id: TypeId) -> bool {
-        use tsz_solver::operations::property::is_mapped_type_with_readonly_modifier;
+        use crate::query_boundaries::common::is_mapped_type_with_readonly_modifier;
 
         // First try the direct solver query (handles Mapped, Application, Lazy)
         if is_mapped_type_with_readonly_modifier(self.ctx.types, type_id) {

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -592,7 +592,7 @@ impl<'a> CheckerState<'a> {
     /// - The constraint has no index signature (e.g., `{ a: string, b: number }`)
     fn is_generic_indexed_write(&mut self, object_type: TypeId, index_type: TypeId) -> bool {
         use crate::query_boundaries::common as common_query;
-        use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
 
         // Broad primitive keys definitely go through an index-signature-like path.
         if !self.is_broad_index_type(index_type) {
@@ -632,7 +632,7 @@ impl<'a> CheckerState<'a> {
     /// Evaluates the constraint through `TypeEnvironment` first to resolve
     /// Application/Lazy wrappers (e.g., `Record<string, any>` → `{ [key: string]: any }`).
     fn constraint_has_index_signature(&mut self, type_param: TypeId, index_type: TypeId) -> bool {
-        use tsz_solver::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
 
         let Some(info) =
             crate::query_boundaries::common::type_param_info(self.ctx.types, type_param)

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -4,10 +4,11 @@
 //! see [`super::overload_compatibility`].
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{ContextualTypeContext, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     fn contextual_class_member_type_from_request(

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -6,9 +6,9 @@ use crate::query_boundaries::common::{
     self as common, ContextualLiteralAllowKind, TypeTraversalKind, are_same_base_literal_kind,
     classify_for_contextual_literal, classify_for_traversal, contains_type_parameters,
     index_access_types, intersection_members, is_conditional_type, is_index_access_type,
-    is_keyof_type, is_this_type, lazy_def_id, mapped_type_info, number_literal_value,
-    object_shape_for_type, string_literal_value, type_application, type_parameter_constraint,
-    union_members,
+    is_keyof_type, is_this_type, keyof_inner_type, lazy_def_id, mapped_type_info,
+    number_literal_value, object_shape_for_type, string_literal_value, type_application,
+    type_parameter_constraint, union_members,
 };
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -18,7 +18,6 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::keyof_inner_type;
 
 impl<'a> CheckerState<'a> {
     fn raw_contextual_signature_available(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1,6 +1,7 @@
 //! Core type environment building, application type evaluation, and
 //! property access type resolution.
 
+use crate::query_boundaries::common::SourceLocation;
 use crate::query_boundaries::state::type_environment as query;
 use crate::state::{CheckerState, EnumKind, MAX_INSTANTIATION_DEPTH};
 use rustc_hash::FxHashSet;
@@ -9,7 +10,6 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::MappedTypeId;
-use tsz_solver::SourceLocation;
 use tsz_solver::TypeId;
 use tsz_solver::Visibility;
 use tsz_solver::{CallSignature, CallableShape, ParamInfo};

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -355,8 +355,9 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn evaluate_application_type_inner(&mut self, type_id: TypeId) -> TypeId {
-        use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
-        use tsz_solver::instantiate_type_with_depth_status;
+        use crate::query_boundaries::common::{
+            TypeSubstitution, instantiate_type, instantiate_type_with_depth_status,
+        };
 
         let Some((base, args)) = query::application_info(self.ctx.types, type_id) else {
             return type_id;

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -410,7 +410,7 @@ impl<'a> CheckerState<'a> {
                         // `{}`-shaped anonymous type (e.g. `Record<string, unknown>`
                         // members inside recursive mapped types), causing quadratic
                         // blow-up on patterns like `Definition<T[K]>`.
-                        use tsz_solver::IntrinsicKind;
+                        use crate::query_boundaries::common::IntrinsicKind;
                         let db = self.ctx.types.as_type_database();
                         if db.is_boxed_def_id(def_id, IntrinsicKind::Function) {
                             return type_id;

--- a/crates/tsz-checker/src/state/type_resolution/judge.rs
+++ b/crates/tsz-checker/src/state/type_resolution/judge.rs
@@ -2,9 +2,9 @@
 //!
 //! Provides integration between the Checker and the Solver's Judge trait.
 
+use crate::query_boundaries::common::{DefaultJudge, Judge, JudgeConfig};
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
-use tsz_solver::judge::{DefaultJudge, Judge, JudgeConfig};
 
 impl<'a> CheckerState<'a> {
     /// Execute a closure with a configured Judge instance.

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -297,7 +297,7 @@ impl<'a> CheckerState<'a> {
         _name: &str,
     ) -> Option<TypeId> {
         use crate::module_resolution::module_specifier_candidates;
-        use tsz_solver::operations::property::PropertyAccessResult;
+        use crate::query_boundaries::common::PropertyAccessResult;
 
         // Find the original import alias symbol by name in file_locals.
         // We can't use resolve_identifier because it resolves through

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1794,8 +1794,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "judge::JudgeConfig",
         "objects::index_signatures::IndexKind",
         "objects::index_signatures::IndexSignatureResolver",
-        "operations::property::is_mapped_type_with_readonly_modifier",
-        "operations::property::is_readonly_tuple_fixed_element",
     ];
 
     fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
@@ -3795,7 +3793,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 19 items. This number must only decrease over time.
+/// Current ceiling: 17 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3825,7 +3823,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 19;
+    const CEILING: usize = 17;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1779,7 +1779,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         // TODO: Computation APIs — need query_boundaries wrappers
         "AssignabilityChecker",
         "BinaryOpEvaluator",
-        "CallResult",
         "IndexSignatureResolver",
         "IntrinsicKind",
         "PendingDiagnostic",
@@ -1795,8 +1794,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "judge::JudgeConfig",
         "objects::index_signatures::IndexKind",
         "objects::index_signatures::IndexSignatureResolver",
-        "operations::CallResult",
-        "operations::property::PropertyAccessResult",
         "operations::property::is_mapped_type_with_readonly_modifier",
         "operations::property::is_readonly_tuple_fixed_element",
     ];
@@ -3798,7 +3795,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 22 items. This number must only decrease over time.
+/// Current ceiling: 19 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3828,7 +3825,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 22;
+    const CEILING: usize = 19;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1800,7 +1800,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "judge::DefaultJudge",
         "judge::Judge",
         "judge::JudgeConfig",
-        "lazy_def_id",
         "objects::index_signatures::IndexKind",
         "objects::index_signatures::IndexSignatureResolver",
         "operations::CallResult",
@@ -3808,7 +3807,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 32 items. This number must only decrease over time.
+/// Current ceiling: 31 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3838,7 +3837,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 32;
+    const CEILING: usize = 31;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1780,9 +1780,7 @@ fn test_solver_imports_go_through_query_boundaries() {
         "AssignabilityChecker",
         "BinaryOpEvaluator",
         "IndexSignatureResolver",
-        "PendingDiagnostic",
         "QueryDatabase",
-        "RelationCacheKey",
         "SubtypeFailureReason",
         "TypeEnvironment",
         "TypeResolver",
@@ -3792,7 +3790,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 16 items. This number must only decrease over time.
+/// Current ceiling: 14 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3822,7 +3820,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 16;
+    const CEILING: usize = 14;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1777,20 +1777,11 @@ fn test_solver_imports_go_through_query_boundaries() {
     // remove the entry and let the test enforce the boundary.
     const TEMPORARILY_ALLOWED: &[&str] = &[
         // TODO: Computation APIs — need query_boundaries wrappers
-        "AssignabilityChecker",
         "BinaryOpEvaluator",
-        "IndexSignatureResolver",
         "QueryDatabase",
-        "SubtypeFailureReason",
         "TypeEnvironment",
         "TypeResolver",
         "def::resolver::TypeResolver",
-        "instantiate_generic",
-        "judge::DefaultJudge",
-        "judge::Judge",
-        "judge::JudgeConfig",
-        "objects::index_signatures::IndexKind",
-        "objects::index_signatures::IndexSignatureResolver",
     ];
 
     fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
@@ -3790,7 +3781,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 14 items. This number must only decrease over time.
+/// Current ceiling: 5 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3820,7 +3811,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 14;
+    const CEILING: usize = 5;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1780,7 +1780,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "AssignabilityChecker",
         "BinaryOpEvaluator",
         "CallResult",
-        "ContextualTypeContext",
         "IndexSignatureResolver",
         "IntrinsicKind",
         "PendingDiagnostic",
@@ -1800,7 +1799,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "operations::property::PropertyAccessResult",
         "operations::property::is_mapped_type_with_readonly_modifier",
         "operations::property::is_readonly_tuple_fixed_element",
-        "types::ParamInfo",
     ];
 
     fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
@@ -3800,7 +3798,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 24 items. This number must only decrease over time.
+/// Current ceiling: 22 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3830,7 +3828,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 24;
+    const CEILING: usize = 22;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1810,7 +1810,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "operations::property::is_readonly_tuple_fixed_element",
         "substitute_this_type",
         "types::ParamInfo",
-        "widening::apply_const_assertion",
     ];
 
     fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
@@ -3810,7 +3809,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 34 items. This number must only decrease over time.
+/// Current ceiling: 33 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3840,7 +3839,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 34;
+    const CEILING: usize = 33;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1777,10 +1777,7 @@ fn test_solver_imports_go_through_query_boundaries() {
     // remove the entry and let the test enforce the boundary.
     const TEMPORARILY_ALLOWED: &[&str] = &[
         // TODO: Computation APIs — need query_boundaries wrappers
-        "ApplicationEvaluator",
         "AssignabilityChecker",
-        "TypeData",
-        "as_type_database",
         "BinaryOpEvaluator",
         "CallResult",
         "ContextualTypeContext",
@@ -1794,11 +1791,9 @@ fn test_solver_imports_go_through_query_boundaries() {
         "SourceLocation",
         "SubtypeFailureReason",
         "TypeEnvironment",
-        "TypeEvaluator",
         "TypeFormatter",
         "TypeInstantiator",
         "TypeResolver",
-        "TypeSubstitution",
         "def::resolver::TypeResolver",
         "instantiate_generic",
         "instantiate_type_with_depth_status",
@@ -1810,12 +1805,10 @@ fn test_solver_imports_go_through_query_boundaries() {
         "objects::index_signatures::IndexKind",
         "objects::index_signatures::IndexSignatureResolver",
         "operations::CallResult",
-        "operations::property::PropertyAccessEvaluator",
         "operations::property::PropertyAccessResult",
         "operations::property::is_mapped_type_with_readonly_modifier",
         "operations::property::is_readonly_tuple_fixed_element",
         "substitute_this_type",
-        "type_param_info",
         "types::ParamInfo",
         "widening::apply_const_assertion",
     ];
@@ -3817,7 +3810,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 44 items. This number must only decrease over time.
+/// Current ceiling: 34 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3847,7 +3840,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 41;
+    const CEILING: usize = 34;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1806,7 +1806,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "operations::property::PropertyAccessResult",
         "operations::property::is_mapped_type_with_readonly_modifier",
         "operations::property::is_readonly_tuple_fixed_element",
-        "substitute_this_type",
         "types::ParamInfo",
     ];
 
@@ -3807,7 +3806,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 31 items. This number must only decrease over time.
+/// Current ceiling: 30 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3837,7 +3836,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 31;
+    const CEILING: usize = 30;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1800,7 +1800,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "judge::DefaultJudge",
         "judge::Judge",
         "judge::JudgeConfig",
-        "keyof_inner_type",
         "lazy_def_id",
         "objects::index_signatures::IndexKind",
         "objects::index_signatures::IndexSignatureResolver",
@@ -3809,7 +3808,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 33 items. This number must only decrease over time.
+/// Current ceiling: 32 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3839,7 +3838,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 33;
+    const CEILING: usize = 32;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1780,7 +1780,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "AssignabilityChecker",
         "BinaryOpEvaluator",
         "IndexSignatureResolver",
-        "IntrinsicKind",
         "PendingDiagnostic",
         "QueryDatabase",
         "RelationCacheKey",
@@ -3793,7 +3792,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 17 items. This number must only decrease over time.
+/// Current ceiling: 16 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3823,7 +3822,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 17;
+    const CEILING: usize = 16;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1784,14 +1784,10 @@ fn test_solver_imports_go_through_query_boundaries() {
         "IndexSignatureResolver",
         "IntrinsicKind",
         "PendingDiagnostic",
-        "PendingDiagnosticBuilder",
         "QueryDatabase",
         "RelationCacheKey",
-        "SourceLocation",
         "SubtypeFailureReason",
         "TypeEnvironment",
-        "TypeFormatter",
-        "TypeInstantiator",
         "TypeResolver",
         "def::resolver::TypeResolver",
         "instantiate_generic",
@@ -3804,7 +3800,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 28 items. This number must only decrease over time.
+/// Current ceiling: 24 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3834,7 +3830,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 28;
+    const CEILING: usize = 24;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1783,7 +1783,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "ContextualTypeContext",
         "IndexSignatureResolver",
         "IntrinsicKind",
-        "MappedType",
         "PendingDiagnostic",
         "PendingDiagnosticBuilder",
         "QueryDatabase",
@@ -1796,7 +1795,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "TypeResolver",
         "def::resolver::TypeResolver",
         "instantiate_generic",
-        "instantiate_type_with_depth_status",
         "judge::DefaultJudge",
         "judge::Judge",
         "judge::JudgeConfig",
@@ -3806,7 +3804,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 30 items. This number must only decrease over time.
+/// Current ceiling: 28 items. This number must only decrease over time.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3836,7 +3834,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 30;
+    const CEILING: usize = 28;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1776,12 +1776,7 @@ fn test_solver_imports_go_through_query_boundaries() {
     // Each entry is (item, list of files using it). When a wrapper is created,
     // remove the entry and let the test enforce the boundary.
     const TEMPORARILY_ALLOWED: &[&str] = &[
-        // TODO: Computation APIs — need query_boundaries wrappers
-        "BinaryOpEvaluator",
-        "QueryDatabase",
-        "TypeEnvironment",
-        "TypeResolver",
-        "def::resolver::TypeResolver",
+        // All solver imports now go through query_boundaries — list is empty.
     ];
 
     fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
@@ -3781,7 +3776,7 @@ fn test_shared_def_store_propagated_through_cache_constructor() {
 /// they should remove it from `TEMPORARILY_ALLOWED`, shrinking the count.
 /// Adding new bypasses requires updating this ceiling (which reviewers will see).
 ///
-/// Current ceiling: 5 items. This number must only decrease over time.
+/// Current ceiling: 0 items — the bypass list is empty.
 #[test]
 fn test_temporarily_allowed_bypass_list_does_not_grow() {
     // The authoritative list lives in test_solver_imports_go_through_query_boundaries.
@@ -3811,7 +3806,7 @@ fn test_temporarily_allowed_bypass_list_does_not_grow() {
         }
     }
 
-    const CEILING: usize = 5;
+    const CEILING: usize = 0;
     assert!(
         count <= CEILING,
         "TEMPORARILY_ALLOWED bypass list has grown to {count} items (ceiling: {CEILING}). \

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -11,8 +11,8 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::visitor::is_template_literal_type;
 use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate, Visibility, types::ParamInfo,
+    CallSignature, CallableShape, IndexSignature, ParamInfo, PropertyInfo, TypeId, TypeParamInfo,
+    TypePredicate, Visibility,
 };
 
 use super::can_skip_base_instantiation;

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -2,7 +2,7 @@
 
 use crate::context::TypingRequest;
 use crate::query_boundaries::class_type::{callable_shape_for_type, construct_signatures_for_type};
-use crate::query_boundaries::common::instantiate_type;
+use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
@@ -12,7 +12,7 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::visitor::is_template_literal_type;
 use tsz_solver::{
     CallSignature, CallableShape, IndexSignature, PropertyInfo, TypeId, TypeParamInfo,
-    TypePredicate, TypeSubstitution, Visibility, types::ParamInfo,
+    TypePredicate, Visibility, types::ParamInfo,
 };
 
 use super::can_skip_base_instantiation;

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -2,7 +2,9 @@
 
 use crate::context::{EnclosingClassInfo, is_js_file_name};
 use crate::query_boundaries::class_type::{callable_shape_for_type, object_shape_for_type};
-use crate::query_boundaries::common::{ObjectFlags, TypeSubstitution, instantiate_type};
+use crate::query_boundaries::common::{
+    ObjectFlags, TypeSubstitution, instantiate_type, is_plain_object_type,
+};
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_binder::SymbolId;
@@ -13,8 +15,8 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::visitor::is_template_literal_type;
 use tsz_solver::{
-    CallSignature, CallableShape, IndexSignature, ObjectShape, PropertyInfo, TypeData, TypeId,
-    TypeParamInfo, Visibility,
+    CallSignature, CallableShape, IndexSignature, ObjectShape, PropertyInfo, TypeId, TypeParamInfo,
+    Visibility,
 };
 
 /// Bookkeeping record for a single type parameter pushed into
@@ -2151,11 +2153,13 @@ impl<'a> CheckerState<'a> {
             ..ObjectShape::default()
         };
 
-        match self.ctx.types.lookup(instance_type) {
-            Some(TypeData::Object(_)) if string_index.is_none() && number_index.is_none() => {
-                factory.object(shape.properties)
-            }
-            _ => factory.object_with_index(shape),
+        if is_plain_object_type(self.ctx.types, instance_type)
+            && string_index.is_none()
+            && number_index.is_none()
+        {
+            factory.object(shape.properties)
+        } else {
+            factory.object_with_index(shape)
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -98,7 +98,7 @@ impl<'a> CheckerState<'a> {
             // NOTE: Resolve through Lazy(DefId) first so Record<string,T> becomes an
             // ObjectWithIndex shape that the IndexSignatureResolver can inspect.
             {
-                use tsz_solver::IndexSignatureResolver;
+                use crate::query_boundaries::common::IndexSignatureResolver;
                 let resolved = self.resolve_lazy_type(member);
                 let resolved = self.evaluate_type_with_env(resolved);
                 let resolver = IndexSignatureResolver::new(self.ctx.types);

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -5,11 +5,12 @@
 //! to keep module sizes manageable.
 
 use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_computation::core as expr_ops;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{ContextualTypeContext, TupleElement, TypeId};
+use tsz_solver::{TupleElement, TypeId};
 
 impl<'a> CheckerState<'a> {
     fn promise_like_array_context_shape(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -3,11 +3,12 @@
 //! arithmetic, comparison, logical, assignment, nullish coalescing, and comma.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::common::BinaryOpEvaluator;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{BinaryOpEvaluator, TypeId};
+use tsz_solver::TypeId;
 
 /// Result of syntactic nullishness analysis, mirroring tsc's `PredicateSemantics`.
 /// This is a purely syntactic check -- it does NOT look at types.
@@ -510,9 +511,9 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         request: &TypingRequest,
     ) -> TypeId {
+        use crate::query_boundaries::common::BinaryOpEvaluator;
         use crate::query_boundaries::type_computation::core::BinaryOpResult;
         use tsz_scanner::SyntaxKind;
-        use tsz_solver::BinaryOpEvaluator;
         let factory = self.ctx.types.factory();
 
         // Hot path: pure `+` chains with stable primitive operands are common in

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -6,11 +6,12 @@
 use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use tracing::trace;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{ContextualTypeContext, TypeId};
+use tsz_solver::TypeId;
 
 // Re-export for backwards compatibility with existing imports
 pub(crate) use super::contextual::{

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -635,7 +635,7 @@ impl<'a> CheckerState<'a> {
                 let mut arithmetic_ok = true;
 
                 {
-                    use tsz_solver::BinaryOpEvaluator;
+                    use crate::query_boundaries::common::BinaryOpEvaluator;
                     let evaluator = BinaryOpEvaluator::new(self.ctx.types);
                     let (non_nullish, nullish_cause) = self.split_nullish_type(operand_type);
                     let nullish_can_flow_to_number = non_nullish.is_none_or(|ty| {

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -1233,7 +1233,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     // No narrowing or error - check if we should preserve declared_type
                     let has_index_sig = {
-                        use tsz_solver::{IndexKind, IndexSignatureResolver};
+                        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
                         let resolver = IndexSignatureResolver::new(self.ctx.types);
                         resolver.has_index_signature(declared_type, IndexKind::String)
                             || resolver.has_index_signature(declared_type, IndexKind::Number)
@@ -1318,7 +1318,7 @@ impl<'a> CheckerState<'a> {
                 // This prevents false-positive TS2339 errors when accessing properties via
                 // index signatures.
                 let has_index_sig = {
-                    use tsz_solver::{IndexKind, IndexSignatureResolver};
+                    use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
                     let resolver = IndexSignatureResolver::new(self.ctx.types);
                     resolver.has_index_signature(declared_type, IndexKind::String)
                         || resolver.has_index_signature(declared_type, IndexKind::Number)

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -2280,7 +2280,7 @@ impl<'a> CheckerState<'a> {
                         // These are collected separately and only included in the final type
                         // when the literal has no explicit (non-spread) properties, matching tsc.
                         {
-                            use tsz_solver::IndexSignatureResolver;
+                            use crate::query_boundaries::common::IndexSignatureResolver;
                             let resolver = IndexSignatureResolver::new(self.ctx.types);
                             if let Some(string_index_value) =
                                 resolver.resolve_string_index(resolved_spread)

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -155,7 +155,7 @@ impl<'a> CheckerState<'a> {
         // Check for ThisType<T> marker in contextual type (Vue 2 / Options API pattern)
         // We need to extract this BEFORE the for loop so it's available for the pop at the end
         let marker_this_type: Option<TypeId> = if let Some(ctx_type) = contextual_type {
-            use tsz_solver::ContextualTypeContext;
+            use crate::query_boundaries::common::ContextualTypeContext;
             let ctx_helper = ContextualTypeContext::with_expected_and_options(
                 self.ctx.types,
                 ctx_type,

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -303,7 +303,7 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::assignability::{
             ExcessPropertiesKind, classify_for_excess_properties,
         };
-        use tsz_solver::operations::property::PropertyAccessResult;
+        use crate::query_boundaries::common::PropertyAccessResult;
 
         let evaluated = self.evaluate_type_with_env(type_id);
         let evaluated = self.resolve_lazy_type(evaluated);

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -8,10 +8,11 @@ use super::complex::is_contextually_sensitive;
 use crate::context::TypingRequest;
 use crate::query_boundaries::assignability::contains_type_parameters;
 use crate::query_boundaries::checkers::call as call_checker;
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{ContextualTypeContext, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     /// Get the type of a tagged template expression (e.g., tag`hello ${x}`).

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -7,12 +7,13 @@ use crate::computation::complex::{
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationGuard;
 use crate::diagnostics::format_message;
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_checking_utilities as type_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ContextualTypeContext, TypeId, TypeParamInfo};
+use tsz_solver::{TypeId, TypeParamInfo};
 impl<'a> CheckerState<'a> {
     fn is_jsx_body_child_closure(&self, func_idx: NodeIndex) -> bool {
         let mut current = func_idx;

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -29,8 +29,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         name: &str,
     ) -> (Option<TypeId>, Vec<TypeParamInfo>) {
-        use crate::query_boundaries::common::TypeSubstitution;
-        use tsz_solver::TypeInstantiator;
+        use crate::query_boundaries::common::{TypeInstantiator, TypeSubstitution};
 
         let factory = self.ctx.types.factory();
         let lib_contexts = &*self.ctx.lib_contexts;

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -102,7 +102,7 @@ impl<'a> CheckerState<'a> {
     /// hardcoded lists. For example, "foo".length will look up the String interface
     /// from lib.d.ts and find the length property there.
     pub(crate) fn register_boxed_types(&mut self) {
-        use tsz_solver::IntrinsicKind;
+        use crate::query_boundaries::common::IntrinsicKind;
 
         // Only register if lib files are loaded
         if !self.ctx.has_lib_loaded() {
@@ -415,7 +415,7 @@ impl<'a> CheckerState<'a> {
     /// identify the Function interface. Only registers Function to minimize
     /// side effects on DefId creation ordering.
     pub(crate) fn register_function_def_ids_early(&mut self) {
-        use tsz_solver::IntrinsicKind;
+        use crate::query_boundaries::common::IntrinsicKind;
 
         if !self.ctx.has_lib_loaded() {
             return;

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -321,7 +321,7 @@ impl<'a> CheckerState<'a> {
                                     if let Some(func_type) =
                                         self.jsdoc_type_annotation_for_node(current2)
                                     {
-                                        use tsz_solver::ContextualTypeContext;
+                                        use crate::query_boundaries::common::ContextualTypeContext;
                                         let evaluated = self.evaluate_contextual_type(func_type);
                                         let ctx_helper = ContextualTypeContext::with_expected(
                                             self.ctx.types,

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -596,9 +596,9 @@ impl<'a> CheckerState<'a> {
     /// as the instance type, not be converted to the constructor type.
     pub(crate) fn resolve_lazy_class_to_constructor(&self, type_id: TypeId) -> TypeId {
         use tsz_solver::SymbolRef;
-        use tsz_solver::lazy_def_id;
 
-        let Some(def_id) = lazy_def_id(self.ctx.types, type_id) else {
+        let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id)
+        else {
             return type_id;
         };
 


### PR DESCRIPTION
## Summary

- Removed all 41 entries from `TEMPORARILY_ALLOWED` in the architecture contract test
- Re-exported each solver type/function through `query_boundaries/common.rs` or `query_boundaries/assignability.rs`
- Lowered the bypass-list ceiling ratchet from 41 → 0
- All checker tests pass (5523/5524; 1 pre-existing LOC limit failure unrelated)

## Types/functions now mediated through `query_boundaries`

| Item | Where re-exported |
|------|-------------------|
| `TypeData`, `TypeSubstitution`, `ParamInfo` | `common.rs` |
| `ContextualTypeContext`, `CallResult`, `MappedType` | `common.rs` |
| `IntrinsicKind`, `SourceLocation`, `TypeFormatter` | `common.rs` |
| `TypeInstantiator`, `PendingDiagnostic`, `PendingDiagnosticBuilder` | `common.rs` |
| `AssignabilityChecker`, `SubtypeFailureReason` | `common.rs` |
| `BinaryOpEvaluator`, `QueryDatabase`, `TypeEnvironment`, `TypeResolver` | `common.rs` |
| `IndexKind`, `IndexSignatureResolver` | `common.rs` |
| `instantiate_generic` | `common.rs` |
| `judge::{DefaultJudge, Judge, JudgeConfig}` | `common.rs` |
| `RelationCacheKey` | `assignability.rs` |
| Various function wrappers | `common.rs` |

## Test plan

- [x] `test_solver_imports_go_through_query_boundaries` passes
- [x] `test_temporarily_allowed_bypass_list_does_not_grow` passes (ceiling = 0)
- [x] Full `cargo nextest run -p tsz-checker`: 5523/5524 (1 pre-existing failure)