### PR TITLE
Use eslint --fix-dry-run with stdin for formatting

### DIFF
--- a/crates/tsz-lsp/src/formatting.rs
+++ b/crates/tsz-lsp/src/formatting.rs
@@ -194,37 +194,92 @@ impl DocumentFormattingProvider {
         Self::compute_line_edits(source_text, &formatted)
     }
 
-    /// Format using eslint with --fix.
+    /// Format using eslint with stdin-based `--fix-dry-run`.
+    ///
+    /// Pipes the in-memory document buffer into `ESLint` via stdin so that
+    /// formatting operates on the current editor buffer rather than whatever
+    /// happens to be on disk. This matches the LSP contract that unsaved
+    /// changes are the source of truth, and avoids the stale-disk/new-buffer
+    /// diff mismatch the previous `--fix --fix-to-stdout <file>` invocation
+    /// produced.
     #[cfg(not(target_arch = "wasm32"))]
     fn format_with_eslint(
         file_path: &str,
         source_text: &str,
         _options: &FormattingOptions,
     ) -> Result<Vec<TextEdit>, String> {
-        let output = Command::new("eslint")
-            .arg("--fix")
-            .arg("--fix-to-stdout")
+        let path = Path::new(file_path);
+
+        let child = Command::new("eslint")
+            .arg("--fix-dry-run")
+            .arg("--stdin")
+            .arg("--stdin-filename")
             .arg(file_path)
+            .arg("--format")
+            .arg("json")
+            .current_dir(path.parent().unwrap_or_else(|| Path::new(".")))
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .map_err(|e| format!("Failed to spawn eslint: {e}"))?;
 
-        let result = output
+        child
+            .stdin
+            .as_ref()
+            .ok_or("Failed to open eslint stdin")?
+            .write_all(source_text.as_bytes())
+            .map_err(|e| format!("Failed to write to eslint stdin: {e}"))?;
+
+        let result = child
             .wait_with_output()
             .map_err(|e| format!("Failed to read eslint output: {e}"))?;
 
-        if !result.status.success() {
+        // Exit code 0 = no problems, 1 = lint problems (fixable or not),
+        // 2 = internal/configuration error. With `--fix-dry-run` we still
+        // want to read stdout for codes 0 and 1.
+        if result.status.code().is_some_and(|c| c >= 2) {
             let stderr = String::from_utf8_lossy(&result.stderr);
-            if result.stdout.is_empty() {
-                return Err(format!("ESLint failed: {stderr}"));
-            }
+            return Err(format!("ESLint failed: {stderr}"));
         }
 
-        let formatted = String::from_utf8_lossy(&result.stdout).to_string();
+        let stdout = String::from_utf8_lossy(&result.stdout);
+        match Self::parse_eslint_fix_output(&stdout) {
+            Ok(Some(formatted)) => Self::compute_line_edits(source_text, &formatted),
+            Ok(None) => Ok(vec![]),
+            Err(err) => {
+                let stderr = String::from_utf8_lossy(&result.stderr);
+                tracing::debug!(error = %err, stderr = %stderr, "eslint JSON parse failed");
+                Err(err)
+            }
+        }
+    }
 
-        Self::compute_line_edits(source_text, &formatted)
+    /// Parse `ESLint` `--format=json` output and return the `output` field
+    /// from the first result, if any fixes were produced.
+    ///
+    /// Returns:
+    /// - `Ok(Some(text))` when `ESLint` emitted a fixed version of the source.
+    /// - `Ok(None)` when `ESLint` produced no fixes (empty stdout or no
+    ///   `output` key on the result object).
+    /// - `Err(msg)` when stdout is non-empty but not valid JSON.
+    pub fn parse_eslint_fix_output(stdout: &str) -> Result<Option<String>, String> {
+        let trimmed = stdout.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(trimmed)
+            .map_err(|e| format!("Failed to parse eslint JSON output: {e}"))?;
+
+        let output = parsed
+            .as_array()
+            .and_then(|arr| arr.first())
+            .and_then(|result| result.get("output"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string);
+
+        Ok(output)
     }
 
     /// Compute per-line text edits between original and formatted text.

--- a/crates/tsz-lsp/tests/formatting_tests.rs
+++ b/crates/tsz-lsp/tests/formatting_tests.rs
@@ -1439,3 +1439,64 @@ fn test_formatting_on_single_line_blocks() {
         "Expected 'if (true) {{ }}' but got: {formatted}"
     );
 }
+
+#[test]
+fn test_parse_eslint_fix_output_empty_stdout() {
+    // ESLint can exit with no stdout at all (e.g. non-applicable file).
+    let result = DocumentFormattingProvider::parse_eslint_fix_output("").unwrap();
+    assert!(result.is_none());
+
+    let result = DocumentFormattingProvider::parse_eslint_fix_output("   \n   ").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_parse_eslint_fix_output_no_fixes() {
+    // Clean file: result object has no `output` field.
+    let json = r#"[{
+        "filePath": "/tmp/foo.ts",
+        "messages": [],
+        "errorCount": 0,
+        "warningCount": 0,
+        "fixableErrorCount": 0,
+        "fixableWarningCount": 0,
+        "source": "let x = 1;\n"
+    }]"#;
+    let result = DocumentFormattingProvider::parse_eslint_fix_output(json).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_parse_eslint_fix_output_with_fixes() {
+    // `output` present: return it verbatim.
+    let json = r#"[{
+        "filePath": "/tmp/foo.ts",
+        "messages": [],
+        "errorCount": 0,
+        "warningCount": 0,
+        "fixableErrorCount": 0,
+        "fixableWarningCount": 0,
+        "output": "let x = 1;\n"
+    }]"#;
+    let result = DocumentFormattingProvider::parse_eslint_fix_output(json).unwrap();
+    assert_eq!(result.as_deref(), Some("let x = 1;\n"));
+}
+
+#[test]
+fn test_parse_eslint_fix_output_invalid_json() {
+    let result = DocumentFormattingProvider::parse_eslint_fix_output("not json at all");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_parse_eslint_fix_output_non_array_root() {
+    // Defensive: non-array JSON should not panic, just yield None.
+    let result = DocumentFormattingProvider::parse_eslint_fix_output(r#"{"foo":"bar"}"#).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_parse_eslint_fix_output_empty_array() {
+    let result = DocumentFormattingProvider::parse_eslint_fix_output("[]").unwrap();
+    assert!(result.is_none());
+}


### PR DESCRIPTION
## Summary
Refactor ESLint formatting to use stdin-based `--fix-dry-run` instead of the previous `--fix --fix-to-stdout <file>` approach. This ensures formatting operates on the current editor buffer rather than disk state, matching the LSP contract that unsaved changes are the source of truth.

## Key Changes
- **Changed ESLint invocation**: Replace `--fix --fix-to-stdout <file>` with `--fix-dry-run --stdin --stdin-filename <file> --format json`
  - Pipes document buffer via stdin instead of reading from disk
  - Uses JSON output format for structured parsing
  - Avoids stale-disk/new-buffer diff mismatches

- **Improved error handling**: 
  - Only treat exit codes ≥ 2 as fatal errors (0 = no problems, 1 = lint problems)
  - With `--fix-dry-run`, both exit codes 0 and 1 produce valid stdout to parse

- **Extracted JSON parsing logic**:
  - New `parse_eslint_fix_output()` method handles ESLint JSON output parsing
  - Returns `Ok(Some(text))` when fixes are present, `Ok(None)` when no fixes needed
  - Defensive handling of edge cases (empty stdout, non-array JSON, missing `output` field)

- **Added comprehensive test coverage**:
  - Tests for empty stdout handling
  - Tests for clean files (no fixes needed)
  - Tests for files with fixes applied
  - Tests for invalid JSON and malformed responses
  - Tests for edge cases (non-array root, empty array)

## Implementation Details
- The stdin approach ensures the formatter always sees the current buffer state, not whatever may be on disk
- JSON parsing is defensive and gracefully handles cases where ESLint produces no `output` field (indicating no changes needed)
- Working directory is set to the file's parent directory to respect ESLint configuration files

https://claude.ai/code/session_01PWL16VZLDFYSTrmrcoraBa