### PR TITLE
fix(checker): anchor rest destructuring TS2322 at rest target

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -389,11 +389,20 @@ impl<'a> CheckerState<'a> {
         // Compute the rest type: source minus named properties
         let rest_type = self.omit_properties_from_type(source_type, &named_properties);
 
-        // Check assignability
+        // Check assignability. Anchor the diagnostic at the rest target
+        // identifier exactly — tsc reports TS2322 at `notAssignable` in
+        // `({ b, ...notAssignable } = o)`, not at the enclosing binary
+        // assignment expression. Using the plain `check_assignable_or_report`
+        // walks up to the assignment and anchors at its start (col 1 of `(`).
         self.ensure_relation_input_ready(rest_type);
         self.ensure_relation_input_ready(rest_target_type);
 
-        let _ = self.check_assignable_or_report(rest_type, rest_target_type, spread_expr);
+        let _ = self.check_assignable_or_report_at_exact_anchor(
+            rest_type,
+            rest_target_type,
+            spread_expr,
+            spread_expr,
+        );
     }
 
     /// TS2341/TS2445: Check private/protected accessibility for properties


### PR DESCRIPTION
## Summary
- For `({ b, ...notAssignable } = o)`, tsc reports TS2322 at `notAssignable` (col 10) but we were anchoring at the enclosing binary assignment's opening paren (col 1).
- Switch `check_object_destructuring_rest_assignability` from `check_assignable_or_report` (which walks up to an assignment anchor) to `check_assignable_or_report_at_exact_anchor`, keeping the spread expression node as both the source and diagnostic anchor.

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter "objectRestNegative"` passes
- [x] Full conformance: no regressions; pass count advances
- [x] `cargo build --release` clean