### PR TITLE
fix(jsdoc): suppress TS2304 for `@type {exports}` in JS files

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1793,6 +1793,13 @@ impl<'a> CheckerState<'a> {
                     && !expr.contains('.')
                     && unresolved
                 {
+                    // In a JS file, `@type {exports}` references the ambient
+                    // CommonJS `exports` object. tsc resolves it without diagnostic;
+                    // tsz's JSDoc resolver doesn't model this special name, so
+                    // suppress TS2304 for the literal `exports` identifier here.
+                    if expr == "exports" && self.is_js_file() {
+                        continue;
+                    }
                     self.emit_jsdoc_cannot_find_name(expr, comment.pos, comment.end, &source_text);
                 }
             }


### PR DESCRIPTION
## Summary
- Suppress spurious `TS2304: Cannot find name 'exports'.` for `/** @type {exports} */` in checked-JS files.
- Mirrors tsc behavior, which silently resolves the ambient CommonJS `exports` symbol in this position.

## Repro
```js
// /tmp/jstyp.js
module.exports = {}
/** @type {exports} */
var x
```
- Before: `error TS2304: Cannot find name 'exports'.`
- After: clean.

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter jsdocTypeReferenceExports` → 1/1 pass
- [x] `./scripts/conformance/conformance.sh run --filter jsdoc` → 343/377 (no regressions vs baseline)
- [x] `tsz --noEmit --allowJs --checkJs /tmp/jstyp.js` → exit 0