### PR TITLE
refactor(tsz-lsp): folderize diagnostics module

### DIFF
--- a/crates/tsz-lsp/src/diagnostics/mod.rs
+++ b/crates/tsz-lsp/src/diagnostics/mod.rs
@@ -427,5 +427,5 @@ impl WorkspaceDiagnosticReport {
 }
 
 #[cfg(test)]
-#[path = "../tests/diagnostics_tests.rs"]
+#[path = "../../tests/diagnostics_tests.rs"]
 mod diagnostics_tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/diagnostics.rs` to `crates/tsz-lsp/src/diagnostics/mod.rs`
- keep module API unchanged (`pub mod diagnostics;` still resolves the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp diagnostics_tests -- --nocapture
