### PR TITLE
test(arch): ratchet tsz-core lib facade line growth

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -428,6 +428,14 @@ LINE_LIMIT_CHECKS = [
     ),
 ]
 
+FILE_LINE_LIMIT_CHECKS = [
+    (
+        "Core boundary: tsz-core lib facade must stay under 2420 LOC",
+        ROOT / "crates" / "tsz-core" / "src" / "lib.rs",
+        2420,
+    ),
+]
+
 EXCLUDE_DIRS = {".git", "target", "node_modules"}
 SOLVER_TYPEDATA_QUARANTINE_ALLOWLIST = {
     "crates/tsz-solver/src/intern/mod.rs",
@@ -506,6 +514,28 @@ def scan_line_limits(base: pathlib.Path, limit: int, exclude_files=None):
         if line_count > limit:
             hits.append(f"{rel}:{line_count} lines (limit {limit})")
     return hits
+
+
+def scan_file_line_limit(path: pathlib.Path, limit: int):
+    if not path.exists():
+        return []
+
+    try:
+        rel = path.relative_to(ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+
+    line_count = 0
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for line_count, _line in enumerate(handle, start=1):
+                pass
+    except OSError:
+        return []
+
+    if line_count > limit:
+        return [f"{rel}:{line_count} lines (limit {limit})"]
+    return []
 
 
 def strip_rust_comments(text: str) -> str:
@@ -722,6 +752,12 @@ def main() -> int:
             continue
         exclude_files = rest[0] if rest else None
         hits = scan_line_limits(base, limit, exclude_files)
+        total_hits += len(hits)
+        if hits:
+            failures.append((name, hits))
+
+    for name, path, limit in FILE_LINE_LIMIT_CHECKS:
+        hits = scan_file_line_limit(path, limit)
         total_hits += len(hits)
         if hits:
             failures.append((name, hits))

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -164,6 +164,38 @@ class ArchGuardCheckerFileSizeBoundaryTests(unittest.TestCase):
             self.assertEqual(hits, [])
 
 
+class ArchGuardCoreLibFacadeSizeBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def _core_lib_size_check(self):
+        for entry in self.arch_guard.FILE_LINE_LIMIT_CHECKS:
+            name, path, limit = entry
+            if name == "Core boundary: tsz-core lib facade must stay under 2420 LOC":
+                return path, limit
+        self.fail("core lib facade size boundary check is missing from FILE_LINE_LIMIT_CHECKS")
+
+    def test_rule_exists_with_expected_limit(self):
+        path, limit = self._core_lib_size_check()
+        self.assertEqual(limit, 2420)
+        self.assertTrue(str(path).endswith("crates/tsz-core/src/lib.rs"))
+
+    def test_scan_file_line_limit_flags_file_above_limit(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            target = pathlib.Path(temp_dir) / "too_big.rs"
+            target.write_text("let x = 0;\n" * 11, encoding="utf-8")
+            hits = self.arch_guard.scan_file_line_limit(target, 10)
+            self.assertEqual(len(hits), 1)
+            self.assertTrue(hits[0].endswith("too_big.rs:11 lines (limit 10)"))
+
+    def test_scan_file_line_limit_allows_file_at_limit(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            target = pathlib.Path(temp_dir) / "at_limit.rs"
+            target.write_text("let x = 0;\n" * 10, encoding="utf-8")
+            hits = self.arch_guard.scan_file_line_limit(target, 10)
+            self.assertEqual(hits, [])
+
+
 class ArchGuardSolverTypeDataQuarantineTests(unittest.TestCase):
     def setUp(self):
         self.arch_guard = load_arch_guard_module()


### PR DESCRIPTION
## Summary
- add a dedicated `FILE_LINE_LIMIT_CHECKS` guardrail to `scripts/arch/arch_guard.py`
- enforce a no-growth ratchet for `crates/tsz-core/src/lib.rs` at the current baseline (`2420` LOC)
- add unit tests for the single-file line-limit scanner and rule registration

## Why
- the architecture review called out `tsz-core/src/lib.rs` as a central structural risk
- this is an incremental ratchet: it doesn't force a big split immediately, but it prevents further facade growth while we keep extracting modules in small PRs

## Validation
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardCoreLibFacadeSizeBoundaryTests`
- `python3 scripts/arch/arch_guard.py`

## Notes
- `python3 scripts/arch/arch_guard.py` still reports two pre-existing failures on `main` unrelated to this change:
  - `crates/tsz-checker/src/query_boundaries/common.rs` direct solver internal import
  - `crates/tsz-checker/src/types/type_checking/indexed_access.rs` over 2000 LOC
