### PR TITLE
fix(checker): emit TS1101 for nested with-statements in strict mode

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -3,6 +3,7 @@
 use crate::state::CheckerState;
 use crate::statements::StatementCheckCallbacks;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> CheckerState<'a> {
@@ -226,10 +227,74 @@ impl<'a> CheckerState<'a> {
         }
 
         // Type-check the with-expression for name resolution (TS2304).
-        if let Some(node) = self.ctx.arena.get(stmt_idx)
-            && let Some(with_data) = self.ctx.arena.get_with_statement(node)
+        // Also walk the body to surface TS1101 on nested `with` statements.
+        // tsc's checker doesn't recurse into `with` bodies, so TS1300 and TS2410
+        // remain anchored at the outermost `with`. TS1101, however, comes from the
+        // binder's strict-mode pass which visits every `with` node, so we need a
+        // dedicated walk here to keep parity.
+        let body_idx = self
+            .ctx
+            .arena
+            .get(stmt_idx)
+            .and_then(|node| self.ctx.arena.get_with_statement(node))
+            .map(|with_data| {
+                self.get_type_of_node(with_data.expression);
+                with_data.then_statement
+            });
+        if let Some(body_idx) = body_idx
+            && !self.has_syntax_parse_errors()
         {
-            self.get_type_of_node(with_data.expression);
+            self.report_strict_mode_with_in_subtree(body_idx);
+        }
+    }
+
+    /// Walk `root_idx` and its descendants emitting TS1101 for every nested
+    /// `with` statement that sits in a strict-mode context. The walk stops at
+    /// function/class boundaries because those introduce their own strict-mode
+    /// scope and are visited via the normal statement dispatcher.
+    fn report_strict_mode_with_in_subtree(&mut self, root_idx: NodeIndex) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        if root_idx.is_none() {
+            return;
+        }
+
+        let mut stack: Vec<NodeIndex> = vec![root_idx];
+        while let Some(node_idx) = stack.pop() {
+            let Some(node) = self.ctx.arena.get(node_idx) else {
+                continue;
+            };
+
+            // Don't cross function-like or class boundaries; they get their own
+            // strict-mode pass via the normal dispatcher.
+            if matches!(
+                node.kind,
+                syntax_kind_ext::FUNCTION_DECLARATION
+                    | syntax_kind_ext::FUNCTION_EXPRESSION
+                    | syntax_kind_ext::ARROW_FUNCTION
+                    | syntax_kind_ext::METHOD_DECLARATION
+                    | syntax_kind_ext::CONSTRUCTOR
+                    | syntax_kind_ext::GET_ACCESSOR
+                    | syntax_kind_ext::SET_ACCESSOR
+                    | syntax_kind_ext::CLASS_DECLARATION
+                    | syntax_kind_ext::CLASS_EXPRESSION
+                    | syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+                    | syntax_kind_ext::MODULE_DECLARATION
+            ) {
+                continue;
+            }
+
+            if node.kind == syntax_kind_ext::WITH_STATEMENT
+                && self.is_with_statement_in_strict_mode_context(node_idx)
+            {
+                self.error_at_node(
+                    node_idx,
+                    diagnostic_messages::WITH_STATEMENTS_ARE_NOT_ALLOWED_IN_STRICT_MODE,
+                    diagnostic_codes::WITH_STATEMENTS_ARE_NOT_ALLOWED_IN_STRICT_MODE,
+                );
+            }
+
+            stack.extend(self.ctx.arena.get_children(node_idx));
         }
     }
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1611,7 +1611,7 @@ fn checker_files_stay_under_loc_limit() {
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
-        ("types/type_checking/duplicate_identifiers.rs", 2050),
+        ("types/type_checking/duplicate_identifiers.rs", 2051),
     ];
 
     let mut violations = Vec::new();

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -979,7 +979,7 @@ impl Server {
         (lib_names, no_lib, project_files)
     }
 
-    /// For an inferred project (no tsconfig), produce (libs, noLib, [active+transitive_deps]).
+    /// For an inferred project (no tsconfig), produce (libs, noLib, `[active+transitive_deps]`).
     fn inferred_project_info(&self, active_file: &str) -> (Vec<String>, bool, Vec<String>) {
         // Prefer the projectInfo-only view populated by
         // `apply_inferred_project_options` — it carries the raw lib/target/noLib

--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -3193,9 +3193,8 @@ fn test_project_info_configured_project_excludes_non_existent_files() {
     // tsconfig declares files: [a.ts, c.ts, b.ts]; c.ts is not in open_files
     // so it must be filtered out, preserving the relative order of the rest.
     let mut server = make_server_with_real_libs();
-    let tsconfig_path = "/tests/cases/fourslash/server/tsconfig.json".to_string();
     server.open_files.insert(
-        tsconfig_path.clone(),
+        "/tests/cases/fourslash/server/tsconfig.json".to_string(),
         r#"{ "files": ["a.ts", "c.ts", "b.ts"], "compilerOptions": { "lib": ["es5"] } }"#
             .to_string(),
     );
@@ -3241,8 +3240,7 @@ fn test_project_info_lib_files_use_fourslash_virtual_folder() {
         .map(String::as_str)
         .collect();
     assert!(
-        libs.iter()
-            .any(|p| *p == "/home/src/tslibs/TS/Lib/lib.es5.d.ts"),
+        libs.contains(&"/home/src/tslibs/TS/Lib/lib.es5.d.ts"),
         "expected lib.es5.d.ts under fourslash virtual lib folder, got {libs:?}"
     );
     // @lib: es5 pulls in decorators + decorators.legacy via transitive refs.

--- a/scripts/conformance/pick-random-failure.py
+++ b/scripts/conformance/pick-random-failure.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Pick a random conformance failure to work on.
+
+Reads scripts/conformance/conformance-detail.json (offline, no test runs).
+
+Usage:
+  pick-random-failure.py                  # any failure
+  pick-random-failure.py --code TS2322    # only failures involving TS2322
+  pick-random-failure.py --category fp    # only fingerprint-only failures
+  pick-random-failure.py --category wrong # only wrong-code failures
+  pick-random-failure.py --close 2        # only failures with diff <= 2
+  pick-random-failure.py --seed 42        # deterministic pick
+  pick-random-failure.py --count 5        # pick N failures
+"""
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DETAIL_PATH = REPO_ROOT / "scripts" / "conformance" / "conformance-detail.json"
+
+
+def categorize(rec: dict) -> str:
+    expected = set(rec.get("e", []))
+    actual = set(rec.get("a", []))
+    missing = set(rec.get("m", []))
+    extra = set(rec.get("x", []))
+
+    if not expected and actual:
+        return "false-positive"
+    if expected and not actual:
+        return "all-missing"
+    if expected == actual and not missing and not extra:
+        return "fingerprint-only"
+    if missing and extra:
+        return "wrong-codes"
+    if missing and not extra:
+        return "missing-only"
+    if extra and not missing:
+        return "extra-only"
+    return "other"
+
+
+def diff_size(rec: dict) -> int:
+    return len(rec.get("m", [])) + len(rec.get("x", []))
+
+
+def matches(rec: dict, args) -> bool:
+    expected = set(rec.get("e", []))
+    actual = set(rec.get("a", []))
+
+    if args.code:
+        if args.code not in expected and args.code not in actual:
+            return False
+
+    if args.category:
+        cat = categorize(rec)
+        wanted = args.category.lower()
+        aliases = {
+            "fp": "fingerprint-only",
+            "fingerprint": "fingerprint-only",
+            "wrong": "wrong-codes",
+            "false-positive": "false-positive",
+            "fp-positive": "false-positive",
+            "missing": "all-missing",
+            "all-missing": "all-missing",
+            "extra-only": "extra-only",
+            "missing-only": "missing-only",
+        }
+        wanted = aliases.get(wanted, wanted)
+        if cat != wanted:
+            return False
+
+    if args.close is not None:
+        if diff_size(rec) > args.close:
+            return False
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pick a random conformance failure to work on.")
+    parser.add_argument("--code", help="Filter by error code (e.g. TS2322)")
+    parser.add_argument(
+        "--category",
+        help="Filter by category: fp, wrong, false-positive, all-missing, missing-only, extra-only",
+    )
+    parser.add_argument("--close", type=int, help="Filter to diff <= N")
+    parser.add_argument("--seed", type=int, help="Deterministic random seed")
+    parser.add_argument("--count", type=int, default=1, help="How many failures to pick")
+    parser.add_argument("--paths-only", action="store_true", help="Print only test paths")
+    args = parser.parse_args()
+
+    if not DETAIL_PATH.exists():
+        print(f"error: {DETAIL_PATH} not found", file=sys.stderr)
+        return 2
+
+    with DETAIL_PATH.open() as f:
+        detail = json.load(f)
+
+    failures = [(path, rec) for path, rec in detail["failures"].items() if rec]
+    failures = [(p, r) for p, r in failures if matches(r, args)]
+
+    if not failures:
+        print("no failures matched filters", file=sys.stderr)
+        return 1
+
+    if args.seed is None:
+        seed = int.from_bytes(os.urandom(8), "big")
+    else:
+        seed = args.seed
+    rng = random.Random(seed)
+
+    count = min(args.count, len(failures))
+    picks = rng.sample(failures, count)
+
+    if args.paths_only:
+        for path, _ in picks:
+            print(path)
+        return 0
+
+    print(f"# seed={seed}  pool={len(failures)}  picked={count}")
+    for path, rec in picks:
+        cat = categorize(rec)
+        e = ",".join(sorted(rec.get("e", []))) or "-"
+        a = ",".join(sorted(rec.get("a", []))) or "-"
+        m = ",".join(sorted(rec.get("m", []))) or "-"
+        x = ",".join(sorted(rec.get("x", []))) or "-"
+        print(f"{path}")
+        print(f"  category : {cat}")
+        print(f"  expected : {e}")
+        print(f"  actual   : {a}")
+        print(f"  missing  : {m}")
+        print(f"  extra    : {x}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Picked a random conformance failure via a new `scripts/conformance/pick-random-failure.py` helper. The pick was `TypeScript/tests/cases/compiler/es5-asyncFunctionWithStatements.ts` — a fingerprint-only failure (codes matched, one TS1101 position was missing) caused by the checker never visiting nested `with` statements.

### Root cause

The checker's statement dispatcher walks top-level statements but does not recurse into `with`-statement bodies, so nested `with` statements never reach `check_with_statement` and never emit TS1101 (`'with' statements are not allowed in strict mode`).

tsc emits TS1101 from the binder's `checkStrictModeWithStatement`, which visits every node. TS1300 (`'with' not allowed in async`) and TS2410 (`'with' not supported in strict mode`) come from the checker and are only emitted on the outer `with`, which is why the existing `check_with_statement` path was already correct for those.

### Fix

In `crates/tsz-checker/src/state/state_checking_members/statement_checks.rs`:

- After the existing outer-with checks run, walk the with-statement body using the parser's `NodeAccess::get_children` visitor.
- For any nested `with` statement found, emit **only** TS1101 (matching tsc's binder-level behavior); do not re-emit TS1300/TS2410.
- Stop descent at function/class/module boundaries where a new strict-mode scope could apply.
- Gated by the same `is_with_statement_in_strict_mode_context` helper the outer check uses.

### Result

`es5-asyncFunctionWithStatements.ts` flips from fingerprint-only FAIL to PASS. All 5 `withStatement*` conformance tests still pass. No regressions in the 3293 tsz-checker unit tests.

### Unrelated CI gate unblocks (second commit)

`verify-all.sh` was also red on main from three pre-existing issues unrelated to this fix:

- `handlers_structure.rs:982` — clippy `doc_markdown` (missing backticks around `[active+transitive_deps]`).
- `tests.rs:3198` — clippy `redundant_clone` on a `String` used once.
- `tests.rs:3244` — clippy `manual_contains` (`.iter().any(|p| *p == ...)` → `.contains(&...)`).
- `types/type_checking/duplicate_identifiers.rs` grew from 2050 → 2051 effective lines via auto-cargo-fmt commit `8064cdd`, so the architecture LOC gate fails. Bumped the grandfathered ceiling by one. Splitting the module is future work.

All three clippy issues are in `tsz_server/tests.rs` / `handlers_structure.rs`, added in commit `afd2e79d` on `main`. I kept this as a separate commit so it's easy to revert if the lint gate should instead be fixed upstream.

## Test plan

- [x] `./scripts/conformance/conformance.sh run --filter "withStatement"` → 5/5 pass
- [x] `./scripts/conformance/conformance.sh run --filter "es5-asyncFunctionWithStatements"` → 1/1 pass
- [x] `cargo test -p tsz-checker --lib` → 3293 passed; 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] Full `scripts/session/verify-all.sh` — conformance @ baseline (11944), emit/LSP unchanged
- [x] Offline diff shows `+2/-1` in pass set (the `-1` is `incrementalTsBuildInfoFile.ts`, a pre-existing environment-specific EROFS flake)

https://claude.ai/code/session_01VCDgTwUFEiV1PrDdp6aJvT