### PR TITLE
refactor(common): move span into folder module

### DIFF
--- a/crates/tsz-common/src/span/mod.rs
+++ b/crates/tsz-common/src/span/mod.rs
@@ -360,5 +360,5 @@ impl std::fmt::Display for ByteSpan<'_> {
 // =============================================================================
 
 #[cfg(test)]
-#[path = "../tests/span.rs"]
+#[path = "../../tests/span.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-common/src/span.rs` to `crates/tsz-common/src/span/mod.rs`
- preserve module path/API (`pub mod span` remains unchanged)
- adjust internal test include path for new directory depth

## Validation
- `cargo fmt`
- `cargo check -p tsz-common -p tsz-core`
- `cargo test -p tsz-common span::tests -- --nocapture`
