### PR TITLE
lsp: class static blocks, kind-based sort, interface signatures, parameter properties

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -53,6 +53,9 @@ fn symbol_kind_to_tsserver(
         SymbolKind::Alias => "alias",
         SymbolKind::Getter => "getter",
         SymbolKind::Setter => "setter",
+        SymbolKind::CallSignature => "call",
+        SymbolKind::ConstructSignature => "construct",
+        SymbolKind::IndexSignature => "index",
         _ => "unknown",
     }
 }
@@ -70,7 +73,13 @@ fn symbol_kind_to_tsserver(
 fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::DocumentSymbol]) {
     use tsz::lsp::symbols::document_symbols::SymbolKind;
     fn sort_key(sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol) -> Option<String> {
-        if sym.name.starts_with('[') {
+        // Mirror tsc's `tryGetName`: anything without a normal declaration
+        // name compares as "nameless" (sorts ahead of named siblings and
+        // falls back to kind ordinal among itself). Covers computed
+        // property names (`[x]`, `["foo"]`, `[1]`) and interface-type
+        // signatures (`()` call, `new()` construct, `[]` index).
+        let nameless = sym.name.starts_with('[') || sym.name == "()" || sym.name == "new()";
+        if nameless {
             None
         } else {
             Some(sym.name.to_lowercase())
@@ -108,6 +117,9 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
             SymbolKind::Alias => 280, // ImportSpecifier / NamespaceImport
             SymbolKind::TypeParameter => 170,
             SymbolKind::Key => 172,
+            SymbolKind::CallSignature => 180,
+            SymbolKind::ConstructSignature => 181,
+            SymbolKind::IndexSignature => 182,
         }
     }
     symbols.sort_by(|a, b| {
@@ -123,8 +135,15 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
             // alone can't distinguish two `[computed]` class methods).
             (None, Some(_)) => std::cmp::Ordering::Less,
             (Some(_), None) => std::cmp::Ordering::Greater,
-            (None, None) => (a.range.start.line, a.range.start.character)
-                .cmp(&(b.range.start.line, b.range.start.character)),
+            // Nameless against nameless: tsc's tiebreaker is kind
+            // ordinal (call < construct < index). Same-kind pairs
+            // (e.g. two computed-name methods) fall back to source
+            // position.
+            (None, None) => match kind_rank(a.kind).cmp(&kind_rank(b.kind)) {
+                std::cmp::Ordering::Equal => (a.range.start.line, a.range.start.character)
+                    .cmp(&(b.range.start.line, b.range.start.character)),
+                other => other,
+            },
         }
     });
     for sym in symbols.iter_mut() {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -68,6 +68,7 @@ fn symbol_kind_to_tsserver(
 /// before `[E.A]` purely by bracket-text, and the navbar diverges
 /// from the source-ordered expected output).
 fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::DocumentSymbol]) {
+    use tsz::lsp::symbols::document_symbols::SymbolKind;
     fn sort_key(sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol) -> Option<String> {
         if sym.name.starts_with('[') {
             None
@@ -75,17 +76,51 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
             Some(sym.name.to_lowercase())
         }
     }
+    // tsc's `compareChildren` tiebreaker is `navigationBarNodeKind` — the
+    // AST SyntaxKind of the underlying node. Map our higher-level
+    // `SymbolKind` to those underlying values so two siblings with the
+    // same name (e.g. `class Foo {}` + `let Foo = 1;`) sort in the same
+    // order tsc produces. Numbers come from TypeScript's SyntaxKind enum.
+    const fn kind_rank(k: SymbolKind) -> u16 {
+        match k {
+            SymbolKind::Property | SymbolKind::Field => 171,
+            SymbolKind::Method => 174,
+            SymbolKind::Constructor => 176,
+            SymbolKind::Getter => 177,
+            SymbolKind::Setter => 178,
+            SymbolKind::EnumMember => 304,
+            SymbolKind::Variable
+            | SymbolKind::Constant
+            | SymbolKind::Boolean
+            | SymbolKind::Array
+            | SymbolKind::Object
+            | SymbolKind::Null
+            | SymbolKind::Number
+            | SymbolKind::String => 260,
+            SymbolKind::Function | SymbolKind::Event | SymbolKind::Operator => 262,
+            SymbolKind::Class => 263,
+            SymbolKind::Interface => 264,
+            SymbolKind::Struct => 265, // type alias
+            SymbolKind::Enum => 266,
+            SymbolKind::Module | SymbolKind::Namespace | SymbolKind::Package | SymbolKind::File => {
+                267
+            }
+            SymbolKind::Alias => 280, // ImportSpecifier / NamespaceImport
+            SymbolKind::TypeParameter => 170,
+            SymbolKind::Key => 172,
+        }
+    }
     symbols.sort_by(|a, b| {
         match (sort_key(a), sort_key(b)) {
             (Some(na), Some(nb)) => match na.cmp(&nb) {
-                std::cmp::Ordering::Equal => (a.range.start.line, a.range.start.character)
-                    .cmp(&(b.range.start.line, b.range.start.character)),
+                std::cmp::Ordering::Equal => kind_rank(a.kind).cmp(&kind_rank(b.kind)),
                 other => other,
             },
             // tsc: `compareStringsCaseInsensitive(undefined, x)` sorts
             // undefined before any string. Computed-name items therefore
             // sort ahead of identifier-name items at the same level, and
-            // amongst themselves fall back to source position.
+            // amongst themselves fall back to source position (kind rank
+            // alone can't distinguish two `[computed]` class methods).
             (None, Some(_)) => std::cmp::Ordering::Less,
             (Some(_), None) => std::cmp::Ordering::Greater,
             (None, None) => (a.range.start.line, a.range.start.character)

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -55,6 +55,12 @@ pub enum SymbolKind {
     Alias = 27,
     Getter = 28,
     Setter = 29,
+    // Interface/object-type signatures — nameless declarations that tsc
+    // represents with synthetic text (`()`, `new()`, `[]`) and dedicated
+    // ScriptElementKind strings. Non-LSP; treat as Property downstream.
+    CallSignature = 30,
+    ConstructSignature = 31,
+    IndexSignature = 32,
 }
 
 impl SymbolKind {
@@ -78,6 +84,9 @@ impl SymbolKind {
             Self::Alias => "alias",
             Self::Getter => "getter",
             Self::Setter => "setter",
+            Self::CallSignature => "call",
+            Self::ConstructSignature => "construct",
+            Self::IndexSignature => "index",
         }
     }
 }
@@ -575,6 +584,53 @@ impl<'a> DocumentSymbolProvider<'a> {
                 }
             }
 
+            // Call signature on an interface/object type: `(): any`.
+            // tsc surfaces these as nameless entries with text `()` and
+            // ScriptElementKind "call".
+            k if k == syntax_kind_ext::CALL_SIGNATURE => {
+                let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
+                vec![DocumentSymbol {
+                    name: "()".to_string(),
+                    detail: None,
+                    kind: SymbolKind::CallSignature,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range: range,
+                    container_name: container_name.map(std::string::ToString::to_string),
+                    children: vec![],
+                }]
+            }
+
+            // Construct signature: `new(): IPoint` — text `new()`.
+            k if k == syntax_kind_ext::CONSTRUCT_SIGNATURE => {
+                let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
+                vec![DocumentSymbol {
+                    name: "new()".to_string(),
+                    detail: None,
+                    kind: SymbolKind::ConstructSignature,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range: range,
+                    container_name: container_name.map(std::string::ToString::to_string),
+                    children: vec![],
+                }]
+            }
+
+            // Index signature: `[key: string]: number` — text `[]`.
+            k if k == syntax_kind_ext::INDEX_SIGNATURE => {
+                let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
+                vec![DocumentSymbol {
+                    name: "[]".to_string(),
+                    detail: None,
+                    kind: SymbolKind::IndexSignature,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range: range,
+                    container_name: container_name.map(std::string::ToString::to_string),
+                    children: vec![],
+                }]
+            }
+
             // Method Signature (Interface Member)
             k if k == syntax_kind_ext::METHOD_SIGNATURE => {
                 if let Some(sig) = self.arena.get_signature(node) {
@@ -601,26 +657,73 @@ impl<'a> DocumentSymbolProvider<'a> {
                 }
             }
 
-            // Constructor (Class Member)
+            // Constructor (Class Member). Parameter properties
+            // (`constructor(public x: number)`) are hoisted into the
+            // enclosing class as siblings of the constructor — tsc treats
+            // them as class members, not as children of the constructor.
             k if k == syntax_kind_ext::CONSTRUCTOR => {
-                let (children, modifiers) = if let Some(ctor) = self.arena.get_constructor(node) {
-                    let c = self.collect_children_from_block(ctor.body, container_name);
-                    let m = self.get_kind_modifiers_from_list(&ctor.modifiers);
-                    (c, m)
-                } else {
-                    (vec![], String::new())
-                };
+                let mut out = Vec::new();
+                if let Some(ctor) = self.arena.get_constructor(node) {
+                    let children = self.collect_children_from_block(ctor.body, container_name);
+                    let modifiers = self.get_kind_modifiers_from_list(&ctor.modifiers);
+                    out.push(DocumentSymbol {
+                        name: "constructor".to_string(),
+                        detail: None,
+                        kind: SymbolKind::Constructor,
+                        kind_modifiers: modifiers,
+                        range: node_range(self.arena, self.line_map, self.source_text, node_idx),
+                        selection_range: self.get_range_keyword(node_idx, 11), // "constructor".len()
+                        container_name: container_name.map(std::string::ToString::to_string),
+                        children,
+                    });
 
-                vec![DocumentSymbol {
-                    name: "constructor".to_string(),
-                    detail: None,
-                    kind: SymbolKind::Constructor,
-                    kind_modifiers: modifiers,
-                    range: node_range(self.arena, self.line_map, self.source_text, node_idx),
-                    selection_range: self.get_range_keyword(node_idx, 11), // "constructor".len()
-                    container_name: container_name.map(std::string::ToString::to_string),
-                    children,
-                }]
+                    for &param_idx in &ctor.parameters.nodes {
+                        let Some(param_node) = self.arena.get(param_idx) else {
+                            continue;
+                        };
+                        let Some(param) = self.arena.get_parameter(param_node) else {
+                            continue;
+                        };
+                        let param_mods = self.get_kind_modifiers_from_list(&param.modifiers);
+                        // A parameter becomes a class property only when
+                        // it carries an access modifier or `readonly`.
+                        // Readonly isn't surfaced in `kindModifiers` (per
+                        // tsc) but does upgrade the parameter to a
+                        // property. Check both the emitted string and
+                        // the raw modifier nodes for readonly.
+                        let has_access = param_mods.contains("public")
+                            || param_mods.contains("private")
+                            || param_mods.contains("protected");
+                        let has_readonly = param.modifiers.as_ref().is_some_and(|ml| {
+                            ml.nodes.iter().any(|&m| {
+                                self.arena
+                                    .get(m)
+                                    .is_some_and(|n| n.kind == SyntaxKind::ReadonlyKeyword as u16)
+                            })
+                        });
+                        if !has_access && !has_readonly {
+                            continue;
+                        }
+                        let Some(name) = self.get_name(param.name) else {
+                            continue;
+                        };
+                        let range =
+                            node_range(self.arena, self.line_map, self.source_text, param_idx);
+                        let selection_range =
+                            node_range(self.arena, self.line_map, self.source_text, param.name);
+                        out.push(DocumentSymbol {
+                            name,
+                            detail: None,
+                            kind: SymbolKind::Property,
+                            kind_modifiers: param_mods,
+                            range,
+                            selection_range,
+                            container_name: container_name.map(std::string::ToString::to_string),
+                            children: vec![],
+                        });
+                    }
+                }
+                out
             }
 
             // Class Static Block (`static { ... }`). tsc doesn't emit an

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -623,6 +623,21 @@ impl<'a> DocumentSymbolProvider<'a> {
                 }]
             }
 
+            // Class Static Block (`static { ... }`). tsc doesn't emit an
+            // entry for the block itself; instead the block's top-level
+            // variable declarations (and nested function/class/etc. forms
+            // that `collect_symbols` already recognizes) bubble up as
+            // siblings of the class's members.
+            k if k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION => {
+                let mut symbols = Vec::new();
+                if let Some(block) = self.arena.get_block(node) {
+                    for &stmt in &block.statements.nodes {
+                        symbols.extend(self.collect_symbols(stmt, container_name));
+                    }
+                }
+                symbols
+            }
+
             // Get Accessor (Class Member)
             k if k == syntax_kind_ext::GET_ACCESSOR => {
                 if let Some(accessor) = self.arena.get_accessor(node) {

--- a/crates/tsz-lsp/tests/symbols_tests.rs
+++ b/crates/tsz-lsp/tests/symbols_tests.rs
@@ -869,13 +869,17 @@ class Router {
 
     assert_eq!(tree.len(), 1);
     assert_eq!(tree[0].name, "Router");
-    assert_eq!(tree[0].children.len(), 4);
+    // `private routes` is a TypeScript parameter property — tsc
+    // surfaces it as a class member sibling of the constructor (in
+    // addition to `add`, `remove`, `get`).
+    assert_eq!(tree[0].children.len(), 5);
 
     let names: Vec<&str> = tree[0].children.iter().map(|c| c.name.as_str()).collect();
     assert!(names.contains(&"constructor"));
     assert!(names.contains(&"add"));
     assert!(names.contains(&"remove"));
     assert!(names.contains(&"get"));
+    assert!(names.contains(&"routes"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bundled navtree parity improvements (all pure-Rust):

1. **\`CLASS_STATIC_BLOCK_DECLARATION\`** arm — \`static { let x; }\` now hoists \`x\` into the class's navtree children (matches tsc).
2. **Kind-based sort tiebreaker** — tsc's \`compareChildren\` falls back to \`navigationBarNodeKind\` when names tie. Map \`SymbolKind\` to those ordinals so \`class Foo {}\` + \`let Foo = 1;\` / \`function Foo()\` combos order correctly.
3. **Interface/object-type signatures** (\`(): any\`, \`new(): T\`, \`[key: string]: T\`) — new \`SymbolKind::CallSignature\` / \`ConstructSignature\` / \`IndexSignature\` with the tsserver \`call\` / \`construct\` / \`index\` kinds. Nameless, so they sort ahead of named siblings with kind-ordinal as tiebreaker.
4. **TS parameter properties** — \`constructor(private routes…)\` now emits \`routes\` as a class-member Property sibling of the constructor.

## Context

Continues the pure-Rust LSP migration. Rust-only navbar suite: **21/68 → 26/68** (+5). Native-TS unchanged at 68/68.

## Test plan

- [x] \`cargo nextest run -p tsz-lsp\` (3759/3759)
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navigationBarClassStaticBlock\` — passes
- [x] Same for \`navigationBarItemsClass2\` / \`navigationBarItemsClass5\` / \`navigationBarItemsClass4\` — pass
- [x] Native-TS full navbar filter: 68/68