### PR TITLE
fix(conformance): keep TS2318 in tsz output under `@noLib`

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -1025,27 +1025,20 @@ impl Runner {
                     let tsc_has_2318 =
                         tsc_error_codes.contains(&2318) || tsc_fps.iter().any(|fp| fp.code == 2318);
                     if is_nolib && tsc_has_2318 {
-                        // When tsc has TS2318 only in fingerprints (not error_codes),
-                        // we need to also filter TS2318 from tsz's output to avoid
-                        // false positives.
+                        // Under @noLib, tsc suppresses cascaded errors from missing
+                        // global types. Mirror that by restricting tsz's output to
+                        // codes tsc reports, plus TS2318 itself so fingerprint
+                        // comparison sees our "Cannot find global type" diagnostics.
+                        // (The tsc cache sometimes stores TS2318 only in fingerprints,
+                        // with an empty error_codes list — keep TS2318 in both cases.)
                         let tsc_code_set: std::collections::HashSet<u32> =
                             tsc_error_codes.iter().cloned().collect();
-                        if !tsc_error_codes.contains(&2318) {
-                            // tsc has TS2318 in fingerprints only — filter it from tsz too
-                            compile_result
-                                .error_codes
-                                .retain(|c| tsc_code_set.contains(c));
-                            compile_result
-                                .diagnostic_fingerprints
-                                .retain(|fp| tsc_code_set.contains(&fp.code));
-                        } else {
-                            compile_result
-                                .error_codes
-                                .retain(|c| tsc_code_set.contains(c) || *c == 2318);
-                            compile_result
-                                .diagnostic_fingerprints
-                                .retain(|fp| tsc_code_set.contains(&fp.code) || fp.code == 2318);
-                        }
+                        compile_result
+                            .error_codes
+                            .retain(|c| tsc_code_set.contains(c) || *c == 2318);
+                        compile_result
+                            .diagnostic_fingerprints
+                            .retain(|fp| tsc_code_set.contains(&fp.code) || fp.code == 2318);
                     }
 
                     // If TSC expects only TS5024, tsz may emit extra diagnostics


### PR DESCRIPTION
## Summary
The `@noLib` branch in the runner had a conditional that dropped TS2318 ("Cannot find global type") from tsz's output when the tsc cache stored TS2318 only in the fingerprint list (with `error_codes: []`). That branch then made fingerprint comparison report all ten TS2318 entries as "missing" from tsz, even though tsz was actually emitting them correctly — tsz's fingerprints had been stripped by the branch itself before comparison.

Collapse the two branches into one that always keeps TS2318 in tsz's output (alongside whatever codes tsc explicitly reports in `error_codes`). Cascaded-from-missing-lib suppression for non-TS2318 codes still applies, since we still intersect with `tsc_code_set` for those.

## Impact
Six tests flip PASS across all `@noLib`-sensitive suites; no regressions:
- `awaitedTypeNoLib.ts`
- `noCrashOnNoLib.ts`
- `strictNullNotNullIndexTypeNoLib.ts`
- `libReferenceNoLib.ts`
- `libReferenceNoLibBundle.ts`
- `parser509698.ts`

Stable across 3 full suite runs (11986/12581 with this fix vs 11982/12581 baseline, net +4 due to existing flakes; 11987 on a clean flake-free run).

Note: `decoratorMetadataNoLibIsolatedModulesTypes.ts` still fails because tsz emits an extra `TypedPropertyDescriptor` TS2318 that tsc doesn't — that's a separate issue (tsz's feature-specific-global-types check firing for non-decorator contexts), not covered by this PR.

## Test plan
- [x] `awaitedTypeNoLib` / `noCrashOnNoLib` / `strictNullNotNullIndexTypeNoLib` / `libReferenceNoLib*` / `parser509698` all pass under `--filter` after the change
- [x] Full suite: 11986/12581 with fix vs 11982/12581 baseline (3 stable runs each)
- [x] Diff of failing tests: 6 tests removed from the fail list, 0 newly failing