### PR TITLE
fix(checker): detect dangling JSDoc `@extends`/`@augments` between classes (TS8022)

### DIFF
--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -891,10 +891,16 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Scan statements for `@extends`/`@augments` not on class declarations (TS8022).
+    ///
+    /// Each result is `(tag, Some((pos, len)))` when the orphan is the leading
+    /// JSDoc of a non-class statement (tsc reports these at the statement's
+    /// position), or `(tag, None)` when it is a fully-dangling JSDoc comment
+    /// not attached to any statement (tsc reports these at program level with
+    /// no file/position).
     pub(crate) fn find_orphaned_extends_tags_for_statements(
         &self,
         statements: &[NodeIndex],
-    ) -> Vec<(&'static str, u32, u32)> {
+    ) -> Vec<(&'static str, Option<(u32, u32)>)> {
         use tsz_parser::parser::syntax_kind_ext;
         let Some(sf) = self.ctx.arena.source_files.first() else {
             return Vec::new();
@@ -942,7 +948,7 @@ impl<'a> CheckerState<'a> {
             } else {
                 (node.pos, node.end - node.pos)
             };
-            results.push((tag, pos, len));
+            results.push((tag, Some((pos, len))));
         }
         // Phase 2: Check for dangling JSDoc comments not attached to any statement
         use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
@@ -950,12 +956,11 @@ impl<'a> CheckerState<'a> {
             if !is_jsdoc_comment(comment, source_text) {
                 continue;
             }
-            if handled_comment_positions
-                .iter()
-                .any(|&stmt_pos| comment.end <= stmt_pos)
-            {
-                continue;
-            }
+            // Note: we intentionally do NOT skip comments simply because they
+            // appear before a handled class — tsc reports `@extends`/`@augments`
+            // as orphaned when another JSDoc comment is interposed between the
+            // tag and the class declaration (see extendsTag2). The
+            // is_leading_of_any_stmt check below is the sole gate.
             let content = get_jsdoc_content(comment, source_text);
             let tag = if Self::jsdoc_contains_tag(&content, "augments") {
                 "augments"
@@ -976,17 +981,9 @@ impl<'a> CheckerState<'a> {
             if is_leading_of_any_stmt {
                 continue;
             }
-            let needle = format!("@{tag}");
-            let (pos, len) = if let Some(offset) = source_text
-                .get(comment.pos as usize..comment.end as usize)
-                .and_then(|s| s.find(&needle))
-            {
-                let tag_pos = comment.pos + offset as u32;
-                (tag_pos, needle.len() as u32)
-            } else {
-                (comment.pos, comment.end - comment.pos)
-            };
-            results.push((tag, pos, len));
+            // Dangling JSDoc comment — tsc emits this as a program-level
+            // diagnostic (no source file / position).
+            results.push((tag, None));
         }
         results
     }

--- a/crates/tsz-checker/src/state/state_checking/js_grammar.rs
+++ b/crates/tsz-checker/src/state/state_checking/js_grammar.rs
@@ -22,17 +22,28 @@ impl<'a> CheckerState<'a> {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 
         let orphaned = self.find_orphaned_extends_tags_for_statements(statements);
-        for (tag_name, pos, len) in orphaned {
+        for (tag_name, position) in orphaned {
             let message = format_message(
                 diagnostic_messages::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
                 &[tag_name],
             );
-            self.ctx.error(
-                pos,
-                len,
-                message,
-                diagnostic_codes::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
-            );
+            match position {
+                Some((pos, len)) => {
+                    self.ctx.error(
+                        pos,
+                        len,
+                        message,
+                        diagnostic_codes::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
+                    );
+                }
+                None => {
+                    // Fully-dangling JSDoc — tsc emits at program level.
+                    self.error_program_level(
+                        message,
+                        diagnostic_codes::JSDOC_IS_NOT_ATTACHED_TO_A_CLASS,
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `find_orphaned_extends_tags_for_statements` had a Phase 2 filter that dropped any JSDoc comment ending before a class declaration, treating all such comments as "handled" by the class. That was too aggressive: tsc considers an `@extends`/`@augments` JSDoc orphaned when another unrelated JSDoc comment is interposed between it and the class.
- Drop the too-broad filter and rely on the existing `is_leading_of_any_stmt` check — the comment counts as "leading" only when it matches a statement's immediate leading JSDoc.
- tsc emits the dangling variant as a program-level diagnostic with no file/position, but continues to anchor the per-statement variant at the statement's position. Preserve both by changing the helper's return type to `(tag, Option<(pos, len)>)` and routing `None` through `error_program_level` and `Some(..)` through `self.ctx.error(..)`.

## Repro (matches `extendsTag2.ts` pattern)
```js
/** @constructor */
class A { constructor() {} }

/** @extends {A} */     // ← dangling, another JSDoc interposed

/** @constructor */     // ← this is class B's real leading JSDoc
class B extends A { constructor() { super(); } }
```

tsc emits `error TS8022: JSDoc '@extends' is not attached to a class.` at program level; tsz now matches.

## Impact
- `extendsTag2.ts` flips to PASS.
- No regressions: `jsdocAugments_notAClass.ts` (existing per-statement variant) still passes because its Phase-1 position is tied to a non-class function statement.

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter extendsTag2` — passes
- [x] `./scripts/conformance/conformance.sh run --filter jsdocAugments_notAClass` — still passes
- [x] `./scripts/conformance/conformance.sh run --filter extendsTag` — 6/7 passes (unchanged)
- [x] Full suite diff: `extendsTag2.ts` removed from fail list, no additions.