### PR TITLE
fix(checker): preserve user function overloads shadowing lib globals

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -161,6 +161,29 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // When the user re-declares a lib global function, keep the user's overloads in scope
+        // (delegating to the lib arena would drop them and mis-resolve calls).
+        {
+            let sym_found = self.get_symbol_globally(sym_id);
+            if let Some(symbol) = sym_found
+                && (symbol.flags & symbol_flags::FUNCTION) != 0
+                && (symbol.flags
+                    & (symbol_flags::CLASS | symbol_flags::INTERFACE | symbol_flags::ALIAS))
+                    == 0
+            {
+                let has_function_in_current_arena = symbol.declarations.iter().any(|&d| {
+                    self.ctx
+                        .arena
+                        .get(d)
+                        .and_then(|n| self.ctx.arena.get_function(n))
+                        .is_some()
+                });
+                if has_function_in_current_arena {
+                    return None; // Handle locally, don't delegate to lib arena
+                }
+            }
+        }
+
         let is_known_cross_file = self.ctx.has_symbol_file_index(sym_id);
 
         if !is_known_cross_file

--- a/scripts/session/pick-random-failure.py
+++ b/scripts/session/pick-random-failure.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Pick a random conformance failure to work on.
+
+Reads scripts/conformance/conformance-detail.json and selects one failing test
+uniformly at random (optionally filtered by category or error code). Prints the
+test path and its expected / actual / missing / extra code sets so an agent can
+immediately start investigating.
+
+Usage:
+    scripts/session/pick-random-failure.py
+    scripts/session/pick-random-failure.py --category fingerprint-only
+    scripts/session/pick-random-failure.py --category wrong-code --code TS2322
+    scripts/session/pick-random-failure.py --seed 42
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+DETAIL_FILE = Path(__file__).resolve().parent.parent / "conformance" / "conformance-detail.json"
+
+
+def classify(entry: dict) -> str:
+    expected = set(entry.get("e", []))
+    actual = set(entry.get("a", []))
+    missing = set(entry.get("m", []))
+    extra = set(entry.get("x", []))
+
+    if not expected and actual:
+        return "false-positive"
+    if expected and not actual:
+        return "all-missing"
+    if expected == actual:
+        return "fingerprint-only"
+    if missing and not extra:
+        return "only-missing"
+    if extra and not missing:
+        return "only-extra"
+    return "wrong-code"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pick a random conformance failure.")
+    parser.add_argument("--category", default="any",
+                        choices=["any", "fingerprint-only", "wrong-code",
+                                 "only-missing", "only-extra",
+                                 "all-missing", "false-positive"],
+                        help="Restrict to one failure category.")
+    parser.add_argument("--code", help="Only pick tests that involve this error code "
+                                       "(expected, actual, missing, or extra).")
+    parser.add_argument("--seed", type=int, help="Random seed for reproducibility.")
+    parser.add_argument("--count", type=int, default=1,
+                        help="Number of random failures to print (default 1).")
+    parser.add_argument("--paths-only", action="store_true",
+                        help="Print just test paths (one per line).")
+    args = parser.parse_args()
+
+    if not DETAIL_FILE.exists():
+        print(f"error: {DETAIL_FILE} not found. Run conformance snapshot first.",
+              file=sys.stderr)
+        return 2
+
+    with DETAIL_FILE.open() as f:
+        detail = json.load(f)
+
+    failures = detail.get("failures", {})
+    candidates: list[tuple[str, dict, str]] = []
+    for path, entry in failures.items():
+        if not entry:
+            continue
+        category = classify(entry)
+        if args.category != "any" and category != args.category:
+            continue
+        if args.code:
+            codes = (set(entry.get("e", [])) | set(entry.get("a", []))
+                     | set(entry.get("m", [])) | set(entry.get("x", [])))
+            if args.code not in codes:
+                continue
+        candidates.append((path, entry, category))
+
+    if not candidates:
+        print("No failures match the given filters.", file=sys.stderr)
+        return 1
+
+    rng = random.Random(args.seed)
+    chosen = rng.sample(candidates, k=min(args.count, len(candidates)))
+
+    for path, entry, category in chosen:
+        if args.paths_only:
+            print(path)
+            continue
+        print(f"path:     {path}")
+        print(f"category: {category}")
+        print(f"expected: {entry.get('e', [])}")
+        print(f"actual:   {entry.get('a', [])}")
+        if entry.get("m"):
+            print(f"missing:  {entry['m']}")
+        if entry.get("x"):
+            print(f"extra:    {entry['x']}")
+        print(f"total candidates: {len(candidates)}")
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

When a user re-declares a lib global function (e.g. `declare function print(s: string)` shadowing lib's `print()`), the binder correctly merges the declarations into a single symbol. However the checker's `delegate_cross_arena_symbol_resolution` was routing the merged symbol to the lib arena, which caused `compute_type_of_symbol`'s function block to iterate only the lib arena's declarations. The user's overload was dropped and call sites emitted a false `TS2554` ("Expected N arguments, but got M").

This change mirrors the existing CLASS special case: when the symbol is a FUNCTION (without class/interface/alias bits) and has at least one function declaration in the current arena, resolve locally instead of delegating to the lib arena.

- Fixes `reachabilityCheckWithEmptyDefault.ts` (previously failing with a spurious TS2554 on `print('1')`).
- Same shape also affects any redeclaration of lib globals like `alert`, `confirm`, etc.
- No other tests regressed in the conformance run (the one observed flake, `incrementalTsBuildInfoFile.ts` with an `EROFS` error, reproduces on `main` without this change).

Also adds `scripts/session/pick-random-failure.py` — a small helper that samples a random conformance failure from `conformance-detail.json` (filterable by category/code, with a `--seed` for reproducibility) for use during campaign work.

## Test plan

- [x] `cargo check -p tsz-checker` — clean
- [x] `cargo test -p tsz-checker` — all suites pass (call resolution, regression, integration)
- [x] `cargo test -p tsz-solver --lib` — 5211/5211 pass
- [x] Targeted conformance: `reachabilityCheckWithEmptyDefault.ts` now PASSES
- [x] Full conformance run — no new regressions attributable to this change
- [x] Clippy on `tsz-checker` — clean (pre-existing warnings in `tsz-cli` unrelated)
