### PR TITLE
Fix TS2430 interface overload compatibility regressions

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1254,6 +1254,40 @@ impl<'a> CheckerState<'a> {
             let substitution =
                 TypeSubstitution::from_args(self.ctx.types, &base_type_params, &type_args);
 
+            // When a base interface has overloaded methods, defer mismatch reporting
+            // for those method names to the dedicated overload coverage pass below.
+            let overloaded_base_method_names: rustc_hash::FxHashSet<String> = {
+                let mut counts: rustc_hash::FxHashMap<String, usize> =
+                    rustc_hash::FxHashMap::default();
+                for &base_iface_idx in &base_iface_indices {
+                    let Some(base_node) = self.ctx.arena.get(base_iface_idx) else {
+                        continue;
+                    };
+                    let Some(base_iface) = self.ctx.arena.get_interface(base_node) else {
+                        continue;
+                    };
+                    for &base_member_idx in &base_iface.members.nodes {
+                        let Some(base_member_node) = self.ctx.arena.get(base_member_idx) else {
+                            continue;
+                        };
+                        if base_member_node.kind != METHOD_SIGNATURE {
+                            continue;
+                        }
+                        let Some(sig) = self.ctx.arena.get_signature(base_member_node) else {
+                            continue;
+                        };
+                        let Some(name) = self.get_property_name(sig.name) else {
+                            continue;
+                        };
+                        *counts.entry(name).or_insert(0) += 1;
+                    }
+                }
+                counts
+                    .into_iter()
+                    .filter_map(|(name, count)| (count > 1).then_some(name))
+                    .collect()
+            };
+
             let mut ts2430_emitted_for_base = false;
             'derived_loop: for (member_name, member_type, derived_member_idx, derived_kind) in
                 &derived_members
@@ -1298,6 +1332,15 @@ impl<'a> CheckerState<'a> {
 
                         found = true;
                         let base_type = instantiate_type(self.ctx.types, base_type, &substitution);
+
+                        if *derived_kind == METHOD_SIGNATURE
+                            && base_member_node.kind == METHOD_SIGNATURE
+                            && overloaded_base_method_names.contains(member_name)
+                        {
+                            // Overloaded method names are validated by the
+                            // overload coverage check after this loop.
+                            break;
+                        }
 
                         // For method signatures, also check required parameter
                         // count: derived methods must not require more parameters
@@ -1423,34 +1466,172 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // For each method with multiple base overloads, check coverage
+                let signature_has_literal_parameter = |type_id: TypeId| -> bool {
+                    let has_literal_param =
+                        |params: &[crate::query_boundaries::common::ParamInfo]| {
+                            params.iter().any(|param| {
+                                crate::query_boundaries::common::is_literal_type(
+                                    self.ctx.types,
+                                    param.type_id,
+                                )
+                            })
+                        };
+
+                    if let Some(signatures) =
+                        crate::query_boundaries::common::call_signatures_for_type(
+                            self.ctx.types,
+                            type_id,
+                        )
+                    {
+                        return signatures
+                            .iter()
+                            .any(|signature| has_literal_param(&signature.params));
+                    }
+
+                    if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    ) {
+                        return has_literal_param(&shape.params);
+                    }
+
+                    if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    ) {
+                        return shape
+                            .call_signatures
+                            .iter()
+                            .any(|signature| has_literal_param(&signature.params));
+                    }
+
+                    if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    ) && shape.properties.len() == 1
+                        && shape.properties[0].is_method
+                    {
+                        let method_type = shape.properties[0].type_id;
+                        if let Some(signatures) =
+                            crate::query_boundaries::common::call_signatures_for_type(
+                                self.ctx.types,
+                                method_type,
+                            )
+                        {
+                            return signatures
+                                .iter()
+                                .any(|signature| has_literal_param(&signature.params));
+                        }
+                        if let Some(shape) =
+                            crate::query_boundaries::common::function_shape_for_type(
+                                self.ctx.types,
+                                method_type,
+                            )
+                        {
+                            return has_literal_param(&shape.params);
+                        }
+                        if let Some(shape) =
+                            crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                method_type,
+                            )
+                        {
+                            return shape
+                                .call_signatures
+                                .iter()
+                                .any(|signature| has_literal_param(&signature.params));
+                        }
+                    }
+
+                    false
+                };
+
+                let select_implementation_signature = |signatures: &[TypeId]| -> Option<TypeId> {
+                    if signatures.is_empty() {
+                        return None;
+                    }
+
+                    let mut last_non_specialized: Option<TypeId> = None;
+                    for &signature in signatures {
+                        if !signature_has_literal_parameter(signature) {
+                            last_non_specialized = Some(signature);
+                        }
+                    }
+
+                    last_non_specialized.or_else(|| signatures.last().copied())
+                };
+
+                let has_non_specialized_signature = |signatures: &[TypeId]| -> bool {
+                    signatures
+                        .iter()
+                        .any(|&signature| !signature_has_literal_parameter(signature))
+                };
+
+                let select_implementation_signature_with_node =
+                    |signatures: &[(TypeId, NodeIndex)]| -> Option<(TypeId, NodeIndex)> {
+                        if signatures.is_empty() {
+                            return None;
+                        }
+
+                        let mut last_non_specialized: Option<(TypeId, NodeIndex)> = None;
+                        for &(signature, node_idx) in signatures {
+                            if !signature_has_literal_parameter(signature) {
+                                last_non_specialized = Some((signature, node_idx));
+                            }
+                        }
+
+                        last_non_specialized.or_else(|| signatures.last().copied())
+                    };
+
+                let has_non_specialized_signature_with_node =
+                    |signatures: &[(TypeId, NodeIndex)]| -> bool {
+                        signatures
+                            .iter()
+                            .any(|&(signature, _)| !signature_has_literal_parameter(signature))
+                    };
+
+                // For overloaded method inheritance, tsc compatibility hinges on
+                // the trailing (implementation) signature.
                 'overload_check: for (method_name, base_sigs) in &base_method_overloads {
                     let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                         continue;
                     };
-                    for &base_type in base_sigs {
-                        let mut matched = false;
-                        for &(derived_type, derived_idx) in derived_sigs {
-                            if !should_report_member_type_mismatch(
-                                self,
-                                derived_type,
-                                base_type,
-                                derived_idx,
-                            ) {
-                                matched = true;
-                                break;
-                            }
-                        }
-                        if !matched {
-                            self.error_at_node(
-                                iface_data.name,
-                                &format!(
-                                    "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
-                                ),
-                                diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
-                            );
-                            break 'overload_check;
-                        }
+                    if has_non_specialized_signature(base_sigs)
+                        && !has_non_specialized_signature_with_node(derived_sigs)
+                    {
+                        self.error_at_node(
+                            iface_data.name,
+                            &format!(
+                                "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
+                            ),
+                            diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
+                        );
+                        break 'overload_check;
+                    }
+                    let Some(base_trailing_sig) = select_implementation_signature(base_sigs) else {
+                        continue;
+                    };
+                    let Some((derived_trailing_sig, derived_trailing_idx)) =
+                        select_implementation_signature_with_node(derived_sigs)
+                    else {
+                        continue;
+                    };
+
+                    if !self
+                        .is_assignable_to_no_erase_generics(derived_trailing_sig, base_trailing_sig)
+                        && !self.should_suppress_assignability_for_parse_recovery(
+                            derived_trailing_idx,
+                            derived_trailing_idx,
+                        )
+                    {
+                        self.error_at_node(
+                            iface_data.name,
+                            &format!(
+                                "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
+                            ),
+                            diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
+                        );
+                        break 'overload_check;
                     }
                 }
             }

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -43,6 +43,12 @@ fn has_polymorphic_this_return_mismatch(
     if source_returns.is_empty() || target_returns.is_empty() {
         return false;
     }
+    // Only apply this fast mismatch rule for single-signature comparisons.
+    // Overload sets need full compatibility checks (including trailing overload
+    // matching) and this shortcut would produce false TS2430s.
+    if source_returns.len() != 1 || target_returns.len() != 1 {
+        return false;
+    }
 
     let source_has_polymorphic_this = source_returns
         .iter()
@@ -162,14 +168,14 @@ pub(crate) fn should_report_member_type_mismatch(
     node_idx: NodeIndex,
 ) -> bool {
     let source = checker.narrow_this_from_enclosing_typeof_guard(node_idx, source);
+    if has_polymorphic_this_return_mismatch(checker, source, target) {
+        return true;
+    }
     if checker.should_suppress_assignability_diagnostic(source, target) {
         return false;
     }
     if checker.should_suppress_assignability_for_parse_recovery(node_idx, node_idx) {
         return false;
-    }
-    if has_polymorphic_this_return_mismatch(checker, source, target) {
-        return true;
     }
     if checker.is_assignable_to_no_erase_generics(source, target) {
         return false;
@@ -213,14 +219,14 @@ pub(crate) fn should_report_own_member_type_mismatch(
     node_idx: NodeIndex,
 ) -> bool {
     let source = checker.narrow_this_from_enclosing_typeof_guard(node_idx, source);
+    if has_polymorphic_this_return_mismatch(checker, source, target) {
+        return true;
+    }
     if checker.should_suppress_member_assignability(source, target) {
         return false;
     }
     if checker.should_suppress_assignability_for_parse_recovery(node_idx, node_idx) {
         return false;
-    }
-    if has_polymorphic_this_return_mismatch(checker, source, target) {
-        return true;
     }
     if checker.is_assignable_to_no_erase_generics(source, target) {
         return false;
@@ -432,6 +438,9 @@ pub(crate) fn should_report_property_type_mismatch(
     node_idx: NodeIndex,
 ) -> bool {
     let narrowed_source = checker.narrow_this_from_enclosing_typeof_guard(node_idx, source);
+    if has_polymorphic_this_return_mismatch(checker, narrowed_source, target) {
+        return true;
+    }
     // TS2430 property compatibility is still a member-compatibility check, even
     // though it uses regular assignability instead of no-erase-generics. Using
     // the broader TS2322 suppression here hides real interface-extends failures
@@ -441,9 +450,6 @@ pub(crate) fn should_report_property_type_mismatch(
     }
     if checker.should_suppress_assignability_for_parse_recovery(node_idx, node_idx) {
         return false;
-    }
-    if has_polymorphic_this_return_mismatch(checker, narrowed_source, target) {
-        return true;
     }
 
     let request = {


### PR DESCRIPTION
## Summary
- tighten polymorphic-this fast-path mismatch detection to single-signature comparisons and run it before suppression gates
- refine interface overload inheritance checks to defer overloaded method names to a dedicated pass while preserving trailing-signature compatibility
- require derived overload sets to include a non-specialized signature when the base overload set has one, fixing `overloadOnConstInheritance2.ts`
- route overload literal-parameter checks through query-boundary wrappers to satisfy architecture constraints
- rebase branch onto latest `main` and validate on rebased head

## Validation
- cargo test -p tsz-checker --lib architecture_contract_tests::test_direct_solver_types_module_usage_is_quarantined_to_query_boundaries -- --exact
- cargo test -p tsz-checker --lib architecture_contract_tests_src::test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning -- --exact
- cargo test -p tsz-checker --lib architecture_contract_tests_src::test_no_inline_solver_function_calls_in_checker_modules -- --exact
- cargo test -p tsz-checker --test conformance_issues overloaded_interface_method_inheritance_uses_trailing_signature_compatibility
- cargo test -p tsz-checker --test conformance_issues polymorphic_this_in_indexed_interface_extension_emits_ts2430
- cargo test -p tsz-checker --test conformance_issues polymorphic_this_in_set_interface_extension_emits_ts2430
- cargo test -p tsz-core checker_state_tests::test_covariant_this_basic_subtyping -- --exact
- cargo test -p tsz-core checker_state_tests::test_covariant_this_unsound_call -- --exact
- scripts/session/verify-all.sh
  - formatting: pass
  - clippy: pass
  - unit tests: pass
  - conformance: pass (`=11981`)
  - emit tests: pass (`JS +5, DTS +29`)
  - fourslash/LSP: pass (`=50`)
