### PR TITLE
refactor(common): move position into folder module

### DIFF
--- a/crates/tsz-common/src/position/mod.rs
+++ b/crates/tsz-common/src/position/mod.rs
@@ -194,5 +194,5 @@ impl LineMap {
 }
 
 #[cfg(test)]
-#[path = "../tests/position_tests.rs"]
+#[path = "../../tests/position_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/position.rs` to `crates/tsz-common/src/position/mod.rs`
- preserve module path/API (`pub mod position` remains unchanged)
- adjust internal test include path for the new module directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common position::tests -- --nocapture`
