### PR TITLE
fix(printer): preserve declaration order for tier-2 anonymous object unions

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -489,24 +489,21 @@ impl<'a> TypeFormatter<'a> {
         // match source declaration order. Display-time sorting fixes this for diagnostics.
         //
         // Sorting rules:
-        // - Tier 0/1 (builtins/user types with source): always sort these
-        // - Tier 2 objects only (all anonymous objects): sort by property count
-        // - Mixed tier 2 or non-object tier 2: preserve original order
+        // - Tier 0/1 (builtins/user types with source): sort by source position.
+        // - Tier 2 (anonymous objects without source): preserve declaration order.
+        //   The previous "sort tier-2 objects by property count" heuristic matched
+        //   tsc's output for some `{} | { a: number }`-style unions but reordered
+        //   legitimate discriminated-union displays (e.g. TS2353/TS2322 messages)
+        //   where tsc preserves declaration order of the anonymous members.
         if let Some(def_store) = self.def_store {
             let positions: Vec<_> = ordered
                 .iter()
                 .map(|&m| self.get_source_position_for_type(m, def_store))
                 .collect();
 
-            // Check if we should sort: either all have positions (tier < 2),
-            // or all are tier 2 objects (which have property count as sort key)
             let all_tier_0_or_1 = positions.iter().all(|&(tier, _, _)| tier < 2);
-            let all_tier_2_objects = positions.iter().all(|&(tier, second, _)| {
-                // Tier 2 objects have second=0, non-objects have second=u32::MAX
-                tier == 2 && second == 0
-            });
 
-            if all_tier_0_or_1 || all_tier_2_objects {
+            if all_tier_0_or_1 {
                 let mut pairs: Vec<_> = ordered.iter().copied().zip(positions).collect();
                 pairs.sort_by_key(|&(_, pos)| pos);
                 ordered = pairs.into_iter().map(|(id, _)| id).collect();


### PR DESCRIPTION
## Summary
`format_union` was sorting tier-2 (anonymous, no source position) object members by property count. The heuristic matched tsc's output for simple cases like `{} | { a: number }`, but it reorders legitimate discriminated-union displays where tsc preserves the source declaration order.

Example: for a discriminated union like \`{ p1: 'left'; p2: true; p3: number } | { p1: 'right'; p2: false; p4: string } | { p1: 'left'; p2: boolean }\`, tsc reports \`Type '{ p1: \"left\"; p2: true; p3: number; } | { p1: \"left\"; p2: boolean; }'\` (source order). Our sort produced \`{ p1: \"left\"; p2: boolean; } | { p1: \"left\"; p2: true; p3: number; }\` (property-count order).

Drop the \"sort tier-2 objects by property count\" branch. Tier-0/1 (builtins + named types with def-store entries) still sort by source position as before; tier-2 preserves the canonicalized union list's existing order.

## Tests flipped FAIL → PASS
- \`circularlySimplifyingConditionalTypesNoCrash.ts\`
- \`cloduleGenericOnSelfMember.ts\`
- \`genericCallInferenceWithGenericLocalFunction.ts\`

Partial improvement on \`excessPropertyCheckWithMultipleDiscriminants.ts\` (union-order fingerprint now matches tsc; test still fails on an unrelated solver-level discriminant-narrowing issue).

## Test plan
- [x] `--filter compiler` — 6254/6519 (was 6250/6519) — **+4**, no regressions
- [x] `--filter types/union` — 19/25, identical failure set vs baseline