### PR TITLE
test(arch): add tsz-core wasm surface boundary guard

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -298,6 +298,21 @@ CHECKS = [
         },
     ),
     (
+        "Core boundary: wasm bindings must stay in current wasm surface files",
+        ROOT / "crates" / "tsz-core" / "src",
+        re.compile(r"\bwasm_bindgen\b|\bserde_wasm_bindgen\b|\bJsValue\b"),
+        {
+            "exclude_dirs": {"tests"},
+            "exclude_files": {
+                # Transitional baseline: core lib exports the wasm API today.
+                "crates/tsz-core/src/lib.rs",
+                # Explicit wasm API module.
+                "crates/tsz-core/src/api/wasm/code_actions.rs",
+            },
+            "ignore_comment_lines": True,
+        },
+    ),
+    (
         "LSP boundary: direct lookup() on solver interner",
         ROOT / "crates" / "tsz-lsp",
         re.compile(r"\.lookup\s*\("),

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -131,6 +131,44 @@ class ArchGuardSolverRelationBoundaryTests(unittest.TestCase):
         self.assertEqual(test_hits, [])
 
 
+class ArchGuardCoreWasmBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def _core_wasm_boundary_check(self):
+        for name, _base, pattern, excludes in self.arch_guard.CHECKS:
+            if name == "Core boundary: wasm bindings must stay in current wasm surface files":
+                return pattern, excludes
+        self.fail("core wasm boundary check is missing from CHECKS")
+
+    def test_rule_exists(self):
+        self._core_wasm_boundary_check()
+
+    def test_rule_flags_non_allowlisted_core_file(self):
+        pattern, excludes = self._core_wasm_boundary_check()
+        text = "use wasm_bindgen::prelude::wasm_bindgen;"
+        hits = self.arch_guard.find_matches(
+            text, pattern, "crates/tsz-core/src/source_file.rs", excludes
+        )
+        self.assertEqual(hits, [1])
+
+    def test_rule_allows_existing_wasm_surface_files(self):
+        pattern, excludes = self._core_wasm_boundary_check()
+        text = "use wasm_bindgen::prelude::JsValue;"
+        lib_hits = self.arch_guard.find_matches(text, pattern, "crates/tsz-core/src/lib.rs", excludes)
+        api_hits = self.arch_guard.find_matches(
+            text, pattern, "crates/tsz-core/src/api/wasm/code_actions.rs", excludes
+        )
+        self.assertEqual(lib_hits, [])
+        self.assertEqual(api_hits, [])
+
+    def test_rule_ignores_tests_directory(self):
+        pattern, excludes = self._core_wasm_boundary_check()
+        text = "use wasm_bindgen::prelude::JsValue;"
+        hits = self.arch_guard.find_matches(text, pattern, "crates/tsz-core/tests/foo.rs", excludes)
+        self.assertEqual(hits, [])
+
+
 class ArchGuardCheckerFileSizeBoundaryTests(unittest.TestCase):
     def setUp(self):
         self.arch_guard = load_arch_guard_module()


### PR DESCRIPTION
## Summary
- add an architecture guardrail to keep `wasm_bindgen`/`JsValue` usage inside the current `tsz-core` wasm surface only
- allowlist the current transitional boundary files (`crates/tsz-core/src/lib.rs` and `crates/tsz-core/src/api/wasm/code_actions.rs`)
- add focused `arch_guard` unit tests for rule presence, enforcement, and allowlist behavior

## Why
- this ratchets architecture in the direction of moving wasm wiring out of broad core code paths
- it prevents new wasm-boundary spread in `tsz-core` without forcing a large refactor in one PR

## Validation
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardCoreWasmBoundaryTests`

## Notes
- `python3 scripts/arch/arch_guard.py` currently fails on `main` due pre-existing baseline debt:
  - `crates/tsz-checker/src/query_boundaries/common.rs` direct solver internal import
  - `crates/tsz-checker/src/types/type_checking/indexed_access.rs` over 2000 LOC
- full `python3 -m unittest scripts.arch.test_arch_guard` also has pre-existing ratchet-baseline failures on `main`.
