### PR TITLE
chore(session): add pick-random-failure.py helper

### DIFF
--- a/scripts/session/pick-random-failure.py
+++ b/scripts/session/pick-random-failure.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Pick a random conformance failure to work on.
+
+Reads scripts/conformance/conformance-detail.json and prints a random
+failing test along with its expected/actual/missing/extra codes.
+
+Usage:
+    scripts/session/pick-random-failure.py                 # any failure
+    scripts/session/pick-random-failure.py --close 2       # diff <= N
+    scripts/session/pick-random-failure.py --one-extra     # one extra code
+    scripts/session/pick-random-failure.py --one-missing   # one missing code
+    scripts/session/pick-random-failure.py --seed 42       # reproducible pick
+    scripts/session/pick-random-failure.py --count 5       # print N picks
+    scripts/session/pick-random-failure.py --paths-only    # test paths only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DETAIL_PATH = REPO_ROOT / "scripts" / "conformance" / "conformance-detail.json"
+
+
+def load_failures() -> dict[str, dict]:
+    if not DETAIL_PATH.exists():
+        sys.exit(f"error: {DETAIL_PATH} not found; run `scripts/conformance/conformance.sh snapshot` first")
+    with DETAIL_PATH.open() as f:
+        data = json.load(f)
+    return data.get("failures", {})
+
+
+def diff(entry: dict) -> int:
+    return len(entry.get("m", [])) + len(entry.get("x", []))
+
+
+def matches(entry: dict, args: argparse.Namespace) -> bool:
+    missing = entry.get("m", [])
+    extra = entry.get("x", [])
+    if args.one_missing and not (len(missing) == 1 and len(extra) == 0):
+        return False
+    if args.one_extra and not (len(extra) == 1 and len(missing) == 0):
+        return False
+    if args.close is not None and diff(entry) > args.close:
+        return False
+    if args.code and args.code not in (entry.get("e", []) + entry.get("a", [])):
+        return False
+    if args.missing_code and args.missing_code not in missing:
+        return False
+    if args.extra_code and args.extra_code not in extra:
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--close", type=int, help="only failures with diff <= N")
+    parser.add_argument("--one-missing", action="store_true", help="only 1-missing-0-extra failures")
+    parser.add_argument("--one-extra", action="store_true", help="only 0-missing-1-extra failures")
+    parser.add_argument("--code", help="only failures involving this code (expected or actual)")
+    parser.add_argument("--missing-code", help="only failures where this code is missing")
+    parser.add_argument("--extra-code", help="only failures where we emit this code extra")
+    parser.add_argument("--seed", type=int, help="random seed for reproducibility")
+    parser.add_argument("--count", type=int, default=1, help="number of failures to pick")
+    parser.add_argument("--paths-only", action="store_true", help="print test paths only")
+    args = parser.parse_args()
+
+    failures = load_failures()
+    candidates = [(path, entry) for path, entry in failures.items() if matches(entry, args)]
+    if not candidates:
+        sys.exit("no failures match the requested filters")
+
+    rng = random.Random(args.seed)
+    picks = rng.sample(candidates, min(args.count, len(candidates)))
+
+    for path, entry in picks:
+        if args.paths_only:
+            print(path)
+            continue
+        expected = ",".join(entry.get("e", [])) or "-"
+        actual = ",".join(entry.get("a", [])) or "-"
+        missing = ",".join(entry.get("m", [])) or "-"
+        extra = ",".join(entry.get("x", [])) or "-"
+        print(f"path:     {path}")
+        print(f"expected: {expected}")
+        print(f"actual:   {actual}")
+        print(f"missing:  {missing}")
+        print(f"extra:    {extra}")
+        print(f"diff:     {diff(entry)}")
+        print()
+
+    print(f"{len(candidates)} candidates matched; picked {len(picks)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/session/pick-random-failure.py`, a small helper that reads
`scripts/conformance/conformance-detail.json` and prints a random failing
conformance test (optionally filtered) so an agent has an easy way to pick
a starting target from the long tail of failures.

Filters:
- `--close N` — only failures with diff ≤ N
- `--one-missing` / `--one-extra` — fingerprint-close cases
- `--code CODE` / `--missing-code CODE` / `--extra-code CODE`
- `--seed N` — reproducible picks
- `--count N` — emit N picks
- `--paths-only` — pipe-friendly test paths

All analysis is **offline** against the pre-computed snapshot, so the tool
is instant and adds no load to CI.

## Test plan
- [x] `python3 -m py_compile scripts/session/pick-random-failure.py`
- [x] `scripts/session/pick-random-failure.py --help`
- [x] `scripts/session/pick-random-failure.py --one-extra --count 5 --seed 42`
- [x] `scripts/session/pick-random-failure.py --code TS2322 --count 2 --seed 1`
- [x] `scripts/session/pick-random-failure.py --one-missing --count 3 --seed 1`

## Notes

No Rust code changed; this is a pure tooling addition. During research for
this change I probed the `reachabilityCheckWithEmptyDefault.ts` failure
(spurious TS2554 when a user `declare function print(s: string): void;`
merges with the lib.dom `declare function print(): void;`) and traced the
root cause to `compute_type_of_symbol` iterating the merged FUNCTION
symbol's declarations against only `self.ctx.arena`, so lib-resident
declarations are silently skipped and only the lib's zero-arg overload
survives. A proper fix needs to route each declaration through
`declaration_arenas_for_declaration` (which already exists for a nearby
purpose) — deferred as a separate change to avoid a broad-surface
regression here.

https://claude.ai/code/session_01GHPEs5BKuT1FiNx3qvbZcr