### PR TITLE
fix(jsx): emit TS2607 when class lacks ElementAttributesProperty member

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -351,9 +351,11 @@ impl<'a> CheckerState<'a> {
         // If props extraction succeeds, the type is already recognized as a
         // valid JSX component shape (callable/constructable in JSX context).
         // Keep `this` tags strict: `<this/>` should still report TS2604.
+        // Pass `None` for element_idx so this probe doesn't emit its own
+        // TS2607 — the call is purely a "did extraction succeed?" check.
         if !is_this_tag
             && self
-                .get_jsx_props_type_for_component_member(component_type, Some(tag_name_idx))
+                .get_jsx_props_type_for_component_member(component_type, None)
                 .is_some()
         {
             return;
@@ -1157,21 +1159,20 @@ impl<'a> CheckerState<'a> {
                             {
                                 return Some(param_type);
                             }
-                            // Class has construct params but none suitable for props.
-                            // Emit TS2607 to flag the missing attributes property.
-                            if let Some(elem_idx) = element_idx {
-                                use crate::diagnostics::diagnostic_codes;
-                                self.error_at_node_msg(
-                                    elem_idx,
-                                    diagnostic_codes::JSX_ELEMENT_CLASS_DOES_NOT_SUPPORT_ATTRIBUTES_BECAUSE_IT_DOES_NOT_HAVE_A_PROPERT,
-                                    &[name],
-                                );
-                            }
                         }
-                        // When the class has no construct parameters (e.g., inherited
-                        // from a generic base like React.Component), tsc falls back
-                        // gracefully without emitting TS2607. Skip the diagnostic
-                        // and let the caller handle the missing props type.
+                        // The class doesn't expose the configured ElementAttributesProperty
+                        // member (e.g., `props`) on its instance and there's no usable
+                        // first-construct-parameter fallback. tsc emits TS2607 in this
+                        // case regardless of whether the class lacks construct params
+                        // entirely (inherited from `any`) or has unusable ones.
+                        if let Some(elem_idx) = element_idx {
+                            use crate::diagnostics::diagnostic_codes;
+                            self.error_at_node_msg(
+                                elem_idx,
+                                diagnostic_codes::JSX_ELEMENT_CLASS_DOES_NOT_SUPPORT_ATTRIBUTES_BECAUSE_IT_DOES_NOT_HAVE_A_PROPERT,
+                                &[name],
+                            );
+                        }
                         None
                     }
                 }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -1374,8 +1374,23 @@ impl<'a> CheckerState<'a> {
     ) -> Option<(TypeId, bool)> {
         let normalized_component_type =
             self.normalize_jsx_component_type_for_resolution(component_type);
+        // Only pass element_idx (which authorizes TS2607 emission) when the
+        // JSX usage actually supplies attributes that would need a props type.
+        // `<Foo />` with no attributes shouldn't trip "missing 'props' property"
+        // even if the class doesn't expose one, since nothing is being checked.
+        let attributes_have_content = self
+            .ctx
+            .arena
+            .get(attributes_idx)
+            .and_then(|n| self.ctx.arena.get_jsx_attributes(n))
+            .is_some_and(|a| !a.properties.nodes.is_empty());
+        let element_idx_for_emit = if attributes_have_content {
+            element_idx
+        } else {
+            None
+        };
         if let Some((props_type, raw_has_type_params)) =
-            self.get_jsx_props_type_for_component(component_type, element_idx)
+            self.get_jsx_props_type_for_component(component_type, element_idx_for_emit)
         {
             if raw_has_type_params
                 && let Some(inferred_props) = self


### PR DESCRIPTION
## Summary
Three coordinated fixes around TS2607 (\"JSX element class does not support attributes because it does not have a 'props' property\"):

1. **Don't skip emission when the class has no construct params.** The previous logic only emitted TS2607 when the class had construct parameters but none usable as a fallback props type. For \`class Empty extends React.Component<{}, {}>\` (with React typed as \`any\`), we silently dropped the diagnostic. tsc emits it.

2. **Stop the validity-probe from emitting its own TS2607.** `get_jsx_props_type_for_component_member` is also called from a \"does extraction succeed?\" probe at line 356 with `Some(tag_name_idx)` — which after fix #1 caused a duplicate TS2607 anchored at the tag-name identifier (off by one column from the JSX element start). Pass `None` for the probe path.

3. **Don't emit TS2607 when no attributes are passed.** \`<Foo />\` with no attributes shouldn't trip the diagnostic — there's nothing to type-check against the missing props member. \`recover_jsx_component_props_type\` now passes \`element_idx\` (which authorizes emission) only when the JSX attributes list is non-empty.

## Tests flipped FAIL → PASS
- \`tsxSpreadAttributesResolution17.tsx\`
- \`tsxElementResolution12.tsx\`
- \`jsxRuntimePragma.ts\`

## Test plan
- [x] \`--filter jsx\` — 254/298 (was 251/298) — **+3**, no regressions
- [x] \`--filter tsx\` — 284/336 (was 282/336) — **+2**, no regressions