### PR TITLE
fix(checker): restrict TS1380/TS1379 to syntactic type-only chains

### DIFF
--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -1262,14 +1262,19 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        // Check alias chain for transitive type-only
-        if self.alias_resolves_to_type_only(sym_id) {
-            return Some(self.determine_type_only_kind_from_alias(sym_id));
-        }
+        // NOTE: we intentionally do NOT shortcut through `alias_resolves_to_type_only`
+        // here. That helper also returns true for *content-based* type-only (e.g. a
+        // namespace whose members are all type aliases), but TS1380/TS1379 are
+        // *syntactic* errors — they only fire when the chain literally used
+        // `import type` / `export type`. A namespace with only type members is a
+        // separate error (e.g. TS1269 under isolatedModules), not TS1380.
+        //
+        // The walking below only checks `is_type_only` flags on each symbol in the
+        // alias chain, which is the correct syntactic check.
 
         // For import-equals aliases (`import A = ns.Member`), the binder doesn't set
-        // import_module, so alias_resolves_to_type_only can't trace through.
-        // Check the declaration's RHS for type-only references.
+        // import_module, so the per-symbol `is_type_only` check alone can't trace
+        // through. Check the declaration's RHS for type-only references.
         // Also follow through export alias → local symbol chains.
         if symbol.flags & tsz_binder::symbol_flags::ALIAS != 0 {
             // Collect all symbols to check: the current symbol plus anything it aliases to


### PR DESCRIPTION
## Summary
TS1380 (`An import alias cannot reference a declaration that was imported using 'import type'`) was firing on plain `import { Ns } from './a'` followed by `export import X = Ns`, whenever `Ns` happened to be a namespace containing only type aliases. No `import type` or `export type` appears anywhere in the chain — it's a content-based type-only rather than a syntactic one.

TS1380/TS1379 are strictly syntactic. The content-based case is already covered by other diagnostics (e.g. TS1269 under `isolatedModules`).

The fix drops a shortcut in `check_symbol_type_only_kind_inner` that used `alias_resolves_to_type_only` — a helper that conflates the two meanings and is needed intact for elision/emit decisions elsewhere. The per-symbol walk below only checks syntactic `is_type_only` flags, which is the correct behavior for TS1380/TS1379.

## Tests flipped FAIL → PASS
- `isolatedModulesExportImportUninstantiatedNamespace.ts`
- `jsxNamespaceImplicitImportJSXNamespace.tsx`
- `jsxNamespaceGlobalReexport.tsx`

## Test plan
- [x] `--filter jsxNamespace` — 12/12 (was 10/12) — **+2**
- [x] `--filter isolatedModules` — 34/36 (was 33/36) — **+1**
- [x] `--filter typeOnly` — 64/68, no regressions
- [x] `--filter import` — 267/281, no regressions