### PR TITLE
checker: drop module prefix when ambient namespace is re-exported

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -509,17 +509,39 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        // tsc includes the module prefix (e.g., '"test".c') for exported namespaces
-        // in external modules. The one exception is global/ambient namespaces that are
-        // re-exported via `export { X }` (where the namespace declaration itself
-        // doesn't have the export modifier). However, detecting this reliably across
-        // arenas is complex, so we conservatively include the prefix for all exported
-        // symbols in external modules. This matches tsc's behavior in the common case.
+        // tsc includes the module prefix (e.g., '"test".c') for namespaces whose
+        // declaration itself carries the `export` modifier. Namespaces declared
+        // ambiently (`declare namespace X {}`) and merely re-exported via a
+        // separate `export { X }` specifier keep the bare local name in tsc's
+        // TS2694 message. Check the declaration modifiers so we match both cases.
+
+        let arena = self.ctx.get_arena_for_file(symbol.decl_file_idx);
+        let declaration_has_export_modifier = symbol.declarations.iter().any(|&decl_idx| {
+            // `export namespace Foo {}` carries modifiers on the declaration
+            // itself.
+            let own_has_export = arena.get(decl_idx).is_some_and(|node| {
+                arena.get_declaration_modifiers(node).is_some_and(|mods| {
+                    arena.has_modifier_ref(Some(mods), SyntaxKind::ExportKeyword)
+                })
+            });
+            if own_has_export {
+                return true;
+            }
+            // `export namespace Foo {}` is parsed as an EXPORT_DECLARATION
+            // wrapper around a modifier-less ModuleDeclaration, so also check
+            // whether the declaration's immediate parent is that wrapper.
+            arena
+                .get_extended(decl_idx)
+                .and_then(|ext| arena.get(ext.parent))
+                .is_some_and(|parent| parent.kind == syntax_kind_ext::EXPORT_DECLARATION)
+        });
+        if !declaration_has_export_modifier {
+            return None;
+        }
 
         let (is_external_module, file_name) = if symbol.decl_file_idx != u32::MAX {
             let file_idx = symbol.decl_file_idx as usize;
             let binder = self.ctx.get_binder_for_file(file_idx)?;
-            let arena = self.ctx.get_arena_for_file(symbol.decl_file_idx);
             let file_name = arena.source_files.first()?.file_name.clone();
             (binder.is_external_module(), file_name)
         } else {

--- a/scripts/session/pick-and-prepare.sh
+++ b/scripts/session/pick-and-prepare.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Pick a random conformance failure and dump everything needed to start work:
+# the chosen test path, its expected/actual/missing/extra codes, the source
+# snippet, and (optionally) a verbose conformance run for fingerprint diffs.
+#
+# Usage:
+#   scripts/session/pick-and-prepare.sh                      # random any category
+#   scripts/session/pick-and-prepare.sh --category wrong-code
+#   scripts/session/pick-and-prepare.sh --code TS2322
+#   scripts/session/pick-and-prepare.sh --seed 42 --no-run   # deterministic, skip run
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+RUN_TEST=true
+PICK_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-run) RUN_TEST=false; shift ;;
+        *) PICK_ARGS+=("$1"); shift ;;
+    esac
+done
+
+cd "$REPO_ROOT"
+
+# 1. Pick a single random failure.
+PICK_OUTPUT="$(python3 scripts/session/pick-random-failure.py --count 1 "${PICK_ARGS[@]}" 2>/dev/null)"
+if [[ -z "$PICK_OUTPUT" ]]; then
+    echo "no failures matched the given filters" >&2
+    exit 1
+fi
+
+printf '%s\n\n' "$PICK_OUTPUT"
+
+TEST_PATH="$(printf '%s\n' "$PICK_OUTPUT" | awk '/^path: /{print $2; exit}')"
+if [[ -z "$TEST_PATH" ]]; then
+    echo "could not parse test path from picker output" >&2
+    exit 1
+fi
+
+# 2. Print the source for quick context.
+SRC="$REPO_ROOT/$TEST_PATH"
+echo "---- source ($SRC) ----"
+if [[ -f "$SRC" ]]; then
+    head -80 "$SRC"
+else
+    echo "source file not found (TypeScript submodule may not be checked out)"
+fi
+echo
+
+# 3. Optionally run the test with --verbose to see the fingerprint diff.
+if $RUN_TEST; then
+    FILTER="$(basename "$TEST_PATH" .ts)"
+    FILTER="${FILTER%.tsx}"
+    echo "---- running: conformance.sh run --filter \"$FILTER\" --verbose ----"
+    ./scripts/conformance/conformance.sh run --filter "$FILTER" --verbose 2>&1 | tail -60
+fi


### PR DESCRIPTION
tsc prints a bare namespace name in TS2694 messages when the namespace declaration itself isn't exported (i.e. `declare namespace X {}` followed by a separate `export { X }`). Previously we always prepended the module prefix ('\"file\".X') for any exported symbol in an external module, which diverged from tsc for the `export { X }` form.

Only prepend the prefix when the declaration carries the `export` modifier directly, or is wrapped by an EXPORT_DECLARATION node (the shape the parser produces for `export namespace X {}`).

Also adds scripts/session/pick-and-prepare.sh, a thin wrapper around pick-random-failure.py that prints the test source and runs the targeted conformance filter so a new session can start with full context on a single chosen failure.

https://claude.ai/code/session_0187yq91RxMfs1zJXSocapVE