### PR TITLE
fix(checker): stop suppressing constructor generic mismatches

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -762,6 +762,38 @@ impl<'a> CheckerState<'a> {
                     })
         };
 
+        let is_constructor_like = |type_id: TypeId| -> bool {
+            if crate::query_boundaries::common::has_construct_signatures(self.ctx.types, type_id) {
+                return true;
+            }
+            if let Some(shape) =
+                crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
+            {
+                if shape.is_constructor {
+                    return true;
+                }
+            }
+            if let Some(app) =
+                crate::query_boundaries::common::type_application(self.ctx.types, type_id)
+            {
+                if crate::query_boundaries::common::has_construct_signatures(
+                    self.ctx.types,
+                    app.base,
+                ) {
+                    return true;
+                }
+                if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
+                    self.ctx.types,
+                    app.base,
+                ) {
+                    if shape.is_constructor {
+                        return true;
+                    }
+                }
+            }
+            false
+        };
+
         let has_own_signature_type_params = |type_id: TypeId| -> bool {
             if let Some(shape) =
                 crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
@@ -1014,6 +1046,8 @@ impl<'a> CheckerState<'a> {
                 && !(!has_own_signature_type_params(source)
                     && contains_type_parameters(source)
                     && !contains_type_parameters(target))
+                && !is_constructor_like(source)
+                && !is_constructor_like(target)
                 && !target_is_index_signature())
     }
 

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -1186,55 +1186,83 @@ impl<'a> CheckerState<'a> {
         // spaces inside braces and trailing semicolons for inline object types.
         // Handle both standalone `{...}` and intersection parts `& {...}`.
         formatted = Self::normalize_inline_object_braces(&formatted);
-        // tsc always displays Array<T> as T[] in error messages.
-        // Convert generic Array form to shorthand when reading from source annotations.
+        // Prefer Array<T> shorthand conversion in annotation text, but preserve
+        // generic constraint surface syntax (`<T extends Array<U>>`) where tsc
+        // keeps the declared Array form.
         formatted = Self::normalize_array_generic_to_shorthand(&formatted);
         formatted
     }
 
     /// Convert `Array<T>` to `T[]` and `ReadonlyArray<T>` to `readonly T[]`
     /// in annotation text to match tsc's diagnostic display.
+    ///
+    /// Do not normalize when the generic array appears directly in a type
+    /// parameter `extends` clause; tsc preserves `Array<T>` there.
     fn normalize_array_generic_to_shorthand(text: &str) -> String {
         if !text.contains("Array<") {
             return text.to_string();
         }
-        let mut result = text.to_string();
-        // Process ReadonlyArray<T> first (before Array<T> to avoid partial matches)
-        while let Some(start) = result.find("ReadonlyArray<") {
-            if let Some(inner) = Self::extract_balanced_angle_bracket_content(&result, start + 14) {
-                let needs_parens = inner.contains("=>") || inner.contains(" | ");
-                let replacement = if needs_parens {
-                    format!("readonly ({inner})[]")
-                } else {
-                    format!("readonly {inner}[]")
-                };
-                let end = start + 14 + inner.len() + 1; // "ReadonlyArray<" + inner + ">"
-                result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
+        let is_extends_constraint_position = |s: &str, start: usize| -> bool {
+            let prefix_start = start.saturating_sub(32);
+            let prefix = &s[prefix_start..start];
+            prefix.trim_end().ends_with("extends")
+        };
+        let mut out = String::with_capacity(text.len());
+        let mut i = 0usize;
+
+        while i < text.len() {
+            let slice = &text[i..];
+
+            // Process ReadonlyArray<T> first to avoid matching inner Array<T>.
+            if slice.starts_with("ReadonlyArray<")
+                && (i == 0 || !text.as_bytes()[i - 1].is_ascii_alphanumeric())
+            {
+                if let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 14) {
+                    let end = i + 14 + inner.len() + 1; // "ReadonlyArray<" + inner + ">"
+                    if is_extends_constraint_position(text, i) {
+                        out.push_str(&text[i..end]);
+                    } else {
+                        let needs_parens = inner.contains("=>") || inner.contains(" | ");
+                        if needs_parens {
+                            out.push_str(&format!("readonly ({inner})[]"));
+                        } else {
+                            out.push_str(&format!("readonly {inner}[]"));
+                        }
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+
+            if slice.starts_with("Array<")
+                && (i == 0 || !text.as_bytes()[i - 1].is_ascii_alphanumeric())
+            {
+                if let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 6) {
+                    let end = i + 6 + inner.len() + 1; // "Array<" + inner + ">"
+                    if is_extends_constraint_position(text, i) {
+                        out.push_str(&text[i..end]);
+                    } else {
+                        let needs_parens = inner.contains("=>") || inner.contains(" | ");
+                        if needs_parens {
+                            out.push_str(&format!("({inner})[]"));
+                        } else {
+                            out.push_str(&format!("{inner}[]"));
+                        }
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+
+            if let Some(ch) = slice.chars().next() {
+                out.push(ch);
+                i += ch.len_utf8();
             } else {
                 break;
             }
         }
-        // Then Array<T>
-        while let Some(start) = result.find("Array<") {
-            // Make sure it's not part of a longer name (e.g., "ReadonlyArray" already handled)
-            if start > 0 && result.as_bytes()[start - 1].is_ascii_alphanumeric() {
-                // Part of a longer identifier, skip
-                break;
-            }
-            if let Some(inner) = Self::extract_balanced_angle_bracket_content(&result, start + 6) {
-                let needs_parens = inner.contains("=>") || inner.contains(" | ");
-                let replacement = if needs_parens {
-                    format!("({inner})[]")
-                } else {
-                    format!("{inner}[]")
-                };
-                let end = start + 6 + inner.len() + 1; // "Array<" + inner + ">"
-                result = format!("{}{}{}", &result[..start], replacement, &result[end..]);
-            } else {
-                break;
-            }
-        }
-        result
+
+        out
     }
 
     /// Extract content between balanced angle brackets starting at `pos`.

--- a/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
@@ -1373,13 +1373,9 @@ var r6 = foo5(a);
 #[test]
 fn test_generic_constructor_callback_with_leading_arg() {
     // foo7<T>(x:T, cb) has two arguments. With the deferral fix (non-context-sensitive
-    // args are no longer deferred), T is correctly inferred from arg 0. However,
-    // the final argument check for generic callables against overloaded concrete
-    // targets does not yet match tsc's `instantiateSignatureInContextOf` behavior
-    // (which infers source type params from both parameter and return type positions).
-    // This causes a false positive TS2345 that tsc does not emit.
-    // TODO: Fix instantiate_generic_function_argument_against_target to use return
-    // type for inference when target has concrete (non-placeholder) types.
+    // args are no longer deferred), T is correctly inferred from arg 0. The constructor
+    // suppression narrowing ensures we no longer emit a false positive TS2345 when the
+    // argument is a constructor-like type application; tsc accepts both calls here.
     let diagnostics = compile_and_get_diagnostics_with_options(
         r#"
 function foo7<T>(x:T, cb: { new(x: T): string; new(x: T, y?: T): string }) {
@@ -1397,11 +1393,10 @@ var r14 = foo7(1, c);
         },
     );
 
-    // Known false positive: tsc accepts these but we emit TS2345 because
-    // the generic callable instantiation doesn't consider the target return type.
+    // Matches tsc: both invocations type-check without TS2345.
     assert!(
-        has_error(&diagnostics, 2345),
-        "Expected TS2345 (known false positive for generic constructor callbacks with leading arg)"
+        !has_error(&diagnostics, 2345),
+        "Expected no TS2345 (constructor callback inference should match tsc)"
     );
 }
 


### PR DESCRIPTION
Re-land of b164b1acd8 in isolation (the original regressing change set in #<prior commit> combined this with two other commits; this narrower version lands only this piece, which is net-positive by itself).

Two independent fixes:

1. Constructor-like suppression narrowing in assignability_checker: the existing type-parameter suppression predicate was too broad and silenced real constructor generic mismatches. Added an is_constructor_like guard that excludes constructor-side types (direct construct signatures, constructor function shapes, and their type applications) from the suppression.

2. Array<T> display preservation in type-parameter extends clauses: rewrote normalize_array_generic_to_shorthand to walk the string once and preserve the declared Array<T> form inside <T extends Array<U>>, matching tsc's display there while still rewriting Array<T> to T[] everywhere else.

Also updates test_generic_constructor_callback_with_leading_arg which was asserting a now-obsolete false positive; the fix correctly makes those constructor callback arguments accepted, matching tsc.

Conformance: 11926 -> 12004 (+78)