### PR TITLE
refactor(common): move limits into folder module

### DIFF
--- a/crates/tsz-common/src/limits/mod.rs
+++ b/crates/tsz-common/src/limits/mod.rs
@@ -227,5 +227,5 @@ pub const MAX_TYPE_RESOLUTION_OPS: u32 = 100_000;
 pub const THREAD_STACK_SIZE_BYTES: usize = 64 * 1024 * 1024;
 
 #[cfg(test)]
-#[path = "../tests/limits.rs"]
+#[path = "../../tests/limits.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/limits.rs` to `crates/tsz-common/src/limits/mod.rs`
- preserve module path/API (`pub mod limits` remains unchanged)
- adjust internal test include path for new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common -- --nocapture`
