### PR TITLE
refactor(common): move comments into folder module

### DIFF
--- a/crates/tsz-common/src/comments/mod.rs
+++ b/crates/tsz-common/src/comments/mod.rs
@@ -256,7 +256,7 @@ pub fn get_jsdoc_content(comment: &CommentRange, source: &str) -> String {
 }
 
 #[cfg(test)]
-#[path = "../tests/comments_tests.rs"]
+#[path = "../../tests/comments_tests.rs"]
 mod tests;
 
 /// Get leading comments from cached comment ranges.


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/comments.rs` to `crates/tsz-common/src/comments/mod.rs`
- preserve module path/API (`pub mod comments` remains unchanged)
- update internal test include path for the new module directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common comments::tests -- --nocapture`
