### PR TITLE
fourslash(adapter): enumerate scriptInfos for full fixture visibility

### DIFF
--- a/scripts/fourslash/tsz-adapter.cjs
+++ b/scripts/fourslash/tsz-adapter.cjs
@@ -409,7 +409,23 @@ function createTszAdapterFactory(ts, Harness, SessionClient, bridge) {
 
                 openKnownFile(fileName, content, scriptKindName);
                 openAncestorConfigs(fileName);
-                for (const path of this.getFilenames()) {
+                // `getFilenames()` restricts to root scripts (isRootFile=true),
+                // which skips fixture files under node_modules even though
+                // fourslash registered them. Enumerate scriptInfos directly so
+                // tsz-server sees the full test virtual FS.
+                const trackedScriptFiles = (() => {
+                    if (typeof this.scriptInfos?.forEach === "function") {
+                        const names = [];
+                        this.scriptInfos.forEach((info) => {
+                            if (info && typeof info.fileName === "string") {
+                                names.push(info.fileName);
+                            }
+                        });
+                        return names;
+                    }
+                    return this.getFilenames();
+                })();
+                for (const path of trackedScriptFiles) {
                     if (!shouldTrackForServer(path)) continue;
                     openKnownFile(path, /*fileContent*/ undefined, /*kindName*/ undefined);
                     openAncestorConfigs(path);


### PR DESCRIPTION
## Summary

One plumbing cleanup in the fourslash adapter, plus a session-summary of the 50-test campaign that's already landed on `main`, and debugging findings on why cluster A can't cleanly flip without collateral.

### This PR

`scripts/fourslash/tsz-adapter.cjs`: `TszClientHost.openFile` was enumerating `this.getFilenames()`, which returns only root scripts (`isRootFile=true`). Fourslash test fixtures that register files under `/node_modules/**` via `@Filename:` pragmas are NOT root, so the adapter silently skipped forwarding them to tsz-server. Switching to `this.scriptInfos` gets every fixture file visible to the server side.

No test-count change in the current snapshot (6,525 / 6,562); plumbing groundwork only.

### Cluster A investigation (not in this PR, but learned here)

Traced why `autoImportProvider_exportMap*` and `_wildcardExports*` still fail even though node_modules fixture files now reach tsz-server. **tsz-server itself DOES return the correct entries.** A trace at `project_completion_items` and `handle_completions` confirms:

```
=== handle_completions entries count=111 ===
  {"name":"fooFromIndex",...,"source":"dependency","data":{"exportName":"fooFromIndex","exportMapKey":"tsz::dependency::fooFromIndex::fooFromIndex"}}
  {"name":"fooFromLol",...,"source":"dependency/lol",...}
```

The problem is in the test harness, not tsz-server. `scripts/fourslash/test-worker.cjs` still has its own copy of `getNativeLanguageService` (independent from the one in `runner.cjs` that was neutralized earlier). It instantiates a real TypeScript `ts.createLanguageService` alongside every test, and when native returns any entries at all, the override at `test-worker.cjs:~1569` does `return ensureMergedReExportConfigEntry(nativeResult)` — throwing away tsz's correct answer.

Attempted two fixes, both rejected:

1. **Neutralize test-worker's native LS too** (same as runner.cjs was). Regression: **2,519 tests** (6,525 → 4,006, 99.4% → 61%). Many fourslash tests tolerate tsz bugs because the harness silently substitutes native's correct output. Not safe.

2. **Merge tsz's auto-import entries into nativeResult** when they're missing. Flips 10 cluster A tests (`exportMap1/2/3/5/6/7/8`, `globalTypingsCache`, `namespaceSameNameAsIntrinsic`, `wildcardExports2`) but exposes **21 real tsz bugs** in other tests (`completionsImport_duplicatePackages_*`, `completionListForExportEquals*`, `completionsImport_ambient`, etc.) — net -11. Those 21 are pre-existing tsz bugs being masked by native-LS replacement; fixing them is a separate workstream.

### Recommendation

The cleanest path to cluster A wins is to **fix the underlying tsz bugs** first (duplicate package resolution, ambient module handling, export-equals completions), so the merge-tsz-entries approach stops exposing regressions. Alternatively, progressively narrow the cases where native-LS replacement fires (e.g. only replace when tsz returned empty).

### Session context (already on main)

Across several commits over the prior session:

| Commit | Cluster | Flips |
|---|---|---|
| `c080825e45` | D+E — root-workspace filter; allowTsExtensions codeActions; type-only/default-export codefix dispatch | +8 |
| `afd2e79d62` | F — projectInfo file list (libs + tsconfig.files + config); separate lib state from type-check path | +4 |
| `bb78ea5d6d` | G — JSX text content completion suppression; non-generic type-arg string suppression | +1 |

Honest fourslash pass rate went **6,502 → 6,525** (+23 tests, -10 timeouts), while *removing* harness cheats (native LS fallback in runner.cjs, per-test hardcoded completion patches, test-file-specific codefix filters).

### Test plan

- [ ] `scripts/fourslash/run-fourslash.sh --json-out=...` — no net regression (still 6,525 / 6,562).
- [ ] `cargo check -p tsz-cli -p tsz-lsp` green.
- [ ] `cargo nextest run -p tsz-lsp` — no new unit-test failures.

### Remaining

- **Cluster A (15 tests):** blocked on fixing pre-existing tsz bugs exposed by merge-tsz-entries.
- **Cluster B+C (17 tests):** cross-project `paths`/symlinks/pnpm; needs full-candidate enumerator + tsserver-parity comparator in `module_specifiers.rs`.
- **Residual (~5):** `stringLiteralType…` (harness empty→undefined quirk), one or two leaves.