### PR TITLE
fix(parser): anchor TS1477 at `<` for instantiation-expression property access

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1991,12 +1991,25 @@ impl ParserState {
                         // setting THIS_NODE_HAS_ERROR on the expression identifier itself,
                         // which would suppress TS2304 for unresolved names like `List`.
                         //
-                        // `<` starts at expression_node.end; `>` ends at node.end.
-                        // NodeList.pos/end are always 0, so we can't use type_args span.
-                        let err_pos = self
-                            .arena
-                            .get(eta.expression)
-                            .map_or(node.pos, |expr_node| expr_node.end);
+                        // tsc's formula: `pos = typeArguments.pos - 1` (the `<`),
+                        // `end = skipTrivia(typeArguments.end) + 1` (past `>`). Prefer
+                        // the first type argument's start - 1 so the column points to
+                        // the `<` itself even when whitespace separates `b` from `<`.
+                        // Fall back to the expression's end when no args are available.
+                        let first_arg_pos = eta
+                            .type_arguments
+                            .as_ref()
+                            .and_then(|list| list.nodes.first())
+                            .and_then(|&idx| self.arena.get(idx))
+                            .map(|n| n.pos);
+                        let err_pos =
+                            first_arg_pos
+                                .map(|p| p.saturating_sub(1))
+                                .unwrap_or_else(|| {
+                                    self.arena
+                                        .get(eta.expression)
+                                        .map_or(node.pos, |expr_node| expr_node.end)
+                                });
                         let err_len = node.end.saturating_sub(err_pos);
                         self.parse_error_at(
                             err_pos,


### PR DESCRIPTION
## Summary
- tsc emits TS1477 at the `<` in `expr<T>.prop`, but we were anchoring one column past it (at the first type argument).
- tsc's formula in `parsePropertyAccessExpressionRest` is `pos = typeArguments.pos - 1`. Match that by using `first_type_arg.pos - 1` as the diagnostic start, falling back to the expression's end only when no type arguments are available.

## Test plan
- [x] `optionalChainWithInstantiationExpression1.ts` flips to PASS
- [x] Full conformance: +1 net from this fix (pre-existing unrelated regression on `anyIndexedAccessArrayNoException` confirmed on main without my changes)
- [x] `cargo build --profile dist-fast` clean