### PR TITLE
lsp: computed names, modifier alignment, computed-name sort

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -58,18 +58,38 @@ fn symbol_kind_to_tsserver(
 }
 
 /// Sort a navtree/navbar symbol slice in-place, recursively sorting each
-/// node's children. Mirrors TypeScript's `compareChildren`: primary key is
-/// case-insensitive name, tiebreaker is source position. tsc sorts nav
-/// items regardless of declaration order, so tsz has to match or every
-/// declaration-order-dependent test drifts.
+/// node's children. Mirrors TypeScript's `compareChildren`: primary key
+/// is case-insensitive name, tiebreaker is source position.
+///
+/// Computed property names (`[key]`, `[1]`, `["foo"]`) are treated as
+/// nameless — tsc's `tryGetName` returns undefined for them and the
+/// comparer then falls back to source position only. Matching that
+/// keeps their relative order stable (otherwise `[a]` gets sorted
+/// before `[E.A]` purely by bracket-text, and the navbar diverges
+/// from the source-ordered expected output).
 fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::DocumentSymbol]) {
+    fn sort_key(sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol) -> Option<String> {
+        if sym.name.starts_with('[') {
+            None
+        } else {
+            Some(sym.name.to_lowercase())
+        }
+    }
     symbols.sort_by(|a, b| {
-        let na = a.name.to_lowercase();
-        let nb = b.name.to_lowercase();
-        match na.cmp(&nb) {
-            std::cmp::Ordering::Equal => (a.range.start.line, a.range.start.character)
+        match (sort_key(a), sort_key(b)) {
+            (Some(na), Some(nb)) => match na.cmp(&nb) {
+                std::cmp::Ordering::Equal => (a.range.start.line, a.range.start.character)
+                    .cmp(&(b.range.start.line, b.range.start.character)),
+                other => other,
+            },
+            // tsc: `compareStringsCaseInsensitive(undefined, x)` sorts
+            // undefined before any string. Computed-name items therefore
+            // sort ahead of identifier-name items at the same level, and
+            // amongst themselves fall back to source position.
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (None, None) => (a.range.start.line, a.range.start.character)
                 .cmp(&(b.range.start.line, b.range.start.character)),
-            other => other,
         }
     });
     for sym in symbols.iter_mut() {

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -162,19 +162,22 @@ impl<'a> DocumentSymbolProvider<'a> {
         let mut result = String::new();
         for &mod_idx in &mod_list.nodes {
             if let Some(mod_node) = self.arena.get(mod_idx) {
+                // Mirror tsc's `getNodeModifiers` output. `const`,
+                // `readonly`, `async`, and `override` are not
+                // ScriptElementKindModifier values — they affect the
+                // declaration's kind or its signature but don't appear as
+                // kindModifier strings. Including them here pollutes
+                // navtree output (e.g. `const enum E` gained a spurious
+                // `kindModifiers: "const"` and diverged from tsc).
                 let modifier_str = match mod_node.kind {
                     k if k == SyntaxKind::ExportKeyword as u16 => Some("export"),
                     k if k == SyntaxKind::DeclareKeyword as u16 => Some("declare"),
                     k if k == SyntaxKind::AbstractKeyword as u16 => Some("abstract"),
                     k if k == SyntaxKind::StaticKeyword as u16 => Some("static"),
-                    k if k == SyntaxKind::AsyncKeyword as u16 => Some("async"),
                     k if k == SyntaxKind::DefaultKeyword as u16 => Some("default"),
-                    k if k == SyntaxKind::ConstKeyword as u16 => Some("const"),
-                    k if k == SyntaxKind::ReadonlyKeyword as u16 => Some("readonly"),
                     k if k == SyntaxKind::PublicKeyword as u16 => Some("public"),
                     k if k == SyntaxKind::PrivateKeyword as u16 => Some("private"),
                     k if k == SyntaxKind::ProtectedKeyword as u16 => Some("protected"),
-                    k if k == SyntaxKind::OverrideKeyword as u16 => Some("override"),
                     _ => None,
                 };
                 if let Some(s) = modifier_str {
@@ -1111,6 +1114,22 @@ impl<'a> DocumentSymbolProvider<'a> {
                 || node.kind == SyntaxKind::NumericLiteral as u16
             {
                 return self.arena.get_literal(node).map(|l| l.text.clone());
+            } else if node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                // `["bar"]` / `[key]` on a class/interface/object member.
+                // tsc uses the source-text form verbatim (including the
+                // surrounding brackets) as the nav item's `text`. The
+                // parser records `end` as the position after the next
+                // token (so `["bar"]:` or `["bar"] ` creeps in). Cut at
+                // the last `]` to keep just the bracket form.
+                let start = node.pos as usize;
+                let end = node.end as usize;
+                if start <= end && end <= self.source_text.len() {
+                    let slice = &self.source_text[start..end];
+                    if let Some(close) = slice.rfind(']') {
+                        return Some(slice[..=close].to_string());
+                    }
+                    return Some(slice.to_string());
+                }
             }
         }
         None

--- a/crates/tsz-lsp/tests/document_symbols_tests.rs
+++ b/crates/tsz-lsp/tests/document_symbols_tests.rs
@@ -695,11 +695,9 @@ fn test_document_symbols_static_property() {
         "Expected 'static' in kind_modifiers, got: '{}'",
         prop.kind_modifiers
     );
-    assert!(
-        prop.kind_modifiers.contains("readonly"),
-        "Expected 'readonly' in kind_modifiers, got: '{}'",
-        prop.kind_modifiers
-    );
+    // `readonly` is not part of tsc's ScriptElementKindModifier set —
+    // it affects the declaration kind (const vs let etc.) but never
+    // appears as a kindModifier string.
 }
 
 #[test]
@@ -757,11 +755,10 @@ fn test_document_symbols_const_enum() {
     assert_eq!(symbols.len(), 1);
     assert_eq!(symbols[0].name, "Direction");
     assert_eq!(symbols[0].kind, SymbolKind::Enum);
-    assert!(
-        symbols[0].kind_modifiers.contains("const"),
-        "Expected 'const' modifier on const enum, got: '{}'",
-        symbols[0].kind_modifiers
-    );
+    // tsc's getNodeModifiers does not emit `const` — it's absorbed
+    // into the declaration kind rather than surfaced as a
+    // ScriptElementKindModifier. We match that exactly.
+    assert_eq!(symbols[0].kind_modifiers, "");
     assert_eq!(symbols[0].children.len(), 2);
 }
 


### PR DESCRIPTION
## Summary

Four related pure-Rust navtree parity wins:

- **\`get_name\` handles \`COMPUTED_PROPERTY_NAME\`** — emits the bracket form verbatim (\`[a]\`, \`[E.A]\`, \`[\"foo\"]\`). The parser's end position creeps into the next token so trim at the last \`]\`.
- **Modifier set matches tsc's \`getNodeModifiers\`** — drop \`const\`, \`readonly\`, \`async\`, \`override\` from kindModifier emission. \`const enum E\` used to emit a spurious \`kindModifiers: \"const\"\`; now it emits nothing.
- **Sort treats computed names as nameless** — tsc's \`tryGetName\` returns undefined for computed property names, so \`compareStringsCaseInsensitive\` falls back to source position. Matching that stops \`[a]\`, \`[E.A]\`, \`[1]\`, \`[\"foo\"]\` from being reshuffled by bracket-text.

## Context

Continues the pure-Rust LSP migration. Rust-only navbar suite at **21/68** (+2). Flips \`getNavigationBarItems\` and \`navigationBarItemsComputedNames\`.

## Test plan

- [x] \`cargo nextest run -p tsz-lsp\` (3759/3759)
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=getNavigationBarItems\` — passes
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navigationBarItemsComputedNames\` — passes
- [x] Native-TS full navbar filter: 68/68