### PR TITLE
refactor(core): centralize wasm compiler options JSON parsing

### DIFF
--- a/crates/tsz-core/src/api/wasm/compiler_options.rs
+++ b/crates/tsz-core/src/api/wasm/compiler_options.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use wasm_bindgen::prelude::JsValue;
 
 /// Compiler options passed from JavaScript/WASM.
 /// Maps to TypeScript compiler options.
@@ -340,5 +341,21 @@ impl CompilerOptions {
             erasable_syntax_only: false,
             no_fallthrough_cases_in_switch: false,
         }
+    }
+}
+
+pub(crate) fn parse_compiler_options_json(options_json: &str) -> Result<CompilerOptions, JsValue> {
+    serde_json::from_str::<CompilerOptions>(options_json)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse compiler options: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_compiler_options_json;
+
+    #[test]
+    fn parse_compiler_options_json_accepts_valid_input() {
+        let parsed = parse_compiler_options_json(r#"{"strict":true,"module":99}"#);
+        assert!(parsed.is_ok(), "valid options JSON should parse");
     }
 }

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -244,7 +244,7 @@ pub fn create_scanner(text: String, skip_trivia: bool) -> ScannerState {
 // Parser WASM Interface (High-Performance Parser)
 // =============================================================================
 
-use crate::api::wasm::compiler_options::CompilerOptions;
+use crate::api::wasm::compiler_options::{CompilerOptions, parse_compiler_options_json};
 use crate::binder::BinderState;
 use crate::checker::context::LibContext;
 use crate::context::emit::EmitContext;
@@ -391,17 +391,11 @@ impl Parser {
     /// ```
     #[wasm_bindgen(js_name = setCompilerOptions)]
     pub fn set_compiler_options(&mut self, options_json: &str) -> Result<(), JsValue> {
-        match serde_json::from_str::<CompilerOptions>(options_json) {
-            Ok(options) => {
-                self.compiler_options = options;
-                // Invalidate type cache when compiler options change
-                self.type_cache = None;
-                Ok(())
-            }
-            Err(e) => Err(JsValue::from_str(&format!(
-                "Failed to parse compiler options: {e}"
-            ))),
-        }
+        let options = parse_compiler_options_json(options_json)?;
+        self.compiler_options = options;
+        // Invalidate type cache when compiler options change
+        self.type_cache = None;
+        Ok(())
     }
 
     /// Add a lib file (e.g., lib.es5.d.ts) for global type resolution.
@@ -1728,18 +1722,12 @@ impl WasmProgram {
     /// * `options_json` - JSON string containing compiler options
     #[wasm_bindgen(js_name = setCompilerOptions)]
     pub fn set_compiler_options(&mut self, options_json: &str) -> Result<(), JsValue> {
-        match serde_json::from_str::<CompilerOptions>(options_json) {
-            Ok(options) => {
-                self.compiler_options = options;
-                // Invalidate any previous compilation since options affect typing
-                self.merged = None;
-                self.bind_results = None;
-                Ok(())
-            }
-            Err(e) => Err(JsValue::from_str(&format!(
-                "Failed to parse compiler options: {e}"
-            ))),
-        }
+        let options = parse_compiler_options_json(options_json)?;
+        self.compiler_options = options;
+        // Invalidate any previous compilation since options affect typing
+        self.merged = None;
+        self.bind_results = None;
+        Ok(())
     }
 
     /// Get the number of files in the program.


### PR DESCRIPTION
## Summary
- add `parse_compiler_options_json` helper in `crates/tsz-core/src/api/wasm/compiler_options.rs`
- reuse this helper from both `Parser::setCompilerOptions` and `WasmProgram::setCompilerOptions`
- keep existing behavior while removing duplicated parse/error mapping logic
- add a small unit test for valid JSON parsing via the helper

## Validation
- `cargo fmt`
- `cargo check -p tsz-core`
- `cargo test -p tsz-core parse_compiler_options_json_accepts_valid_input -- --nocapture`