### PR TITLE
fix(solver): add recursion guards to generic type inference

### DIFF
--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -272,6 +272,15 @@ pub(crate) struct InferenceContext<'a> {
     /// a type annotation rather than a fresh expression. Matches tsc's model where
     /// only types with `RequiresWidening` (from expression context) are widened.
     pub(crate) source_is_type_annotation: bool,
+    /// Depth counter for `infer_from_types` structural recursion.
+    /// Prevents infinite recursion when inferring through self-referential
+    /// interface hierarchies (e.g., `ArrayIterator<T>` which has
+    /// `[Symbol.iterator](): ArrayIterator<T>` returning itself).
+    pub(crate) infer_depth: u32,
+    /// Visited (source, target) pairs during structural inference.
+    /// Prevents re-visiting the same pair, breaking cycles in
+    /// self-referential type hierarchies.
+    pub(crate) infer_visited: FxHashSet<(TypeId, TypeId)>,
 }
 
 impl<'a> InferenceContext<'a> {
@@ -280,6 +289,11 @@ impl<'a> InferenceContext<'a> {
     /// Maximum depth for expanding `TypeApplication` targets during inference.
     /// Prevents infinite recursion for recursive type aliases.
     pub(crate) const MAX_APP_EXPANSION_DEPTH: u32 = 5;
+    /// Maximum depth for `infer_from_types` structural recursion.
+    /// Self-referential interfaces (e.g., `ArrayIterator<T>` with
+    /// `[Symbol.iterator](): ArrayIterator<T>`) can cause unbounded
+    /// recursion during structural property inference.
+    pub(crate) const MAX_INFER_DEPTH: u32 = 20;
 
     pub fn new(interner: &'a dyn TypeDatabase) -> Self {
         InferenceContext {
@@ -294,6 +308,8 @@ impl<'a> InferenceContext<'a> {
             in_contra_mode: false,
             reverse_mapped_properties: FxHashMap::default(),
             source_is_type_annotation: false,
+            infer_depth: 0,
+            infer_visited: FxHashSet::default(),
         }
     }
 
@@ -313,6 +329,8 @@ impl<'a> InferenceContext<'a> {
             in_contra_mode: false,
             reverse_mapped_properties: FxHashMap::default(),
             source_is_type_annotation: false,
+            infer_depth: 0,
+            infer_visited: FxHashSet::default(),
         }
     }
 

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -62,6 +62,24 @@ impl<'a> InferenceContext<'a> {
         target: TypeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
+        if self.infer_depth >= Self::MAX_INFER_DEPTH {
+            return Ok(());
+        }
+        if !self.infer_visited.insert((source, target)) {
+            return Ok(());
+        }
+        self.infer_depth += 1;
+        let result = self.infer_from_types_inner(source, target, priority);
+        self.infer_depth -= 1;
+        result
+    }
+
+    fn infer_from_types_inner(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
         // Resolve the types to their actual TypeDatas
         let source_key = self.interner.lookup(source);
         let target_key = self.interner.lookup(target);


### PR DESCRIPTION
## Summary

- Add depth limit (`MAX_INFER_DEPTH=20`) and visited-pair tracking to `infer_from_types` to prevent unbounded recursion during generic type parameter inference
- Fixes inference failures for self-referential interface hierarchies like `ArrayIterator<T>` (which declares `[Symbol.iterator](): ArrayIterator<T>`)
- Without these guards, structural property inference can revisit the same types indefinitely, causing type parameters to default to `unknown` instead of being correctly inferred

## Details

Self-referential interfaces are common in TypeScript's built-in iterator types:
```typescript
interface ArrayIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
    [Symbol.iterator](): ArrayIterator<T>;  // returns itself
}
```

When inferring `T` from `ArrayIterator<A>` against `Iterable<T>`, the solver matches the `[Symbol.iterator]()` property, finds the return type is `ArrayIterator<A>` again, and recurses without bound. The depth guard caps this at 20 levels, and the visited set prevents re-inferring the same `(source, target)` pair within a single inference context.

## Results

- **Conformance: 11942/12581 (94.9%)** — up from 11933 baseline (+9 tests, 0 regressions)
- **Solver unit tests: 5211 pass, 0 fail**

## Test plan

- [x] `cargo test -p tsz-solver` — all 5211 tests pass
- [x] Full conformance suite — 94.9%, +9 tests over baseline
- [x] No regressions in checker tests (pre-existing LOC limit test excluded)

https://claude.ai/code/session_01DvPXqMm59oM6NXTDHNiZLN