### PR TITLE
test(checker): tighten direct TypeData source guard

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1286,6 +1286,8 @@ fn test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_int
 
         line.contains("tsz_solver::types::")
             || line.contains("use tsz_solver::TypeData")
+            || line.contains("tsz_solver::TypeData::")
+            || line.contains("TypeData::")
             || line.contains("use tsz_solver::TypeKey")
             || line.contains("tsz_solver::TypeKey::")
             || line.contains("TypeKey::")
@@ -1324,7 +1326,7 @@ fn test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_int
 
     assert!(
         violations.is_empty(),
-        "checker source files must not import solver internals, import TypeData/TypeKey, or call raw interner APIs directly; violations: {}",
+        "checker source files must not import solver internals, use TypeData/TypeKey directly, or call raw interner APIs directly; violations: {}",
         violations.join(", ")
     );
 }


### PR DESCRIPTION
## Summary
- tighten checker source architecture guard to explicitly reject direct `TypeData` variant usage patterns outside `query_boundaries/` and test files
- extend `test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning` to catch:
  - `tsz_solver::TypeData::...`
  - bare `TypeData::...`
- update assertion text to reflect direct `TypeData`/`TypeKey` usage prohibition

## Why
- keeps solver-internal representation details quarantined behind checker query boundaries
- complements existing restrictions on `tsz_solver::types::*`, raw interner APIs, and `TypeKey` usage

## Validation
- cargo fmt
- cargo test -p tsz-checker test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning -- --nocapture
