### PR TITLE
refactor(core): extract wasm program result DTOs

### DIFF
--- a/crates/tsz-core/src/api/wasm/mod.rs
+++ b/crates/tsz-core/src/api/wasm/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod compiler_options;
+pub(crate) mod program_results;

--- a/crates/tsz-core/src/api/wasm/program_results.rs
+++ b/crates/tsz-core/src/api/wasm/program_results.rs
@@ -1,0 +1,27 @@
+/// Result of checking a single file in a multi-file program.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FileCheckResultJson {
+    pub(crate) file_name: String,
+    pub(crate) parse_diagnostics: Vec<ParseDiagnosticJson>,
+    pub(crate) check_diagnostics: Vec<CheckDiagnosticJson>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ParseDiagnosticJson {
+    pub(crate) message: String,
+    pub(crate) start: u32,
+    pub(crate) length: u32,
+    pub(crate) code: u32,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CheckDiagnosticJson {
+    pub(crate) message_text: String,
+    pub(crate) code: u32,
+    pub(crate) start: u32,
+    pub(crate) length: u32,
+    pub(crate) category: String,
+}

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -245,6 +245,9 @@ pub fn create_scanner(text: String, skip_trivia: bool) -> ScannerState {
 // =============================================================================
 
 use crate::api::wasm::compiler_options::CompilerOptions;
+use crate::api::wasm::program_results::{
+    CheckDiagnosticJson, FileCheckResultJson, ParseDiagnosticJson,
+};
 use crate::binder::BinderState;
 use crate::checker::context::LibContext;
 use crate::context::emit::EmitContext;
@@ -1603,34 +1606,6 @@ pub fn create_parser(file_name: String, source_text: String) -> Parser {
 use crate::parallel::{
     BindResult, MergedProgram, check_files_parallel, merge_bind_results, parse_and_bind_parallel,
 };
-
-/// Result of checking a single file in a multi-file program
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FileCheckResultJson {
-    file_name: String,
-    parse_diagnostics: Vec<ParseDiagnosticJson>,
-    check_diagnostics: Vec<CheckDiagnosticJson>,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ParseDiagnosticJson {
-    message: String,
-    start: u32,
-    length: u32,
-    code: u32,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CheckDiagnosticJson {
-    message_text: String,
-    code: u32,
-    start: u32,
-    length: u32,
-    category: String,
-}
 
 /// Multi-file TypeScript program for cross-file type checking.
 ///


### PR DESCRIPTION
## Summary
- move `WasmProgram` JSON DTO structs out of `crates/tsz-core/src/lib.rs` into `crates/tsz-core/src/api/wasm/program_results.rs`
- keep serialization field shapes and names identical (`camelCase`)
- wire re-use from `lib.rs` through the new `api::wasm::program_results` module

## Validation
- `cargo fmt`
- `cargo check -p tsz-core`