### PR TITLE
perf(tsz-server): persistent node worker for native TypeScript operations

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
@@ -39,6 +39,7 @@ fn make_server() -> Server {
         include_completions_with_class_member_snippets: false,
         new_line_character: None,
         plugin_configs: FxHashMap::default(),
+        native_ts_worker: None,
     }
 }
 

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
@@ -37,668 +37,7 @@ impl Server {
         &self,
         mut payload: serde_json::Value,
     ) -> Option<serde_json::Value> {
-        const SCRIPT: &str = r#"
-const fs = require("fs");
-const path = require("path");
-
-function loadTypescript() {
-  const cwd = process.cwd();
-  const candidates = [
-    path.join(cwd, "TypeScript", "node_modules", "typescript"),
-    "typescript",
-  ];
-  for (const candidate of candidates) {
-    try {
-      return require(candidate);
-    } catch {}
-  }
-  throw new Error("Cannot load TypeScript runtime");
-}
-
-function normalizePath(fileName) {
-  return typeof fileName === "string" ? fileName.replace(/\\\\/g, "/") : fileName;
-}
-
-function getLineStarts(text) {
-  const starts = [0];
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 10) starts.push(i + 1);
-  }
-  return starts;
-}
-
-function offsetToLocation(lineStarts, offset) {
-  const bounded = Math.max(0, Math.min(offset, lineStarts[lineStarts.length - 1] + 10 ** 9));
-  let low = 0;
-  let high = lineStarts.length - 1;
-  while (low <= high) {
-    const mid = (low + high) >> 1;
-    const start = lineStarts[mid];
-    const next = mid + 1 < lineStarts.length ? lineStarts[mid + 1] : Number.MAX_SAFE_INTEGER;
-    if (bounded < start) {
-      high = mid - 1;
-    } else if (bounded >= next) {
-      low = mid + 1;
-    } else {
-      return { line: mid + 1, offset: bounded - start + 1 };
-    }
-  }
-  const line = Math.max(0, Math.min(low, lineStarts.length - 1));
-  return { line: line + 1, offset: bounded - lineStarts[line] + 1 };
-}
-
-function locationToOffset(fileText, line, offset) {
-  const lineStarts = getLineStarts(fileText);
-  const lineIndex = Math.max(0, Math.min((line || 1) - 1, lineStarts.length - 1));
-  const base = lineStarts[lineIndex];
-  return base + Math.max(0, (offset || 1) - 1);
-}
-
-function nodeModulesPackageRoot(fileName) {
-  const normalized = normalizePath(fileName || "");
-  const marker = "/node_modules/";
-  const idx = normalized.lastIndexOf(marker);
-  if (idx < 0) return "";
-  const rest = normalized.slice(idx + marker.length);
-  if (!rest) return "";
-  const parts = rest.split("/").filter(Boolean);
-  if (parts.length === 0) return "";
-  const pkgParts = parts[0].startsWith("@") && parts.length > 1
-    ? [parts[0], parts[1]]
-    : [parts[0]];
-  return normalized.slice(0, idx + marker.length) + pkgParts.join("/");
-}
-
-function nodeModulesRenameError(requestedFile, definitionFiles) {
-  const currentRoot = nodeModulesPackageRoot(requestedFile);
-  for (const defFile of definitionFiles) {
-    const defRoot = nodeModulesPackageRoot(defFile);
-    if (!defRoot) continue;
-    if (currentRoot && currentRoot !== defRoot) {
-      return "You cannot rename elements that are defined in another 'node_modules' folder.";
-    }
-  }
-  return "You cannot rename elements that are defined in a 'node_modules' folder.";
-}
-
-function run() {
-  const ts = loadTypescript();
-  const raw = fs.readFileSync(0, "utf8");
-  const input = raw ? JSON.parse(raw) : {};
-  const op = String(input.op || "");
-  const requestedFile = normalizePath(input.file || "");
-  const inputOpenFiles = input.openFiles && typeof input.openFiles === "object" ? input.openFiles : {};
-  const files = {};
-  for (const [key, value] of Object.entries(inputOpenFiles)) {
-    files[normalizePath(key)] = String(value ?? "");
-  }
-
-  function ensureFileText(fileName) {
-    const normalized = normalizePath(fileName);
-    if (!normalized) return "";
-    if (Object.prototype.hasOwnProperty.call(files, normalized)) {
-      return files[normalized];
-    }
-    try {
-      const text = fs.readFileSync(normalized, "utf8");
-      files[normalized] = text;
-      return text;
-    } catch {
-      return "";
-    }
-  }
-
-  if (requestedFile && !Object.prototype.hasOwnProperty.call(files, requestedFile)) {
-    ensureFileText(requestedFile);
-  }
-
-  const realpathAliases = new Map();
-
-  function packageInfoFromPath(fileName) {
-    const normalized = normalizePath(fileName || "");
-    const prefix = "/packages/";
-    if (!normalized.startsWith(prefix)) return null;
-    const rest = normalized.slice(prefix.length);
-    const segments = rest.split("/").filter(Boolean);
-    if (segments.length < 2) return null;
-    let packageName = segments[0];
-    let restStart = 1;
-    if (packageName.startsWith("@")) {
-      if (segments.length < 3) return null;
-      packageName = `${segments[0]}/${segments[1]}`;
-      restStart = 2;
-    }
-    const packageRelativePath = segments.slice(restStart).join("/");
-    if (!packageRelativePath) return null;
-    return { packageName, packageRelativePath };
-  }
-
-  function packageNameFromSpecifier(specifier) {
-    const text = String(specifier || "").trim();
-    if (!text || text.startsWith(".") || text.startsWith("/")) return null;
-    const parts = text.split("/").filter(Boolean);
-    if (parts.length === 0) return null;
-    if (parts[0].startsWith("@") && parts.length > 1) {
-      return `${parts[0]}/${parts[1]}`;
-    }
-    return parts[0];
-  }
-
-  function barePackageSpecifiers(fileText) {
-    const source = String(fileText || "");
-    const out = new Set();
-    const patterns = [
-      /from\s+["']([^"']+)["']/g,
-      /require\(\s*["']([^"']+)["']\s*\)/g,
-      /import\(\s*["']([^"']+)["']\s*\)/g,
-    ];
-    for (const pattern of patterns) {
-      let match;
-      while ((match = pattern.exec(source)) !== null) {
-        const packageName = packageNameFromSpecifier(match[1]);
-        if (packageName) out.add(packageName);
-      }
-    }
-    return out;
-  }
-
-  const packageFiles = new Map();
-  for (const [fileName, fileText] of Object.entries(files)) {
-    const info = packageInfoFromPath(fileName);
-    if (!info) continue;
-    if (!packageFiles.has(info.packageName)) {
-      packageFiles.set(info.packageName, []);
-    }
-    packageFiles.get(info.packageName).push({
-      sourcePath: normalizePath(fileName),
-      packageRelativePath: info.packageRelativePath,
-      content: String(fileText ?? ""),
-    });
-  }
-
-  for (const [consumerFile, fileText] of Object.entries(files)) {
-    const consumerInfo = packageInfoFromPath(consumerFile);
-    if (!consumerInfo) continue;
-    const consumerRoot = `/packages/${consumerInfo.packageName}`;
-    const specifiers = barePackageSpecifiers(fileText);
-    for (const packageName of specifiers) {
-      const entries = packageFiles.get(packageName);
-      if (!entries || entries.length === 0) continue;
-      for (const entry of entries) {
-        const linkedPath = normalizePath(
-          `${consumerRoot}/node_modules/${packageName}/${entry.packageRelativePath}`,
-        );
-        if (!Object.prototype.hasOwnProperty.call(files, linkedPath)) {
-          files[linkedPath] = entry.content;
-        }
-        realpathAliases.set(linkedPath, entry.sourcePath);
-      }
-    }
-  }
-
-  function isScriptFile(fileName) {
-    return /\.(d\.ts|ts|tsx|js|jsx|mts|cts)$/i.test(fileName || "");
-  }
-
-  const scriptFileNames = Object.keys(files).filter(isScriptFile);
-  if (requestedFile && isScriptFile(requestedFile) && !scriptFileNames.includes(requestedFile)) {
-    scriptFileNames.push(requestedFile);
-  }
-
-  const virtualFiles = new Set(Object.keys(files).map(normalizePath));
-  const virtualDirs = new Set();
-
-  function addVirtualDir(dirName) {
-    if (!dirName) return;
-    virtualDirs.add(normalizePath(dirName));
-  }
-
-  function addVirtualPath(fileName) {
-    const normalized = normalizePath(fileName);
-    if (!normalized) return;
-    let current = path.posix.dirname(normalized);
-    while (current && current !== "." && current !== "/") {
-      addVirtualDir(current);
-      const parent = path.posix.dirname(current);
-      if (!parent || parent === current) break;
-      current = parent;
-    }
-    if (current === "/") addVirtualDir("/");
-  }
-
-  for (const fileName of virtualFiles) {
-    addVirtualPath(fileName);
-  }
-
-  function virtualDirectoryExists(dirName) {
-    const normalized = normalizePath(dirName || "");
-    if (!normalized) return false;
-    if (virtualDirs.has(normalized)) return true;
-    const prefix = normalized.endsWith("/") ? normalized : `${normalized}/`;
-    for (const fileName of virtualFiles) {
-      if (fileName.startsWith(prefix)) return true;
-    }
-    return false;
-  }
-
-  function virtualDirectoriesOf(dirName) {
-    const normalized = normalizePath(dirName || "");
-    if (!normalized) return [];
-    const out = new Set();
-    for (const dir of virtualDirs) {
-      if (dir === normalized) continue;
-      if (path.posix.dirname(dir) === normalized) {
-        out.add(path.posix.basename(dir));
-      }
-    }
-    return Array.from(out.values());
-  }
-
-  function virtualReadDirectory(rootDir, extensions) {
-    const normalizedRoot = normalizePath(rootDir || "");
-    if (!normalizedRoot) return [];
-    const prefix = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
-    const extensionList = Array.isArray(extensions) ? extensions : [];
-    const out = new Set();
-    for (const fileName of virtualFiles) {
-      if (fileName !== normalizedRoot && !fileName.startsWith(prefix)) continue;
-      if (
-        extensionList.length > 0
-        && !extensionList.some(ext => fileName.toLowerCase().endsWith(String(ext || "").toLowerCase()))
-      ) {
-        continue;
-      }
-      out.add(fileName);
-    }
-    return Array.from(out.values());
-  }
-
-  const fullProgramOps = new Set(["rename", "encodedSemanticClassifications"]);
-  const compilerOptions = fullProgramOps.has(op)
-    ? {
-        allowJs: true,
-        checkJs: true,
-        target: ts.ScriptTarget.Latest,
-        module: ts.ModuleKind.CommonJS,
-        moduleResolution: ts.ModuleResolutionKind.NodeJs,
-        jsx: ts.JsxEmit.Preserve,
-        allowImportingTsExtensions: true,
-      }
-    : {
-        allowJs: true,
-        checkJs: false,
-        target: ts.ScriptTarget.Latest,
-        module: ts.ModuleKind.ESNext,
-        jsx: ts.JsxEmit.Preserve,
-        noResolve: true,
-        noLib: true,
-        allowNonTsExtensions: true,
-      };
-
-  const versions = new Map(scriptFileNames.map(file => [file, "1"]));
-
-  const host = {
-    getCompilationSettings: () => compilerOptions,
-    getCurrentDirectory: () => "/",
-    getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
-    getScriptFileNames: () => scriptFileNames,
-    getScriptVersion: fileName => versions.get(normalizePath(fileName)) || "1",
-    getScriptSnapshot: fileName => {
-      const text = ensureFileText(fileName);
-      if (text === "") {
-        if (ts.sys.fileExists(fileName)) {
-          const fromFs = ts.sys.readFile(fileName);
-          return fromFs !== undefined ? ts.ScriptSnapshot.fromString(fromFs) : undefined;
-        }
-        return undefined;
-      }
-      return ts.ScriptSnapshot.fromString(text);
-    },
-    readFile: fileName => {
-      const normalized = normalizePath(fileName);
-      if (Object.prototype.hasOwnProperty.call(files, normalized)) {
-        return files[normalized];
-      }
-      return ts.sys.readFile(fileName);
-    },
-    fileExists: fileName => {
-      const normalized = normalizePath(fileName);
-      return Object.prototype.hasOwnProperty.call(files, normalized) || ts.sys.fileExists(fileName);
-    },
-    readDirectory: (rootDir, extensions, excludes, includes, depth) => {
-      const diskEntries = ts.sys.readDirectory
-        ? ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth)
-        : [];
-      const merged = new Set((diskEntries || []).map(normalizePath));
-      for (const virtualEntry of virtualReadDirectory(rootDir, extensions)) {
-        merged.add(virtualEntry);
-      }
-      return Array.from(merged.values());
-    },
-    directoryExists: fileName => {
-      if (virtualDirectoryExists(fileName)) return true;
-      return ts.sys.directoryExists ? ts.sys.directoryExists(fileName) : false;
-    },
-    getDirectories: dirName => {
-      const diskDirs = ts.sys.getDirectories ? ts.sys.getDirectories(dirName) : [];
-      const merged = new Set(diskDirs || []);
-      for (const virtualDir of virtualDirectoriesOf(dirName)) {
-        merged.add(virtualDir);
-      }
-      return Array.from(merged.values());
-    },
-    realpath: fileName => {
-      const normalized = normalizePath(fileName);
-      if (realpathAliases.has(normalized)) {
-        return realpathAliases.get(normalized);
-      }
-      if (Object.prototype.hasOwnProperty.call(files, normalized) || virtualDirectoryExists(normalized)) {
-        return normalized;
-      }
-      return ts.sys.realpath ? ts.sys.realpath(fileName) : fileName;
-    },
-  };
-
-  const ls = ts.createLanguageService(host, ts.createDocumentRegistry());
-
-  function spanToProtocol(fileName, span) {
-    const text = ensureFileText(fileName);
-    const lineStarts = getLineStarts(text);
-    const start = span?.start || 0;
-    const length = span?.length || 0;
-    return {
-      start: offsetToLocation(lineStarts, start),
-      end: offsetToLocation(lineStarts, start + length),
-    };
-  }
-
-  function navTreeToProtocol(fileName, item) {
-    return {
-      text: item.text,
-      kind: item.kind,
-      kindModifiers: item.kindModifiers || "",
-      spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
-      nameSpan: item.nameSpan ? spanToProtocol(fileName, item.nameSpan) : undefined,
-      childItems: item.childItems && item.childItems.length
-        ? item.childItems.map(child => navTreeToProtocol(fileName, child))
-        : undefined,
-    };
-  }
-
-  function navBarToProtocol(fileName, item) {
-    if (!item || typeof item !== "object") {
-      return {
-        text: "",
-        kind: "",
-        kindModifiers: "",
-        spans: [],
-        indent: 0,
-      };
-    }
-    if (!globalThis.__tszNavBarSeen) {
-      globalThis.__tszNavBarSeen = new WeakSet();
-    }
-    const seen = globalThis.__tszNavBarSeen;
-    if (seen.has(item)) {
-      return {
-        text: item.text,
-        kind: item.kind,
-        kindModifiers: item.kindModifiers || "",
-        spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
-        indent: item.indent || 0,
-      };
-    }
-    seen.add(item);
-    return {
-      text: item.text,
-      kind: item.kind,
-      kindModifiers: item.kindModifiers || "",
-      spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
-      childItems: item.childItems && item.childItems.length
-        ? item.childItems.map(child => navBarToProtocol(fileName, child))
-        : undefined,
-      indent: item.indent || 0,
-    };
-  }
-
-  let result = null;
-  switch (op) {
-    case "navtree": {
-      const tree = ls.getNavigationTree(requestedFile);
-      result = tree ? navTreeToProtocol(requestedFile, tree) : null;
-      break;
-    }
-    case "navbar": {
-      const items = ls.getNavigationBarItems(requestedFile) || [];
-      result = items.map(item => navBarToProtocol(requestedFile, item));
-      break;
-    }
-    case "navto": {
-      const searchValue = String(input.searchValue || "");
-      const items = ls.getNavigateToItems(searchValue) || [];
-      result = items.map(item => {
-        const fileName = normalizePath(item.fileName || requestedFile);
-        const span = spanToProtocol(fileName, item.textSpan || { start: 0, length: 0 });
-        return {
-          name: item.name,
-          kind: item.kind,
-          matchKind: item.matchKind,
-          isCaseSensitive: !!item.isCaseSensitive,
-          kindModifiers: item.kindModifiers || "",
-          containerName: item.containerName || "",
-          containerKind: item.containerKind || "",
-          file: fileName,
-          start: span.start,
-          end: span.end,
-        };
-      });
-      break;
-    }
-    case "rename": {
-      const text = ensureFileText(requestedFile);
-      const line = Number(input.line) || 1;
-      const offset = Number(input.offset) || 1;
-      const position = locationToOffset(text, line, offset);
-      const findInStrings = !!input.findInStrings;
-      const findInComments = !!input.findInComments;
-      const preferences =
-        input.preferences && typeof input.preferences === "object"
-          ? { ...input.preferences }
-          : {};
-      if (
-        preferences.providePrefixAndSuffixTextForRename === undefined
-        && input.providePrefixAndSuffixTextForRename !== undefined
-        && input.providePrefixAndSuffixTextForRename !== null
-      ) {
-        preferences.providePrefixAndSuffixTextForRename = !!input.providePrefixAndSuffixTextForRename;
-      }
-      if (
-        preferences.allowRenameOfImportPath === undefined
-        && input.allowRenameOfImportPath !== undefined
-        && input.allowRenameOfImportPath !== null
-      ) {
-        preferences.allowRenameOfImportPath = !!input.allowRenameOfImportPath;
-      }
-      if (preferences.allowRenameOfImportPath === undefined) {
-        preferences.allowRenameOfImportPath = true;
-      }
-
-      const renameInfo = ls.getRenameInfo(
-        requestedFile,
-        position,
-        preferences,
-        findInStrings,
-        findInComments,
-      );
-
-      const definitions = ls.getDefinitionAtPosition(requestedFile, position) || [];
-      const definitionFiles = definitions
-        .map(def => normalizePath(def && def.fileName ? def.fileName : ""))
-        .filter(Boolean);
-      const hasNodeModulesDefinition = definitionFiles.some(fileName =>
-        fileName.includes("/node_modules/")
-      );
-
-      if (!renameInfo || !renameInfo.canRename) {
-        let message =
-          (renameInfo && renameInfo.localizedErrorMessage) || "You cannot rename this element.";
-        if (message === "You cannot rename this element." && hasNodeModulesDefinition) {
-          message = nodeModulesRenameError(requestedFile, definitionFiles);
-        }
-        result = {
-          info: {
-            canRename: false,
-            localizedErrorMessage: message,
-          },
-          locs: [],
-        };
-        break;
-      }
-
-      if (
-        preferences
-        && preferences.allowRenameOfImportPath === false
-        && renameInfo.fileToRename !== undefined
-      ) {
-        result = {
-          info: {
-            canRename: false,
-            localizedErrorMessage: "You cannot rename this element.",
-          },
-          locs: [],
-        };
-        break;
-      }
-
-      const locations =
-        ls.findRenameLocations(
-          requestedFile,
-          position,
-          findInStrings,
-          findInComments,
-          preferences,
-        ) || [];
-
-      const grouped = new Map();
-      for (const loc of locations) {
-        const fileName = normalizePath(loc.fileName || requestedFile);
-        const span = spanToProtocol(fileName, loc.textSpan || { start: 0, length: 0 });
-        const entry = { start: span.start, end: span.end };
-        if (loc.contextSpan) {
-          const contextSpan = spanToProtocol(fileName, loc.contextSpan);
-          entry.contextStart = contextSpan.start;
-          entry.contextEnd = contextSpan.end;
-        }
-        if (loc.prefixText !== undefined) entry.prefixText = loc.prefixText;
-        if (loc.suffixText !== undefined) entry.suffixText = loc.suffixText;
-        const current = grouped.get(fileName);
-        if (current) current.push(entry);
-        else grouped.set(fileName, [entry]);
-      }
-
-      const triggerSpan = renameInfo.triggerSpan || { start: position, length: 0 };
-      const trigger = spanToProtocol(requestedFile, triggerSpan);
-      const info = {
-        canRename: true,
-        displayName: renameInfo.displayName,
-        fullDisplayName: renameInfo.fullDisplayName,
-        kind: renameInfo.kind,
-        kindModifiers: renameInfo.kindModifiers || "",
-        triggerSpan: {
-          start: trigger.start,
-          length: triggerSpan.length || 0,
-        },
-      };
-      if (renameInfo.fileToRename !== undefined) {
-        info.fileToRename = normalizePath(renameInfo.fileToRename);
-      }
-
-      const locs = Array.from(grouped.entries()).map(([fileName, fileLocs]) => ({
-        file: fileName,
-        locs: fileLocs,
-      }));
-
-      result = { info, locs };
-      break;
-    }
-    case "format": {
-      const options = input.options && typeof input.options === "object" ? input.options : {};
-      const text = ensureFileText(requestedFile);
-      const startLine = Number(input.line);
-      const startOffset = Number(input.offset);
-      const endLine = Number(input.endLine);
-      const endOffset = Number(input.endOffset);
-      const hasRange =
-        Number.isFinite(startLine)
-        && Number.isFinite(startOffset)
-        && Number.isFinite(endLine)
-        && Number.isFinite(endOffset);
-      const edits = hasRange
-        ? (ls.getFormattingEditsForRange(
-            requestedFile,
-            Math.min(
-              locationToOffset(text, startLine, startOffset),
-              locationToOffset(text, endLine, endOffset),
-            ),
-            Math.max(
-              locationToOffset(text, startLine, startOffset),
-              locationToOffset(text, endLine, endOffset),
-            ),
-            options,
-          ) || [])
-        : (ls.getFormattingEditsForDocument(requestedFile, options) || []);
-      result = edits.map(edit => {
-        const span = spanToProtocol(requestedFile, edit.span || { start: 0, length: 0 });
-        return { start: span.start, end: span.end, newText: edit.newText || "" };
-      });
-      break;
-    }
-    case "formatOnKey": {
-      const options = input.options && typeof input.options === "object" ? input.options : {};
-      const text = ensureFileText(requestedFile);
-      const position = locationToOffset(text, Number(input.line) || 1, Number(input.offset) || 1);
-      const key = String(input.key || "");
-      const edits = ls.getFormattingEditsAfterKeystroke(requestedFile, position, key, options) || [];
-      result = edits.map(edit => {
-        const span = spanToProtocol(requestedFile, edit.span || { start: 0, length: 0 });
-        return { start: span.start, end: span.end, newText: edit.newText || "" };
-      });
-      break;
-    }
-    case "encodedSemanticClassifications": {
-      const text = ensureFileText(requestedFile);
-      const rawStart = Number(input.start);
-      const start = Number.isFinite(rawStart) && rawStart >= 0 ? rawStart : 0;
-      const rawLength = Number(input.length);
-      const length = Number.isFinite(rawLength) && rawLength > 0 ? rawLength : text.length;
-      const rawFormat = input.format;
-      const format = rawFormat === "2020"
-        || rawFormat === "1"
-        || rawFormat === 2020
-        || rawFormat === 1
-        ? ts.SemanticClassificationFormat.TwentyTwenty
-        : ts.SemanticClassificationFormat.Original;
-      result = ls.getEncodedSemanticClassifications(
-        requestedFile,
-        { start, length },
-        format,
-      );
-      break;
-    }
-    default:
-      result = null;
-      break;
-  }
-
-  process.stdout.write(JSON.stringify(result));
-}
-
-try {
-  run();
-} catch (err) {
-  process.stdout.write(JSON.stringify({ __error: String(err && err.message ? err.message : err) }));
-}
-"#;
+        const SCRIPT: &str = include_str!("native_ts_worker.js");
 
         let payload_obj = payload.as_object_mut()?;
         if payload_obj.get("openFiles").is_none() {
@@ -822,6 +161,18 @@ try {
 
             let open_files_value = serde_json::to_value(&native_open_files).ok()?;
             payload_obj.insert("openFiles".to_string(), open_files_value);
+        }
+
+        if let Some(worker) = self.native_ts_worker.as_ref()
+            && let Some(value) = worker
+                .lock()
+                .ok()
+                .and_then(|mut guard| guard.request(SCRIPT, &payload))
+        {
+            if value.get("__error").is_some() {
+                return None;
+            }
+            return (!value.is_null()).then_some(value);
         }
 
         let mut child = Command::new("node")
@@ -2205,6 +1556,88 @@ try {
             return None;
         }
         Some((line_start as u32, line_end as u32))
+    }
+}
+
+/// Long-running Node.js subprocess that delegates to the real `tsc`
+/// LanguageService. The first request pays the TypeScript-module load
+/// cost; subsequent requests reuse the loaded runtime, turning ~1–2 s
+/// per-operation cold starts into tens of milliseconds.
+pub(crate) struct NativeTsWorker {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: std::io::BufReader<std::process::ChildStdout>,
+}
+
+impl NativeTsWorker {
+    pub(crate) fn spawn() -> Option<Self> {
+        let script = Self::loop_script()?;
+        let mut child = std::process::Command::new("node")
+            .arg("-e")
+            .arg(&script)
+            .env("TSZ_NATIVE_TS_PERSISTENT", "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .ok()?;
+        let stdin = child.stdin.take()?;
+        let stdout = std::io::BufReader::new(child.stdout.take()?);
+        Some(Self {
+            child,
+            stdin,
+            stdout,
+        })
+    }
+
+    /// Synchronous request/response roundtrip against the worker.
+    /// Returns `None` if the worker isn't healthy or the response is
+    /// malformed; the caller should then fall back to spawning a fresh
+    /// subprocess via the legacy single-shot path.
+    pub(crate) fn request(
+        &mut self,
+        _script: &str,
+        payload: &serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        use std::io::{BufRead, Write};
+        if self.child.try_wait().ok().flatten().is_some() {
+            return None;
+        }
+        let mut line = serde_json::to_vec(payload).ok()?;
+        line.push(b'\n');
+        self.stdin.write_all(&line).ok()?;
+        self.stdin.flush().ok()?;
+        let mut response = Vec::new();
+        self.stdout.read_until(b'\n', &mut response).ok()?;
+        if response.ends_with(b"\n") {
+            response.pop();
+        }
+        if response.is_empty() {
+            return None;
+        }
+        serde_json::from_slice(&response).ok()
+    }
+
+    /// Extracts the embedded Node.js worker script. Shared with the
+    /// single-shot path so that we don't drift between the two modes.
+    fn loop_script() -> Option<String> {
+        // The worker script is stored inline in `try_native_typescript_operation`
+        // as the `SCRIPT` constant. We reach it via a tiny dummy Server
+        // instance at spawn time — but since that would be circular, we
+        // instead embed a small prelude that triggers the TypeScript-module
+        // load and loops. For now, reuse the full script source via
+        // `include_str!` if we split it out; fall back to re-emitting the
+        // known loop harness.
+        Some(include_str!("native_ts_worker.js").to_string())
+    }
+}
+
+impl Drop for NativeTsWorker {
+    fn drop(&mut self) {
+        // Closing stdin lets the child exit cleanly on its next read.
+        // If the worker is already gone, kill() is a no-op.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -571,6 +571,12 @@ pub(crate) struct Server {
     pub(crate) enable_telemetry: bool,
     /// Plugin configurations stored via `configurePlugin` command.
     pub(crate) plugin_configs: FxHashMap<String, serde_json::Value>,
+    /// Persistent native-TypeScript worker subprocess used for operations
+    /// that delegate to real `tsc` (rename, classification, etc.). Loaded
+    /// lazily on first use so that test/CLI invocations that never call
+    /// native TypeScript don't pay the spawn cost.
+    pub(crate) native_ts_worker:
+        Option<std::sync::Mutex<self::handlers_info_alias::NativeTsWorker>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -639,6 +645,8 @@ impl Server {
             _log_config: log_config,
             enable_telemetry: args.enable_telemetry,
             plugin_configs: FxHashMap::default(),
+            native_ts_worker: self::handlers_info_alias::NativeTsWorker::spawn()
+                .map(std::sync::Mutex::new),
         })
     }
 

--- a/crates/tsz-cli/src/bin/tsz_server/native_ts_worker.js
+++ b/crates/tsz-cli/src/bin/tsz_server/native_ts_worker.js
@@ -1,0 +1,701 @@
+const fs = require("fs");
+const path = require("path");
+
+function loadTypescript() {
+  const cwd = process.cwd();
+  const candidates = [
+    path.join(cwd, "TypeScript", "node_modules", "typescript"),
+    "typescript",
+  ];
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch {}
+  }
+  throw new Error("Cannot load TypeScript runtime");
+}
+
+function normalizePath(fileName) {
+  return typeof fileName === "string" ? fileName.replace(/\\\\/g, "/") : fileName;
+}
+
+function getLineStarts(text) {
+  const starts = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) starts.push(i + 1);
+  }
+  return starts;
+}
+
+function offsetToLocation(lineStarts, offset) {
+  const bounded = Math.max(0, Math.min(offset, lineStarts[lineStarts.length - 1] + 10 ** 9));
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const start = lineStarts[mid];
+    const next = mid + 1 < lineStarts.length ? lineStarts[mid + 1] : Number.MAX_SAFE_INTEGER;
+    if (bounded < start) {
+      high = mid - 1;
+    } else if (bounded >= next) {
+      low = mid + 1;
+    } else {
+      return { line: mid + 1, offset: bounded - start + 1 };
+    }
+  }
+  const line = Math.max(0, Math.min(low, lineStarts.length - 1));
+  return { line: line + 1, offset: bounded - lineStarts[line] + 1 };
+}
+
+function locationToOffset(fileText, line, offset) {
+  const lineStarts = getLineStarts(fileText);
+  const lineIndex = Math.max(0, Math.min((line || 1) - 1, lineStarts.length - 1));
+  const base = lineStarts[lineIndex];
+  return base + Math.max(0, (offset || 1) - 1);
+}
+
+function nodeModulesPackageRoot(fileName) {
+  const normalized = normalizePath(fileName || "");
+  const marker = "/node_modules/";
+  const idx = normalized.lastIndexOf(marker);
+  if (idx < 0) return "";
+  const rest = normalized.slice(idx + marker.length);
+  if (!rest) return "";
+  const parts = rest.split("/").filter(Boolean);
+  if (parts.length === 0) return "";
+  const pkgParts = parts[0].startsWith("@") && parts.length > 1
+    ? [parts[0], parts[1]]
+    : [parts[0]];
+  return normalized.slice(0, idx + marker.length) + pkgParts.join("/");
+}
+
+function nodeModulesRenameError(requestedFile, definitionFiles) {
+  const currentRoot = nodeModulesPackageRoot(requestedFile);
+  for (const defFile of definitionFiles) {
+    const defRoot = nodeModulesPackageRoot(defFile);
+    if (!defRoot) continue;
+    if (currentRoot && currentRoot !== defRoot) {
+      return "You cannot rename elements that are defined in another 'node_modules' folder.";
+    }
+  }
+  return "You cannot rename elements that are defined in a 'node_modules' folder.";
+}
+
+const TSZ_PERSISTENT_MODE = process.env.TSZ_NATIVE_TS_PERSISTENT === "1";
+
+function runOne(ts, input) {
+  const op = String(input.op || "");
+  const requestedFile = normalizePath(input.file || "");
+  const inputOpenFiles = input.openFiles && typeof input.openFiles === "object" ? input.openFiles : {};
+  const files = {};
+  for (const [key, value] of Object.entries(inputOpenFiles)) {
+    files[normalizePath(key)] = String(value ?? "");
+  }
+  return runWithFiles(ts, input, op, requestedFile, files);
+}
+
+function run() {
+  const ts = loadTypescript();
+  if (TSZ_PERSISTENT_MODE) {
+    // Persistent-worker protocol: newline-delimited JSON requests on
+    // stdin, newline-delimited JSON responses on stdout. The TypeScript
+    // module is loaded once and reused for every request, which turns
+    // the per-call cost from 1–2 s (fresh module load) into tens of ms.
+    let buffer = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      buffer += chunk;
+      let nl;
+      while ((nl = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        let result;
+        try {
+          const input = line ? JSON.parse(line) : {};
+          result = runOne(ts, input);
+        } catch (err) {
+          result = { __error: String(err && err.message ? err.message : err) };
+        }
+        try {
+          process.stdout.write(JSON.stringify(result === undefined ? null : result) + "\n");
+        } catch {
+          // Broken pipe — parent exited.
+        }
+      }
+    });
+    process.stdin.on("end", () => process.exit(0));
+    return;
+  }
+
+  const raw = fs.readFileSync(0, "utf8");
+  const input = raw ? JSON.parse(raw) : {};
+  process.stdout.write(JSON.stringify(runOne(ts, input)));
+}
+
+function runWithFiles(ts, input, op, requestedFile, files) {
+
+  function ensureFileText(fileName) {
+    const normalized = normalizePath(fileName);
+    if (!normalized) return "";
+    if (Object.prototype.hasOwnProperty.call(files, normalized)) {
+      return files[normalized];
+    }
+    try {
+      const text = fs.readFileSync(normalized, "utf8");
+      files[normalized] = text;
+      return text;
+    } catch {
+      return "";
+    }
+  }
+
+  if (requestedFile && !Object.prototype.hasOwnProperty.call(files, requestedFile)) {
+    ensureFileText(requestedFile);
+  }
+
+  const realpathAliases = new Map();
+
+  function packageInfoFromPath(fileName) {
+    const normalized = normalizePath(fileName || "");
+    const prefix = "/packages/";
+    if (!normalized.startsWith(prefix)) return null;
+    const rest = normalized.slice(prefix.length);
+    const segments = rest.split("/").filter(Boolean);
+    if (segments.length < 2) return null;
+    let packageName = segments[0];
+    let restStart = 1;
+    if (packageName.startsWith("@")) {
+      if (segments.length < 3) return null;
+      packageName = `${segments[0]}/${segments[1]}`;
+      restStart = 2;
+    }
+    const packageRelativePath = segments.slice(restStart).join("/");
+    if (!packageRelativePath) return null;
+    return { packageName, packageRelativePath };
+  }
+
+  function packageNameFromSpecifier(specifier) {
+    const text = String(specifier || "").trim();
+    if (!text || text.startsWith(".") || text.startsWith("/")) return null;
+    const parts = text.split("/").filter(Boolean);
+    if (parts.length === 0) return null;
+    if (parts[0].startsWith("@") && parts.length > 1) {
+      return `${parts[0]}/${parts[1]}`;
+    }
+    return parts[0];
+  }
+
+  function barePackageSpecifiers(fileText) {
+    const source = String(fileText || "");
+    const out = new Set();
+    const patterns = [
+      /from\s+["']([^"']+)["']/g,
+      /require\(\s*["']([^"']+)["']\s*\)/g,
+      /import\(\s*["']([^"']+)["']\s*\)/g,
+    ];
+    for (const pattern of patterns) {
+      let match;
+      while ((match = pattern.exec(source)) !== null) {
+        const packageName = packageNameFromSpecifier(match[1]);
+        if (packageName) out.add(packageName);
+      }
+    }
+    return out;
+  }
+
+  const packageFiles = new Map();
+  for (const [fileName, fileText] of Object.entries(files)) {
+    const info = packageInfoFromPath(fileName);
+    if (!info) continue;
+    if (!packageFiles.has(info.packageName)) {
+      packageFiles.set(info.packageName, []);
+    }
+    packageFiles.get(info.packageName).push({
+      sourcePath: normalizePath(fileName),
+      packageRelativePath: info.packageRelativePath,
+      content: String(fileText ?? ""),
+    });
+  }
+
+  for (const [consumerFile, fileText] of Object.entries(files)) {
+    const consumerInfo = packageInfoFromPath(consumerFile);
+    if (!consumerInfo) continue;
+    const consumerRoot = `/packages/${consumerInfo.packageName}`;
+    const specifiers = barePackageSpecifiers(fileText);
+    for (const packageName of specifiers) {
+      const entries = packageFiles.get(packageName);
+      if (!entries || entries.length === 0) continue;
+      for (const entry of entries) {
+        const linkedPath = normalizePath(
+          `${consumerRoot}/node_modules/${packageName}/${entry.packageRelativePath}`,
+        );
+        if (!Object.prototype.hasOwnProperty.call(files, linkedPath)) {
+          files[linkedPath] = entry.content;
+        }
+        realpathAliases.set(linkedPath, entry.sourcePath);
+      }
+    }
+  }
+
+  function isScriptFile(fileName) {
+    return /\.(d\.ts|ts|tsx|js|jsx|mts|cts)$/i.test(fileName || "");
+  }
+
+  const scriptFileNames = Object.keys(files).filter(isScriptFile);
+  if (requestedFile && isScriptFile(requestedFile) && !scriptFileNames.includes(requestedFile)) {
+    scriptFileNames.push(requestedFile);
+  }
+
+  const virtualFiles = new Set(Object.keys(files).map(normalizePath));
+  const virtualDirs = new Set();
+
+  function addVirtualDir(dirName) {
+    if (!dirName) return;
+    virtualDirs.add(normalizePath(dirName));
+  }
+
+  function addVirtualPath(fileName) {
+    const normalized = normalizePath(fileName);
+    if (!normalized) return;
+    let current = path.posix.dirname(normalized);
+    while (current && current !== "." && current !== "/") {
+      addVirtualDir(current);
+      const parent = path.posix.dirname(current);
+      if (!parent || parent === current) break;
+      current = parent;
+    }
+    if (current === "/") addVirtualDir("/");
+  }
+
+  for (const fileName of virtualFiles) {
+    addVirtualPath(fileName);
+  }
+
+  function virtualDirectoryExists(dirName) {
+    const normalized = normalizePath(dirName || "");
+    if (!normalized) return false;
+    if (virtualDirs.has(normalized)) return true;
+    const prefix = normalized.endsWith("/") ? normalized : `${normalized}/`;
+    for (const fileName of virtualFiles) {
+      if (fileName.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
+  function virtualDirectoriesOf(dirName) {
+    const normalized = normalizePath(dirName || "");
+    if (!normalized) return [];
+    const out = new Set();
+    for (const dir of virtualDirs) {
+      if (dir === normalized) continue;
+      if (path.posix.dirname(dir) === normalized) {
+        out.add(path.posix.basename(dir));
+      }
+    }
+    return Array.from(out.values());
+  }
+
+  function virtualReadDirectory(rootDir, extensions) {
+    const normalizedRoot = normalizePath(rootDir || "");
+    if (!normalizedRoot) return [];
+    const prefix = normalizedRoot.endsWith("/") ? normalizedRoot : `${normalizedRoot}/`;
+    const extensionList = Array.isArray(extensions) ? extensions : [];
+    const out = new Set();
+    for (const fileName of virtualFiles) {
+      if (fileName !== normalizedRoot && !fileName.startsWith(prefix)) continue;
+      if (
+        extensionList.length > 0
+        && !extensionList.some(ext => fileName.toLowerCase().endsWith(String(ext || "").toLowerCase()))
+      ) {
+        continue;
+      }
+      out.add(fileName);
+    }
+    return Array.from(out.values());
+  }
+
+  const fullProgramOps = new Set(["rename", "encodedSemanticClassifications"]);
+  const compilerOptions = fullProgramOps.has(op)
+    ? {
+        allowJs: true,
+        checkJs: true,
+        target: ts.ScriptTarget.Latest,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        jsx: ts.JsxEmit.Preserve,
+        allowImportingTsExtensions: true,
+      }
+    : {
+        allowJs: true,
+        checkJs: false,
+        target: ts.ScriptTarget.Latest,
+        module: ts.ModuleKind.ESNext,
+        jsx: ts.JsxEmit.Preserve,
+        noResolve: true,
+        noLib: true,
+        allowNonTsExtensions: true,
+      };
+
+  const versions = new Map(scriptFileNames.map(file => [file, "1"]));
+
+  const host = {
+    getCompilationSettings: () => compilerOptions,
+    getCurrentDirectory: () => "/",
+    getDefaultLibFileName: options => ts.getDefaultLibFilePath(options),
+    getScriptFileNames: () => scriptFileNames,
+    getScriptVersion: fileName => versions.get(normalizePath(fileName)) || "1",
+    getScriptSnapshot: fileName => {
+      const text = ensureFileText(fileName);
+      if (text === "") {
+        if (ts.sys.fileExists(fileName)) {
+          const fromFs = ts.sys.readFile(fileName);
+          return fromFs !== undefined ? ts.ScriptSnapshot.fromString(fromFs) : undefined;
+        }
+        return undefined;
+      }
+      return ts.ScriptSnapshot.fromString(text);
+    },
+    readFile: fileName => {
+      const normalized = normalizePath(fileName);
+      if (Object.prototype.hasOwnProperty.call(files, normalized)) {
+        return files[normalized];
+      }
+      return ts.sys.readFile(fileName);
+    },
+    fileExists: fileName => {
+      const normalized = normalizePath(fileName);
+      return Object.prototype.hasOwnProperty.call(files, normalized) || ts.sys.fileExists(fileName);
+    },
+    readDirectory: (rootDir, extensions, excludes, includes, depth) => {
+      const diskEntries = ts.sys.readDirectory
+        ? ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth)
+        : [];
+      const merged = new Set((diskEntries || []).map(normalizePath));
+      for (const virtualEntry of virtualReadDirectory(rootDir, extensions)) {
+        merged.add(virtualEntry);
+      }
+      return Array.from(merged.values());
+    },
+    directoryExists: fileName => {
+      if (virtualDirectoryExists(fileName)) return true;
+      return ts.sys.directoryExists ? ts.sys.directoryExists(fileName) : false;
+    },
+    getDirectories: dirName => {
+      const diskDirs = ts.sys.getDirectories ? ts.sys.getDirectories(dirName) : [];
+      const merged = new Set(diskDirs || []);
+      for (const virtualDir of virtualDirectoriesOf(dirName)) {
+        merged.add(virtualDir);
+      }
+      return Array.from(merged.values());
+    },
+    realpath: fileName => {
+      const normalized = normalizePath(fileName);
+      if (realpathAliases.has(normalized)) {
+        return realpathAliases.get(normalized);
+      }
+      if (Object.prototype.hasOwnProperty.call(files, normalized) || virtualDirectoryExists(normalized)) {
+        return normalized;
+      }
+      return ts.sys.realpath ? ts.sys.realpath(fileName) : fileName;
+    },
+  };
+
+  const ls = ts.createLanguageService(host, ts.createDocumentRegistry());
+
+  function spanToProtocol(fileName, span) {
+    const text = ensureFileText(fileName);
+    const lineStarts = getLineStarts(text);
+    const start = span?.start || 0;
+    const length = span?.length || 0;
+    return {
+      start: offsetToLocation(lineStarts, start),
+      end: offsetToLocation(lineStarts, start + length),
+    };
+  }
+
+  function navTreeToProtocol(fileName, item) {
+    return {
+      text: item.text,
+      kind: item.kind,
+      kindModifiers: item.kindModifiers || "",
+      spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
+      nameSpan: item.nameSpan ? spanToProtocol(fileName, item.nameSpan) : undefined,
+      childItems: item.childItems && item.childItems.length
+        ? item.childItems.map(child => navTreeToProtocol(fileName, child))
+        : undefined,
+    };
+  }
+
+  function navBarToProtocol(fileName, item) {
+    if (!item || typeof item !== "object") {
+      return {
+        text: "",
+        kind: "",
+        kindModifiers: "",
+        spans: [],
+        indent: 0,
+      };
+    }
+    if (!globalThis.__tszNavBarSeen) {
+      globalThis.__tszNavBarSeen = new WeakSet();
+    }
+    const seen = globalThis.__tszNavBarSeen;
+    if (seen.has(item)) {
+      return {
+        text: item.text,
+        kind: item.kind,
+        kindModifiers: item.kindModifiers || "",
+        spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
+        indent: item.indent || 0,
+      };
+    }
+    seen.add(item);
+    return {
+      text: item.text,
+      kind: item.kind,
+      kindModifiers: item.kindModifiers || "",
+      spans: (item.spans || []).map(span => spanToProtocol(fileName, span)),
+      childItems: item.childItems && item.childItems.length
+        ? item.childItems.map(child => navBarToProtocol(fileName, child))
+        : undefined,
+      indent: item.indent || 0,
+    };
+  }
+
+  let result = null;
+  switch (op) {
+    case "navtree": {
+      const tree = ls.getNavigationTree(requestedFile);
+      result = tree ? navTreeToProtocol(requestedFile, tree) : null;
+      break;
+    }
+    case "navbar": {
+      const items = ls.getNavigationBarItems(requestedFile) || [];
+      result = items.map(item => navBarToProtocol(requestedFile, item));
+      break;
+    }
+    case "navto": {
+      const searchValue = String(input.searchValue || "");
+      const items = ls.getNavigateToItems(searchValue) || [];
+      result = items.map(item => {
+        const fileName = normalizePath(item.fileName || requestedFile);
+        const span = spanToProtocol(fileName, item.textSpan || { start: 0, length: 0 });
+        return {
+          name: item.name,
+          kind: item.kind,
+          matchKind: item.matchKind,
+          isCaseSensitive: !!item.isCaseSensitive,
+          kindModifiers: item.kindModifiers || "",
+          containerName: item.containerName || "",
+          containerKind: item.containerKind || "",
+          file: fileName,
+          start: span.start,
+          end: span.end,
+        };
+      });
+      break;
+    }
+    case "rename": {
+      const text = ensureFileText(requestedFile);
+      const line = Number(input.line) || 1;
+      const offset = Number(input.offset) || 1;
+      const position = locationToOffset(text, line, offset);
+      const findInStrings = !!input.findInStrings;
+      const findInComments = !!input.findInComments;
+      const preferences =
+        input.preferences && typeof input.preferences === "object"
+          ? { ...input.preferences }
+          : {};
+      if (
+        preferences.providePrefixAndSuffixTextForRename === undefined
+        && input.providePrefixAndSuffixTextForRename !== undefined
+        && input.providePrefixAndSuffixTextForRename !== null
+      ) {
+        preferences.providePrefixAndSuffixTextForRename = !!input.providePrefixAndSuffixTextForRename;
+      }
+      if (
+        preferences.allowRenameOfImportPath === undefined
+        && input.allowRenameOfImportPath !== undefined
+        && input.allowRenameOfImportPath !== null
+      ) {
+        preferences.allowRenameOfImportPath = !!input.allowRenameOfImportPath;
+      }
+      if (preferences.allowRenameOfImportPath === undefined) {
+        preferences.allowRenameOfImportPath = true;
+      }
+
+      const renameInfo = ls.getRenameInfo(
+        requestedFile,
+        position,
+        preferences,
+        findInStrings,
+        findInComments,
+      );
+
+      const definitions = ls.getDefinitionAtPosition(requestedFile, position) || [];
+      const definitionFiles = definitions
+        .map(def => normalizePath(def && def.fileName ? def.fileName : ""))
+        .filter(Boolean);
+      const hasNodeModulesDefinition = definitionFiles.some(fileName =>
+        fileName.includes("/node_modules/")
+      );
+
+      if (!renameInfo || !renameInfo.canRename) {
+        let message =
+          (renameInfo && renameInfo.localizedErrorMessage) || "You cannot rename this element.";
+        if (message === "You cannot rename this element." && hasNodeModulesDefinition) {
+          message = nodeModulesRenameError(requestedFile, definitionFiles);
+        }
+        result = {
+          info: {
+            canRename: false,
+            localizedErrorMessage: message,
+          },
+          locs: [],
+        };
+        break;
+      }
+
+      if (
+        preferences
+        && preferences.allowRenameOfImportPath === false
+        && renameInfo.fileToRename !== undefined
+      ) {
+        result = {
+          info: {
+            canRename: false,
+            localizedErrorMessage: "You cannot rename this element.",
+          },
+          locs: [],
+        };
+        break;
+      }
+
+      const locations =
+        ls.findRenameLocations(
+          requestedFile,
+          position,
+          findInStrings,
+          findInComments,
+          preferences,
+        ) || [];
+
+      const grouped = new Map();
+      for (const loc of locations) {
+        const fileName = normalizePath(loc.fileName || requestedFile);
+        const span = spanToProtocol(fileName, loc.textSpan || { start: 0, length: 0 });
+        const entry = { start: span.start, end: span.end };
+        if (loc.contextSpan) {
+          const contextSpan = spanToProtocol(fileName, loc.contextSpan);
+          entry.contextStart = contextSpan.start;
+          entry.contextEnd = contextSpan.end;
+        }
+        if (loc.prefixText !== undefined) entry.prefixText = loc.prefixText;
+        if (loc.suffixText !== undefined) entry.suffixText = loc.suffixText;
+        const current = grouped.get(fileName);
+        if (current) current.push(entry);
+        else grouped.set(fileName, [entry]);
+      }
+
+      const triggerSpan = renameInfo.triggerSpan || { start: position, length: 0 };
+      const trigger = spanToProtocol(requestedFile, triggerSpan);
+      const info = {
+        canRename: true,
+        displayName: renameInfo.displayName,
+        fullDisplayName: renameInfo.fullDisplayName,
+        kind: renameInfo.kind,
+        kindModifiers: renameInfo.kindModifiers || "",
+        triggerSpan: {
+          start: trigger.start,
+          length: triggerSpan.length || 0,
+        },
+      };
+      if (renameInfo.fileToRename !== undefined) {
+        info.fileToRename = normalizePath(renameInfo.fileToRename);
+      }
+
+      const locs = Array.from(grouped.entries()).map(([fileName, fileLocs]) => ({
+        file: fileName,
+        locs: fileLocs,
+      }));
+
+      result = { info, locs };
+      break;
+    }
+    case "format": {
+      const options = input.options && typeof input.options === "object" ? input.options : {};
+      const text = ensureFileText(requestedFile);
+      const startLine = Number(input.line);
+      const startOffset = Number(input.offset);
+      const endLine = Number(input.endLine);
+      const endOffset = Number(input.endOffset);
+      const hasRange =
+        Number.isFinite(startLine)
+        && Number.isFinite(startOffset)
+        && Number.isFinite(endLine)
+        && Number.isFinite(endOffset);
+      const edits = hasRange
+        ? (ls.getFormattingEditsForRange(
+            requestedFile,
+            Math.min(
+              locationToOffset(text, startLine, startOffset),
+              locationToOffset(text, endLine, endOffset),
+            ),
+            Math.max(
+              locationToOffset(text, startLine, startOffset),
+              locationToOffset(text, endLine, endOffset),
+            ),
+            options,
+          ) || [])
+        : (ls.getFormattingEditsForDocument(requestedFile, options) || []);
+      result = edits.map(edit => {
+        const span = spanToProtocol(requestedFile, edit.span || { start: 0, length: 0 });
+        return { start: span.start, end: span.end, newText: edit.newText || "" };
+      });
+      break;
+    }
+    case "formatOnKey": {
+      const options = input.options && typeof input.options === "object" ? input.options : {};
+      const text = ensureFileText(requestedFile);
+      const position = locationToOffset(text, Number(input.line) || 1, Number(input.offset) || 1);
+      const key = String(input.key || "");
+      const edits = ls.getFormattingEditsAfterKeystroke(requestedFile, position, key, options) || [];
+      result = edits.map(edit => {
+        const span = spanToProtocol(requestedFile, edit.span || { start: 0, length: 0 });
+        return { start: span.start, end: span.end, newText: edit.newText || "" };
+      });
+      break;
+    }
+    case "encodedSemanticClassifications": {
+      const text = ensureFileText(requestedFile);
+      const rawStart = Number(input.start);
+      const start = Number.isFinite(rawStart) && rawStart >= 0 ? rawStart : 0;
+      const rawLength = Number(input.length);
+      const length = Number.isFinite(rawLength) && rawLength > 0 ? rawLength : text.length;
+      const rawFormat = input.format;
+      const format = rawFormat === "2020"
+        || rawFormat === "1"
+        || rawFormat === 2020
+        || rawFormat === 1
+        ? ts.SemanticClassificationFormat.TwentyTwenty
+        : ts.SemanticClassificationFormat.Original;
+      result = ls.getEncodedSemanticClassifications(
+        requestedFile,
+        { start, length },
+        format,
+      );
+      break;
+    }
+    default:
+      result = null;
+      break;
+  }
+
+  return result;
+}
+
+try {
+  run();
+} catch (err) {
+  process.stdout.write(JSON.stringify({ __error: String(err && err.message ? err.message : err) }));
+}

--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -36,6 +36,7 @@ fn make_server() -> Server {
         include_completions_with_class_member_snippets: false,
         new_line_character: None,
         plugin_configs: FxHashMap::default(),
+        native_ts_worker: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Rename/classification/etc. delegates to real `tsc` via a Node.js subprocess. Previously every call spawned a fresh `node` process that had to `require(\"typescript\")` from scratch — roughly 1–2 s of module-load overhead per call. Tests that make many native-LS calls in series (rename across node_modules, autoImportFileExcludePatterns, etc.) kept hitting the 15 s watchdog timeout.

## What changed

- Extracted the inline Node.js worker script into a sibling file (`native_ts_worker.js`) so both the legacy single-shot path and the new persistent path share the same source of truth.
- Added a `TSZ_NATIVE_TS_PERSISTENT=1` mode to the script: newline-delimited JSON requests on stdin, newline-delimited JSON responses on stdout, TypeScript runtime loaded once and reused for every request.
- `Server` grows a `native_ts_worker: Option<Mutex<NativeTsWorker>>` field, populated at startup. `try_native_typescript_operation` now tries the worker first and falls back to the original per-call `node -e SCRIPT` pathway if the worker isn't healthy.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo nextest run -p tsz-cli` (966/966)
- [x] Architecture guardrail (`scripts/arch/check-checker-boundaries.sh`)
- [x] Fourslash: 6562/6562 on a fresh local run
- [x] Individual slow-path sanity:
  - `renameImport.ts` 30 s → 5.7 s
  - `renameTemplateLiteralsComputedProperties` 22 s → 2.4 s