### PR TITLE
refactor(tsz-solver): folderize utils module

### DIFF
--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -368,5 +368,5 @@ pub(crate) fn expand_tuple_rest(db: &dyn TypeDatabase, type_id: TypeId) -> Tuple
 }
 
 #[cfg(test)]
-#[path = "../tests/utils_tests.rs"]
+#[path = "../../tests/utils_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-solver/src/utils.rs` to `crates/tsz-solver/src/utils/mod.rs`
- keep module API unchanged (`pub mod utils;` still resolves the same)
- update internal test path attribute after module move

## Validation
- cargo fmt
- cargo check -p tsz-solver
- cargo test -p tsz-solver utils::tests -- --nocapture
