### PR TITLE
checker: preserve declared literal property types in property-access errors

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -653,8 +653,17 @@ impl<'a> CheckerState<'a> {
             return self.format_type_diagnostic(ty);
         }
         if has_object_shape && !has_def && !has_alias && !has_display_alias {
-            let widened = self.widen_fresh_object_literal_properties_for_display(ty);
-            return self.format_type_diagnostic_widened(widened);
+            // Only widen literal properties of *fresh* object literal types
+            // (e.g., the type of `{ x: 1 }` expression). Declared object
+            // annotations like `let a: { __foo: 10 }` preserve their literal
+            // property types in property-access diagnostics, matching tsc.
+            let display_ty =
+                if crate::query_boundaries::common::is_fresh_object_type(self.ctx.types, ty) {
+                    self.widen_fresh_object_literal_properties_for_display(ty)
+                } else {
+                    ty
+                };
+            return self.format_type_diagnostic_widened(display_ty);
         }
         // Only widen object-like types (to convert literal properties to primitives).
         // For literal/primitive receiver types (e.g., `""`, `42`), tsc preserves the

--- a/scripts/session/roll-failure.sh
+++ b/scripts/session/roll-failure.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# =============================================================================
+# roll-failure.sh — Quick pick of a random conformance failure
+# =============================================================================
+#
+# Rolls one random failing test from the latest conformance snapshot,
+# preferring Tier 1 fingerprint-only targets by default, and prints the
+# ready-to-use `conformance.sh --filter` command.
+#
+# Usage:
+#   scripts/session/roll-failure.sh                 # fingerprint-only (default)
+#   scripts/session/roll-failure.sh any             # any category
+#   scripts/session/roll-failure.sh wrong-code
+#   scripts/session/roll-failure.sh --code TS2322
+#   scripts/session/roll-failure.sh --seed 42
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+[[ -d "$REPO_ROOT/TypeScript/tests" ]] || \
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing; run scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+CATEGORY="fingerprint-only"
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        any|fingerprint-only|wrong-code|only-missing|only-extra|all-missing|false-positive)
+            CATEGORY="$1"; shift ;;
+        *) ARGS+=("$1"); shift ;;
+    esac
+done
+
+exec python3 - "$DETAIL" "$CATEGORY" "${ARGS[@]}" <<'PY'
+import json, random, sys, argparse, os
+
+detail_path, category, *rest = sys.argv[1:]
+ap = argparse.ArgumentParser()
+ap.add_argument("--code")
+ap.add_argument("--seed", type=int)
+args = ap.parse_args(rest)
+
+def classify(e):
+    exp, act = set(e.get("e", [])), set(e.get("a", []))
+    miss, extra = set(e.get("m", [])), set(e.get("x", []))
+    if not exp and act: return "false-positive"
+    if exp and not act: return "all-missing"
+    if exp == act:      return "fingerprint-only"
+    if miss and not extra: return "only-missing"
+    if extra and not miss: return "only-extra"
+    return "wrong-code"
+
+with open(detail_path) as f:
+    failures = json.load(f).get("failures", {})
+
+pool = []
+for path, entry in failures.items():
+    if not entry: continue
+    if category != "any" and classify(entry) != category: continue
+    if args.code:
+        codes = set(entry.get("e", [])) | set(entry.get("a", [])) \
+              | set(entry.get("m", [])) | set(entry.get("x", []))
+        if args.code not in codes: continue
+    pool.append((path, entry))
+
+if not pool:
+    sys.exit(f"no failures match category={category} code={args.code}")
+
+rng = random.Random(args.seed)
+path, entry = rng.choice(pool)
+cat = classify(entry)
+filt = os.path.splitext(os.path.basename(path))[0]
+
+print(f"path:     {path}")
+print(f"category: {cat}")
+print(f"expected: {','.join(entry.get('e', [])) or '-'}")
+print(f"actual:   {','.join(entry.get('a', [])) or '-'}")
+print(f"missing:  {','.join(entry.get('m', [])) or '-'}")
+print(f"extra:    {','.join(entry.get('x', [])) or '-'}")
+print(f"diff:     {len(entry.get('m', [])) + len(entry.get('x', []))}")
+print()
+print(f"pool:     {len(pool)} candidates")
+print(f"run:      ./scripts/conformance/conformance.sh run --filter '{filt}' --verbose")
+PY


### PR DESCRIPTION
## Summary
- Fix fingerprint divergence on TS2551 / TS2339 property-access diagnostics where tsc preserves declared literal property types (e.g. `{ __foo: 10 }`) but tsz was widening them to primitives (`{ __foo: number }`).
- Root cause: `format_property_receiver_type_for_diagnostic` in `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs` always called `widen_fresh_object_literal_properties_for_display` on anonymous object shapes; that helper widens every property regardless of freshness. Now gated on `is_fresh_object_type` so only types from `{ x: 1 }` expressions get widened.
- Conformance: 12020 → 12023 (+3) — `spellingSuggestionLeadingUnderscores01`, `errorInUnnamedClassExpression`, `importElisionConstEnumMerge1`. No regressions.
- Adds `scripts/session/roll-failure.sh`, a quick random-failure picker that defaults to fingerprint-only targets and prints a ready-to-run `conformance.sh --filter` command.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p tsz-checker -p tsz-solver` → 10820 passed
- [x] `cargo nextest run --workspace --exclude tsz-checker --exclude tsz-solver` → 2 pre-existing tsz-cli failures (tsbuildinfo permission test runs as root; LSP fourslash formatter) confirmed to reproduce on the branch without this change
- [x] `scripts/session/verify-all.sh --quick` (conformance +3, no regressions)
- [x] `./scripts/conformance/conformance.sh run --filter 'spellingSuggestionLeadingUnderscores01' --verbose` → PASS