### PR TITLE
fix(checker): synthesize call signature from JSDoc @param when JS function uses `arguments`

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params.rs
+++ b/crates/tsz-checker/src/jsdoc/params.rs
@@ -231,7 +231,7 @@ impl<'a> CheckerState<'a> {
     /// (variable initializer, property/shorthand assignment, binary `=`
     /// assignment, parameter default). False for anonymous expressions in
     /// positions like `return function() {...}` or array literals.
-    fn function_has_effective_name(&self, func_idx: NodeIndex) -> bool {
+    pub(crate) fn function_has_effective_name(&self, func_idx: NodeIndex) -> bool {
         use tsz_parser::syntax_kind_ext;
         let Some(node) = self.ctx.arena.get(func_idx) else {
             return false;

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1210,6 +1210,51 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // JS files: if the function has no AST parameters but its body references
+        // `arguments`, synthesize a call signature from JSDoc `@param` tags so that
+        // calls are checked against the declared JSDoc parameter types.
+        // Mirrors tsc's `getSignatureFromDeclaration` JSDoc fallback.
+        if parameters.nodes.is_empty()
+            && params.is_empty()
+            && self.is_js_file()
+            && let Some(ref jsdoc) = func_jsdoc
+            && !jsdoc.contains("@callback")
+            && self.body_has_arguments_reference(body)
+        {
+            let function_has_name = self.function_has_effective_name(idx);
+            let comment_pos = self.get_jsdoc_comment_pos_for_function(idx);
+            for (pname, _) in Self::extract_jsdoc_param_names(jsdoc) {
+                if pname == "this" {
+                    continue;
+                }
+                let is_rest = Self::jsdoc_param_is_rest(jsdoc, &pname);
+                // tsc only promotes {...T} → T[] when the function has an
+                // effective name; anonymous expressions leave the type as T
+                // and TS8029 is emitted by check_jsdoc_param_tag_names.
+                if is_rest && !function_has_name {
+                    continue;
+                }
+                let is_optional = Self::is_jsdoc_param_optional_by_brackets(jsdoc, &pname)
+                    || Self::extract_jsdoc_param_type_string(jsdoc, &pname)
+                        .is_some_and(|t| t.trim().ends_with('='));
+                let Some(type_id) =
+                    self.resolve_jsdoc_param_type_with_pos(jsdoc, &pname, comment_pos)
+                else {
+                    continue;
+                };
+                // `resolve_jsdoc_param_type_with_pos` already strips the `...` prefix
+                // and returns the element type. For rest params we store the element
+                // type and set `rest: true`, matching the AST-param JSDoc path.
+                let name = self.ctx.types.intern_string(&pname);
+                params.push(ParamInfo {
+                    name: Some(name),
+                    type_id,
+                    optional: is_optional,
+                    rest: is_rest,
+                });
+            }
+        }
+
         // Record that we've checked this closure for implicit-any diagnostics so
         // later re-entrant passes do not re-emit TS7006/TS7031. Do this after the
         // full parameter walk so sibling parameters in the same closure are all checked.


### PR DESCRIPTION
## Summary
- tsc's `getSignatureFromDeclaration` builds a call signature from JSDoc `@param` tags when a JS function has no AST parameters but its body references `arguments`. tsz already emitted the right TS8024/TS8029 diagnostics for mismatched `@param` tags via `check_jsdoc_param_tag_names`, but it never populated the `params` vec — the resulting `FunctionShape` had zero parameters, so calls like `correct(1,2,3)` against a `@param {...string}` declaration were not type-checked.
- After the main parameter loop in `get_type_of_function_impl`, detect the "zero AST params + uses arguments + has JSDoc" case and synthesize `ParamInfo` entries from the `@param` tags.
- Match the existing AST-param JSDoc path for rest handling: `resolve_jsdoc_param_type_with_pos` already strips the `...` prefix and returns the element type; setting `rest: true` lets call-checking treat it as a rest parameter and lets error messages use the element type (e.g. `'string'`, not `'string[]'`), which is what tsc emits.
- Only rest tags on effectively-named functions are synthesized; anonymous rest tags are intentionally dropped since `check_jsdoc_param_tag_names` already reports TS8029 for that case.

## Impact
- jsdoc conformance lane: 345 → 346 (+1, `paramTagOnFunctionUsingArguments.ts`).
- Compiler lane: no regressions vs baseline. `jsxRuntimePragma.ts` flickers across runs on `origin/main` independently of this change (verified by running baseline 5× — 2 fails out of 5).
- Error message parity confirmed manually against `tsc@6.0.2` for both the rest case and the no-args case (preserves TS8024 for orphan `@param` when `arguments` is not used).

## Test plan
- [x] Target test: `./scripts/conformance/conformance.sh run --filter paramTagOnFunctionUsingArguments` → passes.
- [x] JSDoc lane: 346/377 with fix vs 345/377 baseline.
- [x] Conformance lane: 5536/5872 with fix vs 5535/5872 baseline.
- [x] Compiler lane: 262 fails with fix vs 262 fails baseline (flaky `jsxRuntimePragma` excluded).
- [x] Manual parity with `tsc --allowJs --checkJs --strict` for `/** @param {...string} s */ function f() { arguments } f(1,2,3);` (matches exactly) and for `/** @param {...string} s */ function g() { return 1 } g(1,2,3);` (still emits TS8024 + TS2554, no synthesis).