### PR TITLE
refactor(common): move source_map into folder module

### DIFF
--- a/crates/tsz-common/src/source_map/mod.rs
+++ b/crates/tsz-common/src/source_map/mod.rs
@@ -541,5 +541,5 @@ pub fn base64_encode(input: &[u8]) -> String {
 }
 
 #[cfg(test)]
-#[path = "../tests/source_map.rs"]
+#[path = "../../tests/source_map.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/source_map.rs` to `crates/tsz-common/src/source_map/mod.rs`
- preserve module path/API (`pub mod source_map` remains unchanged)
- adjust internal test module include path for the new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common source_map::tests -- --nocapture`
