### PR TITLE
fix(solver): treat `prototype` as implicit on callable sources in TS2739/TS2741

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -57,6 +57,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         name.starts_with("[Symbol.") || name.starts_with("__@")
     }
 
+    /// Returns `true` if `type_id` is function-like — i.e. has at least one
+    /// call or construct signature. Used by TS2739/TS2741 explain code to skip
+    /// `prototype` from the missing-property list (tsc treats `prototype` as
+    /// implicit on any callable value).
+    fn type_has_callable_signature(&self, type_id: TypeId) -> bool {
+        use crate::type_queries::has_call_signatures;
+        if has_call_signatures(self.interner, type_id) {
+            return true;
+        }
+        if let Some(cid) = callable_shape_id(self.interner, type_id) {
+            let shape = self.interner.callable_shape(cid);
+            return !shape.call_signatures.is_empty() || !shape.construct_signatures.is_empty();
+        }
+        if function_shape_id(self.interner, type_id).is_some() {
+            return true;
+        }
+        false
+    }
+
     /// Explain why `source` is not assignable to `target`.
     ///
     /// This is the "slow path" - called only when `is_assignable_to` returns false
@@ -709,6 +728,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             missing_with_order.clear();
         } else {
             missing_with_order = non_symbol_missing;
+        }
+
+        // tsc treats `prototype` as implicit on callable sources (any function
+        // or class value has a `.prototype` in JS), so it never lists it as a
+        // missing property — even when comparing a plain function type against
+        // an interface like `ArrayConstructor` that declares `prototype`.
+        // Strip it here if the source has call or construct signatures.
+        if !missing_with_order.is_empty() && self.type_has_callable_signature(source) {
+            let prototype_atom = self.interner.intern_string("prototype");
+            missing_with_order.retain(|(name, _, _)| *name != prototype_atom);
         }
         let missing_props: Vec<tsz_common::interner::Atom> = missing_with_order
             .into_iter()


### PR DESCRIPTION
## Summary
When a function- or class-like source is assigned to an interface that declares a `prototype` member (e.g. `ArrayConstructor`, the RHS of `new X()`, or any `typeof Klass`), tsc never reports `prototype` as a missing property — every callable value has an implicit `.prototype` in JS. tsz was listing it, producing TS2739/TS2741 diagnostics like `Type ... is missing the following properties from type 'ArrayConstructor': isArray, prototype, from, of` where tsc emits `isArray, from, of`.

## Fix
In `explain_object_failure`, after collecting the missing properties, drop `prototype` whenever the source type has at least one call or construct signature. Added a small `type_has_callable_signature` helper in the same file to cover `Function`, `Callable` shapes, and bare function types.

## Tests flipped ✗ → ✓
- `compiler/exportEqualsProperty2.ts`
- `compiler/importAssertionsDeprecated.ts`
- `conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts`

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter "redefineArray"` → prototype no longer listed
- [x] `./scripts/conformance/conformance.sh run --filter "arrayAssignmentTest1"` → no regression (1/1 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "didYouMeanElaborations"` → no regression (1/1 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "missing"` → 61/63 (unchanged)
- [x] `./scripts/conformance/conformance.sh run --filter "assignmentCompat"` → 119/128 (unchanged)
- [x] `scripts/session/verify-all.sh --quick` → ALL SUITES PASSED (conformance +3 vs baseline)