### PR TITLE
lsp: bundled navtree parity — variable initializers, binding patterns, JS prototype/expando/defineProperty

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -124,22 +124,36 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
         return;
     }
     fn sort_key(sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol) -> Option<String> {
-        // Mirror tsc's `tryGetName`: anything without a normal declaration
-        // name compares as "nameless" (sorts ahead of named siblings and
-        // falls back to kind ordinal among itself). Covers computed
-        // property names (`[x]`, `["foo"]`, `[1]`), interface-type
-        // signatures (`()` call, `new()` construct, `[]` index), and
-        // constructors (tsc's `tryGetName` returns undefined for
-        // Constructor since it has no declaration name).
-        let nameless = sym.name.starts_with('[')
-            || sym.name == "()"
-            || sym.name == "new()"
-            || matches!(sym.kind, SymbolKind::Constructor);
-        if nameless {
-            None
-        } else {
-            Some(sym.name.to_lowercase())
+        // Mirror tsc's `tryGetName`: constructors and interface-type
+        // signatures are truly nameless. Computed property names
+        // where the inner expression is a simple literal (`[1]`,
+        // `["foo"]`) unwrap to the literal's value so they sort
+        // alongside identifier-named siblings — `[1]` compares as
+        // `"1"`, `["A7"]` as `"A7"`. Complex computed expressions
+        // stay nameless.
+        if sym.name == "()" || sym.name == "new()" || sym.name == "[]" {
+            return None;
         }
+        if matches!(sym.kind, SymbolKind::Constructor) {
+            return None;
+        }
+        if let Some(stripped) = sym.name.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            let inner = stripped.trim();
+            // Numeric literal: `[1]`, `[42]`, `[3.14]`.
+            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit() || c == '.') {
+                return Some(inner.to_lowercase());
+            }
+            // String literal: `["foo"]` or `['foo']`. Strip the quotes.
+            if (inner.starts_with('"') && inner.ends_with('"') && inner.len() >= 2)
+                || (inner.starts_with('\'') && inner.ends_with('\'') && inner.len() >= 2)
+            {
+                return Some(inner[1..inner.len() - 1].to_lowercase());
+            }
+            // Anything else (`[Symbol.iterator]`, `[a]`, `[1+1]`) —
+            // tsc's `tryGetName` returns undefined → nameless.
+            return None;
+        }
+        Some(sym.name.to_lowercase())
     }
     // tsc's `compareChildren` tiebreaker is `navigationBarNodeKind` — the
     // AST SyntaxKind of the underlying node. Map our higher-level

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -2065,15 +2065,20 @@ impl Server {
                     | SymbolKind::Namespace
                     | SymbolKind::File
                     | SymbolKind::Struct => true,
+                    // tsc's `isTopLevelFunctionDeclaration` allows only
+                    // SourceFile, ModuleBlock, MethodDeclaration, and
+                    // Constructor as parents. A function at the source
+                    // file level (None parent) or inside a method /
+                    // constructor body surfaces — but a function inside
+                    // a namespace body is NOT top-level here, because
+                    // tsc's parent-check sees the ModuleDeclaration
+                    // nav node (which isn't in the allowed list), not
+                    // the underlying ModuleBlock.
                     SymbolKind::Function => matches!(
                         parent_kind,
                         None // root (source file)
                             | Some(
-                                SymbolKind::File
-                                    | SymbolKind::Module
-                                    | SymbolKind::Namespace
-                                    | SymbolKind::Method
-                                    | SymbolKind::Constructor
+                                SymbolKind::File | SymbolKind::Method | SymbolKind::Constructor
                             )
                     ),
                     _ => false,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -60,6 +60,36 @@ fn symbol_kind_to_tsserver(
     }
 }
 
+/// Mirror tsc's `escapeString(s, '"')` — replace control characters
+/// and backslash/double-quote with their JS escape sequences, and
+/// encode non-printable high chars as `\uNNNN`. Used on the filename
+/// stem before wrapping it in double quotes for external-module
+/// navbar/navtree root entries, so a filename like `my fil<TAB>e`
+/// renders as `"my fil\te"` rather than embedding a literal tab.
+fn escape_string_double_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            '\x0b' => out.push_str("\\v"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            '\u{0085}' => out.push_str("\\u0085"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// Sort a navtree/navbar symbol slice in-place, recursively sorting each
 /// node's children. Mirrors TypeScript's `compareChildren`: primary key
 /// is case-insensitive name, tiebreaker is source position.
@@ -1921,7 +1951,14 @@ impl Server {
                     .and_then(|stem| stem.to_str())
                     .unwrap_or("")
                     .to_string();
-                (format!("\"{basename}\""), "module")
+                // tsc's `getItemName` wraps the filename-derived module
+                // name with `escapeString` (double-quote style) before
+                // quoting. Mirrors that so control characters render as
+                // their escape sequences (\t, \n, \\…).
+                (
+                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    "module",
+                )
             } else {
                 ("<global>".to_string(), "script")
             };
@@ -2105,7 +2142,10 @@ impl Server {
                     .and_then(|stem| stem.to_str())
                     .unwrap_or("")
                     .to_string();
-                (format!("\"{basename}\""), "module")
+                (
+                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    "module",
+                )
             } else {
                 ("<global>".to_string(), "script")
             };

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -106,9 +106,14 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
         // Mirror tsc's `tryGetName`: anything without a normal declaration
         // name compares as "nameless" (sorts ahead of named siblings and
         // falls back to kind ordinal among itself). Covers computed
-        // property names (`[x]`, `["foo"]`, `[1]`) and interface-type
-        // signatures (`()` call, `new()` construct, `[]` index).
-        let nameless = sym.name.starts_with('[') || sym.name == "()" || sym.name == "new()";
+        // property names (`[x]`, `["foo"]`, `[1]`), interface-type
+        // signatures (`()` call, `new()` construct, `[]` index), and
+        // constructors (tsc's `tryGetName` returns undefined for
+        // Constructor since it has no declaration name).
+        let nameless = sym.name.starts_with('[')
+            || sym.name == "()"
+            || sym.name == "new()"
+            || matches!(sym.kind, SymbolKind::Constructor);
         if nameless {
             None
         } else {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -56,6 +56,8 @@ fn symbol_kind_to_tsserver(
         SymbolKind::CallSignature => "call",
         SymbolKind::ConstructSignature => "construct",
         SymbolKind::IndexSignature => "index",
+        SymbolKind::SynthesizedConstructor => "constructor",
+        SymbolKind::Unknown => "",
         _ => "unknown",
     }
 }
@@ -102,6 +104,25 @@ fn escape_string_double_quote(s: &str) -> String {
 /// from the source-ordered expected output).
 fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::DocumentSymbol]) {
     use tsz::lsp::symbols::document_symbols::SymbolKind;
+    // Children of an expando-promoted class (synthesized constructor +
+    // BinaryExpression / CallExpression nav nodes from
+    // `X.prototype.y = …` / `Object.defineProperty(X, …)`) sort by
+    // source position — tsc's `compareChildren` falls through to
+    // `compareValues(node.pos, node.pos)` for expando nodes since
+    // their `tryGetName` returns undefined (or the owner's name).
+    let is_expando_container = symbols
+        .iter()
+        .any(|s| matches!(s.kind, SymbolKind::SynthesizedConstructor));
+    if is_expando_container {
+        symbols.sort_by(|a, b| {
+            (a.range.start.line, a.range.start.character)
+                .cmp(&(b.range.start.line, b.range.start.character))
+        });
+        for sym in symbols.iter_mut() {
+            sort_symbols_deep(&mut sym.children);
+        }
+        return;
+    }
     fn sort_key(sym: &tsz::lsp::symbols::document_symbols::DocumentSymbol) -> Option<String> {
         // Mirror tsc's `tryGetName`: anything without a normal declaration
         // name compares as "nameless" (sorts ahead of named siblings and
@@ -155,6 +176,13 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
             SymbolKind::CallSignature => 180,
             SymbolKind::ConstructSignature => 181,
             SymbolKind::IndexSignature => 182,
+            // Same ordinal as FunctionDeclaration: the synthetic
+            // constructor is backed by a function node, so tsc's
+            // comparer uses the FunctionDeclaration SyntaxKind.
+            SymbolKind::SynthesizedConstructor => 262,
+            // Unknown maps to BinaryExpression (227) — expando assignments
+            // like `X.y = 42` are BinaryExpression nav nodes in tsc.
+            SymbolKind::Unknown => 227,
         }
     }
     symbols.sort_by(|a, b| {

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -301,8 +301,13 @@ impl<'a> DocumentSymbolProvider<'a> {
                 }
             }
 
-            // Class Declaration
-            k if k == syntax_kind_ext::CLASS_DECLARATION => {
+            // Class Declaration / Class Expression share the same
+            // ClassData shape; tsc surfaces both as a `class` nav node
+            // with their members as children. Anonymous class
+            // expressions fall back to `<class>` as their text.
+            k if k == syntax_kind_ext::CLASS_DECLARATION
+                || k == syntax_kind_ext::CLASS_EXPRESSION =>
+            {
                 if let Some(class) = self.arena.get_class(node) {
                     let name_node = class.name;
                     let name = self
@@ -604,6 +609,13 @@ impl<'a> DocumentSymbolProvider<'a> {
             // Property Declaration (Class Member)
             k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
                 if let Some(prop) = self.arena.get_property_decl(node) {
+                    // Class properties with computed names whose inner
+                    // expression isn't a simple literal (e.g. `[1+1]`
+                    // or `[expr()]`) are dropped from navtree — tsc
+                    // leaves them out entirely.
+                    if self.is_complex_computed_name(prop.name) {
+                        return Vec::new();
+                    }
                     let name = self
                         .get_name(prop.name)
                         .unwrap_or_else(|| "<property>".to_string());
@@ -611,6 +623,11 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let selection_range =
                         node_range(self.arena, self.line_map, self.source_text, prop.name);
                     let modifiers = self.get_kind_modifiers_from_list(&prop.modifiers);
+                    // Class property initializers behave like variable
+                    // initializers for navtree purposes — `x = class {…}`
+                    // surfaces inner members, `y = function() {…}` walks
+                    // the body, `z = { a, b }` surfaces object members.
+                    let children = self.collect_initializer_children(prop.initializer, Some(&name));
 
                     vec![DocumentSymbol {
                         name,
@@ -620,7 +637,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                         range,
                         selection_range,
                         container_name: container_name.map(std::string::ToString::to_string),
-                        children: vec![],
+                        children,
                     }]
                 } else {
                     vec![]
@@ -1117,10 +1134,15 @@ impl<'a> DocumentSymbolProvider<'a> {
             return self.collect_object_literal_members(init_idx, container_name);
         }
 
-        // `class Foo {}` as an initializer — delegate to the class arm so
-        // modifiers / members render the same.
+        // `class Foo {}` as an initializer — unwrap to the class's
+        // members so `prop = class { x, y() }` emits x/y as direct
+        // children of `prop` rather than wrapping in a class entry.
         if init_node.kind == syntax_kind_ext::CLASS_EXPRESSION {
-            return self.collect_symbols(init_idx, container_name);
+            let wrapper = self.collect_symbols(init_idx, container_name);
+            if wrapper.len() == 1 {
+                return wrapper.into_iter().next().unwrap().children;
+            }
+            return wrapper;
         }
 
         // Arrow and function expressions: only surface nested
@@ -1934,6 +1956,36 @@ impl<'a> DocumentSymbolProvider<'a> {
             }
         }
         symbols
+    }
+
+    /// A class-member name is "complex-computed" when it's a
+    /// `[expr]` bracket form whose inner expression isn't a simple
+    /// identifier or literal. tsc omits these entries from the
+    /// navbar outline entirely (compare
+    /// `navigationBarPropertyDeclarations`: `[1+1]` → not surfaced).
+    fn is_complex_computed_name(&self, name_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(name_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(comp) = self.arena.get_computed_property(node) else {
+            return false;
+        };
+        let expr_idx = comp.expression;
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        // Simple identifier / literal cases are not complex.
+        matches!(
+            expr_node.kind,
+            k if !(k == SyntaxKind::Identifier as u16
+                || k == SyntaxKind::PrivateIdentifier as u16
+                || k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::NumericLiteral as u16
+                || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION)
+        )
     }
 
     /// The declaration arms use `<class>`, `<function>`, etc. as a stable

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -237,7 +237,13 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let modifiers = self.get_kind_modifiers_from_list(&func.modifiers);
 
                     // Collect nested symbols (functions/classes inside this function)
-                    let children = self.collect_children_from_block(func.body, Some(&name));
+                    let mut children = self.collect_children_from_block(func.body, Some(&name));
+                    // Also surface members of a returned object literal —
+                    // tsc treats `function F() { return { a, b } }` as if
+                    // `a` and `b` were direct children of F.
+                    if children.is_empty() {
+                        children = self.collect_returned_object_members(func.body, Some(&name));
+                    }
 
                     let mut sym = DocumentSymbol {
                         name,
@@ -1228,6 +1234,52 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
     }
 
+    /// Scan a function/method body for a RETURN_STATEMENT whose
+    /// expression is an OBJECT_LITERAL_EXPRESSION. When found, emit
+    /// that object's members as if they were direct children of the
+    /// enclosing function — this mirrors tsc's treatment of factory
+    /// functions (`function F() { return { a, b } }`).
+    fn collect_returned_object_members(
+        &self,
+        block_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        if block_idx.is_none() {
+            return Vec::new();
+        }
+        let Some(block_node) = self.arena.get(block_idx) else {
+            return Vec::new();
+        };
+        if block_node.kind != syntax_kind_ext::BLOCK {
+            return Vec::new();
+        }
+        let Some(block) = self.arena.get_block(block_node) else {
+            return Vec::new();
+        };
+        for &stmt in &block.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::RETURN_STATEMENT {
+                continue;
+            }
+            let Some(ret) = self.arena.get_return_statement(stmt_node) else {
+                continue;
+            };
+            let expr_idx = ret.expression;
+            if expr_idx.is_none() {
+                continue;
+            }
+            let Some(expr_node) = self.arena.get(expr_idx) else {
+                continue;
+            };
+            if expr_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                return self.collect_object_literal_members(expr_idx, container_name);
+            }
+        }
+        Vec::new()
+    }
+
     /// Helper to collect children from a block (e.g. inside function).
     /// Only collects nested functions/classes for the outline.
     fn collect_children_from_block(
@@ -1487,9 +1539,18 @@ impl<'a> DocumentSymbolProvider<'a> {
                         format!("#{}", id.escaped_text)
                     }
                 });
-            } else if node.kind == SyntaxKind::StringLiteral as u16
-                || node.kind == SyntaxKind::NumericLiteral as u16
-            {
+            } else if node.kind == SyntaxKind::StringLiteral as u16 {
+                // tsc's `nodeText(name)` returns the literal's source
+                // form — keep the surrounding quotes so `"prop": 1` in
+                // an object literal becomes navbar text `"prop"` (and
+                // `declare module 'x'` stays `'x'` with single quotes).
+                let start = node.pos as usize;
+                let end = node.end as usize;
+                if start <= end && end <= self.source_text.len() {
+                    return Some(self.source_text[start..end].trim().to_string());
+                }
+                return self.arena.get_literal(node).map(|l| l.text.clone());
+            } else if node.kind == SyntaxKind::NumericLiteral as u16 {
                 return self.arena.get_literal(node).map(|l| l.text.clone());
             } else if node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
                 // `["bar"]` / `[key]` on a class/interface/object member.

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -237,6 +237,11 @@ impl<'a> DocumentSymbolProvider<'a> {
                     // entry with the assigned names as its members.
                     // Match tsc's navigation-bar behavior for JS files.
                     self.apply_expando_assignments(&sf.statements.nodes, &mut symbols);
+                    // Top-level assignment `x = { … }` where `x` is a
+                    // previously-declared var — treat the RHS object
+                    // literal as `x`'s children. Handles patterns like
+                    // `var b; b = { foo: function() {} }`.
+                    self.apply_identifier_object_assignments(&sf.statements.nodes, &mut symbols);
                     // Multiple `namespace A {}` / `namespace A.B {}`
                     // declarations merge into a single nested nav
                     // entry (matches tsc's `mergeChildren`).
@@ -1400,6 +1405,65 @@ impl<'a> DocumentSymbolProvider<'a> {
         // SymbolKind::Struct }` entries. Until then this is a no-op.
     }
 
+    /// Post-process: scan top-level expression statements for
+    /// `identifier = { … }` and attach the RHS object literal's
+    /// members as children of the matching var / const entry. Skips
+    /// owners that already have children (from an initializer or an
+    /// expando promotion).
+    fn apply_identifier_object_assignments(
+        &self,
+        statements: &[NodeIndex],
+        symbols: &mut [DocumentSymbol],
+    ) {
+        for &stmt_idx in statements {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                continue;
+            }
+            let Some(exp_stmt) = self.arena.get_expression_statement(stmt_node) else {
+                continue;
+            };
+            let Some(expr_node) = self.arena.get(exp_stmt.expression) else {
+                continue;
+            };
+            if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                continue;
+            }
+            let Some(bin) = self.arena.get_binary_expr(expr_node) else {
+                continue;
+            };
+            if bin.operator_token != SyntaxKind::EqualsToken as u16 {
+                continue;
+            }
+            let Some(lhs) = self.arena.get(bin.left) else {
+                continue;
+            };
+            if lhs.kind != SyntaxKind::Identifier as u16 {
+                continue;
+            }
+            let Some(owner) = self.get_name(bin.left) else {
+                continue;
+            };
+            let Some(rhs_node) = self.arena.get(bin.right) else {
+                continue;
+            };
+            if rhs_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                continue;
+            }
+            for sym in symbols.iter_mut() {
+                if sym.name == owner
+                    && sym.children.is_empty()
+                    && matches!(sym.kind, SymbolKind::Variable | SymbolKind::Constant)
+                {
+                    sym.children = self.collect_object_literal_members(bin.right, Some(&sym.name));
+                    break;
+                }
+            }
+        }
+    }
+
     fn apply_expando_assignments(&self, statements: &[NodeIndex], symbols: &mut [DocumentSymbol]) {
         // Group expando members by owner name. `(owner → Vec<(member_name,
         // prototype?, method?, fn_body?)>)`. We also track whether any
@@ -1757,7 +1821,15 @@ impl<'a> DocumentSymbolProvider<'a> {
                 if start > end || end > self.source_text.len() {
                     return None;
                 }
-                format!("[{}]", self.source_text[start..end].trim())
+                // Parser records `end` as the position after the next
+                // consumed token, so for `f[Symbol.iterator]` the arg
+                // slice picks up the closing `]`. Trim trailing `]`
+                // before wrapping so the bracket form doesn't double up.
+                let mut inner = self.source_text[start..end].trim();
+                if inner.ends_with(']') {
+                    inner = &inner[..inner.len() - 1];
+                }
+                format!("[{}]", inner.trim_end())
             }
         };
 

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -237,6 +237,14 @@ impl<'a> DocumentSymbolProvider<'a> {
                     // entry with the assigned names as its members.
                     // Match tsc's navigation-bar behavior for JS files.
                     self.apply_expando_assignments(&sf.statements.nodes, &mut symbols);
+                    // Multiple `namespace A {}` / `namespace A.B {}`
+                    // declarations merge into a single nested nav
+                    // entry (matches tsc's `mergeChildren`).
+                    merge_same_name_modules(&mut symbols);
+                    // JS files can declare types via JSDoc
+                    // `@typedef` tags on any top-level statement.
+                    // Scan them so they surface as `type` nav entries.
+                    self.apply_jsdoc_typedefs(&sf.statements.nodes, &mut symbols);
                 }
                 symbols
             }
@@ -1359,6 +1367,17 @@ impl<'a> DocumentSymbolProvider<'a> {
     /// entry named `X`, promoting it to a class and synthesizing a
     /// `constructor` child so the navtree matches tsc's JS-mode
     /// behavior.
+    /// Walk top-level statements for `@typedef` / `@callback` JSDoc
+    /// tags and surface their names as `type` nav entries. For now
+    /// this is a stub — JSDoc AST plumbing would need to flow through
+    /// the parser to the LSP to implement properly.
+    #[allow(clippy::unused_self)]
+    fn apply_jsdoc_typedefs(&self, _statements: &[NodeIndex], _symbols: &mut [DocumentSymbol]) {
+        // TODO: when the parser exposes JSDoc nodes, walk them for
+        // `@typedef T` and append `DocumentSymbol { name: T, kind:
+        // SymbolKind::Struct }` entries. Until then this is a no-op.
+    }
+
     fn apply_expando_assignments(&self, statements: &[NodeIndex], symbols: &mut [DocumentSymbol]) {
         // Group expando members by owner name. `(owner → Vec<(member_name,
         // prototype?, method?, fn_body?)>)`. We also track whether any
@@ -2217,6 +2236,63 @@ fn clean_module_text(text: &str) -> String {
         }
     }
     out
+}
+
+/// Merge sibling Module/Namespace entries that share a name — tsc's
+/// `mergeChildren` behavior for TypeScript's declaration merging
+/// (`namespace A {} / namespace A {}` shows one entry whose children
+/// combine both declarations). Recurses so nested namespaces
+/// (`namespace A.B {} / namespace A {}`) also merge at every level.
+fn merge_same_name_modules(symbols: &mut Vec<DocumentSymbol>) {
+    // First recurse into each symbol's children so we merge deepest
+    // first (avoids seeing pre-merged children on subsequent passes).
+    for sym in symbols.iter_mut() {
+        merge_same_name_modules(&mut sym.children);
+    }
+    // Now merge at this level. Walk children left to right; for each
+    // Module entry, look ahead for another Module with the same name
+    // and fold its children in, dropping the duplicate.
+    let mut i = 0;
+    while i < symbols.len() {
+        let mergeable = is_mergeable_kind(symbols[i].kind);
+        if mergeable.is_none() {
+            i += 1;
+            continue;
+        }
+        let target_group = mergeable.unwrap();
+        let name = symbols[i].name.clone();
+        let mut j = i + 1;
+        while j < symbols.len() {
+            let same =
+                is_mergeable_kind(symbols[j].kind) == Some(target_group) && symbols[j].name == name;
+            if same {
+                let other = symbols.remove(j);
+                symbols[i].children.extend(other.children);
+            } else {
+                j += 1;
+            }
+        }
+        // After merging this slot's siblings, its children may now
+        // contain duplicates from the folded-in entries (e.g.
+        // `namespace A { interface I {} } + namespace A { interface I {} }`
+        // → merged A has two `I` children). Recurse once more to resolve.
+        merge_same_name_modules(&mut symbols[i].children);
+        i += 1;
+    }
+}
+
+/// Group mergeable nav kinds — tsc's declaration-merge rules allow
+/// same-name modules/namespaces, interfaces, and enums to fold their
+/// children together, but not mixed-kind siblings. Returns Some for
+/// mergeable groups and None otherwise (functions, variables, classes,
+/// etc., which never merge).
+const fn is_mergeable_kind(kind: SymbolKind) -> Option<u8> {
+    match kind {
+        SymbolKind::Module | SymbolKind::Namespace | SymbolKind::Package => Some(1),
+        SymbolKind::Interface => Some(2),
+        SymbolKind::Enum => Some(3),
+        _ => None,
+    }
 }
 
 /// Helper to append a modifier to a comma-separated string.

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -223,9 +223,13 @@ impl<'a> DocumentSymbolProvider<'a> {
             k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                 if let Some(func) = self.arena.get_function(node) {
                     let name_node = func.name;
+                    // tsc uses the literal `<function>` placeholder for
+                    // name-less function declarations (parser error
+                    // recovery cases like `function;`). Keep the same
+                    // placeholder so snapshot diffs stay aligned.
                     let name = self
                         .get_name(name_node)
-                        .unwrap_or_else(|| "<anonymous>".to_string());
+                        .unwrap_or_else(|| "<function>".to_string());
 
                     let range = node_range(self.arena, self.line_map, self.source_text, node_idx);
                     let selection_range = if name_node.is_some() {
@@ -400,21 +404,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                                     if let Some(decl_node) = self.arena.get(decl_idx)
                                         && let Some(decl) =
                                             self.arena.get_variable_declaration(decl_node)
-                                        && let Some(name) = self.get_name(decl.name)
                                     {
-                                        let range = node_range(
-                                            self.arena,
-                                            self.line_map,
-                                            self.source_text,
-                                            decl_idx,
-                                        );
-                                        let selection_range = node_range(
-                                            self.arena,
-                                            self.line_map,
-                                            self.source_text,
-                                            decl.name,
-                                        );
-
                                         let var_modifiers = if is_let {
                                             if stmt_modifiers.is_empty() {
                                                 "let".to_string()
@@ -424,25 +414,51 @@ impl<'a> DocumentSymbolProvider<'a> {
                                         } else {
                                             stmt_modifiers.clone()
                                         };
-                                        // Walk the initializer expression:
-                                        // object literals / class expressions
-                                        // / arrow bodies surface their members
-                                        // as children of the variable entry.
-                                        let children = self.collect_initializer_children(
-                                            decl.initializer,
-                                            Some(&name),
-                                        );
-                                        symbols.push(DocumentSymbol {
-                                            name,
-                                            detail: None,
-                                            kind,
-                                            kind_modifiers: var_modifiers,
-                                            range,
-                                            selection_range,
-                                            container_name: container_name
-                                                .map(std::string::ToString::to_string),
-                                            children,
-                                        });
+                                        if let Some(name) = self.get_name(decl.name) {
+                                            let range = node_range(
+                                                self.arena,
+                                                self.line_map,
+                                                self.source_text,
+                                                decl_idx,
+                                            );
+                                            let selection_range = node_range(
+                                                self.arena,
+                                                self.line_map,
+                                                self.source_text,
+                                                decl.name,
+                                            );
+                                            let children = self.collect_initializer_children(
+                                                decl.initializer,
+                                                Some(&name),
+                                            );
+                                            symbols.push(DocumentSymbol {
+                                                name,
+                                                detail: None,
+                                                kind,
+                                                kind_modifiers: var_modifiers,
+                                                range,
+                                                selection_range,
+                                                container_name: container_name
+                                                    .map(std::string::ToString::to_string),
+                                                children,
+                                            });
+                                        } else if let Some(name_node) = self.arena.get(decl.name)
+                                            && (name_node.kind
+                                                == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                                                || name_node.kind
+                                                    == syntax_kind_ext::ARRAY_BINDING_PATTERN)
+                                        {
+                                            // `const { a, b } = …` / `const [c, d] = …`
+                                            // — surface each bound name as its own nav
+                                            // entry matching tsc's `navigationBar`.
+                                            self.collect_binding_pattern(
+                                                decl.name,
+                                                kind,
+                                                &var_modifiers,
+                                                container_name,
+                                                &mut symbols,
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -493,6 +509,15 @@ impl<'a> DocumentSymbolProvider<'a> {
             k if k == syntax_kind_ext::ENUM_MEMBER => {
                 if let Some(member) = self.arena.get_enum_member(node) {
                     let name_node = member.name;
+                    // Reject computed property names even though
+                    // `get_name` can stringify them to `[…]` — tsc
+                    // leaves enum members with computed keys out of the
+                    // navbar entirely.
+                    if let Some(name_inner) = self.arena.get(name_node)
+                        && name_inner.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                    {
+                        return vec![];
+                    }
                     let Some(name) = self.get_name(name_node) else {
                         return vec![];
                     };
@@ -1234,6 +1259,73 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
     }
 
+    /// Recursively walk an OBJECT_BINDING_PATTERN or
+    /// ARRAY_BINDING_PATTERN and append a nav entry per bound name.
+    /// Nested patterns (`{ x: [a, b] }`) recurse so every terminal
+    /// identifier in the destructure surfaces. Uses the declaration's
+    /// inherited `kind` / `kind_modifiers` so `const [a, b] = ...`
+    /// gives two `const` leaves, etc. Function-shaped initializers on
+    /// binding elements (`{ h: i = function j() {} }`) additionally
+    /// surface the inner function name.
+    fn collect_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        kind: SymbolKind,
+        modifiers: &str,
+        container_name: Option<&str>,
+        out: &mut Vec<DocumentSymbol>,
+    ) {
+        if pattern_idx.is_none() {
+            return;
+        }
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        for &elem_idx in &pattern.elements.nodes {
+            let Some(elem_node) = self.arena.get(elem_idx) else {
+                continue;
+            };
+            if elem_node.kind != syntax_kind_ext::BINDING_ELEMENT {
+                continue;
+            }
+            let Some(elem) = self.arena.get_binding_element(elem_node) else {
+                continue;
+            };
+            let name_idx = elem.name;
+            if name_idx.is_none() {
+                continue;
+            }
+            let Some(name_node) = self.arena.get(name_idx) else {
+                continue;
+            };
+            if name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || name_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+            {
+                // Nested destructure: recurse into the inner pattern.
+                self.collect_binding_pattern(name_idx, kind, modifiers, container_name, out);
+                continue;
+            }
+            let Some(name) = self.get_name(name_idx) else {
+                continue;
+            };
+            let range = node_range(self.arena, self.line_map, self.source_text, elem_idx);
+            let selection_range = node_range(self.arena, self.line_map, self.source_text, name_idx);
+            out.push(DocumentSymbol {
+                name: name.clone(),
+                detail: None,
+                kind,
+                kind_modifiers: modifiers.to_string(),
+                range,
+                selection_range,
+                container_name: container_name.map(std::string::ToString::to_string),
+                children: vec![],
+            });
+        }
+    }
+
     /// Scan a function/method body for a RETURN_STATEMENT whose
     /// expression is an OBJECT_LITERAL_EXPRESSION. When found, emit
     /// that object's members as if they were direct children of the
@@ -1525,10 +1617,17 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
         if let Some(node) = self.arena.get(node_idx) {
             if node.kind == SyntaxKind::Identifier as u16 {
-                return self
-                    .arena
-                    .get_identifier(node)
-                    .map(|id| id.escaped_text.clone());
+                return self.arena.get_identifier(node).and_then(|id| {
+                    // An empty identifier is typically produced by
+                    // parser error recovery (e.g. `function;` gives a
+                    // name-less FUNCTION_DECLARATION). Treat as missing
+                    // so callers fall back to `<function>` / `<class>`.
+                    if id.escaped_text.is_empty() {
+                        None
+                    } else {
+                        Some(id.escaped_text.clone())
+                    }
+                });
             } else if node.kind == SyntaxKind::PrivateIdentifier as u16 {
                 // Private identifiers keep their `#` prefix in navbar
                 // output (`#foo`). The scanner's token value may or may

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -1297,11 +1297,12 @@ impl<'a> DocumentSymbolProvider<'a> {
             && let Some(block) = self.arena.get_block(node)
         {
             for &stmt in &block.statements.nodes {
-                // Collect declaration-ish statements that tsc includes in
-                // the outline for a block body: functions, classes,
-                // interfaces, enums, and type aliases. Variable
-                // declarations inside function/constructor/method bodies
-                // are deliberately omitted — tsc doesn't surface them.
+                // tsc's `addChildrenRecursively` walks every statement
+                // inside a block and treats function/class/interface/
+                // enum/type-alias/module declarations AND variable
+                // statements as nav nodes. Surfacing vars matches tests
+                // like `navigationBarItemsFunctions` which expect
+                // `function baz() { var v = 10 }` → baz has child v.
                 if let Some(stmt_node) = self.arena.get(stmt)
                     && matches!(
                         stmt_node.kind,
@@ -1311,6 +1312,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                             || k == syntax_kind_ext::ENUM_DECLARATION
                             || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
                             || k == syntax_kind_ext::MODULE_DECLARATION
+                            || k == syntax_kind_ext::VARIABLE_STATEMENT
                     )
                 {
                     symbols.extend(self.collect_symbols(stmt, container_name));

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -418,6 +418,14 @@ impl<'a> DocumentSymbolProvider<'a> {
                                         } else {
                                             stmt_modifiers.clone()
                                         };
+                                        // Walk the initializer expression:
+                                        // object literals / class expressions
+                                        // / arrow bodies surface their members
+                                        // as children of the variable entry.
+                                        let children = self.collect_initializer_children(
+                                            decl.initializer,
+                                            Some(&name),
+                                        );
                                         symbols.push(DocumentSymbol {
                                             name,
                                             detail: None,
@@ -427,7 +435,7 @@ impl<'a> DocumentSymbolProvider<'a> {
                                             selection_range,
                                             container_name: container_name
                                                 .map(std::string::ToString::to_string),
-                                            children: vec![],
+                                            children,
                                         });
                                     }
                                 }
@@ -1023,6 +1031,200 @@ impl<'a> DocumentSymbolProvider<'a> {
 
             // Default fallback
             _ => vec![],
+        }
+    }
+
+    /// Walk a variable / property initializer and produce nav-item
+    /// children for object-literal properties, class expressions, and
+    /// arrow / function expressions with a block body. Mirrors tsc's
+    /// behavior for entries like `const o = { a: function() {} }` and
+    /// `const x = () => { function inner() {} }`.
+    fn collect_initializer_children(
+        &self,
+        init_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        if init_idx.is_none() {
+            return Vec::new();
+        }
+        let Some(init_node) = self.arena.get(init_idx) else {
+            return Vec::new();
+        };
+
+        // `{ a: ..., b() {}, c }` — walk each property.
+        if init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return self.collect_object_literal_members(init_idx, container_name);
+        }
+
+        // `class Foo {}` as an initializer — delegate to the class arm so
+        // modifiers / members render the same.
+        if init_node.kind == syntax_kind_ext::CLASS_EXPRESSION {
+            return self.collect_symbols(init_idx, container_name);
+        }
+
+        // Arrow and function expressions: only surface nested
+        // declarations from their block body, matching tsc's
+        // "inner function causes the var to be a top-level function"
+        // behavior.
+        if init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            if let Some(func) = self.arena.get_function(init_node) {
+                return self.collect_children_from_block(func.body, container_name);
+            }
+        }
+
+        Vec::new()
+    }
+
+    /// Emit a child entry for each property in an OBJECT_LITERAL_EXPRESSION.
+    /// `PROPERTY_ASSIGNMENT` → property / nested object / method depending
+    /// on the initializer; `SHORTHAND_PROPERTY_ASSIGNMENT` → property;
+    /// `METHOD_DECLARATION` (`m() {}` shorthand) → method. Computed
+    /// property names retain their bracket form via `get_name`.
+    fn collect_object_literal_members(
+        &self,
+        obj_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> Vec<DocumentSymbol> {
+        let Some(obj_node) = self.arena.get(obj_idx) else {
+            return Vec::new();
+        };
+        let Some(obj) = self.arena.get_literal_expr(obj_node) else {
+            return Vec::new();
+        };
+        let mut symbols = Vec::new();
+        for &prop_idx in &obj.elements.nodes {
+            let Some(prop_node) = self.arena.get(prop_idx) else {
+                continue;
+            };
+            if prop_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                let Some(prop) = self.arena.get_property_assignment(prop_node) else {
+                    continue;
+                };
+                let Some(name) = self.get_name(prop.name) else {
+                    continue;
+                };
+                let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                let selection_range =
+                    node_range(self.arena, self.line_map, self.source_text, prop.name);
+                // Classify by initializer shape: function-like inits
+                // become methods, everything else stays a property.
+                let (kind, children) =
+                    self.classify_property_initializer(prop.initializer, Some(&name));
+                symbols.push(DocumentSymbol {
+                    name,
+                    detail: None,
+                    kind,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range,
+                    container_name: container_name.map(std::string::ToString::to_string),
+                    children,
+                });
+            } else if prop_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+                if let Some(short) = self.arena.get_shorthand_property(prop_node)
+                    && let Some(name) = self.get_name(short.name)
+                {
+                    let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                    let selection_range =
+                        node_range(self.arena, self.line_map, self.source_text, short.name);
+                    symbols.push(DocumentSymbol {
+                        name,
+                        detail: None,
+                        kind: SymbolKind::Property,
+                        kind_modifiers: String::new(),
+                        range,
+                        selection_range,
+                        container_name: container_name.map(std::string::ToString::to_string),
+                        children: vec![],
+                    });
+                }
+            } else if prop_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                // Object-literal shorthand method `m() {}` — the
+                // existing METHOD_DECLARATION arm already produces the
+                // right shape.
+                symbols.extend(self.collect_symbols(prop_idx, container_name));
+            } else if prop_node.kind == syntax_kind_ext::GET_ACCESSOR
+                || prop_node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                symbols.extend(self.collect_symbols(prop_idx, container_name));
+            } else if prop_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                // `...b` — tsc surfaces the spread expression's name as
+                // a property entry when it's an identifier. Anything
+                // more complex is skipped.
+                if let Some(spread) = self.arena.get_spread(prop_node)
+                    && let Some(name) = self.get_name(spread.expression)
+                {
+                    let range = node_range(self.arena, self.line_map, self.source_text, prop_idx);
+                    let selection_range = node_range(
+                        self.arena,
+                        self.line_map,
+                        self.source_text,
+                        spread.expression,
+                    );
+                    symbols.push(DocumentSymbol {
+                        name,
+                        detail: None,
+                        kind: SymbolKind::Property,
+                        kind_modifiers: String::new(),
+                        range,
+                        selection_range,
+                        container_name: container_name.map(std::string::ToString::to_string),
+                        children: vec![],
+                    });
+                }
+            }
+        }
+        symbols
+    }
+
+    /// Classify a PROPERTY_ASSIGNMENT's initializer for navbar display.
+    /// Function / arrow initializers are methods (optionally with a
+    /// body-walked child list); object literals become nested objects;
+    /// class expressions become class entries; everything else is a
+    /// plain property leaf.
+    fn classify_property_initializer(
+        &self,
+        init_idx: NodeIndex,
+        container_name: Option<&str>,
+    ) -> (SymbolKind, Vec<DocumentSymbol>) {
+        if init_idx.is_none() {
+            return (SymbolKind::Property, Vec::new());
+        }
+        let Some(init_node) = self.arena.get(init_idx) else {
+            return (SymbolKind::Property, Vec::new());
+        };
+        match init_node.kind {
+            k if k == syntax_kind_ext::ARROW_FUNCTION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
+            {
+                let children = self
+                    .arena
+                    .get_function(init_node)
+                    .map(|f| self.collect_children_from_block(f.body, container_name))
+                    .unwrap_or_default();
+                (SymbolKind::Method, children)
+            }
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
+                let children = self.collect_object_literal_members(init_idx, container_name);
+                (SymbolKind::Property, children)
+            }
+            k if k == syntax_kind_ext::CLASS_EXPRESSION => {
+                let children = self.collect_symbols(init_idx, container_name);
+                // The CLASS_EXPRESSION arm returns a class entry; when
+                // used as a property initializer, we usually want to
+                // inline its members. But tsc keeps the wrapper — mirror
+                // that by taking the class entry's children as the
+                // property's children and treating the property as
+                // a class-shaped entry.
+                if children.len() == 1 {
+                    let class_entry = &children[0];
+                    return (SymbolKind::Class, class_entry.children.clone());
+                }
+                (SymbolKind::Property, children)
+            }
+            _ => (SymbolKind::Property, Vec::new()),
         }
     }
 

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -61,6 +61,19 @@ pub enum SymbolKind {
     CallSignature = 30,
     ConstructSignature = 31,
     IndexSignature = 32,
+    // A function declaration that was promoted to a class through
+    // expando / prototype assignments. Its nav entry is labeled
+    // `constructor` but the underlying node is still a
+    // FunctionDeclaration — tsc sorts it by that kind rather than
+    // treating it as nameless the way a real Constructor member is.
+    SynthesizedConstructor = 33,
+    // Unknown kind — rendered as an empty ScriptElementKind string.
+    // tsc returns `ScriptElementKind.unknown ("")` for some nav
+    // entries (expando property assignments where the RHS isn't a
+    // function, certain JS patterns). Keep the name field populated
+    // and let the navbar/navtree serializer omit the kind field when
+    // it's falsy, matching the fourslash harness JSON compare.
+    Unknown = 34,
 }
 
 impl SymbolKind {
@@ -87,6 +100,8 @@ impl SymbolKind {
             Self::CallSignature => "call",
             Self::ConstructSignature => "construct",
             Self::IndexSignature => "index",
+            Self::SynthesizedConstructor => "constructor",
+            Self::Unknown => "",
         }
     }
 }
@@ -215,6 +230,13 @@ impl<'a> DocumentSymbolProvider<'a> {
                     for &stmt in &sf.statements.nodes {
                         symbols.extend(self.collect_symbols(stmt, container_name));
                     }
+                    // JS expando / prototype assignments: patterns like
+                    // `A.prototype.x = fn`, `A.y = fn`, and
+                    // `Object.defineProperty(A, 'p', …)` turn a plain
+                    // function / var declaration into a class-shaped
+                    // entry with the assigned names as its members.
+                    // Match tsc's navigation-bar behavior for JS files.
+                    self.apply_expando_assignments(&sf.statements.nodes, &mut symbols);
                 }
                 symbols
             }
@@ -1331,6 +1353,487 @@ impl<'a> DocumentSymbolProvider<'a> {
     /// that object's members as if they were direct children of the
     /// enclosing function — this mirrors tsc's treatment of factory
     /// functions (`function F() { return { a, b } }`).
+    /// Scan top-level expression statements for JS "expando" patterns
+    /// (`X.prototype.Y = fn`, `X.Y = fn`) and `Object.defineProperty(X,
+    /// 'Y', …)` calls. Each assignment attaches a member to the nav
+    /// entry named `X`, promoting it to a class and synthesizing a
+    /// `constructor` child so the navtree matches tsc's JS-mode
+    /// behavior.
+    fn apply_expando_assignments(&self, statements: &[NodeIndex], symbols: &mut [DocumentSymbol]) {
+        // Group expando members by owner name. `(owner → Vec<(member_name,
+        // prototype?, method?, fn_body?)>)`. We also track whether any
+        // assignment for that owner came through `.prototype` — that
+        // drives whether a synthetic constructor is injected.
+        // Kind override for a prototype-object method shorthand. tsc
+        // uses ScriptElementKind.method for `X.prototype = { m() {} }`
+        // and ScriptElementKind.function for `X.prototype.m = function(){}`.
+        #[derive(Clone, Copy, Debug)]
+        enum MemberKindHint {
+            None,
+            Method,
+        }
+        #[derive(Default)]
+        struct Expando {
+            // (name, is_function_like, body_block_idx for children,
+            // statement index for source-position sort,
+            // descriptor_idx for `Object.defineProperty` cases so the
+            // descriptor's `get`/`set` properties surface as children,
+            // member_via_prototype — whether *this specific* member
+            // was assigned through `.prototype.y` so we distinguish
+            // `X.prototype.y = 0` (kind: property) from `X.y = 0`
+            // (kind: "" unknown),
+            // kind_hint — `Method` when the member came from an
+            // object-literal shorthand method (`{ m() {} }` in
+            // `X.prototype = {…}`), so it renders as `method` instead
+            // of `function`.)
+            members: Vec<(
+                String,
+                bool,
+                NodeIndex,
+                NodeIndex,
+                NodeIndex,
+                bool,
+                MemberKindHint,
+            )>,
+            via_prototype: bool,
+        }
+        let mut groups: std::collections::BTreeMap<String, Expando> =
+            std::collections::BTreeMap::new();
+
+        for &stmt_idx in statements {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                continue;
+            }
+            let Some(exp_stmt) = self.arena.get_expression_statement(stmt_node) else {
+                continue;
+            };
+            let expr_idx = exp_stmt.expression;
+            let Some(expr_node) = self.arena.get(expr_idx) else {
+                continue;
+            };
+            if expr_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+                let Some(bin) = self.arena.get_binary_expr(expr_node) else {
+                    continue;
+                };
+                if bin.operator_token != SyntaxKind::EqualsToken as u16 {
+                    continue;
+                }
+                // Special case: `X.prototype = { a, b() {}, … }` — treat
+                // each property of the RHS object literal as a prototype
+                // member (same as `X.prototype.a = …` for each).
+                if let Some(owner) = self.parse_prototype_assignment(bin.left) {
+                    let rhs = self.arena.get(bin.right);
+                    if let Some(rhs_node) = rhs
+                        && rhs_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                        && let Some(obj) = self.arena.get_literal_expr(rhs_node)
+                    {
+                        let entry = groups.entry(owner.clone()).or_default();
+                        entry.via_prototype = true;
+                        for &prop_idx in &obj.elements.nodes {
+                            let Some(prop_node) = self.arena.get(prop_idx) else {
+                                continue;
+                            };
+                            let (name_idx, init_idx, is_shorthand_method) = match prop_node.kind {
+                                k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                                    let Some(prop) = self.arena.get_property_assignment(prop_node)
+                                    else {
+                                        continue;
+                                    };
+                                    (prop.name, prop.initializer, false)
+                                }
+                                k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                                    let Some(m) = self.arena.get_method_decl(prop_node) else {
+                                        continue;
+                                    };
+                                    (m.name, NodeIndex::NONE, true)
+                                }
+                                k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                                    let Some(s) = self.arena.get_shorthand_property(prop_node)
+                                    else {
+                                        continue;
+                                    };
+                                    (s.name, NodeIndex::NONE, false)
+                                }
+                                _ => continue,
+                            };
+                            let Some(member_name) = self.get_name(name_idx) else {
+                                continue;
+                            };
+                            let is_fn =
+                                is_shorthand_method || self.is_function_like_expression(init_idx);
+                            let body = if is_fn {
+                                if is_shorthand_method {
+                                    self.arena
+                                        .get_method_decl_at(prop_idx)
+                                        .map_or(NodeIndex::NONE, |m| m.body)
+                                } else {
+                                    self.arena
+                                        .get(init_idx)
+                                        .and_then(|n| self.arena.get_function(n))
+                                        .map_or(NodeIndex::NONE, |f| f.body)
+                                }
+                            } else {
+                                NodeIndex::NONE
+                            };
+                            let hint = if is_shorthand_method {
+                                MemberKindHint::Method
+                            } else {
+                                MemberKindHint::None
+                            };
+                            entry.members.push((
+                                member_name,
+                                is_fn,
+                                body,
+                                stmt_idx,
+                                NodeIndex::NONE,
+                                true,
+                                hint,
+                            ));
+                        }
+                        continue;
+                    }
+                }
+                if let Some((owner, name, via_prototype)) = self.parse_expando_lhs(bin.left) {
+                    let is_fn = self.is_function_like_expression(bin.right);
+                    let body = if is_fn {
+                        self.arena
+                            .get(bin.right)
+                            .and_then(|n| self.arena.get_function(n))
+                            .map_or(NodeIndex::NONE, |f| f.body)
+                    } else {
+                        NodeIndex::NONE
+                    };
+                    let entry = groups.entry(owner).or_default();
+                    entry.members.push((
+                        name,
+                        is_fn,
+                        body,
+                        stmt_idx,
+                        NodeIndex::NONE,
+                        via_prototype,
+                        MemberKindHint::None,
+                    ));
+                    if via_prototype {
+                        entry.via_prototype = true;
+                    }
+                }
+            } else if expr_node.kind == syntax_kind_ext::CALL_EXPRESSION {
+                // `Object.defineProperty(X, 'y', descriptor)` /
+                // `Object.defineProperty(X.prototype, 'y', descriptor)` —
+                // descriptor's own property members (e.g. `get`/`set`)
+                // surface as the navbar entry's children. is_fn=false
+                // gives it `Unknown` kind so tsc's omit-empty-kind
+                // behavior kicks in.
+                if let Some((owner, name, via_prototype, descriptor)) =
+                    self.parse_define_property(expr_idx)
+                {
+                    let entry = groups.entry(owner).or_default();
+                    entry.members.push((
+                        name,
+                        false,
+                        NodeIndex::NONE,
+                        stmt_idx,
+                        descriptor,
+                        via_prototype,
+                        MemberKindHint::None,
+                    ));
+                    if via_prototype {
+                        entry.via_prototype = true;
+                    }
+                }
+            }
+        }
+
+        if groups.is_empty() {
+            return;
+        }
+
+        for sym in symbols.iter_mut() {
+            let Some(expando) = groups.get(&sym.name) else {
+                continue;
+            };
+            // Only promote var / function entries — actual `class X {}`
+            // declarations keep their own structure.
+            let promote = matches!(
+                sym.kind,
+                SymbolKind::Function | SymbolKind::Variable | SymbolKind::Constant
+            );
+            if !promote {
+                continue;
+            }
+            let was_function = matches!(sym.kind, SymbolKind::Function);
+            sym.kind = SymbolKind::Class;
+            // Add synthetic constructor when the underlying declaration
+            // was a function (callable as `new X()`) or we've seen a
+            // `.prototype.*` write against a var. Mirrors tsc's
+            // promoted-class output which always shows a constructor.
+            let has_ctor = sym.children.iter().any(|c| c.name == "constructor");
+            if (was_function || expando.via_prototype) && !has_ctor {
+                sym.children.insert(
+                    0,
+                    DocumentSymbol {
+                        name: "constructor".to_string(),
+                        detail: None,
+                        // Always use SynthesizedConstructor for expando-
+                        // promoted classes. The presence of this kind
+                        // is the signal `sort_symbols_deep` uses to
+                        // switch its sort to source-position order for
+                        // this container's children (matches tsc's
+                        // behavior for expando nav nodes that tryGetName
+                        // can't name).
+                        kind: SymbolKind::SynthesizedConstructor,
+                        kind_modifiers: String::new(),
+                        range: sym.range,
+                        selection_range: sym.selection_range,
+                        container_name: sym.container_name.clone(),
+                        children: vec![],
+                    },
+                );
+            }
+            for (name, is_fn, body, stmt_idx, descriptor, member_via_proto, kind_hint) in
+                &expando.members
+            {
+                let children = if !body.is_none() {
+                    self.collect_children_from_block(*body, Some(&sym.name))
+                } else if !descriptor.is_none() {
+                    // defineProperty descriptor — walk its literal
+                    // members so `get` / `set` show up as methods.
+                    self.collect_object_literal_members(*descriptor, Some(&sym.name))
+                } else {
+                    Vec::new()
+                };
+                let kind = match kind_hint {
+                    MemberKindHint::Method => SymbolKind::Method,
+                    MemberKindHint::None => {
+                        if *is_fn {
+                            SymbolKind::Function
+                        } else if !descriptor.is_none() {
+                            // `Object.defineProperty(X, 'y', …)` has no
+                            // inferable kind at tsc — the entry renders
+                            // with no kind field.
+                            SymbolKind::Unknown
+                        } else if *member_via_proto {
+                            // `X.prototype.y = 0` is treated as a
+                            // prototype property assignment →
+                            // ScriptElementKind.property.
+                            SymbolKind::Property
+                        } else {
+                            // `X.y = 0` (static, non-function) — tsc
+                            // omits the kind field entirely.
+                            SymbolKind::Unknown
+                        }
+                    }
+                };
+                // Use the original statement's range so the
+                // expando-child sort (by source position) orders these
+                // relative to the synthesized constructor in the same
+                // order they appear in source.
+                let range = node_range(self.arena, self.line_map, self.source_text, *stmt_idx);
+                sym.children.push(DocumentSymbol {
+                    name: name.clone(),
+                    detail: None,
+                    kind,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range: range,
+                    container_name: Some(sym.name.clone()),
+                    children,
+                });
+            }
+        }
+    }
+
+    /// Parse the LHS of an assignment as an expando access chain:
+    ///   `X.Y` → (X, Y, false)
+    ///   `X.prototype.Y` → (X, Y, true)
+    ///   `X[Symbol.something]` → (X, "[Symbol.something]", false)
+    /// Returns `None` if the shape isn't a simple dotted/bracketed
+    /// access rooted at an identifier.
+    /// Match the LHS of an assignment as `X.prototype` (or
+    /// `X["prototype"]`). Returns `X`'s name on success. This is the
+    /// whole-object prototype form (`X.prototype = {...}`), not the
+    /// per-member form handled by `parse_expando_lhs`.
+    fn parse_prototype_assignment(&self, lhs: NodeIndex) -> Option<String> {
+        let node = self.arena.get(lhs)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return None;
+        }
+        let access = self.arena.get_access_expr(node)?;
+        let member = if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            self.get_name(access.name_or_argument)?
+        } else {
+            let arg = self.arena.get(access.name_or_argument)?;
+            if arg.kind != SyntaxKind::StringLiteral as u16 {
+                return None;
+            }
+            self.arena.get_literal(arg)?.text.clone()
+        };
+        if member != "prototype" {
+            return None;
+        }
+        let root = self.arena.get(access.expression)?;
+        if root.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        self.get_name(access.expression)
+    }
+
+    fn parse_expando_lhs(&self, lhs: NodeIndex) -> Option<(String, String, bool)> {
+        let node = self.arena.get(lhs)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return None;
+        }
+        let access = self.arena.get_access_expr(node)?;
+        // The rhs (name_or_argument) can be a name (property access) or
+        // an expression (element access). Stringify with get_name so
+        // computed accesses like `f[Symbol.iterator]` surface a
+        // `[Symbol.iterator]` text just like computed property names do.
+        let member_name = if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            self.get_name(access.name_or_argument)?
+        } else {
+            // Element access: for string-literal keys (`X["a"]`) keep
+            // the quoted source form (tsc's navbar uses the literal
+            // text with quotes). For computed accesses (e.g.
+            // `f[Symbol.iterator]`) emit the `[expr]` bracket form.
+            let arg = self.arena.get(access.name_or_argument)?;
+            if arg.kind == SyntaxKind::StringLiteral as u16 {
+                let start = arg.pos as usize;
+                let end = arg.end as usize;
+                if start > end || end > self.source_text.len() {
+                    return None;
+                }
+                self.source_text[start..end].trim().to_string()
+            } else {
+                let start = arg.pos as usize;
+                let end = arg.end as usize;
+                if start > end || end > self.source_text.len() {
+                    return None;
+                }
+                format!("[{}]", self.source_text[start..end].trim())
+            }
+        };
+
+        // Inner expression: `X` (identifier), `X.prototype`, or
+        // `X["prototype"]`.
+        let inner = access.expression;
+        let inner_node = self.arena.get(inner)?;
+        if inner_node.kind == SyntaxKind::Identifier as u16 {
+            let owner = self.get_name(inner)?;
+            return Some((owner, member_name, false));
+        }
+        if inner_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || inner_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            let inner_access = self.arena.get_access_expr(inner_node)?;
+            // Inner member must be the string "prototype" — either the
+            // identifier `prototype` or a `["prototype"]` literal.
+            let proto = if inner_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                self.get_name(inner_access.name_or_argument)?
+            } else {
+                let arg = self.arena.get(inner_access.name_or_argument)?;
+                if arg.kind != SyntaxKind::StringLiteral as u16 {
+                    return None;
+                }
+                self.arena.get_literal(arg)?.text.clone()
+            };
+            if proto != "prototype" {
+                return None;
+            }
+            let root = self.arena.get(inner_access.expression)?;
+            if root.kind != SyntaxKind::Identifier as u16 {
+                return None;
+            }
+            let owner = self.get_name(inner_access.expression)?;
+            return Some((owner, member_name, true));
+        }
+        None
+    }
+
+    /// Detect `Object.defineProperty(X, 'y', descriptor)` — returns
+    /// `(X_name, y_name, via_prototype, descriptor_idx)`. Returns None
+    /// for any non-matching call shape.
+    fn parse_define_property(
+        &self,
+        call_idx: NodeIndex,
+    ) -> Option<(String, String, bool, NodeIndex)> {
+        let call_node = self.arena.get(call_idx)?;
+        if call_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(call_node)?;
+        // Callee must be `Object.defineProperty`.
+        let callee = self.arena.get(call.expression)?;
+        if callee.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let callee_access = self.arena.get_access_expr(callee)?;
+        let callee_name = self.get_name(callee_access.name_or_argument)?;
+        if callee_name != "defineProperty" {
+            return None;
+        }
+        let root = self.arena.get(callee_access.expression)?;
+        if root.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let root_name = self.get_name(callee_access.expression)?;
+        if root_name != "Object" {
+            return None;
+        }
+        // Need at least two args: target, name-literal.
+        let args = call.arguments.as_ref()?;
+        if args.nodes.len() < 2 {
+            return None;
+        }
+        let target_idx = args.nodes[0];
+        let name_idx = args.nodes[1];
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind != SyntaxKind::StringLiteral as u16 {
+            return None;
+        }
+        let member = self.arena.get_literal(name_node)?.text.clone();
+        let descriptor = args.nodes.get(2).copied().unwrap_or(NodeIndex::NONE);
+        // Target: either `X` (identifier) or `X.prototype`.
+        let target = self.arena.get(target_idx)?;
+        if target.kind == SyntaxKind::Identifier as u16 {
+            let owner = self.get_name(target_idx)?;
+            return Some((owner, member, false, descriptor));
+        }
+        if target.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(target)?;
+            let proto_name = self.get_name(access.name_or_argument)?;
+            if proto_name != "prototype" {
+                return None;
+            }
+            let root = self.arena.get(access.expression)?;
+            if root.kind != SyntaxKind::Identifier as u16 {
+                return None;
+            }
+            let owner = self.get_name(access.expression)?;
+            return Some((owner, member, true, descriptor));
+        }
+        None
+    }
+
+    /// Check whether an expression is a function-like value
+    /// (`function () {}`, `function name() {}`, or `(a) => {}`).
+    fn is_function_like_expression(&self, expr: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(expr) else {
+            return false;
+        };
+        matches!(
+            node.kind,
+            k if k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION
+        )
+    }
+
     fn collect_returned_object_members(
         &self,
         block_idx: NodeIndex,


### PR DESCRIPTION
## Summary

Meaty pure-Rust navtree/navbar parity bundle. Rust-only fourslash navbar suite: **29/68 → 52/68** (+23 tests, 42% → 76%). Native-TS path unchanged at 68/68 throughout. Full Rust-only fourslash: **99.44%** (6525/6562).

Consolidates all the previously-unmerged navtree work into one PR per your feedback on PR size.

### Changes (stacked commits)

1. **Walk variable initializers + object-literal members** — `const o = { a, b: {…}, c() {} }` surfaces a/b/c; classifier picks method / nested object / class / plain property; spread `…x` surfaces identifier; arrow/function expression initializers walk their body.
2. **Factory-function return bodies + string-literal names** — `function F() { return { a, b } }` surfaces a/b; `"prop": value` renders with quotes preserved.
3. **Filename escape + vars in block bodies** — external-module filename runs through tsc's `escapeString`; `collect_children_from_block` surfaces VARIABLE_STATEMENT.
4. **Binding patterns + placeholder normalization** — `const {a, b} = …`, nested destructures; empty-identifier fallback to `<function>`.
5. **Constructor-first sort ordering** — constructors sort as nameless.
6. **JS prototype / expando / defineProperty** — walk top-level expression statements for `X.prototype.y = fn`, `X.y = fn`, `X.prototype = { m() {} }`, `Object.defineProperty(X, 'y', {get, set})`, and `X["y"]` element-access variants. New `SymbolKind::SynthesizedConstructor` and `SymbolKind::Unknown` (renders as `""` to get omitted from JSON).
7. **Namespace declaration merging** — same-name modules/interfaces/enums fold children together, matching tsc's `mergeChildren`. Also tightens `should_appear_in_primary_navbar` for functions so a function inside a namespace stays collapsed under its namespace entry.
8. **Class property initializers + sort-by-literal-value + complex-computed skip** — `prop = class { … }` unwraps to property's children; `[1]` / `["A7"]` sort by their literal value; `[1+1]` and other complex computed names are skipped entirely.
9. **Element access `[Symbol.x]` fix + indirect-assignment members** — trim trailing `]` on computed-access names; `var b; b = { foo… }` attaches the object literal to `b`'s children.

### Test plan

- [x] `cargo nextest run -p tsz-lsp` — 3759/3759
- [x] `TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navigationBar` — 52/68 (up from 29)
- [x] Full Rust-only fourslash: 6525/6562 (99.44%)
- [x] Native-TS full navbar: 68/68 (unchanged)
- [x] Native-TS full fourslash: 6562/6562 (unchanged)