### PR TITLE
lsp: CommonJS chain exports + navbar-scoped ES module check

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -64,6 +64,97 @@ fn symbol_kind_to_tsserver(
     }
 }
 
+/// Mirror tsc's navigationBar `isExternalModule` check (narrower than
+/// the binder's which also treats CommonJS indicators as making a
+/// file modular). For the nav entry's root label, tsc emits
+/// `"<file>"` module only when the file contains ES
+/// import/export/import.meta, or uses a module-only extension
+/// (.mts/.cts/.mjs/.cjs).
+fn is_es_module_for_navbar(
+    arena: &tsz::parser::node::NodeArena,
+    root: tsz::parser::NodeIndex,
+    file: &str,
+) -> bool {
+    use tsz::parser::syntax_kind_ext;
+    let lower = file.to_lowercase();
+    if lower.ends_with(".mts")
+        || lower.ends_with(".cts")
+        || lower.ends_with(".mjs")
+        || lower.ends_with(".cjs")
+    {
+        return true;
+    }
+    let Some(node) = arena.get(root) else {
+        return false;
+    };
+    let Some(sf) = arena.get_source_file(node) else {
+        return false;
+    };
+    for &stmt_idx in &sf.statements.nodes {
+        let Some(stmt) = arena.get(stmt_idx) else {
+            continue;
+        };
+        if matches!(
+            stmt.kind,
+            k if k == syntax_kind_ext::IMPORT_DECLARATION
+                || k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                || k == syntax_kind_ext::EXPORT_DECLARATION
+                || k == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                || k == syntax_kind_ext::EXPORT_ASSIGNMENT
+        ) {
+            return true;
+        }
+        // Top-level `export`-prefixed declaration also counts.
+        if has_export_modifier(arena, stmt_idx) {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_export_modifier(
+    arena: &tsz::parser::node::NodeArena,
+    node_idx: tsz::parser::NodeIndex,
+) -> bool {
+    use tsz::parser::syntax_kind_ext;
+    use tsz_scanner::SyntaxKind;
+    let Some(node) = arena.get(node_idx) else {
+        return false;
+    };
+    let modifiers = match node.kind {
+        k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
+            arena.get_function(node).and_then(|f| f.modifiers.as_ref())
+        }
+        k if k == syntax_kind_ext::CLASS_DECLARATION => {
+            arena.get_class(node).and_then(|c| c.modifiers.as_ref())
+        }
+        k if k == syntax_kind_ext::INTERFACE_DECLARATION => {
+            arena.get_interface(node).and_then(|i| i.modifiers.as_ref())
+        }
+        k if k == syntax_kind_ext::TYPE_ALIAS_DECLARATION => arena
+            .get_type_alias(node)
+            .and_then(|a| a.modifiers.as_ref()),
+        k if k == syntax_kind_ext::ENUM_DECLARATION => {
+            arena.get_enum(node).and_then(|e| e.modifiers.as_ref())
+        }
+        k if k == syntax_kind_ext::MODULE_DECLARATION => {
+            arena.get_module(node).and_then(|m| m.modifiers.as_ref())
+        }
+        k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
+            arena.get_variable(node).and_then(|v| v.modifiers.as_ref())
+        }
+        _ => None,
+    };
+    let Some(mods) = modifiers else {
+        return false;
+    };
+    mods.nodes.iter().any(|&m_idx| {
+        arena
+            .get(m_idx)
+            .is_some_and(|m| m.kind == SyntaxKind::ExportKeyword as u16)
+    })
+}
+
 /// Mirror tsc's `escapeString(s, '"')` — replace control characters
 /// and backslash/double-quote with their JS escape sequences, and
 /// encode non-printable high chars as `\uNNNN`. Used on the filename
@@ -1934,8 +2025,15 @@ impl Server {
             })) {
                 return Some(native);
             }
-            let (arena, binder, root, source_text) = self.parse_and_bind_file(file)?;
-            let is_external_module = binder.is_external_module;
+            let (arena, _binder, root, source_text) = self.parse_and_bind_file(file)?;
+            // tsc's navigationBar treats a file as "external module"
+            // only when it has ES module indicators (import/export
+            // statements). Binder's `is_external_module` additionally
+            // fires on CommonJS `exports.X` / `module.exports = …`,
+            // which makes the root render as `"<file>" module` even
+            // when tsc would emit `<global> script`. Compute a
+            // narrower check here.
+            let is_external_module = is_es_module_for_navbar(&arena, root, file);
             let line_map = LineMap::build(&source_text);
             let provider = DocumentSymbolProvider::new(&arena, &line_map, &source_text);
             let mut symbols = provider.get_document_symbols(root);
@@ -2051,8 +2149,8 @@ impl Server {
             })) {
                 return Some(native);
             }
-            let (arena, binder, root, source_text) = self.parse_and_bind_file(file)?;
-            let is_external_module = binder.is_external_module;
+            let (arena, _binder, root, source_text) = self.parse_and_bind_file(file)?;
+            let is_external_module = is_es_module_for_navbar(&arena, root, file);
             let line_map = LineMap::build(&source_text);
             let provider = DocumentSymbolProvider::new(&arena, &line_map, &source_text);
             let mut symbols = provider.get_document_symbols(root);

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -256,6 +256,11 @@ impl<'a> DocumentSymbolProvider<'a> {
                     // each named class/function expression as a
                     // top-level nav entry regardless of nesting depth.
                     self.apply_nested_named_expressions(&sf.statements.nodes, &mut symbols);
+                    // CommonJS `exports.a = exports.b = exports.c = 0`
+                    // → tsc surfaces a nested `a > b > c` tree rather
+                    // than three siblings. Detect chained
+                    // `exports.X = …` assignments and emit them nested.
+                    self.apply_commonjs_exports_chain(&sf.statements.nodes, &mut symbols);
                     // Multiple `namespace A {}` / `namespace A.B {}`
                     // declarations merge into a single nested nav
                     // entry (matches tsc's `mergeChildren`).
@@ -1590,6 +1595,101 @@ impl<'a> DocumentSymbolProvider<'a> {
     /// members as children of the matching var / const entry. Skips
     /// owners that already have children (from an initializer or an
     /// expando promotion).
+    /// Detect CommonJS chained `exports.X = exports.Y = … = value`
+    /// assignments and emit a nested nav tree (X → Y → …). tsc models
+    /// these as declaration merging for the CommonJS module
+    /// namespace. Handles only simple `exports.<name>` LHS forms.
+    fn apply_commonjs_exports_chain(
+        &self,
+        statements: &[NodeIndex],
+        symbols: &mut Vec<DocumentSymbol>,
+    ) {
+        // Walk an assignment, collecting (name, stmt_idx) in order.
+        // Returns None if the chain breaks (non-exports LHS or wrong
+        // shape). `value_idx` is the innermost RHS for span purposes.
+        fn walk(
+            provider: &DocumentSymbolProvider,
+            expr_idx: NodeIndex,
+            out: &mut Vec<String>,
+        ) -> bool {
+            let Some(expr) = provider.arena.get(expr_idx) else {
+                return false;
+            };
+            if expr.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                return true; // non-assignment terminator — OK (end of chain)
+            }
+            let Some(bin) = provider.arena.get_binary_expr(expr) else {
+                return false;
+            };
+            if bin.operator_token != SyntaxKind::EqualsToken as u16 {
+                return false;
+            }
+            // LHS must be exports.<name>
+            let Some(lhs) = provider.arena.get(bin.left) else {
+                return false;
+            };
+            if lhs.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                return false;
+            }
+            let Some(access) = provider.arena.get_access_expr(lhs) else {
+                return false;
+            };
+            let Some(root) = provider.arena.get(access.expression) else {
+                return false;
+            };
+            if root.kind != SyntaxKind::Identifier as u16 {
+                return false;
+            }
+            if provider.get_name(access.expression).as_deref() != Some("exports") {
+                return false;
+            }
+            let Some(name) = provider.get_name(access.name_or_argument) else {
+                return false;
+            };
+            out.push(name);
+            walk(provider, bin.right, out)
+        }
+
+        for &stmt_idx in statements {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+                continue;
+            }
+            let Some(exp_stmt) = self.arena.get_expression_statement(stmt_node) else {
+                continue;
+            };
+            let mut names: Vec<String> = Vec::new();
+            if !walk(self, exp_stmt.expression, &mut names) || names.is_empty() {
+                continue;
+            }
+            // Build nested chain: names[0] is outermost, names[n-1]
+            // innermost. tsc renders them all as `const`.
+            let range = node_range(self.arena, self.line_map, self.source_text, stmt_idx);
+            let mut inner: Option<DocumentSymbol> = None;
+            for name in names.iter().rev() {
+                let mut children = Vec::new();
+                if let Some(child) = inner.take() {
+                    children.push(child);
+                }
+                inner = Some(DocumentSymbol {
+                    name: name.clone(),
+                    detail: None,
+                    kind: SymbolKind::Constant,
+                    kind_modifiers: String::new(),
+                    range,
+                    selection_range: range,
+                    container_name: None,
+                    children,
+                });
+            }
+            if let Some(top) = inner {
+                symbols.push(top);
+            }
+        }
+    }
+
     /// Walk top-level expression statements for named class / function
     /// expressions at any nesting depth (most commonly inside call
     /// arguments like `console.log(class Foo {})`). Each named class /


### PR DESCRIPTION
## Summary

Two paired fixes to surface \`exports.a = exports.b = exports.c = 0;\` as the nested \`a > b > c\` tree tsc produces:

1. **Chained CommonJS exports** — new \`apply_commonjs_exports_chain\` walks top-level ExpressionStatements for \`exports.X = (exports.Y = (exports.Z = value))\` patterns and emits a nested \`Constant\` chain. Previously the expando pass produced three independent siblings.

2. **Navbar-scoped \`isExternalModule\` check** — the binder's \`is_external_module\` is too broad for the navbar root label: it returns true for files using CommonJS \`exports.X\` / \`module.exports = …\`, so a \`.js\` file with only CommonJS was rendering as \`"<file>" module\` instead of tsc's \`<global> script\`. Replace the binder lookup with an inline \`is_es_module_for_navbar\` that walks top-level statements for ES indicators only (import/export statements, or module-only file extensions).

## Test plan

- [x] \`cargo nextest run -p tsz-lsp\` — 3765/3765
- [x] \`TSZ_DISABLE_NATIVE_TS=1 run-fourslash.sh --filter=navbarNestedCommonJsExports\` — passes (was failing)
- [x] Full Rust-only fourslash: 6532 → **6533**
- [x] Native-TS full fourslash: 6561/6562 (unchanged modulo timeouts)