### PR TITLE
fix(checker): fall back to TS2495 in for-await-of when AsyncIterator lib missing

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -786,6 +786,22 @@ impl<'a> CheckerState<'a> {
                 );
                 return true;
             }
+            // If the AsyncIterator/AsyncIterable globals aren't in scope (e.g. `@lib: es5`
+            // with no es2018.asynciterable lib entry), tsc can't talk about
+            // `[Symbol.asyncIterator]()` at all and falls back to the ES5-style
+            // "not an array type or a string type" check. Mirror that: if neither
+            // AsyncIterator nor AsyncIterable resolves in the current program, treat
+            // the `for await ... of` like a plain `for ... of` in ES5 mode.
+            let async_iter_available = self.resolve_lib_type_by_name("AsyncIterator").is_some()
+                || self.resolve_lib_type_by_name("AsyncIterable").is_some();
+            if !async_iter_available {
+                if self.is_array_or_tuple_or_string(expr_type) {
+                    return true;
+                }
+                let allows_strings = !self.has_string_constituent(expr_type);
+                self.emit_es5_not_iterable_error(expr_type, expr_type, expr_idx, allows_strings);
+                return false;
+            }
             // Not async iterable - emit TS2504
             if let Some((start, end)) = self.get_node_span(expr_idx) {
                 let type_str = self.format_type(expr_type);

--- a/crates/tsz-core/tests/checker_state_tests.rs
+++ b/crates/tsz-core/tests/checker_state_tests.rs
@@ -31893,9 +31893,14 @@ const [[a]] = [num];  // TS2488: inner array contains non-iterable number
 // Async Iterator Protocol Tests (TS2504)
 // =============================================================================
 
-/// Test that for-await-of with a non-async-iterable number type emits TS2504
+/// Test that for-await-of with a non-async-iterable number type emits an error.
+///
+/// The shared test-fixture lib chain loads only `es5.d.ts` + the es2015 lib
+/// set, so `AsyncIterator`/`AsyncIterable` are not in scope. Matching tsc,
+/// tsz falls back to the ES5-style "not an array type or a string type"
+/// check and emits TS2495 rather than TS2504 in this configuration.
 #[test]
-fn test_async_iterator_for_await_of_number_emits_ts2504() {
+fn test_async_iterator_for_await_of_number_emits_ts2495_without_asynciter_lib() {
     use crate::binder::BinderState;
     use crate::checker::diagnostics::diagnostic_codes;
     use crate::checker::state::CheckerState;
@@ -31930,14 +31935,14 @@ async function test() {
     checker.check_source_file(root);
 
     let codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
-    let ts2504_count = codes
+    let ts2495_count = codes
         .iter()
-        .filter(|&&c| c == diagnostic_codes::TYPE_MUST_HAVE_A_SYMBOL_ASYNCITERATOR_METHOD_THAT_RETURNS_AN_ASYNC_ITERATOR)
+        .filter(|&&c| c == diagnostic_codes::TYPE_IS_NOT_AN_ARRAY_TYPE_OR_A_STRING_TYPE)
         .count();
 
     assert_eq!(
-        ts2504_count, 1,
-        "Expected 1 TS2504 error for for-await-of on number. All codes: {codes:?}"
+        ts2495_count, 1,
+        "Expected 1 TS2495 error for for-await-of on number (AsyncIterator lib missing). All codes: {codes:?}"
     );
 }
 
@@ -31991,7 +31996,7 @@ async function test() {
 
 /// Test that for-await-of with a boolean type emits TS2504
 #[test]
-fn test_async_iterator_for_await_of_boolean_emits_ts2504() {
+fn test_async_iterator_for_await_of_boolean_emits_ts2495_without_asynciter_lib() {
     use crate::binder::BinderState;
     use crate::checker::diagnostics::diagnostic_codes;
     use crate::checker::state::CheckerState;
@@ -32026,20 +32031,23 @@ async function test() {
     checker.check_source_file(root);
 
     let codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
-    let ts2504_count = codes
+    let ts2495_count = codes
         .iter()
-        .filter(|&&c| c == diagnostic_codes::TYPE_MUST_HAVE_A_SYMBOL_ASYNCITERATOR_METHOD_THAT_RETURNS_AN_ASYNC_ITERATOR)
+        .filter(|&&c| c == diagnostic_codes::TYPE_IS_NOT_AN_ARRAY_TYPE_OR_A_STRING_TYPE)
         .count();
 
     assert_eq!(
-        ts2504_count, 1,
-        "Expected 1 TS2504 error for for-await-of on boolean. All codes: {codes:?}"
+        ts2495_count, 1,
+        "Expected 1 TS2495 error for for-await-of on boolean (AsyncIterator lib missing). All codes: {codes:?}"
     );
 }
 
-/// Test that for-await-of with an object type (non-iterable) emits TS2504
+/// Test that for-await-of with an object type (non-iterable) emits an error.
+///
+/// With only the es5/es2015 lib set loaded, `AsyncIterator`/`AsyncIterable`
+/// aren't available, so tsc (and now tsz) emit TS2495 rather than TS2504.
 #[test]
-fn test_async_iterator_for_await_of_object_emits_ts2504() {
+fn test_async_iterator_for_await_of_object_emits_ts2495_without_asynciter_lib() {
     use crate::binder::BinderState;
     use crate::checker::diagnostics::diagnostic_codes;
     use crate::checker::state::CheckerState;
@@ -32074,14 +32082,14 @@ async function test() {
     checker.check_source_file(root);
 
     let codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
-    let ts2504_count = codes
+    let ts2495_count = codes
         .iter()
-        .filter(|&&c| c == diagnostic_codes::TYPE_MUST_HAVE_A_SYMBOL_ASYNCITERATOR_METHOD_THAT_RETURNS_AN_ASYNC_ITERATOR)
+        .filter(|&&c| c == diagnostic_codes::TYPE_IS_NOT_AN_ARRAY_TYPE_OR_A_STRING_TYPE)
         .count();
 
     assert_eq!(
-        ts2504_count, 1,
-        "Expected 1 TS2504 error for for-await-of on object. All codes: {codes:?}"
+        ts2495_count, 1,
+        "Expected 1 TS2495 error for for-await-of on object (AsyncIterator lib missing). All codes: {codes:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
Fixes `types.forAwait.es2018.3.ts` — when the program's lib chain doesn't include `es2018.asynciterable`, tsc cannot talk about `[Symbol.asyncIterator]()` and falls back to the ES5-style "not an array type or a string type" check, emitting `TS2495` instead of `TS2504`. tsz was always emitting `TS2504`, producing a spurious mismatch.

## Fix
In `check_for_of_iterability` (async branch), when the expression isn't async- or sync-iterable, probe `resolve_lib_type_by_name("AsyncIterator")` / `"AsyncIterable"`. If neither resolves, reuse `is_array_or_tuple_or_string` + `emit_es5_not_iterable_error` so the diagnostic matches tsc.

Also updates three `test_async_iterator_for_await_of_*_emits_ts2504` unit tests: the shared test-fixture lib chain only loads es5 + es2015, so `AsyncIterator` is out of scope in the fixture. Under the new (correct) behavior those tests expect `TS2495`. Renamed `…_emits_ts2495_without_asynciter_lib` to document the lib dependency.

## Tests flipped ✗ → ✓
- `TypeScript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts`

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter "types.forAwait.es2018.3"` → 1/1 pass (was 0/1)
- [x] `./scripts/conformance/conformance.sh run --filter "forAwait"` → 7/8 (was 6/8)
- [x] `./scripts/conformance/conformance.sh run --filter "iterable"` → 48/49 (unchanged)
- [x] `./scripts/conformance/conformance.sh run --filter "iterator"` → 24/25 (unchanged)
- [x] `cargo nextest run -p tsz-core -E 'test(for_await_of)'` → 5/5 pass
- [x] `scripts/session/verify-all.sh --quick` → ALL SUITES PASSED (conformance +1 vs baseline)