### PR TITLE
refactor(common): move interner into folder module

### DIFF
--- a/crates/tsz-common/src/interner/mod.rs
+++ b/crates/tsz-common/src/interner/mod.rs
@@ -498,5 +498,5 @@ impl Default for ShardedInterner {
 }
 
 #[cfg(test)]
-#[path = "../tests/interner_tests.rs"]
+#[path = "../../tests/interner_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/interner.rs` to `crates/tsz-common/src/interner/mod.rs`
- preserve module path/API (`pub mod interner` remains unchanged)
- adjust internal test include path for new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common interner::tests -- --nocapture`
