### PR TITLE
fix(checker): TS7027 for 'var x = N' after unreachable point

### DIFF
--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -834,17 +834,22 @@ impl<'a> CheckerState<'a> {
         let Some(var_data) = self.ctx.arena.get_variable(node) else {
             return false;
         };
-        // Check if it's `var` (not let/const) by examining declaration list flags
-        // The flags are on the VariableDeclarationList child node
-        for &decl_idx in &var_data.declarations.nodes {
-            if let Some(decl_node) = self.ctx.arena.get(decl_idx) {
-                // Check if it's let/const (not var) using combined node+parent flags
+        // VARIABLE_STATEMENT.declarations holds a VARIABLE_DECLARATION_LIST; the
+        // individual VARIABLE_DECLARATION nodes live one level deeper.
+        for &list_idx in &var_data.declarations.nodes {
+            let Some(list_node) = self.ctx.arena.get(list_idx) else {
+                continue;
+            };
+            let Some(list_data) = self.ctx.arena.get_variable(list_node) else {
+                continue;
+            };
+            for &decl_idx in &list_data.declarations.nodes {
                 let flags = self.ctx.arena.get_variable_declaration_flags(decl_idx);
                 if (flags & (node_flags::LET | node_flags::CONST)) != 0 {
                     return false;
                 }
-                // Check that declaration has no initializer
-                if let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
+                if let Some(decl_node) = self.ctx.arena.get(decl_idx)
+                    && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
                     && var_decl.initializer.is_some()
                 {
                     return false;


### PR DESCRIPTION
## Summary
- `is_var_without_initializer` was iterating `VARIABLE_STATEMENT.declarations` as if it contained `VARIABLE_DECLARATION` nodes directly, but it actually contains a single `VARIABLE_DECLARATION_LIST` that wraps the individual declarations.
- As a consequence, every `var x = N` after a terminator was silently suppressed (treated as "without initializer"), while `let`/`const` still reported TS7027 because the list flag check was independent of the data access.
- Descend into the inner list before checking each declaration's initializer, matching the pattern used elsewhere (e.g. `module_augmentation.rs`, `cross_file_conflicts.rs`).

## Impact
- Fixes `jsFileCompilationBindReachabilityErrors.ts`.
- Compiler lane: +1 test (6257 → 6258), no regressions.
- `var t;` (no initializer) after a terminator remains correctly suppressed.
- `unreachableDeclarations.ts` — pre-existing fingerprint-only extras are unchanged by this fix.

## Test plan
- [x] Target test passes: `./scripts/conformance/conformance.sh run --filter "jsFileCompilationBindReachabilityErrors"`
- [x] Compiler lane: `./scripts/conformance/conformance.sh run --filter "compiler"` — 6258/6519 (+1 vs baseline 6257)
- [x] Reachability neighborhood: `--filter "controlFlow"`, `--filter "unreach"`, `--filter "Reachab"` — no new regressions
- [x] Manual parity with tsc for `var x = N`, `var t`, and `let` after a `return`