### PR TITLE
refactor(tsz-lsp): folderize jsdoc module

### DIFF
--- a/crates/tsz-lsp/src/jsdoc/mod.rs
+++ b/crates/tsz-lsp/src/jsdoc/mod.rs
@@ -308,7 +308,7 @@ fn parse_param_tag(line: &str) -> Option<(String, String)> {
 }
 
 #[cfg(test)]
-#[path = "../tests/jsdoc_tests.rs"]
+#[path = "../../tests/jsdoc_tests.rs"]
 mod jsdoc_tests;
 
 fn normalize_param_name(name: &str) -> String {


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/jsdoc.rs` to `crates/tsz-lsp/src/jsdoc/mod.rs`
- keep module API unchanged (`pub mod jsdoc;` remains the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp jsdoc_tests -- --nocapture
