### PR TITLE
refactor(common): move checker options into options domain folder

### DIFF
--- a/crates/tsz-common/src/lib.rs
+++ b/crates/tsz-common/src/lib.rs
@@ -38,6 +38,8 @@ pub mod comments;
 pub mod diagnostics;
 
 // Compiler options for type checking (shared by solver and checker)
-pub mod checker_options;
+pub mod options;
+// Back-compat alias while we migrate to domain-folder layout.
 pub use checker_options::CheckerOptions;
+pub use options::checker as checker_options;
 pub mod numeric;

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -183,7 +183,7 @@ pub enum JsxMode {
 }
 
 #[cfg(test)]
-#[path = "../tests/checker_options_tests.rs"]
+#[path = "../../tests/checker_options_tests.rs"]
 mod tests;
 
 impl Default for CheckerOptions {

--- a/crates/tsz-common/src/options/mod.rs
+++ b/crates/tsz-common/src/options/mod.rs
@@ -1,0 +1,1 @@
+pub mod checker;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/checker_options.rs` to `crates/tsz-common/src/options/checker.rs`
- add `crates/tsz-common/src/options/mod.rs`
- switch `tsz-common` root to expose `pub mod options`
- preserve external compatibility via `pub use options::checker as checker_options`
  so existing paths like `tsz_common::checker_options::CheckerOptions` continue to work
- update relocated module’s test include path for the new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-checker`
- `cargo test -p tsz-common checker_options -- --nocapture`
