### PR TITLE
tsz-server: start removing Node/tsc dependency from LSP handlers

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -1758,7 +1758,8 @@ impl Server {
             })) {
                 return Some(native);
             }
-            let (arena, _binder, root, source_text) = self.parse_and_bind_file(file)?;
+            let (arena, binder, root, source_text) = self.parse_and_bind_file(file)?;
+            let is_external_module = binder.is_external_module;
             let line_map = LineMap::build(&source_text);
             let provider = DocumentSymbolProvider::new(&arena, &line_map, &source_text);
             let symbols = provider.get_document_symbols(root);
@@ -1813,9 +1814,22 @@ impl Server {
             // Compute the end span based on source text length
             let total_lines = source_text.lines().count();
             let last_line_len = source_text.lines().last().map_or(0, str::len);
+            // External modules get a filename-as-module wrapper instead of
+            // the `<global>` / `script` header that scripts use. Matches
+            // tsserver's `getNavigationTree` output.
+            let (text, kind) = if is_external_module {
+                let basename = std::path::Path::new(file)
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                (format!("\"{basename}\""), "module")
+            } else {
+                ("<global>".to_string(), "script")
+            };
             Some(serde_json::json!({
-                "text": "<global>",
-                "kind": "script",
+                "text": text,
+                "kind": kind,
                 "childItems": child_items,
                 "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": total_lines, "offset": last_line_len + 1}}],
             }))

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
@@ -37,6 +37,13 @@ impl Server {
         &self,
         mut payload: serde_json::Value,
     ) -> Option<serde_json::Value> {
+        // Temporary short-circuit: probe how many LSP operations still work
+        // when tsz-server answers them entirely in Rust, without delegating
+        // to a `node` subprocess running the real `tsc` LanguageService.
+        if std::env::var_os("TSZ_DISABLE_NATIVE_TS").is_some() {
+            let _ = &mut payload;
+            return None;
+        }
         const SCRIPT: &str = r#"
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
## Motivation

The tsz-server LSP handlers for rename, navtree, navbar, navto, encodedSemanticClassifications, and format currently delegate to the real TypeScript LanguageService by spawning a Node.js subprocess (\`try_native_typescript_operation\`). That's contrary to tsz's goal of being a pure-Rust TypeScript implementation, and it makes the tsz-server binary require a Node runtime at the call site.

## This PR

A small, self-contained first step toward removing that dependency:

1. **\`TSZ_DISABLE_NATIVE_TS\` probe flag.** When set, \`try_native_typescript_operation\` returns \`None\` up front, and the existing Rust fallbacks run. This makes it cheap to audit parity gaps — the fourslash suite currently surfaces ~87 failures with the flag on, which fall cleanly into three clusters:
   - \`verifyNavigationTree\` / \`verifyNavigationBar\` (navtree + navbar output shapes)
   - \`encodedSemanticClassificationsLength\` (semantic highlighting)
   - A handful of rename edge cases (findAllRefsPrimitive, findAllRefsImportMeta, findAllRefs_importType_exportEquals)

2. **Fix one concrete gap surfaced by the probe.** The navigation-tree fallback now wraps external-module files with the \`\\"basename\\" / module\` header matching tsserver, rather than the \`<global> / script\` header used for plain scripts. The external-module check reuses \`BinderState.is_external_module\` so it stays accurate across every export form.

## Default behavior

Nothing changes by default: native delegation still runs, so the full fourslash suite continues to pass (6562/6562 modulo transient rename-suite timeouts). The flag is opt-in.

## Follow-ups

Next passes (separate PRs) will close the 87 identified gaps one cluster at a time, starting with navbar (which shares most of its logic with the already-correct navtree fallback).

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo nextest run -p tsz-cli\` (966/966)
- [x] Architecture guardrail
- [x] Full fourslash suite with native on: 6562/6562
- [x] Full fourslash suite with \`TSZ_DISABLE_NATIVE_TS=1\`: 6475/6562 (no regressions vs a baseline run of the probe)