### PR TITLE
fix(checker): visit element-access index on ANY/ERROR receivers

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -444,6 +444,22 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
+        // Defensively visit the index expression for diagnostics (TS2304 on
+        // unresolved identifiers, etc.) BEFORE short-circuiting on an
+        // ANY/ERROR receiver. tsc still flags `a[b]` — both unresolved — as
+        // two separate errors; if we return on the receiver being ERROR we'd
+        // miss diagnostics on the index. Skip for string/numeric literal
+        // indices — those don't contain identifiers to resolve.
+        if (object_type == TypeId::ANY || object_type == TypeId::ERROR)
+            && literal_string.is_none()
+            && literal_index.is_none()
+        {
+            let prev_preserve = self.ctx.preserve_literal_types;
+            self.ctx.preserve_literal_types = true;
+            let _ = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
+            self.ctx.preserve_literal_types = prev_preserve;
+        }
+
         // Don't report errors for any/error types - check BEFORE accessibility
         // to prevent cascading errors when the object type is already invalid.
         if object_type == TypeId::ANY {


### PR DESCRIPTION
## Summary

When `obj[name]` has a receiver that resolves to `ANY` or `ERROR`, the element-access path short-circuits before the canonical index-expression visit, which drops diagnostics on the index — most visibly `TS2304` for unresolved identifiers (e.g. `_.jh[a]` where both `_` and `a` are undefined).

Add a defensive visit of the index expression before those short-circuits. Skip when the index is a string/numeric literal (no identifier to resolve). Matches tsc's behavior of flagging every name independently.

## Target test

`TypeScript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement3.ts` — `for(d in _.jh[a]=_.jh[a]||[],b);` used to drop `TS2304 a` at cols 15 and 23 because `_.jh` resolved to ERROR before we reached the index visit.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run` — 0 failures
- [x] `./scripts/conformance/conformance.sh run` — 12041/12581 (+12 vs baseline 12029)
- [x] Target test `parserForStatement3` flipped from fingerprint-only to passing