### PR TITLE
fix(checker): visit element access index before any/error short-circuit

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -235,6 +235,15 @@ impl<'a> CheckerState<'a> {
             .get_literal_index_from_node(access.name_or_argument)
             .or(numeric_string_index);
 
+        // Visit the index expression up front so identifier diagnostics
+        // (TS2304 etc.) fire even when the object type short-circuits through
+        // the any/error/never/nullish paths below. tsc always resolves the
+        // bracket argument regardless of the receiver's type.
+        let prev_preserve = self.ctx.preserve_literal_types;
+        self.ctx.preserve_literal_types = true;
+        let index_type = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
+        self.ctx.preserve_literal_types = prev_preserve;
+
         // Get the type of the object. In write context, prefer the receiver's
         // declared type when it already has the indexed member, otherwise fall
         // back to the flow-narrowed receiver so subtype-based writes still work.
@@ -484,11 +493,6 @@ impl<'a> CheckerState<'a> {
         {
             self.report_nullish_object(access.expression, cause, false);
         }
-
-        let prev_preserve = self.ctx.preserve_literal_types;
-        self.ctx.preserve_literal_types = true;
-        let index_type = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
-        self.ctx.preserve_literal_types = prev_preserve;
 
         // Preserve the write target when the index expression already errored.
         if index_type == TypeId::ERROR {

--- a/scripts/session/quick-pick.sh
+++ b/scripts/session/quick-pick.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# quick-pick.sh — Minimal random failure picker
+# =============================================================================
+#
+# A tiny "just give me something to work on" wrapper. Picks one random
+# conformance failure from conformance-detail.json, prints the essentials,
+# and shows the command to run it verbosely.
+#
+# Usage:
+#   scripts/session/quick-pick.sh              # any failure
+#   scripts/session/quick-pick.sh --seed 42    # reproducible
+#   scripts/session/quick-pick.sh --code TS2322  # filter by error code
+#   scripts/session/quick-pick.sh --run        # also run conformance --verbose
+#
+# For richer options, use pick-random-failure.sh / random-failure.sh.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+RUN_AFTER=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="$2"; shift 2 ;;
+        --code) CODE="$2"; shift 2 ;;
+        --run) RUN_AFTER=true; shift ;;
+        -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Ensure submodule and snapshot exist.
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initializing..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+FILTER="$(SEED="$SEED" CODE="$CODE" python3 - "$DETAIL" <<'PY'
+import json, os, random, sys
+
+detail_path = sys.argv[1]
+seed = os.environ.get("SEED") or None
+code = os.environ.get("CODE") or None
+
+with open(detail_path) as f:
+    failures = json.load(f).get("failures", {})
+
+def matches(entry):
+    if not code:
+        return True
+    all_codes = set(entry.get("e", [])) | set(entry.get("a", [])) \
+              | set(entry.get("m", [])) | set(entry.get("x", []))
+    return code in all_codes
+
+cands = [(p, e) for p, e in failures.items() if e and matches(e)]
+if not cands:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(cands)
+
+expected = entry.get("e", [])
+actual   = entry.get("a", [])
+missing  = entry.get("m", [])
+extra    = entry.get("x", [])
+
+if not expected and actual:        category = "false-positive"
+elif expected and not actual:      category = "all-missing"
+elif set(expected) == set(actual): category = "fingerprint-only"
+elif missing and not extra:        category = "only-missing"
+elif extra and not missing:        category = "only-extra"
+else:                              category = "wrong-code"
+
+filt = os.path.splitext(os.path.basename(path))[0]
+
+# Human-readable summary → stderr. Filter name → stdout (captured by caller).
+print(f"path:     {path}",                    file=sys.stderr)
+print(f"category: {category}",                file=sys.stderr)
+print(f"expected: {','.join(expected) or '-'}", file=sys.stderr)
+print(f"actual:   {','.join(actual)   or '-'}", file=sys.stderr)
+print(f"missing:  {','.join(missing)  or '-'}", file=sys.stderr)
+print(f"extra:    {','.join(extra)    or '-'}", file=sys.stderr)
+print(f"pool:     {len(cands)}",              file=sys.stderr)
+print("",                                     file=sys.stderr)
+print(f"verbose run: ./scripts/conformance/conformance.sh run --filter \"{filt}\" --verbose",
+      file=sys.stderr)
+print(filt)
+PY
+)"
+
+if $RUN_AFTER; then
+    echo
+    echo "Running: ./scripts/conformance/conformance.sh run --filter \"$FILTER\" --verbose"
+    exec "$REPO_ROOT/scripts/conformance/conformance.sh" run --filter "$FILTER" --verbose
+fi


### PR DESCRIPTION
## Summary

Fixes a checker bug where unresolved identifiers used as **bracket indices** (e.g. `a` in `_.jh[a]`) were silently skipped when the base expression resolved to `any` or `error`. tsc always emits `TS2304` for such unresolved identifiers; tsz was short-circuiting the element-access check without ever visiting the index expression.

### Root cause

In `crates/tsz-checker/src/types/computation/access.rs`, `get_type_of_element_access_with_request` short-circuits through `any`/`error`/`never`/nullish paths **before** calling `get_type_of_node_with_request` on the index expression. So for `_.jh[a]` where `_` is unknown:

1. `_.jh` resolves to `TypeId::ERROR`
2. The check reaches `if object_type == TypeId::ERROR { return TypeId::ERROR; }`
3. `access.name_or_argument` (the `a`) is never visited, so no `TS2304` fires

### Fix

Move the index-expression visit (with `preserve_literal_types = true`) to **before** all the short-circuit paths. The visit has side effects (identifier resolution, nested diagnostics) that tsc always performs regardless of receiver type. Downstream logic still uses `index_type` as before — only the location moved.

### Conformance impact

Net **+4 tests** (12036 → 12040) on the full suite:

- `parser/ecmascript5/Statements/parserForStatement3.ts` (the test this fix was driven by)
- `parser/ecmascript5/Expressions/parserConditionalExpression1.ts`
- `parser/ecmascript5/StrictMode/parserStrictMode15-negative.ts`
- `statements/VariableStatements/usingDeclarations/usingDeclarations.4.ts`

No new regressions — the sole flagged "regression" (`anyIndexedAccessArrayNoException.ts`) fails identically on `main` (confirmed by `git stash && conformance run`); its baseline entry is stale.

### Additional: `scripts/session/quick-pick.sh`

A minimal random failure picker used to select the target for this PR. Existing `pick-random-failure.sh` / `random-failure.sh` remain the fully-featured options; `quick-pick.sh` is the "just give me something to work on" 80-line wrapper:

```bash
scripts/session/quick-pick.sh              # any failure
scripts/session/quick-pick.sh --seed 42    # reproducible
scripts/session/quick-pick.sh --code TS2322  # filter by error code
scripts/session/quick-pick.sh --run        # also run --verbose
```

It also auto-initializes the TypeScript submodule if missing.

## Test plan

- [x] `scripts/session/quick-pick.sh` (target `parserForStatement3`): `0/1 passed` → `1/1 passed`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Full conformance: `12036 → 12040 (+4)`
- [x] Regression reproduction tests (`_[a]`, `x[a]` with `x: any`, `_.jh[a]`) — all emit `TS2304` at correct column now
- [ ] `cargo nextest run` full — blocked locally by 2 pre-existing env-specific failures (file-permission & fourslash marker tests); both reproduce on clean `main` with my change stashed

https://claude.ai/code/session_01HMPMBUkYVmFapyrWyJ6HwF