### PR TITLE
refactor(tsz-solver): folderize canonicalize module

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -644,5 +644,5 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
 }
 
 #[cfg(test)]
-#[path = "../tests/canonicalize_tests.rs"]
+#[path = "../../tests/canonicalize_tests.rs"]
 mod tests;


### PR DESCRIPTION
## Summary
- move `crates/tsz-solver/src/canonicalize.rs` to `crates/tsz-solver/src/canonicalize/mod.rs`
- keep module API unchanged (`pub mod canonicalize;` still resolves the same)
- update internal test path attribute after module move

## Validation
- cargo fmt
- cargo check -p tsz-solver
- cargo test -p tsz-solver canonicalize::tests -- --nocapture
