### PR TITLE
test(checker): enforce relations access via query boundaries

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -152,3 +152,11 @@ pub(crate) mod type_computation;
     clippy::manual_map
 )]
 pub(crate) mod type_construction;
+#[allow(
+    dead_code,
+    clippy::missing_const_for_fn,
+    clippy::match_same_arms,
+    clippy::doc_markdown,
+    clippy::manual_map
+)]
+pub(crate) mod variance;

--- a/crates/tsz-checker/src/query_boundaries/variance.rs
+++ b/crates/tsz-checker/src/query_boundaries/variance.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use tsz_common::interner::Atom;
+use tsz_solver::def::DefId;
+use tsz_solver::def::resolver::TypeResolver;
+use tsz_solver::type_handles::Variance;
+use tsz_solver::{TypeDatabase, TypeId};
+
+pub(crate) fn compute_variance_with_resolver(
+    db: &dyn TypeDatabase,
+    resolver: &dyn TypeResolver,
+    type_id: TypeId,
+    target_param: Atom,
+) -> Variance {
+    tsz_solver::relations::variance::compute_variance_with_resolver(
+        db,
+        resolver,
+        type_id,
+        target_param,
+    )
+}
+
+pub(crate) fn compute_type_param_variances_with_resolver(
+    db: &dyn TypeDatabase,
+    resolver: &dyn TypeResolver,
+    def_id: DefId,
+) -> Option<Arc<[Variance]>> {
+    tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
+        db, resolver, def_id,
+    )
+}

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -426,7 +426,7 @@ impl<'a> CheckerState<'a> {
             let sym_id = self.ctx.binder.get_node_symbol(stmt_idx);
             let def_id = sym_id.and_then(|sid| self.ctx.get_existing_def_id(sid));
             let def_variances = def_id.and_then(|did| {
-                tsz_solver::relations::variance::compute_type_param_variances_with_resolver(
+                crate::query_boundaries::variance::compute_type_param_variances_with_resolver(
                     db, resolver, did,
                 )
             });
@@ -437,7 +437,7 @@ impl<'a> CheckerState<'a> {
                     // Try direct body type computation first (more reliable for
                     // type aliases where the DefId body may not be resolved yet)
                     if let Some(body) = body_type {
-                        let v = tsz_solver::relations::variance::compute_variance_with_resolver(
+                        let v = crate::query_boundaries::variance::compute_variance_with_resolver(
                             db, resolver, body, info.atom,
                         );
                         if !v.is_independent() {

--- a/crates/tsz-checker/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/tests/architecture_contract_tests.rs
@@ -244,6 +244,57 @@ fn test_direct_call_evaluator_usage_is_quarantined_to_query_boundaries() {
 }
 
 #[test]
+fn test_direct_solver_relations_usage_is_quarantined_to_query_boundaries() {
+    fn collect_checker_rs_files_recursive(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
+        let entries = fs::read_dir(dir).unwrap_or_else(|_| {
+            panic!("failed to read checker source directory {}", dir.display())
+        });
+        for entry in entries {
+            let entry = entry.expect("failed to read checker source directory entry");
+            let path = entry.path();
+            if path.is_dir() {
+                collect_checker_rs_files_recursive(&path, files);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    collect_checker_rs_files_recursive(Path::new("src"), &mut files);
+
+    let mut violations = Vec::new();
+    for path in files {
+        let rel = path.display().to_string();
+        let allowed = rel.contains("/query_boundaries/") || rel.contains("/tests/");
+        if allowed {
+            continue;
+        }
+
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("failed to read {}", path.display()));
+        for (line_index, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+
+            if line.contains("tsz_solver::relations::") {
+                violations.push(format!("{}:{}", rel, line_index + 1));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "direct solver relations usage should stay in query_boundaries modules; violations: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
 fn test_constructor_checker_uses_solver_anchor_for_abstract_constructor_resolution() {
     let constructor_checker_src = fs::read_to_string("src/classes/constructor_checker.rs")
         .expect("failed to read src/classes/constructor_checker.rs");


### PR DESCRIPTION
## Summary
- add `query_boundaries/variance.rs` as the checker-side wrapper for solver variance relation helpers
- route interface variance checks through `crate::query_boundaries::variance::*`
- add architecture contract test that forbids direct `tsz_solver::relations::` usage outside `query_boundaries/` and tests

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker test_direct_solver_relations_usage_is_quarantined_to_query_boundaries -- --nocapture`