### PR TITLE
chore(meta): align workspace metadata and add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Validate workspace metadata
+        run: scripts/arch/check-workspace-metadata.sh
+
       - name: Run clippy (workspace crates - deny warnings)
         run: |
           cargo clippy \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ resolver = "3"
 [workspace.package]
 version = "0.1.9"
 edition = "2024"
-repository = "https://github.com/mohsenazimi/tsz"
-homepage = "https://github.com/mohsenazimi/tsz"
+repository = "https://github.com/mohsen1/tsz"
+homepage = "https://github.com/mohsen1/tsz"
 license = "Apache-2.0"
 authors = ["Mohsen Azimi <mohsen@users.noreply.github.com>"]
 keywords = ["typescript", "type-checker", "compiler", "language", "tsz"]

--- a/scripts/arch/check-workspace-metadata.sh
+++ b/scripts/arch/check-workspace-metadata.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+normalize_github_url() {
+  local raw="$1"
+  local url="$raw"
+
+  if [[ "$url" =~ ^git@github\.com: ]]; then
+    url="https://github.com/${url#git@github.com:}"
+  elif [[ "$url" =~ ^ssh://git@github\.com/ ]]; then
+    url="https://github.com/${url#ssh://git@github.com/}"
+  fi
+
+  url="${url%.git}"
+  url="${url%/}"
+  printf '%s\n' "$url"
+}
+
+origin_url="$(git config --get remote.origin.url || true)"
+if [[ -z "$origin_url" ]]; then
+  echo "error: remote.origin.url is not configured" >&2
+  exit 1
+fi
+
+expected_url="$(normalize_github_url "$origin_url")"
+
+extract_workspace_package_field() {
+  local field="$1"
+  awk -F '"' -v key="$field" '
+    BEGIN { in_workspace_pkg = 0 }
+    /^\[workspace\.package\]/ { in_workspace_pkg = 1; next }
+    /^\[/ { if (in_workspace_pkg) exit }
+    in_workspace_pkg && $1 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      print $2
+      exit
+    }
+  ' Cargo.toml
+}
+
+repository="$(extract_workspace_package_field "repository")"
+homepage="$(extract_workspace_package_field "homepage")"
+
+if [[ "$repository" != "$expected_url" ]]; then
+  echo "error: workspace.package.repository mismatch" >&2
+  echo "expected: $expected_url" >&2
+  echo "actual:   $repository" >&2
+  exit 1
+fi
+
+if [[ "$homepage" != "$expected_url" ]]; then
+  echo "error: workspace.package.homepage mismatch" >&2
+  echo "expected: $expected_url" >&2
+  echo "actual:   $homepage" >&2
+  exit 1
+fi
+
+echo "workspace package metadata matches origin URL: $expected_url"


### PR DESCRIPTION
## Summary
- align `workspace.package.repository` and `workspace.package.homepage` with the canonical repository URL
- add `scripts/arch/check-workspace-metadata.sh` to validate workspace metadata against normalized `origin` URL
- run this metadata guard in CI lint job to prevent future drift

## Validation
- `scripts/arch/check-workspace-metadata.sh`