### PR TITLE
test(checker): guard solver types module boundary

### DIFF
--- a/crates/tsz-checker/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/tests/architecture_contract_tests.rs
@@ -244,6 +244,57 @@ fn test_direct_call_evaluator_usage_is_quarantined_to_query_boundaries() {
 }
 
 #[test]
+fn test_direct_solver_types_module_usage_is_quarantined_to_query_boundaries() {
+    fn collect_checker_rs_files_recursive(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
+        let entries = fs::read_dir(dir).unwrap_or_else(|_| {
+            panic!("failed to read checker source directory {}", dir.display())
+        });
+        for entry in entries {
+            let entry = entry.expect("failed to read checker source directory entry");
+            let path = entry.path();
+            if path.is_dir() {
+                collect_checker_rs_files_recursive(&path, files);
+                continue;
+            }
+            if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    collect_checker_rs_files_recursive(Path::new("src"), &mut files);
+
+    let mut violations = Vec::new();
+    for path in files {
+        let rel = path.display().to_string();
+        let allowed = rel.contains("/query_boundaries/") || rel.contains("/tests/");
+        if allowed {
+            continue;
+        }
+
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("failed to read {}", path.display()));
+        for (line_index, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+
+            if line.contains("tsz_solver::types::") {
+                violations.push(format!("{}:{}", rel, line_index + 1));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "direct solver types module usage should stay in query_boundaries modules; violations: {}",
+        violations.join(", ")
+    );
+}
+
+#[test]
 fn test_constructor_checker_uses_solver_anchor_for_abstract_constructor_resolution() {
     let constructor_checker_src = fs::read_to_string("src/classes/constructor_checker.rs")
         .expect("failed to read src/classes/constructor_checker.rs");


### PR DESCRIPTION
## Summary
- add architecture contract test to forbid direct `tsz_solver::types::` module usage outside `query_boundaries/` and tests
- keep boundary policy enforcement in Rust test suite (in addition to script-based guards)

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker test_direct_solver_types_module_usage_is_quarantined_to_query_boundaries -- --nocapture`