### PR TITLE
lsp: export default classification + semantic-tokens 2020 format

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -232,8 +232,43 @@ impl Server {
             let mut provider =
                 SemanticTokensProvider::new(&arena, &binder, &line_map, &source_text);
             let tokens = provider.get_semantic_tokens(root);
+            // Provider emits the LSP 5-tuple delta encoding
+            // (deltaLine, deltaChar, length, tokenType, tokenModifiers).
+            // tsserver's `encodedSemanticClassifications-full` expects the
+            // "2020" format: triples of (absStart, length, classId) with
+            // `classId = (modifierBits << 8) | tokenType`. Convert in
+            // place so the fourslash harness's span-length assertions
+            // match tsc.
+            let mut converted: Vec<u32> = Vec::with_capacity(tokens.len() / 5 * 3);
+            let mut prev_line: u32 = 0;
+            let mut prev_char: u32 = 0;
+            let mut i = 0;
+            while i + 4 < tokens.len() {
+                let delta_line = tokens[i];
+                let delta_char = tokens[i + 1];
+                let length = tokens[i + 2];
+                let token_type = tokens[i + 3];
+                let token_modifiers = tokens[i + 4];
+                let line = prev_line + delta_line;
+                let char = if delta_line == 0 {
+                    prev_char + delta_char
+                } else {
+                    delta_char
+                };
+                let position = tsz_common::position::Position::new(line, char);
+                let abs_start = line_map
+                    .position_to_offset(position, &source_text)
+                    .unwrap_or(0);
+                let class_id = (token_modifiers << 8) | token_type;
+                converted.push(abs_start);
+                converted.push(length);
+                converted.push(class_id);
+                prev_line = line;
+                prev_char = char;
+                i += 5;
+            }
             Some(serde_json::json!({
-                "spans": tokens,
+                "spans": converted,
                 "endOfLineState": 0,
             }))
         })();

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -1061,19 +1061,82 @@ impl<'a> DocumentSymbolProvider<'a> {
                     // export default <expression> (non-declaration). tsc
                     // labels these with `default` as the text and only
                     // `export` as the modifier (no `default` modifier).
+                    // The kind depends on the expression shape:
+                    //   - function / arrow expression → `function` (with
+                    //     body-walked children)
+                    //   - object literal / call expression → `const`
+                    //     (with property / argument members)
+                    //   - identifier referencing an existing decl →
+                    //     entry is dropped (tsc doesn't show `export
+                    //     default identifier` as its own nav entry).
+                    //   - everything else → `var`.
                     if is_default {
                         let range =
                             node_range(self.arena, self.line_map, self.source_text, node_idx);
                         let selection_range = self.get_range_keyword(node_idx, 6); // "export".len()
+                        let expr_idx = export_clause;
+                        let Some(expr_node) = self.arena.get(expr_idx) else {
+                            return vec![];
+                        };
+                        let (kind, children) = match expr_node.kind {
+                            k if k == syntax_kind_ext::FUNCTION_EXPRESSION
+                                || k == syntax_kind_ext::ARROW_FUNCTION =>
+                            {
+                                let body = self
+                                    .arena
+                                    .get_function(expr_node)
+                                    .map_or(NodeIndex::NONE, |f| f.body);
+                                (
+                                    SymbolKind::Function,
+                                    self.collect_children_from_block(body, Some("default")),
+                                )
+                            }
+                            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => (
+                                SymbolKind::Constant,
+                                self.collect_object_literal_members(expr_idx, Some("default")),
+                            ),
+                            k if k == syntax_kind_ext::CALL_EXPRESSION => {
+                                // `export default foo({ x: 1, y: 1 })` →
+                                // tsc surfaces the argument object's
+                                // members as children of the default
+                                // entry.
+                                let mut children = Vec::new();
+                                if let Some(call) = self.arena.get_call_expr(expr_node)
+                                    && let Some(args) = call.arguments.as_ref()
+                                {
+                                    for &arg_idx in &args.nodes {
+                                        let Some(arg_node) = self.arena.get(arg_idx) else {
+                                            continue;
+                                        };
+                                        if arg_node.kind
+                                            == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                                        {
+                                            children.extend(self.collect_object_literal_members(
+                                                arg_idx,
+                                                Some("default"),
+                                            ));
+                                        }
+                                    }
+                                }
+                                (SymbolKind::Constant, children)
+                            }
+                            k if k == SyntaxKind::Identifier as u16 => {
+                                // `export default someName` — tsc
+                                // drops this from the navbar since
+                                // `someName` already has its own entry.
+                                return vec![];
+                            }
+                            _ => (SymbolKind::Variable, Vec::new()),
+                        };
                         return vec![DocumentSymbol {
                             name: "default".to_string(),
                             detail: None,
-                            kind: SymbolKind::Variable,
+                            kind,
                             kind_modifiers: "export".to_string(),
                             range,
                             selection_range,
                             container_name: container_name.map(std::string::ToString::to_string),
-                            children: vec![],
+                            children,
                         }];
                     }
                 }


### PR DESCRIPTION
## Summary

Two non-navbar pure-Rust parity fixes, bundled into one PR:

1. **\`export default\` expression classification** — previously rendered every non-declaration default export as \`var\`. Now classified per tsc's rules:
   - function / arrow → \`function\` (body walked)
   - object literal → \`const\` (members as children)
   - call expression → \`const\` (object-literal arguments surface)
   - identifier → dropped (the identifier has its own nav node)
   - else → \`var\`

2. **Semantic-tokens 2020 format** — \`encodedSemanticClassifications-full\` was returning the LSP 5-tuple delta encoding; tsc's \"2020\" format is triples of \`(absStart, length, classId)\` with \`classId = (modifierBits << 8) | tokenType\`. Convert in the handler. Fixes \`deduplicateErrors\` and \`classSymbolLookup\`.

## Test plan

- [x] \`cargo nextest run -p tsz-lsp\` — 3759/3759
- [x] \`cargo nextest run -p tsz-cli\` — 966/966
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=deduplicateErrors\` — passes
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=classSymbolLookup\` — passes
- [x] \`navbar_exportDefault\` — 1/1 still passes
- [x] Full Rust-only fourslash: 6522/6562 (+2); full native-TS: 6555/6562 (unchanged, timeouts only)