### PR TITLE
refactor(cli): move project refs module under project

### DIFF
--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -11,7 +11,6 @@ pub mod driver;
 pub mod incremental;
 pub mod locale;
 pub mod project;
-pub mod project_refs;
 pub mod reporter;
 pub mod reporting;
 pub mod tracing_config;
@@ -19,6 +18,7 @@ pub mod watch;
 pub use commands::build;
 pub use commands::help;
 pub use project::fs;
+pub use project::refs as project_refs;
 pub use reporting::trace;
 
 #[cfg(test)]

--- a/crates/tsz-cli/src/project/mod.rs
+++ b/crates/tsz-cli/src/project/mod.rs
@@ -1,1 +1,2 @@
 pub mod fs;
+pub mod refs;

--- a/crates/tsz-cli/src/project/refs.rs
+++ b/crates/tsz-cli/src/project/refs.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BinaryHeap;
 use std::path::{Path, PathBuf};
 
-use super::config::{CompilerOptions, TsConfig};
+use crate::config::{CompilerOptions, TsConfig};
 
 /// A project reference as specified in tsconfig.json
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -695,5 +695,5 @@ fn remove_trailing_commas(input: &str) -> String {
 }
 
 #[cfg(test)]
-#[path = "project_refs_tests.rs"]
+#[path = "../project_refs_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-cli/src/project_refs.rs` to `crates/tsz-cli/src/project/refs.rs`
- register `refs` in `crates/tsz-cli/src/project/mod.rs`
- keep `crate::project_refs` and `tsz_cli::project_refs` stable via `pub use project::refs as project_refs`
- update the moved file’s config import and test module path for its new location

## Validation
- `cargo fmt`
- `cargo check -p tsz-cli`
- `cargo test -p tsz-cli project::refs::tests -- --nocapture`
