### PR TITLE
refactor(tsz-lsp): folderize dependency_graph module

### DIFF
--- a/crates/tsz-lsp/src/dependency_graph/mod.rs
+++ b/crates/tsz-lsp/src/dependency_graph/mod.rs
@@ -166,5 +166,5 @@ impl DependencyGraph {
 }
 
 #[cfg(test)]
-#[path = "../tests/dependency_graph_tests.rs"]
+#[path = "../../tests/dependency_graph_tests.rs"]
 mod dependency_graph_tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/dependency_graph.rs` to `crates/tsz-lsp/src/dependency_graph/mod.rs`
- keep module API unchanged (`pub mod dependency_graph;` remains the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp dependency_graph_tests -- --nocapture
