### PR TITLE
test(arch): ignore block comments in guard line matching

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -462,10 +462,11 @@ def find_matches(file_text: str, pattern: re.Pattern[str], rel: str, excludes: d
     if excludes.get("exclude_test_files") and is_test_file(rel):
         return matches
 
-    for i, line in enumerate(file_text.splitlines(), start=1):
-        if excludes.get("ignore_comment_lines", False):
-            if line.lstrip().startswith("//"):
-                continue
+    text_for_matching = (
+        strip_rust_comments(file_text) if excludes.get("ignore_comment_lines", False) else file_text
+    )
+
+    for i, line in enumerate(text_for_matching.splitlines(), start=1):
         if pattern.search(line):
             matches.append(i)
     return matches

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -250,6 +250,54 @@ class ArchGuardSolverTypeDataQuarantineTests(unittest.TestCase):
             self.assertTrue(hits[0].endswith("/mixed.rs:4"))
 
 
+class ArchGuardCommentStrippingTests(unittest.TestCase):
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_find_matches_ignores_block_comments_when_requested(self):
+        pattern = self.arch_guard.re.compile(r"\bTypeKey::")
+        text = "\n".join(
+            [
+                "/* TypeKey::Foo should be ignored */",
+                "let x = 1;",
+            ]
+        )
+        hits = self.arch_guard.find_matches(
+            text,
+            pattern,
+            "crates/tsz-checker/src/foo.rs",
+            {"ignore_comment_lines": True},
+        )
+        self.assertEqual(hits, [])
+
+    def test_find_matches_preserves_real_code_hits_with_inline_block_comments(self):
+        pattern = self.arch_guard.re.compile(r"\bTypeKey::")
+        text = "\n".join(
+            [
+                "let ok = true; /* TypeKey::CommentOnly */",
+                "let value = TypeKey::Real;",
+            ]
+        )
+        hits = self.arch_guard.find_matches(
+            text,
+            pattern,
+            "crates/tsz-checker/src/foo.rs",
+            {"ignore_comment_lines": True},
+        )
+        self.assertEqual(hits, [2])
+
+    def test_find_matches_keeps_comment_hits_without_ignore_flag(self):
+        pattern = self.arch_guard.re.compile(r"\bTypeKey::")
+        text = "/* TypeKey::Foo should match when comments are not ignored */"
+        hits = self.arch_guard.find_matches(
+            text,
+            pattern,
+            "crates/tsz-checker/src/foo.rs",
+            {},
+        )
+        self.assertEqual(hits, [1])
+
+
 class ArchGuardRatchetDirectionTests(unittest.TestCase):
     """Ensure the exclusion lists can only shrink, never grow."""
 


### PR DESCRIPTION
## Summary
- update `find_matches()` in `scripts/arch/arch_guard.py` so `ignore_comment_lines` mode strips Rust comments (including block comments) before pattern matching
- this now ignores:
  - `// ...`
  - `/* ... */` (including multiline blocks)
- add focused unit tests in `scripts/arch/test_arch_guard.py` to verify:
  - block-comment-only matches are ignored
  - real code matches still fire when inline comments are present
  - behavior without `ignore_comment_lines` is unchanged

## Why
- reduces false positives in architecture checks when forbidden tokens appear only in comments
- keeps guardrail behavior consistent with Rust comment syntax (line + block comments)

## Validation
- python3 scripts/arch/arch_guard.py
- python3 -m unittest scripts.arch.test_arch_guard.ArchGuardCommentStrippingTests
- note: full `python3 -m unittest scripts.arch.test_arch_guard` currently has unrelated baseline ratchet failures on `main`
