### PR TITLE
chore(metadata): enforce crate repository/homepage alignment

### DIFF
--- a/crates/conformance/Cargo.toml
+++ b/crates/conformance/Cargo.toml
@@ -2,6 +2,8 @@
 name = "tsz-conformance"
 version = "0.1.0"
 edition = "2021"
+repository.workspace = true
+homepage.workspace = true
 autotests = false
 publish = false
 

--- a/crates/tsz-wasm/Cargo.toml
+++ b/crates/tsz-wasm/Cargo.toml
@@ -4,6 +4,7 @@ description = "WebAssembly bindings for the tsz TypeScript compiler"
 version.workspace = true
 edition.workspace = true
 repository.workspace = true
+homepage.workspace = true
 license.workspace = true
 authors.workspace = true
 publish = false

--- a/crates/tsz-website/Cargo.toml
+++ b/crates/tsz-website/Cargo.toml
@@ -2,6 +2,8 @@
 name = "tsz-website"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
 publish = false
 description = "tsz project website — Eleventy static site deployed to tsz.dev"
 

--- a/scripts/arch/check-workspace-metadata.sh
+++ b/scripts/arch/check-workspace-metadata.sh
@@ -40,21 +40,78 @@ extract_workspace_package_field() {
   ' Cargo.toml
 }
 
-repository="$(extract_workspace_package_field "repository")"
-homepage="$(extract_workspace_package_field "homepage")"
+extract_package_field() {
+  local cargo_toml="$1"
+  local field="$2"
 
-if [[ "$repository" != "$expected_url" ]]; then
-  echo "error: workspace.package.repository mismatch" >&2
-  echo "expected: $expected_url" >&2
-  echo "actual:   $repository" >&2
+  awk -v key="$field" '
+    BEGIN { in_package = 0 }
+    /^\[package\]/ { in_package = 1; next }
+    /^\[/ { if (in_package) exit }
+    !in_package { next }
+
+    $0 ~ "^[[:space:]]*" key "\\.workspace[[:space:]]*=[[:space:]]*true[[:space:]]*$" {
+      print "__WORKSPACE__"
+      exit
+    }
+
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      if (match($0, /"[^"]+"/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+      }
+      exit
+    }
+  ' "$cargo_toml"
+}
+
+failures=()
+
+workspace_repository="$(extract_workspace_package_field "repository")"
+workspace_homepage="$(extract_workspace_package_field "homepage")"
+
+if [[ "$workspace_repository" != "$expected_url" ]]; then
+  failures+=("workspace.package.repository mismatch (expected: $expected_url, actual: ${workspace_repository:-<missing>})")
+fi
+
+if [[ "$workspace_homepage" != "$expected_url" ]]; then
+  failures+=("workspace.package.homepage mismatch (expected: $expected_url, actual: ${workspace_homepage:-<missing>})")
+fi
+
+validate_crate_field() {
+  local cargo_toml="$1"
+  local field="$2"
+  local value="$3"
+
+  if [[ -z "$value" ]]; then
+    failures+=("$cargo_toml: missing package.$field (set $field.workspace = true or $field = \"$expected_url\")")
+    return
+  fi
+
+  if [[ "$value" == "__WORKSPACE__" ]]; then
+    return
+  fi
+
+  if [[ "$value" != "$expected_url" ]]; then
+    failures+=("$cargo_toml: package.$field mismatch (expected workspace value $expected_url, actual: $value)")
+  fi
+}
+
+for cargo_toml in crates/*/Cargo.toml; do
+  [[ -f "$cargo_toml" ]] || continue
+
+  crate_repository="$(extract_package_field "$cargo_toml" "repository")"
+  crate_homepage="$(extract_package_field "$cargo_toml" "homepage")"
+
+  validate_crate_field "$cargo_toml" "repository" "$crate_repository"
+  validate_crate_field "$cargo_toml" "homepage" "$crate_homepage"
+done
+
+if [[ "${#failures[@]}" -gt 0 ]]; then
+  echo "error: workspace metadata validation failed." >&2
+  for failure in "${failures[@]}"; do
+    echo "  - $failure" >&2
+  done
   exit 1
 fi
 
-if [[ "$homepage" != "$expected_url" ]]; then
-  echo "error: workspace.package.homepage mismatch" >&2
-  echo "expected: $expected_url" >&2
-  echo "actual:   $homepage" >&2
-  exit 1
-fi
-
-echo "workspace package metadata matches origin URL: $expected_url"
+echo "workspace package and crate metadata match origin URL: $expected_url"


### PR DESCRIPTION
## Summary
- add missing `repository.workspace = true` / `homepage.workspace = true` metadata to:
  - `crates/conformance/Cargo.toml`
  - `crates/tsz-wasm/Cargo.toml`
  - `crates/tsz-website/Cargo.toml`
- extend `scripts/arch/check-workspace-metadata.sh` to validate crate-level `[package]` metadata in addition to `[workspace.package]`
- allow crates to satisfy the check via either:
  - `repository.workspace = true` / `homepage.workspace = true`, or
  - explicit URL values equal to normalized `remote.origin.url`

## Why
- prevents metadata drift between workspace-level and crate-level package information
- strengthens release hygiene for crates and generated package pages
- keeps CI guardrails aligned with the architecture/release hardening effort

## Validation
- scripts/arch/check-workspace-metadata.sh
