### PR TITLE
fix(checker): use wrapper-class apparent type in binding-destructuring TS2339

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -13,6 +13,21 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// Returns the tsc apparent-type display name used in destructuring TS2339
+/// messages (e.g. `string` → `String`, `object` → `{}`). Returns `None` for
+/// types that use their regular diagnostic formatting.
+fn apparent_type_display_for_destructuring(type_id: TypeId) -> Option<String> {
+    match type_id {
+        TypeId::OBJECT => Some("{}".to_string()),
+        TypeId::STRING => Some("String".to_string()),
+        TypeId::NUMBER => Some("Number".to_string()),
+        TypeId::BOOLEAN => Some("Boolean".to_string()),
+        TypeId::BIGINT => Some("BigInt".to_string()),
+        TypeId::SYMBOL => Some("Symbol".to_string()),
+        _ => None,
+    }
+}
+
 impl<'a> CheckerState<'a> {
     fn report_unknown_empty_binding_pattern(
         &mut self,
@@ -1390,14 +1405,18 @@ impl<'a> CheckerState<'a> {
                             false
                         };
                         if !emitted_ts2538 {
-                            // In tsc, destructuring from `object` uses the apparent type `{}`
-                            // in error messages (getApparentType(object) = {}).
+                            // In tsc, destructuring uses the *apparent* type in the
+                            // error message: `object` → `{}`, and primitives widen
+                            // to their wrapper class (`string` → `String`,
+                            // `number` → `Number`, etc.). Match that so binding
+                            // patterns like `var { a } = "s"` report `type 'String'`
+                            // rather than the raw `type 'string'`.
+                            let apparent_type_display =
+                                apparent_type_display_for_destructuring(parent_type);
                             if let Some(ce) = computed_expr {
-                                let type_str = if parent_type == TypeId::OBJECT {
-                                    "{}".to_string()
-                                } else {
+                                let type_str = apparent_type_display.clone().unwrap_or_else(|| {
                                     self.format_type_for_assignability_message(parent_type)
-                                };
+                                });
                                 let message = format!(
                                     "Property '{prop_name_str}' does not exist on type '{type_str}'."
                                 );
@@ -1406,10 +1425,10 @@ impl<'a> CheckerState<'a> {
                                     &message,
                                     crate::diagnostics::diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
                                 );
-                            } else if parent_type == TypeId::OBJECT {
+                            } else if let Some(type_str) = apparent_type_display {
                                 self.error_property_not_exist_with_apparent_type(
                                     prop_name_str,
-                                    "{}",
+                                    &type_str,
                                     error_node,
                                 );
                             } else {


### PR DESCRIPTION
## Summary

Picked a random conformance failure via `scripts/session/random-failure.sh` (tier-weighted) and landed on `TypeScript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts` — a fingerprint-only failure (right error codes, wrong message text).

**Source:**
```ts
for (var {a, b} in []) {}
```

**tsc expects** `Property 'a' does not exist on type 'String'.` (wrapper class), **tsz was emitting** `type 'string'` (lowercase primitive).

### Root cause
`CheckerState::get_binding_element_type_with_request` already applied tsc's apparent-type rule for `TypeId::OBJECT` (→ `{}`) in the binding-destructuring TS2339 path, and the *assignment*-destructuring branch already handled primitive → wrapper-class display via a private `get_boxed_type_display_name` helper. The binding branch, however, fell through to `error_property_not_exist_at` for primitives, producing `'string'` / `'number'` / `'boolean'` / `'bigint'` / `'symbol'` instead of `'String'` / `'Number'` / `'Boolean'` / `'BigInt'` / `'Symbol'`.

### Fix
Introduce a single `apparent_type_display_for_destructuring` helper that covers `TypeId::OBJECT` **and** all primitives, and reuse it in both the computed-key and bare-name branches of `check destructuring property not found`. No semantic change outside the message string.

### Impact
- **+8 conformance tests** (12027 → 12035):
  - `conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts` (target)
  - `compiler/exportEqualsProperty2.ts`
  - `compiler/importAssertionsDeprecated.ts`
  - `compiler/jsdocFunctionTypeFalsePositive.ts`
  - `compiler/jsxRuntimePragma.ts`
  - `compiler/spellingSuggestionLeadingUnderscores01.ts`
  - `conformance/classes/propertyMemberDeclarations/redeclaredProperty.ts`
- 0 conformance regressions
- All 3344 `tsz-checker` unit tests pass; 6746 tests across `tsz-solver`/`tsz-binder`/`tsz-parser`/`tsz-scanner`/`tsz-common` pass
- `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass

### Verified parity with tsc
```
$ echo 'const { a } = "hello"; const { foo } = 42; const { bar } = true; const { baz } = 1n;' | tsz /dev/stdin
error TS2339: Property 'a' does not exist on type 'String'.
error TS2339: Property 'foo' does not exist on type 'Number'.
error TS2339: Property 'bar' does not exist on type 'Boolean'.
error TS2339: Property 'baz' does not exist on type 'BigInt'.
```
Byte-for-byte identical to `tsc --noEmit` output.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --package tsz-checker` (3344 passed)
- [x] `cargo nextest run --package tsz-solver --package tsz-binder --package tsz-parser --package tsz-scanner --package tsz-common` (6746 passed)
- [x] `./scripts/conformance/conformance.sh run --filter "for-inStatementsDestructuring"` (4/4 pass)
- [x] Full conformance run: 12027 → 12035 (+8), 0 regressions
- [x] Direct tsz vs tsc byte comparison on primitive binding destructuring

> Note: two pre-existing `tsz-cli` tests fail on both `main` and this branch when the suite is run as root (readonly-dir permission test bypassed; fourslash formatting test). They are unrelated to this change.

https://claude.ai/code/session_013ti3KhPen2T9QyDWG9cdKs