### PR TITLE
Make safe_slice return Result instead of silently returning empty

### DIFF
--- a/crates/tsz-core/tests/printer_tests.rs
+++ b/crates/tsz-core/tests/printer_tests.rs
@@ -141,17 +141,22 @@ fn test_printer_struct() {
 #[test]
 fn test_safe_slice_normal() {
     let s = "hello world";
-    assert_eq!(safe_slice::slice(s, 0, 5), "hello");
-    assert_eq!(safe_slice::slice(s, 6, 11), "world");
-    assert_eq!(safe_slice::slice(s, 0, 11), "hello world");
+    assert_eq!(safe_slice::slice(s, 0, 5), Ok("hello"));
+    assert_eq!(safe_slice::slice(s, 6, 11), Ok("world"));
+    assert_eq!(safe_slice::slice(s, 0, 11), Ok("hello world"));
 }
 
 #[test]
 fn test_safe_slice_out_of_bounds() {
     let s = "hello";
-    assert_eq!(safe_slice::slice(s, 0, 100), "");
-    assert_eq!(safe_slice::slice(s, 100, 200), "");
-    assert_eq!(safe_slice::slice(s, 5, 3), ""); // start > end
+    assert!(safe_slice::slice(s, 0, 100).is_err());
+    assert!(safe_slice::slice(s, 100, 200).is_err());
+    assert!(safe_slice::slice(s, 5, 3).is_err()); // start > end
+
+    // The compatibility shim preserves the old "empty on invalid" behavior.
+    assert_eq!(safe_slice::slice_or_empty(s, 0, 100), "");
+    assert_eq!(safe_slice::slice_or_empty(s, 100, 200), "");
+    assert_eq!(safe_slice::slice_or_empty(s, 5, 3), "");
 }
 
 #[test]
@@ -161,11 +166,12 @@ fn test_safe_slice_unicode() {
     let crab_end = 10; // 🦀 is 4 bytes
 
     // Valid boundaries
-    assert_eq!(safe_slice::slice(s, 0, crab_start), "hello ");
-    assert_eq!(safe_slice::slice(s, crab_end + 1, s.len()), "world");
+    assert_eq!(safe_slice::slice(s, 0, crab_start), Ok("hello "));
+    assert_eq!(safe_slice::slice(s, crab_end + 1, s.len()), Ok("world"));
 
-    // Invalid boundaries (mid-emoji)
-    assert_eq!(safe_slice::slice(s, 7, 9), "");
+    // Invalid boundaries (mid-emoji) surface a structured error.
+    assert!(safe_slice::slice(s, 7, 9).is_err());
+    assert_eq!(safe_slice::slice_or_empty(s, 7, 9), "");
 }
 
 // =============================================================================

--- a/crates/tsz-emitter/src/emitter/comments/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/comments/helpers.rs
@@ -115,7 +115,8 @@ impl<'a> Printer<'a> {
 
             // This is a trailing comment on the same line — emit it
             self.write_space();
-            let comment_text = crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+            let comment_text =
+                crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
             if !comment_text.is_empty() {
                 self.write_comment_with_reindent(comment_text, Some(c_pos));
             }
@@ -333,7 +334,7 @@ impl<'a> Printer<'a> {
                     let c_pos = self.all_comments[self.comment_emit_idx].pos;
                     let c_trailing = self.all_comments[self.comment_emit_idx].has_trailing_new_line;
                     let comment_text =
-                        crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                        crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                     self.write_comment_with_reindent(comment_text, Some(c_pos));
                     if c_trailing {
                         self.write_line();
@@ -425,7 +426,8 @@ impl<'a> Printer<'a> {
 
             let comment_pos_usize = comment_pos as usize;
             if comment_pos_usize > cursor_pos {
-                let leading_text = crate::safe_slice::slice(text, cursor_pos, comment_pos_usize);
+                let leading_text =
+                    crate::safe_slice::slice_or_empty(text, cursor_pos, comment_pos_usize);
                 if normalize_leading_text {
                     self.write_normalized_jsx_comment_leading_text(
                         leading_text,
@@ -442,7 +444,7 @@ impl<'a> Printer<'a> {
             }
 
             let comment_text =
-                crate::safe_slice::slice(text, comment_pos as usize, comment_end as usize);
+                crate::safe_slice::slice_or_empty(text, comment_pos as usize, comment_end as usize);
             self.write_comment_with_reindent(comment_text, Some(comment_pos));
             if comment_has_new_line {
                 self.write_line();
@@ -618,7 +620,8 @@ impl<'a> Printer<'a> {
         let mut trailing = Vec::new();
         for c in &self.all_comments {
             if c.pos >= actual_end && c.end <= line_end {
-                let comment_text = crate::safe_slice::slice(text, c.pos as usize, c.end as usize);
+                let comment_text =
+                    crate::safe_slice::slice_or_empty(text, c.pos as usize, c.end as usize);
                 trailing.push(comment_text.to_string());
             }
             if c.pos > line_end {
@@ -661,7 +664,7 @@ impl<'a> Printer<'a> {
                     && bytes[c.pos as usize + 1] == b'*'
                 {
                     let comment_text =
-                        crate::safe_slice::slice(text, c.pos as usize, c.end as usize);
+                        crate::safe_slice::slice_or_empty(text, c.pos as usize, c.end as usize);
                     result.push(comment_text.to_string());
                 }
             }
@@ -689,7 +692,8 @@ impl<'a> Printer<'a> {
         while idx < self.all_comments.len() {
             let c = &self.all_comments[idx];
             if c.end <= actual_start {
-                let comment_text = crate::safe_slice::slice(text, c.pos as usize, c.end as usize);
+                let comment_text =
+                    crate::safe_slice::slice_or_empty(text, c.pos as usize, c.end as usize);
                 result.push((comment_text.to_string(), c.pos));
                 idx += 1;
             } else {

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1377,8 +1377,11 @@ impl<'a> Printer<'a> {
                         while idx < self.all_comments.len() {
                             let c = &self.all_comments[idx];
                             if c.pos >= actual_end && c.end <= line_end {
-                                let comment_text =
-                                    crate::safe_slice::slice(text, c.pos as usize, c.end as usize);
+                                let comment_text = crate::safe_slice::slice_or_empty(
+                                    text,
+                                    c.pos as usize,
+                                    c.end as usize,
+                                );
                                 trailing.push(comment_text.to_string());
                             }
                             if c.end > line_end {

--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -362,8 +362,11 @@ impl<'a> Printer<'a> {
         // Use source text scan: search for the identifier as a binding in the body.
         // This catches parameters, local vars, nested functions/classes at any depth.
         if let Some(text) = self.source_text {
-            let body_text =
-                crate::safe_slice::slice(text, body_node.pos as usize, body_node.end as usize);
+            let body_text = crate::safe_slice::slice_or_empty(
+                text,
+                body_node.pos as usize,
+                body_node.end as usize,
+            );
             return Self::text_has_binding_named(body_text, ns_name);
         }
         false

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -22,7 +22,7 @@ impl<'a> Printer<'a> {
                     if c_pos > bracket_pos && c_end < node.end {
                         self.write_space();
                         let comment_text =
-                            crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                            crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                         self.write_comment_with_reindent(comment_text, Some(c_pos));
                         self.comment_emit_idx += 1;
                     } else {
@@ -116,7 +116,7 @@ impl<'a> Printer<'a> {
                     if c_end < node.end {
                         self.write_space();
                         let comment_text =
-                            crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                            crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                         self.write_comment_with_reindent(comment_text, Some(c_pos));
                         self.comment_emit_idx += 1;
                     } else {
@@ -178,7 +178,7 @@ impl<'a> Printer<'a> {
                                 let c_end = self.all_comments[self.comment_emit_idx].end;
                                 if c_end <= actual_start {
                                     let c_pos = self.all_comments[self.comment_emit_idx].pos;
-                                    let comment_text = crate::safe_slice::slice(
+                                    let comment_text = crate::safe_slice::slice_or_empty(
                                         text,
                                         c_pos as usize,
                                         c_end as usize,
@@ -257,7 +257,7 @@ impl<'a> Printer<'a> {
                                             } else {
                                                 self.write_space();
                                             }
-                                            let comment_text = crate::safe_slice::slice(
+                                            let comment_text = crate::safe_slice::slice_or_empty(
                                                 text,
                                                 c_pos as usize,
                                                 c_end as usize,
@@ -306,7 +306,7 @@ impl<'a> Printer<'a> {
                                     {
                                         self.write_space();
                                         let comment_text =
-                                            crate::safe_slice::slice(text, c_pos, c_end);
+                                            crate::safe_slice::slice_or_empty(text, c_pos, c_end);
                                         self.write_comment_with_reindent(
                                             comment_text,
                                             Some(c_pos as u32),
@@ -341,8 +341,11 @@ impl<'a> Printer<'a> {
                             } else {
                                 self.write_space();
                             }
-                            let comment_text =
-                                crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                            let comment_text = crate::safe_slice::slice_or_empty(
+                                text,
+                                c_pos as usize,
+                                c_end as usize,
+                            );
                             self.write_comment_with_reindent(comment_text, Some(c_pos));
                             self.comment_emit_idx += 1;
                         } else {

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -857,7 +857,7 @@ impl<'a> Printer<'a> {
                     if name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
                         && let Some(text) = self.source_text
                     {
-                        let name_text = crate::safe_slice::slice(
+                        let name_text = crate::safe_slice::slice_or_empty(
                             text,
                             name_node.pos as usize,
                             name_node.end as usize,
@@ -1145,9 +1145,12 @@ impl<'a> Printer<'a> {
         // Recovery path: malformed parameter names like `yield`/`await`
         // can be parsed as expressions. Preserve original text for JS parity.
         if let Some(source) = self.source_text {
-            let text =
-                crate::safe_slice::slice(source, name_node.pos as usize, name_node.end as usize)
-                    .trim();
+            let text = crate::safe_slice::slice_or_empty(
+                source,
+                name_node.pos as usize,
+                name_node.end as usize,
+            )
+            .trim();
             if !text.is_empty() {
                 self.write(text);
                 return;

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -730,7 +730,7 @@ impl<'a> Printer<'a> {
             let c = &self.all_comments[scan_idx];
             if c.pos >= from_pos && c.end <= to_pos {
                 // Found a comment in our range - emit it
-                let comment_text = safe_slice::slice(text, c.pos as usize, c.end as usize);
+                let comment_text = safe_slice::slice_or_empty(text, c.pos as usize, c.end as usize);
                 let has_trailing_new_line = c.has_trailing_new_line;
                 if !comment_text.is_empty() {
                     self.write_comment_with_reindent(comment_text, Some(c.pos));

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
@@ -300,7 +300,7 @@ impl<'a> Printer<'a> {
                 let is_use_strict = if let Some(lit) = self.arena.get_literal(expr_node) {
                     lit.text == "use strict"
                 } else if let Some(text) = self.source_text {
-                    let s = crate::safe_slice::slice(
+                    let s = crate::safe_slice::slice_or_empty(
                         text,
                         expr_node.pos as usize,
                         expr_node.end as usize,

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -258,7 +258,11 @@ impl<'a> Printer<'a> {
                             // Check for blank line between reference end and erased
                             // stmt start. If there's a blank line, the reference is
                             // "detached" (file-level) and should be preserved.
-                            let gap = crate::safe_slice::slice(text, c.end as usize, fep as usize);
+                            let gap = crate::safe_slice::slice_or_empty(
+                                text,
+                                c.end as usize,
+                                fep as usize,
+                            );
                             if gap.contains("\n\n") || gap.contains("\r\n\r\n") {
                                 return true;
                             }
@@ -334,7 +338,7 @@ impl<'a> Printer<'a> {
                 let is_use_strict = if let Some(lit) = self.arena.get_literal(expr_node) {
                     lit.text == "use strict"
                 } else if let Some(text) = self.source_text {
-                    let s = crate::safe_slice::slice(
+                    let s = crate::safe_slice::slice_or_empty(
                         text,
                         expr_node.pos as usize,
                         expr_node.end as usize,
@@ -500,12 +504,18 @@ impl<'a> Printer<'a> {
                 let next_start = pinned
                     .get(pi + 1)
                     .map_or(first_stmt_pos, |next_c| next_c.pos);
-                let between =
-                    crate::safe_slice::slice(text, comment.end as usize, next_start as usize);
+                let between = crate::safe_slice::slice_or_empty(
+                    text,
+                    comment.end as usize,
+                    next_start as usize,
+                );
                 let is_detached = between.contains("\n\n") || between.contains("\r\n\r\n");
                 if is_detached {
-                    let comment_text =
-                        crate::safe_slice::slice(text, comment.pos as usize, comment.end as usize);
+                    let comment_text = crate::safe_slice::slice_or_empty(
+                        text,
+                        comment.pos as usize,
+                        comment.end as usize,
+                    );
                     self.write_comment_with_reindent(comment_text, Some(comment.pos));
                     if comment.has_trailing_new_line {
                         self.write_line();
@@ -596,7 +606,7 @@ impl<'a> Printer<'a> {
                     let c_pos = self.all_comments[self.comment_emit_idx].pos;
                     let c_trailing = self.all_comments[self.comment_emit_idx].has_trailing_new_line;
                     let comment_text =
-                        crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                        crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                     let trimmed_comment = comment_text.trim_start();
                     let is_triple_slash_reference = trimmed_comment.starts_with("///<reference")
                         || trimmed_comment.starts_with("/// <reference");
@@ -1161,7 +1171,7 @@ impl<'a> Printer<'a> {
                 let is_strict = if let Some(lit) = self.arena.get_literal(expr_node) {
                     lit.text == "use strict"
                 } else if let Some(text) = self.source_text {
-                    let s = crate::safe_slice::slice(
+                    let s = crate::safe_slice::slice_or_empty(
                         text,
                         expr_node.pos as usize,
                         expr_node.end as usize,
@@ -1371,7 +1381,7 @@ impl<'a> Printer<'a> {
                     // AND hasn't been emitted by a nested expression emitter
                     if c_end <= actual_start {
                         let comment_text =
-                            crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                            crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                         self.write_comment_with_reindent(comment_text, Some(c_pos));
                         if c_trailing {
                             self.write_line();
@@ -1605,7 +1615,8 @@ impl<'a> Printer<'a> {
                 let c_pos = self.all_comments[self.comment_emit_idx].pos;
                 let c_end = self.all_comments[self.comment_emit_idx].end;
                 let c_trailing = self.all_comments[self.comment_emit_idx].has_trailing_new_line;
-                let comment_text = crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                let comment_text =
+                    crate::safe_slice::slice_or_empty(text, c_pos as usize, c_end as usize);
                 self.write_comment_with_reindent(comment_text, Some(c_pos));
                 if c_trailing {
                     self.write_line();

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -356,8 +356,11 @@ impl<'a> Printer<'a> {
                             let c_pos = self.all_comments[self.comment_emit_idx].pos;
                             let c_trailing =
                                 self.all_comments[self.comment_emit_idx].has_trailing_new_line;
-                            let comment_text =
-                                crate::safe_slice::slice(text, c_pos as usize, c_end as usize);
+                            let comment_text = crate::safe_slice::slice_or_empty(
+                                text,
+                                c_pos as usize,
+                                c_end as usize,
+                            );
                             self.write_comment_with_reindent(comment_text, Some(c_pos));
                             if c_trailing {
                                 self.write_line();
@@ -1348,7 +1351,7 @@ impl<'a> Printer<'a> {
             for comment in comments {
                 self.write_space();
                 let comment_text =
-                    safe_slice::slice(text, comment.pos as usize, comment.end as usize);
+                    safe_slice::slice_or_empty(text, comment.pos as usize, comment.end as usize);
                 if !comment_text.is_empty() {
                     self.write_comment_with_reindent(comment_text, Some(comment.pos));
                 }

--- a/crates/tsz-emitter/src/safe_slice.rs
+++ b/crates/tsz-emitter/src/safe_slice.rs
@@ -1,23 +1,101 @@
 //! Safe string slice utilities that never panic.
 //!
-//! These functions handle edge cases like:
-//! - Out-of-bounds indices
-//! - Non-UTF8 boundary slicing
+//! The public API is fallible: callers must decide how to handle an invalid
+//! slice request (out-of-bounds index, reversed range, or non-UTF-8 boundary).
+//! Returning an empty string silently hides emitter span bugs, so the main
+//! entry point surfaces a structured [`SliceError`] instead.
+//!
+//! A [`slice_or_empty`] compatibility shim is kept temporarily for call sites
+//! where the historical "empty on invalid" behavior is still deliberate. It
+//! should be removed once every call site has been audited.
 
-/// Safely slice a string, returning an empty string if bounds are invalid.
+use tracing::debug;
+
+/// Error returned by [`slice`] when the requested range is not valid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SliceError {
+    /// `start` points past the end of the string.
+    StartOutOfBounds { start: usize, len: usize },
+    /// `end` points past the end of the string.
+    EndOutOfBounds { end: usize, len: usize },
+    /// `start > end` — the range is reversed.
+    ReversedRange { start: usize, end: usize },
+    /// `start` or `end` does not fall on a UTF-8 character boundary.
+    InvalidUtf8Boundary { index: usize },
+}
+
+impl core::fmt::Display for SliceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SliceError::StartOutOfBounds { start, len } => {
+                write!(f, "slice start {start} is out of bounds (len {len})")
+            }
+            SliceError::EndOutOfBounds { end, len } => {
+                write!(f, "slice end {end} is out of bounds (len {len})")
+            }
+            SliceError::ReversedRange { start, end } => {
+                write!(f, "slice range is reversed (start {start} > end {end})")
+            }
+            SliceError::InvalidUtf8Boundary { index } => {
+                write!(f, "slice index {index} is not on a UTF-8 boundary")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SliceError {}
+
+/// Fallibly borrow `&s[start..end]` without panicking.
 ///
-/// Unlike `&s[start..end]`, this never panics.
-pub fn slice(s: &str, start: usize, end: usize) -> &str {
-    if start >= s.len() || end > s.len() || start > end {
-        return "";
+/// Returns the most specific [`SliceError`] possible when the range is not
+/// valid. Checks happen in a fixed order: start bound → end bound → reversed
+/// range → UTF-8 boundary, so the error always describes the first problem.
+///
+/// Invalid requests emit a `tracing::debug!` so bad span math is visible in
+/// development builds without crashing release.
+pub fn slice(s: &str, start: usize, end: usize) -> Result<&str, SliceError> {
+    let len = s.len();
+
+    if start > len {
+        let err = SliceError::StartOutOfBounds { start, len };
+        debug!(target: "tsz_emitter::safe_slice", "{err}");
+        return Err(err);
+    }
+    if end > len {
+        let err = SliceError::EndOutOfBounds { end, len };
+        debug!(target: "tsz_emitter::safe_slice", "{err}");
+        return Err(err);
+    }
+    if start > end {
+        let err = SliceError::ReversedRange { start, end };
+        debug!(target: "tsz_emitter::safe_slice", "{err}");
+        return Err(err);
+    }
+    if !s.is_char_boundary(start) {
+        let err = SliceError::InvalidUtf8Boundary { index: start };
+        debug!(target: "tsz_emitter::safe_slice", "{err}");
+        return Err(err);
+    }
+    if !s.is_char_boundary(end) {
+        let err = SliceError::InvalidUtf8Boundary { index: end };
+        debug!(target: "tsz_emitter::safe_slice", "{err}");
+        return Err(err);
     }
 
-    // Check if indices are valid UTF-8 boundaries
-    if !s.is_char_boundary(start) || !s.is_char_boundary(end) {
-        return "";
-    }
+    Ok(&s[start..end])
+}
 
-    &s[start..end]
+/// Compatibility shim that returns `""` when [`slice`] would fail.
+///
+/// This preserves the historical "silent empty on invalid" behavior for call
+/// sites where an empty fallback is intentional (e.g., best-effort comment
+/// text extraction where a bad span should simply skip the comment).
+///
+/// New code should call [`slice`] directly and handle [`SliceError`].
+///
+/// TODO(safe_slice): remove once every emitter call site has been audited.
+pub fn slice_or_empty(s: &str, start: usize, end: usize) -> &str {
+    slice(s, start, end).unwrap_or("")
 }
 
 #[cfg(test)]

--- a/crates/tsz-emitter/tests/safe_slice.rs
+++ b/crates/tsz-emitter/tests/safe_slice.rs
@@ -1,30 +1,120 @@
 use super::*;
 
 #[test]
-fn test_safe_slice_basic() {
+fn valid_non_empty_slice() {
     let s = "hello world";
-    assert_eq!(slice(s, 0, 5), "hello");
-    assert_eq!(slice(s, 6, 11), "world");
+    assert_eq!(slice(s, 0, 5), Ok("hello"));
+    assert_eq!(slice(s, 6, 11), Ok("world"));
+    assert_eq!(slice(s, 0, 11), Ok("hello world"));
 }
 
 #[test]
-fn test_safe_slice_empty() {
+fn valid_empty_slice() {
     let s = "hello";
-    assert_eq!(slice(s, 10, 20), "");
-    assert_eq!(slice(s, 5, 3), "");
+    assert_eq!(slice(s, 0, 0), Ok(""));
+    assert_eq!(slice(s, 3, 3), Ok(""));
+    assert_eq!(slice(s, 5, 5), Ok(""));
 }
 
 #[test]
-fn test_safe_slice_unicode() {
+fn start_out_of_bounds() {
+    let s = "hello"; // len 5
+    assert_eq!(
+        slice(s, 6, 6),
+        Err(SliceError::StartOutOfBounds { start: 6, len: 5 }),
+    );
+    assert_eq!(
+        slice(s, 100, 200),
+        Err(SliceError::StartOutOfBounds { start: 100, len: 5 }),
+    );
+}
+
+#[test]
+fn end_out_of_bounds() {
+    let s = "hello"; // len 5
+    assert_eq!(
+        slice(s, 0, 6),
+        Err(SliceError::EndOutOfBounds { end: 6, len: 5 }),
+    );
+    assert_eq!(
+        slice(s, 2, 100),
+        Err(SliceError::EndOutOfBounds { end: 100, len: 5 }),
+    );
+}
+
+#[test]
+fn reversed_range() {
+    let s = "hello";
+    assert_eq!(
+        slice(s, 4, 2),
+        Err(SliceError::ReversedRange { start: 4, end: 2 }),
+    );
+}
+
+#[test]
+fn invalid_utf8_boundary() {
     let s = "hello 🦀 world";
-    // The crab emoji is 4 bytes
-    let crab_start = 6;
-    let crab_end = 10;
+    // The crab emoji starts at byte 6 and occupies 4 bytes (6..10).
+    // Byte 7 lands in the middle of the emoji — not a char boundary.
+    assert_eq!(
+        slice(s, 7, 10),
+        Err(SliceError::InvalidUtf8Boundary { index: 7 }),
+    );
+    // Valid start, invalid end (mid-emoji).
+    assert_eq!(
+        slice(s, 6, 9),
+        Err(SliceError::InvalidUtf8Boundary { index: 9 }),
+    );
+    // Valid boundaries around the emoji should still work.
+    assert_eq!(slice(s, 0, 6), Ok("hello "));
+    assert_eq!(slice(s, 6, 10), Ok("🦀"));
+}
 
-    // Safe slice should work with valid boundaries
-    assert_eq!(slice(s, 0, crab_start), "hello ");
-    assert_eq!(slice(s, crab_end + 1, s.len()), "world");
+#[test]
+fn error_order_start_before_end_before_reversed() {
+    // When both start and end are out of bounds, StartOutOfBounds wins.
+    let s = "ab"; // len 2
+    assert_eq!(
+        slice(s, 10, 5),
+        Err(SliceError::StartOutOfBounds { start: 10, len: 2 }),
+    );
+    // Start in-bounds, end out-of-bounds: EndOutOfBounds wins.
+    assert_eq!(
+        slice(s, 1, 9),
+        Err(SliceError::EndOutOfBounds { end: 9, len: 2 }),
+    );
+    // Both in-bounds but reversed: ReversedRange wins (not boundary error).
+    let u = "🦀🦀"; // len 8, crab boundaries at 0/4/8
+    assert_eq!(
+        slice(u, 4, 1),
+        Err(SliceError::ReversedRange { start: 4, end: 1 }),
+    );
+}
 
-    // Invalid boundary should return empty
-    assert_eq!(slice(s, 7, 9), ""); // Mid-emoji
+#[test]
+fn slice_or_empty_returns_valid_content() {
+    let s = "hello world";
+    assert_eq!(slice_or_empty(s, 0, 5), "hello");
+    assert_eq!(slice_or_empty(s, 6, 11), "world");
+    assert_eq!(slice_or_empty(s, 3, 3), "");
+}
+
+#[test]
+fn slice_or_empty_swallows_errors() {
+    let s = "hello";
+    assert_eq!(slice_or_empty(s, 0, 100), "");
+    assert_eq!(slice_or_empty(s, 100, 200), "");
+    assert_eq!(slice_or_empty(s, 5, 3), "");
+
+    let u = "hello 🦀";
+    assert_eq!(slice_or_empty(u, 7, 9), ""); // mid-emoji
+}
+
+#[test]
+fn slice_error_display_is_informative() {
+    let s = "ab";
+    let err = slice(s, 10, 5).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("10"), "msg={msg}");
+    assert!(msg.contains("out of bounds"), "msg={msg}");
 }


### PR DESCRIPTION
## Summary
Refactor the `safe_slice::slice()` function to return a `Result<&str, SliceError>` instead of silently returning an empty string on invalid input. This surfaces span bugs during development while maintaining backward compatibility through a `slice_or_empty()` shim.

## Key Changes

- **New `SliceError` enum**: Structured error type with four variants:
  - `StartOutOfBounds { start, len }` — start index exceeds string length
  - `EndOutOfBounds { end, len }` — end index exceeds string length
  - `ReversedRange { start, end }` — start > end
  - `InvalidUtf8Boundary { index }` — index not on UTF-8 character boundary

- **Fallible `slice()` function**: Now returns `Result<&str, SliceError>` with deterministic error ordering (start bound → end bound → reversed range → UTF-8 boundary). Emits `tracing::debug!` logs for invalid requests.

- **Compatibility shim `slice_or_empty()`**: Preserves the historical "silent empty on invalid" behavior for call sites where it's intentional (e.g., best-effort comment extraction). Marked for eventual removal once all call sites are audited.

- **Comprehensive test coverage**: Expanded test suite covering valid slices, empty slices, all four error conditions, error ordering precedence, and the compatibility shim.

- **Updated all call sites**: Migrated ~30 call sites in the emitter to use `slice_or_empty()` where the empty fallback is deliberate (comment text extraction, span-based text retrieval).

## Implementation Details

- Error checking follows a fixed order to ensure consistent, predictable error reporting
- `SliceError` implements `Display` and `std::error::Error` for ergonomic error handling
- Debug logging targets `"tsz_emitter::safe_slice"` for visibility in development builds
- No panics — all invalid requests are caught and reported

https://claude.ai/code/session_01EtUeWiMfj4CRrhMHgPVFg5