### PR TITLE
fix(conformance,checker): preserve TS2318 under @noLib; skip feature-specific global checks

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -93,13 +93,22 @@ fn filter_lib_diagnostics_tsc(
     let mut fps = tsc_result.diagnostic_fingerprints.clone();
 
     // Structural invariant: every fingerprint's code must also appear in
-    // `error_codes`. If it doesn't, the fingerprint is a parser artifact —
-    // typically a `--traceResolution` trace line shaped like `error TSxxxx:`
-    // that our no-position regex matched but the code-list regex did not.
-    // Drop such orphan fingerprints unconditionally; this supersedes the
-    // previous hardcoded `TS6053 | TS2688 when codes.is_empty()` filter.
+    // `error_codes`. If it doesn't, the fingerprint is usually a parser
+    // artifact — typically a `--traceResolution` trace line shaped like
+    // `error TSxxxx:` that our no-position regex matched but the code-list
+    // regex did not. Drop such orphan fingerprints.
+    //
+    // Exception: TS2318 "Cannot find global type" at synthetic position
+    // (`<unknown>:0:0`) is legitimately stored only in fingerprints for
+    // @noLib tests (the tsc cache generator records them that way when
+    // tsc's test harness produces them as program-level diagnostics).
+    // Keep those so the noLib branch in the runner can compare against
+    // tsz's TS2318 emissions. See PR #578 and #612.
     let code_set: std::collections::HashSet<u32> = codes.iter().copied().collect();
-    fps.retain(|fp| code_set.contains(&fp.code));
+    fps.retain(|fp| {
+        code_set.contains(&fp.code)
+            || (fp.code == 2318 && fp.file.is_empty() && fp.line == 0 && fp.column == 0)
+    });
 
     let had_lib = fps.iter().any(is_lib_diagnostic);
     if !had_lib {

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -457,6 +457,16 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn check_feature_specific_global_types(&mut self) {
         use crate::query_boundaries::capabilities::EnvironmentCapabilities;
 
+        // Under @noLib, the user has explicitly opted out of the default lib.
+        // tsc reports the core TS2318 set (Array/Boolean/Function/etc.) for
+        // the fundamental types the compiler always needs, but does NOT report
+        // feature-specific globals like TypedPropertyDescriptor even when the
+        // corresponding feature (decorators, generators, await, using) is used.
+        // The user is responsible for providing any types they need.
+        if self.ctx.capabilities.no_lib {
+            return;
+        }
+
         // Feature-specific global types checked via the capability boundary.
         // The mapping from type name → feature gate is centralized in
         // `EnvironmentCapabilities::gate_for_required_type()`.


### PR DESCRIPTION
## Summary
Two bugs together prevent several @noLib tests from passing:

1. **Runner**: `filter_lib_diagnostics_tsc` was dropping ALL orphan fingerprints (fingerprints whose code isn't in `error_codes`). That broke PR #578's TS2318 retention under @noLib: tsc's cache stores TS2318 "Cannot find global type" fingerprints at synthetic position `<unknown>:0:0` with an empty `error_codes` list, and the general drop filter wiped them before the noLib branch could see them. So `tsc_has_2318` evaluated to false and tsz's TS2318 output leaked through instead of being compared against tsc's expected set.

   Added an exception for TS2318 at synthetic position — that's a legitimate cache encoding for @noLib diagnostics, not a trace artifact.

2. **Checker**: `check_feature_specific_global_types` emitted TS2318 for feature-specific globals (TypedPropertyDescriptor, IterableIterator, AsyncIterableIterator, Awaited, Disposable, AsyncDisposable) whenever the corresponding feature was used, including under @noLib. tsc reports only the CORE globals under @noLib — the user has explicitly opted out of the default lib and is responsible for providing any feature-specific types they need. Added an early-return under @noLib.

## Impact
+4 tests, no regressions:
- `decoratorMetadataNoLibIsolatedModulesTypes.ts` (uses `@Decorate` without `TypedPropertyDescriptor`; we were emitting an extra TS2318 for it plus TS2304 + TS2583 cascaded errors that tsc suppresses)
- `declarationBasicSyntax.ts`
- `jsWithInlineSourceMapBasic.ts`
- `jsWithSourceMapBasic.ts`

## Test plan
- [x] Target test `decoratorMetadataNoLibIsolatedModulesTypes.ts` — passes
- [x] Full-suite diff: 4 tests removed from fail list, no new regressions
- [x] Other noLib tests still pass (`awaitedTypeNoLib`, `strictNullNotNullIndexTypeNoLib`, etc.)
- [x] Tests with feature-specific types under normal lib still work (no regressions in decorator/generator/await/using coverage)