### PR TITLE
fix(parser): avoid double-wrap when export modifier recovery forwards `import =`

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -621,6 +621,19 @@ impl ParserState {
     pub(crate) fn parse_export_declaration_or_statement(&mut self, start_pos: u32) -> NodeIndex {
         let declaration = self.parse_exported_declaration(start_pos);
 
+        // If the inner parse already produced an EXPORT_DECLARATION (because the
+        // recovery path forwarded `import = ...` through `parse_export_import_equals`,
+        // which wraps), don't double-wrap. Otherwise the binder sees an
+        // EXPORT_DECLARATION whose export_clause is itself another EXPORT_DECLARATION
+        // and never reaches `bind_import_equals_declaration` for the inner alias —
+        // causing false TS2304 ("Cannot find name 'X'") for later references to the
+        // import alias.
+        if let Some(declaration_node) = self.arena.get(declaration)
+            && declaration_node.kind == syntax_kind_ext::EXPORT_DECLARATION
+        {
+            return declaration;
+        }
+
         let end_pos = self.token_end();
         self.arena.add_export_decl(
             syntax_kind_ext::EXPORT_DECLARATION,


### PR DESCRIPTION
## Summary
Fixes a false-positive TS2304 "Cannot find name 'X'" that fires on references to an import alias declared with an illegal class modifier before `export`, e.g.:

```ts
namespace x { interface c {} }
export public import a = x.c;  // TS1044 for `public`
var b: a;                       // Erroneously emits TS2304 "Cannot find name 'a'"
```

tsc emits TS1044 (plus TS2694/TS2708 for the RHS being a type-only namespace member), but **not** TS2304 — it still binds `a` so later references resolve. tsz was emitting the extra TS2304.

## Root cause
`parse_export_declaration_or_statement` wraps the inner declaration in an `EXPORT_DECLARATION`, assuming the inner parser returns a non-export node (function, class, import-equals, …). The modifier-recovery branch inside `parse_exported_declaration` (public/private/protected/static/readonly on a module/namespace element, TS1044) consumes the invalid modifier and recurses into `parse_exported_declaration(start_pos)`. If the next token is `import` with `=` look-ahead, that recursion routes through `parse_export_import_equals`, which **already** wraps the import-equals declaration in an `EXPORT_DECLARATION`.

The outer `parse_export_declaration_or_statement` then wraps **again**, producing:
`EXPORT_DECLARATION → EXPORT_DECLARATION → IMPORT_EQUALS_DECLARATION`

`bind_export_declaration` dispatches by the export clause's kind. It sees `EXPORT_DECLARATION` (the inner wrapper), not `IMPORT_EQUALS_DECLARATION`, so `bind_import_equals_declaration` is never called and the alias `a` is never bound. Later references then fail with TS2304.

## Fix
In `parse_export_declaration_or_statement`, detect when the inner parse already produced an `EXPORT_DECLARATION` and return it unwrapped instead of double-wrapping. Single check, no behavior change for any other path.

## Tests flipped FAIL → PASS
- `importDeclWithClassModifiers.ts`

## Test plan
- [x] `--filter compiler` — 6256/6519 → +1 test flipped, zero regressions (diff shows only the target test added to PASS, no new FAILs)
- [x] `--filter conformance` — 5533/5872, identical failure set vs baseline