### PR TITLE
fix(checker): stop tracking import bindings as referenced during type-only probe

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -803,7 +803,11 @@ impl<'a> CheckerState<'a> {
     fn import_local_binding_is_type_only(&self, local_name_idx: NodeIndex) -> bool {
         use tsz_binder::symbol_flags;
 
-        let Some(sym_id) = self.resolve_identifier_symbol(local_name_idx) else {
+        // Use the non-tracking resolver here: this is a pure pre-condition
+        // probe (asking whether the import binding is type-only). Tracking it
+        // as "referenced" would cause noUnusedLocals to silently treat every
+        // import binding as used — even one that no source code ever refers to.
+        let Some(sym_id) = self.resolve_identifier_symbol_without_tracking(local_name_idx) else {
             return false;
         };
         let lib_binders = self.get_lib_binders();


### PR DESCRIPTION
## Summary
`import_local_binding_is_type_only` is a pre-condition probe used during import-declaration checking — it asks \"does this import have only type usages?\". It was calling the *tracking* form of `resolve_identifier_symbol`, which inserts the resolved symbol into `referenced_symbols` as a side effect.

The result: every import binding (default, named, namespace) was silently marked as used before the unused-locals check ever ran, so **`noUnusedLocals` never flagged any unused import**. Even a bare `import d from \"./mod\"` with no other code emitted no diagnostic.

The fix swaps the call to the existing non-tracking variant. Reference tracking should only happen at real value/type-use sites, not during checker-internal probes.

## Tests flipped FAIL → PASS
- `unusedImports6.ts`
- `unusedImports12.ts`
- `unusedImports_entireImportDeclaration.ts`

## Test plan
- [x] `--filter unused` — 148/151 (was 145/151) — **+3**, no regressions
- [x] `--filter import` — 267/281, identical failure set vs baseline
- [x] `--filter verbatimModule` — 13/16, identical
- [x] `--filter isolatedModules` — 34/36, identical