### PR TITLE
refactor(tsz-lsp): folderize export_signature module

### DIFF
--- a/crates/tsz-lsp/src/export_signature/mod.rs
+++ b/crates/tsz-lsp/src/export_signature/mod.rs
@@ -361,5 +361,5 @@ impl ExportSignature {
 }
 
 #[cfg(test)]
-#[path = "../tests/export_signature_tests.rs"]
+#[path = "../../tests/export_signature_tests.rs"]
 mod export_signature_tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-lsp/src/export_signature.rs` to `crates/tsz-lsp/src/export_signature/mod.rs`
- keep module API unchanged (`pub mod export_signature;` remains the same)
- update internal test path attribute after the move

## Validation
- cargo fmt
- cargo check -p tsz-lsp
- cargo test -p tsz-lsp export_signature_tests -- --nocapture
