### PR TITLE
solver: avoid over-narrow co/contra generic-call inference

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -11,18 +11,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         &self,
         lower_bounds: &[TypeId],
         inferred: TypeId,
+        has_usable_contra_candidates: bool,
     ) -> TypeId {
         if lower_bounds.len() <= 1 {
-            return inferred;
-        }
-
-        let member_list_id = match self.interner.lookup(inferred) {
-            Some(TypeData::Union(id)) => id,
-            _ => return inferred,
-        };
-
-        // If this is already a single-member union, keep it as-is.
-        if self.interner.type_list(member_list_id).len() <= 1 {
             return inferred;
         }
 
@@ -32,19 +23,33 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return preferred_tuple_candidate;
         }
 
+        let inferred_is_union = matches!(self.interner.lookup(inferred), Some(TypeData::Union(_)));
+
+        let all_mergeable = lower_bounds
+            .iter()
+            .all(|ty| self.is_mergeable_direct_inference_candidate(*ty));
+
         // Direct arguments should stay narrow when there are heterogeneous candidates.
         // Otherwise TypeScript-style checks can get masked by a broad union result.
-        if lower_bounds
-            .iter()
-            .all(|ty| self.is_mergeable_direct_inference_candidate(*ty))
-        {
+        if all_mergeable {
             // Guard: if lower bounds contain literals with different primitive bases
             // (e.g., "" and 3 → string vs number), fall back to the first candidate.
             // tsc keeps the first candidate in those cases so later argument checks
             // can report a proper TS2345 mismatch.
             if !self.has_conflicting_literal_bases(lower_bounds) {
+                // If direct inference collapsed to a single non-union candidate while
+                // we also have contravariant evidence, preserve the combined direct
+                // argument information. This prevents over-narrowing from first-wins in
+                // co/contra scenarios such as callback predicates over union arrays.
+                if has_usable_contra_candidates && !inferred_is_union {
+                    return crate::utils::union_or_single(self.interner, lower_bounds.to_vec());
+                }
                 return inferred;
             }
+        }
+
+        if !inferred_is_union {
+            return inferred;
         }
 
         // Fall back to the first lower-bound candidate so later argument checks

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1317,6 +1317,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             let ty = if has_constraints {
                 let mut resolved_direct = None;
                 let contra_only = infer_ctx.has_only_contra_candidates(var);
+                let has_usable_contra_candidates =
+                    infer_ctx.has_usable_contra_candidates(var, self.interner.as_type_database());
 
                 if direct_param_vars.contains(&var)
                     && let Some(constraint_ty) = tp.constraint
@@ -1343,6 +1345,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             let candidate = self.resolve_direct_parameter_inference_type(
                                 &non_constraint_bounds,
                                 infer_ctx.best_common_type(&non_constraint_bounds),
+                                has_usable_contra_candidates,
                             );
                             let upper_bounds_ok = constraints.upper_bounds.iter().all(|upper| {
                                 !matches!(upper, &TypeId::ANY | &TypeId::UNKNOWN | &TypeId::ERROR)
@@ -1381,15 +1384,86 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                 pre_adjusted = ?ty,
                                 "Adjusting resolved inference type"
                             );
-                            let ty = if all_return_type {
+                            let mut ty = if all_return_type {
                                 self.resolve_return_position_inference_type(&lower_bounds, ty)
                             } else if direct_param_vars.contains(&var)
                                 && !has_index_signature_candidates
                             {
-                                self.resolve_direct_parameter_inference_type(&lower_bounds, ty)
+                                self.resolve_direct_parameter_inference_type(
+                                    &lower_bounds,
+                                    ty,
+                                    has_usable_contra_candidates,
+                                )
                             } else {
                                 ty
                             };
+                            if direct_param_vars.contains(&var)
+                                && has_usable_contra_candidates
+                                && lower_bounds.len() == 1
+                            {
+                                let contra_types = infer_ctx.get_contra_candidate_types(var);
+                                let concrete_contra: Vec<_> = contra_types
+                                    .into_iter()
+                                    .filter(|contra| {
+                                        !crate::type_queries::data::is_bare_infer_placeholder_db(
+                                            self.interner.as_type_database(),
+                                            *contra,
+                                        )
+                                    })
+                                    .collect();
+                                if concrete_contra.len() == 1 {
+                                    let contra = concrete_contra[0];
+                                    let mut needs_broader_due_dependent_constraint = false;
+                                    if self.checker.is_assignable_to(ty, contra)
+                                        && !self.checker.is_assignable_to(contra, ty)
+                                    {
+                                        for (other_tp, &other_var) in
+                                            func.type_params.iter().zip(type_param_vars.iter())
+                                        {
+                                            if other_tp.name == tp.name {
+                                                continue;
+                                            }
+                                            let Some(other_constraint) = other_tp.constraint else {
+                                                continue;
+                                            };
+                                            if !crate::visitors::visitor_predicates::contains_type_parameter_named(
+                                                self.interner,
+                                                other_constraint,
+                                                tp.name,
+                                            ) {
+                                                continue;
+                                            }
+                                            let Some(other_constraints) =
+                                                infer_ctx.get_constraints(other_var)
+                                            else {
+                                                continue;
+                                            };
+                                            for lb in other_constraints.lower_bounds.iter().copied()
+                                            {
+                                                if matches!(
+                                                    lb,
+                                                    TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
+                                                ) {
+                                                    continue;
+                                                }
+                                                if !self.checker.is_assignable_to(lb, ty)
+                                                    && self.checker.is_assignable_to(lb, contra)
+                                                {
+                                                    needs_broader_due_dependent_constraint = true;
+                                                    break;
+                                                }
+                                            }
+                                            if needs_broader_due_dependent_constraint {
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    if needs_broader_due_dependent_constraint {
+                                        ty = contra;
+                                    }
+                                }
+                            }
                             trace!(
                                 resolved_type = ?ty,
                                 "Type parameter resolved successfully from constraints"
@@ -1446,6 +1520,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                 self.resolve_direct_parameter_inference_type(
                                     &lower_bounds,
                                     fallback,
+                                    has_usable_contra_candidates,
                                 )
                             } else {
                                 fallback


### PR DESCRIPTION
## Summary
- avoid over-narrowing direct generic-call inference when contravariant evidence exists but the resolved direct result collapses to a single non-union type
- wire `has_usable_contra_candidates` into direct-parameter inference adjustment so callback/predicate co+contra scenarios keep combined direct candidates
- add a narrowly-scoped broaden step for single-lower-bound direct vars only when another dependent type parameter constraint requires the broader contra candidate

## Why
Some co/contra inference cases were resolving a concrete/narrow type argument too early, producing extra TS2345/TS2769-style diagnostics in the `coAndContraVariantInferences*` family. This change keeps inference aligned with TypeScript’s behavior for these patterns without broadening unrelated lanes.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `./scripts/conformance/conformance.sh run --filter coAndContraVariantInferences`
- `./scripts/conformance/conformance.sh run --filter assignmentCompatWith`
- `./scripts/conformance/conformance.sh run --filter callSignature`
- `./scripts/conformance/conformance.sh run --filter constructSignature`
- `scripts/session/verify-all.sh`

`verify-all.sh` status:
- formatting ✅
- clippy ✅
- conformance ✅ (11982, unchanged)
- emit ✅ (improved)
- fourslash ✅
- unit tests ❌ blocked by architecture gate:
  - `architecture_contract_tests_src::checker_files_stay_under_loc_limit`
  - reports `crates/tsz-checker/src/types/function_type.rs` over LOC limit
  - unrelated to touched files in this PR (`tsz-solver` only)
