### PR TITLE
refactor(common): move common module into folder

### DIFF
--- a/crates/tsz-common/src/common/mod.rs
+++ b/crates/tsz-common/src/common/mod.rs
@@ -327,5 +327,5 @@ pub enum Visibility {
 }
 
 #[cfg(test)]
-#[path = "../tests/common.rs"]
+#[path = "../../tests/common.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/common.rs` to `crates/tsz-common/src/common/mod.rs`
- preserve module path/API (`pub mod common` remains unchanged)
- adjust internal test include path for new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common common::tests -- --nocapture`
