### PR TITLE
test(checker): tighten TypeKey source boundary guard

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1286,6 +1286,9 @@ fn test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_int
 
         line.contains("tsz_solver::types::")
             || line.contains("use tsz_solver::TypeData")
+            || line.contains("use tsz_solver::TypeKey")
+            || line.contains("tsz_solver::TypeKey::")
+            || line.contains("TypeKey::")
             || (line.contains("use ") && contains_type_data_ident(line))
             || line.contains("intern(TypeData::")
             || line.contains("intern(tsz_solver::TypeData::")
@@ -1321,7 +1324,7 @@ fn test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_int
 
     assert!(
         violations.is_empty(),
-        "checker source files must not import solver internals, import TypeData, or call raw interner APIs directly; violations: {}",
+        "checker source files must not import solver internals, import TypeData/TypeKey, or call raw interner APIs directly; violations: {}",
         violations.join(", ")
     );
 }


### PR DESCRIPTION
## Summary
- tighten checker source architecture guard to explicitly reject direct `TypeKey` usage patterns outside `query_boundaries/` and test files
- extend the guard to catch:
  - `use tsz_solver::TypeKey`
  - `tsz_solver::TypeKey::...`
  - bare `TypeKey::...`
- update assertion text to include `TypeKey`

## Why
- keeps TypeKey-level solver internals quarantined behind checker query boundaries
- complements existing `tsz_solver::types::` / `TypeData` / raw interner guardrails with explicit top-level TypeKey checks

## Validation
- cargo fmt
- cargo test -p tsz-checker test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning -- --nocapture
