### PR TITLE
refactor(lsp): remove fourslash/test-fixture coupling from production

### DIFF
--- a/crates/tsz-lsp/src/completions/context.rs
+++ b/crates/tsz-lsp/src/completions/context.rs
@@ -33,9 +33,7 @@ impl<'a> Completions<'a> {
     /// This indicates a spread operator or syntax error, not member access.
     pub(super) fn is_after_double_dot(&self, offset: u32) -> bool {
         if offset >= 2 {
-            let text_before =
-                Self::strip_trailing_fourslash_marker(&self.source_text[..offset as usize]);
-            let trimmed = text_before.trim_end();
+            let trimmed = self.source_text[..offset as usize].trim_end();
             // Check for ".." but not "..." (spread operator — which should get
             // completions for the spread argument)
             trimmed.ends_with("..") && !trimmed.ends_with("...")
@@ -55,13 +53,7 @@ impl<'a> Completions<'a> {
         // for specific token/parent-kind combinations. Our heuristic approximates this
         // by checking AST context and text patterns.
 
-        let node_idx = if let Some(marker_start) =
-            Self::fourslash_marker_comment_start(self.source_text, offset)
-        {
-            self.find_completions_node(root, marker_start.saturating_sub(1))
-        } else {
-            self.find_completions_node(root, offset)
-        };
+        let node_idx = self.find_completions_node(root, offset);
 
         // Check if we're inside a JSX context - most JSX positions return false
         if self.is_in_jsx_context(node_idx) {
@@ -134,21 +126,18 @@ impl<'a> Completions<'a> {
         // Text-based heuristic for the context token
         let text = &self.source_text[..offset as usize];
         let trimmed = text.trim_end();
-        let trimmed_without_marker = Self::strip_trailing_fourslash_marker(trimmed);
-        if trimmed_without_marker.is_empty() {
+        if trimmed.is_empty() {
             return false;
         }
-        if trimmed_without_marker.ends_with('.')
-            && self.is_dotted_namespace_name_context(trimmed_without_marker)
-        {
+        if trimmed.ends_with('.') && self.is_dotted_namespace_name_context(trimmed) {
             return true;
         }
 
         // Find the last word before cursor
-        let last_word_start = trimmed_without_marker
+        let last_word_start = trimmed
             .rfind(|c: char| !c.is_alphanumeric() && c != '_')
             .map_or(0, |p| p + 1);
-        let last_word = &trimmed_without_marker[last_word_start..];
+        let last_word = &trimmed[last_word_start..];
 
         // Keywords after which we are creating a new identifier (name declaration position).
         if matches!(
@@ -182,7 +171,7 @@ impl<'a> Completions<'a> {
         }
 
         // Check the last non-whitespace character for common expression-start operators.
-        let last_char = trimmed_without_marker.as_bytes().last().copied();
+        let last_char = trimmed.as_bytes().last().copied();
         match last_char {
             // After `=` in variable declarations and property assignments,
             // but NOT after `==`, `===`, `!=`, `>=`, `<=`
@@ -191,7 +180,7 @@ impl<'a> Completions<'a> {
                 if self.is_in_parameter_list(offset) {
                     return false;
                 }
-                let before = &trimmed_without_marker[..trimmed_without_marker.len() - 1];
+                let before = &trimmed[..trimmed.len() - 1];
                 let prev = before.as_bytes().last().copied();
                 if prev != Some(b'=')
                     && prev != Some(b'!')
@@ -224,19 +213,19 @@ impl<'a> Completions<'a> {
             }
             // After `[` - only in specific contexts (array literal, binding pattern)
             // NOT in element access expressions.
-            Some(b'[') if !self.is_element_access_context(trimmed_without_marker) => {
+            Some(b'[') if !self.is_element_access_context(trimmed) => {
                 return true;
             }
             // After `<` - only for type parameter lists, NOT for JSX or comparison.
             // Type parameter: `<T, |` or `func<|`.
-            Some(b'<') if self.is_type_parameter_context(trimmed_without_marker) => {
+            Some(b'<') if self.is_type_parameter_context(trimmed) => {
                 return true;
             }
             _ => {}
         }
 
         // After `${` in template literal expressions
-        if trimmed_without_marker.ends_with("${") {
+        if trimmed.ends_with("${") {
             return true;
         }
         // Dotted namespace/module declaration names are identifier-definition
@@ -247,10 +236,10 @@ impl<'a> Completions<'a> {
 
         // If the user is typing an identifier prefix in expression/member-declaration
         // context, treat this as a new identifier location.
-        if let Some(prev) = trimmed_without_marker.chars().last()
+        if let Some(prev) = trimmed.chars().last()
             && (prev == '_' || prev == '$' || prev.is_ascii_alphanumeric())
         {
-            let bytes = trimmed_without_marker.as_bytes();
+            let bytes = trimmed.as_bytes();
             let mut idx = bytes.len();
             while idx > 0 {
                 let ch = bytes[idx - 1] as char;
@@ -260,7 +249,7 @@ impl<'a> Completions<'a> {
                     break;
                 }
             }
-            let current_word = &trimmed_without_marker[idx..];
+            let current_word = &trimmed[idx..];
             if current_word
                 .chars()
                 .next()
@@ -356,45 +345,9 @@ impl<'a> Completions<'a> {
         false
     }
 
-    pub(super) fn fourslash_marker_comment_start(
-        source_text: &str,
-        base_offset: u32,
-    ) -> Option<u32> {
-        let bytes = source_text.as_bytes();
-        let len = bytes.len() as u32;
-        if len < 4 {
-            return None;
-        }
-        let offset = base_offset.min(len.saturating_sub(1));
-        let search_start = offset.saturating_sub(8);
-        let search_end = (offset + 1).min(len.saturating_sub(2));
-        for start in search_start..=search_end {
-            if bytes[start as usize] != b'/' || bytes[(start + 1) as usize] != b'*' {
-                continue;
-            }
-            let mut end = start + 2;
-            while end + 1 < len && end - start <= 8 {
-                if bytes[end as usize] == b'*' && bytes[(end + 1) as usize] == b'/' {
-                    let digits = &bytes[(start + 2) as usize..end as usize];
-                    let is_fourslash_marker =
-                        digits.is_empty() || digits.iter().all(u8::is_ascii_digit);
-                    if is_fourslash_marker {
-                        let comment_end = end + 1;
-                        if offset >= start && offset <= comment_end {
-                            return Some(start);
-                        }
-                    }
-                    break;
-                }
-                end += 1;
-            }
-        }
-        None
-    }
-
     pub(super) fn is_dotted_namespace_completion_context(&self, offset: u32) -> bool {
         let text = &self.source_text[..offset as usize];
-        let trimmed = Self::strip_trailing_fourslash_marker(text.trim_end());
+        let trimmed = text.trim_end();
         let line_start = trimmed.rfind('\n').map_or(0, |idx| idx + 1);
         let line = trimmed[line_start..].trim_start();
         if let Some(rest) = line.strip_prefix("namespace ") {
@@ -416,28 +369,6 @@ impl<'a> Completions<'a> {
             return !rest.is_empty();
         }
         false
-    }
-
-    pub(super) fn strip_trailing_fourslash_marker(text: &str) -> &str {
-        let trimmed = text.trim_end();
-        if let Some(start) = trimmed.rfind("/*") {
-            let after = &trimmed[start + 2..];
-            if !after.contains("*/") {
-                return trimmed[..start].trim_end();
-            }
-        }
-        if !trimmed.ends_with("*/") {
-            return trimmed;
-        }
-        let Some(start) = trimmed.rfind("/*") else {
-            return trimmed;
-        };
-        let marker = &trimmed[start + 2..trimmed.len() - 2];
-        if marker.is_empty() || marker.bytes().all(|b| b.is_ascii_digit()) {
-            trimmed[..start].trim_end()
-        } else {
-            trimmed
-        }
     }
 
     /// Check if the current node is inside a JSX element/attribute context
@@ -651,13 +582,7 @@ impl<'a> Completions<'a> {
     }
 
     pub(super) fn should_offer_constructor_keyword(&self, offset: u32) -> bool {
-        let node_idx = if let Some(marker_start) =
-            Self::fourslash_marker_comment_start(self.source_text, offset)
-        {
-            crate::utils::find_node_at_offset(self.arena, marker_start.saturating_sub(1))
-        } else {
-            crate::utils::find_node_at_offset(self.arena, offset)
-        };
+        let node_idx = crate::utils::find_node_at_offset(self.arena, offset);
         let in_class_body = node_idx.is_some() && self.is_in_class_body_context(node_idx);
         if !in_class_body && !self.text_likely_in_class_body(offset) {
             return false;
@@ -667,7 +592,7 @@ impl<'a> Completions<'a> {
         let text = &self.source_text[..end];
         let line_start = text.rfind('\n').map_or(0, |idx| idx + 1);
         let line = &text[line_start..];
-        let prefix = Self::strip_trailing_fourslash_marker(line).trim_end();
+        let prefix = line.trim_end();
         if prefix.is_empty() {
             return true;
         }

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -144,9 +144,7 @@ impl<'a> Completions<'a> {
             .line_map
             .position_to_offset(position, self.source_text)?;
         let node_idx = self.find_completions_node(root, offset);
-        let member_target = self
-            .member_completion_target(node_idx, offset)
-            .or_else(|| self.marker_comment_member_completion_target(offset));
+        let member_target = self.member_completion_target(node_idx, offset);
         let is_dotted_namespace = self.is_dotted_namespace_completion_context(offset);
         let is_member =
             !is_dotted_namespace && (member_target.is_some() || self.is_member_context(offset));
@@ -258,11 +256,7 @@ impl<'a> Completions<'a> {
         }
 
         // 4b. Resolve member completion targets before lexical suppression checks.
-        // Fourslash marker comments (e.g. `obj./**/`) often place the cursor inside
-        // comment trivia where no-completion filters would otherwise short-circuit.
-        let member_target = self
-            .member_completion_target(node_idx, offset)
-            .or_else(|| self.marker_comment_member_completion_target(offset));
+        let member_target = self.member_completion_target(node_idx, offset);
         if let Some(expr_idx) = member_target {
             if let Some(items) = self.get_member_completions(expr_idx, type_cache.as_deref_mut()) {
                 if !items.is_empty() {
@@ -441,7 +435,7 @@ impl<'a> Completions<'a> {
         }
 
         // 9. Add global variables (globalThis, Array, etc.)
-        //    These are always available and match fourslash globalsVars order.
+        //    These are declared by the configured lib files and are always visible.
         let inside_func = if global_this_member_fallback {
             false
         } else {
@@ -913,7 +907,7 @@ impl<'a> Completions<'a> {
 
     fn get_meta_property_completions(&self, offset: u32) -> Option<Vec<CompletionItem>> {
         let end = (offset as usize).min(self.source_text.len());
-        let prefix = Self::strip_trailing_fourslash_marker(&self.source_text[..end]).trim_end();
+        let prefix = self.source_text[..end].trim_end();
         let before_dot = prefix.strip_suffix('.')?;
         let expr = before_dot.trim_end();
         if expr.ends_with("import.meta") {
@@ -963,7 +957,7 @@ impl<'a> Completions<'a> {
         offset: u32,
     ) -> Option<Vec<CompletionItem>> {
         let end = (offset as usize).min(self.source_text.len());
-        let prefix = Self::strip_trailing_fourslash_marker(&self.source_text[..end]).trim_end();
+        let prefix = self.source_text[..end].trim_end();
         if !prefix.ends_with("typeof") {
             return None;
         }
@@ -1098,137 +1092,6 @@ impl<'a> Completions<'a> {
                 }
             }
 
-            let ext = self.arena.get_extended(current)?;
-            current = ext.parent;
-        }
-
-        None
-    }
-
-    fn marker_comment_member_completion_target(&self, offset: u32) -> Option<NodeIndex> {
-        let bytes = self.source_text.as_bytes();
-        let len = bytes.len() as u32;
-        if len == 0 {
-            return None;
-        }
-        let mut cursor = offset.min(len);
-
-        loop {
-            // If cursor is inside a block comment (`/*...*/`), jump back to the
-            // marker start so member-context detection can inspect the preceding
-            // `.`/`?.` token.
-            let scan_end = cursor as usize;
-            let prefix = &self.source_text[..scan_end];
-            if let Some(block_start) = prefix.rfind("/*") {
-                let block_body = &self.source_text[block_start + 2..scan_end];
-                if !block_body.contains("*/") {
-                    cursor = block_start as u32;
-                    continue;
-                }
-            }
-
-            while cursor > 0 && bytes[(cursor - 1) as usize].is_ascii_whitespace() {
-                cursor -= 1;
-            }
-
-            if cursor >= 2
-                && bytes[(cursor - 2) as usize] == b'*'
-                && bytes[(cursor - 1) as usize] == b'/'
-            {
-                cursor -= 2;
-                while cursor >= 2 {
-                    if bytes[(cursor - 2) as usize] == b'/' && bytes[(cursor - 1) as usize] == b'*'
-                    {
-                        cursor -= 2;
-                        break;
-                    }
-                    cursor -= 1;
-                }
-                continue;
-            }
-
-            break;
-        }
-
-        let line_start = self.source_text[..cursor as usize]
-            .rfind('\n')
-            .map_or(0, |idx| idx + 1);
-        let line_prefix = &self.source_text[line_start..cursor as usize];
-        if line_prefix.contains("//") {
-            let comment_pos = line_prefix.find("//").unwrap_or(usize::MAX);
-            if !(comment_pos == 0 && line_prefix.starts_with("////")) {
-                return None;
-            }
-        }
-
-        if cursor == 0 {
-            return None;
-        }
-        // Check for `.` or `?.` (optional chaining)
-        if bytes[(cursor - 1) as usize] != b'.' {
-            return None;
-        }
-
-        let dot = cursor - 1;
-        // Skip the `?` in `?.` (optional chaining)
-        let scan_from = if dot > 0 && bytes[(dot - 1) as usize] == b'?' {
-            dot - 1
-        } else {
-            dot
-        };
-        if scan_from > 0 {
-            let node_idx = find_node_at_offset(self.arena, scan_from - 1);
-            if node_idx.is_some()
-                && let Some(node) = self.arena.get(node_idx)
-                && node.kind == SyntaxKind::RegularExpressionLiteral as u16
-            {
-                return Some(node_idx);
-            }
-        }
-        let mut ident_end = scan_from;
-        while ident_end > 0 && bytes[(ident_end - 1) as usize].is_ascii_whitespace() {
-            ident_end -= 1;
-        }
-        let mut ident_start = ident_end;
-        while ident_start > 0 {
-            let ch = bytes[(ident_start - 1) as usize];
-            if ch == b'_' || ch == b'$' || ch.is_ascii_alphanumeric() {
-                ident_start -= 1;
-            } else {
-                break;
-            }
-        }
-        if ident_start >= ident_end {
-            return None;
-        }
-
-        let mut current = find_node_at_offset(self.arena, ident_end.saturating_sub(1));
-        while current.is_some() {
-            let node = self.arena.get(current)?;
-            if node.kind == SyntaxKind::Identifier as u16
-                && node.pos <= ident_start
-                && node.end >= ident_end
-            {
-                if let Some(ext) = self.arena.get_extended(current)
-                    && let Some(parent) = self.arena.get(ext.parent)
-                    && parent.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                    && let Some(access) = self.arena.get_access_expr(parent)
-                    && access.name_or_argument == current
-                {
-                    return Some(ext.parent);
-                }
-                return Some(current);
-            }
-            let ext = self.arena.get_extended(current)?;
-            current = ext.parent;
-        }
-
-        let mut current = find_node_at_offset(self.arena, ident_end.saturating_sub(1));
-        while current.is_some() {
-            let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION && node.end == ident_end {
-                return Some(current);
-            }
             let ext = self.arena.get_extended(current)?;
             current = ext.parent;
         }

--- a/crates/tsz-lsp/src/completions/filters.rs
+++ b/crates/tsz-lsp/src/completions/filters.rs
@@ -53,16 +53,12 @@ impl<'a> Completions<'a> {
                 let comment_pos = line_prefix
                     .find("//")
                     .expect("guarded by line_prefix.contains(\"//\")");
-                if comment_pos == 0 && line_prefix.starts_with("////") {
-                    // Ignore fourslash test line prefixes.
-                } else {
-                    let before_comment = &line_prefix[..comment_pos];
-                    let single_quotes = before_comment.chars().filter(|&c| c == '\'').count();
-                    let double_quotes = before_comment.chars().filter(|&c| c == '"').count();
-                    let backticks = before_comment.chars().filter(|&c| c == '`').count();
-                    if single_quotes % 2 == 0 && double_quotes % 2 == 0 && backticks % 2 == 0 {
-                        return true;
-                    }
+                let before_comment = &line_prefix[..comment_pos];
+                let single_quotes = before_comment.chars().filter(|&c| c == '\'').count();
+                let double_quotes = before_comment.chars().filter(|&c| c == '"').count();
+                let backticks = before_comment.chars().filter(|&c| c == '`').count();
+                if single_quotes % 2 == 0 && double_quotes % 2 == 0 && backticks % 2 == 0 {
+                    return true;
                 }
             }
 
@@ -174,7 +170,7 @@ impl<'a> Completions<'a> {
         let text = &self.source_text[..end];
         let line_start = text.rfind('\n').map_or(0, |idx| idx + 1);
         let line = &text[line_start..];
-        let prefix = Self::strip_trailing_fourslash_marker(line).trim_end();
+        let prefix = line.trim_end();
         if prefix.is_empty() {
             return false;
         }
@@ -919,20 +915,9 @@ impl<'a> Completions<'a> {
         if end == 0 {
             return false;
         }
-        let mut prefix = &self.source_text[..end];
-        loop {
-            let trimmed = prefix.trim_end();
-            if trimmed.ends_with("*/")
-                && let Some(start) = trimmed.rfind("/*")
-            {
-                prefix = &trimmed[..start];
-                continue;
-            }
-            prefix = trimmed;
-            break;
-        }
+        let prefix = self.source_text[..end].trim_end();
         let line_start = prefix.rfind('\n').map_or(0, |idx| idx + 1);
-        let line = Self::strip_trailing_fourslash_marker(&prefix[line_start..]).trim_end();
+        let line = prefix[line_start..].trim_end();
         let Some(before_dot) = line.strip_suffix('.') else {
             return false;
         };
@@ -948,20 +933,9 @@ impl<'a> Completions<'a> {
         if end == 0 {
             return false;
         }
-        let mut prefix = &self.source_text[..end];
-        loop {
-            let trimmed = prefix.trim_end();
-            if trimmed.ends_with("*/")
-                && let Some(start) = trimmed.rfind("/*")
-            {
-                prefix = &trimmed[..start];
-                continue;
-            }
-            prefix = trimmed;
-            break;
-        }
+        let prefix = self.source_text[..end].trim_end();
         let line_start = prefix.rfind('\n').map_or(0, |idx| idx + 1);
-        let line = Self::strip_trailing_fourslash_marker(&prefix[line_start..]).trim_end();
+        let line = prefix[line_start..].trim_end();
         let Some(before_dot) = line.strip_suffix('.') else {
             return false;
         };
@@ -1056,46 +1030,14 @@ impl<'a> Completions<'a> {
     /// Find the best node for completions at the given offset.
     /// When the cursor is in whitespace, finds the smallest containing scope node.
     pub(super) fn find_completions_node(&self, root: NodeIndex, offset: u32) -> NodeIndex {
-        let mut lookup_offset = offset;
-        if let Some(marker_start) = Self::fourslash_marker_comment_start(self.source_text, offset) {
-            if marker_start > 0 && self.source_text.as_bytes()[(marker_start - 1) as usize] == b'}'
-            {
-                let mut current = find_node_at_offset(self.arena, marker_start - 1);
-                let mut depth = 0;
-                while current.is_some() && depth < 16 {
-                    if let Some(node) = self.arena.get(current)
-                        && (node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                            || node.kind == syntax_kind_ext::ARROW_FUNCTION
-                            || node.kind == syntax_kind_ext::METHOD_DECLARATION)
-                        && let Some(ext) = self.arena.get_extended(current)
-                    {
-                        return ext.parent;
-                    }
-                    if let Some(ext) = self.arena.get_extended(current) {
-                        if ext.parent == current {
-                            break;
-                        }
-                        current = ext.parent;
-                    } else {
-                        break;
-                    }
-                    depth += 1;
-                }
-            }
-            let suffix = &self.source_text[marker_start as usize..];
-            if let Some(rel_end) = suffix.find("*/") {
-                lookup_offset = marker_start + rel_end as u32 + 2;
-            }
-        }
         // Try exact offset first
-        let mut node_idx = find_node_at_offset(self.arena, lookup_offset);
+        let mut node_idx = find_node_at_offset(self.arena, offset);
         if node_idx.is_some() {
             return node_idx;
         }
         // Try offset-1 (common when cursor is right after a token boundary)
-        if lookup_offset > 0 {
-            node_idx = find_node_at_offset(self.arena, lookup_offset - 1);
+        if offset > 0 {
+            node_idx = find_node_at_offset(self.arena, offset - 1);
             if node_idx.is_some() {
                 return node_idx;
             }
@@ -1105,7 +1047,7 @@ impl<'a> Completions<'a> {
         let mut best = root;
         let mut best_len = u32::MAX;
         for (i, node) in self.arena.nodes.iter().enumerate() {
-            if node.pos <= lookup_offset && node.end >= lookup_offset {
+            if node.pos <= offset && node.end >= offset {
                 let len = node.end - node.pos;
                 if len < best_len {
                     best_len = len;
@@ -1147,10 +1089,10 @@ impl<'a> Completions<'a> {
 
         // 2) Text-based fallback for the "`<div>/*...*/<div/>`" case where
         //    the cursor sits between a `>` that closes a JSX tag and the
-        //    next JSX child. The AST for the marker's position is ambiguous
-        //    (the block comment lives inside the JSX element children), so
-        //    we scan backward past whitespace and comments to find the
-        //    governing `>` and confirm its enclosing JSX element context.
+        //    next JSX child. The AST at that offset is ambiguous (the block
+        //    comment lives inside the JSX element children), so we scan
+        //    backward past whitespace and comments to find the governing
+        //    `>` and confirm its enclosing JSX element context.
         let mut cursor = offset.min(len);
         loop {
             while cursor > 0 {

--- a/crates/tsz-lsp/src/completions/member.rs
+++ b/crates/tsz-lsp/src/completions/member.rs
@@ -1193,7 +1193,7 @@ impl<'a> Completions<'a> {
 
     fn meta_property_parent_type_name(&self, offset: u32) -> Option<String> {
         let end = (offset as usize).min(self.source_text.len());
-        let prefix = Self::strip_trailing_fourslash_marker(&self.source_text[..end]).trim_end();
+        let prefix = self.source_text[..end].trim_end();
         let before_dot = prefix.strip_suffix('.')?;
         let expr = before_dot.trim_end();
         if expr.ends_with("import.meta") {
@@ -1251,11 +1251,6 @@ impl<'a> Completions<'a> {
     ) {
         let members = apparent_primitive_members(interner, kind);
         for member in members {
-            if kind == IntrinsicKind::String
-                && !Self::is_baseline_string_completion_member(member.name)
-            {
-                continue;
-            }
             let type_id = match member.kind {
                 ApparentMemberKind::Value(type_id) | ApparentMemberKind::Method(type_id) => type_id,
             };
@@ -1268,34 +1263,6 @@ impl<'a> Completions<'a> {
                 is_method,
             );
         }
-    }
-
-    fn is_baseline_string_completion_member(name: &str) -> bool {
-        matches!(
-            name,
-            "toString"
-                | "charAt"
-                | "charCodeAt"
-                | "concat"
-                | "indexOf"
-                | "lastIndexOf"
-                | "localeCompare"
-                | "match"
-                | "replace"
-                | "search"
-                | "slice"
-                | "split"
-                | "substring"
-                | "toLowerCase"
-                | "toLocaleLowerCase"
-                | "toUpperCase"
-                | "toLocaleUpperCase"
-                | "toLocaleString"
-                | "trim"
-                | "length"
-                | "substr"
-                | "valueOf"
-        )
     }
 
     pub(super) const fn literal_intrinsic_kind(

--- a/crates/tsz-lsp/src/completions/symbols.rs
+++ b/crates/tsz-lsp/src/completions/symbols.rs
@@ -6,7 +6,9 @@
 use super::CompletionItemKind;
 
 /// JavaScript/TypeScript keywords for completion.
-/// Matches tsserver's `globalKeywords` list.
+///
+/// Ordered by tsserver convention so completions are sorted consistently with
+/// the TypeScript language service.
 pub(super) const KEYWORDS: &[&str] = &[
     "abstract",
     "any",
@@ -76,7 +78,6 @@ pub(super) const KEYWORDS: &[&str] = &[
 ];
 
 /// Keywords valid inside a function body (subset without top-level-only keywords).
-/// Matches tsserver's `globalKeywordsInsideFunction`.
 pub(super) const KEYWORDS_INSIDE_FUNCTION: &[&str] = &[
     "as",
     "async",
@@ -127,8 +128,8 @@ pub(super) const KEYWORDS_INSIDE_FUNCTION: &[&str] = &[
     "yield",
 ];
 
-/// Global variable names from lib.d.ts that should appear in completions.
-/// Matches tsserver's `globalsVars` list.
+/// Global variable names declared by the default ECMAScript lib files
+/// (lib.es*.d.ts) that should always appear in global completions.
 pub(super) const GLOBAL_VARS: &[(&str, CompletionItemKind)] = &[
     ("Array", CompletionItemKind::Variable),
     ("ArrayBuffer", CompletionItemKind::Variable),

--- a/crates/tsz-lsp/src/diagnostics/mod.rs
+++ b/crates/tsz-lsp/src/diagnostics/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module provides:
 //! - `LspDiagnostic` - the LSP-native diagnostic format (used by LSP clients)
-//! - `TsDiagnostic` - the tsserver-compatible diagnostic format (used by fourslash tests)
+//! - `TsDiagnostic` - the tsserver-compatible diagnostic format (for tsserver
+//!   protocol clients that expect the wire format below)
 //! - Conversion functions between checker diagnostics and both output formats
 //! - Filtering helpers for semantic, syntactic, and suggestion diagnostics
 //!

--- a/crates/tsz-lsp/src/fourslash.rs
+++ b/crates/tsz-lsp/src/fourslash.rs
@@ -1,8 +1,31 @@
-//! Fourslash-style test framework for LSP features.
+//! Fourslash-style test harness for LSP features.
 //!
 //! Provides a declarative test DSL inspired by TypeScript's fourslash test format.
 //! Tests use markers (`/*name*/`) in source text to identify cursor positions,
 //! then verify LSP features like hover, definition, completions, references, etc.
+//!
+//! # Architectural boundary
+//!
+//! This module is a **test harness only**. It owns all knowledge of fourslash
+//! marker syntax.
+//!
+//! The harness is responsible for translating a marker-annotated source string
+//! into:
+//!
+//! 1. A *cleaned* source string with the marker comments stripped out, and
+//! 2. A set of marker positions expressed as plain `(file, line, character)`
+//!    tuples in the cleaned coordinates.
+//!
+//! **Production LSP provider modules (`completions`, `hover`, `signature_help`,
+//! `navigation`, `rename`, `diagnostics`, `project`, ...) must not import from,
+//! depend on, or inspect anything in this module.** They must not branch on
+//! marker-like comments, recognize marker names, reorder results to match
+//! fourslash expectations, or read fourslash-specific directives.
+//!
+//! Any request sent from a fourslash test into LSP code is first converted to
+//! the ordinary LSP inputs: file URI, document text, and cursor offset/range.
+//! The LSP code behaves exactly as it would for a user-typed file opened in an
+//! editor.
 //!
 //! # Example
 //!

--- a/crates/tsz-lsp/src/lib.rs
+++ b/crates/tsz-lsp/src/lib.rs
@@ -57,6 +57,9 @@ mod code_actions_tests;
 #[path = "../tests/fourslash_tests.rs"]
 mod fourslash_tests;
 #[cfg(test)]
+#[path = "../tests/marker_lookalike_tests.rs"]
+mod marker_lookalike_tests;
+#[cfg(test)]
 #[path = "../tests/project_tests.rs"]
 mod project_tests;
 #[cfg(test)]

--- a/crates/tsz-lsp/src/project/imports.rs
+++ b/crates/tsz-lsp/src/project/imports.rs
@@ -806,7 +806,7 @@ impl Project {
             || node_stripped
                 .is_some_and(|candidate| existing_imported_packages.contains(candidate));
 
-        // Guard against stale parser snapshots in edit-heavy server tests:
+        // Guard against stale parser snapshots after incremental edits:
         // only trust existing-import evidence when the package literal is
         // still present in the current source text.
         let quoted_in_source = cached_quoted_literal_match(package_name)

--- a/crates/tsz-lsp/src/project/module_specifiers.rs
+++ b/crates/tsz-lsp/src/project/module_specifiers.rs
@@ -960,9 +960,6 @@ impl Project {
 
     pub(crate) fn auto_imports_allowed_for_file(&self, from_file: &str) -> bool {
         let Some((_, compiler_options)) = self.nearest_compiler_options_for_file(from_file) else {
-            if let Some(allow) = self.auto_imports_allowed_from_fourslash_directives(from_file) {
-                return allow;
-            }
             return self.auto_imports_allowed_without_tsconfig;
         };
 
@@ -978,51 +975,6 @@ impl Project {
             .get("target")
             .and_then(serde_json::Value::as_str)
             .is_some_and(target_supports_import_syntax)
-    }
-
-    fn auto_imports_allowed_from_fourslash_directives(&self, from_file: &str) -> Option<bool> {
-        self.files
-            .get(from_file)
-            .and_then(|file| Self::fourslash_auto_import_directive_result(file.source_text()))
-            .or_else(|| {
-                self.files.values().find_map(|file| {
-                    (file.file_name != from_file)
-                        .then(|| Self::fourslash_auto_import_directive_result(file.source_text()))
-                        .flatten()
-                })
-            })
-    }
-
-    fn fourslash_auto_import_directive_result(source_text: &str) -> Option<bool> {
-        let mut saw_module = false;
-        let mut module_none = false;
-        let mut saw_target = false;
-        let mut target_supports_imports = false;
-
-        for line in source_text.lines().take(64) {
-            let trimmed = line.trim_start();
-            if let Some(rest) = trimmed.strip_prefix("// @module:") {
-                saw_module = true;
-                module_none = rest.split(',').map(str::trim).any(|value| {
-                    value.eq_ignore_ascii_case("none") || value.parse::<i64>().ok() == Some(0)
-                });
-                continue;
-            }
-
-            if let Some(rest) = trimmed.strip_prefix("// @target:") {
-                saw_target = true;
-                target_supports_imports = rest
-                    .split(',')
-                    .map(str::trim)
-                    .any(target_supports_import_syntax);
-            }
-        }
-
-        if saw_module && module_none {
-            return Some(saw_target && target_supports_imports);
-        }
-
-        None
     }
 
     fn relative_module_specifier_from_files(
@@ -3394,40 +3346,6 @@ mod tests {
         );
 
         assert!(project.auto_imports_allowed_for_file("/index.ts"));
-    }
-
-    #[test]
-    fn auto_imports_disabled_from_fourslash_directives_for_module_none_es5() {
-        let mut project = Project::new();
-        project.set_file(
-            "/index.ts".to_string(),
-            "// @module: none\n// @target: es5\nx".to_string(),
-        );
-
-        assert!(!project.auto_imports_allowed_for_file("/index.ts"));
-    }
-
-    #[test]
-    fn auto_imports_enabled_from_fourslash_directives_for_module_none_es2015() {
-        let mut project = Project::new();
-        project.set_file(
-            "/index.ts".to_string(),
-            "// @module: none\n// @target: es2015\nx".to_string(),
-        );
-
-        assert!(project.auto_imports_allowed_for_file("/index.ts"));
-    }
-
-    #[test]
-    fn auto_imports_disabled_from_fourslash_directives_in_sibling_file() {
-        let mut project = Project::new();
-        project.set_file(
-            "/fourslash.ts".to_string(),
-            "// @module: none\n// @target: es5\n".to_string(),
-        );
-        project.set_file("/index.ts".to_string(), "x".to_string());
-
-        assert!(!project.auto_imports_allowed_for_file("/index.ts"));
     }
 
     #[test]

--- a/crates/tsz-lsp/src/signature_help.rs
+++ b/crates/tsz-lsp/src/signature_help.rs
@@ -794,9 +794,9 @@ impl<'a> SignatureHelpProvider<'a> {
                 current = self.arena.get_extended(current)?.parent;
             }
         } else {
-            // Comment-marker cursors can sit outside any concrete syntax node.
-            // In that case, recover by locating the tightest variable declaration
-            // initializer span containing the cursor.
+            // When a cursor sits in trivia (whitespace, comments) the AST lookup
+            // can return no node. Recover by locating the tightest variable
+            // declaration whose initializer span contains the cursor.
             let mut best_len = u32::MAX;
             for (idx, node) in self.arena.nodes.iter().enumerate() {
                 if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
@@ -4631,8 +4631,11 @@ mod signature_help_internal_tests {
     }
 
     #[test]
-    fn contextual_variable_initializer_inside_comment_still_has_help() {
-        let source = "const cb2: () => void = (/*contextualFunctionType*/)";
+    fn contextual_variable_initializer_gives_function_type_help() {
+        // Cursor sits inside the empty parens of a parenthesized expression that
+        // is the initializer of a variable with a contextual function type.
+        let source = "const cb2: () => void = ()";
+        let cursor_offset = (source.rfind('(').expect("open paren") + 1) as u32;
         let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
         let root = parser.parse_source_file();
 
@@ -4650,12 +4653,11 @@ mod signature_help_internal_tests {
             "test.ts".to_string(),
         );
 
-        let marker = source.find("/*contextualFunctionType*/").expect("marker");
-        let position = line_map.offset_to_position(marker as u32, source);
+        let position = line_map.offset_to_position(cursor_offset, source);
         let mut cache = None;
         let help = provider
             .get_signature_help(root, position, &mut cache)
-            .expect("function type contextual signature help in comments");
+            .expect("function type contextual signature help");
         assert_eq!(
             help.signatures[help.active_signature as usize].label,
             "cb2(): void"
@@ -4664,7 +4666,10 @@ mod signature_help_internal_tests {
 
     #[test]
     fn textual_type_argument_trigger_skips_function_declaration_name() {
-        let source = "function f</**/\nx";
+        // After `<` in a function declaration head we are naming a new type
+        // parameter, which must not trigger signature help.
+        let source = "function f<\nx";
+        let cursor_offset = (source.find('<').expect("less than") + 1) as u32;
         let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
         let root = parser.parse_source_file();
 
@@ -4682,19 +4687,22 @@ mod signature_help_internal_tests {
             "test.ts".to_string(),
         );
 
-        let marker = source.find("/**/").expect("marker") as u32;
-        let position = line_map.offset_to_position(marker, source);
+        let position = line_map.offset_to_position(cursor_offset, source);
         let mut cache = None;
         let help = provider.get_signature_help(root, position, &mut cache);
         assert!(
             help.is_none(),
-            "declaration marker should not produce signature help"
+            "type parameter declaration position should not produce signature help"
         );
     }
 
     #[test]
     fn contextual_object_literal_method_from_typed_initializer() {
-        let source = "interface Obj { optionalMethod?: (current: any) => any; }\nconst o: Obj = {\n  optionalMethod(/*m*/) { return {}; }\n};";
+        // Cursor sits inside the parameter list of a method in an object literal
+        // whose contextual type has a matching method signature.
+        let source = "interface Obj { optionalMethod?: (current: any) => any; }\nconst o: Obj = {\n  optionalMethod() { return {}; }\n};";
+        let cursor_offset =
+            (source.find("optionalMethod()").expect("call") + "optionalMethod(".len()) as u32;
         let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
         let root = parser.parse_source_file();
 
@@ -4712,8 +4720,7 @@ mod signature_help_internal_tests {
             "test.ts".to_string(),
         );
 
-        let marker = source.find("/*m*/").expect("marker") as u32;
-        let position = line_map.offset_to_position(marker, source);
+        let position = line_map.offset_to_position(cursor_offset, source);
         let mut cache = None;
         let help = provider
             .get_signature_help(root, position, &mut cache)

--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -80,7 +80,7 @@ pub enum SymbolKind {
     // entries (expando property assignments where the RHS isn't a
     // function, certain JS patterns). Keep the name field populated
     // and let the navbar/navtree serializer omit the kind field when
-    // it's falsy, matching the fourslash harness JSON compare.
+    // it's an empty string to match tsserver's wire format.
     Unknown = 34,
 }
 
@@ -279,8 +279,8 @@ impl<'a> DocumentSymbolProvider<'a> {
                     let name_node = func.name;
                     // tsc uses the literal `<function>` placeholder for
                     // name-less function declarations (parser error
-                    // recovery cases like `function;`). Keep the same
-                    // placeholder so snapshot diffs stay aligned.
+                    // recovery cases like `function;`). Emit the same
+                    // placeholder so the LSP wire format matches tsserver.
                     let name = self
                         .get_name(name_node)
                         .unwrap_or_else(|| "<function>".to_string());

--- a/crates/tsz-lsp/tests/completions_tests.rs
+++ b/crates/tsz-lsp/tests/completions_tests.rs
@@ -335,8 +335,8 @@ fn test_completions_member_parameter_typeof_class_includes_static_and_namespace_
 }
 
 #[test]
-fn test_completions_member_parameter_typeof_class_with_marker_comment_after_dot() {
-    let source = "class C<T> {\n    static foo(x: number) { }\n    x: T;\n}\n\nnamespace C {\n    export function f(x: typeof C) {\n        x./*1*/\n    }\n}\n";
+fn test_completions_member_parameter_typeof_class_after_dot() {
+    let source = "class C<T> {\n    static foo(x: number) { }\n    x: T;\n}\n\nnamespace C {\n    export function f(x: typeof C) {\n        x.\n    }\n}\n";
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();
     let arena = parser.get_arena();
@@ -355,14 +355,12 @@ fn test_completions_member_parameter_typeof_class_with_marker_comment_after_dot(
         "test.ts".to_string(),
     );
 
+    // Cursor immediately after `x.` on line 7 (0-based), column 10.
     let position = Position::new(7, 10);
     let mut cache = None;
     let items = completions.get_completions_with_cache(root, position, &mut cache);
 
-    assert!(
-        items.is_some(),
-        "Should have marker-adjacent member completions"
-    );
+    assert!(items.is_some(), "Should have member completions after `.`");
     let items = items.unwrap();
     let names: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
 

--- a/crates/tsz-lsp/tests/marker_lookalike_tests.rs
+++ b/crates/tsz-lsp/tests/marker_lookalike_tests.rs
@@ -1,0 +1,184 @@
+//! Regression tests: production LSP providers must treat marker-looking
+//! comments as ordinary TypeScript block comments.
+//!
+//! A user may legitimately write a source file containing comments that look
+//! like fourslash markers (e.g. `/*1*/`, `/**/`, `/*completion*/`). Such
+//! comments must not alter completion, hover, signature help, rename,
+//! definition, or diagnostic results.
+//!
+//! These tests compare behavior between a plain source file and the same
+//! file with marker-looking comments interleaved, asserting that the results
+//! are equivalent (modulo legitimate offset shifts caused by the inserted
+//! comment text).
+
+use super::*;
+use tsz_binder::BinderState;
+use tsz_common::position::LineMap;
+use tsz_parser::ParserState;
+use tsz_solver::TypeInterner;
+
+/// Completion labels at `position` for the given source string.
+fn completion_labels(source: &str, position: Position) -> Vec<String> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let line_map = LineMap::build(source);
+    let interner = TypeInterner::new();
+    let completions = Completions::new_with_types(
+        arena,
+        &binder,
+        &line_map,
+        &interner,
+        source,
+        "test.ts".to_string(),
+    );
+
+    let items = completions
+        .get_completions(root, position)
+        .unwrap_or_default();
+    let mut labels: Vec<String> = items.into_iter().map(|i| i.label).collect();
+    labels.sort();
+    labels
+}
+
+fn hover_display_at(source: &str, position: Position) -> Option<String> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let line_map = LineMap::build(source);
+    let interner = TypeInterner::new();
+    let provider = hover::HoverProvider::new(
+        arena,
+        &binder,
+        &line_map,
+        &interner,
+        source,
+        "test.ts".to_string(),
+    );
+    let mut cache = None;
+    provider
+        .get_hover(root, position, &mut cache)
+        .map(|info| info.display_string)
+}
+
+#[test]
+fn marker_lookalike_comments_do_not_affect_member_completions() {
+    // Plain file: member completions after `obj.` include declared properties.
+    let plain = "const obj = { hello: 1, world: 2 };\nobj.\n";
+    // Same file with a marker-looking comment sprinkled in.
+    let annotated = "const obj = { hello: 1, world: 2 };\nobj./*1*/\n";
+
+    // Cursor immediately after `obj.` on line 1 col 4.
+    let plain_labels = completion_labels(plain, Position::new(1, 4));
+    let annotated_labels = completion_labels(annotated, Position::new(1, 4));
+
+    assert!(
+        plain_labels.contains(&"hello".to_string()),
+        "plain member completions must include 'hello'; got {plain_labels:?}"
+    );
+    assert!(
+        annotated_labels.contains(&"hello".to_string()),
+        "annotated member completions must also include 'hello'; got {annotated_labels:?}"
+    );
+    assert!(
+        annotated_labels.contains(&"world".to_string()),
+        "annotated member completions must also include 'world'; got {annotated_labels:?}"
+    );
+}
+
+#[test]
+fn marker_lookalike_comment_does_not_enable_completion_inside_comment() {
+    // If the cursor is *inside* a block comment, completions must be
+    // suppressed. That the comment looks like a fourslash marker
+    // (`/*1*/`, `/**/`) must not re-enable completion.
+    let source = "const x = 42;\n/*1*/\n";
+    // Cursor sits inside `/*1*/` (between the `*` and `1`).
+    let position = Position::new(1, 3);
+
+    let labels = completion_labels(source, position);
+    assert!(
+        labels.is_empty(),
+        "expected no completions while cursor is inside a block comment, got {labels:?}"
+    );
+}
+
+#[test]
+fn marker_lookalike_comments_do_not_affect_hover() {
+    let plain = "const greeting = 'hello';\ngreeting;\n";
+    // Same code with marker-looking comments near each identifier.
+    let annotated = "const /*def*/greeting = 'hello';\n/*ref*/greeting;\n";
+
+    // Hover on the use of `greeting` on line 1.
+    let plain_display = hover_display_at(plain, Position::new(1, 0));
+    // In the annotated source `greeting` starts at column 7 (after `/*ref*/`).
+    let annotated_display = hover_display_at(annotated, Position::new(1, 7));
+
+    let plain_display = plain_display.expect("plain hover should return info");
+    let annotated_display = annotated_display.expect("annotated hover should return info");
+    assert_eq!(
+        plain_display, annotated_display,
+        "marker-looking comments must not change hover output"
+    );
+}
+
+#[test]
+fn marker_lookalike_identifier_suffix_does_not_filter_members() {
+    // Strings have many apparent members (toString, charAt, replace, ...).
+    // A marker-looking comment after the value must not filter the set.
+    let source = "const s = 'a';\ns.\n";
+    let annotated = "const s = 'a';\ns./*after*/\n";
+
+    let plain_labels = completion_labels(source, Position::new(1, 2));
+    let annotated_labels = completion_labels(annotated, Position::new(1, 2));
+
+    for expected in ["toString", "charAt", "replace", "split", "trim", "length"] {
+        assert!(
+            plain_labels.iter().any(|l| l == expected),
+            "plain string member completions must include '{expected}', got {plain_labels:?}"
+        );
+        assert!(
+            annotated_labels.iter().any(|l| l == expected),
+            "annotated string member completions must include '{expected}', got {annotated_labels:?}"
+        );
+    }
+}
+
+#[test]
+fn completion_ordering_is_independent_of_marker_names() {
+    // Two functionally identical files that differ only in marker content.
+    // Completion labels must match exactly.
+    let a = "const apple = 1;\nconst banana = 2;\n/*a*/\n";
+    let b = "const apple = 1;\nconst banana = 2;\n/*zzz*/\n";
+
+    let labels_a = completion_labels(a, Position::new(2, 3));
+    let labels_b = completion_labels(b, Position::new(2, 3));
+
+    // Cursor inside a block comment → no completions from either source.
+    assert_eq!(labels_a, labels_b);
+    assert!(labels_a.is_empty());
+}
+
+#[test]
+fn production_code_does_not_special_case_slashslashslashslash_prefix() {
+    // Real user code can start a line with `////`. It is just a line comment
+    // with two forward slashes at the start of the comment body — nothing
+    // more. Completions must be suppressed on that line exactly as for any
+    // other line comment.
+    let source = "const x = 1;\n//// typed a thought\n";
+    // Cursor after the `//// typed a thought` text.
+    let position = Position::new(1, 20);
+
+    let labels = completion_labels(source, position);
+    assert!(
+        labels.is_empty(),
+        "line starting with `////` must suppress completions like any other `//` comment; got {labels:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Production LSP providers must be completely ignorant of fourslash test harness artifacts. Previously the completions, signature_help, and project modules inspected marker comments (`/**/`, `/*1*/`) and fourslash-specific source directives (`// @module:`, `// @target:`) to satisfy tests that shipped markers inline in their source text. That behavior has no legitimate editor counterpart and was a form of cheating — the LSP produced different results on user files that happened to contain marker-looking comments than it did on the same file stripped of those comments.

The fourslash test harness already strips markers from source before sending it into LSP APIs, so the only callers that still relied on production-side marker awareness were a handful of inline unit tests. Those have been rewritten to compute cursor offsets from real syntax.

## What was removed from production LSP

- `strip_trailing_fourslash_marker`, `fourslash_marker_comment_start`, and `marker_comment_member_completion_target` in `completions/*` (and every call site). Text-based heuristics now run on the cursor's plain source prefix.
- The `////` "fourslash test line prefix" special case in `is_in_no_completion_context`. `////` is just `//` with more slashes — it must suppress completions like any line comment.
- `is_baseline_string_completion_member` — a hard-coded whitelist of String methods that filtered out everything else. String member completion now returns the full apparent member set.
- `auto_imports_allowed_from_fourslash_directives` and `fourslash_auto_import_directive_result` in `project/module_specifiers`. Auto-import behavior is now driven exclusively by `tsconfig` compiler options.
- Comments that described logic as existing "for fourslash", "match globalsVars", "stale parser snapshots in edit-heavy server tests", "matching the fourslash harness JSON compare", etc. Replaced with honest descriptions of real LSP behavior.

## Test-side changes

- Rewrote three inline `signature_help` unit tests that embedded markers in source text (`/*contextualFunctionType*/`, `/**/`, `/*m*/`). They now use ordinary TypeScript source and compute the cursor offset from real syntax.
- Renamed `test_completions_member_parameter_typeof_class_with_marker_comment_after_dot` and dropped the embedded `/*1*/` so the test exercises plain member access on line 7 col 10.
- Documented in `src/fourslash.rs` that the fourslash module is a **test harness only** and that production LSP providers must not import from or depend on it, with an explicit "architectural boundary" section in the module docs.

## New regression tests (`crates/tsz-lsp/tests/marker_lookalike_tests.rs`, 6 tests)

1. Member completions with and without a marker-looking comment after `.` return the same symbols.
2. A cursor inside a block comment that looks like a fourslash marker (`/*1*/`, `/**/`) suppresses completions exactly like any other comment.
3. Hover on an identifier is identical between a plain source and one annotated with marker-looking comments.
4. String member completions expose the full apparent member set regardless of a trailing marker-looking comment.
5. Completion ordering is independent of marker name content.
6. A line starting with `////` behaves identically to any other `//` comment line.

## Verification

- `cargo fmt` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p tsz-lsp` — 3705 passed, 0 failed (including the 6 new regression tests).
- Final grep `rg -n "fourslash|marker|globalsVars|fixture|baseline|snapshot|expected" crates/tsz-lsp/src` shows no production cheating: remaining matches are either inside `src/fourslash.rs` (the test harness itself), assertion messages inside `#[test]` blocks, local variable names like `marker = "/node_modules/"` for path parsing, or legitimate comments about fingerprint snapshots and `#region`/`#endregion` markers.

One unrelated failure exists in `tsz-cli` (`compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`) — it asserts a file-write permission error and fails when the test runs as root. It is outside `crates/tsz-lsp` and unaffected by this change.

## Test plan

- [x] `cargo test -p tsz-lsp` passes (3705/3705).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes.
- [x] New regression tests cover marker-looking comments in ordinary user files.
- [x] No production provider imports from `crate::fourslash`.
- [x] No production provider branches on marker comments or fourslash directives.

https://claude.ai/code/session_0127Q9168bHpgFwcxQXhkdKU