### PR TITLE
binder/jsdoc: bind named @import aliases for implements lookup

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -131,16 +131,13 @@ impl BinderState {
                 let Some(rest) = trimmed.strip_prefix("@import") else {
                     continue;
                 };
+                let has_attributes = rest.contains(" with ");
                 for (local_name, specifier, import_name) in Self::parse_jsdoc_import_tag(rest) {
                     if local_name.is_empty() || specifier.is_empty() {
                         continue;
                     }
                     self.file_import_sources.push(specifier.clone());
-                    // Namespace JSDoc imports (`* as NS`) must be visible to the
-                    // regular symbol resolver for qualified references like `NS.I`.
-                    // Default/named JSDoc imports already flow through the JSDoc typedef
-                    // path and creating parallel ALIAS symbols for those can recurse.
-                    if import_name != "*" {
+                    if has_attributes {
                         continue;
                     }
                     let sym_id =

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -169,14 +169,31 @@ class C {}
     assert_eq!(ns_sym.import_module.as_deref(), Some("./a"));
     assert_eq!(ns_sym.import_name.as_deref(), Some("*"));
 
-    assert!(
-        binder.file_locals.get("RenamedI").is_none(),
-        "named JSDoc imports should stay in typedef machinery (no binder alias)"
-    );
-    assert!(
-        binder.file_locals.get("DefaultThing").is_none(),
-        "default JSDoc imports should stay in typedef machinery (no binder alias)"
-    );
+    let renamed_i_sym_id = binder
+        .file_locals
+        .get("RenamedI")
+        .expect("expected JSDoc named import alias");
+    let renamed_i_sym = binder
+        .symbols
+        .get(renamed_i_sym_id)
+        .expect("expected symbol data for RenamedI");
+    assert_ne!(renamed_i_sym.flags & symbol_flags::ALIAS, 0);
+    assert!(renamed_i_sym.is_type_only);
+    assert_eq!(renamed_i_sym.import_module.as_deref(), Some("./a"));
+    assert_eq!(renamed_i_sym.import_name.as_deref(), Some("I"));
+
+    let default_sym_id = binder
+        .file_locals
+        .get("DefaultThing")
+        .expect("expected JSDoc default import alias");
+    let default_sym = binder
+        .symbols
+        .get(default_sym_id)
+        .expect("expected symbol data for DefaultThing");
+    assert_ne!(default_sym.flags & symbol_flags::ALIAS, 0);
+    assert!(default_sym.is_type_only);
+    assert_eq!(default_sym.import_module.as_deref(), Some("./a"));
+    assert_eq!(default_sym.import_name.as_deref(), Some("default"));
 
     assert!(
         binder.file_import_sources.iter().any(|spec| spec == "./a"),

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1407,6 +1407,12 @@ impl<'a> CheckerState<'a> {
         if (symbol.flags & symbol_flags::ALIAS) != 0 {
             let mut visited_aliases = Vec::new();
             if let Some(target) = self.resolve_alias_symbol(sym_id, &mut visited_aliases) {
+                if target == sym_id {
+                    // Some unresolved aliases (notably synthetic JSDoc @import aliases)
+                    // can legitimately resolve to themselves. Re-entering with the same
+                    // symbol would recurse forever and overflow the stack.
+                    return TypeId::ERROR;
+                }
                 return self.resolve_jsdoc_symbol_type(target);
             }
         }

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -172,12 +172,8 @@ impl<'a> CheckerState<'a> {
             member_name,
             Some(self.ctx.current_file_idx),
         )
-        .or_else(|| {
-            self.ctx
-                .binder
-                .resolve_import_with_reexports_type_only(module_specifier, member_name)
-                .map(|(sym_id, _)| sym_id)
-        })
+        // Avoid raw binder fallback here: it returns unscoped SymbolIds without
+        // file-target registration, which can alias-collide across binders.
         .or_else(|| self.resolve_cross_file_export(module_specifier, member_name))
     }
 

--- a/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
@@ -217,6 +217,34 @@ export let bar;
 }
 
 #[test]
+fn jsdoc_named_import_binding_is_visible_to_implements_clause() {
+    let codes = check_js_file_with_types(
+        "a.ts",
+        r#"
+export interface I {
+    method(): void;
+}
+"#,
+        "b.js",
+        r#"
+/** @import { I as ImportedI } from "./a" */
+/** @implements {ImportedI} */
+class C {}
+"#,
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        codes.contains(&2420),
+        "Expected TS2420 when @implements references a named JSDoc @import alias, got codes: {codes:?}"
+    );
+}
+
+#[test]
 fn exported_js_variable_with_jsdoc_type_is_not_implicit_any() {
     let codes = check_js_file_with_types(
         "types.d.ts",


### PR DESCRIPTION
## Summary
- bind JSDoc `@import` names into binder `file_locals` as type-only ALIAS symbols for JS files
- keep attribute-bearing `@import ... with { ... }` directives on the existing typedef path to preserve resolution-mode behavior
- harden JSDoc alias type resolution against self-alias recursion (stack overflow guard)
- avoid unscoped cross-binder fallback in JSDoc import-member lookup
- add checker regression test ensuring a named JSDoc import alias is visible in `@implements`
- expand binder unit test to assert namespace + named + default JSDoc import alias metadata

## Validation
- `cargo test -p tsz-binder jsdoc_import_tag_binds_alias_symbols_in_js_files -- --nocapture`
- `cargo test -p tsz-checker jsdoc_named_import_binding_is_visible_to_implements_clause -- --nocapture`
- `./scripts/conformance/conformance.sh run --filter "importTag"` (25/25)
- `./scripts/conformance/conformance.sh run --filter "jsdoc"` (345/377, no baseline drop)
- `./scripts/conformance/conformance.sh run --filter "import"` (272/281)
