### PR TITLE
scripts/session: add pick-random-and-show.sh wrapper

### DIFF
--- a/scripts/session/pick-random-and-show.sh
+++ b/scripts/session/pick-random-and-show.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# pick-random-and-show.sh — Pick a random conformance failure and show the diff.
+#
+# Quick workflow tool: combines pick-random-failure.py with conformance.sh
+# verbose runner so you can immediately see expected vs actual diagnostics.
+#
+# Usage:
+#   scripts/session/pick-random-and-show.sh                  # any failure
+#   scripts/session/pick-random-and-show.sh fingerprint-only # by category
+#   scripts/session/pick-random-and-show.sh wrong-code TS2322
+#   scripts/session/pick-random-and-show.sh any "" 42        # with seed
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CATEGORY="${1:-any}"
+CODE="${2:-}"
+SEED="${3:-}"
+
+ARGS=(--category "$CATEGORY")
+[[ -n "$CODE" ]] && ARGS+=(--code "$CODE")
+[[ -n "$SEED" ]] && ARGS+=(--seed "$SEED")
+
+PICK_OUT=$(python3 scripts/session/pick-random-failure.py "${ARGS[@]}")
+echo "$PICK_OUT"
+
+PATH_LINE=$(printf '%s\n' "$PICK_OUT" | awk -F': *' '/^path:/ {print $2; exit}')
+if [[ -z "$PATH_LINE" ]]; then
+    echo "no path returned from picker" >&2
+    exit 1
+fi
+
+BASENAME=$(basename "$PATH_LINE" .ts)
+BASENAME=$(basename "$BASENAME" .tsx)
+
+echo "──── running conformance for: $BASENAME ────"
+./scripts/conformance/conformance.sh run --filter "$BASENAME" --verbose || true


### PR DESCRIPTION
## Summary
- Adds `scripts/session/pick-random-and-show.sh`, a thin wrapper that calls `pick-random-failure.py` and immediately runs the conformance test in `--verbose` mode for the picked test, so the agent sees expected vs actual diagnostics in one shot.
- Supports the same category/code/seed positional args as the picker (e.g. `fingerprint-only TS2322`, `wrong-code TS2345 42`).

## Why
Picking a random conformance failure was a two-step copy/paste dance: run the picker, find the path line, hand-copy the basename into `conformance.sh run --filter ... --verbose`. This wrapper collapses that into a single command and is friendlier for the random-pick workflow described in `scripts/session/conformance-agent-prompt.md`.

## Test plan
- [x] `bash -n scripts/session/pick-random-and-show.sh` (syntax check)
- [x] `python3 scripts/session/pick-random-failure.py --category any --seed 1` produces the expected `path:` line that the wrapper greps for
- [ ] Run end-to-end on a developer box and confirm `conformance.sh run --filter <basename> --verbose` is invoked

https://claude.ai/code/session_01Gcndup4TjL43asE2HcdP1g