### PR TITLE
fix(conformance): filter synthetic TS6053/TS2688 cache artifacts when tsc reports no real errors

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -86,11 +86,29 @@ fn filter_lib_diagnostics_tsz(
 /// tsc emits TS6053 for unresolved `/.lib/` references. Since our wrapper
 /// resolves them, these TS6053 entries are artifacts that should not count
 /// as "missing" diagnostics.
+///
+/// Also filter synthetic-position TS6053 entries when tsc reports NO error
+/// codes. Those are cache-generation artifacts (tsc's `--traceResolution`
+/// output captured during `generate-tsc-cache`) that do not correspond to
+/// any expected baseline diagnostic and should not count as expected.
 fn filter_lib_diagnostics_tsc(
     tsc_result: &crate::tsc_results::TscResult,
 ) -> (Vec<u32>, Vec<DiagnosticFingerprint>) {
     let mut codes = tsc_result.error_codes.clone();
     let mut fps = tsc_result.diagnostic_fingerprints.clone();
+
+    // Cache-artifact cleanup: when tsc reports no real error codes, drop
+    // synthetic-position TS6053 / TS2688 entries that snuck into the
+    // fingerprint list (e.g. trace-resolution output for tests like
+    // library-reference-3). They don't correspond to anything tsc actually
+    // flags as a diagnostic in its baseline .errors.txt output.
+    if codes.is_empty() {
+        fps.retain(|fp| {
+            let synthetic =
+                fp.file.is_empty() && fp.line == 0 && fp.column == 0;
+            !(synthetic && matches!(fp.code, 6053 | 2688))
+        });
+    }
 
     let had_lib = fps.iter().any(is_lib_diagnostic);
     if !had_lib {


### PR DESCRIPTION
## Summary
The tsc cache generator captured `TS6053 File 'X' not found.` and `TS2688 Cannot find type definition file for 'jquery'.` fingerprints at `<unknown>:0:0` for several tests in `conformance/references/library-reference-*.ts`, but tsc's actual `.errors.txt` baseline files for those tests don't exist — tsc reports no expected errors.

These entries are artifacts from tsc's trace-resolution output during the cache-generation run (the tests use `@traceResolution: true`). They get captured as synthetic-position fingerprints but don't correspond to any diagnostic tsc reports as part of the test's error baseline, so the runner incorrectly treats them as expected and flags tsz (which correctly emits no errors) as "missing" those fingerprints.

Extend `filter_lib_diagnostics_tsc` to drop synthetic-position TS6053 and TS2688 entries whenever tsc's `error_codes` list is empty. "No error codes reported" means no expected errors, even if trace output sneaks into the fingerprints.

## Impact
+3 tests across `conformance/references/`:
- `library-reference-3.ts`
- `library-reference-8.ts`
- `library-reference-14.ts`

No regressions — the noLib TS2318 case (handled in a separate code block below this filter) still fires as before, and the `.lib/` TS6053 retention logic further down is unchanged.

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter library-reference-3/8/14` — all pass
- [x] Full-suite diff: 3 tests removed from fail list, only `jsxRuntimePragma.ts` reappears (pre-existing flake, confirmed via repeated baseline runs)
- [x] Manual verification that tests in other categories with TS6053 at source positions (not `<unknown>:0:0`) are NOT affected — only synthetic-position entries with empty `error_codes` are filtered