### PR TITLE
test(arch): ratchet tsz-core global mutable cache statics

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -298,6 +298,26 @@ CHECKS = [
         },
     ),
     (
+        "Core boundary: global mutable cache statics must stay in dedicated cache modules",
+        ROOT / "crates" / "tsz-core" / "src",
+        re.compile(
+            r"\bstatic\s+[A-Z_][A-Z0-9_]*\s*:\s*"
+            r"(?:std::sync::Mutex|Mutex<|std::sync::RwLock|RwLock<|"
+            r"Lazy<\s*(?:Mutex|RwLock)<|LazyLock<\s*(?:Mutex|RwLock)<|"
+            r"std::sync::LazyLock<\s*(?:Mutex|RwLock)<)"
+        ),
+        {
+            "exclude_dirs": {"tests"},
+            "exclude_files": {
+                # Transitional baseline: config-level map cache.
+                "crates/tsz-core/src/config.rs",
+                # Transitional baseline: project library cache.
+                "crates/tsz-core/src/project/lib_cache.rs",
+            },
+            "ignore_comment_lines": True,
+        },
+    ),
+    (
         "LSP boundary: direct lookup() on solver interner",
         ROOT / "crates" / "tsz-lsp",
         re.compile(r"\.lookup\s*\("),

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -131,6 +131,44 @@ class ArchGuardSolverRelationBoundaryTests(unittest.TestCase):
         self.assertEqual(test_hits, [])
 
 
+class ArchGuardCoreGlobalCacheBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def _core_global_cache_boundary_check(self):
+        for name, _base, pattern, excludes in self.arch_guard.CHECKS:
+            if name == "Core boundary: global mutable cache statics must stay in dedicated cache modules":
+                return pattern, excludes
+        self.fail("core global mutable cache boundary check is missing from CHECKS")
+
+    def test_rule_exists(self):
+        self._core_global_cache_boundary_check()
+
+    def test_rule_flags_non_allowlisted_core_file(self):
+        pattern, excludes = self._core_global_cache_boundary_check()
+        text = "static GLOBAL_CACHE: std::sync::Mutex<u8> = std::sync::Mutex::new(0);"
+        hits = self.arch_guard.find_matches(
+            text, pattern, "crates/tsz-core/src/source_file.rs", excludes
+        )
+        self.assertEqual(hits, [1])
+
+    def test_rule_allows_current_baseline_cache_modules(self):
+        pattern, excludes = self._core_global_cache_boundary_check()
+        text = "static LIB_FILE_CACHE: Lazy<Mutex<LibFileCache>> = Lazy::new(|| todo!());"
+        config_hits = self.arch_guard.find_matches(text, pattern, "crates/tsz-core/src/config.rs", excludes)
+        project_hits = self.arch_guard.find_matches(
+            text, pattern, "crates/tsz-core/src/project/lib_cache.rs", excludes
+        )
+        self.assertEqual(config_hits, [])
+        self.assertEqual(project_hits, [])
+
+    def test_rule_ignores_tests_directory(self):
+        pattern, excludes = self._core_global_cache_boundary_check()
+        text = "static TEST_CACHE: std::sync::Mutex<u8> = std::sync::Mutex::new(0);"
+        hits = self.arch_guard.find_matches(text, pattern, "crates/tsz-core/tests/foo.rs", excludes)
+        self.assertEqual(hits, [])
+
+
 class ArchGuardCheckerFileSizeBoundaryTests(unittest.TestCase):
     def setUp(self):
         self.arch_guard = load_arch_guard_module()


### PR DESCRIPTION
## Summary
- add an architecture guard that forbids new global mutable cache statics in `tsz-core/src`
- allowlist only the two current transitional cache files:
  - `crates/tsz-core/src/config.rs`
  - `crates/tsz-core/src/project/lib_cache.rs`
- add focused unit tests covering rule existence, enforcement, allowlist behavior, and test-dir exclusion

## Why
- this enforces an incremental boundary around ambient mutable global state in core
- keeps refactors safe and small while preventing new spread of process-wide mutable caches

## Validation
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardCoreGlobalCacheBoundaryTests`

## Notes
- `python3 scripts/arch/arch_guard.py` currently fails on `main` due pre-existing baseline debt:
  - `crates/tsz-checker/src/query_boundaries/common.rs` direct solver internal import
  - `crates/tsz-checker/src/types/type_checking/indexed_access.rs` over 2000 LOC
