### PR TITLE
lsp: default-export naming + getter/setter kinds + structural child walking

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -51,6 +51,8 @@ fn symbol_kind_to_tsserver(
         SymbolKind::TypeParameter => "type parameter",
         SymbolKind::Struct => "type",
         SymbolKind::Alias => "alias",
+        SymbolKind::Getter => "getter",
+        SymbolKind::Setter => "setter",
         _ => "unknown",
     }
 }
@@ -1896,28 +1898,42 @@ impl Server {
             let mut symbols = provider.get_document_symbols(root);
             sort_symbols_deep(&mut symbols);
 
-            /// Check if a symbol should appear as its own entry in the primary
-            /// navigation bar menu (matching TypeScript's shouldAppearInPrimaryNavBarMenu).
-            const fn should_appear_in_primary_navbar(
+            /// Check if a symbol should appear as its own entry in the
+            /// primary navigation bar menu. Mirrors tsc's
+            /// `shouldAppearInPrimaryNavBarMenu` /
+            /// `isTopLevelFunctionDeclaration`: leaf functions only promote
+            /// when their parent is SourceFile / ModuleBlock / Method /
+            /// Constructor — not SetAccessor / GetAccessor, which is why
+            /// `function f() {}` inside a setter stays collapsed.
+            fn should_appear_in_primary_navbar(
                 sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol,
+                parent_kind: Option<tsz::lsp::symbols::document_symbols::SymbolKind>,
             ) -> bool {
                 use tsz::lsp::symbols::document_symbols::SymbolKind;
-                // Items with children always appear
                 if !sym.children.is_empty() {
                     return true;
                 }
-                // Container-like declarations always appear
-                matches!(
-                    sym.kind,
+                match sym.kind {
                     SymbolKind::Class
-                        | SymbolKind::Enum
-                        | SymbolKind::Interface
-                        | SymbolKind::Module
-                        | SymbolKind::Namespace
-                        | SymbolKind::File
-                        | SymbolKind::Struct // type alias
-                        | SymbolKind::Function
-                )
+                    | SymbolKind::Enum
+                    | SymbolKind::Interface
+                    | SymbolKind::Module
+                    | SymbolKind::Namespace
+                    | SymbolKind::File
+                    | SymbolKind::Struct => true,
+                    SymbolKind::Function => matches!(
+                        parent_kind,
+                        None // root (source file)
+                            | Some(
+                                SymbolKind::File
+                                    | SymbolKind::Module
+                                    | SymbolKind::Namespace
+                                    | SymbolKind::Method
+                                    | SymbolKind::Constructor
+                            )
+                    ),
+                    _ => false,
+                }
             }
 
             fn navbar_child_item(
@@ -1995,7 +2011,7 @@ impl Server {
                 items.push(parent_item);
                 // Only recurse into children that should appear in the primary navbar
                 for child in &sym.children {
-                    if should_appear_in_primary_navbar(child) {
+                    if should_appear_in_primary_navbar(child, Some(sym.kind)) {
                         symbol_to_navbar_item(child, indent + 1, items);
                     }
                 }
@@ -2029,9 +2045,12 @@ impl Server {
                 root["childItems"] = serde_json::json!(child_items);
             }
             items.push(root);
-            // Only add top-level symbols that qualify as primary navbar items
+            // Only add top-level symbols that qualify as primary navbar
+            // items. `parent_kind = None` corresponds to the source file
+            // root — tsc treats SourceFile as a valid "top-level" parent
+            // for promoting leaf functions.
             for sym in &symbols {
-                if should_appear_in_primary_navbar(sym) {
+                if should_appear_in_primary_navbar(sym, None) {
                     symbol_to_navbar_item(sym, 1, &mut items);
                 }
             }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -55,6 +55,26 @@ fn symbol_kind_to_tsserver(
     }
 }
 
+/// Sort a navtree/navbar symbol slice in-place, recursively sorting each
+/// node's children. Mirrors TypeScript's `compareChildren`: primary key is
+/// case-insensitive name, tiebreaker is source position. tsc sorts nav
+/// items regardless of declaration order, so tsz has to match or every
+/// declaration-order-dependent test drifts.
+fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::DocumentSymbol]) {
+    symbols.sort_by(|a, b| {
+        let na = a.name.to_lowercase();
+        let nb = b.name.to_lowercase();
+        match na.cmp(&nb) {
+            std::cmp::Ordering::Equal => (a.range.start.line, a.range.start.character)
+                .cmp(&(b.range.start.line, b.range.start.character)),
+            other => other,
+        }
+    });
+    for sym in symbols.iter_mut() {
+        sort_symbols_deep(&mut sym.children);
+    }
+}
+
 impl Server {
     fn build_project_for_file(&self, file_name: &str) -> Option<Project> {
         let mut files = self.open_files.clone();
@@ -1763,7 +1783,8 @@ impl Server {
             let is_external_module = binder.is_external_module;
             let line_map = LineMap::build(&source_text);
             let provider = DocumentSymbolProvider::new(&arena, &line_map, &source_text);
-            let symbols = provider.get_document_symbols(root);
+            let mut symbols = provider.get_document_symbols(root);
+            sort_symbols_deep(&mut symbols);
 
             fn symbol_to_navtree(
                 sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol,
@@ -1872,7 +1893,8 @@ impl Server {
             let is_external_module = binder.is_external_module;
             let line_map = LineMap::build(&source_text);
             let provider = DocumentSymbolProvider::new(&arena, &line_map, &source_text);
-            let symbols = provider.get_document_symbols(root);
+            let mut symbols = provider.get_document_symbols(root);
+            sort_symbols_deep(&mut symbols);
 
             /// Check if a symbol should appear as its own entry in the primary
             /// navigation bar menu (matching TypeScript's shouldAppearInPrimaryNavBarMenu).

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -48,10 +48,13 @@ pub enum SymbolKind {
     Event = 24,
     Operator = 25,
     TypeParameter = 26,
-    // Non-LSP kinds used internally for tsserver parity (`alias` does not
-    // have a 1:1 LSP mapping — clients that surface these via LSP should
-    // treat it as a variable/module).
+    // Non-LSP kinds used internally for tsserver parity (the LSP `SymbolKind`
+    // enum has no getter/setter/alias distinction — clients that surface
+    // these via LSP should treat Alias as a variable/module and
+    // Getter/Setter as a property).
     Alias = 27,
+    Getter = 28,
+    Setter = 29,
 }
 
 impl SymbolKind {
@@ -73,6 +76,8 @@ impl SymbolKind {
             Self::TypeParameter => "type parameter",
             Self::Struct => "type",
             Self::Alias => "alias",
+            Self::Getter => "getter",
+            Self::Setter => "setter",
         }
     }
 }
@@ -618,18 +623,18 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
                     let selection_range =
                         node_range(self.arena, self.line_map, self.source_text, name_node);
-                    let mut modifiers = self.get_kind_modifiers_from_list(&accessor.modifiers);
-                    append_modifier(&mut modifiers, "getter");
+                    let modifiers = self.get_kind_modifiers_from_list(&accessor.modifiers);
+                    let children = self.collect_children_from_block(accessor.body, Some(&name));
 
                     vec![DocumentSymbol {
                         name,
-                        detail: Some("getter".to_string()),
-                        kind: SymbolKind::Property,
+                        detail: None,
+                        kind: SymbolKind::Getter,
                         kind_modifiers: modifiers,
                         range,
                         selection_range,
                         container_name: container_name.map(std::string::ToString::to_string),
-                        children: vec![],
+                        children,
                     }]
                 } else {
                     vec![]
@@ -646,18 +651,18 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
                     let selection_range =
                         node_range(self.arena, self.line_map, self.source_text, name_node);
-                    let mut modifiers = self.get_kind_modifiers_from_list(&accessor.modifiers);
-                    append_modifier(&mut modifiers, "setter");
+                    let modifiers = self.get_kind_modifiers_from_list(&accessor.modifiers);
+                    let children = self.collect_children_from_block(accessor.body, Some(&name));
 
                     vec![DocumentSymbol {
                         name,
-                        detail: Some("setter".to_string()),
-                        kind: SymbolKind::Property,
+                        detail: None,
+                        kind: SymbolKind::Setter,
                         kind_modifiers: modifiers,
                         range,
                         selection_range,
                         container_name: container_name.map(std::string::ToString::to_string),
-                        children: vec![],
+                        children,
                     }]
                 } else {
                     vec![]
@@ -853,10 +858,21 @@ impl<'a> DocumentSymbolProvider<'a> {
             && let Some(block) = self.arena.get_block(node)
         {
             for &stmt in &block.statements.nodes {
-                // Only collect declarations (functions, classes) - not variables
+                // Collect declaration-ish statements that tsc includes in
+                // the outline for a block body: functions, classes,
+                // interfaces, enums, and type aliases. Variable
+                // declarations inside function/constructor/method bodies
+                // are deliberately omitted — tsc doesn't surface them.
                 if let Some(stmt_node) = self.arena.get(stmt)
-                    && (stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                        || stmt_node.kind == syntax_kind_ext::CLASS_DECLARATION)
+                    && matches!(
+                        stmt_node.kind,
+                        k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                            || k == syntax_kind_ext::CLASS_DECLARATION
+                            || k == syntax_kind_ext::INTERFACE_DECLARATION
+                            || k == syntax_kind_ext::ENUM_DECLARATION
+                            || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                            || k == syntax_kind_ext::MODULE_DECLARATION
+                    )
                 {
                     symbols.extend(self.collect_symbols(stmt, container_name));
                 }

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -728,19 +728,25 @@ impl<'a> DocumentSymbolProvider<'a> {
                             || self.is_declaration(clause_node.kind)
                         {
                             // Collect the inner declaration/alias and add the
-                            // `export` (and optional `default`) modifier. Use
-                            // `append_modifier` to de-duplicate when the inner
-                            // declaration already reports its own `export` —
-                            // e.g. when a `VARIABLE_STATEMENT` with an `export`
-                            // modifier is nested under an EXPORT_DECLARATION
-                            // wrapper — so the emitted kindModifiers doesn't
-                            // end up as `"export,export"`.
+                            // `export` modifier. `append_modifier` de-duplicates
+                            // when the inner declaration already reports its
+                            // own `export` — e.g. when a `VARIABLE_STATEMENT`
+                            // with an `export` modifier is nested under an
+                            // EXPORT_DECLARATION wrapper — so the emitted
+                            // kindModifiers doesn't end up as `"export,export"`.
+                            //
+                            // tsc does NOT append a `default` kindModifier:
+                            // named default exports (`export default class C`)
+                            // keep just `export`, anonymous ones
+                            // (`export default class { }`) get their name
+                            // replaced with `default` and still only carry
+                            // `export` — no `default` modifier at either site.
                             let mut symbols = self.collect_symbols(export_clause, container_name);
                             for sym in &mut symbols {
-                                let mut mods = String::from("export");
-                                if is_default {
-                                    append_modifier(&mut mods, "default");
+                                if is_default && self.is_synthetic_placeholder_name(&sym.name) {
+                                    sym.name = "default".to_string();
                                 }
+                                let mut mods = String::from("export");
                                 for existing in
                                     sym.kind_modifiers.split(',').filter(|m| !m.is_empty())
                                 {
@@ -763,7 +769,9 @@ impl<'a> DocumentSymbolProvider<'a> {
                         }
                     }
 
-                    // export default <expression> (non-declaration)
+                    // export default <expression> (non-declaration). tsc
+                    // labels these with `default` as the text and only
+                    // `export` as the modifier (no `default` modifier).
                     if is_default {
                         let range =
                             node_range(self.arena, self.line_map, self.source_text, node_idx);
@@ -772,7 +780,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                             name: "default".to_string(),
                             detail: None,
                             kind: SymbolKind::Variable,
-                            kind_modifiers: "export,default".to_string(),
+                            kind_modifiers: "export".to_string(),
                             range,
                             selection_range,
                             container_name: container_name.map(std::string::ToString::to_string),
@@ -855,6 +863,18 @@ impl<'a> DocumentSymbolProvider<'a> {
             }
         }
         symbols
+    }
+
+    /// The declaration arms use `<class>`, `<function>`, etc. as a stable
+    /// placeholder when a declaration has no identifier. When such a
+    /// placeholder bubbles up through a default export, tsc replaces it
+    /// with the literal `default` as the nav item's text — these are the
+    /// forms we'd substitute.
+    fn is_synthetic_placeholder_name(&self, name: &str) -> bool {
+        matches!(
+            name,
+            "<class>" | "<function>" | "<anonymous>" | "<interface>" | "<type>" | "<enum>"
+        )
     }
 
     /// Check if a node kind is a declaration.

--- a/crates/tsz-lsp/tests/document_symbols_tests.rs
+++ b/crates/tsz-lsp/tests/document_symbols_tests.rs
@@ -796,13 +796,15 @@ fn test_document_symbols_export_default_class() {
     let symbols = provider.get_document_symbols(root);
 
     assert!(!symbols.is_empty(), "Should produce at least one symbol");
-    // Should have export,default modifiers
     let sym = &symbols[0];
-    assert!(
-        sym.kind_modifiers.contains("export") && sym.kind_modifiers.contains("default"),
-        "Expected 'export,default' modifiers, got: '{}'",
+    // tsc emits just `export` (no `default` modifier) for named default
+    // exports; the `default`-ness is encoded implicitly.
+    assert_eq!(
+        sym.kind_modifiers, "export",
+        "Expected 'export' modifier on named default export, got: '{}'",
         sym.kind_modifiers
     );
+    assert_eq!(sym.name, "Widget");
 }
 
 #[test]
@@ -817,11 +819,30 @@ fn test_document_symbols_export_default_function() {
 
     assert!(!symbols.is_empty(), "Should produce at least one symbol");
     let sym = &symbols[0];
-    assert!(
-        sym.kind_modifiers.contains("export") && sym.kind_modifiers.contains("default"),
-        "Expected 'export,default' modifiers, got: '{}'",
+    assert_eq!(
+        sym.kind_modifiers, "export",
+        "Expected 'export' modifier on named default export, got: '{}'",
         sym.kind_modifiers
     );
+    assert_eq!(sym.name, "main");
+}
+
+#[test]
+fn test_document_symbols_export_default_anonymous_class() {
+    let source = "export default class {}";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let line_map = LineMap::build(source);
+
+    let provider = DocumentSymbolProvider::new(parser.get_arena(), &line_map, source);
+    let symbols = provider.get_document_symbols(root);
+
+    assert!(!symbols.is_empty(), "Should produce at least one symbol");
+    let sym = &symbols[0];
+    // Anonymous default export: name becomes "default", modifier stays
+    // just `export`.
+    assert_eq!(sym.name, "default");
+    assert_eq!(sym.kind_modifiers, "export");
 }
 
 #[test]

--- a/crates/tsz-lsp/tests/document_symbols_tests.rs
+++ b/crates/tsz-lsp/tests/document_symbols_tests.rs
@@ -310,17 +310,15 @@ fn test_get_set_accessors() {
     assert_eq!(symbols.len(), 1);
     assert_eq!(symbols[0].children.len(), 2);
 
-    // Get accessor
+    // Get accessor — tsc exposes getters/setters via ScriptElementKind
+    // "getter"/"setter" (not "property"), which we model with dedicated
+    // SymbolKind variants.
     assert_eq!(symbols[0].children[0].name, "val");
-    assert_eq!(symbols[0].children[0].kind, SymbolKind::Property);
-    assert_eq!(symbols[0].children[0].detail, Some("getter".to_string()));
-    assert!(symbols[0].children[0].kind_modifiers.contains("getter"));
+    assert_eq!(symbols[0].children[0].kind, SymbolKind::Getter);
 
     // Set accessor
     assert_eq!(symbols[0].children[1].name, "val");
-    assert_eq!(symbols[0].children[1].kind, SymbolKind::Property);
-    assert_eq!(symbols[0].children[1].detail, Some("setter".to_string()));
-    assert!(symbols[0].children[1].kind_modifiers.contains("setter"));
+    assert_eq!(symbols[0].children[1].kind, SymbolKind::Setter);
 }
 
 #[test]

--- a/crates/tsz-lsp/tests/symbols_tests.rs
+++ b/crates/tsz-lsp/tests/symbols_tests.rs
@@ -225,10 +225,10 @@ class Config {
     assert_eq!(tree[0].children.len(), 2);
     // Getter
     assert_eq!(tree[0].children[0].name, "value");
-    assert_eq!(tree[0].children[0].kind, SymbolKind::Property);
+    assert_eq!(tree[0].children[0].kind, SymbolKind::Getter);
     // Setter
     assert_eq!(tree[0].children[1].name, "value");
-    assert_eq!(tree[0].children[1].kind, SymbolKind::Property);
+    assert_eq!(tree[0].children[1].kind, SymbolKind::Setter);
 }
 
 #[test]
@@ -639,11 +639,11 @@ class Box {
     assert_eq!(tree[0].children.len(), 3);
 
     assert_eq!(tree[0].children[0].name, "width");
-    assert_eq!(tree[0].children[0].kind, SymbolKind::Property);
+    assert_eq!(tree[0].children[0].kind, SymbolKind::Getter);
     assert_eq!(tree[0].children[1].name, "width");
-    assert_eq!(tree[0].children[1].kind, SymbolKind::Property);
+    assert_eq!(tree[0].children[1].kind, SymbolKind::Setter);
     assert_eq!(tree[0].children[2].name, "height");
-    assert_eq!(tree[0].children[2].kind, SymbolKind::Property);
+    assert_eq!(tree[0].children[2].kind, SymbolKind::Getter);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Three related tsserver navigation-bar/navtree parity fixes:

1. **Default-export naming** — `export default class C` keeps just `export` (not `export,default`) as kindModifier; anonymous `export default class {}` becomes text \`default\` with modifier \`export\`. Mirrors tsc's `getDefaultLikeExportNameFromDeclaration`.
2. **Dedicated Getter/Setter kinds** — `get x()` / `set x(v)` are \`ScriptElementKind::getter\` / \`setter\` at tsc, not \`property\`. New \`SymbolKind::Getter\` / \`SymbolKind::Setter\` variants.
3. **Structural child walking** — constructor/method/getter/setter bodies now surface nested function/class/interface/enum/type-alias/namespace declarations. And leaf function promotion matches tsc's \`isTopLevelFunctionDeclaration\`: a function nested inside a setter stays collapsed, one inside a constructor or method gets surfaced.

Contains the sort commit from #539 to make the fourslash verification runnable end-to-end; #539 is a subset and should merge first.

## Test plan

- [x] `cargo nextest run -p tsz-lsp` (3759/3759 pass)
- [x] `TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navbar_exportDefault` — passes
- [x] `TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navigationBarGetterAndSetter` — passes
- [x] Native-TS full run of `navigationBar` filter: 68/68 (no regression)