### PR TITLE
refactor(boundary): remove checker dependency on solver internal StringIntrinsicKind path

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1696,7 +1696,7 @@ pub(crate) fn widen_type_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId 
 pub(crate) fn string_intrinsic_components(
     db: &dyn TypeDatabase,
     type_id: TypeId,
-) -> Option<(tsz_solver::types::StringIntrinsicKind, TypeId)> {
+) -> Option<(tsz_solver::StringIntrinsicKind, TypeId)> {
     tsz_solver::string_intrinsic_components(db, type_id)
 }
 

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -251,8 +251,8 @@ pub use types::{
 pub use types::{
     CallableShape, ConditionalType, ConditionalTypeId, FunctionShape, FunctionShapeId,
     IndexSignature, MappedType, MappedTypeId, ObjectFlags, ObjectShape, OrderedFloat, ParamInfo,
-    RelationCacheKey, TemplateSpan, TupleElement, TupleListId, TypeParamInfo, TypePredicate,
-    TypePredicateTarget,
+    RelationCacheKey, StringIntrinsicKind, TemplateSpan, TupleElement, TupleListId, TypeParamInfo,
+    TypePredicate, TypePredicateTarget,
 };
 // unsoundness_audit: accessed via tsz_solver::unsoundness_audit module path
 pub use widening::*;


### PR DESCRIPTION
## Summary
- re-export `StringIntrinsicKind` from `tsz-solver` root API (`pub use types::...`)
- update checker boundary helper signature to use `tsz_solver::StringIntrinsicKind` instead of `tsz_solver::types::StringIntrinsicKind`

## Why
- removes direct checker dependency on a solver internal module path (`tsz_solver::types::...`)
- aligns checker/solver boundary with public API usage and reduces architecture guard debt

## Validation
- `cargo check -p tsz-solver -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`

## Result
- architecture guard failure count dropped by one; remaining failure is only:
  - `crates/tsz-checker/src/types/type_checking/indexed_access.rs` over 2000 LOC
