### PR TITLE
refactor(lsp): make formatting fallback conservative and syntax-free

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -1592,7 +1592,18 @@ fn test_call_hierarchy_incoming_file_start_query_returns_no_calls() {
 }
 
 #[test]
-fn test_format_range_paste_matches_fourslash_auto_formatting_on_paste() {
+fn test_format_range_paste_applies_cleanly() {
+    // When the server format handler runs, edits may come from either the
+    // native tsserver worker (which produces tsserver-shaped structural
+    // rewrites) or the LSP crate's conservative whitespace-only fallback
+    // (which does not rewrite structure). Either way, reapplying the edits
+    // must produce valid UTF-8 output that still contains the declarations
+    // from the source.
+    //
+    // Structural-rewrite assertions were removed: they belong in prettier /
+    // eslint / native tsserver tests, not in the LSP fallback. The LSP
+    // fallback's conservative contract is covered by the formatting_tests
+    // suite in tsz-lsp.
     let mut server = make_server();
     let file = "/test.ts";
     let source = "namespace TestModule {\n class TestClass{\nprivate   foo;\npublic testMethod( )\n{}\n}\n}\n";
@@ -1624,8 +1635,14 @@ fn test_format_range_paste_matches_fourslash_auto_formatting_on_paste() {
         .expect("format body should be array")
         .clone();
     let updated = apply_tsserver_text_edits(source.to_string(), &edits);
-    let expected = "namespace TestModule {\n    class TestClass {\n        private foo;\n        public testMethod() { }\n    }\n}\n";
-    assert_eq!(updated, expected);
+    assert!(
+        updated.contains("namespace TestModule") && updated.contains("class TestClass"),
+        "formatted output lost its declarations: {updated:?}"
+    );
+    assert!(
+        updated.contains("testMethod"),
+        "formatted output lost the method: {updated:?}"
+    );
 }
 
 #[test]

--- a/crates/tsz-lsp/src/formatting.rs
+++ b/crates/tsz-lsp/src/formatting.rs
@@ -1,11 +1,24 @@
 //! Document Formatting implementation for LSP.
 //!
-//! Provides code formatting capabilities for TypeScript files.
-//! Delegates to external formatters (prettier, eslint) when available,
-//! and falls back to an internal formatter that handles indentation,
-//! semicolons, whitespace normalization, and common TS/JS patterns.
+//! External formatters (`Prettier`, `ESLint` `--fix`) handle real TypeScript /
+//! JavaScript formatting. This module is a thin wrapper around them:
 //!
-//! Also provides format-on-key support for semicolon and newline triggers.
+//! 1. Try `Prettier` via stdin.
+//! 2. Fall back to `ESLint` with `--fix-dry-run` via stdin.
+//! 3. If neither is available, run a strictly conservative internal
+//!    fallback that only performs **whitespace-only** cleanup:
+//!    - trim trailing whitespace,
+//!    - normalize the final newline.
+//!
+//! The internal fallback never rewrites code structure: it does not infer
+//! indentation, does not insert or remove semicolons, does not change brace
+//! spacing, and does not re-format statements. Structural formatting is
+//! fundamentally syntax-sensitive (template literals, regex literals, JSX,
+//! generics, conditional types, decorators, etc.), and correct handling
+//! requires a real parser — which lives in `Prettier` / `ESLint`, not here.
+//!
+//! Format-on-key follows the same policy: in fallback mode it only trims
+//! trailing whitespace; it does not re-indent or manipulate semicolons.
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
@@ -32,11 +45,13 @@ pub struct FormattingOptions {
     #[serde(rename = "insertFinalNewline")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_final_newline: Option<bool>,
-    /// Trim trailing whitespace on all lines.
+    /// Trim trailing blank lines at the end of the file.
     #[serde(rename = "trimFinalNewlines")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trim_final_newlines: Option<bool>,
-    /// Semicolons preference: "insert" or "remove". Default is "insert".
+    /// Semicolons preference. Accepted by the public API for forward
+    /// compatibility, but the internal fallback never inserts or removes
+    /// semicolons — only external formatters implement this preference.
     #[serde(rename = "semicolons")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semicolons: Option<String>,
@@ -70,6 +85,29 @@ impl TextEdit {
     pub const fn new(range: Range, new_text: String) -> Self {
         Self { range, new_text }
     }
+}
+
+/// Capability boundary for the internal fallback formatter.
+///
+/// The fallback is allowed to perform [`FallbackFormattingMode::WhitespaceOnly`]
+/// operations. Anything else — re-indenting, semicolon adjustment, brace
+/// spacing, member spacing, `as` spacing, etc. — is
+/// [`FallbackFormattingMode::UnsupportedForStructuralFormatting`] and must be
+/// produced by an external formatter. When a request would require structural
+/// changes and no external formatter is available, prefer "no edits" over
+/// "risky edits".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FallbackFormattingMode {
+    /// Whitespace-only cleanup. Safe without syntax awareness:
+    /// - trim trailing whitespace,
+    /// - normalize final newline.
+    ///
+    /// Preserves every non-whitespace character exactly.
+    WhitespaceOnly,
+    /// The caller requested a transformation that needs a real parser
+    /// (indentation, semicolons, brace spacing, etc.). The internal fallback
+    /// refuses and returns no edits.
+    UnsupportedForStructuralFormatting,
 }
 
 /// Provider for document formatting.
@@ -110,8 +148,12 @@ impl DocumentFormattingProvider {
 
     /// Format a document using the best available formatter.
     ///
-    /// Returns a list of text edits to apply, or an error message.
+    /// Tries `Prettier` first, then `ESLint` `--fix-dry-run`. If neither is
+    /// available, falls back to [`apply_safe_whitespace_formatting`].
+    ///
     /// All positions in returned edits are 0-based (LSP convention).
+    ///
+    /// [`apply_safe_whitespace_formatting`]: Self::apply_safe_whitespace_formatting
     pub fn format_document(
         file_path: &str,
         source_text: &str,
@@ -135,8 +177,8 @@ impl DocumentFormattingProvider {
         // Suppress unused warning on WASM where file_path isn't needed
         let _ = file_path;
 
-        // No external formatter available - return internal formatting edits
-        Self::apply_basic_formatting(source_text, options)
+        // Conservative, whitespace-only fallback.
+        Self::apply_safe_whitespace_formatting(source_text, options)
     }
 
     /// Format using prettier.
@@ -190,7 +232,6 @@ impl DocumentFormattingProvider {
 
         let formatted = String::from_utf8_lossy(&result.stdout).to_string();
 
-        // Compute per-line edits to avoid overlapping ranges
         Self::compute_line_edits(source_text, &formatted)
     }
 
@@ -199,9 +240,7 @@ impl DocumentFormattingProvider {
     /// Pipes the in-memory document buffer into `ESLint` via stdin so that
     /// formatting operates on the current editor buffer rather than whatever
     /// happens to be on disk. This matches the LSP contract that unsaved
-    /// changes are the source of truth, and avoids the stale-disk/new-buffer
-    /// diff mismatch the previous `--fix --fix-to-stdout <file>` invocation
-    /// produced.
+    /// changes are the source of truth.
     #[cfg(not(target_arch = "wasm32"))]
     fn format_with_eslint(
         file_path: &str,
@@ -282,9 +321,20 @@ impl DocumentFormattingProvider {
         Ok(output)
     }
 
-    /// Compute per-line text edits between original and formatted text.
-    /// This produces non-overlapping edits where each edit replaces exactly one line.
-    /// Positions are 0-based.
+    /// Compute a minimal set of text edits that transforms `original` into
+    /// `formatted`.
+    ///
+    /// Strategy:
+    /// - If the texts are equal, return no edits.
+    /// - If they have the same line count and the same final-newline state,
+    ///   emit one edit per changed line. Edits are returned in descending
+    ///   order (bottom-to-top) so that applying them sequentially does not
+    ///   invalidate subsequent ranges.
+    /// - Otherwise, emit a single whole-document replacement. This is both
+    ///   simpler and safer than reconstructing line-level diffs across
+    ///   insertions/deletions.
+    ///
+    /// All positions are 0-based.
     pub fn compute_line_edits(original: &str, formatted: &str) -> Result<Vec<TextEdit>, String> {
         if original == formatted {
             return Ok(vec![]);
@@ -292,589 +342,127 @@ impl DocumentFormattingProvider {
 
         let orig_lines: Vec<&str> = original.lines().collect();
         let fmt_lines: Vec<&str> = formatted.lines().collect();
+        let same_trailing_newline = original.ends_with('\n') == formatted.ends_with('\n');
 
-        let orig_count = orig_lines.len();
-        let fmt_count = fmt_lines.len();
+        if orig_lines.len() == fmt_lines.len() && same_trailing_newline {
+            let mut edits: Vec<TextEdit> = orig_lines
+                .iter()
+                .zip(fmt_lines.iter())
+                .enumerate()
+                .filter_map(|(i, (orig, fmt))| {
+                    if orig == fmt {
+                        return None;
+                    }
+                    Some(TextEdit::new(
+                        Range::new(
+                            Position::new(i as u32, 0),
+                            Position::new(i as u32, orig.len() as u32),
+                        ),
+                        (*fmt).to_string(),
+                    ))
+                })
+                .collect();
 
-        // Build per-line edits for lines that differ
-        let mut edits = Vec::new();
-        let max_common = orig_count.min(fmt_count);
-
-        for i in 0..max_common {
-            if orig_lines[i] != fmt_lines[i] {
-                let line_len = orig_lines[i].len() as u32;
-                edits.push(TextEdit::new(
-                    Range::new(
-                        Position::new(i as u32, 0),
-                        Position::new(i as u32, line_len),
-                    ),
-                    fmt_lines[i].to_string(),
-                ));
-            }
+            // Emit edits from bottom-to-top so that consumers applying them
+            // sequentially do not shift later ranges.
+            edits.sort_by(|a, b| {
+                b.range
+                    .start
+                    .line
+                    .cmp(&a.range.start.line)
+                    .then_with(|| b.range.start.character.cmp(&a.range.start.character))
+            });
+            return Ok(edits);
         }
 
-        // Handle extra lines in original (need to delete them)
-        if orig_count > fmt_count && fmt_count > 0 {
-            let start_line = fmt_count.saturating_sub(1);
-            let start_char = fmt_lines[start_line].len() as u32;
-            let end_line = orig_count.saturating_sub(1);
-            let end_char = orig_lines[end_line].len() as u32;
-            edits.push(TextEdit::new(
-                Range::new(
-                    Position::new(start_line as u32, start_char),
-                    Position::new(end_line as u32, end_char),
-                ),
-                String::new(),
-            ));
-        }
-
-        // Handle extra lines in formatted (need to insert them)
-        if fmt_count > orig_count {
-            let insert_line = if orig_count > 0 {
-                orig_count.saturating_sub(1)
-            } else {
-                0
-            };
-            let insert_char = if orig_count > 0 {
-                orig_lines[insert_line].len() as u32
-            } else {
-                0
-            };
-            let extra: Vec<&str> = fmt_lines[orig_count..].to_vec();
-            let mut new_text = String::new();
-            for line in &extra {
-                new_text.push('\n');
-                new_text.push_str(line);
-            }
-            edits.push(TextEdit::new(
-                Range::new(
-                    Position::new(insert_line as u32, insert_char),
-                    Position::new(insert_line as u32, insert_char),
-                ),
-                new_text,
-            ));
-        }
-
-        // Emit edits from bottom-to-top so consumers that apply them
-        // sequentially do not invalidate later ranges.
-        edits.sort_by(|a, b| {
-            b.range
-                .start
-                .line
-                .cmp(&a.range.start.line)
-                .then_with(|| b.range.start.character.cmp(&a.range.start.character))
-        });
-
-        Ok(edits)
+        // Line counts differ or EOF-newline state differs: emit one
+        // whole-document replacement. This keeps edits correct without
+        // risking overlapping ranges.
+        let end_position = document_end_position(original);
+        Ok(vec![TextEdit::new(
+            Range::new(Position::new(0, 0), end_position),
+            formatted.to_string(),
+        )])
     }
 
-    /// Apply basic formatting when no external formatter is available.
+    /// Conservative, whitespace-only fallback formatter.
     ///
-    /// This handles:
-    /// - Trimming trailing whitespace
-    /// - Adding final newline if missing
-    /// - Converting tabs to spaces (or vice versa)
-    /// - Indentation normalization for common TS patterns
-    /// - Semicolon normalization
-    pub fn apply_basic_formatting(
+    /// Safe operations (no syntax awareness required):
+    /// - trim trailing whitespace on each line (when
+    ///   [`FormattingOptions::trim_trailing_whitespace`] is enabled),
+    /// - normalize trailing blank lines at EOF (when
+    ///   [`FormattingOptions::trim_final_newlines`] is enabled),
+    /// - add a final newline at EOF (when
+    ///   [`FormattingOptions::insert_final_newline`] is enabled).
+    ///
+    /// Anything that would require syntax awareness — re-indentation, brace
+    /// spacing, semicolon normalization, `as` operator spacing, member
+    /// spacing, collapsing `{}` etc. — is intentionally not performed. Those
+    /// rewrites require an external formatter.
+    ///
+    /// This is the policy expressed by
+    /// [`FallbackFormattingMode::WhitespaceOnly`].
+    pub fn apply_safe_whitespace_formatting(
         source_text: &str,
         options: &FormattingOptions,
     ) -> Result<Vec<TextEdit>, String> {
-        let formatted = Self::format_text(source_text, options);
+        let formatted = Self::safe_whitespace_text(source_text, options);
         Self::compute_line_edits(source_text, &formatted)
     }
 
-    /// Core formatting logic that returns the fully formatted text.
-    pub fn format_text(source_text: &str, options: &FormattingOptions) -> String {
-        let lines: Vec<&str> = source_text.lines().collect();
-        let mut formatted_lines: Vec<String> = Vec::with_capacity(lines.len());
+    /// Produce the whitespace-only normalized form of `source_text`.
+    ///
+    /// Preserves every non-whitespace byte exactly: code content, string
+    /// literals, template literals, regex literals, decorators, JSX and
+    /// conditional types are all untouched. Only trailing whitespace per
+    /// line and end-of-file newlines are adjusted, according to `options`.
+    pub fn safe_whitespace_text(source_text: &str, options: &FormattingOptions) -> String {
+        let trim_trailing = options.trim_trailing_whitespace.unwrap_or(true);
+        let trim_final_newlines = options.trim_final_newlines.unwrap_or(true);
+        let insert_final_newline = options.insert_final_newline.unwrap_or(true);
 
-        // Track indent level for smart indentation
-        let mut indent_level: i32 = 0;
-        let indent_str = Self::make_indent_string(options, 1);
-        let mut line_index = 0usize;
-        while line_index < lines.len() {
-            let line = lines[line_index];
-            let trimmed = line.trim();
+        let had_trailing_newline = source_text.ends_with('\n');
 
-            // Skip empty lines - preserve them as-is (just trim whitespace)
-            if trimmed.is_empty() {
-                formatted_lines.push(String::new());
-                line_index += 1;
-                continue;
-            }
+        // Per-line trailing whitespace trim, preserving line contents.
+        let mut lines: Vec<String> = source_text
+            .split('\n')
+            .map(|line| {
+                // Strip a trailing '\r' so Windows line endings are normalized
+                // consistently with the trim step on the payload below.
+                let stripped = line.strip_suffix('\r').unwrap_or(line);
+                if trim_trailing {
+                    stripped.trim_end_matches([' ', '\t']).to_string()
+                } else {
+                    stripped.to_string()
+                }
+            })
+            .collect();
 
-            let mut structural_line = trimmed.to_string();
-            if line_index + 1 < lines.len()
-                && Self::can_precede_empty_block(trimmed)
-                && lines[line_index + 1].trim() == "{}"
-            {
-                // Match tsserver-style formatting for compact empty blocks/bodies.
-                structural_line = format!("{} {{ }}", Self::normalize_member_spacing(trimmed));
-            }
+        // `split('\n')` on a string ending in '\n' yields an extra empty
+        // trailing element. Drop it; the trailing-newline flag below governs
+        // whether one is re-emitted.
+        if had_trailing_newline && lines.last().is_some_and(std::string::String::is_empty) {
+            lines.pop();
+        }
 
-            // Adjust indent before processing the line
-            // Closing braces/brackets/parens reduce indent before the line
-            let dedent_this_line = Self::line_starts_with_closing(&structural_line);
-            let case_dedent = Self::is_case_or_default(&structural_line) && indent_level > 0;
-
-            let effective_indent = if dedent_this_line {
-                (indent_level - 1).max(0)
-            } else if case_dedent {
-                // case/default labels are indented one less than their body
-                (indent_level - 1).max(0)
-            } else {
-                indent_level
-            };
-
-            // Build the formatted line
-            let mut processed = structural_line.clone();
-
-            // Trim trailing whitespace
-            if options.trim_trailing_whitespace.unwrap_or(true) {
-                processed = processed.trim_end().to_string();
-            }
-
-            // Normalize semicolons: ensure statements end with semicolons
-            if options.semicolons.as_deref() != Some("remove") {
-                processed = Self::normalize_semicolons(&processed);
-            }
-            processed = Self::normalize_member_spacing(&processed);
-            processed = Self::normalize_as_operator_spacing(&processed);
-
-            // Apply proper indentation
-            let indent_prefix = indent_str.repeat(effective_indent as usize);
-            let formatted_line = format!("{indent_prefix}{processed}");
-
-            formatted_lines.push(formatted_line);
-
-            // Adjust indent level for subsequent lines
-            let opens = Self::count_openers(&structural_line);
-            let closes = Self::count_closers(&structural_line);
-            indent_level += opens - closes;
-            indent_level = indent_level.max(0);
-
-            if structural_line.ends_with(" { }") && line_index + 1 < lines.len() {
-                line_index += 2;
-            } else {
-                line_index += 1;
+        if trim_final_newlines {
+            while lines.last().is_some_and(std::string::String::is_empty) {
+                lines.pop();
             }
         }
 
-        // Trim final empty lines if requested
-        if options.trim_final_newlines.unwrap_or(true) {
-            while formatted_lines
-                .last()
-                .is_some_and(std::string::String::is_empty)
-            {
-                formatted_lines.pop();
-            }
+        let mut result = lines.join("\n");
+
+        if result.is_empty() {
+            // Don't synthesize a newline-only file from empty input.
+            return String::new();
         }
 
-        let mut result = formatted_lines.join("\n");
-
-        // Add final newline if requested
-        if options.insert_final_newline.unwrap_or(true) && !result.is_empty() {
+        if insert_final_newline || (had_trailing_newline && !trim_final_newlines) {
             result.push('\n');
         }
 
         result
-    }
-
-    /// Create the indentation string for one level.
-    fn make_indent_string(options: &FormattingOptions, levels: u32) -> String {
-        if options.insert_spaces {
-            " ".repeat((options.tab_size * levels) as usize)
-        } else {
-            "\t".repeat(levels as usize)
-        }
-    }
-
-    /// Check if a trimmed line starts with a closing brace/bracket/paren.
-    fn line_starts_with_closing(trimmed: &str) -> bool {
-        trimmed.starts_with('}') || trimmed.starts_with(')') || trimmed.starts_with(']')
-    }
-
-    /// Check if a trimmed line is a case or default label in a switch.
-    fn is_case_or_default(trimmed: &str) -> bool {
-        trimmed.starts_with("case ")
-            || trimmed.starts_with("default:")
-            || trimmed.starts_with("default :")
-    }
-
-    /// Count opening braces/brackets/parens in a line (outside strings).
-    fn count_openers(line: &str) -> i32 {
-        let mut count = 0i32;
-        let mut in_string = None;
-        let mut escape = false;
-
-        for ch in line.chars() {
-            if escape {
-                escape = false;
-                continue;
-            }
-            if ch == '\\' {
-                escape = true;
-                continue;
-            }
-            match in_string {
-                Some(q) if ch == q => in_string = None,
-                Some(_) => {}
-                None => match ch {
-                    '\'' | '"' | '`' => in_string = Some(ch),
-                    '{' | '(' | '[' => count += 1,
-                    _ => {}
-                },
-            }
-        }
-        count
-    }
-
-    /// Count closing braces/brackets/parens in a line (outside strings).
-    fn count_closers(line: &str) -> i32 {
-        let mut count = 0i32;
-        let mut in_string = None;
-        let mut escape = false;
-
-        for ch in line.chars() {
-            if escape {
-                escape = false;
-                continue;
-            }
-            if ch == '\\' {
-                escape = true;
-                continue;
-            }
-            match in_string {
-                Some(q) if ch == q => in_string = None,
-                Some(_) => {}
-                None => match ch {
-                    '\'' | '"' | '`' => in_string = Some(ch),
-                    '}' | ')' | ']' => count += 1,
-                    _ => {}
-                },
-            }
-        }
-        count
-    }
-
-    /// Normalize semicolons: add missing semicolons to statement lines.
-    fn normalize_semicolons(line: &str) -> String {
-        let trimmed = line.trim_end();
-
-        // Don't add semicolons after these patterns
-        if trimmed.is_empty()
-            || trimmed.ends_with('{')
-            || trimmed.ends_with('}')
-            || trimmed.ends_with('(')
-            || trimmed.ends_with(',')
-            || trimmed.ends_with(':')
-            || trimmed.ends_with(';')
-            || trimmed.ends_with('*')
-            || trimmed.ends_with('/')
-            || trimmed.starts_with("//")
-            || trimmed.starts_with("/*")
-            || trimmed.starts_with('*')
-            || trimmed.ends_with("*/")
-            || (trimmed.starts_with("import ") && !trimmed.contains("from "))
-            || (trimmed.starts_with("export {") && !trimmed.ends_with('}'))
-            || Self::is_case_or_default(trimmed)
-            || trimmed.starts_with("if ")
-            || trimmed.starts_with("if(")
-            || trimmed.starts_with("} else")
-            || trimmed.starts_with("else {")
-            || trimmed.starts_with("else{")
-            || trimmed.starts_with("for ")
-            || trimmed.starts_with("for(")
-            || trimmed.starts_with("while ")
-            || trimmed.starts_with("while(")
-            || trimmed.starts_with("switch ")
-            || trimmed.starts_with("switch(")
-            || trimmed.starts_with("try {")
-            || trimmed.starts_with("try{")
-            || trimmed.starts_with("} catch")
-            || trimmed.starts_with("} finally")
-            || trimmed.starts_with("class ")
-            || trimmed.starts_with("interface ")
-            || trimmed.starts_with("enum ")
-            || trimmed.starts_with("namespace ")
-            || trimmed.starts_with("module ")
-            || trimmed.starts_with("@")  // decorators
-            || trimmed.starts_with("function ")
-            || trimmed.starts_with("async function ")
-            || trimmed.starts_with("export default function ")
-            || trimmed.starts_with("export function ")
-            || trimmed.starts_with("export async function ")
-            || trimmed.starts_with("export class ")
-            || trimmed.starts_with("export interface ")
-            || trimmed.starts_with("export enum ")
-            || Self::looks_like_method_signature(trimmed)
-        {
-            return trimmed.to_string();
-        }
-
-        // Lines that look like statements needing semicolons
-        let needs_semi = trimmed.starts_with("let ")
-            || trimmed.starts_with("const ")
-            || trimmed.starts_with("var ")
-            || trimmed.starts_with("type ")
-            || trimmed.starts_with("return ")
-            || trimmed == "return"
-            || trimmed.starts_with("throw ")
-            || trimmed.starts_with("break")
-            || trimmed.starts_with("continue")
-            || trimmed.starts_with("export default ")
-            || (trimmed.starts_with("import ") && trimmed.contains("from "))
-            || (trimmed.starts_with("export ") && trimmed.contains("from "))
-            || trimmed.ends_with(')')
-            || trimmed.ends_with(']')
-            || trimmed.ends_with('"')
-            || trimmed.ends_with('\'')
-            || trimmed.ends_with('`');
-
-        if needs_semi && !trimmed.ends_with(';') {
-            format!("{trimmed};")
-        } else {
-            trimmed.to_string()
-        }
-    }
-
-    /// Normalize spacing around the `as` type-assertion operator.
-    fn normalize_as_operator_spacing(line: &str) -> String {
-        if !line.contains("as") {
-            return line.to_string();
-        }
-
-        let mut out = String::with_capacity(line.len());
-        let mut i = 0usize;
-        while i < line.len() {
-            let Some(ch) = line[i..].chars().next() else {
-                break;
-            };
-            if !ch.is_whitespace() {
-                out.push(ch);
-                i += ch.len_utf8();
-                continue;
-            }
-
-            let ws_start = i;
-            while let Some(next) = line[i..].chars().next() {
-                if !next.is_whitespace() {
-                    break;
-                }
-                i += next.len_utf8();
-            }
-
-            if line[i..].starts_with("as") {
-                let as_end = i + 2;
-                let mut after_as = as_end;
-                while let Some(next) = line[after_as..].chars().next() {
-                    if !next.is_whitespace() {
-                        break;
-                    }
-                    after_as += next.len_utf8();
-                }
-                if after_as > as_end {
-                    if !out.ends_with(' ') && !out.is_empty() {
-                        out.push(' ');
-                    }
-                    out.push_str("as");
-                    if after_as < line.len() {
-                        out.push(' ');
-                    }
-                    i = after_as;
-                    continue;
-                }
-            }
-
-            out.push_str(&line[ws_start..i]);
-        }
-
-        out
-    }
-
-    fn looks_like_method_signature(trimmed: &str) -> bool {
-        if !trimmed.ends_with(')') || !trimmed.contains('(') {
-            return false;
-        }
-        trimmed.starts_with("public ")
-            || trimmed.starts_with("private ")
-            || trimmed.starts_with("protected ")
-            || trimmed.starts_with("readonly ")
-    }
-
-    /// Returns true if a line can precede `{}` and should be merged into `... { }`.
-    fn can_precede_empty_block(trimmed: &str) -> bool {
-        // Method/function signatures ending with ')'
-        if trimmed.ends_with(')') {
-            return true;
-        }
-        // Generic signatures ending with '>'
-        if trimmed.ends_with('>') {
-            return true;
-        }
-        // Standalone keywords: else, do, try, finally
-        if matches!(trimmed, "else" | "do" | "try" | "finally") {
-            return true;
-        }
-        // catch(...) is covered by ends_with ')' above
-        // Declarations: class/interface/enum/namespace/module (line ends with identifier)
-        if trimmed.starts_with("class ")
-            || trimmed.starts_with("interface ")
-            || trimmed.starts_with("enum ")
-            || trimmed.starts_with("namespace ")
-            || trimmed.starts_with("module ")
-            || trimmed.starts_with("abstract class ")
-            || trimmed.starts_with("export class ")
-            || trimmed.starts_with("export interface ")
-            || trimmed.starts_with("export enum ")
-            || trimmed.starts_with("export default class")
-            || trimmed.starts_with("declare class ")
-            || trimmed.starts_with("declare interface ")
-            || trimmed.starts_with("declare enum ")
-            || trimmed.starts_with("declare namespace ")
-            || trimmed.starts_with("declare module ")
-        {
-            return true;
-        }
-        false
-    }
-
-    fn normalize_member_spacing(line: &str) -> String {
-        // Normalize multiple whitespace to single space, respecting strings.
-        let mut out = Self::collapse_whitespace(line);
-        // After collapsing, `( )` → `()`
-        out = out.replace("( )", "()");
-        // Remove space before semicolon: `foo ;` → `foo;`
-        out = out.replace(" ;", ";");
-        // Remove space before comma: `foo ,` → `foo,`
-        out = out.replace(" ,", ",");
-        // Remove space after `@` in decorators: `@ decorator` → `@decorator`
-        if out.starts_with("@ ") {
-            out = format!("@{}", out[2..].trim_start());
-        }
-        // Ensure space inside empty braces: `{}` → `{ }`
-        out = out.replace("{}", "{ }");
-        // Ensure space before opening brace (not at start of line): `foo{` → `foo {`
-        out = Self::ensure_space_before_brace(&out);
-        out
-    }
-
-    /// Ensure there's a space before `{` when preceded by non-whitespace,
-    /// but not after `$` (template literal `${`).
-    fn ensure_space_before_brace(line: &str) -> String {
-        let bytes = line.as_bytes();
-        let len = bytes.len();
-        let mut result = Vec::with_capacity(len + 4);
-        let mut in_string: Option<u8> = None;
-        let mut i = 0;
-
-        while i < len {
-            let ch = bytes[i];
-
-            // Track string state
-            if in_string.is_none() && (ch == b'\'' || ch == b'"' || ch == b'`') {
-                in_string = Some(ch);
-                result.push(ch);
-                i += 1;
-                continue;
-            }
-            if let Some(q) = in_string {
-                if ch == b'\\' && i + 1 < len {
-                    result.push(ch);
-                    result.push(bytes[i + 1]);
-                    i += 2;
-                    continue;
-                }
-                if ch == q {
-                    in_string = None;
-                }
-                result.push(ch);
-                i += 1;
-                continue;
-            }
-
-            if ch == b'{' && i > 0 {
-                let prev = bytes[i - 1];
-                // Add space before `{` if preceded by non-whitespace
-                // but NOT after `$` (template literal `${`)
-                if prev != b' ' && prev != b'\t' && prev != b'$' && prev != b'(' {
-                    result.push(b' ');
-                }
-            }
-
-            result.push(ch);
-            i += 1;
-        }
-
-        String::from_utf8(result).unwrap_or_else(|_| line.to_string())
-    }
-
-    /// Collapse runs of whitespace to single spaces, but preserve whitespace
-    /// inside string literals (single, double, backtick quotes).
-    fn collapse_whitespace(line: &str) -> String {
-        let bytes = line.as_bytes();
-        let len = bytes.len();
-        let mut result = Vec::with_capacity(len);
-        let mut i = 0;
-        let mut in_whitespace_run = false;
-
-        while i < len {
-            let ch = bytes[i];
-
-            // Handle string literals — copy them verbatim
-            if ch == b'\'' || ch == b'"' || ch == b'`' {
-                if in_whitespace_run {
-                    result.push(b' ');
-                    in_whitespace_run = false;
-                }
-                result.push(ch);
-                i += 1;
-                // Scan to matching close quote
-                while i < len {
-                    let c = bytes[i];
-                    result.push(c);
-                    if c == b'\\' && i + 1 < len {
-                        // Escape sequence — copy next char too
-                        i += 1;
-                        result.push(bytes[i]);
-                    } else if c == ch {
-                        break;
-                    }
-                    i += 1;
-                }
-                i += 1;
-                continue;
-            }
-
-            if ch == b' ' || ch == b'\t' {
-                in_whitespace_run = true;
-                i += 1;
-            } else {
-                if in_whitespace_run {
-                    result.push(b' ');
-                    in_whitespace_run = false;
-                }
-                result.push(ch);
-                i += 1;
-            }
-        }
-
-        // Don't add trailing space
-        String::from_utf8(result).unwrap_or_else(|_| line.to_string())
-    }
-
-    /// Convert leading spaces to tabs based on tab size.
-    pub fn convert_leading_spaces_to_tabs(line: &str, tab_size: usize) -> String {
-        let leading_spaces = line.chars().take_while(|&c| c == ' ').count();
-        let leading_tabs = leading_spaces / tab_size;
-        let remaining_spaces = leading_spaces % tab_size;
-
-        let rest = &line[leading_spaces..];
-        let tabs = "\t".repeat(leading_tabs);
-        let spaces = " ".repeat(remaining_spaces);
-
-        format!("{tabs}{spaces}{rest}")
     }
 
     // =========================================================================
@@ -883,31 +471,37 @@ impl DocumentFormattingProvider {
 
     /// Format a specific range within a document.
     ///
-    /// This implements the LSP `textDocument/rangeFormatting` request.
-    /// Only lines that fall within the given range are reformatted;
-    /// surrounding lines are left untouched.
+    /// External formatters do not provide stable range-only formatting from
+    /// stdin (`Prettier` and `ESLint` operate on whole files), so this method
+    /// runs the conservative whitespace-only fallback and returns only the
+    /// edits that intersect the requested line range. Lines outside the
+    /// range are left untouched.
     pub fn format_range(
         source_text: &str,
         range: Range,
         options: &FormattingOptions,
     ) -> Result<Vec<TextEdit>, String> {
-        let lines: Vec<&str> = source_text.lines().collect();
+        let lines: Vec<&str> = source_text.split('\n').collect();
+        if lines.is_empty() {
+            return Ok(vec![]);
+        }
         let start_line = range.start.line as usize;
         let end_line = (range.end.line as usize).min(lines.len().saturating_sub(1));
         if start_line > end_line || start_line >= lines.len() {
             return Ok(vec![]);
         }
 
-        // Preserve lexical indentation context by formatting the full document,
-        // then keeping only edits that intersect the requested line range.
-        let formatted = Self::format_text(
-            source_text,
-            &FormattingOptions {
-                insert_final_newline: Some(false),
-                trim_final_newlines: Some(false),
-                ..options.clone()
-            },
-        );
+        // Apply whitespace-only normalization to the full document so that
+        // `compute_line_edits` can still emit minimal per-line edits, then
+        // keep only edits that intersect the requested line range.
+        let range_options = FormattingOptions {
+            // A range-format request must not force a final newline on the
+            // whole document; leave EOF alone.
+            insert_final_newline: Some(false),
+            trim_final_newlines: Some(false),
+            ..options.clone()
+        };
+        let formatted = Self::safe_whitespace_text(source_text, &range_options);
         let mut edits = Self::compute_line_edits(source_text, &formatted)?;
         edits.retain(|edit| {
             let edit_start = edit.range.start.line as usize;
@@ -923,10 +517,19 @@ impl DocumentFormattingProvider {
 
     /// Handle format-on-key trigger.
     ///
-    /// `key` is the character that was typed (e.g. ";" or "\n").
-    /// `line` and `offset` are the 0-based position after the key was typed.
+    /// `key` is the character that was typed (e.g. `";"`, `"\n"`, `"}"`).
+    /// `line` and `_offset` are the 0-based position after the key was typed.
     ///
-    /// Returns a list of text edits to apply to the line where the key was typed.
+    /// In fallback mode (no external formatter) this is strictly
+    /// whitespace-safe:
+    /// - `";"`: trims trailing whitespace on the current line.
+    /// - `"\n"`: trims trailing whitespace on the previous line.
+    /// - `"}"`: no edits. Re-indentation on close-brace requires a parser.
+    /// - any other key: no edits.
+    ///
+    /// This intentionally does **not** remove double semicolons, insert
+    /// indentation, or adjust brace placement — those would require syntax
+    /// awareness. See [`FallbackFormattingMode`].
     pub fn format_on_key(
         source_text: &str,
         line: u32,
@@ -935,192 +538,65 @@ impl DocumentFormattingProvider {
         options: &FormattingOptions,
     ) -> Result<Vec<TextEdit>, String> {
         match key {
-            ";" => Self::format_on_semicolon(source_text, line, options),
-            "\n" => Self::format_on_enter(source_text, line, options),
-            "}" => Self::format_on_closing_brace(source_text, line, options),
+            ";" => Self::trim_trailing_whitespace_on_line(source_text, line, options),
+            "\n" => {
+                if line == 0 {
+                    return Ok(vec![]);
+                }
+                Self::trim_trailing_whitespace_on_line(source_text, line - 1, options)
+            }
             _ => Ok(vec![]),
         }
     }
 
-    /// Format the current line when a semicolon is typed.
-    /// Normalizes whitespace on the line that just received the semicolon.
-    fn format_on_semicolon(
+    /// Return an edit that trims trailing whitespace on `line`, or no edit
+    /// if the line already has no trailing whitespace / trimming is disabled.
+    fn trim_trailing_whitespace_on_line(
         source_text: &str,
         line: u32,
         options: &FormattingOptions,
     ) -> Result<Vec<TextEdit>, String> {
-        let lines: Vec<&str> = source_text.lines().collect();
-        let line_idx = line as usize;
-        if line_idx >= lines.len() {
+        if !options.trim_trailing_whitespace.unwrap_or(true) {
             return Ok(vec![]);
         }
-
-        let current_line = lines[line_idx];
-        let trimmed = current_line.trim();
-
-        // If the line has double semicolons, remove one
-        if trimmed.ends_with(";;") {
-            let fixed = &trimmed[..trimmed.len() - 1];
-            let indent = Self::compute_indent_for_line(lines.as_slice(), line_idx, options);
-            let new_text = format!("{indent}{fixed}");
-            let line_len = current_line.len() as u32;
-            return Ok(vec![TextEdit::new(
-                Range::new(Position::new(line, 0), Position::new(line, line_len)),
-                new_text,
-            )]);
+        let lines: Vec<&str> = source_text.split('\n').collect();
+        let line_idx = line as usize;
+        let Some(current_line_with_cr) = lines.get(line_idx) else {
+            return Ok(vec![]);
+        };
+        // Treat a CR at end of line as part of trailing whitespace; but
+        // don't edit it here to avoid changing line-ending style.
+        let current_line = current_line_with_cr
+            .strip_suffix('\r')
+            .unwrap_or(current_line_with_cr);
+        let trimmed = current_line.trim_end_matches([' ', '\t']);
+        if trimmed.len() == current_line.len() {
+            return Ok(vec![]);
         }
-
-        // Trim trailing whitespace on the current line
-        let new_trimmed = current_line.trim_end();
-        if new_trimmed != current_line {
-            return Ok(vec![TextEdit::new(
-                Range::new(
-                    Position::new(line, new_trimmed.len() as u32),
-                    Position::new(line, current_line.len() as u32),
-                ),
-                String::new(),
-            )]);
-        }
-
-        Ok(vec![])
+        Ok(vec![TextEdit::new(
+            Range::new(
+                Position::new(line, trimmed.len() as u32),
+                Position::new(line, current_line.len() as u32),
+            ),
+            String::new(),
+        )])
     }
+}
 
-    /// Format after pressing enter.
-    /// Ensures proper indentation of the new line and trims the previous line.
-    fn format_on_enter(
-        source_text: &str,
-        line: u32,
-        options: &FormattingOptions,
-    ) -> Result<Vec<TextEdit>, String> {
-        let lines: Vec<&str> = source_text.lines().collect();
-        let line_idx = line as usize;
-
-        let mut edits = Vec::new();
-
-        // Trim trailing whitespace on the previous line
-        if line_idx > 0 {
-            let prev_line = lines[line_idx - 1];
-            let prev_trimmed = prev_line.trim_end();
-            if prev_trimmed.len() < prev_line.len() {
-                edits.push(TextEdit::new(
-                    Range::new(
-                        Position::new(line - 1, prev_trimmed.len() as u32),
-                        Position::new(line - 1, prev_line.len() as u32),
-                    ),
-                    String::new(),
-                ));
-            }
-        }
-
-        // Set proper indentation on the current (new) line
-        if line_idx < lines.len() {
-            let current_line = lines[line_idx];
-            let current_trimmed = current_line.trim();
-            let expected_indent =
-                Self::compute_indent_for_line(lines.as_slice(), line_idx, options);
-
-            let current_leading_len = current_line.len() - current_line.trim_start().len();
-            let current_leading = &current_line[..current_leading_len];
-            if current_leading != expected_indent && !current_trimmed.is_empty() {
-                let old_indent_len = current_leading.len() as u32;
-                edits.push(TextEdit::new(
-                    Range::new(Position::new(line, 0), Position::new(line, old_indent_len)),
-                    expected_indent,
-                ));
-            }
-        }
-
-        Ok(edits)
-    }
-
-    /// Format after typing a closing brace `}`.
-    /// Re-indents the current line to match the corresponding opening brace.
-    fn format_on_closing_brace(
-        source_text: &str,
-        line: u32,
-        options: &FormattingOptions,
-    ) -> Result<Vec<TextEdit>, String> {
-        let lines: Vec<&str> = source_text.lines().collect();
-        let line_idx = line as usize;
-        if line_idx >= lines.len() {
-            return Ok(vec![]);
-        }
-
-        let current_line = lines[line_idx];
-        let trimmed = current_line.trim();
-
-        // Only apply if the line is just a closing brace (with possible whitespace)
-        if !trimmed.starts_with('}') {
-            return Ok(vec![]);
-        }
-
-        let expected_indent = Self::compute_indent_for_line(lines.as_slice(), line_idx, options);
-        let new_text = format!("{expected_indent}{trimmed}");
-
-        if new_text != current_line {
-            Ok(vec![TextEdit::new(
-                Range::new(
-                    Position::new(line, 0),
-                    Position::new(line, current_line.len() as u32),
-                ),
-                new_text,
-            )])
+/// Compute the end position of a document (the position immediately past the
+/// last character). Used to build a whole-document replacement range.
+fn document_end_position(source: &str) -> Position {
+    let mut line: u32 = 0;
+    let mut character: u32 = 0;
+    for ch in source.chars() {
+        if ch == '\n' {
+            line += 1;
+            character = 0;
         } else {
-            Ok(vec![])
+            character += 1;
         }
     }
-
-    /// Compute the expected indentation string for a given line index,
-    /// based on the context of surrounding lines.
-    fn compute_indent_for_line(
-        lines: &[&str],
-        line_idx: usize,
-        options: &FormattingOptions,
-    ) -> String {
-        let indent_unit = Self::make_indent_string(options, 1);
-
-        // Look at the previous non-empty line
-        let mut prev_idx = line_idx.saturating_sub(1);
-        while prev_idx > 0 && lines.get(prev_idx).is_none_or(|l| l.trim().is_empty()) {
-            prev_idx -= 1;
-        }
-
-        let prev_line = lines.get(prev_idx).copied().unwrap_or("");
-        let prev_trimmed = prev_line.trim();
-
-        // Get the indentation of the previous line
-        let prev_indent_len = prev_line.len() - prev_line.trim_start().len();
-        let prev_indent = &prev_line[..prev_indent_len];
-
-        // Check the current line for dedent
-        let current_trimmed = lines.get(line_idx).map_or("", |l| l.trim());
-        let needs_dedent = Self::line_starts_with_closing(current_trimmed)
-            || Self::is_case_or_default(current_trimmed);
-
-        // Determine if we should increase indent
-        let should_indent = prev_trimmed.ends_with('{')
-            || prev_trimmed.ends_with('(')
-            || prev_trimmed.ends_with('[')
-            || prev_trimmed.ends_with("=>")
-            || (prev_trimmed.ends_with(':') && Self::is_case_or_default(prev_trimmed));
-
-        if needs_dedent && should_indent {
-            // Opening and closing on adjacent lines: same indent as previous
-            prev_indent.to_string()
-        } else if needs_dedent {
-            // Dedent from previous
-            let unit_len = indent_unit.len();
-            if prev_indent_len >= unit_len {
-                prev_indent[..prev_indent_len - unit_len].to_string()
-            } else {
-                String::new()
-            }
-        } else if should_indent {
-            format!("{prev_indent}{indent_unit}")
-        } else {
-            prev_indent.to_string()
-        }
-    }
+    Position::new(line, character)
 }
 
 #[cfg(test)]

--- a/crates/tsz-lsp/tests/formatting_tests.rs
+++ b/crates/tsz-lsp/tests/formatting_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+// =========================================================================
+// Options + TextEdit basics
+// =========================================================================
+
 #[test]
 fn test_formatting_options_default() {
     let options = FormattingOptions::default();
@@ -7,63 +11,8 @@ fn test_formatting_options_default() {
     assert!(options.insert_spaces);
     assert_eq!(options.trim_trailing_whitespace, Some(true));
     assert_eq!(options.insert_final_newline, Some(true));
-}
-
-#[test]
-fn test_basic_formatting_trailing_whitespace() {
-    let source = "let x = 1;   \nlet y = 2;\n";
-    let options = FormattingOptions {
-        trim_trailing_whitespace: Some(true),
-        ..Default::default()
-    };
-
-    let result = DocumentFormattingProvider::apply_basic_formatting(source, &options);
-    assert!(result.is_ok());
-
-    let edits = result.unwrap();
-    assert!(!edits.is_empty());
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(formatted.contains("let x = 1;\n"));
-    assert!(!formatted.contains("let x = 1;   "));
-}
-
-#[test]
-fn test_basic_formatting_insert_final_newline() {
-    let source = "let x = 1;";
-    let options = FormattingOptions {
-        insert_final_newline: Some(true),
-        ..Default::default()
-    };
-
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(formatted.ends_with('\n'));
-}
-
-#[test]
-fn test_basic_formatting_tabs_to_spaces() {
-    let source = "\tlet x = 1;";
-    let options = FormattingOptions {
-        tab_size: 4,
-        insert_spaces: true,
-        ..Default::default()
-    };
-
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // The formatter re-indents, so a top-level let should have no indent
-    assert!(formatted.starts_with("let x = 1;"));
-}
-
-#[test]
-fn test_basic_formatting_spaces_to_tabs() {
-    let source = "    let x = 1;";
-    let options = FormattingOptions {
-        tab_size: 4,
-        insert_spaces: false,
-        ..Default::default()
-    };
-
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(formatted.starts_with("let x = 1;"));
+    assert_eq!(options.trim_final_newlines, Some(true));
+    assert_eq!(options.semicolons, None);
 }
 
 #[test]
@@ -76,240 +25,342 @@ fn test_text_edit_creation() {
 }
 
 #[test]
-fn test_convert_leading_spaces_to_tabs() {
-    let result =
-        DocumentFormattingProvider::convert_leading_spaces_to_tabs("        let x = 1;", 4);
-    assert_eq!(result, "\t\tlet x = 1;");
-
-    let result = DocumentFormattingProvider::convert_leading_spaces_to_tabs("      let x = 1;", 4);
-    assert_eq!(result, "\t  let x = 1;");
-
-    let result = DocumentFormattingProvider::convert_leading_spaces_to_tabs("  let x = 1;", 4);
-    assert_eq!(result, "  let x = 1;");
-}
-
-#[test]
-fn test_basic_formatting_preserves_multiline() {
-    let source = "function foo() {\n  return 1;\n}";
-    let options = FormattingOptions::default();
-
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(formatted.contains("function foo()"));
-    assert!(formatted.contains("return 1;"));
-}
-
-#[test]
-fn test_basic_formatting_empty_source() {
-    let source = "";
-    let options = FormattingOptions::default();
-
-    let result = DocumentFormattingProvider::apply_basic_formatting(source, &options);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    assert!(
-        edits.is_empty()
-            || edits
-                .iter()
-                .all(|e| e.new_text.is_empty() || e.new_text == "\n")
-    );
-}
-
-// =========================================================================
-// New tests: indentation
-// =========================================================================
-
-#[test]
-fn test_format_if_else_indentation() {
-    let source = "if (x) {\nlet a = 1;\n} else {\nlet b = 2;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "if (x) {");
-    assert_eq!(lines[1], "    let a = 1;");
-    assert_eq!(lines[2], "} else {");
-    assert_eq!(lines[3], "    let b = 2;");
-    assert_eq!(lines[4], "}");
-}
-
-#[test]
-fn test_format_function_body_indentation() {
-    let source = "function greet(name: string) {\nconst msg = \"hi\";\nreturn msg;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "function greet(name: string) {");
-    assert_eq!(lines[1], "    const msg = \"hi\";");
-    assert_eq!(lines[2], "    return msg;");
-    assert_eq!(lines[3], "}");
-}
-
-#[test]
-fn test_format_switch_case_indentation() {
-    let source = "switch (x) {\ncase 1:\nlet a = 1;\nbreak;\ncase 2:\nlet b = 2;\nbreak;\ndefault:\nlet c = 3;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "switch (x) {");
-    assert!(lines[1].starts_with("case 1:"), "got: {}", lines[1]);
-    assert!(
-        lines[2].starts_with("    "),
-        "case body should be indented, got: {}",
-        lines[2]
-    );
-}
-
-#[test]
-fn test_format_nested_blocks() {
-    let source = "function foo() {\nif (true) {\nlet x = 1;\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "function foo() {");
-    assert_eq!(lines[1], "    if (true) {");
-    assert_eq!(lines[2], "        let x = 1;");
-    assert_eq!(lines[3], "    }");
-    assert_eq!(lines[4], "}");
-}
-
-#[test]
-fn test_format_semicolon_normalization() {
-    let source = "let x = 1\nlet y = 2\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-
-    assert!(
-        formatted.contains("let x = 1;"),
-        "should add semicolon, got: {formatted}"
-    );
-    assert!(
-        formatted.contains("let y = 2;"),
-        "should add semicolon, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_no_double_semicolons() {
-    let source = "let x = 1;\nlet y = 2;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-
-    assert!(
-        !formatted.contains(";;"),
-        "should not produce double semicolons"
-    );
-}
-
-#[test]
-fn test_format_normalizes_as_operator_spacing() {
-    let source = "var x = 3   as  number;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert_eq!(formatted, "var x = 3 as number;\n");
-}
-
-#[test]
-fn test_format_tab_size_2() {
-    let source = "function foo() {\nlet x = 1;\n}";
+fn test_formatting_options_custom_tab_size() {
     let options = FormattingOptions {
         tab_size: 2,
         insert_spaces: true,
         ..Default::default()
     };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[1], "  let x = 1;");
+    assert_eq!(options.tab_size, 2);
+    assert!(options.insert_spaces);
 }
 
+// =========================================================================
+// FallbackFormattingMode capability boundary
+// =========================================================================
+
 #[test]
-fn test_format_with_tabs() {
-    let source = "function foo() {\nlet x = 1;\n}";
+fn test_fallback_mode_variants_are_distinct() {
+    // The enum is the documented capability boundary between safe whitespace
+    // cleanup and "needs a real parser". Guard against a future merge that
+    // silently collapses the two variants.
+    assert_ne!(
+        FallbackFormattingMode::WhitespaceOnly,
+        FallbackFormattingMode::UnsupportedForStructuralFormatting
+    );
+}
+
+// =========================================================================
+// Conservative fallback: whitespace-only operations
+// =========================================================================
+
+#[test]
+fn test_fallback_trims_trailing_whitespace_only() {
+    let source = "let x = 1;   \nlet y = 2;\n";
     let options = FormattingOptions {
-        tab_size: 4,
-        insert_spaces: false,
+        trim_trailing_whitespace: Some(true),
         ..Default::default()
     };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[1], "\tlet x = 1;");
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, "let x = 1;\nlet y = 2;\n");
 }
 
-// =========================================================================
-// New tests: format on key
-// =========================================================================
+#[test]
+fn test_fallback_respects_trim_trailing_whitespace_disabled() {
+    let source = "let x = 1;   \nlet y = 2;\n";
+    let options = FormattingOptions {
+        trim_trailing_whitespace: Some(false),
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, "let x = 1;   \nlet y = 2;\n");
+}
 
 #[test]
-fn test_format_on_semicolon_removes_double() {
-    let source = "let x = 1;;\n";
+fn test_fallback_adds_final_newline_when_missing() {
+    let source = "let x = 1;";
+    let options = FormattingOptions {
+        insert_final_newline: Some(true),
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, "let x = 1;\n");
+}
+
+#[test]
+fn test_fallback_does_not_add_final_newline_when_disabled() {
+    let source = "let x = 1;";
+    let options = FormattingOptions {
+        insert_final_newline: Some(false),
+        trim_final_newlines: Some(false),
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, "let x = 1;");
+}
+
+#[test]
+fn test_fallback_empty_source_stays_empty() {
+    let source = "";
     let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 0, 11, ";", &options);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    assert!(
-        !edits.is_empty(),
-        "should produce edit for double semicolon"
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, "",
+        "empty input must not become a newline-only file"
     );
-    let edit = &edits[0];
-    assert!(
-        edit.new_text.ends_with("let x = 1;"),
-        "got: {}",
-        edit.new_text
-    );
-    assert!(!edit.new_text.ends_with(";;"));
 }
 
 #[test]
-fn test_format_on_enter_trims_prev_line() {
+fn test_fallback_trims_final_blank_lines_when_enabled() {
+    let source = "let x = 1;\n\n\n\n";
+    let options = FormattingOptions {
+        trim_final_newlines: Some(true),
+        insert_final_newline: Some(true),
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, "let x = 1;\n");
+}
+
+// =========================================================================
+// Fallback must NOT perform structural rewrites
+// =========================================================================
+
+#[test]
+fn test_fallback_does_not_insert_semicolons() {
+    // Previously, the heuristic formatter would append `;` to statement lines.
+    // The conservative fallback must not.
+    let source = "let x = 1\nlet y = 2\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not insert semicolons, got: {formatted:?}"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_remove_semicolons() {
+    let source = "let x = 1;\nlet y = 2;\n";
+    let options = FormattingOptions {
+        semicolons: Some("remove".to_string()),
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not remove semicolons even when option asks for it"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_rewrite_brace_spacing() {
+    let source = "function foo(){\nreturn 1;\n}\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not insert a space before '{{', got: {formatted:?}"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_collapse_empty_block() {
+    // Previously `... ()\n{}` was heuristically merged into `...() { }`.
+    let source = "class C\n{}\nif (true)\n{}\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not merge single-line blocks"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_reindent() {
+    // The input deliberately has no leading indentation inside the block.
+    // A syntax-aware formatter would indent; the conservative fallback must not.
+    let source = "function foo() {\nlet x = 1;\n}\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not infer indentation from braces"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_normalize_as_operator() {
+    let source = "var x = 3   as  number;\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source, "fallback must not rewrite `as` spacing");
+}
+
+#[test]
+fn test_fallback_does_not_collapse_internal_whitespace() {
+    let source = "const   x   =   1;\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not collapse internal whitespace in code"
+    );
+}
+
+#[test]
+fn test_fallback_does_not_touch_tabs_as_indentation() {
+    // Converting tab → spaces inside code is syntax-sensitive (the tab may be
+    // inside a string or regex literal), so the fallback must leave it alone.
+    let source = "function foo() {\n\treturn 42;\n}\n";
+    let options = FormattingOptions {
+        tab_size: 2,
+        insert_spaces: true,
+        ..Default::default()
+    };
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not convert tabs to spaces"
+    );
+}
+
+// =========================================================================
+// Preservation of syntax-sensitive constructs
+// =========================================================================
+
+#[test]
+fn test_fallback_preserves_template_literals() {
+    let source = "const msg = `hello ${name}\n  world`;\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "template literal must be preserved exactly"
+    );
+}
+
+#[test]
+fn test_fallback_preserves_regex_literals() {
+    // A regex containing `/`, `{`, and `}` characters could easily confuse
+    // naive text heuristics. The fallback must pass it through untouched.
+    let source = "const re = /\\/foo\\{bar\\}baz/g;\nconst s = 'a/b/c';\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_fallback_preserves_multiline_generics_and_conditionals() {
+    let source = "type Unwrap<T> = T extends Promise<\n    infer U\n> ? U : T;\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_fallback_preserves_decorators() {
+    let source = "@Component({\n    selector: 'app-root',\n})\nclass AppComponent {}\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_fallback_preserves_tsx_like_syntax() {
+    let source = "const el = <div className=\"t\">{value}</div>;\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_fallback_preserves_string_literals_with_whitespace() {
+    // Whitespace inside string literals must never be touched, even with
+    // trailing-whitespace trimming on.
+    let source = "const s = \"hello   world\";\n";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(formatted, source);
+}
+
+#[test]
+fn test_fallback_preserves_complex_typescript_input() {
+    // Larger integration-shaped fixture. The fallback may only adjust EOF
+    // newline / trailing whitespace. Non-whitespace content must be identical.
+    let source = "\
+import { foo } from \"bar\";
+
+@decorator({ option: true })
+class Complex<T extends Record<string, unknown>> {
+    private readonly items: Array<T> = [];
+
+    async process(input: string): Promise<T | null> {
+        const pattern = /^[a-z]+/i;
+        const label = `<${input}>`;
+        return input.match(pattern) ? null : (label as unknown as T);
+    }
+}
+";
+    let options = FormattingOptions::default();
+    let formatted = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    assert_eq!(
+        formatted, source,
+        "fallback must not touch complex TS content"
+    );
+}
+
+// =========================================================================
+// apply_safe_whitespace_formatting produces edits consistent with text form
+// =========================================================================
+
+#[test]
+fn test_apply_safe_whitespace_formatting_trailing_whitespace_edits() {
     let source = "let x = 1;   \nlet y = 2;\n";
     let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 1, 0, "\n", &options);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    let has_trim = edits
-        .iter()
-        .any(|e| e.range.start.line == 0 && e.new_text.is_empty());
-    assert!(has_trim, "should trim trailing whitespace on previous line");
+    let edits =
+        DocumentFormattingProvider::apply_safe_whitespace_formatting(source, &options).unwrap();
+    assert!(
+        !edits.is_empty(),
+        "trailing whitespace should produce at least one edit"
+    );
+    // Applying the edit must yield the whitespace-only normalized form.
+    let expected = DocumentFormattingProvider::safe_whitespace_text(source, &options);
+    let applied = apply_text_edits(source, &edits);
+    assert_eq!(applied, expected);
 }
 
 #[test]
-fn test_format_on_enter_indents_after_brace() {
-    let source = "function foo() {\n\n";
+fn test_apply_safe_whitespace_formatting_noop_when_clean() {
+    let source = "let x = 1;\nlet y = 2;\n";
     let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 1, 0, "\n", &options);
-    assert!(result.is_ok());
-    // The current line is empty, so no indent edit is produced (graceful)
+    let edits =
+        DocumentFormattingProvider::apply_safe_whitespace_formatting(source, &options).unwrap();
+    assert!(edits.is_empty(), "clean input must produce no edits");
 }
 
 #[test]
-fn test_format_on_key_unknown_key() {
-    let source = "let x = 1;\n";
+fn test_apply_safe_whitespace_formatting_empty_source() {
+    let source = "";
     let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 0, 5, "a", &options);
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_empty());
+    let edits =
+        DocumentFormattingProvider::apply_safe_whitespace_formatting(source, &options).unwrap();
+    assert!(edits.is_empty(), "empty source must not synthesize edits");
 }
 
 // =========================================================================
-// New tests: line edit correctness (0-based positions)
+// compute_line_edits
 // =========================================================================
 
 #[test]
 fn test_compute_line_edits_no_change() {
-    let result = DocumentFormattingProvider::compute_line_edits("hello\n", "hello\n");
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_empty());
+    let edits = DocumentFormattingProvider::compute_line_edits("hello\n", "hello\n").unwrap();
+    assert!(edits.is_empty());
 }
 
 #[test]
-fn test_compute_line_edits_single_line_change() {
-    let result = DocumentFormattingProvider::compute_line_edits("hello  \n", "hello\n");
-    assert!(result.is_ok());
-    let edits = result.unwrap();
+fn test_compute_line_edits_single_line_change_emits_one_line_edit() {
+    let edits = DocumentFormattingProvider::compute_line_edits("hello  \n", "hello\n").unwrap();
     assert_eq!(edits.len(), 1);
     let edit = &edits[0];
     assert_eq!(edit.range.start.line, 0);
@@ -319,12 +370,78 @@ fn test_compute_line_edits_single_line_change() {
 }
 
 #[test]
+fn test_compute_line_edits_same_line_count_emits_per_line_edits() {
+    let original = "a  \nb\nc  \n";
+    let formatted = "a\nb\nc\n";
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
+    assert_eq!(edits.len(), 2);
+    // Edits must be descending (bottom-to-top) so that sequential application
+    // does not invalidate later ranges.
+    assert!(edits[0].range.start.line >= edits[1].range.start.line);
+    let applied = apply_text_edits(original, &edits);
+    assert_eq!(applied, formatted);
+}
+
+#[test]
+fn test_compute_line_edits_different_line_count_emits_whole_document_edit() {
+    let original = "line1\n";
+    let formatted = "line1\nline2\nline3\n";
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
+    assert_eq!(
+        edits.len(),
+        1,
+        "differing line counts must produce a single whole-document edit"
+    );
+    assert_eq!(edits[0].range.start, Position::new(0, 0));
+    let applied = apply_text_edits(original, &edits);
+    assert_eq!(applied, formatted);
+}
+
+#[test]
+fn test_compute_line_edits_fewer_lines_in_formatted() {
+    let original = "line1\nline2\nline3\n";
+    let formatted = "line1\n";
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
+    assert_eq!(edits.len(), 1, "should collapse to one whole-document edit");
+    let applied = apply_text_edits(original, &edits);
+    assert_eq!(applied, formatted);
+}
+
+#[test]
+fn test_compute_line_edits_trailing_newline_change_emits_whole_document_edit() {
+    let original = "a\nb\n";
+    let formatted = "a\nb";
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
+    // Trailing-newline state differs — treat as a whole-document change.
+    assert_eq!(edits.len(), 1);
+    let applied = apply_text_edits(original, &edits);
+    assert_eq!(applied, formatted);
+}
+
+#[test]
+fn test_compute_line_edits_descending_order_preserves_sequential_apply() {
+    // Multiple per-line edits must be sorted bottom-to-top.
+    let original = "a  \nb  \nc  \n";
+    let formatted = "a\nb\nc\n";
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
+    assert!(!edits.is_empty());
+    for window in edits.windows(2) {
+        let curr = &window[0].range.start;
+        let next = &window[1].range.start;
+        assert!(
+            curr.line > next.line || (curr.line == next.line && curr.character >= next.character),
+            "edits must be sorted descending: {edits:#?}"
+        );
+    }
+    let applied = apply_text_edits(original, &edits);
+    assert_eq!(applied, formatted);
+}
+
+#[test]
 fn test_compute_line_edits_no_overlapping_ranges() {
     let original = "line1\nline2  \nline3\n";
     let formatted = "line1\nline2\nline3\n";
-    let result = DocumentFormattingProvider::compute_line_edits(original, formatted);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
+    let edits = DocumentFormattingProvider::compute_line_edits(original, formatted).unwrap();
 
     for i in 0..edits.len() {
         for j in (i + 1)..edits.len() {
@@ -344,1101 +461,121 @@ fn test_compute_line_edits_no_overlapping_ranges() {
     }
 }
 
-#[test]
-fn test_format_positions_are_zero_based() {
-    let source = "function foo() {\nlet x = 1\n}";
-    let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::apply_basic_formatting(source, &options);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
+// =========================================================================
+// format_on_key: fallback is whitespace-safe only
+// =========================================================================
 
+#[test]
+fn test_format_on_semicolon_trims_trailing_whitespace_only() {
+    let source = "let x = 1;   \n";
+    let options = FormattingOptions::default();
+    let edits = DocumentFormattingProvider::format_on_key(source, 0, 11, ";", &options).unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "");
+    assert_eq!(edits[0].range.start.line, 0);
+    // The trim range must start exactly after the last non-whitespace char.
+    assert_eq!(edits[0].range.start.character, "let x = 1;".len() as u32);
+}
+
+#[test]
+fn test_format_on_semicolon_does_not_remove_double_semicolons() {
+    let source = "let x = 1;;\n";
+    let options = FormattingOptions::default();
+    let edits = DocumentFormattingProvider::format_on_key(source, 0, 11, ";", &options).unwrap();
+    // No trailing whitespace to trim; fallback is not allowed to remove
+    // a second semicolon by guess — that requires knowing the line is a
+    // real statement.
+    assert!(edits.is_empty(), "fallback must not rewrite `;;`");
+}
+
+#[test]
+fn test_format_on_enter_trims_previous_line_trailing_whitespace() {
+    let source = "let x = 1;   \nlet y = 2;\n";
+    let options = FormattingOptions::default();
+    let edits = DocumentFormattingProvider::format_on_key(source, 1, 0, "\n", &options).unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].range.start.line, 0);
+    assert_eq!(edits[0].new_text, "");
+}
+
+#[test]
+fn test_format_on_enter_does_not_indent_new_line() {
+    let source = "function foo() {\n\n";
+    let options = FormattingOptions::default();
+    let edits = DocumentFormattingProvider::format_on_key(source, 1, 0, "\n", &options).unwrap();
+    // Fallback must not invent indentation for the blank new line.
     for edit in &edits {
         assert!(
-            edit.range.start.line < 1000,
-            "Start line too large: {}",
-            edit.range.start.line
-        );
-        assert!(
-            edit.range.end.line < 1000,
-            "End line too large: {}",
-            edit.range.end.line
+            edit.new_text.chars().all(|c| c == ' ' || c == '\t') || edit.new_text.is_empty(),
+            "fallback must not insert non-whitespace content, got: {:?}",
+            edit.new_text
         );
     }
 }
 
 #[test]
-fn test_format_class_body_indentation() {
-    let source = "class Foo {\nbar: number;\nbaz() {\nreturn 1;\n}\n}";
+fn test_format_on_closing_brace_is_noop_in_fallback() {
+    let source = "function foo() {\n    let x = 1;\n}";
     let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "class Foo {");
-    assert_eq!(lines[1], "    bar: number;");
-    assert_eq!(lines[2], "    baz() {");
-    assert_eq!(lines[3], "        return 1;");
-    assert_eq!(lines[4], "    }");
-    assert_eq!(lines[5], "}");
-}
-
-#[test]
-fn test_format_preserves_empty_lines() {
-    let source = "let x = 1;\n\nlet y = 2;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
+    let edits = DocumentFormattingProvider::format_on_key(source, 2, 1, "}", &options).unwrap();
     assert!(
-        formatted.contains("let x = 1;\n\nlet y = 2;"),
-        "got: {formatted}"
+        edits.is_empty(),
+        "close-brace formatting requires a parser; fallback returns no edits, got: {edits:?}"
     );
 }
 
 #[test]
-fn test_format_arrow_function() {
-    let source = "const fn = () => {\nreturn 1;\n}";
+fn test_format_on_key_unknown_key() {
+    let source = "let x = 1;\n";
     let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "const fn = () => {");
-    assert_eq!(lines[1], "    return 1;");
-    assert_eq!(lines[2], "}");
+    let edits = DocumentFormattingProvider::format_on_key(source, 0, 5, "a", &options).unwrap();
+    assert!(edits.is_empty());
 }
 
 #[test]
-fn test_format_pasted_class_member_spacing_matches_tsserver_shape() {
-    let source =
-        "namespace TestModule {\n class TestClass{\nprivate   foo;\npublic testMethod( )\n{}\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert_eq!(
-        formatted,
-        "namespace TestModule {\n    class TestClass {\n        private foo;\n        public testMethod() { }\n    }\n}\n"
-    );
-}
-
-#[test]
-fn test_format_multiline_import() {
-    let source = "import { foo } from \"bar\";\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("import { foo } from \"bar\";"),
-        "got: {formatted}"
-    );
-}
-
-#[test]
-fn test_compute_line_edits_descending_order_preserves_markers_on_sequential_apply() {
-    fn position_to_offset(text: &str, position: Position) -> usize {
-        let mut line = 0u32;
-        let mut character = 0u32;
-        for (idx, ch) in text.char_indices() {
-            if line == position.line && character == position.character {
-                return idx;
-            }
-            if ch == '\n' {
-                line += 1;
-                character = 0;
-            } else {
-                character += 1;
-            }
-        }
-        if line == position.line && character == position.character {
-            return text.len();
-        }
-        panic!("invalid position: {position:?}");
-    }
-
-    let source = "class TestClass {\n    private testMethod1(param1: boolean,\n                        param2/*1*/: boolean) {\n    }\n\n    public testMethod2(a: number, b: number, c: number) {\n        if (a === b) {\n        }\n        else if (a != c &&\n                 a/*2*/ > b &&\n                 b/*3*/ < c) {\n        }\n\n    }\n}\n";
-    let options = FormattingOptions::default();
-    let edits = DocumentFormattingProvider::apply_basic_formatting(source, &options).unwrap();
-
-    assert!(!edits.is_empty());
-    for window in edits.windows(2) {
-        let current = &window[0].range.start;
-        let next = &window[1].range.start;
-        assert!(
-            current.line > next.line
-                || (current.line == next.line && current.character >= next.character),
-            "edits must be sorted descending: {edits:#?}"
-        );
-    }
-
-    let mut text = source.to_string();
-    for edit in edits {
-        let start = position_to_offset(&text, edit.range.start);
-        let end = position_to_offset(&text, edit.range.end);
-        text.replace_range(start..end, &edit.new_text);
-    }
-
-    assert!(text.contains("/*1*/"), "marker 1 was removed: {text}");
-    assert!(text.contains("/*2*/"), "marker 2 was removed: {text}");
-    assert!(text.contains("/*3*/"), "marker 3 was removed: {text}");
-}
-
-#[test]
-fn test_formatting_empty_string() {
-    let source = "";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Empty string should produce empty or just a newline
-    assert!(
-        formatted.is_empty() || formatted == "\n",
-        "Empty source should format to empty or newline, got: {formatted:?}"
-    );
-}
-
-#[test]
-fn test_formatting_only_whitespace() {
-    let source = "   \n  \n   ";
+fn test_format_on_key_respects_trim_trailing_whitespace_disabled() {
+    let source = "let x = 1;   \n";
     let options = FormattingOptions {
-        trim_trailing_whitespace: Some(true),
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // All whitespace should be trimmed from each line
-    for line in formatted.lines() {
-        assert!(
-            !line.ends_with(' '),
-            "Line should not end with spaces: {line:?}"
-        );
-    }
-}
-
-#[test]
-fn test_formatting_preserves_content() {
-    let source = "function foo() {\n  return 42;\n}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("function foo()"),
-        "Should preserve function declaration"
-    );
-    assert!(
-        formatted.contains("return 42"),
-        "Should preserve return statement"
-    );
-}
-
-#[test]
-fn test_formatting_tab_to_spaces() {
-    let source = "function foo() {\n\treturn 42;\n}\n";
-    let options = FormattingOptions {
-        tab_size: 2,
-        insert_spaces: true,
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Tabs should be converted to spaces
-    if !formatted.contains('\t') {
-        assert!(
-            formatted.contains("  return"),
-            "Should convert tab to 2 spaces, got: {formatted:?}"
-        );
-    }
-}
-
-#[test]
-fn test_formatting_no_trailing_whitespace() {
-    let source = "const x = 1;    \nconst y = 2;  \nconst z = 3;\n";
-    let options = FormattingOptions {
-        trim_trailing_whitespace: Some(true),
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    for (i, line) in formatted.lines().enumerate() {
-        assert!(
-            !line.ends_with(' ') && !line.ends_with('\t'),
-            "Line {i} should not have trailing whitespace: {line:?}"
-        );
-    }
-}
-
-#[test]
-fn test_formatting_options_custom_tab_size() {
-    let options = FormattingOptions {
-        tab_size: 2,
-        insert_spaces: true,
-        ..Default::default()
-    };
-    assert_eq!(options.tab_size, 2);
-    assert!(options.insert_spaces);
-}
-
-#[test]
-fn test_formatting_single_line() {
-    let source = "const x = 1;";
-    let options = FormattingOptions {
-        insert_final_newline: Some(false),
         trim_trailing_whitespace: Some(false),
         ..Default::default()
     };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
+    let edits = DocumentFormattingProvider::format_on_key(source, 0, 11, ";", &options).unwrap();
     assert!(
-        formatted.contains("const x = 1"),
-        "Should preserve single line content"
+        edits.is_empty(),
+        "disabling trim_trailing_whitespace must silence format-on-key"
     );
 }
 
 // =========================================================================
-// Additional coverage tests
+// Range formatting
 // =========================================================================
 
 #[test]
-fn test_format_arrow_function_with_params() {
-    let source = "const add = (a: number, b: number) => {\nreturn a + b;\n}";
+fn test_format_range_limits_edits_to_selected_lines() {
+    let source = "let a = 1;   \nlet b = 2;   \nlet c = 3;\n";
     let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "const add = (a: number, b: number) => {");
-    assert_eq!(lines[1], "    return a + b;");
-    assert_eq!(lines[2], "}");
-}
-
-#[test]
-fn test_format_arrow_function_single_expression() {
-    let source = "const square = (x: number) => x * x";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("const square = (x: number) => x * x;"),
-        "Should add semicolon to single-expression arrow, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_class_method_with_modifiers() {
-    let source = "class MyClass {\npublic greet(name: string) {\nreturn name;\n}\nprivate helper() {\nreturn 1;\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "class MyClass {");
-    assert!(
-        lines[1].starts_with("    public greet"),
-        "public method should be indented, got: {}",
-        lines[1]
-    );
-    assert!(
-        lines[4].starts_with("    private helper"),
-        "private method should be indented, got: {}",
-        lines[4]
-    );
-}
-
-#[test]
-fn test_format_template_literal_preserves_content() {
-    let source = "const msg = `hello ${name} world`;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("`hello ${name} world`"),
-        "Template literal content should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_switch_with_default() {
-    let source = "switch (x) {\ncase 'a':\nlet a = 1;\nbreak;\ndefault:\nlet d = 0;\nbreak;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "switch (x) {");
-    // default: should be at same level as case
-    let default_line = lines.iter().find(|l| l.trim().starts_with("default:"));
-    assert!(default_line.is_some(), "Should have a default: line");
-}
-
-#[test]
-fn test_format_destructuring_assignment() {
-    let source = "const { a, b } = obj\nconst [x, y] = arr\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("const { a, b } = obj;"),
-        "Should add semicolon to destructured object, got: {formatted}"
-    );
-    assert!(
-        formatted.contains("const [x, y] = arr;"),
-        "Should add semicolon to destructured array, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_import_with_from() {
-    let source = "import { useState, useEffect } from \"react\"\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("import { useState, useEffect } from \"react\";"),
-        "Should add semicolon to import with from, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_import_without_from_no_semicolon() {
-    // Import without 'from' (side-effect import) should not get extra semicolons
-    let source = "import \"polyfill\";\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        !formatted.contains(";;"),
-        "Should not double-semicolon side-effect import, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_enum_declaration() {
-    let source = "enum Color {\nRed,\nGreen,\nBlue,\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "enum Color {");
-    assert_eq!(lines[1], "    Red,");
-    assert_eq!(lines[2], "    Green,");
-    assert_eq!(lines[3], "    Blue,");
-    assert_eq!(lines[4], "}");
-}
-
-#[test]
-fn test_format_multiline_array_indentation() {
-    let source = "const arr = [\n1,\n2,\n3,\n]";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    // Array elements should be indented inside brackets
-    assert!(lines[0].starts_with("const arr = ["), "got: {}", lines[0]);
-    assert_eq!(lines[1], "    1,");
-    assert_eq!(lines[2], "    2,");
-    assert_eq!(lines[3], "    3,");
-    assert!(
-        lines[4].trim() == "]" || lines[4].trim() == "];",
-        "got: {}",
-        lines[4]
-    );
-}
-
-#[test]
-fn test_format_decorator_no_semicolon() {
-    let source = "@Component({\nselector: 'app-root',\n})\nclass AppComponent {\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Decorator line should not end with semicolon
-    let first_line = formatted.lines().next().unwrap();
-    assert!(
-        !first_line.ends_with(';'),
-        "Decorator line should not have semicolon, got: {first_line}"
-    );
-}
-
-#[test]
-fn test_format_semicolon_remove_mode() {
-    let source = "let x = 1;\nlet y = 2;\n";
-    let options = FormattingOptions {
-        semicolons: Some("remove".to_string()),
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // In remove mode, existing semicolons should be preserved (we only skip adding new ones)
-    // The formatter doesn't strip semicolons; it just doesn't add them
-    assert!(
-        formatted.contains("let x = 1;"),
-        "Remove mode should preserve existing semicolons, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_no_semicolon_after_control_flow() {
-    let source = "if (condition) {\nreturn 1;\n}\nfor (const x of items) {\nprocess(x);\n}\nwhile (true) {\nbreak;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-
-    // Control flow keywords should not get semicolons
-    for line in formatted.lines() {
-        let t = line.trim();
-        if t.starts_with("if ") || t.starts_with("for ") || t.starts_with("while ") {
-            assert!(
-                !t.ends_with(';'),
-                "Control flow line should not have semicolon: {t}"
-            );
-        }
+    let range = Range::new(Position::new(0, 0), Position::new(0, 0));
+    let edits = DocumentFormattingProvider::format_range(source, range, &options).unwrap();
+    for edit in &edits {
+        assert_eq!(
+            edit.range.start.line, 0,
+            "edits must be confined to the requested line 0: {edit:?}"
+        );
     }
 }
 
 #[test]
-fn test_format_no_final_newline_option() {
-    let source = "let x = 1;\n";
-    let options = FormattingOptions {
-        insert_final_newline: Some(false),
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        !formatted.ends_with('\n'),
-        "Should not end with newline when insert_final_newline is false, got: {formatted:?}"
-    );
-}
-
-#[test]
-fn test_format_collapse_whitespace_in_code() {
-    let source = "const   x   =   1;\n";
+fn test_format_range_empty_for_out_of_bounds() {
+    let source = "let a = 1;\n";
     let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("const x = 1;"),
-        "Should collapse multiple spaces, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_ensure_space_before_brace() {
-    let source = "function foo(){\nreturn 1;\n}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("function foo() {"),
-        "Should add space before brace, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_try_catch_no_semicolons() {
-    let source = "try {\nthrow new Error('oops');\n} catch (e) {\nlet x = 1;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-
-    for line in formatted.lines() {
-        let t = line.trim();
-        if t.starts_with("try ") || t.starts_with("} catch") {
-            assert!(
-                !t.ends_with(';'),
-                "try/catch line should not have semicolon: {t}"
-            );
-        }
-    }
-}
-
-#[test]
-fn test_compute_line_edits_extra_lines_in_formatted() {
-    let original = "line1\n";
-    let formatted = "line1\nline2\nline3\n";
-    let result = DocumentFormattingProvider::compute_line_edits(original, formatted);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    assert!(
-        !edits.is_empty(),
-        "Should produce edits for extra lines in formatted output"
-    );
-}
-
-#[test]
-fn test_compute_line_edits_fewer_lines_in_formatted() {
-    let original = "line1\nline2\nline3\n";
-    let formatted = "line1\n";
-    let result = DocumentFormattingProvider::compute_line_edits(original, formatted);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    assert!(
-        !edits.is_empty(),
-        "Should produce edits when formatted has fewer lines"
-    );
-}
-
-#[test]
-fn test_formatting_class_with_methods() {
-    let source = "class Foo{\n  method1()  {}\n  method2()  {}\n}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_interface_members() {
-    let source = "interface IFoo{\n  name:string;\n  age  :  number;\n}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_arrow_functions() {
-    let source = "const add=(a:number,b:number)=>a+b;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_template_literals() {
-    let source = "const msg = `Hello\n  ${name}\n  world`;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_switch_case() {
-    let source = "switch(x){\ncase 1:\nbreak;\ncase 2:\nbreak;\ndefault:\nbreak;\n}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_enum_declaration() {
-    let source = "enum Color  {Red,Green,  Blue}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_type_alias() {
-    let source = "type Result<T,E>=  {ok:T}|{err:E};\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_destructuring() {
-    let source = "const {a,b,c}=obj;\nconst [x,y,...rest]=arr;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_async_await() {
-    let source = "async function fetch(){const data=await   getData();return data;}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_try_catch() {
-    let source = "try{doSomething();}catch(e){handleError(e);}finally{cleanup();}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_generics() {
-    let source = "function identity<T>(arg:T):T{return arg;}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
-}
-
-#[test]
-fn test_formatting_jsx_like() {
-    let source = "const el = <div className=\"test\">content</div>;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let _ = formatted;
+    let range = Range::new(Position::new(50, 0), Position::new(60, 0));
+    let edits = DocumentFormattingProvider::format_range(source, range, &options).unwrap();
+    assert!(edits.is_empty());
 }
 
 // =========================================================================
-// Batch 3: edge cases and additional coverage
+// External formatter flow (parse_eslint_fix_output)
 // =========================================================================
-
-#[test]
-fn test_format_for_loop_indentation() {
-    let source = "for (let i = 0; i < 10; i++) {\nconsole.log(i);\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "for (let i = 0; i < 10; i++) {");
-    assert_eq!(lines[1], "    console.log(i);");
-    assert_eq!(lines[2], "}");
-}
-
-#[test]
-fn test_format_while_loop_indentation() {
-    let source = "while (condition) {\ndoWork();\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "while (condition) {");
-    assert_eq!(lines[1], "    doWork();");
-    assert_eq!(lines[2], "}");
-}
-
-#[test]
-fn test_format_do_while_indentation() {
-    let source = "do {\nx++;\n} while (x < 10)";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "do {");
-    assert_eq!(lines[1], "    x++;");
-}
-
-#[test]
-fn test_format_triple_nested_blocks() {
-    let source = "function a() {\nif (true) {\nfor (let i = 0; i < 1; i++) {\nlet x = i;\n}\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "function a() {");
-    assert_eq!(lines[1], "    if (true) {");
-    assert_eq!(lines[2], "        for (let i = 0; i < 1; i++) {");
-    assert_eq!(lines[3], "            let x = i;");
-    assert_eq!(lines[4], "        }");
-    assert_eq!(lines[5], "    }");
-    assert_eq!(lines[6], "}");
-}
-
-#[test]
-fn test_format_interface_indentation() {
-    let source = "interface User {\nname: string;\nage: number;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "interface User {");
-    assert_eq!(lines[1], "    name: string;");
-    assert_eq!(lines[2], "    age: number;");
-    assert_eq!(lines[3], "}");
-}
-
-#[test]
-fn test_format_type_alias_indentation() {
-    let source = "type Result<T> = {\nvalue: T;\nerror: string;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "type Result<T> = {");
-    assert_eq!(lines[1], "    value: T;");
-    assert_eq!(lines[2], "    error: string;");
-    assert_eq!(lines[3], "}");
-}
-
-#[test]
-fn test_format_object_literal_indentation() {
-    let source = "const obj = {\na: 1,\nb: 2,\nc: 3,\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(lines[0].starts_with("const obj = {"), "got: {}", lines[0]);
-    assert_eq!(lines[1], "    a: 1,");
-    assert_eq!(lines[2], "    b: 2,");
-    assert_eq!(lines[3], "    c: 3,");
-}
-
-#[test]
-fn test_format_tab_size_8() {
-    let source = "function foo() {\nlet x = 1;\n}";
-    let options = FormattingOptions {
-        tab_size: 8,
-        insert_spaces: true,
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[1], "        let x = 1;");
-}
-
-#[test]
-fn test_format_multiple_statements_same_line_semicolons() {
-    let source = "let a = 1; let b = 2; let c = 3;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Should not produce double semicolons
-    assert!(
-        !formatted.contains(";;"),
-        "Should not produce double semicolons, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_export_default_function() {
-    let source = "export default function handler() {\nreturn null;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].starts_with("export default function"),
-        "got: {}",
-        lines[0]
-    );
-    assert_eq!(lines[1], "    return null;");
-}
-
-#[test]
-fn test_format_const_enum() {
-    let source = "const enum Direction {\nUp,\nDown,\nLeft,\nRight,\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].starts_with("const enum Direction"),
-        "got: {}",
-        lines[0]
-    );
-    assert_eq!(lines[1], "    Up,");
-}
-
-#[test]
-fn test_format_class_extends_implements() {
-    let source = "class Dog extends Animal {\nbark() {\nreturn 'woof';\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].contains("class Dog extends Animal"),
-        "got: {}",
-        lines[0]
-    );
-    assert_eq!(lines[1], "    bark() {");
-    assert_eq!(lines[2], "        return 'woof';");
-}
-
-#[test]
-fn test_format_multiline_string_concatenation() {
-    let source = "const s = 'hello' +\n'world';\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("'hello'"),
-        "Should preserve string content, got: {formatted}"
-    );
-    assert!(
-        formatted.contains("'world'"),
-        "Should preserve string content, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_namespace_indentation() {
-    let source = "namespace MyApp {\nexport function init() {\nreturn true;\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "namespace MyApp {");
-    assert!(
-        lines[1].starts_with("    export function init()"),
-        "got: {}",
-        lines[1]
-    );
-    assert_eq!(lines[2], "        return true;");
-}
-
-#[test]
-fn test_format_ternary_expression() {
-    let source = "const x = condition ? 'yes' : 'no'\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("condition ? 'yes' : 'no'"),
-        "Ternary should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_only_newlines() {
-    let source = "\n\n\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Should not crash; output may be empty or just newlines
-    let _ = formatted;
-}
-
-#[test]
-fn test_format_unicode_identifiers() {
-    let source = "const cafe\u{0301} = 'coffee';\nconst \u{03B1} = 1;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Should handle unicode without panic
-    let _ = formatted;
-}
-
-#[test]
-fn test_format_computed_property() {
-    let source = "const obj = {\n[key]: value,\n[Symbol.iterator]: fn,\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-    // Computed properties should be indented
-    assert!(
-        lines[1].starts_with("    "),
-        "Computed property should be indented, got: {}",
-        lines[1]
-    );
-}
-
-#[test]
-fn test_format_try_catch_finally() {
-    let source = "try {\nfoo();\n} catch (e) {\nbar();\n} finally {\nbaz();\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "try {");
-    assert_eq!(lines[1], "    foo();");
-    assert!(
-        lines[4].contains("finally"),
-        "Should have finally block, got: {}",
-        lines[4]
-    );
-}
-
-#[test]
-fn test_compute_line_edits_identical_multiline() {
-    let original = "line1\nline2\nline3\n";
-    let formatted = "line1\nline2\nline3\n";
-    let result = DocumentFormattingProvider::compute_line_edits(original, formatted);
-    assert!(result.is_ok());
-    assert!(
-        result.unwrap().is_empty(),
-        "Identical content should produce no edits"
-    );
-}
-
-#[test]
-fn test_format_on_key_closing_brace() {
-    let source = "function foo() {\n    let x = 1;\n}";
-    let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 2, 1, "}", &options);
-    assert!(result.is_ok());
-}
-
-// =========================================================================
-// Batch: additional edge case tests
-// =========================================================================
-
-#[test]
-fn test_format_class_with_readonly_property() {
-    let source = "class Config {\nreadonly name: string;\nreadonly value: number;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[0], "class Config {");
-    assert!(
-        lines[1].starts_with("    readonly name"),
-        "readonly property should be indented, got: {}",
-        lines[1]
-    );
-}
-
-#[test]
-fn test_format_abstract_class_indentation() {
-    let source =
-        "abstract class Shape {\nabstract area(): number;\ntoString() {\nreturn 'shape';\n}\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].contains("abstract class Shape"),
-        "got: {}",
-        lines[0]
-    );
-    assert!(
-        lines[1].starts_with("    "),
-        "abstract method should be indented, got: {}",
-        lines[1]
-    );
-}
-
-#[test]
-fn test_format_multiple_blank_lines_preserved() {
-    let source = "let a = 1;\n\n\nlet b = 2;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Multiple blank lines should not crash
-    assert!(
-        formatted.contains("let a = 1;"),
-        "Should preserve first statement, got: {formatted}"
-    );
-    assert!(
-        formatted.contains("let b = 2;"),
-        "Should preserve second statement, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_optional_chaining() {
-    let source = "const x = obj?.prop?.method?.()\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("obj?.prop?.method?.()"),
-        "Optional chaining should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_nullish_coalescing() {
-    let source = "const x = value ?? defaultValue\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("value ?? defaultValue"),
-        "Nullish coalescing should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_for_of_loop_indentation() {
-    let source = "for (const item of items) {\nprocess(item);\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].starts_with("for (const item of items)"),
-        "got: {}",
-        lines[0]
-    );
-    assert_eq!(lines[1], "    process(item);");
-    assert_eq!(lines[2], "}");
-}
-
-#[test]
-fn test_format_for_in_loop_indentation() {
-    let source = "for (const key in obj) {\nconsole.log(key);\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert!(
-        lines[0].starts_with("for (const key in obj)"),
-        "got: {}",
-        lines[0]
-    );
-    assert_eq!(lines[1], "    console.log(key);");
-}
-
-#[test]
-fn test_format_labeled_statement() {
-    let source = "outer:\nfor (let i = 0; i < 10; i++) {\nbreak outer;\n}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    // Should not crash on labeled statements
-    let _ = formatted;
-}
-
-#[test]
-fn test_format_empty_function_body() {
-    let source = "function noop() {}";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("function noop()"),
-        "Should preserve empty function, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_spread_operator() {
-    let source = "const merged = { ...a, ...b }\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("...a") && formatted.contains("...b"),
-        "Spread operator should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_type_assertion() {
-    let source = "const x = value as string\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("value as string"),
-        "Type assertion should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_single_line_comment_preserved() {
-    let source = "// This is a comment\nlet x = 1;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("// This is a comment"),
-        "Single-line comment should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_block_comment_preserved() {
-    let source = "/* block comment */\nlet x = 1;\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("/* block comment */"),
-        "Block comment should be preserved, got: {formatted}"
-    );
-}
-
-#[test]
-fn test_format_tab_size_1() {
-    let source = "function foo() {\nlet x = 1;\n}";
-    let options = FormattingOptions {
-        tab_size: 1,
-        insert_spaces: true,
-        ..Default::default()
-    };
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    let lines: Vec<&str> = formatted.trim_end().lines().collect();
-
-    assert_eq!(lines[1], " let x = 1;");
-}
-
-#[test]
-fn test_compute_line_edits_all_lines_changed() {
-    let original = "aaa\nbbb\nccc\n";
-    let formatted = "xxx\nyyy\nzzz\n";
-    let result = DocumentFormattingProvider::compute_line_edits(original, formatted);
-    assert!(result.is_ok());
-    let edits = result.unwrap();
-    assert!(!edits.is_empty(), "All lines changed should produce edits");
-}
-
-#[test]
-fn test_format_on_key_semicolon_basic() {
-    let source = "let x = 1;\n";
-    let options = FormattingOptions::default();
-    let result = DocumentFormattingProvider::format_on_key(source, 0, 10, ";", &options);
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_formatting_on_single_line_blocks() {
-    // Matches fourslash test: formattingOnSingleLineBlocks.ts
-    let source = "class C\n{}\nif (true)\n{}\n";
-    let options = FormattingOptions::default();
-    let formatted = DocumentFormattingProvider::format_text(source, &options);
-    assert!(
-        formatted.contains("class C { }"),
-        "Expected 'class C {{ }}' but got: {formatted}"
-    );
-    assert!(
-        formatted.contains("if (true) { }"),
-        "Expected 'if (true) {{ }}' but got: {formatted}"
-    );
-}
 
 #[test]
 fn test_parse_eslint_fix_output_empty_stdout() {
@@ -1452,7 +589,6 @@ fn test_parse_eslint_fix_output_empty_stdout() {
 
 #[test]
 fn test_parse_eslint_fix_output_no_fixes() {
-    // Clean file: result object has no `output` field.
     let json = r#"[{
         "filePath": "/tmp/foo.ts",
         "messages": [],
@@ -1468,7 +604,6 @@ fn test_parse_eslint_fix_output_no_fixes() {
 
 #[test]
 fn test_parse_eslint_fix_output_with_fixes() {
-    // `output` present: return it verbatim.
     let json = r#"[{
         "filePath": "/tmp/foo.ts",
         "messages": [],
@@ -1490,7 +625,6 @@ fn test_parse_eslint_fix_output_invalid_json() {
 
 #[test]
 fn test_parse_eslint_fix_output_non_array_root() {
-    // Defensive: non-array JSON should not panic, just yield None.
     let result = DocumentFormattingProvider::parse_eslint_fix_output(r#"{"foo":"bar"}"#).unwrap();
     assert!(result.is_none());
 }
@@ -1499,4 +633,42 @@ fn test_parse_eslint_fix_output_non_array_root() {
 fn test_parse_eslint_fix_output_empty_array() {
     let result = DocumentFormattingProvider::parse_eslint_fix_output("[]").unwrap();
     assert!(result.is_none());
+}
+
+// =========================================================================
+// Test helpers
+// =========================================================================
+
+/// Apply `compute_line_edits`-shaped edits (sorted bottom-to-top) to `source`.
+fn apply_text_edits(source: &str, edits: &[TextEdit]) -> String {
+    let mut text = source.to_string();
+    for edit in edits {
+        let start = position_to_offset(&text, edit.range.start);
+        let end = position_to_offset(&text, edit.range.end);
+        text.replace_range(start..end, &edit.new_text);
+    }
+    text
+}
+
+fn position_to_offset(text: &str, position: Position) -> usize {
+    let mut line = 0u32;
+    let mut character = 0u32;
+    for (idx, ch) in text.char_indices() {
+        if line == position.line && character == position.character {
+            return idx;
+        }
+        if ch == '\n' {
+            line += 1;
+            character = 0;
+        } else {
+            character += 1;
+        }
+    }
+    if line == position.line && character == position.character {
+        return text.len();
+    }
+    panic!(
+        "invalid position: {position:?} for text of length {}",
+        text.len()
+    );
 }


### PR DESCRIPTION
The internal fallback formatter previously performed line-based structural rewrites (indent inference from counted braces, semicolon normalization, brace/member/`as` spacing, empty-block merging). Those heuristics are fragile under real TS/JS syntax — template literals, regex literals, JSX, multi-line generics, conditional types, and decorators can all fool line-text guessing.

External formatters (Prettier, ESLint --fix) remain the primary path and are unchanged. The fallback is now strictly whitespace-only: trim trailing whitespace, normalize final newlines. `FallbackFormattingMode` documents the capability boundary so future changes can't silently reintroduce structural rewrites.

`compute_line_edits` is simpler: same-line-count inputs produce minimal per-line edits (sorted bottom-to-top); differing line counts produce one whole-document replacement. `format_on_key` is likewise conservative — `}` becomes a no-op (re-indent needs a parser), `;;` is not auto-fixed.

Tests are rewritten to pin both sides of the boundary: safe whitespace cleanup works, and structural rewrites are explicitly absent (no semicolon insertion, no brace spacing, no template-literal or regex mutation). One server-level paste test that asserted heuristic tsserver-shaped output is relaxed to a content-preservation assertion.

https://claude.ai/code/session_01FyGtP4pGUp3AFM6W1nJbCW