### PR TITLE
feat(conformance): add random-failure picker script

### DIFF
--- a/scripts/conformance/pick-random-failure.py
+++ b/scripts/conformance/pick-random-failure.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Pick a random conformance failure to work on.
+
+Reads failure data from scripts/conformance/conformance-detail.json and prints
+one randomly selected failing test along with its expected/actual/missing/extra
+error codes. Useful when an agent needs a starting point without biasing toward
+a particular campaign.
+
+Usage:
+  python3 scripts/conformance/pick-random-failure.py
+  python3 scripts/conformance/pick-random-failure.py --seed 42
+  python3 scripts/conformance/pick-random-failure.py --count 5
+  python3 scripts/conformance/pick-random-failure.py --category fingerprint-only
+  python3 scripts/conformance/pick-random-failure.py --code TS2322
+  python3 scripts/conformance/pick-random-failure.py --path-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+DETAIL_FILE = Path(__file__).parent / "conformance-detail.json"
+
+
+def classify(entry: dict) -> str:
+    expected = entry.get("e", []) or []
+    actual = entry.get("a", []) or []
+    missing = entry.get("m", []) or []
+    extra = entry.get("x", []) or []
+
+    if not expected and actual:
+        return "false-positive"
+    if expected and not actual:
+        return "all-missing"
+    if not missing and not extra and expected:
+        return "fingerprint-only"
+    if missing and not extra:
+        return "only-missing"
+    if extra and not missing:
+        return "only-extra"
+    return "wrong-codes"
+
+
+def load_failures() -> dict:
+    if not DETAIL_FILE.exists():
+        sys.exit(
+            f"error: {DETAIL_FILE} not found. Run "
+            "`scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot` first."
+        )
+    with DETAIL_FILE.open() as fh:
+        data = json.load(fh)
+    return data.get("failures", {})
+
+
+def filter_failures(
+    failures: dict,
+    *,
+    category: str | None,
+    code: str | None,
+) -> list[tuple[str, dict]]:
+    items: list[tuple[str, dict]] = []
+    for path, entry in failures.items():
+        if not entry:
+            # Empty payload means we lack detail (often a crash). Keep it as
+            # a catch-all under 'unknown' so a random pick can still surface it.
+            if category in (None, "unknown"):
+                items.append((path, entry))
+            continue
+
+        cat = classify(entry)
+        if category and cat != category:
+            continue
+
+        if code:
+            codes = set(entry.get("e", []) or []) | set(entry.get("a", []) or [])
+            if code not in codes:
+                continue
+
+        items.append((path, entry))
+    return items
+
+
+def format_entry(path: str, entry: dict) -> str:
+    if not entry:
+        return f"{path}\n  (no diagnostic detail — likely crash or missing snapshot)"
+
+    lines = [path, f"  category: {classify(entry)}"]
+
+    def fmt(key: str, label: str) -> None:
+        vals = entry.get(key) or []
+        if vals:
+            lines.append(f"  {label:<9}: {', '.join(vals)}")
+
+    fmt("e", "expected")
+    fmt("a", "actual")
+    fmt("m", "missing")
+    fmt("x", "extra")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seed", type=int, help="Seed RNG for reproducible picks.")
+    parser.add_argument("--count", type=int, default=1, help="Number of failures to pick.")
+    parser.add_argument(
+        "--category",
+        choices=[
+            "fingerprint-only",
+            "only-missing",
+            "only-extra",
+            "wrong-codes",
+            "false-positive",
+            "all-missing",
+            "unknown",
+        ],
+        help="Restrict to one failure category.",
+    )
+    parser.add_argument("--code", help="Only pick failures involving this error code (e.g. TS2322).")
+    parser.add_argument("--path-only", action="store_true", help="Print only the test path(s).")
+    args = parser.parse_args()
+
+    if args.count < 1:
+        parser.error("--count must be >= 1")
+
+    failures = load_failures()
+    pool = filter_failures(failures, category=args.category, code=args.code)
+    if not pool:
+        sys.exit("error: no failures matched the given filters.")
+
+    rng = random.Random(args.seed)
+    picks = rng.sample(pool, k=min(args.count, len(pool)))
+
+    if args.path_only:
+        for path, _ in picks:
+            print(path)
+        return 0
+
+    print(f"# Picked {len(picks)} of {len(pool)} candidate failures")
+    if args.category:
+        print(f"# Filter: category={args.category}")
+    if args.code:
+        print(f"# Filter: code={args.code}")
+    if args.seed is not None:
+        print(f"# Seed: {args.seed}")
+    print()
+    for path, entry in picks:
+        print(format_entry(path, entry))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/conformance/pick-random-failure.py` — a tiny helper that reads the offline `conformance-detail.json` snapshot and prints one (or more) randomly selected failing tests along with their expected/actual/missing/extra error codes.
- Designed for agents following `scripts/session/conformance-agent-prompt.md` who need an unbiased starting point for leaf-tier work, or want to spot-check representative failures across the campaign surface.
- Pure Python, no runtime dependencies, no changes to any Rust crate.

## Usage

```bash
# Fully random pick
python3 scripts/conformance/pick-random-failure.py

# Deterministic (seeded) pick — reproducible
python3 scripts/conformance/pick-random-failure.py --seed 42

# Pull 5 picks at once
python3 scripts/conformance/pick-random-failure.py --count 5

# Restrict to a failure category
python3 scripts/conformance/pick-random-failure.py --category fingerprint-only
python3 scripts/conformance/pick-random-failure.py --category only-extra
python3 scripts/conformance/pick-random-failure.py --category false-positive

# Restrict to failures involving a specific error code
python3 scripts/conformance/pick-random-failure.py --code TS2322

# Pipe raw paths into the conformance runner
python3 scripts/conformance/pick-random-failure.py --path-only --count 10
```

Categories it classifies:
- `fingerprint-only` — same code set, wrong message/position/count
- `only-missing` — tsc has codes we don't emit
- `only-extra` — we emit codes tsc doesn't
- `wrong-codes` — codes differ in both directions
- `false-positive` — tsc expects zero, we emit errors
- `all-missing` — tsc expects errors, we emit zero
- `unknown` — snapshot has no detail payload (e.g. crashes)

## Example

```
$ python3 scripts/conformance/pick-random-failure.py --seed 42
# Picked 1 of 637 candidate failures
# Seed: 42

TypeScript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
  category: wrong-codes
  expected : TS7006
  actual   : TS6133
  missing  : TS7006
  extra    : TS6133
```

## Verification notes

- Python syntax verified via `python3 -m py_compile`.
- Exercised `--seed`, `--count`, `--category`, `--code`, `--path-only` modes against the current snapshot (637 failures across 7 categories) — all return the expected shapes.
- `cargo clippy` is green for every crate except pre-existing warnings in `crates/tsz-cli/src/bin/tsz_server/tests.rs` (`redundant_clone`, `manual_contains`); those exist unchanged on `origin/main` and are unrelated to this additive Python helper.
- `scripts/session/verify-all.sh --quick` reports:
  - unit tests: `cargo nextest` is not installed in this environment (no test failures — tool missing);
  - conformance: 11942/12581 vs a 11944 baseline, with the single PASS→FAIL being `compiler/incrementalTsBuildInfoFile.ts` (fails with `EROFS: read-only file system` in the sandbox — environmental, not caused by this change).

This change is purely additive under `scripts/conformance/`; no test runner loads it, and no Rust code is touched. The snapshot files it reads are already checked in and already produced by `conformance.sh snapshot`.

## Test plan

- [x] `python3 -m py_compile scripts/conformance/pick-random-failure.py`
- [x] `python3 scripts/conformance/pick-random-failure.py --help`
- [x] `python3 scripts/conformance/pick-random-failure.py --seed 42` (deterministic)
- [x] `python3 scripts/conformance/pick-random-failure.py --category false-positive --count 3 --seed 1`
- [x] `python3 scripts/conformance/pick-random-failure.py --code TS2322 --category fingerprint-only --seed 7`
- [x] `python3 scripts/conformance/pick-random-failure.py --path-only --seed 42`
- [x] `cargo clippy --workspace --lib --bins --exclude tsz-cli -- -D warnings` — clean
- [x] `cargo clippy -p tsz-cli --lib -- -D warnings` — clean

https://claude.ai/code/session_013AEDgFwKKeu5y4WRj5yJw6