### PR TITLE
Replace TypeId::DELEGATE sentinel with ExprCheckResult enum

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -788,7 +788,16 @@ impl<'a> CheckerState<'a> {
         // When clear_type_cache_recursive removes the RHS entry for contextual
         // re-checking, the result ends up only in request_node_types. Flow analysis
         // needs node_types to compute assignment-based narrowing (e.g., `d ?? (d = x ?? "x")`).
-        if right_raw != TypeId::ERROR && right_raw != TypeId::DELEGATE {
+        //
+        // `get_type_of_node_with_request` always returns a real `TypeId`
+        // (never `DELEGATE`); the assert is defence-in-depth in case that
+        // contract regresses.
+        debug_assert_ne!(
+            right_raw,
+            TypeId::DELEGATE,
+            "get_type_of_node_with_request must never return the DELEGATE sentinel"
+        );
+        if right_raw != TypeId::ERROR {
             self.ctx.node_types.or_insert(right_idx.0, right_raw);
         }
 

--- a/crates/tsz-checker/src/expr.rs
+++ b/crates/tsz-checker/src/expr.rs
@@ -8,15 +8,19 @@
 //!
 //! `ExpressionChecker` serves as the primary dispatcher for expression types.
 //! Simple expressions are handled directly here, while complex expressions
-//! that need full `CheckerState` context return `TypeId::DELEGATE` to signal
-//! that `CheckerState::compute_type_of_node` should handle them.
+//! that need full `CheckerState` context are reported as
+//! [`ExprCheckResult::Delegate`] so `CheckerState::compute_type_of_node`
+//! can handle them.
+//!
+//! Delegation is control flow, not a type — it indicates "this expression
+//! is not handled here, ask `CheckerState`". It must never appear as a
+//! `TypeId` in `ctx.node_types` or `ctx.request_node_types`.
 //!
 //! ### Expressions handled directly:
 //! - Simple literals without contextual typing (null)
 //! - typeof expressions (always string)
 //! - void expressions (always undefined)
-//! - Postfix unary (++/-- always return number)
-//! - Parenthesized expressions (pass through)
+//! - Parenthesized expressions (pass through in TS files)
 //!
 //! ### Expressions delegated to `CheckerState`:
 //! - Literals with contextual typing (numeric, string, boolean, template)
@@ -38,6 +42,44 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 use tsz_solver::recursion::{DepthCounter, RecursionProfile};
+
+/// Result of dispatching an expression through [`ExpressionChecker`].
+///
+/// Either the expression was handled directly here and produced a real
+/// [`TypeId`], or the expression requires full [`CheckerState`] context
+/// and must be delegated.
+///
+/// [`CheckerState`]: crate::state::CheckerState
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ExprCheckResult {
+    /// Expression was fully resolved to a concrete [`TypeId`].
+    ///
+    /// Only values of this variant may be written into `ctx.node_types`
+    /// or `ctx.request_node_types`.
+    Type(TypeId),
+    /// Expression must be handled by [`CheckerState`] — this is control
+    /// flow, not a type, and must never reach a type cache.
+    ///
+    /// [`CheckerState`]: crate::state::CheckerState
+    Delegate,
+}
+
+impl ExprCheckResult {
+    /// Return the concrete type if fully resolved, else `None`.
+    #[inline]
+    pub const fn type_id(self) -> Option<TypeId> {
+        match self {
+            Self::Type(ty) => Some(ty),
+            Self::Delegate => None,
+        }
+    }
+
+    /// Return `true` when the result represents a delegation marker.
+    #[inline]
+    pub const fn is_delegate(self) -> bool {
+        matches!(self, Self::Delegate)
+    }
+}
 
 /// Expression type checker that operates on the shared context.
 ///
@@ -64,25 +106,37 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
         }
     }
 
-    /// Check an expression and return its type.
+    /// Dispatch an expression, caching only concrete results.
     ///
-    /// This is the main entry point for expression type checking.
-    /// It handles caching and dispatches to specific expression handlers.
-    pub fn check(&mut self, idx: NodeIndex) -> TypeId {
+    /// Returns [`ExprCheckResult::Type`] for expressions handled directly,
+    /// [`ExprCheckResult::Delegate`] for expressions that must be resolved
+    /// by [`CheckerState`]. Delegation markers are never written to any
+    /// cache.
+    ///
+    /// [`CheckerState`]: crate::state::CheckerState
+    pub fn check(&mut self, idx: NodeIndex) -> ExprCheckResult {
         self.check_with_context(idx, None)
     }
 
-    /// Check an expression with a contextual type hint.
+    /// Dispatch an expression with a contextual type hint.
     ///
     /// Contextual types enable downward inference where the expected type
     /// influences the inferred type. For example:
-    /// - `const x: string = expr` - `expr` is checked with context `string`
-    /// - `const f: (x: number) => void = (x) => {}` - `x` is inferred as `number`
+    /// - `const x: string = expr` — `expr` is checked with context `string`
+    /// - `const f: (x: number) => void = (x) => {}` — `x` is inferred as `number`
     ///
-    pub fn check_with_context(&mut self, idx: NodeIndex, context_type: Option<TypeId>) -> TypeId {
+    /// Only real types ([`ExprCheckResult::Type`]) are ever cached in
+    /// `ctx.node_types`/`ctx.request_node_types`. Delegation results
+    /// bypass all caches, so repeated calls on delegated nodes always
+    /// return [`ExprCheckResult::Delegate`] rather than a cached sentinel.
+    pub fn check_with_context(
+        &mut self,
+        idx: NodeIndex,
+        context_type: Option<TypeId>,
+    ) -> ExprCheckResult {
         // Stack overflow protection
         if !self.depth.enter() {
-            return TypeId::ERROR;
+            return ExprCheckResult::Type(TypeId::ERROR);
         }
 
         let result = if let Some(ctx_type) = context_type {
@@ -92,38 +146,56 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
                     .then(|| RequestCacheKey::from_request(&request))
                     .flatten()
             });
-            if let Some(key) = cache_key {
-                if let Some(&cached) = self.ctx.request_node_types.get(&(idx.0, key)) {
-                    self.ctx.request_cache_counters.request_cache_hits += 1;
-                    self.depth.leave();
-                    return cached;
-                }
+            if let Some(key) = cache_key
+                && let Some(&cached) = self.ctx.request_node_types.get(&(idx.0, key))
+            {
+                self.ctx.request_cache_counters.request_cache_hits += 1;
+                self.depth.leave();
+                return ExprCheckResult::Type(cached);
+            }
+            if cache_key.is_some() {
                 self.ctx.request_cache_counters.request_cache_misses += 1;
             }
 
             let result = self.compute_type_with_context(idx, ctx_type);
-            if let Some(key) = cache_key {
-                if result != TypeId::DELEGATE {
-                    self.ctx.request_node_types.insert((idx.0, key), result);
-                } else {
+            match result {
+                ExprCheckResult::Type(ty) => {
+                    if let Some(key) = cache_key {
+                        debug_assert_ne!(
+                            ty,
+                            TypeId::DELEGATE,
+                            "DELEGATE sentinel must never be inserted into request_node_types"
+                        );
+                        self.ctx.request_node_types.insert((idx.0, key), ty);
+                    } else {
+                        // Keep unaudited contextual direct checks uncached until
+                        // their request dependencies are made explicit and reviewed.
+                        self.ctx.request_cache_counters.contextual_cache_bypasses += 1;
+                    }
+                }
+                ExprCheckResult::Delegate => {
                     self.ctx.request_cache_counters.contextual_cache_bypasses += 1;
                 }
-            } else {
-                // Keep unaudited contextual direct checks uncached until their
-                // request dependencies are made explicit and reviewed.
-                self.ctx.request_cache_counters.contextual_cache_bypasses += 1;
             }
             result
         } else {
             // Check cache first for non-contextual checks
             if let Some(&cached) = self.ctx.node_types.get(&idx.0) {
                 self.depth.leave();
-                return cached;
+                return ExprCheckResult::Type(cached);
             }
 
-            // Compute and cache
+            // Compute; cache only concrete results. Delegation is control
+            // flow, not a type, so the cache contract forbids storing it.
             let result = self.compute_type(idx);
-            self.ctx.node_types.insert(idx.0, result);
+            if let ExprCheckResult::Type(ty) = result {
+                debug_assert_ne!(
+                    ty,
+                    TypeId::DELEGATE,
+                    "DELEGATE sentinel must never be inserted into node_types"
+                );
+                self.ctx.node_types.insert(idx.0, ty);
+            }
             result
         };
 
@@ -131,25 +203,42 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
         result
     }
 
-    /// Compute the type of an expression without caching.
+    /// Try to compute an expression's type without touching caches.
     ///
-    /// This is called by `CheckerState::compute_type_of_node` to get an initial
-    /// type for expressions. Returns `TypeId::DELEGATE` if the expression needs
-    /// full `CheckerState` context for proper type resolution.
+    /// Returns [`ExprCheckResult::Delegate`] for expressions that need
+    /// [`CheckerState`] context for proper resolution.
     ///
-    /// Simple expressions that don't need contextual typing or symbol resolution
-    /// are handled directly here. Complex expressions delegate to `CheckerState`.
-    pub fn compute_type_uncached(&mut self, idx: NodeIndex) -> TypeId {
+    /// [`CheckerState`]: crate::state::CheckerState
+    pub fn try_compute_expr_type(&mut self, idx: NodeIndex) -> ExprCheckResult {
         self.compute_type_impl(idx, None)
     }
 
-    /// Compute the type of an expression with an optional contextual type, without caching.
+    /// Try to compute an expression's type under a contextual type, without caching.
+    pub fn try_compute_expr_type_with_context(
+        &mut self,
+        idx: NodeIndex,
+        context_type: Option<TypeId>,
+    ) -> ExprCheckResult {
+        self.compute_type_impl(idx, context_type)
+    }
+
+    /// Back-compat alias for [`Self::try_compute_expr_type`].
+    ///
+    /// Prefer the `try_compute_expr_type*` names — they advertise that the
+    /// result may be a delegation marker.
+    #[inline]
+    pub fn compute_type_uncached(&mut self, idx: NodeIndex) -> ExprCheckResult {
+        self.try_compute_expr_type(idx)
+    }
+
+    /// Back-compat alias for [`Self::try_compute_expr_type_with_context`].
+    #[inline]
     pub fn compute_type_uncached_with_context(
         &mut self,
         idx: NodeIndex,
         context_type: Option<TypeId>,
-    ) -> TypeId {
-        self.compute_type_impl(idx, context_type)
+    ) -> ExprCheckResult {
+        self.try_compute_expr_type_with_context(idx, context_type)
     }
 
     /// Compute the type of an expression with contextual typing (no caching).
@@ -157,27 +246,38 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
     /// This is called when a contextual type is available (e.g., from variable
     /// declarations, assignments, function parameters). The contextual type
     /// influences how the expression is inferred.
-    fn compute_type_with_context(&mut self, idx: NodeIndex, context_type: TypeId) -> TypeId {
+    fn compute_type_with_context(
+        &mut self,
+        idx: NodeIndex,
+        context_type: TypeId,
+    ) -> ExprCheckResult {
         self.compute_type_impl(idx, Some(context_type))
     }
 
     /// Compute the type of an expression (internal, not cached).
-    fn compute_type(&mut self, idx: NodeIndex) -> TypeId {
+    fn compute_type(&mut self, idx: NodeIndex) -> ExprCheckResult {
         self.compute_type_impl(idx, None)
     }
 
     /// Core implementation for computing expression types.
     ///
-    /// Returns `TypeId::DELEGATE` for complex expressions that need `CheckerState`.
+    /// Returns [`ExprCheckResult::Delegate`] for complex expressions that
+    /// need [`CheckerState`].
     ///
     /// # Parameters
     /// - `idx`: The node index to check
     /// - `context_type`: Optional contextual type hint for downward inference
-    fn compute_type_impl(&mut self, idx: NodeIndex, _context_type: Option<TypeId>) -> TypeId {
+    ///
+    /// [`CheckerState`]: crate::state::CheckerState
+    fn compute_type_impl(
+        &mut self,
+        idx: NodeIndex,
+        _context_type: Option<TypeId>,
+    ) -> ExprCheckResult {
         let Some(node) = self.ctx.arena.get(idx) else {
             // Return ERROR for missing arena nodes (typically cross-file references)
             // to suppress cascading false diagnostics like TS18046.
-            return TypeId::ERROR;
+            return ExprCheckResult::Type(TypeId::ERROR);
         };
 
         match node.kind {
@@ -186,13 +286,13 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
             // =====================================================================
 
             // Null literal - always TypeId::NULL (context doesn't affect null)
-            k if k == SyntaxKind::NullKeyword as u16 => TypeId::NULL,
+            k if k == SyntaxKind::NullKeyword as u16 => ExprCheckResult::Type(TypeId::NULL),
 
             // typeof expression always returns string (context doesn't affect typeof)
-            k if k == syntax_kind_ext::TYPE_OF_EXPRESSION => TypeId::STRING,
+            k if k == syntax_kind_ext::TYPE_OF_EXPRESSION => ExprCheckResult::Type(TypeId::STRING),
 
             // void expression always returns undefined (context doesn't affect void)
-            k if k == syntax_kind_ext::VOID_EXPRESSION => TypeId::UNDEFINED,
+            k if k == syntax_kind_ext::VOID_EXPRESSION => ExprCheckResult::Type(TypeId::UNDEFINED),
 
             // Parenthesized expression - pass through context to inner expression.
             // In JS files, parenthesized expressions may carry JSDoc type casts
@@ -200,126 +300,118 @@ impl<'a, 'ctx> ExpressionChecker<'a, 'ctx> {
             k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
                 if self.ctx.is_js_file() {
                     // Delegate to CheckerState which handles JSDoc @type and @satisfies
-                    return TypeId::DELEGATE;
+                    return ExprCheckResult::Delegate;
                 }
                 if let Some(paren) = self.ctx.arena.get_parenthesized(node) {
                     // Check if expression is missing (parse error: empty parentheses)
                     if paren.expression.is_none() {
                         // Parse error - return ERROR to suppress cascading errors
-                        return TypeId::ERROR;
+                        return ExprCheckResult::Type(TypeId::ERROR);
                     }
                     // Recursively check inner expression with same context
                     self.compute_type_impl(paren.expression, _context_type)
                 } else {
-                    // Return DELEGATE to let CheckerState handle malformed nodes
-                    TypeId::DELEGATE
+                    // Let CheckerState handle malformed nodes
+                    ExprCheckResult::Delegate
                 }
             }
 
             // =====================================================================
-            // Literals with contextual typing - DELEGATE to CheckerState
+            // Literals with contextual typing - delegate to CheckerState.
             // These need contextual typing analysis to decide between literal types
             // (e.g., `42` as literal) vs widened types (e.g., `number`).
             // =====================================================================
-            k if k == SyntaxKind::NumericLiteral as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::StringLiteral as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::TrueKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::FalseKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 => TypeId::DELEGATE,
+            k if k == SyntaxKind::NumericLiteral as u16
+                || k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::TrueKeyword as u16
+                || k == SyntaxKind::FalseKeyword as u16
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
+            {
+                ExprCheckResult::Delegate
+            }
 
             // =====================================================================
-            // Expressions requiring symbol resolution - DELEGATE to CheckerState
+            // Expressions requiring symbol resolution
             // =====================================================================
-            k if k == SyntaxKind::Identifier as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::ThisKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::SuperKeyword as u16 => TypeId::DELEGATE,
-
-            // =====================================================================
-            // Complex expressions - DELEGATE to CheckerState
-            // =====================================================================
-
-            // Binary expressions need operator type resolution and narrowing
-            k if k == syntax_kind_ext::BINARY_EXPRESSION => TypeId::DELEGATE,
-
-            // Call/new expressions need signature resolution
-            k if k == syntax_kind_ext::CALL_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::NEW_EXPRESSION => TypeId::DELEGATE,
-
-            // Property/element access need object type resolution
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => TypeId::DELEGATE,
-
-            // Conditional expressions need union type building
-            k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => TypeId::DELEGATE,
-
-            // Function expressions need signature building
-            k if k == syntax_kind_ext::FUNCTION_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::ARROW_FUNCTION => TypeId::DELEGATE,
-
-            // Object/array literals need contextual typing
-            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => TypeId::DELEGATE,
-
-            // Class expressions need class type building
-            k if k == syntax_kind_ext::CLASS_EXPRESSION => TypeId::DELEGATE,
-
-            // Unary expressions need operand type checking
-            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION => TypeId::DELEGATE,
-
-            // Await expressions need Promise unwrapping
-            k if k == syntax_kind_ext::AWAIT_EXPRESSION => TypeId::DELEGATE,
-
-            // Type assertions need type node resolution
-            k if k == syntax_kind_ext::AS_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::SATISFIES_EXPRESSION => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::TYPE_ASSERTION => TypeId::DELEGATE,
-
-            // Template expressions need string interpolation handling
-            k if k == syntax_kind_ext::TEMPLATE_EXPRESSION => TypeId::DELEGATE,
-
-            // Variable declarations need initializer/annotation handling
-            k if k == syntax_kind_ext::VARIABLE_DECLARATION => TypeId::DELEGATE,
-
-            // Function declarations need signature building
-            k if k == syntax_kind_ext::FUNCTION_DECLARATION => TypeId::DELEGATE,
+            k if k == SyntaxKind::Identifier as u16
+                || k == SyntaxKind::ThisKeyword as u16
+                || k == SyntaxKind::SuperKeyword as u16 =>
+            {
+                ExprCheckResult::Delegate
+            }
 
             // =====================================================================
-            // Type nodes - DELEGATE to CheckerState
-            // These are not expressions but may be passed through get_type_of_node
+            // Complex expressions
             // =====================================================================
-            k if k == syntax_kind_ext::TYPE_REFERENCE => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::UNION_TYPE => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::INTERSECTION_TYPE => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::ARRAY_TYPE => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::TYPE_OPERATOR => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::FUNCTION_TYPE => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::TYPE_LITERAL => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::TYPE_QUERY => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::QUALIFIED_NAME => TypeId::DELEGATE,
+            k if k == syntax_kind_ext::BINARY_EXPRESSION
+                || k == syntax_kind_ext::CALL_EXPRESSION
+                || k == syntax_kind_ext::NEW_EXPRESSION
+                || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::CONDITIONAL_EXPRESSION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION
+                || k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::CLASS_EXPRESSION
+                || k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+                || k == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION
+                || k == syntax_kind_ext::AWAIT_EXPRESSION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION
+                || k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::TEMPLATE_EXPRESSION
+                || k == syntax_kind_ext::VARIABLE_DECLARATION
+                || k == syntax_kind_ext::FUNCTION_DECLARATION =>
+            {
+                ExprCheckResult::Delegate
+            }
 
-            // Type keywords - DELEGATE to CheckerState for consistency
-            k if k == SyntaxKind::NumberKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::StringKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::BooleanKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::VoidKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::AnyKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::NeverKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::UnknownKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::UndefinedKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::ObjectKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::BigIntKeyword as u16 => TypeId::DELEGATE,
-            k if k == SyntaxKind::SymbolKeyword as u16 => TypeId::DELEGATE,
+            // =====================================================================
+            // Type nodes - delegate to CheckerState.
+            // These are not expressions but may be passed through get_type_of_node.
+            // =====================================================================
+            k if k == syntax_kind_ext::TYPE_REFERENCE
+                || k == syntax_kind_ext::UNION_TYPE
+                || k == syntax_kind_ext::INTERSECTION_TYPE
+                || k == syntax_kind_ext::ARRAY_TYPE
+                || k == syntax_kind_ext::TYPE_OPERATOR
+                || k == syntax_kind_ext::FUNCTION_TYPE
+                || k == syntax_kind_ext::TYPE_LITERAL
+                || k == syntax_kind_ext::TYPE_QUERY
+                || k == syntax_kind_ext::QUALIFIED_NAME =>
+            {
+                ExprCheckResult::Delegate
+            }
 
-            // JSX elements - DELEGATE to CheckerState
-            k if k == syntax_kind_ext::JSX_ELEMENT => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT => TypeId::DELEGATE,
-            k if k == syntax_kind_ext::JSX_FRAGMENT => TypeId::DELEGATE,
+            // Type keywords - delegate for consistency.
+            k if k == SyntaxKind::NumberKeyword as u16
+                || k == SyntaxKind::StringKeyword as u16
+                || k == SyntaxKind::BooleanKeyword as u16
+                || k == SyntaxKind::VoidKeyword as u16
+                || k == SyntaxKind::AnyKeyword as u16
+                || k == SyntaxKind::NeverKeyword as u16
+                || k == SyntaxKind::UnknownKeyword as u16
+                || k == SyntaxKind::UndefinedKeyword as u16
+                || k == SyntaxKind::ObjectKeyword as u16
+                || k == SyntaxKind::BigIntKeyword as u16
+                || k == SyntaxKind::SymbolKeyword as u16 =>
+            {
+                ExprCheckResult::Delegate
+            }
+
+            // JSX elements
+            k if k == syntax_kind_ext::JSX_ELEMENT
+                || k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT
+                || k == syntax_kind_ext::JSX_FRAGMENT =>
+            {
+                ExprCheckResult::Delegate
+            }
 
             // =====================================================================
             // Default - unknown node type, delegate to CheckerState
             // =====================================================================
-            _ => TypeId::DELEGATE,
+            _ => ExprCheckResult::Delegate,
         }
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -403,7 +403,7 @@ pub use context::{CheckerContext, CheckerOptions, EnclosingClassInfo, TypeCache}
 pub use control_flow::{FlowAnalyzer, FlowGraph as ControlFlowGraph};
 pub use declarations::DeclarationChecker;
 pub use dispatch::ExpressionDispatcher;
-pub use expr::ExpressionChecker;
+pub use expr::{ExprCheckResult, ExpressionChecker};
 pub use flow_analyzer::{
     AssignmentState, AssignmentStateMap, DefiniteAssignmentAnalyzer, DefiniteAssignmentResult,
     merge_assignment_states,

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1706,17 +1706,18 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         request: &crate::context::TypingRequest,
     ) -> TypeId {
-        use crate::ExpressionChecker;
+        use crate::{ExprCheckResult, ExpressionChecker};
 
         let expr_result = {
             let mut expr_checker = ExpressionChecker::new(&mut self.ctx);
-            expr_checker.compute_type_uncached_with_context(idx, request.contextual_type)
+            expr_checker.try_compute_expr_type_with_context(idx, request.contextual_type)
         };
 
-        if expr_result != TypeId::DELEGATE {
-            expr_result
-        } else {
-            self.compute_type_of_node_complex_with_request(idx, request)
+        match expr_result {
+            ExprCheckResult::Type(ty) => ty,
+            ExprCheckResult::Delegate => {
+                self.compute_type_of_node_complex_with_request(idx, request)
+            }
         }
     }
 
@@ -1949,15 +1950,11 @@ impl<'a> CheckerState<'a> {
 
     /// Compute the type of a node (internal, not cached).
     ///
-    /// This method first delegates to `ExpressionChecker` for expression type checking.
-    /// If `ExpressionChecker` returns `TypeId::DELEGATE`, we fall back to the full
-    /// `CheckerState` implementation that has access to symbol resolution, contextual
-    /// typing, and other complex type checking features.
-    /// Complex type computation that needs full `CheckerState` context.
-    ///
-    /// This is called when `ExpressionChecker` returns `TypeId::DELEGATE`,
-    /// indicating the expression needs symbol resolution, contextual typing,
-    /// or other features only available in `CheckerState`.
+    /// This method first dispatches through `ExpressionChecker`. If the
+    /// dispatcher returns [`crate::ExprCheckResult::Delegate`], we fall back
+    /// to the full `CheckerState` implementation that has access to symbol
+    /// resolution, contextual typing, and other complex type checking
+    /// features. Delegation is control flow — it never appears as a `TypeId`.
     #[allow(dead_code)]
     fn compute_type_of_node_complex(&mut self, idx: NodeIndex) -> TypeId {
         self.compute_type_of_node_complex_with_request(idx, &crate::context::TypingRequest::NONE)

--- a/crates/tsz-checker/tests/expr.rs
+++ b/crates/tsz-checker/tests/expr.rs
@@ -3,40 +3,140 @@ use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
 use tsz_solver::TypeInterner;
 
+use crate::CheckerState;
+use crate::context::{RequestCacheKey, TypingRequest};
+use crate::expr::ExprCheckResult;
+
+/// Parse `source` and return the expression node of the first expression
+/// statement. Panics if the source doesn't contain exactly that shape.
+macro_rules! with_first_expression {
+    ($source:expr, |$arena:ident, $expr_idx:ident, $ctx:ident| $body:block) => {{
+        let mut parser = ParserState::new("test.ts".to_string(), $source.to_string());
+        let root = parser.parse_source_file();
+
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+
+        let types = TypeInterner::new();
+        let mut $ctx = CheckerContext::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            crate::context::CheckerOptions::default(),
+        );
+
+        let $arena = parser.get_arena();
+        let root_node = $arena.get(root).expect("root node");
+        let sf = $arena.get_source_file(root_node).expect("source file");
+        let &stmt_idx = sf.statements.nodes.first().expect("at least one statement");
+        let stmt_node = $arena.get(stmt_idx).expect("stmt node");
+        let expr_stmt = $arena
+            .get_expression_statement(stmt_node)
+            .expect("expression statement");
+        let $expr_idx = expr_stmt.expression;
+
+        $body
+    }};
+}
+
 #[test]
 fn test_expression_checker_null_literal() {
-    let source = "null";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut ctx = CheckerContext::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    // Get the expression statement and its expression
-    if let Some(root_node) = parser.get_arena().get(root)
-        && let Some(sf_data) = parser.get_arena().get_source_file(root_node)
-        && let Some(&stmt_idx) = sf_data.statements.nodes.first()
-        && let Some(stmt_node) = parser.get_arena().get(stmt_idx)
-        && let Some(expr_stmt) = parser.get_arena().get_expression_statement(stmt_node)
-    {
+    with_first_expression!("null", |_arena, expr_idx, ctx| {
         let mut checker = ExpressionChecker::new(&mut ctx);
-        let ty = checker.compute_type_uncached(expr_stmt.expression);
-        assert_eq!(ty, TypeId::NULL);
-    }
+        let result = checker.try_compute_expr_type(expr_idx);
+        assert_eq!(result, ExprCheckResult::Type(TypeId::NULL));
+    });
 }
 
 #[test]
 fn test_expression_checker_delegates_numeric_literal() {
-    let source = "42";
+    with_first_expression!("42", |_arena, expr_idx, ctx| {
+        let mut checker = ExpressionChecker::new(&mut ctx);
+        // Numeric literals need contextual typing, so they should delegate.
+        let result = checker.try_compute_expr_type(expr_idx);
+        assert_eq!(result, ExprCheckResult::Delegate);
+        assert!(result.is_delegate());
+        assert!(result.type_id().is_none());
+    });
+}
+
+#[test]
+fn test_check_does_not_cache_delegation_in_node_types() {
+    // Identifier requires symbol resolution — ExpressionChecker delegates it.
+    // ExpressionChecker::check must NEVER write a DELEGATE sentinel into
+    // ctx.node_types.
+    with_first_expression!("foo", |_arena, expr_idx, ctx| {
+        assert!(
+            !ctx.node_types.contains_key(&expr_idx.0),
+            "node_types should be empty before check()"
+        );
+        let result = {
+            let mut checker = ExpressionChecker::new(&mut ctx);
+            checker.check(expr_idx)
+        };
+        assert_eq!(result, ExprCheckResult::Delegate);
+        assert!(
+            !ctx.node_types.contains_key(&expr_idx.0),
+            "delegated node must not leak a cache entry into node_types"
+        );
+    });
+}
+
+#[test]
+fn test_check_with_context_does_not_cache_delegation_in_request_cache() {
+    // Numeric literal with a contextual type normally populates
+    // request_node_types; but if the expression delegates, nothing must be
+    // written — delegation is control flow, not a type.
+    with_first_expression!("42", |_arena, expr_idx, ctx| {
+        let before = ctx.request_node_types.len();
+        let result = {
+            let mut checker = ExpressionChecker::new(&mut ctx);
+            checker.check_with_context(expr_idx, Some(TypeId::NUMBER))
+        };
+        assert_eq!(result, ExprCheckResult::Delegate);
+        assert_eq!(
+            ctx.request_node_types.len(),
+            before,
+            "delegated contextual node must not leak a cache entry into request_node_types"
+        );
+
+        // And even if we reach into the audited-kind cache key directly,
+        // there must not be a DELEGATE entry keyed for this node.
+        let request = TypingRequest::with_contextual_type(TypeId::NUMBER);
+        if let Some(key) = RequestCacheKey::from_request(&request) {
+            assert!(
+                !ctx.request_node_types.contains_key(&(expr_idx.0, key)),
+                "request_node_types must not contain an entry for a delegated node"
+            );
+        }
+    });
+}
+
+#[test]
+fn test_check_repeated_delegation_does_not_return_cached_sentinel() {
+    // Regardless of how many times we dispatch a delegated node, we must
+    // always get `Delegate` back — never a cached `Type(DELEGATE)`.
+    with_first_expression!("foo.bar", |_arena, expr_idx, ctx| {
+        let mut checker = ExpressionChecker::new(&mut ctx);
+        for _ in 0..3 {
+            let result = checker.check(expr_idx);
+            assert_eq!(result, ExprCheckResult::Delegate);
+            assert!(
+                matches!(result, ExprCheckResult::Delegate),
+                "repeated dispatch must keep reporting Delegate, not a cached TypeId sentinel"
+            );
+        }
+        // And still nothing in the cache.
+        assert!(!checker.context().node_types.contains_key(&expr_idx.0));
+    });
+}
+
+#[test]
+fn test_checker_state_resolves_delegated_nodes_to_real_type() {
+    // CheckerState::get_type_of_node must resolve a delegated node to a
+    // real TypeId or ERROR, never to the DELEGATE sentinel.
+    let source = "const x = 1; x";
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();
 
@@ -44,7 +144,7 @@ fn test_expression_checker_delegates_numeric_literal() {
     binder.bind_source_file(parser.get_arena(), root);
 
     let types = TypeInterner::new();
-    let mut ctx = CheckerContext::new(
+    let mut state = CheckerState::new(
         parser.get_arena(),
         &binder,
         &types,
@@ -52,16 +152,55 @@ fn test_expression_checker_delegates_numeric_literal() {
         crate::context::CheckerOptions::default(),
     );
 
-    // Get the expression statement and its expression
-    if let Some(root_node) = parser.get_arena().get(root)
-        && let Some(sf_data) = parser.get_arena().get_source_file(root_node)
-        && let Some(&stmt_idx) = sf_data.statements.nodes.first()
-        && let Some(stmt_node) = parser.get_arena().get(stmt_idx)
-        && let Some(expr_stmt) = parser.get_arena().get_expression_statement(stmt_node)
-    {
-        let mut checker = ExpressionChecker::new(&mut ctx);
-        // Numeric literals need contextual typing, so they should delegate
-        let ty = checker.compute_type_uncached(expr_stmt.expression);
-        assert_eq!(ty, TypeId::DELEGATE);
-    }
+    let arena = parser.get_arena();
+    let root_node = arena.get(root).expect("root node");
+    let sf = arena.get_source_file(root_node).expect("source file");
+    // Second statement is the bare `x` expression statement.
+    let &stmt_idx = sf.statements.nodes.get(1).expect("second statement");
+    let stmt_node = arena.get(stmt_idx).expect("stmt node");
+    let expr_stmt = arena
+        .get_expression_statement(stmt_node)
+        .expect("expression statement");
+    let expr_idx = expr_stmt.expression;
+
+    let ty = state.get_type_of_node(expr_idx);
+    assert_ne!(
+        ty,
+        TypeId::DELEGATE,
+        "get_type_of_node must resolve delegated nodes to a real type, not the DELEGATE sentinel"
+    );
+}
+
+#[test]
+fn test_simple_expressions_still_cache() {
+    // Directly-handled expressions (null, typeof, void) must continue to
+    // populate ctx.node_types so repeated calls take the cached fast path.
+    with_first_expression!("null", |_arena, expr_idx, ctx| {
+        assert!(!ctx.node_types.contains_key(&expr_idx.0));
+        let result = {
+            let mut checker = ExpressionChecker::new(&mut ctx);
+            checker.check(expr_idx)
+        };
+        assert_eq!(result, ExprCheckResult::Type(TypeId::NULL));
+        assert_eq!(
+            ctx.node_types.get(&expr_idx.0),
+            Some(&TypeId::NULL),
+            "simple expressions must still cache their concrete TypeId"
+        );
+    });
+}
+
+#[test]
+fn test_parenthesized_malformed_node_is_delegated_not_cached() {
+    // A parenthesized expression whose inner expression is parsed normally
+    // should pass through. This test exercises the pass-through branch of
+    // compute_type_impl and verifies no DELEGATE sentinel leaks in.
+    with_first_expression!("(null)", |_arena, expr_idx, ctx| {
+        let result = {
+            let mut checker = ExpressionChecker::new(&mut ctx);
+            checker.check(expr_idx)
+        };
+        assert_eq!(result, ExprCheckResult::Type(TypeId::NULL));
+        assert_eq!(ctx.node_types.get(&expr_idx.0), Some(&TypeId::NULL));
+    });
 }


### PR DESCRIPTION
## Summary

This PR replaces the use of `TypeId::DELEGATE` as a sentinel value with a proper `ExprCheckResult` enum that explicitly distinguishes between concrete types and delegation markers. This improves type safety and makes the control flow semantics clearer throughout the expression checker.

## Key Changes

- **Introduced `ExprCheckResult` enum** with two variants:
  - `Type(TypeId)` — expression was fully resolved to a concrete type
  - `Delegate` — expression requires `CheckerState` context for resolution
  - Added helper methods `type_id()` and `is_delegate()` for ergonomic pattern matching

- **Updated `ExpressionChecker` methods** to return `ExprCheckResult` instead of `TypeId`:
  - `check()` and `check_with_context()` now return `ExprCheckResult`
  - `compute_type_uncached()` and related methods updated
  - Renamed internal methods to `try_compute_expr_type*` to advertise delegation possibility
  - Kept old method names as back-compat aliases

- **Fixed cache contract violations**:
  - `Delegate` markers are now never written to `ctx.node_types` or `ctx.request_node_types`
  - Added `debug_assert!` guards to catch any future violations
  - Repeated calls on delegated nodes always return `Delegate` rather than a cached sentinel

- **Updated callers** in `CheckerState` and assignment checker to handle `ExprCheckResult`:
  - Pattern match on `ExprCheckResult::Type` vs `ExprCheckResult::Delegate`
  - Added documentation clarifying that `get_type_of_node_with_request` never returns `DELEGATE`

- **Improved documentation**:
  - Clarified that delegation is control flow, not a type
  - Updated module-level docs to explain the new enum
  - Added comprehensive test coverage for delegation semantics

## Notable Implementation Details

- The change maintains backward compatibility through alias methods while encouraging migration to the new `try_compute_expr_type*` naming
- Cache logic now explicitly handles the two cases: concrete types are cached, delegation markers bypass all caches
- Tests verify that delegation markers never leak into type caches and that repeated calls on delegated nodes consistently return `Delegate`

https://claude.ai/code/session_01MrsqbPs32pbpP3CbftzPNj