### PR TITLE
refactor(tsz-lsp): folderize document_links module

### DIFF
--- a/crates/tsz-lsp/src/document_links/mod.rs
+++ b/crates/tsz-lsp/src/document_links/mod.rs
@@ -241,5 +241,5 @@ impl<'a> DocumentLinkProvider<'a> {
 }
 
 #[cfg(test)]
-#[path = "../tests/document_links_tests.rs"]
+#[path = "../../tests/document_links_tests.rs"]
 mod document_links_tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/document_links.rs` to `crates/tsz-lsp/src/document_links/mod.rs`
- keep module API unchanged (`pub mod document_links;` remains the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp document_links_tests -- --nocapture
