### PR TITLE
session: add pick-and-run-random helper + clippy doc fix

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -95,7 +95,7 @@ pub struct TypeFormatter<'a> {
     /// Application (e.g., `type Foo = Id<{...}>`). In assignability error messages,
     /// tsc shows the Application form `Id<{...}>` rather than the outer alias `Foo`.
     skip_application_alias_names: bool,
-    /// When true, don't follow display_alias when it points to an Intersection
+    /// When true, don't follow `display_alias` when it points to an Intersection
     /// type and the current type is an Object. Used for TS2741 messages where
     /// tsc shows the merged object form instead of the intersection form.
     skip_intersection_display_alias: bool,
@@ -209,7 +209,7 @@ impl<'a> TypeFormatter<'a> {
         self
     }
 
-    /// Don't follow display_alias when it points to an Intersection type
+    /// Don't follow `display_alias` when it points to an Intersection type
     /// and the current type is an Object. tsc shows the merged object form
     /// in TS2741 messages, not the intersection form.
     pub const fn with_skip_intersection_display_alias(mut self) -> Self {

--- a/scripts/session/pick-and-run-random.sh
+++ b/scripts/session/pick-and-run-random.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-and-run-random.sh — Pick a random conformance failure and run it verbose
+# =============================================================================
+#
+# One-shot helper for an agent starting a new unit of work. Picks a random
+# failing test from conformance-detail.json, prints its expected/actual
+# diagnostic summary, and then runs the conformance harness on just that test
+# with --verbose so fingerprint deltas are visible immediately.
+#
+# Usage:
+#   scripts/session/pick-and-run-random.sh
+#   scripts/session/pick-and-run-random.sh --category fingerprint-only
+#   scripts/session/pick-and-run-random.sh --code TS2322
+#   scripts/session/pick-and-run-random.sh --seed 42
+#   scripts/session/pick-and-run-random.sh --no-run     # just pick, don't run
+#
+# All unrecognized flags are forwarded to pick-random-failure.py, so filters
+# like --one-missing, --close N, --extra-code TS7053 work too.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+PICKER="$REPO_ROOT/scripts/session/pick-random-failure.py"
+CONFORMANCE="$REPO_ROOT/scripts/conformance/conformance.sh"
+
+if [[ -t 1 ]]; then
+    BOLD='\033[1m' CYAN='\033[0;36m' YELLOW='\033[0;33m' RESET='\033[0m'
+else
+    BOLD='' CYAN='' YELLOW='' RESET=''
+fi
+
+RUN=true
+PICKER_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-run) RUN=false; shift ;;
+        --help|-h)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        *) PICKER_ARGS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ! -x "$PICKER" ]] && [[ ! -f "$PICKER" ]]; then
+    echo "error: picker script not found at $PICKER" >&2
+    exit 1
+fi
+
+echo -e "${BOLD}${CYAN}━━━ Picking a random failure ━━━${RESET}"
+PICK_OUTPUT="$(python3 "$PICKER" --count 1 "${PICKER_ARGS[@]}")"
+echo "$PICK_OUTPUT"
+
+TEST_PATH="$(printf '%s\n' "$PICK_OUTPUT" | awk -F': *' '/^path: /{print $2; exit}')"
+if [[ -z "$TEST_PATH" ]]; then
+    echo "error: could not extract test path from picker output" >&2
+    exit 1
+fi
+
+TEST_BASENAME="$(basename "$TEST_PATH")"
+TEST_STEM="${TEST_BASENAME%.ts}"
+TEST_STEM="${TEST_STEM%.tsx}"
+
+echo ""
+echo -e "${BOLD}${CYAN}━━━ Test: ${TEST_BASENAME} ━━━${RESET}"
+echo -e "${YELLOW}Filter pattern:${RESET} ${TEST_STEM}"
+echo ""
+
+if ! $RUN; then
+    cat <<EOF
+To run this test verbose:
+  ${CONFORMANCE} run --filter "${TEST_STEM}" --verbose
+
+To inspect the source:
+  cat "${REPO_ROOT}/${TEST_PATH}"
+EOF
+    exit 0
+fi
+
+echo -e "${BOLD}${CYAN}━━━ Running conformance with --verbose ━━━${RESET}"
+exec "$CONFORMANCE" run --filter "$TEST_STEM" --verbose


### PR DESCRIPTION
## Summary

- New `scripts/session/pick-and-run-random.sh` — one-shot wrapper that picks a random conformance failure from `conformance-detail.json` and runs the conformance harness against it with `--verbose` in a single command. Forwards unknown flags to `pick-random-failure.py`, so filters like `--code TS2322`, `--category fingerprint-only`, `--one-missing`, `--close 2` still work. Supports `--no-run` for dry inspection.
- `crates/tsz-solver/src/diagnostics/format/mod.rs` — wrap `display_alias` in backticks inside two doc comments to satisfy `clippy::doc_markdown` under `-D warnings`.
- TypeScript git submodule initialized locally (no repo state change beyond what `conformance.sh` expects).

## Why

Agents starting a new unit of work against the 93% conformance baseline need a fast, deterministic way to get from "I want a random failure" to "here is its verbose fingerprint diff" without juggling three commands. This ties the existing picker to the conformance runner.

The clippy backtick fixes are straight off `cargo clippy --workspace -- -D warnings` on a clean baseline.

## Usage

```bash
# pick a random failure and run it verbose
scripts/session/pick-and-run-random.sh

# pick from a specific campaign
scripts/session/pick-and-run-random.sh --category fingerprint-only --code TS2322

# reproducible selection
scripts/session/pick-and-run-random.sh --seed 42

# just pick, don't run
scripts/session/pick-and-run-random.sh --no-run
```

## Pre-existing blocker for `verify-all.sh`

The branch was at `a129e9c`, already carrying two pre-existing breakages (unrelated to this PR) that keep `scripts/session/verify-all.sh` from going fully green:

1. **`tsz-checker` integration test `conformance_issues` does not compile.** Commit `da4a21b "refactor: split conformance issues tests into modules"` left `tests/conformance_issues.rs` declaring `mod core; mod errors; …` without the `#[path]` attributes needed for an integration-test root to find nested module layouts. `cargo build --tests`, `cargo fmt --check`, and `cargo clippy` all hit `E0583: file not found for module core` on this file. Adding `#[path]` uncovers ~2,885 latent compile errors inside the split files themselves, which is well outside the scope of this task.
2. **`cargo fmt --check` fails** as a downstream effect of (1) — rustfmt aborts on the same mod-resolution failure.

Ahead of this branch, `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes for every crate that compiles; the only remaining errors are the pre-existing `E0583`s from (1). `cargo clippy -p tsz-solver` is clean on this PR.

I did not push a fix for the `conformance_issues` test split because it would require repairing thousands of downstream compile errors introduced by that earlier refactor — that should be its own PR.

## Test plan

- [x] `cargo clippy -p tsz-solver --all-targets --all-features -- -D warnings` — passes
- [x] `scripts/session/pick-and-run-random.sh --no-run --seed 42` — picks, prints path/category/expected/actual, does not run
- [x] `scripts/session/pick-and-run-random.sh --no-run --category wrong-code --seed 7` — category filter forwarded through
- [x] TypeScript submodule initialized at pinned SHA `607a22a9`
- [ ] Full `scripts/session/verify-all.sh` — blocked by pre-existing `conformance_issues` breakage noted above

https://claude.ai/code/session_01AHW3oNomahL4zsk8iYCs9x