### PR TITLE
ci: harden wasm build by skipping wasm-opt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build WASM (nodejs target for conformance)
-        run: wasm-pack build --target nodejs --out-dir ../../pkg
+        run: wasm-pack build --target nodejs --out-dir ../../pkg --no-opt
         working-directory: crates/tsz-wasm
 
       - name: Copy TypeScript lib files into pkg

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -30292,6 +30292,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             no_resolve: false,
             no_unchecked_side_effect_imports: false,
             no_implicit_override: false,
+            no_fallthrough_cases_in_switch: false,
             jsx_mode: tsz_common::checker_options::JsxMode::None,
             module_explicitly_set: false,
             suppress_excess_property_errors: false,


### PR DESCRIPTION
## Summary
- disable `wasm-pack` optimization in CI's `WASM Build` (nodejs target) by adding `--no-opt`
- avoid flaky external Binaryen downloads during CI-only artifact generation

## Why
A recent failing run hit:
- `failed to download ... binaryen-version_117-x86_64-linux.tar.gz`

This job only builds a WASM artifact for downstream CI test shards, so skipping `wasm-opt` improves reliability without changing checker/binder/runtime behavior.

## Validation
- inspected failing Actions log for run `24611035791`, job `71965393571`
- confirmed failure was in `wasm-pack` Binaryen download path
