### PR TITLE
refactor(tsz-lsp): folderize utils module

### DIFF
--- a/crates/tsz-lsp/src/utils/mod.rs
+++ b/crates/tsz-lsp/src/utils/mod.rs
@@ -372,5 +372,5 @@ fn relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
-#[path = "../tests/utils_tests.rs"]
+#[path = "../../tests/utils_tests.rs"]
 mod utils_tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/utils.rs` to `crates/tsz-lsp/src/utils/mod.rs`
- keep module API unchanged (`pub mod utils;` remains the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp utils_tests -- --nocapture
