### PR TITLE
Unignore and fix checker regressions for TS2344/TS2712/class member access

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -465,7 +465,28 @@ impl<'a> CheckerState<'a> {
                                 self.ctx.types.as_type_database(),
                                 type_arg,
                             ) {
-                                continue;
+                                // Keep eager checking for callable constraints when
+                                // the application evaluates to a generic indexed-access
+                                // form (e.g., `Alias<T, F>` -> `DataFetchFns[T][F]`).
+                                // tsc reports TS2344 in this case because callability
+                                // is not provable at definition time.
+                                let constraint_resolved = self.resolve_lazy_type(constraint);
+                                let constraint_is_callable = query::is_callable_type(
+                                    self.ctx.types.as_type_database(),
+                                    constraint_resolved,
+                                ) || self.is_function_constraint(
+                                    param.constraint.unwrap_or(TypeId::NEVER),
+                                );
+                                let generic_indexed_type_arg =
+                                    self.generic_indexed_access_subject(type_arg);
+                                let keep_eager_check = constraint_is_callable
+                                    && generic_indexed_type_arg.is_some()
+                                    && !self.indexed_access_resolves_to_callable(
+                                        generic_indexed_type_arg.unwrap_or(type_arg),
+                                    );
+                                if !keep_eager_check {
+                                    continue;
+                                }
                             }
                             let constraint_resolved = self.resolve_lazy_type(constraint);
                             let mut subst =
@@ -489,6 +510,8 @@ impl<'a> CheckerState<'a> {
                             }
                             let db = self.ctx.types.as_type_database();
                             let original_constraint = param.constraint.unwrap_or(TypeId::NEVER);
+                            let generic_indexed_type_arg =
+                                self.generic_indexed_access_subject(type_arg);
 
                             // Special case: tsc eagerly reports TS2344 for generic indexed access
                             // types (A[B] where A contains type params) when the constraint is
@@ -501,8 +524,10 @@ impl<'a> CheckerState<'a> {
                                 query::is_callable_type(db, inst_constraint)
                                     || self.is_function_constraint(original_constraint);
                             if constraint_is_callable
-                                && self.is_generic_indexed_access(type_arg)
-                                && !self.indexed_access_resolves_to_callable(type_arg)
+                                && generic_indexed_type_arg.is_some()
+                                && !self.indexed_access_resolves_to_callable(
+                                    generic_indexed_type_arg.unwrap_or(type_arg),
+                                )
                                 && let Some(&arg_idx) = type_args_list.nodes.get(i)
                                 && !self.type_argument_is_narrowed_by_conditional_true_branch(
                                     arg_idx,
@@ -1195,6 +1220,47 @@ impl<'a> CheckerState<'a> {
             return query::contains_type_parameters(self.ctx.types, object);
         }
         false
+    }
+
+    /// Return the indexed-access subject used for TS2344 callable checks.
+    ///
+    /// Supports both direct indexed-access type arguments (`A[B]`) and
+    /// application-wrapped aliases whose instantiated body is indexed access
+    /// (e.g., `Alias<T, F>` where `type Alias<T, F> = A[T][F]`).
+    fn generic_indexed_access_subject(&mut self, type_id: TypeId) -> Option<TypeId> {
+        if self.is_generic_indexed_access(type_id) {
+            return Some(type_id);
+        }
+
+        let db = self.ctx.types.as_type_database();
+        let (Some(base_def), app_args) = query::application_base_def_and_args(db, type_id)? else {
+            return None;
+        };
+        let Some(def_info) = self.ctx.definition_store.get(base_def) else {
+            return None;
+        };
+        if def_info.kind != tsz_solver::def::DefKind::TypeAlias {
+            return None;
+        }
+        let body = self.ctx.definition_store.get_body(base_def)?;
+
+        let mut instantiated_body = body;
+        if let Some(type_params) = self.ctx.definition_store.get_type_params(base_def)
+            && !type_params.is_empty()
+            && !app_args.is_empty()
+        {
+            let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
+            for (param, arg) in type_params.iter().zip(app_args.iter()) {
+                subst.insert(param.name, *arg);
+            }
+            if !subst.is_empty() {
+                instantiated_body =
+                    crate::query_boundaries::common::instantiate_type(self.ctx.types, body, &subst);
+            }
+        }
+
+        self.is_generic_indexed_access(instantiated_body)
+            .then_some(instantiated_body)
     }
 
     /// Check if an indexed access type `T[M]` resolves to a callable type

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -160,6 +160,7 @@ impl<'a> CheckerState<'a> {
         apply_module_augmentations: bool,
     ) -> TypeId {
         let current_sym = self.ctx.binder.get_node_symbol(class_idx);
+        let had_instance_cache = self.ctx.class_instance_type_cache.contains_key(&class_idx);
         if apply_module_augmentations
             && request.is_empty()
             && let Some(&cached) = self.ctx.class_constructor_type_cache.get(&class_idx)
@@ -252,6 +253,18 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .class_constructor_type_cache
                 .insert(class_idx, result);
+        }
+
+        // During constructor resolution, `get_class_instance_type_inner` can
+        // intentionally fall back to `any` for method return inference to break
+        // constructor/instance cycles. If this constructor query is the first
+        // touch for the class, that provisional instance type can get cached and
+        // leak into later property reads (e.g., `instance.method` -> `(...args) => any`).
+        // Once constructor resolution is complete, refresh the instance cache in
+        // normal mode so downstream reads observe the stabilized instance shape.
+        if apply_module_augmentations && did_insert && !had_instance_cache {
+            self.ctx.class_instance_type_cache.remove(&class_idx);
+            let _ = self.get_class_instance_type(class_idx, class);
         }
 
         // Register constructor type -> DefId(ClassConstructor) so the formatter

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -4,6 +4,8 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::common as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 const MAX_AWAIT_DEPTH: u32 = 10;
@@ -106,6 +108,19 @@ impl<'a> CheckerState<'a> {
             request.read().contextual_opt(None)
         };
 
+        // Ensure awaited dynamic imports report TS2712 even when call-expression
+        // checking paths skip nested async callback bodies.
+        if self.ctx.promise_constructor_diagnostics_required()
+            && let Some(import_call_idx) = self.await_operand_dynamic_import_call(unary.expression)
+        {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+            self.error_at_node(
+                import_call_idx,
+                diagnostic_messages::A_DYNAMIC_IMPORT_CALL_IN_ES5_REQUIRES_THE_PROMISE_CONSTRUCTOR_MAKE_SURE_YOU_HAVE,
+                diagnostic_codes::A_DYNAMIC_IMPORT_CALL_IN_ES5_REQUIRES_THE_PROMISE_CONSTRUCTOR_MAKE_SURE_YOU_HAVE,
+            );
+        }
+
         // Get the type of the await operand with transformed contextual type
         // Guard: if the operand is missing (e.g. `await;`), return ANY
         if unary.expression.is_none() {
@@ -132,6 +147,34 @@ impl<'a> CheckerState<'a> {
             }
         }
         current_type
+    }
+
+    fn await_operand_dynamic_import_call(&self, operand_idx: NodeIndex) -> Option<NodeIndex> {
+        let node = self.ctx.arena.get(operand_idx)?;
+
+        if let Some(call) = self.ctx.arena.get_call_expr(node)
+            && self.is_dynamic_import(call)
+        {
+            return Some(operand_idx);
+        }
+
+        if node.kind != SyntaxKind::ImportKeyword as u16 {
+            return None;
+        }
+
+        let parent_idx = self.ctx.arena.get_extended(operand_idx)?.parent;
+        if parent_idx.is_none() {
+            return None;
+        }
+        let parent_node = self.ctx.arena.get(parent_idx)?;
+        if parent_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.ctx.arena.get_call_expr(parent_node)?;
+        if call.expression != operand_idx || !self.is_dynamic_import(call) {
+            return None;
+        }
+        Some(parent_idx)
     }
 
     fn await_expression_uses_call_like_syntax(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/tests/conformance_issues/errors/runtime.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/runtime.rs
@@ -411,7 +411,6 @@ type DS<TRec extends MyRecord | { [key: string]: unknown }> =
 }
 
 #[test]
-#[ignore] // TODO: TS2344 for composite indexed access type args not yet emitted
 fn test_ts2344_reports_for_composite_indexed_access_type_args() {
     let diagnostics = compile_and_get_diagnostics(
         r"

--- a/crates/tsz-checker/tests/promise_constructor_capability_tests.rs
+++ b/crates/tsz-checker/tests/promise_constructor_capability_tests.rs
@@ -133,7 +133,6 @@ const loadAsync = async () => {
 }
 
 #[test]
-#[ignore] // TODO: dynamic import inside async arrow missing TS2712
 fn reports_ts2712_for_each_dynamic_import_site_in_conformance_shape() {
     let source = r#"
 declare var console: any;

--- a/crates/tsz-checker/tests/static_member_access_types.rs
+++ b/crates/tsz-checker/tests/static_member_access_types.rs
@@ -82,7 +82,6 @@ fn first_call_with_property_name(parser: &ParserState, property_name: &str) -> N
 }
 
 #[test]
-#[ignore] // TODO: static getter returning static method call resolves as error type
 fn class_member_access_keeps_concrete_types() {
     let source = r#"
 class C {


### PR DESCRIPTION
## Summary
- unignore and fix `class_member_access_keeps_concrete_types` by refreshing provisional class instance cache after constructor resolution
- unignore and fix TS2344 composite indexed-access type-arg case by handling alias-wrapped generic indexed access in constraint validation
- unignore and fix TS2712 dynamic import await diagnostics so awaited import sites are reported consistently

## Verification
- `scripts/session/verify-all.sh` (full run)
  - formatting: pass
  - clippy: pass
  - unit tests: pass
  - conformance: improved +1 (`11979` vs `11978` baseline)
  - emit: improved (`JS +5`, `DTS +28`)
  - fourslash: pass (`50/50` verify set)
