### PR TITLE
fix(checker): accept JSDoc `@template {Constraint} Name` syntax

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params.rs
+++ b/crates/tsz-checker/src/jsdoc/params.rs
@@ -2197,6 +2197,46 @@ impl<'a> CheckerState<'a> {
             let leading_ws = rest.len() - trimmed.len();
             let brace_rel = template_start + "@template".len() + leading_ws;
             let after_brace = &trimmed[1..];
+
+            // tsc accepts `@template {Constraint} Name` as a type parameter
+            // with a constraint (equivalent to `Name extends Constraint`).
+            // Detect that form by finding the matching close-brace and
+            // checking whether an identifier follows it (after whitespace).
+            // If so, this is valid JSDoc syntax — skip.
+            let balanced_close_brace_offset = |s: &str| -> Option<usize> {
+                let mut depth: i32 = 1;
+                for (i, ch) in s.char_indices() {
+                    match ch {
+                        '{' => depth += 1,
+                        '}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                return Some(i);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                None
+            };
+            if let Some(close_rel) = balanced_close_brace_offset(after_brace) {
+                let after_close = &after_brace[close_rel + 1..];
+                let ws_len = after_close
+                    .chars()
+                    .take_while(|c| c.is_whitespace())
+                    .map(|c| c.len_utf8())
+                    .sum::<usize>();
+                let ident_rest = &after_close[ws_len..];
+                let has_ident = ident_rest
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphabetic());
+                if has_ident {
+                    scan_start = brace_rel + 1 + close_rel + 1;
+                    continue;
+                }
+            }
+
             let name_len = after_brace
                 .chars()
                 .take_while(|ch| *ch == '_' || *ch == '$' || ch.is_ascii_alphanumeric())


### PR DESCRIPTION
## Summary
`validate_jsdoc_template_tag_syntax_at_decl` in `crates/tsz-checker/src/jsdoc/params.rs` emitted TS1069 + TS2304 whenever it saw \`@template {X}\`, but tsc actually accepts \`@template {Constraint} Name\` as a type parameter with a constraint (equivalent to \`Name extends Constraint\`).

Detect the valid form by finding the matching close-brace and checking whether an identifier follows it (after whitespace). If so, skip the diagnostic emission. Truly invalid forms (\`@template {T}\` with no following name) still get flagged.

## Example that was incorrectly flagged
```
/**
 * @typedef {{ a: number; b: string[] }} Foo
 */
/**
 * @template {Foo} T
 */
class A { }
```

Before: tsz emitted \`TS1069 Unexpected token\` + \`TS2304 Cannot find name 'Foo'\` for the \`@template\` line. After: no false diagnostics.

## Impact
+4 tests net (stable 12024/12581 across 3 runs vs 12020 baseline). Only deterministic regression seen in diffs was \`jsxRuntimePragma.ts\` which is pre-existing flaky. Deterministic win visible in the diff: \`declarationEmitIsolatedDeclarationErrorNotEmittedForNonEmittedFile.ts\`.

## Test plan
- [x] \`./scripts/conformance/conformance.sh run --filter extendsTag5\` — TS1069/TS2304 extras gone (TS2344 missing is separate follow-up work)
- [x] \`./scripts/conformance/conformance.sh run --filter extendsTag\` — 6/7 passes (extendsTag5 still fails on TS2344, unrelated)
- [x] Full suite: 12024-12025 across 3 runs vs 12020 baseline, +4 net

## Follow-up
The parser fix only stops false diagnostics. Actually honoring the constraint in type-checking (producing proper TS2344 when the extends argument violates \`Foo\`) requires wiring JSDoc constraint extraction through the class-type-parameter builder — separate work.