### PR TITLE
refactor(core): extract wasm transform context wrapper

### DIFF
--- a/crates/tsz-core/src/api/wasm/mod.rs
+++ b/crates/tsz-core/src/api/wasm/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod compiler_options;
+pub(crate) mod transforms;

--- a/crates/tsz-core/src/api/wasm/transforms.rs
+++ b/crates/tsz-core/src/api/wasm/transforms.rs
@@ -1,0 +1,21 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::common::ModuleKind;
+use crate::context::transform::TransformContext;
+
+/// Opaque wrapper for transform directives across the wasm boundary.
+#[wasm_bindgen]
+pub struct WasmTransformContext {
+    pub(crate) inner: TransformContext,
+    pub(crate) target_es5: bool,
+    pub(crate) module_kind: ModuleKind,
+}
+
+#[wasm_bindgen]
+impl WasmTransformContext {
+    /// Get the number of transform directives generated.
+    #[wasm_bindgen(js_name = getCount)]
+    pub fn get_count(&self) -> usize {
+        self.inner.len()
+    }
+}

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -245,6 +245,7 @@ pub fn create_scanner(text: String, skip_trivia: bool) -> ScannerState {
 // =============================================================================
 
 use crate::api::wasm::compiler_options::CompilerOptions;
+use crate::api::wasm::transforms::WasmTransformContext;
 use crate::binder::BinderState;
 use crate::checker::context::LibContext;
 use crate::context::emit::EmitContext;
@@ -313,23 +314,6 @@ impl TryFrom<ImportCandidateInput> for ImportCandidate {
             kind,
             is_type_only: input.is_type_only,
         })
-    }
-}
-
-/// Opaque wrapper for transform directives across the wasm boundary.
-#[wasm_bindgen]
-pub struct WasmTransformContext {
-    inner: TransformContext,
-    target_es5: bool,
-    module_kind: ModuleKind,
-}
-
-#[wasm_bindgen]
-impl WasmTransformContext {
-    /// Get the number of transform directives generated.
-    #[wasm_bindgen(js_name = getCount)]
-    pub fn get_count(&self) -> usize {
-        self.inner.len()
     }
 }
 


### PR DESCRIPTION
## Summary
- move `WasmTransformContext` out of `crates/tsz-core/src/lib.rs` into `crates/tsz-core/src/api/wasm/transforms.rs`
- keep field/method behavior unchanged while reducing `lib.rs` surface
- wire the module through `crates/tsz-core/src/api/wasm/mod.rs`

## Validation
- `cargo fmt`
- `cargo check -p tsz-core`