### PR TITLE
tooling: add work-random.sh helper + fix doc_markdown clippy errors

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -95,7 +95,7 @@ pub struct TypeFormatter<'a> {
     /// Application (e.g., `type Foo = Id<{...}>`). In assignability error messages,
     /// tsc shows the Application form `Id<{...}>` rather than the outer alias `Foo`.
     skip_application_alias_names: bool,
-    /// When true, don't follow display_alias when it points to an Intersection
+    /// When true, don't follow `display_alias` when it points to an Intersection
     /// type and the current type is an Object. Used for TS2741 messages where
     /// tsc shows the merged object form instead of the intersection form.
     skip_intersection_display_alias: bool,
@@ -209,7 +209,7 @@ impl<'a> TypeFormatter<'a> {
         self
     }
 
-    /// Don't follow display_alias when it points to an Intersection type
+    /// Don't follow `display_alias` when it points to an Intersection type
     /// and the current type is an Object. tsc shows the merged object form
     /// in TS2741 messages, not the intersection form.
     pub const fn with_skip_intersection_display_alias(mut self) -> Self {

--- a/scripts/session/work-random.sh
+++ b/scripts/session/work-random.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# =============================================================================
+# work-random.sh — Pick a random conformance failure and dump everything you
+# need to start working on it.
+# =============================================================================
+#
+# Uses scripts/session/pick-random-failure.py to select a failing test, then
+# prints:
+#   1. The chosen test path and failure category (expected/actual/missing/extra)
+#   2. The test source (first N lines)
+#   3. tsc's expected diagnostic fingerprints from tsc-cache-full.json
+#
+# Usage:
+#   scripts/session/work-random.sh                       # any failure
+#   scripts/session/work-random.sh --category fingerprint-only
+#   scripts/session/work-random.sh --code TS2322
+#   scripts/session/work-random.sh --seed 42 --source-lines 50
+#
+# All unrecognised flags are forwarded to pick-random-failure.py.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+SOURCE_LINES=40
+PICKER_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-lines) SOURCE_LINES="$2"; shift 2 ;;
+        --source-lines=*) SOURCE_LINES="${1#*=}"; shift ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0 ;;
+        *) PICKER_ARGS+=("$1"); shift ;;
+    esac
+done
+
+PICKER="$REPO_ROOT/scripts/session/pick-random-failure.py"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+CACHE="$REPO_ROOT/scripts/conformance/tsc-cache-full.json"
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL not found — run scripts/conformance/conformance.sh snapshot first" >&2
+    exit 1
+fi
+
+# 1. Pick the failure (paths-only so we can re-query detail ourselves).
+TEST_PATH="$(python3 "$PICKER" "${PICKER_ARGS[@]}" --count 1 --paths-only 2>/dev/null || true)"
+if [[ -z "$TEST_PATH" ]]; then
+    echo "error: picker returned no test (filters too narrow?)" >&2
+    exit 1
+fi
+
+echo "=== Random failure ==="
+echo "path: $TEST_PATH"
+echo
+
+# 2. Failure summary (codes / missing / extra).
+python3 - "$DETAIL" "$TEST_PATH" <<'PY'
+import json, sys
+detail_path, test_path = sys.argv[1], sys.argv[2]
+with open(detail_path) as f:
+    entry = json.load(f).get("failures", {}).get(test_path) or {}
+def fmt(k, label):
+    v = entry.get(k) or []
+    print(f"  {label:<8}: {', '.join(v) if v else '-'}")
+print("=== Diagnostic diff ===")
+fmt("e", "expected"); fmt("a", "actual"); fmt("m", "missing"); fmt("x", "extra")
+print()
+PY
+
+# 3. Test source (truncated).
+ABS_PATH="$REPO_ROOT/$TEST_PATH"
+if [[ -f "$ABS_PATH" ]]; then
+    echo "=== Test source (first $SOURCE_LINES lines) ==="
+    head -n "$SOURCE_LINES" "$ABS_PATH"
+    TOTAL_LINES="$(wc -l < "$ABS_PATH")"
+    if (( TOTAL_LINES > SOURCE_LINES )); then
+        echo "... ($((TOTAL_LINES - SOURCE_LINES)) more lines)"
+    fi
+    echo
+else
+    echo "warn: source file not found at $ABS_PATH" >&2
+fi
+
+# 4. tsc's expected fingerprints (message, line:col) for parity reference.
+if [[ -f "$CACHE" ]]; then
+    echo "=== tsc expected fingerprints ==="
+    python3 - "$CACHE" "$TEST_PATH" <<'PY'
+import json, sys
+cache_path, test_path = sys.argv[1], sys.argv[2]
+with open(cache_path) as f:
+    cache = json.load(f)
+# tsc-cache keys are relative to TypeScript/tests/cases/ — strip that prefix.
+prefix = "TypeScript/tests/cases/"
+key = test_path[len(prefix):] if test_path.startswith(prefix) else test_path
+entry = cache.get(key) or cache.get(test_path) or {}
+fps = entry.get("diagnostic_fingerprints") or []
+if not fps:
+    print("  (no tsc fingerprints recorded)")
+else:
+    for fp in fps:
+        code = fp.get("code", "?")
+        loc = f"{fp.get('file', '?')}:{fp.get('line', '?')}:{fp.get('column', '?')}"
+        msg = fp.get("message_key") or fp.get("message") or ""
+        print(f"  {code} {loc} — {msg}")
+PY
+    echo
+fi
+
+echo "=== Next steps ==="
+echo "  ./scripts/conformance/conformance.sh run --filter \"$(basename "$TEST_PATH" .ts)\" --verbose"


### PR DESCRIPTION
## Summary

Small tooling change to make it faster to start a conformance-fixing session.

- **`scripts/session/work-random.sh`** — new one-command wrapper that picks a random conformance failure (delegating to the existing `pick-random-failure.py`) and dumps everything an agent needs to start working on it:
  1. The chosen test path and failure category
  2. Expected / actual / missing / extra diagnostic codes
  3. The test source (first N lines, configurable)
  4. tsc's expected diagnostic fingerprints from `tsc-cache-full.json` (code, position, `message_key`)
  5. The exact `conformance.sh run --filter` command to reproduce

  All `pick-random-failure.py` flags (`--category`, `--code`, `--seed`, `--one-missing`, etc.) are forwarded through.

- **`crates/tsz-solver/src/diagnostics/format/mod.rs`** — wrap `display_alias` in backticks inside two doc comments so `clippy::doc_markdown` no longer fails the workspace lint (`cargo clippy --workspace -- -D warnings`).

- **TypeScript submodule** — initialized locally via `git submodule update --init --depth 1` so conformance tooling (`conformance.sh`, the random-failure picker) can actually run. No tree change, just the checked-out submodule pointer.

## Verification

- `cargo clippy --workspace --lib --bins --all-features -- -D warnings` → **passes** (previously failed on the two `doc_markdown` errors in `tsz-solver`).
- `cargo clippy -p tsz-solver -p tsz-parser -p tsz-binder -p tsz-common --all-targets -- -D warnings` → **passes**.
- `scripts/session/work-random.sh --seed 7` → runs end-to-end, prints the test, diffs, source, and tsc fingerprints.

### Pre-existing baseline issues (not introduced by this PR)

`scripts/session/verify-all.sh` is not fully green on `main` and this PR does not change that. The following failures exist on `main` prior to this change and stem from commit `da4a21b refactor: split conformance issues tests into modules`:

- `cargo fmt --all --check` exits 1 with `Error writing files: failed to resolve mod 'core'` plus three import-sort diffs in `tests/conformance_issues/{core/helpers.rs, features/namespace_construct_signature.rs}`. rustfmt 1.8 on stable can't resolve the relocated submodule layout (`tests/conformance_issues/core/mod.rs` vs. the conventional `tests/core/mod.rs`). Fixing this properly needs either a `#[path]` rework or moving the tests back — both larger than the scope of this PR.
- `cargo check --tests -p tsz-checker` reports 5 `E0583 file not found for module` errors in `tests/conformance_issues.rs` for the same reason, so the `conformance_issues` integration test / lib-test harness does not compile on `main`. This blocks the `cargo nextest run` step of `verify-all.sh`.

Happy to open a follow-up to fix the test module layout if you want, but I kept this PR narrow.

## Test plan

- [x] `cargo clippy --workspace --lib --bins -- -D warnings` passes locally
- [x] `scripts/session/work-random.sh --seed 7` renders a valid failure with tsc fingerprints
- [x] `git submodule status` shows `TypeScript` checked out at the pinned SHA

https://claude.ai/code/session_01FuFKD4evcCEnmMeJfzxKAL