### PR TITLE
lsp: big navtree parity batch (initializers, objects, modules, signatures, params, sort, static blocks)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -60,6 +60,36 @@ fn symbol_kind_to_tsserver(
     }
 }
 
+/// Mirror tsc's `escapeString(s, '"')` — replace control characters
+/// and backslash/double-quote with their JS escape sequences, and
+/// encode non-printable high chars as `\uNNNN`. Used on the filename
+/// stem before wrapping it in double quotes for external-module
+/// navbar/navtree root entries, so a filename like `my fil<TAB>e`
+/// renders as `"my fil\te"` rather than embedding a literal tab.
+fn escape_string_double_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            '\x0b' => out.push_str("\\v"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            '\u{0085}' => out.push_str("\\u0085"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// Sort a navtree/navbar symbol slice in-place, recursively sorting each
 /// node's children. Mirrors TypeScript's `compareChildren`: primary key
 /// is case-insensitive name, tiebreaker is source position.
@@ -1921,7 +1951,14 @@ impl Server {
                     .and_then(|stem| stem.to_str())
                     .unwrap_or("")
                     .to_string();
-                (format!("\"{basename}\""), "module")
+                // tsc's `getItemName` wraps the filename-derived module
+                // name with `escapeString` (double-quote style) before
+                // quoting. Mirrors that so control characters render as
+                // their escape sequences (\t, \n, \\…).
+                (
+                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    "module",
+                )
             } else {
                 ("<global>".to_string(), "script")
             };
@@ -2105,7 +2142,10 @@ impl Server {
                     .and_then(|stem| stem.to_str())
                     .unwrap_or("")
                     .to_string();
-                (format!("\"{basename}\""), "module")
+                (
+                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    "module",
+                )
             } else {
                 ("<global>".to_string(), "script")
             };

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -106,9 +106,14 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
         // Mirror tsc's `tryGetName`: anything without a normal declaration
         // name compares as "nameless" (sorts ahead of named siblings and
         // falls back to kind ordinal among itself). Covers computed
-        // property names (`[x]`, `["foo"]`, `[1]`) and interface-type
-        // signatures (`()` call, `new()` construct, `[]` index).
-        let nameless = sym.name.starts_with('[') || sym.name == "()" || sym.name == "new()";
+        // property names (`[x]`, `["foo"]`, `[1]`), interface-type
+        // signatures (`()` call, `new()` construct, `[]` index), and
+        // constructors (tsc's `tryGetName` returns undefined for
+        // Constructor since it has no declaration name).
+        let nameless = sym.name.starts_with('[')
+            || sym.name == "()"
+            || sym.name == "new()"
+            || matches!(sym.kind, SymbolKind::Constructor);
         if nameless {
             None
         } else {

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -237,7 +237,13 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let modifiers = self.get_kind_modifiers_from_list(&func.modifiers);
 
                     // Collect nested symbols (functions/classes inside this function)
-                    let children = self.collect_children_from_block(func.body, Some(&name));
+                    let mut children = self.collect_children_from_block(func.body, Some(&name));
+                    // Also surface members of a returned object literal —
+                    // tsc treats `function F() { return { a, b } }` as if
+                    // `a` and `b` were direct children of F.
+                    if children.is_empty() {
+                        children = self.collect_returned_object_members(func.body, Some(&name));
+                    }
 
                     let mut sym = DocumentSymbol {
                         name,
@@ -1228,6 +1234,52 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
     }
 
+    /// Scan a function/method body for a RETURN_STATEMENT whose
+    /// expression is an OBJECT_LITERAL_EXPRESSION. When found, emit
+    /// that object's members as if they were direct children of the
+    /// enclosing function — this mirrors tsc's treatment of factory
+    /// functions (`function F() { return { a, b } }`).
+    fn collect_returned_object_members(
+        &self,
+        block_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        if block_idx.is_none() {
+            return Vec::new();
+        }
+        let Some(block_node) = self.arena.get(block_idx) else {
+            return Vec::new();
+        };
+        if block_node.kind != syntax_kind_ext::BLOCK {
+            return Vec::new();
+        }
+        let Some(block) = self.arena.get_block(block_node) else {
+            return Vec::new();
+        };
+        for &stmt in &block.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::RETURN_STATEMENT {
+                continue;
+            }
+            let Some(ret) = self.arena.get_return_statement(stmt_node) else {
+                continue;
+            };
+            let expr_idx = ret.expression;
+            if expr_idx.is_none() {
+                continue;
+            }
+            let Some(expr_node) = self.arena.get(expr_idx) else {
+                continue;
+            };
+            if expr_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                return self.collect_object_literal_members(expr_idx, container_name);
+            }
+        }
+        Vec::new()
+    }
+
     /// Helper to collect children from a block (e.g. inside function).
     /// Only collects nested functions/classes for the outline.
     fn collect_children_from_block(
@@ -1487,9 +1539,18 @@ impl<'a> DocumentSymbolProvider<'a> {
                         format!("#{}", id.escaped_text)
                     }
                 });
-            } else if node.kind == SyntaxKind::StringLiteral as u16
-                || node.kind == SyntaxKind::NumericLiteral as u16
-            {
+            } else if node.kind == SyntaxKind::StringLiteral as u16 {
+                // tsc's `nodeText(name)` returns the literal's source
+                // form — keep the surrounding quotes so `"prop": 1` in
+                // an object literal becomes navbar text `"prop"` (and
+                // `declare module 'x'` stays `'x'` with single quotes).
+                let start = node.pos as usize;
+                let end = node.end as usize;
+                if start <= end && end <= self.source_text.len() {
+                    return Some(self.source_text[start..end].trim().to_string());
+                }
+                return self.arena.get_literal(node).map(|l| l.text.clone());
+            } else if node.kind == SyntaxKind::NumericLiteral as u16 {
                 return self.arena.get_literal(node).map(|l| l.text.clone());
             } else if node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
                 // `["bar"]` / `[key]` on a class/interface/object member.

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -223,9 +223,13 @@ impl<'a> DocumentSymbolProvider<'a> {
             k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                 if let Some(func) = self.arena.get_function(node) {
                     let name_node = func.name;
+                    // tsc uses the literal `<function>` placeholder for
+                    // name-less function declarations (parser error
+                    // recovery cases like `function;`). Keep the same
+                    // placeholder so snapshot diffs stay aligned.
                     let name = self
                         .get_name(name_node)
-                        .unwrap_or_else(|| "<anonymous>".to_string());
+                        .unwrap_or_else(|| "<function>".to_string());
 
                     let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
                     let selection_range = if name_node.is_some() {
@@ -400,21 +404,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                                     if let Some(decl_node) = self.arena.get(decl_idx)
                                         && let Some(decl) =
                                             self.arena.get_variable_declaration(decl_node)
-                                        && let Some(name) = self.get_name(decl.name)
                                     {
-                                        let range = node_range(
-                                            self.arena,
-                                            self.line_map,
-                                            self.source_text,
-                                            decl_idx,
-                                        );
-                                        let selection_range = node_range(
-                                            self.arena,
-                                            self.line_map,
-                                            self.source_text,
-                                            decl.name,
-                                        );
-
                                         let var_modifiers = if is_let {
                                             if stmt_modifiers.is_empty() {
                                                 "let".to_string()
@@ -424,25 +414,51 @@ impl<'a> DocumentSymbolProvider<'a> {
                                         } else {
                                             stmt_modifiers.clone()
                                         };
-                                        // Walk the initializer expression:
-                                        // object literals / class expressions
-                                        // / arrow bodies surface their members
-                                        // as children of the variable entry.
-                                        let children = self.collect_initializer_children(
-                                            decl.initializer,
-                                            Some(&name),
-                                        );
-                                        symbols.push(DocumentSymbol {
-                                            name,
-                                            detail: None,
-                                            kind,
-                                            kind_modifiers: var_modifiers,
-                                            range,
-                                            selection_range,
-                                            container_name: container_name
-                                                .map(std::string::ToString::to_string),
-                                            children,
-                                        });
+                                        if let Some(name) = self.get_name(decl.name) {
+                                            let range = node_range(
+                                                self.arena,
+                                                self.line_map,
+                                                self.source_text,
+                                                decl_idx,
+                                            );
+                                            let selection_range = node_range(
+                                                self.arena,
+                                                self.line_map,
+                                                self.source_text,
+                                                decl.name,
+                                            );
+                                            let children = self.collect_initializer_children(
+                                                decl.initializer,
+                                                Some(&name),
+                                            );
+                                            symbols.push(DocumentSymbol {
+                                                name,
+                                                detail: None,
+                                                kind,
+                                                kind_modifiers: var_modifiers,
+                                                range,
+                                                selection_range,
+                                                container_name: container_name
+                                                    .map(std::string::ToString::to_string),
+                                                children,
+                                            });
+                                        } else if let Some(name_node) = self.arena.get(decl.name)
+                                            && (name_node.kind
+                                                == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                                                || name_node.kind
+                                                    == syntax_kind_ext::ARRAY_BINDING_PATTERN)
+                                        {
+                                            // `const { a, b } = …` / `const [c, d] = …`
+                                            // — surface each bound name as its own nav
+                                            // entry matching tsc's `navigationBar`.
+                                            self.collect_binding_pattern(
+                                                decl.name,
+                                                kind,
+                                                &var_modifiers,
+                                                container_name,
+                                                &mut symbols,
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -493,6 +509,15 @@ impl<'a> DocumentSymbolProvider<'a> {
             k if k == syntax_kind_ext::ENUM_MEMBER => {
                 if let Some(member) = self.arena.get_enum_member(node) {
                     let name_node = member.name;
+                    // Reject computed property names even though
+                    // `get_name` can stringify them to `[…]` — tsc
+                    // leaves enum members with computed keys out of the
+                    // navbar entirely.
+                    if let Some(name_inner) = self.arena.get(name_node)
+                        && name_inner.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                    {
+                        return vec![];
+                    }
                     let Some(name) = self.get_name(name_node) else {
                         return vec![];
                     };
@@ -1234,6 +1259,73 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
     }
 
+    /// Recursively walk an OBJECT_BINDING_PATTERN or
+    /// ARRAY_BINDING_PATTERN and append a nav entry per bound name.
+    /// Nested patterns (`{ x: [a, b] }`) recurse so every terminal
+    /// identifier in the destructure surfaces. Uses the declaration's
+    /// inherited `kind` / `kind_modifiers` so `const [a, b] = ...`
+    /// gives two `const` leaves, etc. Function-shaped initializers on
+    /// binding elements (`{ h: i = function j() {} }`) additionally
+    /// surface the inner function name.
+    fn collect_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        kind: SymbolKind,
+        modifiers: &str,
+        container_name: Option<&str>,
+        out: &mut Vec<DocumentSymbol>,
+    ) {
+        if pattern_idx.is_none() {
+            return;
+        }
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        for &elem_idx in &pattern.elements.nodes {
+            let Some(elem_node) = self.arena.get(elem_idx) else {
+                continue;
+            };
+            if elem_node.kind != syntax_kind_ext::BINDING_ELEMENT {
+                continue;
+            }
+            let Some(elem) = self.arena.get_binding_element(elem_node) else {
+                continue;
+            };
+            let name_idx = elem.name;
+            if name_idx.is_none() {
+                continue;
+            }
+            let Some(name_node) = self.arena.get(name_idx) else {
+                continue;
+            };
+            if name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || name_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+            {
+                // Nested destructure: recurse into the inner pattern.
+                self.collect_binding_pattern(name_idx, kind, modifiers, container_name, out);
+                continue;
+            }
+            let Some(name) = self.get_name(name_idx) else {
+                continue;
+            };
+            let range = node_range(self.arena, self.line_map, self.source_text, elem_idx);
+            let selection_range = node_range(self.arena, self.line_map, self.source_text, name_idx);
+            out.push(DocumentSymbol {
+                name: name.clone(),
+                detail: None,
+                kind,
+                kind_modifiers: modifiers.to_string(),
+                range,
+                selection_range,
+                container_name: container_name.map(std::string::ToString::to_string),
+                children: vec![],
+            });
+        }
+    }
+
     /// Scan a function/method body for a RETURN_STATEMENT whose
     /// expression is an OBJECT_LITERAL_EXPRESSION. When found, emit
     /// that object's members as if they were direct children of the
@@ -1525,10 +1617,17 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
         if let Some(node) = self.arena.get(node_idx) {
             if node.kind == SyntaxKind::Identifier as u16 {
-                return self
-                    .arena
-                    .get_identifier(node)
-                    .map(|id| id.escaped_text.clone());
+                return self.arena.get_identifier(node).and_then(|id| {
+                    // An empty identifier is typically produced by
+                    // parser error recovery (e.g. `function;` gives a
+                    // name-less FUNCTION_DECLARATION). Treat as missing
+                    // so callers fall back to `<function>` / `<class>`.
+                    if id.escaped_text.is_empty() {
+                        None
+                    } else {
+                        Some(id.escaped_text.clone())
+                    }
+                });
             } else if node.kind == SyntaxKind::PrivateIdentifier as u16 {
                 // Private identifiers keep their `#` prefix in navbar
                 // output (`#foo`). The scanner's token value may or may

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -800,20 +800,77 @@ impl<'a> DocumentSymbolProvider<'a> {
             // Module / Namespace Declaration
             k if k == syntax_kind_ext::MODULE_DECLARATION => {
                 if let Some(module) = self.arena.get_module(node) {
-                    let name = self
-                        .get_name(module.name)
-                        .unwrap_or_else(|| "<module>".to_string());
+                    // Build the fully-qualified module name the way tsc
+                    // does: `namespace A.B.C {}` is modeled as nested
+                    // MODULE_DECLARATION nodes; tsc flattens them into a
+                    // single "A.B.C" nav entry whose children belong to
+                    // the innermost body. String-literal module names
+                    // (`declare module 'foo'`) keep their surrounding
+                    // quotes. `clean_module_text` strips line
+                    // continuations and truncates at 150 chars.
+                    let is_string_literal = self
+                        .arena
+                        .get(module.name)
+                        .is_some_and(|n| n.kind == SyntaxKind::StringLiteral as u16);
+                    let mut name_parts = Vec::new();
+                    let first_part = if is_string_literal {
+                        let start = module.name.0 as usize;
+                        let end = self
+                            .arena
+                            .get(module.name)
+                            .map_or(start, |n| n.end as usize);
+                        // Use raw source text so the quote character is
+                        // preserved exactly.
+                        self.source_text
+                            .get(
+                                self.arena
+                                    .get(module.name)
+                                    .map(|n| n.pos as usize)
+                                    .unwrap_or(0)..end,
+                            )
+                            .unwrap_or("")
+                            .to_string()
+                    } else {
+                        self.get_name(module.name).unwrap_or_default()
+                    };
+                    name_parts.push(first_part);
+
+                    let mut innermost = node_idx;
+                    let mut innermost_body = module.body;
+                    if !is_string_literal {
+                        let mut body = module.body;
+                        while !body.is_none() {
+                            let Some(body_node) = self.arena.get(body) else {
+                                break;
+                            };
+                            if body_node.kind != syntax_kind_ext::MODULE_DECLARATION {
+                                break;
+                            }
+                            let Some(inner) = self.arena.get_module(body_node) else {
+                                break;
+                            };
+                            if let Some(part) = self.get_name(inner.name) {
+                                name_parts.push(part);
+                            }
+                            innermost = body;
+                            innermost_body = inner.body;
+                            body = inner.body;
+                        }
+                    }
+
+                    let name = clean_module_text(&name_parts.join("."));
                     let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
                     let selection_range =
                         node_range(self.arena, self.line_map, self.source_text, module.name);
 
                     let modifiers = self.get_kind_modifiers_from_list(&module.modifiers);
 
-                    let children = if module.body.is_some() {
-                        self.collect_symbols(module.body, Some(&name))
+                    let children = if innermost_body.is_some() {
+                        self.collect_symbols(innermost_body, Some(&name))
                     } else {
                         vec![]
                     };
+                    let _ = innermost;
 
                     vec![DocumentSymbol {
                         name,
@@ -1252,6 +1309,50 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
         None
     }
+}
+
+/// Mirror tsc's `cleanText`: truncate to 150 characters (appending
+/// `...`) and strip ECMAScript line terminators, including the
+/// trailing backslash from multiline string literal continuations.
+/// Used exclusively for module names — tsc applies this to every
+/// navbar/navtree text, but for our purposes identifier text doesn't
+/// ever contain line terminators so applying it narrowly is enough.
+fn clean_module_text(text: &str) -> String {
+    const MAX_LEN: usize = 150;
+    let truncated = if text.chars().count() > MAX_LEN {
+        let head: String = text.chars().take(MAX_LEN).collect();
+        format!("{head}...")
+    } else {
+        text.to_string()
+    };
+    let mut out = String::with_capacity(truncated.len());
+    let mut chars = truncated.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // Backslash before a newline (line continuation inside a
+            // multi-line string) — drop both.
+            '\\' if matches!(chars.peek(), Some('\r' | '\n' | '\u{2028}' | '\u{2029}')) => {
+                // consume the paired line terminator (handling \r\n too)
+                match chars.next() {
+                    Some('\r') => {
+                        if matches!(chars.peek(), Some('\n')) {
+                            chars.next();
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // Bare line terminators are removed.
+            '\r' => {
+                if matches!(chars.peek(), Some('\n')) {
+                    chars.next();
+                }
+            }
+            '\n' | '\u{2028}' | '\u{2029}' => {}
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 /// Helper to append a modifier to a comma-separated string.

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -1297,11 +1297,12 @@ impl<'a> DocumentSymbolProvider<'a> {
             && let Some(block) = self.arena.get_block(node)
         {
             for &stmt in &block.statements.nodes {
-                // Collect declaration-ish statements that tsc includes in
-                // the outline for a block body: functions, classes,
-                // interfaces, enums, and type aliases. Variable
-                // declarations inside function/constructor/method bodies
-                // are deliberately omitted — tsc doesn't surface them.
+                // tsc's `addChildrenRecursively` walks every statement
+                // inside a block and treats function/class/interface/
+                // enum/type-alias/module declarations AND variable
+                // statements as nav nodes. Surfacing vars matches tests
+                // like `navigationBarItemsFunctions` which expect
+                // `function baz() { var v = 10 }` → baz has child v.
                 if let Some(stmt_node) = self.arena.get(stmt)
                     && matches!(
                         stmt_node.kind,
@@ -1311,6 +1312,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                             || k == syntax_kind_ext::ENUM_DECLARATION
                             || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
                             || k == syntax_kind_ext::MODULE_DECLARATION
+                            || k == syntax_kind_ext::VARIABLE_STATEMENT
                     )
                 {
                     symbols.extend(self.collect_symbols(stmt, container_name));

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -418,6 +418,14 @@ impl<'a> DocumentSymbolProvider<'a> {
                                         } else {
                                             stmt_modifiers.clone()
                                         };
+                                        // Walk the initializer expression:
+                                        // object literals / class expressions
+                                        // / arrow bodies surface their members
+                                        // as children of the variable entry.
+                                        let children = self.collect_initializer_children(
+                                            decl.initializer,
+                                            Some(&name),
+                                        );
                                         symbols.push(DocumentSymbol {
                                             name,
                                             detail: None,
@@ -427,7 +435,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                                             selection_range,
                                             container_name: container_name
                                                 .map(std::string::ToString::to_string),
-                                            children: vec![],
+                                            children,
                                         });
                                     }
                                 }
@@ -1023,6 +1031,200 @@ impl<'a> DocumentSymbolProvider<'a> {
 
             // Default fallback
             _ => vec![],
+        }
+    }
+
+    /// Walk a variable / property initializer and produce nav-item
+    /// children for object-literal properties, class expressions, and
+    /// arrow / function expressions with a block body. Mirrors tsc's
+    /// behavior for entries like `const o = { a: function() {} }` and
+    /// `const x = () => { function inner() {} }`.
+    fn collect_initializer_children(
+        &self,
+        init_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        if init_idx.is_none() {
+            return Vec::new();
+        }
+        let Some(init_node) = self.arena.get(init_idx) else {
+            return Vec::new();
+        };
+
+        // `{ a: ..., b() {}, c }` — walk each property.
+        if init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return self.collect_object_literal_members(init_idx, container_name);
+        }
+
+        // `class Foo {}` as an initializer — delegate to the class arm so
+        // modifiers / members render the same.
+        if init_node.kind == syntax_kind_ext::CLASS_EXPRESSION {
+            return self.collect_symbols(init_idx, container_name);
+        }
+
+        // Arrow and function expressions: only surface nested
+        // declarations from their block body, matching tsc's
+        // "inner function causes the var to be a top-level function"
+        // behavior.
+        if init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            if let Some(func) = self.arena.get_function(init_node) {
+                return self.collect_children_from_block(func.body, container_name);
+            }
+        }
+
+        Vec::new()
+    }
+
+    /// Emit a child entry for each property in an OBJECT_LITERAL_EXPRESSION.
+    /// `PROPERTY_ASSIGNMENT` → property / nested object / method depending
+    /// on the initializer; `SHORTHAND_PROPERTY_ASSIGNMENT` → property;
+    /// `METHOD_DECLARATION` (`m() {}` shorthand) → method. Computed
+    /// property names retain their bracket form via `get_name`.
+    fn collect_object_literal_members(
+        &self,
+        obj_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        let Some(obj_node) = self.arena.get(obj_idx) else {
+            return Vec::new();
+        };
+        let Some(obj) = self.arena.get_literal_expr(obj_node) else {
+            return Vec::new();
+        };
+        let mut symbols = Vec::new();
+        for &prop_idx in &obj.elements.nodes {
+            let Some(prop_node) = self.arena.get(prop_idx) else {
+                continue;
+            };
+            if prop_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                let Some(prop) = self.arena.get_property_assignment(prop_node) else {
+                    continue;
+                };
+                let Some(name) = self.get_name(prop.name) else {
+                    continue;
+                };
+                let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                let selection_range =
+                    node_range(self.arena, self.line_map, self.source_text, prop.name);
+                // Classify by initializer shape: function-like inits
+                // become methods, everything else stays a property.
+                let (kind, children) =
+                    self.classify_property_initializer(prop.initializer, Some(&name));
+                symbols.push(DocumentSymbol {
+                    name,
+                    detail: None,
+                    kind,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range,
+                    container_name: container_name.map(std::string::ToString::to_string),
+                    children,
+                });
+            } else if prop_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+                if let Some(short) = self.arena.get_shorthand_property(prop_node)
+                    && let Some(name) = self.get_name(short.name)
+                {
+                    let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                    let selection_range =
+                        node_range(self.arena, self.line_map, self.source_text, short.name);
+                    symbols.push(DocumentSymbol {
+                        name,
+                        detail: None,
+                        kind: SymbolKind::Property,
+                        kind_modifiers: String::new(),
+                        range,
+                        selection_range,
+                        container_name: container_name.map(std::string::ToString::to_string),
+                        children: vec![],
+                    });
+                }
+            } else if prop_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                // Object-literal shorthand method `m() {}` — the
+                // existing METHOD_DECLARATION arm already produces the
+                // right shape.
+                symbols.extend(self.collect_symbols(prop_idx, container_name));
+            } else if prop_node.kind == syntax_kind_ext::GET_ACCESSOR
+                || prop_node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                symbols.extend(self.collect_symbols(prop_idx, container_name));
+            } else if prop_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                // `...b` — tsc surfaces the spread expression's name as
+                // a property entry when it's an identifier. Anything
+                // more complex is skipped.
+                if let Some(spread) = self.arena.get_spread(prop_node)
+                    && let Some(name) = self.get_name(spread.expression)
+                {
+                    let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                    let selection_range = node_range(
+                        self.arena,
+                        self.line_map,
+                        self.source_text,
+                        spread.expression,
+                    );
+                    symbols.push(DocumentSymbol {
+                        name,
+                        detail: None,
+                        kind: SymbolKind::Property,
+                        kind_modifiers: String::new(),
+                        range,
+                        selection_range,
+                        container_name: container_name.map(std::string::ToString::to_string),
+                        children: vec![],
+                    });
+                }
+            }
+        }
+        symbols
+    }
+
+    /// Classify a PROPERTY_ASSIGNMENT's initializer for navbar display.
+    /// Function / arrow initializers are methods (optionally with a
+    /// body-walked child list); object literals become nested objects;
+    /// class expressions become class entries; everything else is a
+    /// plain property leaf.
+    fn classify_property_initializer(
+        &self,
+        init_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> (SymbolKind, Vec<DocumentSymbol>) {
+        if init_idx.is_none() {
+            return (SymbolKind::Property, Vec::new());
+        }
+        let Some(init_node) = self.arena.get(init_idx) else {
+            return (SymbolKind::Property, Vec::new());
+        };
+        match init_node.kind {
+            k if k == syntax_kind_ext::ARROW_FUNCTION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
+            {
+                let children = self
+                    .arena
+                    .get_function(init_node)
+                    .map(|f| self.collect_children_from_block(f.body, container_name))
+                    .unwrap_or_default();
+                (SymbolKind::Method, children)
+            }
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
+                let children = self.collect_object_literal_members(init_idx, container_name);
+                (SymbolKind::Property, children)
+            }
+            k if k == syntax_kind_ext::CLASS_EXPRESSION => {
+                let children = self.collect_symbols(init_idx, container_name);
+                // The CLASS_EXPRESSION arm returns a class entry; when
+                // used as a property initializer, we usually want to
+                // inline its members. But tsc keeps the wrapper — mirror
+                // that by taking the class entry's children as the
+                // property's children and treating the property as
+                // a class-shaped entry.
+                if children.len() == 1 {
+                    let class_entry = &children[0];
+                    return (SymbolKind::Class, class_entry.children.clone());
+                }
+                (SymbolKind::Property, children)
+            }
+            _ => (SymbolKind::Property, Vec::new()),
         }
     }
 


### PR DESCRIPTION
## Summary

Large navtree/navbar parity batch — pure-Rust path without the Node/tsc native-TS fallback. Flips **23 tests** under \`TSZ_DISABLE_NATIVE_TS=1\` (21/68 → 44/68, from 30.9% → 64.7%). Native-TS path unchanged throughout (68/68).

### Changes

1. **Module name parity** — qualified namespace flattening (\`A.B.C\` modeled as nested MODULE_DECLARATIONs now renders as one nav item), string-literal module names keep quotes, \`cleanText\` rule (150-char cap + line-continuation stripping), \`escapeString\` on external-module filenames.

2. **Variable-initializer walks** — \`const o = { a: ..., b: { m() {} } }\` surfaces a/b/m. Classifier picks between method / nested object / class / plain property based on the initializer shape. Spread \`...x\` surfaces its identifier name. Arrow/function-expression initializers walk their body for nested declarations.

3. **Factory-function returns** — \`function F() { return { a, b } }\` surfaces a/b as F's navtree children when no inner declarations already bubbled up.

4. **String-literal names** — \`"prop": value\` renders navbar text \`"prop"\` with quotes preserved (matches tsc's \`nodeText(name)\`).

5. **Variable statements in block bodies** — \`collect_children_from_block\` now surfaces \`VARIABLE_STATEMENT\`s alongside declaration kinds (tsc treats vars as nav nodes too), which fixes \`function baz() { var v }\` dropping v.

6. **Binding patterns** — \`const { a, b } = …\` / \`const [c, d] = …\` / nested \`var {e, x: [f, g]} = …\` surface every terminal name with the enclosing declaration's kind/modifiers.

7. **Enum members with computed keys** — \`[Symbol.isRegExp]\` regressed after we started stringifying COMPUTED_PROPERTY_NAME; explicit skip in the ENUM_MEMBER arm.

8. **Name-less function recovery** — \`function;\` (parser error recovery) now renders as \`<function>\` instead of an empty-string entry.

9. **Constructor-first ordering** — \`Constructor\` sorts as "nameless" (tsc's \`tryGetName\` returns undefined), so constructors always lead their sibling properties.

### Test plan

- [x] \`cargo nextest run -p tsz-lsp\` — 3759/3759
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navigationBar\` — 44/68 (up from 21)
- [x] Targeted tests verified individually (listed per commit)
- [x] Native-TS full navbar filter: 68/68 unchanged