### PR TITLE
Fix export= named-import resolution for namespace/alias targets

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -546,12 +546,8 @@ impl BinderState {
                         }
                         syntax_kind_ext::EXPORT_ASSIGNMENT => {
                             if let Some(assign) = arena.get_export_assignment(stmt_node)
-                                && let Some(target_name) =
-                                    Self::get_identifier_name(arena, assign.expression)
                                 && let Some(sym_id) = self
-                                    .current_scope
-                                    .get(target_name)
-                                    .or_else(|| self.file_locals.get(target_name))
+                                    .resolve_export_assignment_target_symbol(arena, assign.expression)
                             {
                                 if assign.is_export_equals {
                                     exported_symbols.push(("export=".to_string(), sym_id));
@@ -584,12 +580,10 @@ impl BinderState {
                                             if let Some(module_ref_node) = arena.get(module_ref)
                                                 && module_ref_node.kind
                                                     != SyntaxKind::StringLiteral as u16
-                                                && let Some(ref_name) =
-                                                    Self::get_identifier_name(arena, module_ref)
                                                 && let Some(resolved) = self
-                                                    .current_scope
-                                                    .get(ref_name)
-                                                    .or_else(|| self.file_locals.get(ref_name))
+                                                    .resolve_export_assignment_target_symbol(
+                                                        arena, module_ref,
+                                                    )
                                             {
                                                 target_sym_id = resolved;
                                             }

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -763,12 +763,10 @@ impl BinderState {
                     // For example: export = Utils; makes all Utils exports available
                     self.bind_node(arena, assign.expression);
 
-                    // If the expression is an identifier, resolve it and copy its exports
-                    if let Some(name) = Self::get_identifier_name(arena, assign.expression)
-                        && let Some(sym_id) = self
-                            .current_scope
-                            .get(name)
-                            .or_else(|| self.file_locals.get(name))
+                    // Resolve the `export =` target (identifier or qualified name)
+                    // and copy its exports to the current module.
+                    if let Some(sym_id) =
+                        self.resolve_export_assignment_target_symbol(arena, assign.expression)
                     {
                         // Track the explicit `export =` target so require-import resolution
                         // can recover the assigned symbol directly.
@@ -1201,6 +1199,72 @@ impl BinderState {
                 // For other node types, no symbols to create
             }
         }
+    }
+
+    pub(crate) fn resolve_export_assignment_target_symbol(
+        &self,
+        arena: &NodeArena,
+        expression: NodeIndex,
+    ) -> Option<crate::SymbolId> {
+        fn collect_qualified_parts(
+            arena: &NodeArena,
+            node_idx: NodeIndex,
+            out: &mut Vec<String>,
+        ) -> bool {
+            let Some(node) = arena.get(node_idx) else {
+                return false;
+            };
+            if let Some(ident) = arena.get_identifier(node) {
+                out.push(ident.escaped_text.to_string());
+                return true;
+            }
+            if node.kind == syntax_kind_ext::QUALIFIED_NAME
+                && let Some(qualified) = arena.get_qualified_name(node)
+            {
+                return collect_qualified_parts(arena, qualified.left, out)
+                    && collect_qualified_parts(arena, qualified.right, out);
+            }
+            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                && let Some(access) = arena.get_access_expr(node)
+            {
+                return collect_qualified_parts(arena, access.expression, out)
+                    && collect_qualified_parts(arena, access.name_or_argument, out);
+            }
+            false
+        }
+
+        if let Some(name) = Self::get_identifier_name(arena, expression) {
+            return self
+                .current_scope
+                .get(name)
+                .or_else(|| self.file_locals.get(name));
+        }
+
+        let mut parts = Vec::new();
+        if !collect_qualified_parts(arena, expression, &mut parts) || parts.is_empty() {
+            return None;
+        }
+
+        let mut current_sym_id = self
+            .current_scope
+            .get(parts[0].as_str())
+            .or_else(|| self.file_locals.get(parts[0].as_str()))?;
+
+        for part in parts.iter().skip(1) {
+            let symbol = self.symbols.get(current_sym_id)?;
+            current_sym_id = symbol
+                .exports
+                .as_ref()
+                .and_then(|exports| exports.get(part))
+                .or_else(|| {
+                    symbol
+                        .members
+                        .as_ref()
+                        .and_then(|members| members.get(part))
+                })?;
+        }
+
+        Some(current_sym_id)
     }
 
     /// Check if a node is exported.

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -550,6 +550,59 @@ export = Point;
 }
 
 #[test]
+fn export_equals_qualified_namespace_target_populates_cached_members() {
+    let source = r#"
+declare module "nestNamespaceModule" {
+    namespace a1.a2 {
+        class d {}
+    }
+    namespace a1.a2.n3 {
+        class c {}
+    }
+    export = a1.a2;
+}
+"#;
+    let mut parser = ParserState::new("ambient.d.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let exports = binder
+        .module_exports
+        .get("nestNamespaceModule")
+        .expect("expected cached module exports for ambient module");
+    assert!(exports.has("export="), "expected export= entry");
+    assert!(exports.has("d"), "expected export= target member d");
+    assert!(exports.has("n3"), "expected export= target member n3");
+}
+
+#[test]
+fn export_equals_import_equals_qualified_target_populates_cached_members() {
+    let source = r#"
+declare module "renameModule" {
+    namespace a.b {
+        class c {}
+    }
+    import d = a.b;
+    export = d;
+}
+"#;
+    let mut parser = ParserState::new("ambient2.d.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let exports = binder
+        .module_exports
+        .get("renameModule")
+        .expect("expected cached module exports for ambient module");
+    assert!(exports.has("export="), "expected export= entry");
+    assert!(exports.has("c"), "expected export= target member c");
+}
+
+#[test]
 fn iife_no_flow_start_node() {
     // For a non-async, non-generator IIFE, the binder should NOT create a
     // FlowStart node for the function body. This means the IIFE body runs

--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -508,25 +508,28 @@ impl<'a> CheckerState<'a> {
         // For `export = alias` where `alias` comes from `import alias = Namespace`,
         // resolve the namespace target explicitly so named imports can see members.
         if (target_symbol.flags & symbol_flags::ALIAS) != 0 {
-            let decl_idx = if target_symbol.value_declaration.is_some() {
-                target_symbol.value_declaration
-            } else if let Some(&first_decl) = target_symbol.declarations.first() {
-                first_decl
-            } else {
-                NodeIndex::NONE
-            };
-
-            if decl_idx.is_some()
-                && let Some(decl_node) = self.ctx.arena.get(decl_idx)
-                && decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                && let Some(import_decl) = self.ctx.arena.get_import_decl(decl_node)
+            let mut decl_candidates = target_symbol.declarations.clone();
+            if target_symbol.value_declaration.is_some()
+                && !decl_candidates.contains(&target_symbol.value_declaration)
             {
-                let module_ref = import_decl.module_specifier;
-                if let Some(module_ref_node) = self.ctx.arena.get(module_ref)
-                    && module_ref_node.kind != SyntaxKind::StringLiteral as u16
-                    && let Some(target_id) = self.resolve_qualified_symbol(module_ref)
+                decl_candidates.push(target_symbol.value_declaration);
+            }
+
+            for decl_idx in decl_candidates {
+                if !decl_idx.is_some() {
+                    continue;
+                }
+                if let Some(decl_node) = self.ctx.arena.get(decl_idx)
+                    && decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                    && let Some(import_decl) = self.ctx.arena.get_import_decl(decl_node)
                 {
-                    candidate_symbol_ids.push(target_id);
+                    let module_ref = import_decl.module_specifier;
+                    if let Some(module_ref_node) = self.ctx.arena.get(module_ref)
+                        && module_ref_node.kind != SyntaxKind::StringLiteral as u16
+                        && let Some(target_id) = self.resolve_qualified_symbol(module_ref)
+                    {
+                        candidate_symbol_ids.push(target_id);
+                    }
                 }
             }
         }
@@ -578,7 +581,6 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
-
         false
     }
 

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -380,6 +380,16 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
 
+                    // Some ambient/module-resolution paths don't materialize a direct
+                    // exports table, but named imports can still be satisfied via
+                    // members of an `export =` target (e.g. `export = a.b`).
+                    if self
+                        .resolve_named_export_via_export_equals(module_name, import_name)
+                        .is_some()
+                    {
+                        continue;
+                    }
+
                     if let Some(renamed_as) = self.local_named_export_alias_for_module(
                         module_name,
                         import_name,

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -2485,7 +2485,7 @@ mod tests {
     use crate::module_resolution::build_module_resolution_maps;
     use crate::query_boundaries::common::TypeInterner;
     use std::sync::Arc;
-    use tsz_binder::BinderState;
+    use tsz_binder::{BinderState, symbol_flags};
     use tsz_parser::parser::ParserState;
 
     // TODO: module augmentation should take precedence over named reexport,
@@ -2591,5 +2591,109 @@ export interface Row2 { b: string }
             Some(index_dts_idx),
             "Row2 currently resolves through the re-export chain (index.d.ts), not the augmentation"
         );
+    }
+
+    #[test]
+    fn resolve_named_export_via_export_equals_handles_qualified_and_alias_targets() {
+        let source = r#"
+declare module "events" {
+    namespace EventEmitter {
+        class EventEmitter {
+            constructor();
+        }
+    }
+    export = EventEmitter;
+}
+
+declare module "nestNamespaceModule" {
+    namespace a1.a2 {
+        class d { }
+    }
+    namespace a1.a2.n3 {
+        class c { }
+    }
+    export = a1.a2;
+}
+
+declare module "renameModule" {
+    namespace a.b {
+        class c { }
+    }
+    import d = a.b;
+    export = d;
+}
+"#;
+
+        let mut parser = ParserState::new("/ambient.d.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+
+        let arena = Arc::new(parser.get_arena().clone());
+        let binder = Arc::new(binder);
+        let all_arenas = Arc::new(vec![Arc::clone(&arena)]);
+        let all_binders = Arc::new(vec![Arc::clone(&binder)]);
+
+        let types = TypeInterner::new();
+        let mut checker = CheckerState::new(
+            arena.as_ref(),
+            binder.as_ref(),
+            &types,
+            "/ambient.d.ts".to_string(),
+            CheckerOptions {
+                target: ScriptTarget::ES2015,
+                ..Default::default()
+            },
+        );
+        checker.ctx.set_all_arenas(all_arenas);
+        checker.ctx.set_all_binders(all_binders);
+        checker.ctx.set_current_file_idx(0);
+
+        let n3_sym = checker
+            .resolve_named_export_via_export_equals("nestNamespaceModule", "n3")
+            .expect("expected n3 to resolve via export= a1.a2");
+        let d_sym = checker
+            .resolve_named_export_via_export_equals("nestNamespaceModule", "d")
+            .expect("expected d to resolve via export= a1.a2");
+        let c_sym = checker
+            .resolve_named_export_via_export_equals("renameModule", "c")
+            .expect("expected c to resolve via export= d (import equals alias)");
+        let ee_sym = checker
+            .resolve_named_export_via_export_equals("events", "EventEmitter")
+            .expect("expected EventEmitter to resolve via export= namespace");
+
+        let n3_symbol = checker
+            .ctx
+            .binder
+            .get_symbol(n3_sym)
+            .expect("expected symbol data for n3");
+        let d_symbol = checker
+            .ctx
+            .binder
+            .get_symbol(d_sym)
+            .expect("expected symbol data for d");
+        let c_symbol = checker
+            .ctx
+            .binder
+            .get_symbol(c_sym)
+            .expect("expected symbol data for c");
+        let ee_symbol = checker
+            .ctx
+            .binder
+            .get_symbol(ee_sym)
+            .expect("expected symbol data for EventEmitter");
+
+        assert_eq!(n3_symbol.escaped_name, "n3");
+        assert!(
+            (n3_symbol.flags
+                & (symbol_flags::MODULE
+                    | symbol_flags::NAMESPACE_MODULE
+                    | symbol_flags::VALUE_MODULE))
+                != 0,
+            "n3 should resolve to a namespace/module-like symbol"
+        );
+        assert_ne!(d_symbol.flags & symbol_flags::CLASS, 0);
+        assert_ne!(c_symbol.flags & symbol_flags::CLASS, 0);
+        assert_ne!(ee_symbol.flags & symbol_flags::CLASS, 0);
     }
 }

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -2084,6 +2084,34 @@ impl<'a> CheckerState<'a> {
             }
             result
         };
+        let prefer_value_named_member = |member_id: tsz_binder::SymbolId| -> tsz_binder::SymbolId {
+            let Some(member_symbol) = lookup_symbol(member_id) else {
+                return member_id;
+            };
+            if (member_symbol.flags
+                & (symbol_flags::MODULE
+                    | symbol_flags::NAMESPACE_MODULE
+                    | symbol_flags::VALUE_MODULE))
+                == 0
+            {
+                return member_id;
+            }
+            for candidate_id in lookup_by_name(&member_symbol.escaped_name) {
+                let Some(candidate_symbol) = lookup_symbol(candidate_id) else {
+                    continue;
+                };
+                if (candidate_symbol.flags
+                    & (symbol_flags::CLASS
+                        | symbol_flags::FUNCTION
+                        | symbol_flags::VARIABLE
+                        | symbol_flags::ENUM))
+                    != 0
+                {
+                    return candidate_id;
+                }
+            }
+            member_id
+        };
 
         let resolve_from_exports =
             |exports: &tsz_binder::SymbolTable| -> Option<tsz_binder::SymbolId> {
@@ -2091,30 +2119,86 @@ impl<'a> CheckerState<'a> {
                 if export_name == "default" {
                     return Some(export_equals_sym);
                 }
-                let export_equals_symbol = lookup_symbol(export_equals_sym)?;
+                let mut candidate_symbol_ids = vec![export_equals_sym];
 
-                if let Some(sym_id) = symbol_export_named_member(export_equals_symbol, export_name)
+                // If `export =` points at an alias, follow the alias chain first.
+                // This is required for ambient patterns like:
+                //   namespace a.b { class C {} } export = a.b;
+                // where named imports should resolve via members on `a.b`.
+                if let Some(export_equals_symbol) = lookup_symbol(export_equals_sym)
+                    && (export_equals_symbol.flags & symbol_flags::ALIAS) != 0
                 {
-                    return Some(sym_id);
+                    let mut visited_aliases = Vec::new();
+                    if let Some(resolved_export_equals) =
+                        self.resolve_alias_symbol(export_equals_sym, &mut visited_aliases)
+                        && resolved_export_equals != export_equals_sym
+                    {
+                        candidate_symbol_ids.push(resolved_export_equals);
+                    }
+
+                    // For `export = alias` where alias is an import-equals qualified
+                    // name (`import x = a.b`), resolve the qualified target too.
+                    let mut decl_candidates = export_equals_symbol.declarations.clone();
+                    if export_equals_symbol.value_declaration.is_some()
+                        && !decl_candidates.contains(&export_equals_symbol.value_declaration)
+                    {
+                        decl_candidates.push(export_equals_symbol.value_declaration);
+                    }
+                    for decl_idx in decl_candidates {
+                        if !decl_idx.is_some() {
+                            continue;
+                        }
+                        if let Some(decl_node) = self.ctx.arena.get(decl_idx)
+                            && decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                            && let Some(import_decl) = self.ctx.arena.get_import_decl(decl_node)
+                        {
+                            let module_ref = import_decl.module_specifier;
+                            if let Some(module_ref_node) = self.ctx.arena.get(module_ref)
+                                && module_ref_node.kind != SyntaxKind::StringLiteral as u16
+                                && let Some(target_id) = self.resolve_qualified_symbol(module_ref)
+                            {
+                                candidate_symbol_ids.push(target_id);
+                            }
+                        }
+                    }
                 }
 
-                // Namespace-merge fallback (function/class + namespace split symbols).
-                let candidates = lookup_by_name(&export_equals_symbol.escaped_name);
-                for candidate_id in candidates {
-                    let Some(candidate_symbol) = lookup_symbol(candidate_id) else {
-                        continue;
-                    };
-                    if (candidate_symbol.flags
-                        & (symbol_flags::MODULE
-                            | symbol_flags::NAMESPACE_MODULE
-                            | symbol_flags::VALUE_MODULE))
-                        == 0
-                    {
+                let mut seen_symbol_ids = rustc_hash::FxHashSet::default();
+                for sym_id in candidate_symbol_ids {
+                    if !seen_symbol_ids.insert(sym_id) {
                         continue;
                     }
-                    if let Some(sym_id) = symbol_export_named_member(candidate_symbol, export_name)
+                    let Some(candidate_symbol) = lookup_symbol(sym_id) else {
+                        continue;
+                    };
+
+                    if let Some(member_id) = symbol_export_named_member(candidate_symbol, export_name)
                     {
-                        return Some(sym_id);
+                        return Some(prefer_value_named_member(member_id));
+                    }
+
+                    // Namespace-merge fallback (function/class + namespace split symbols).
+                    let merged_candidates = lookup_by_name(&candidate_symbol.escaped_name);
+                    for candidate_id in merged_candidates {
+                        if !seen_symbol_ids.insert(candidate_id) {
+                            continue;
+                        }
+                        let Some(merged_symbol) = lookup_symbol(candidate_id) else {
+                            continue;
+                        };
+                        if (merged_symbol.flags
+                            & (symbol_flags::MODULE
+                                | symbol_flags::NAMESPACE_MODULE
+                                | symbol_flags::VALUE_MODULE))
+                            == 0
+                        {
+                            continue;
+                        }
+                        if let Some(member_id) =
+                            symbol_export_named_member(merged_symbol, export_name)
+                        {
+                            return Some(prefer_value_named_member(member_id));
+                        }
                     }
                 }
 
@@ -2179,6 +2263,67 @@ impl<'a> CheckerState<'a> {
             return Some(sym_id);
         }
 
+        // Global ambient-module index fallback: module_specifier -> export name ->
+        // (file_idx, SymbolId). This catches declared modules that are indexed
+        // globally but not directly reachable through local module_exports maps.
+        if let Some(global_exports_index) = self.ctx.global_module_exports_index.as_ref() {
+            for candidate in module_specifier_candidates(module_specifier) {
+                if let Some(by_name) = global_exports_index.get(&candidate)
+                    && let Some(entries) = by_name.get("export=")
+                {
+                    for &(file_idx, export_equals_sym_id) in entries {
+                        self.ctx
+                            .register_symbol_file_target(export_equals_sym_id, file_idx);
+                        let mut export_equals_only = tsz_binder::SymbolTable::new();
+                        export_equals_only.set("export=".to_string(), export_equals_sym_id);
+                        if let Some(sym_id) = resolve_from_exports(&export_equals_only) {
+                            return Some(sym_id);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: ambient module declarations may not always be indexed in
+        // `module_exports` maps (especially in reduced/single-binder contexts).
+        // Probe module-like symbols by name and resolve through their own exports.
+        let mut ambient_module_symbol_ids = rustc_hash::FxHashSet::default();
+        for candidate in module_specifier_candidates(module_specifier) {
+            if let Some(sym_id) = self.ctx.binder.file_locals.get(&candidate) {
+                ambient_module_symbol_ids.insert(sym_id);
+            }
+            for &sym_id in self.ctx.binder.get_symbols().find_all_by_name(&candidate) {
+                ambient_module_symbol_ids.insert(sym_id);
+            }
+            if let Some(all_binders) = self.ctx.all_binders.as_ref() {
+                for binder in all_binders.iter() {
+                    if let Some(sym_id) = binder.file_locals.get(&candidate) {
+                        ambient_module_symbol_ids.insert(sym_id);
+                    }
+                    for &sym_id in binder.get_symbols().find_all_by_name(&candidate) {
+                        ambient_module_symbol_ids.insert(sym_id);
+                    }
+                }
+            }
+        }
+        for module_sym_id in ambient_module_symbol_ids {
+            let Some(module_symbol) = lookup_symbol(module_sym_id) else {
+                continue;
+            };
+            if (module_symbol.flags
+                & (symbol_flags::MODULE
+                    | symbol_flags::NAMESPACE_MODULE
+                    | symbol_flags::VALUE_MODULE))
+                == 0
+            {
+                continue;
+            }
+            if let Some(exports) = module_symbol.exports.as_ref()
+                && let Some(sym_id) = resolve_from_exports(exports)
+            {
+                return Some(sym_id);
+            }
+        }
         None
     }
 

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -258,7 +258,21 @@ impl<'a> CheckerState<'a> {
         if let Some(resolved_sym_id) = self.ctx.binder.resolve_import_symbol(sym_id) {
             // Prevent infinite loops in re-export chains
             if !visited_aliases.contains(&resolved_sym_id) {
-                return self.resolve_alias_symbol(resolved_sym_id, visited_aliases);
+                let mut preferred_target = resolved_sym_id;
+                if let Some(module_name) = symbol.import_module.as_ref() {
+                    let export_name = symbol
+                        .import_name
+                        .as_deref()
+                        .unwrap_or(symbol.escaped_name.as_str());
+                    if export_name != "*"
+                        && self.symbol_is_namespace_only(resolved_sym_id)
+                        && let Some(member_sym_id) =
+                            self.resolve_named_export_via_export_equals(module_name, export_name)
+                    {
+                        preferred_target = member_sym_id;
+                    }
+                }
+                return self.resolve_alias_symbol(preferred_target, visited_aliases);
             }
         }
 
@@ -281,11 +295,18 @@ impl<'a> CheckerState<'a> {
             // a specific export, resolving the alias to that export instead
             // of the module namespace.
             if symbol.import_name.is_some() {
+                let export_equals_member =
+                    self.resolve_named_export_via_export_equals(module_name, export_name);
                 if let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
                     module_name,
                     export_name,
                     Some(source_file_idx),
                 ) {
+                    let resolved_target = if self.symbol_is_namespace_only(target_sym_id) {
+                        export_equals_member.unwrap_or(target_sym_id)
+                    } else {
+                        target_sym_id
+                    };
                     if let Some(target_file_idx) = self.ctx.resolve_symbol_file_index(target_sym_id)
                     {
                         // Keep the alias itself pinned to the owning file so later
@@ -294,13 +315,18 @@ impl<'a> CheckerState<'a> {
                         self.ctx
                             .register_symbol_file_target(sym_id, target_file_idx);
                     }
-                    return Some(target_sym_id);
+                    return Some(resolved_target);
                 }
                 if let Some(exports) = self.ctx.binder.module_exports.get(module_name)
                     && let Some(target_sym_id) = exports.get(export_name)
                 {
+                    let resolved_target = if self.symbol_is_namespace_only(target_sym_id) {
+                        export_equals_member.unwrap_or(target_sym_id)
+                    } else {
+                        target_sym_id
+                    };
                     // Recursively resolve if the target is also an alias
-                    return self.resolve_alias_symbol(target_sym_id, visited_aliases);
+                    return self.resolve_alias_symbol(resolved_target, visited_aliases);
                 }
                 if let Some(all_binders) = &self.ctx.all_binders {
                     if let Some(file_indices) = self.ctx.files_for_module_specifier(module_name) {
@@ -309,7 +335,16 @@ impl<'a> CheckerState<'a> {
                                 && let Some(exports) = binder.module_exports.get(module_name)
                                 && let Some(target_sym_id) = exports.get(export_name)
                             {
-                                return self.resolve_alias_symbol(target_sym_id, visited_aliases);
+                                let resolved_target = if self.symbol_is_namespace_only(target_sym_id)
+                                {
+                                    export_equals_member.unwrap_or(target_sym_id)
+                                } else {
+                                    target_sym_id
+                                };
+                                return self.resolve_alias_symbol(
+                                    resolved_target,
+                                    visited_aliases,
+                                );
                             }
                         }
                     } else {
@@ -317,7 +352,16 @@ impl<'a> CheckerState<'a> {
                             if let Some(exports) = binder.module_exports.get(module_name)
                                 && let Some(target_sym_id) = exports.get(export_name)
                             {
-                                return self.resolve_alias_symbol(target_sym_id, visited_aliases);
+                                let resolved_target = if self.symbol_is_namespace_only(target_sym_id)
+                                {
+                                    export_equals_member.unwrap_or(target_sym_id)
+                                } else {
+                                    target_sym_id
+                                };
+                                return self.resolve_alias_symbol(
+                                    resolved_target,
+                                    visited_aliases,
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- bind `export =` targets for qualified names (e.g. `export = a1.a2`) in binder node/module export paths
- improve `export = alias` target discovery by scanning all alias declarations (not just first/value decl)
- resolve named import aliases to value members when direct resolution lands on namespace-only symbols
- add fallback named-import satisfaction via `resolve_named_export_via_export_equals` when no direct exports table is materialized

## Why
This fixes `importDeclFromTypeNodeInJsSource.ts` regressions where named imports from ambient `export =` modules were not bound/resolved correctly:
- `import { n3, d } from "nestNamespaceModule"`
- `import { c } from "renameModule"`
- `import { EventEmitter } from "events"` value usage in `extends`

## Validation
- `./scripts/conformance/conformance.sh run --filter "importDeclFromTypeNodeInJsSource"` -> **1/1 passed**
- `./scripts/conformance/conformance.sh run --filter "jsdoc"` -> **347/377 passed** (>= baseline)
- `./scripts/conformance/conformance.sh run --filter "import"` -> **273/281 passed** (>= required 267)
