### PR TITLE
chore(session): one-shot pick-random-failure.sh wrapper

### DIFF
--- a/scripts/session/pick-random-failure.sh
+++ b/scripts/session/pick-random-failure.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-random-failure.sh — One-shot "give me a random conformance failure to fix"
+# =============================================================================
+#
+# Usage:
+#   scripts/session/pick-random-failure.sh                     # any category
+#   scripts/session/pick-random-failure.sh --fingerprint-only  # Tier 1 target
+#   scripts/session/pick-random-failure.sh --wrong-code        # Tier 2 target
+#   scripts/session/pick-random-failure.sh --code TS2322       # specific code
+#   scripts/session/pick-random-failure.sh --one-extra         # leaf fix
+#   scripts/session/pick-random-failure.sh --one-missing       # leaf fix
+#   scripts/session/pick-random-failure.sh --seed 42           # reproducible
+#   scripts/session/pick-random-failure.sh --run               # also run it
+#
+# What it does:
+#   1. Ensures the TypeScript submodule is initialized.
+#   2. Picks a random failure from conformance-detail.json using the Python
+#      picker, forwarding any remaining filter flags.
+#   3. Prints the target and, with --run, runs it through the conformance
+#      runner in --verbose mode so you see the fingerprint diff immediately.
+#
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+PICKER="$SCRIPT_DIR/pick-random-failure.py"
+
+if [[ -t 1 ]]; then
+    BOLD='\033[1m' CYAN='\033[0;36m' GREEN='\033[0;32m' YELLOW='\033[0;33m' RESET='\033[0m'
+else
+    BOLD='' CYAN='' GREEN='' YELLOW='' RESET=''
+fi
+
+RUN_AFTER=false
+FORWARD_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run) RUN_AFTER=true; shift ;;
+        # Category shortcuts — translate to the picker's --category flag.
+        --fingerprint-only|--wrong-code|--only-missing|--only-extra|--all-missing|--false-positive)
+            FORWARD_ARGS+=(--category "${1#--}"); shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0"
+            echo
+            echo "Forwarded to pick-random-failure.py:"
+            python3 "$PICKER" --help | sed 's/^/  /'
+            exit 0
+            ;;
+        *) FORWARD_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# --- 1. Ensure TypeScript submodule is initialized ---
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo -e "${YELLOW}!${RESET} TypeScript submodule missing — initializing…"
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript
+fi
+
+# --- 2. Ensure conformance snapshot exists ---
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+if [[ ! -f "$DETAIL" ]]; then
+    echo -e "${YELLOW}!${RESET} Conformance detail missing. Run:"
+    echo "    scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot"
+    exit 1
+fi
+
+# --- 3. Pick a random failure ---
+echo -e "${CYAN}${BOLD}Picking random failure…${RESET}"
+PICK_OUTPUT="$(python3 "$PICKER" "${FORWARD_ARGS[@]}")"
+echo "$PICK_OUTPUT"
+
+if ! $RUN_AFTER; then
+    echo
+    echo -e "${CYAN}tip:${RESET} rerun with --run to execute it through conformance.sh --verbose"
+    exit 0
+fi
+
+# --- 4. Run the picked test through the conformance runner ---
+TARGET_PATH="$(echo "$PICK_OUTPUT" | awk '/^path: /{print $2; exit}')"
+if [[ -z "$TARGET_PATH" ]]; then
+    echo "error: could not parse picked test path" >&2
+    exit 1
+fi
+
+# conformance.sh --filter matches on the test name (basename without extension)
+FILTER="$(basename "$TARGET_PATH")"
+FILTER="${FILTER%.*}"
+
+echo
+echo -e "${CYAN}${BOLD}Running conformance with --verbose for: ${GREEN}$FILTER${RESET}"
+exec "$REPO_ROOT/scripts/conformance/conformance.sh" run --filter "$FILTER" --verbose


### PR DESCRIPTION
## Summary

Adds `scripts/session/pick-random-failure.sh`, a thin shell wrapper around the existing `pick-random-failure.py` that collapses three common setup steps into one command for conformance-campaign work:

1. Ensures the `TypeScript` git submodule is initialized (auto `git submodule update --init --depth 1 TypeScript` if missing).
2. Picks a random failure from `scripts/conformance/conformance-detail.json`, with ergonomic shortcut flags that map to the Python picker's `--category` argument.
3. With `--run`, immediately pipes the picked test through `scripts/conformance/conformance.sh --verbose` so the fingerprint diff is visible in one invocation.

### Usage

```bash
scripts/session/pick-random-failure.sh                     # any category
scripts/session/pick-random-failure.sh --fingerprint-only  # Tier 1 target
scripts/session/pick-random-failure.sh --wrong-code        # Tier 2 target
scripts/session/pick-random-failure.sh --one-extra         # leaf fix
scripts/session/pick-random-failure.sh --code TS2322 --run # run it too
scripts/session/pick-random-failure.sh --seed 42           # reproducible
```

All other flags (`--code`, `--close`, `--seed`, `--count`, `--paths-only`, `--missing-code`, `--extra-code`, ...) pass straight through to the Python picker.

### Design notes

- Keeps the Python picker as the single source of truth for filtering/sampling logic — the wrapper only adds submodule bootstrap + one-flag category shortcuts + an optional `--run` step.
- Exits early with an actionable message if `conformance-detail.json` is missing (tells the user to run `conformance.sh snapshot`).
- Script is idempotent: it does not modify the submodule if it's already initialized.

## Test plan

- [x] `scripts/session/pick-random-failure.sh --seed 42 --fingerprint-only --code TS2322` — picks a TS2322 fingerprint-only target deterministically.
- [x] `scripts/session/pick-random-failure.sh --seed 1 --wrong-code` — picks from wrong-code category.
- [x] `scripts/session/pick-random-failure.sh --seed 2 --one-extra` — picks from 1-extra leaf failures.
- [x] `scripts/session/pick-random-failure.sh --seed 3 --close 2` — picks close-to-passing failures.
- [x] `scripts/session/pick-random-failure.sh --help` — prints usage + forwarded picker help.
- [x] `bash -n scripts/session/pick-random-failure.sh` — syntax check passes.
- [x] Submodule bootstrap verified: `git submodule update --init --depth 1 TypeScript` runs automatically when `TypeScript/tests` is missing.

## Verification caveat

`scripts/session/verify-all.sh`, `cargo fmt --check`, and `cargo clippy` currently fail on `origin/main` (at `cd1ba48`) due to unrelated broken module resolution introduced in commit `da4a21b` ("refactor: split conformance issues tests into modules"). Specifically:

- `tests/conformance_issues.rs` declares `mod core; mod errors; mod features; mod modules; mod types;` but the corresponding files live under `tests/conformance_issues/<area>/mod.rs`, so rustc/rustfmt look in the wrong location (`tests/core.rs`, ...).
- The submodule `.rs` files internally use `use crate::core::*;`, which only resolves when `tests/conformance_issues.rs` is the crate root — but `src/lib.rs` also `#[path]`-includes the same file as a lib test, where that path doesn't resolve.

This pre-existing breakage is orthogonal to this PR — the change here is a pure additive shell script — and fixing it would require either reverting `da4a21b` or touching ~25 test files to rewire their `crate::` paths. Flagging here so the verification gate can be addressed in a separate, focused PR.

