### PR TITLE
refactor(cli): move trace module under reporting folder

### DIFF
--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -13,11 +13,12 @@ pub mod incremental;
 pub mod locale;
 pub mod project_refs;
 pub mod reporter;
-pub mod trace;
+pub mod reporting;
 pub mod tracing_config;
 pub mod watch;
 pub use commands::build;
 pub use commands::help;
+pub use reporting::trace;
 
 #[cfg(test)]
 #[path = "../tests/args_tests.rs"]

--- a/crates/tsz-cli/src/reporting/mod.rs
+++ b/crates/tsz-cli/src/reporting/mod.rs
@@ -1,0 +1,1 @@
+pub mod trace;

--- a/crates/tsz-cli/src/reporting/trace.rs
+++ b/crates/tsz-cli/src/reporting/trace.rs
@@ -327,5 +327,5 @@ macro_rules! trace_span {
 }
 
 #[cfg(test)]
-#[path = "trace_tests.rs"]
+#[path = "../trace_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-cli/src/trace.rs` to `crates/tsz-cli/src/reporting/trace.rs`
- add `crates/tsz-cli/src/reporting/mod.rs`
- preserve compatibility by re-exporting `trace` from crate root (`pub use reporting::trace`)
- update in-file test module path after relocation

## Why
- reduces root-level module sprawl in `tsz-cli`
- keeps existing imports and macro paths (`tsz_cli::trace::...`, `$crate::trace::...`) working

## Validation
- `cargo check -p tsz-cli`
- `cargo test -p tsz-cli trace -- --nocapture`
