### PR TITLE
fix(checker): reapply element-access index visit on ANY/ERROR receivers

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -444,6 +444,22 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
+        // Defensively visit the bracket expression for diagnostics (TS2304 on
+        // unresolved identifiers, etc.) BEFORE short-circuiting on an
+        // ANY/ERROR receiver. tsc still flags `a[b]` — both unresolved — as
+        // two separate TS2304s; if we return on the receiver being ERROR we'd
+        // miss diagnostics on the index. Skip literal indices since they
+        // contain no identifiers to resolve.
+        if (object_type == TypeId::ANY || object_type == TypeId::ERROR)
+            && literal_string.is_none()
+            && literal_index.is_none()
+        {
+            let prev_preserve = self.ctx.preserve_literal_types;
+            self.ctx.preserve_literal_types = true;
+            let _ = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
+            self.ctx.preserve_literal_types = prev_preserve;
+        }
+
         // Don't report errors for any/error types - check BEFORE accessibility
         // to prevent cascading errors when the object type is already invalid.
         if object_type == TypeId::ANY {


### PR DESCRIPTION
## Summary
The prior "reapply element-access index visit" commit (09eda48305) didn't actually touch `access.rs` — the diff included only tooling/docs files. Reapply the defensive index visit so TS2304 fires on unresolved identifiers in `a[b]` where `a` is also unresolved.

When `obj[x]` has a receiver that resolves to ANY/ERROR, the element-access path short-circuits at the ANY/ERROR guard without visiting the bracket expression, dropping diagnostics on the index. tsc still flags both `a` and `b` in `a[b]` as separate TS2304s.

Added a defensive `get_type_of_node_with_request(access.name_or_argument, ...)` before the ANY/ERROR short-circuit. Skipped literal string/numeric indices since they contain no identifiers to resolve.

## Test plan
- [x] `parserStrictMode15-negative.ts`, `parserForStatement3.ts`, `parserConditionalExpression1.ts`, `usingDeclarations.4.ts` flip to PASS
- [x] Full conformance: 12029 → 12043 (+14) with two flaky regressions that pass when run in isolation
- [x] `cargo build --profile dist-fast` clean