### PR TITLE
fix(checker): reset TS7027 'already reported' marker after hoisted declarations

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -731,6 +731,13 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 crate::diagnostics::diagnostic_codes::UNREACHABLE_CODE_DETECTED,
             );
             self.ctx.has_reported_unreachable = true;
+        } else if should_skip {
+            // tsc resets the "already reported" marker after a statement that
+            // doesn't affect runtime control flow (function declaration, etc.).
+            // This lets a subsequent unreachable statement emit a fresh TS7027,
+            // matching tsc's one-per-unreachable-group behavior where hoisted
+            // declarations separate groups. See `unreachableJavascriptChecked`.
+            self.ctx.has_reported_unreachable = false;
         }
     }
 


### PR DESCRIPTION
## Summary
\`report_unreachable_statement\` emits TS7027 at the first unreachable statement in a block, then suppresses further emissions by setting \`has_reported_unreachable = true\`. That matches tsc for a contiguous sequence of unreachable runtime statements, but tsc also emits a FRESH TS7027 after a hoisted declaration separates one unreachable group from another.

Repro (\`unreachableJavascriptChecked.ts\`):
\`\`\`js
function unreachable() {
    return f();
    return 2;           // tsc: TS7027 (we already match)
    return 3;           //      (suppressed — same group)
    function f() {}     //      hoisted — doesn't produce runtime code
    return 4;           // tsc: TS7027 — we previously missed this
}
\`\`\`

Clear \`has_reported_unreachable\` when we encounter a \`should_skip\` statement (function declaration, interface/type alias, empty block, const enum without preserveConstEnums, ambient module, or var-without-initializer). The next non-skipped unreachable statement then emits a fresh TS7027.

## Impact
- \`unreachableJavascriptChecked.ts\` flips PASS.
- No regressions other than \`jsxRuntimePragma.ts\` which is a pre-existing flake (confirmed 2/5 fails at baseline independently).

## Test plan
- [x] \`./scripts/conformance/conformance.sh run --filter unreachableJavascriptChecked\` — passes
- [x] \`./scripts/conformance/conformance.sh run --filter unreach\` — 5/6 (one unrelated pre-existing fail)
- [x] Full suite diff: \`unreachableJavascriptChecked\` removed from fail list, no new regressions.