### PR TITLE
refactor(core): re-export wasm transform context from api module

### DIFF
--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -316,22 +316,7 @@ impl TryFrom<ImportCandidateInput> for ImportCandidate {
     }
 }
 
-/// Opaque wrapper for transform directives across the wasm boundary.
-#[wasm_bindgen]
-pub struct WasmTransformContext {
-    inner: TransformContext,
-    target_es5: bool,
-    module_kind: ModuleKind,
-}
-
-#[wasm_bindgen]
-impl WasmTransformContext {
-    /// Get the number of transform directives generated.
-    #[wasm_bindgen(js_name = getCount)]
-    pub fn get_count(&self) -> usize {
-        self.inner.len()
-    }
-}
+pub use crate::api::wasm::transforms::WasmTransformContext;
 
 /// High-performance parser using Node architecture (16 bytes/node).
 /// This is the optimized path for Phase 8 test suite evaluation.


### PR DESCRIPTION
## Summary
- remove duplicated `WasmTransformContext` definition from `crates/tsz-core/src/lib.rs`
- re-export the canonical type from `crates/tsz-core/src/api/wasm/transforms.rs`

## Why
- continues root-facade thinning by removing duplicated wasm API surface
- keeps transform context as a single source of truth in `api/wasm`

## Validation
- `cargo check -p tsz-core`
- `cargo test -p tsz-core transform_api_tests -- --nocapture`
