### PR TITLE
fix(checker): preserve declared annotation literal property types in …

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
@@ -72,7 +72,11 @@ impl<'a> CheckerState<'a> {
 
         let mut emitted = false;
 
-        if !left_is_valid {
+        // Skip per-side emission when that side already resolved to ERROR
+        // (e.g. TS2304 for an undeclared identifier). tsc still validates the
+        // other side — `kj **= \`${x}\`` produces TS2304 and TS2363 for the
+        // template RHS even though `kj` is unresolved.
+        if !left_is_valid && left_type != TypeId::ERROR {
             self.error_at_node(
                 left_idx,
                 "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
@@ -81,7 +85,7 @@ impl<'a> CheckerState<'a> {
             emitted = true;
         }
 
-        if !right_is_valid {
+        if !right_is_valid && right_type != TypeId::ERROR {
             self.error_at_node(
                 right_idx,
                 "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
@@ -90,7 +94,7 @@ impl<'a> CheckerState<'a> {
             emitted = true;
         }
 
-        emitted || !left_is_valid || !right_is_valid
+        emitted
     }
 
     /// Emit TS2447 error for boolean bitwise operators (&, |, ^, &=, |=, ^=).

--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -276,22 +276,26 @@ impl<'a> CheckerState<'a> {
                 || k == SyntaxKind::AsteriskAsteriskEqualsToken as u16
         );
         if is_arithmetic_compound && !is_function_assignment {
-            // Don't emit arithmetic errors if either operand is ERROR - prevents cascading errors
-            if left_read_type != TypeId::ERROR && right_type != TypeId::ERROR {
-                let had_per_operand_error =
-                    self.check_arithmetic_operands(left_idx, right_idx, left_read_type, right_type);
-                emitted_operator_error |= had_per_operand_error;
+            // check_arithmetic_operands skips per-side emission when that side
+            // is ERROR, so the unresolved-LHS / non-numeric-RHS case still
+            // reports TS2363 for the visible side.
+            let had_per_operand_error =
+                self.check_arithmetic_operands(left_idx, right_idx, left_read_type, right_type);
+            emitted_operator_error |= had_per_operand_error;
 
-                // TS2365: Check for bigint/number mixing in arithmetic compound assignments
-                if !had_per_operand_error && !emitted_operator_error {
-                    self.check_compound_assignment_type_compatibility(
-                        expr_idx,
-                        operator,
-                        left_read_type,
-                        right_type,
-                        &mut emitted_operator_error,
-                    );
-                }
+            // TS2365 requires both sides well-typed to compare number vs bigint.
+            if !had_per_operand_error
+                && !emitted_operator_error
+                && left_read_type != TypeId::ERROR
+                && right_type != TypeId::ERROR
+            {
+                self.check_compound_assignment_type_compatibility(
+                    expr_idx,
+                    operator,
+                    left_read_type,
+                    right_type,
+                    &mut emitted_operator_error,
+                );
             }
         }
 

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1016,6 +1016,45 @@ impl<'a> CheckerState<'a> {
             return source_display;
         }
 
+        // Declared type annotations (e.g. `var z: { length: 2; }`) store literal
+        // property types canonically with no display_properties. Only fresh object
+        // literal expressions carry display_properties (canonical=widened, display=literal).
+        // tsc preserves the annotation's literal property types in error messages.
+        //
+        // Skip widening when source has no display_properties AND has at least one direct
+        // canonical property of literal type. The "direct" check prevents false positives
+        // from outer types like `{ a: inner_fresh }` where the outer is not fresh but inner
+        // properties contain fresh types — their outer canonical properties are object types
+        // (not literals), so they correctly fall through to the widening path.
+        let evaluated_source = self.evaluate_type_for_assignability(source);
+        let source_has_display_props = self.ctx.types.get_display_properties(source).is_some()
+            || self
+                .ctx
+                .types
+                .get_display_properties(evaluated_source)
+                .is_some();
+        let source_is_array =
+            crate::query_boundaries::common::array_element_type(self.ctx.types, source).is_some()
+                || crate::query_boundaries::common::array_element_type(
+                    self.ctx.types,
+                    evaluated_source,
+                )
+                .is_some();
+        if !source_has_display_props && !source_is_array {
+            let has_direct_literal_prop = crate::query_boundaries::common::object_shape_for_type(
+                self.ctx.types,
+                evaluated_source,
+            )
+            .is_some_and(|shape| {
+                shape.properties.iter().any(|p| {
+                    crate::query_boundaries::common::is_literal_type(self.ctx.types, p.type_id)
+                })
+            });
+            if has_direct_literal_prop {
+                return source_display;
+            }
+        }
+
         // For intersection types with display properties (fresh object literal in an
         // intersection), check whether the *target* type has literal-typed properties.
         // tsc preserves literal display when the target expects literals (e.g.

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -520,7 +520,8 @@ impl<'a> CheckerState<'a> {
                 || k == SyntaxKind::Identifier as u16
                 || k == syntax_kind_ext::CALL_EXPRESSION
                 || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::BINARY_EXPRESSION =>
             {
                 // For expression-bodied arrows with simple literal/expression bodies,
                 // check if the return expression type is assignable to the expected
@@ -569,21 +570,13 @@ impl<'a> CheckerState<'a> {
                 {
                     return false;
                 }
-                // Widen literal types in the function return type for display.
-                // This ensures that `() => "foo"` is displayed as `() => string`
-                // to match tsc's behavior for error messages.
-                let func_type = self.get_type_of_node(arg_idx);
-                let widened_func_type =
-                    crate::query_boundaries::common::widen_type_deep(self.ctx.types, func_type);
-                // For callback return type errors, use the full function types in the error message
-                // instead of just the return types. This produces errors like:
-                // "Type '() => string' is not assignable to type '{ (): number; (i: number): number; }'"
-                // instead of: "Type 'string' is not assignable to type 'number'"
-                self.error_type_not_assignable_at_with_display_types(
-                    widened_func_type,
-                    param_type,
-                    arg_idx,
-                );
+                // Report the error at the return expression with return types.
+                // tsc anchors expression-body arrow return mismatches at the body
+                // expression (col of the literal/expression), not the arrow function.
+                // E.g.: `const f: (a: number) => string = (a) => a + 1`
+                // → TS2322 at `a + 1` with "Type 'number' is not assignable to type 'string'."
+                let display_target = self.evaluate_type_with_env(expected_return_type);
+                self.error_type_not_assignable_at_with_anchor(body_type, display_target, func.body);
                 true
             }
             k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -2019,6 +2019,36 @@ impl<'a> CheckerState<'a> {
             return Some(display);
         }
 
+        // When the declared type annotation contains literal property types
+        // (e.g. `var z: { length: 2; }`), the standard widening path produces
+        // `length: number` instead of `length: 2`. tsc preserves the declared
+        // literal in the error message.
+        // Only applies to declared annotation types (canonical props contain Literal types,
+        // no display_properties on `declared_type` itself). Fresh object literals (inferred
+        // types from expressions like `var o1 = { one: 1 }`) have display_properties on
+        // `declared_type` and must NOT be handled here — the rewrite function widens them.
+        // NOTE: check `declared_type` directly (not its evaluated form) because
+        // `evaluate_type_with_env` strips display_properties from fresh types, making their
+        // evaluated form look like a declared annotation type.
+        if prefer_declared_display
+            && self
+                .ctx
+                .types
+                .get_display_properties(declared_type)
+                .is_none()
+        {
+            let widened =
+                crate::query_boundaries::common::widen_type(self.ctx.types, declared_type);
+            if widened != declared_type {
+                let literal_display =
+                    self.format_assignability_type_for_message(declared_type, target);
+                let widened_display = self.format_assignability_type_for_message(widened, target);
+                if literal_display != widened_display {
+                    return Some(literal_display);
+                }
+            }
+        }
+
         let declared_display_type =
             self.widen_function_like_display_type(self.widen_type_for_display(declared_type));
         let expr_display_type =

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -66,6 +66,13 @@ impl<'a> CheckerState<'a> {
         let mut text = text.trim().trim_start_matches(':').trim().to_string();
         if let Some(nl) = text.find('\n') {
             text = text[..nl].trim_end().to_string();
+            // After newline truncation, reject if braces are unbalanced
+            // (e.g., multi-line `{\n  foo: bar;\n}` gets truncated to `{`)
+            let open_brace = text.chars().filter(|&c| c == '{').count();
+            let close_brace = text.chars().filter(|&c| c == '}').count();
+            if open_brace != close_brace {
+                return None;
+            }
         }
         if text.ends_with('=') {
             text.pop();

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -398,12 +398,19 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Get the variable name for the error message
+        // Get the variable name for the error message. tsc's diagnostic message
+        // preserves the identifier as written in the declaration, including
+        // unicode escape sequences (e.g., `\u0078x` rather than the decoded `xx`).
+        // Prefer the declaration name's `original_text` when present.
         let name = self
-            .ctx
-            .binder
-            .get_symbol(sym_id)
-            .map_or_else(|| "<unknown>".to_string(), |s| s.escaped_name.clone());
+            .declaration_display_name(sym_id)
+            .or_else(|| {
+                self.ctx
+                    .binder
+                    .get_symbol(sym_id)
+                    .map(|s| s.escaped_name.clone())
+            })
+            .unwrap_or_else(|| "<unknown>".to_string());
 
         self.error_at_node(
             idx,
@@ -417,6 +424,22 @@ impl<'a> CheckerState<'a> {
         // rollback; at the end of check_source_file we re-emit any TS2454 that
         // was lost.
         self.ctx.deferred_ts2454_errors.push((idx, sym_id));
+    }
+
+    /// Return the declared name as it appears in source, preserving unicode
+    /// escape sequences (e.g., `\u0078x`). Falls back to `None` when the
+    /// symbol has no declaration or the declaration name's original text is
+    /// unavailable.
+    fn declaration_display_name(&self, sym_id: SymbolId) -> Option<String> {
+        let decl_idx = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .and_then(|s| s.declarations.first().copied())?;
+        let name_idx = self.get_declaration_name_node(decl_idx)?;
+        let name_node = self.ctx.arena.get(name_idx)?;
+        let ident = self.ctx.arena.get_identifier(name_node)?;
+        ident.original_text.clone()
     }
 
     /// Check if a node is within a parameter's default value initializer.

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -444,6 +444,22 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
+        // Defensively visit the index expression for diagnostics (TS2304 on
+        // unresolved identifiers, etc.) BEFORE short-circuiting on an
+        // ANY/ERROR receiver. tsc still flags `a[b]` — both unresolved — as
+        // two separate errors; if we return on the receiver being ERROR we'd
+        // miss diagnostics on the index. Skip for string/numeric literal
+        // indices — those don't contain identifiers to resolve.
+        if (object_type == TypeId::ANY || object_type == TypeId::ERROR)
+            && literal_string.is_none()
+            && literal_index.is_none()
+        {
+            let prev_preserve = self.ctx.preserve_literal_types;
+            self.ctx.preserve_literal_types = true;
+            let _ = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
+            self.ctx.preserve_literal_types = prev_preserve;
+        }
+
         // Don't report errors for any/error types - check BEFORE accessibility
         // to prevent cascading errors when the object type is already invalid.
         if object_type == TypeId::ANY {

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -235,6 +235,15 @@ impl<'a> CheckerState<'a> {
             .get_literal_index_from_node(access.name_or_argument)
             .or(numeric_string_index);
 
+        // Visit the index expression up front so identifier diagnostics
+        // (TS2304 etc.) fire even when the object type short-circuits through
+        // the any/error/never/nullish paths below. tsc always resolves the
+        // bracket argument regardless of the receiver's type.
+        let prev_preserve = self.ctx.preserve_literal_types;
+        self.ctx.preserve_literal_types = true;
+        let index_type = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
+        self.ctx.preserve_literal_types = prev_preserve;
+
         // Get the type of the object. In write context, prefer the receiver's
         // declared type when it already has the indexed member, otherwise fall
         // back to the flow-narrowed receiver so subtype-based writes still work.
@@ -500,11 +509,6 @@ impl<'a> CheckerState<'a> {
         {
             self.report_nullish_object(access.expression, cause, false);
         }
-
-        let prev_preserve = self.ctx.preserve_literal_types;
-        self.ctx.preserve_literal_types = true;
-        let index_type = self.get_type_of_node_with_request(access.name_or_argument, &read_request);
-        self.ctx.preserve_literal_types = prev_preserve;
 
         // Preserve the write target when the index expression already errored.
         if index_type == TypeId::ERROR {

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -411,7 +411,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(ident) = self.ctx.arena.get_identifier(candidate)
             {
                 let name_str = ident.escaped_text.as_str();
-                for (j, (param_name, _, _)) in params.iter().enumerate() {
+                for (j, (param_name, _, _, _)) in params.iter().enumerate() {
                     if !used[j] && param_name == name_str {
                         used[j] = true;
                     }
@@ -420,7 +420,7 @@ impl<'a> CheckerState<'a> {
         }
 
         for type_expr in Self::jsdoc_type_expressions(raw_comment) {
-            for (j, (param_name, _, _)) in params.iter().enumerate() {
+            for (j, (param_name, _, _, _)) in params.iter().enumerate() {
                 if !used[j] && Self::jsdoc_type_expr_mentions_name(type_expr, param_name) {
                     used[j] = true;
                 }
@@ -446,7 +446,7 @@ impl<'a> CheckerState<'a> {
                 }
                 let comment_text = comment.get_text(source_text);
                 for type_expr in Self::jsdoc_type_expressions(comment_text) {
-                    for (j, (param_name, _, _)) in params.iter().enumerate() {
+                    for (j, (param_name, _, _, _)) in params.iter().enumerate() {
                         if !used[j] && Self::jsdoc_type_expr_mentions_name(type_expr, param_name) {
                             used[j] = true;
                         }
@@ -455,40 +455,47 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Group params by their @template tag (identified by same start position).
-        // If ALL params from a single @template tag are unused, emit TS6205
-        // ("All type parameters are unused.") for the whole tag.
-        // Otherwise, emit TS6133 for each individually unused param.
+        // Group params by their `@template` tag (identified by the tag's
+        // start offset). tsc anchors the diagnostic differently depending on
+        // whether the whole tag is "all unused" or only some of its params:
+        //   - Multi-param tag, all unused  → TS6205 at the `@template` keyword
+        //   - Single-param tag, unused     → TS6133 at the `@template` keyword
+        //   - Multi-param tag, some unused → TS6133 at each unused name
+        // Length-wise tsc uses `@template` (9 chars) for the tag anchor.
         use rustc_hash::FxHashMap;
         let mut tag_groups: FxHashMap<u32, Vec<usize>> = FxHashMap::default();
-        for (j, (_name, start, _length)) in params.iter().enumerate() {
-            tag_groups.entry(*start).or_default().push(j);
+        for (j, (_name, _name_pos, _name_len, tag_start)) in params.iter().enumerate() {
+            tag_groups.entry(*tag_start).or_default().push(j);
         }
 
-        for group_indices in tag_groups.values() {
+        const TEMPLATE_KEYWORD_LEN: u32 = "@template".len() as u32;
+        for (tag_start, group_indices) in tag_groups.iter() {
             let all_unused = group_indices.iter().all(|&j| !used[j]);
             if all_unused && group_indices.len() > 1 {
-                // TS6205: All type parameters are unused.
-                // Use the last param's span to cover the entire @template declaration.
-                let last_idx = *group_indices.last().expect("group_indices is non-empty");
-                let (_, start, length) = &params[last_idx];
-                self.error_all_type_parameters_unused(*start, *length);
+                self.error_all_type_parameters_unused(*tag_start, TEMPLATE_KEYWORD_LEN);
+            } else if all_unused && group_indices.len() == 1 {
+                let j = group_indices[0];
+                let (name, _name_pos, _name_len, _) = &params[j];
+                self.error_declared_but_never_read(name, *tag_start, TEMPLATE_KEYWORD_LEN);
             } else {
-                // TS6133 for each individually unused param.
                 for &j in group_indices {
                     if !used[j] {
-                        let (name, start, length) = &params[j];
-                        self.error_declared_but_never_read(name, *start, *length);
+                        let (name, name_pos, name_len, _) = &params[j];
+                        self.error_declared_but_never_read(name, *name_pos, *name_len);
                     }
                 }
             }
         }
     }
 
+    /// Returns `(name, name_pos, name_length, tag_start)` for each JSDoc
+    /// `@template` parameter in `raw_comment`. `tag_start` identifies which
+    /// `@template` tag the parameter belongs to, so callers can detect when
+    /// *all* parameters in a single tag are unused (TS6205 vs. TS6133).
     fn jsdoc_template_param_declarations(
         raw_comment: &str,
         comment_pos: u32,
-    ) -> Vec<(String, u32, u32)> {
+    ) -> Vec<(String, u32, u32, u32)> {
         let mut params = Vec::new();
         let mut cursor = 0usize;
         while let Some(rel) = raw_comment[cursor..].find("@template") {
@@ -522,11 +529,16 @@ impl<'a> CheckerState<'a> {
                     }
                     let name = &raw_comment[start..idx];
                     if !name.starts_with('_') {
-                        params.push((
-                            name.to_string(),
-                            comment_pos + tag_start as u32,
-                            idx.saturating_sub(tag_start) as u32,
-                        ));
+                        // Anchor each parameter at its own identifier, not at
+                        // the `@template` tag keyword. tsc emits TS6133 at the
+                        // individual name (e.g. `V` at col 16 in
+                        // `@template T,V,X`), but the grouping key below still
+                        // needs to identify params that share the same tag, so
+                        // track the absolute `@template` position separately.
+                        let name_pos = comment_pos + start as u32;
+                        let name_len = (idx - start) as u32;
+                        let tag_abs = comment_pos + tag_start as u32;
+                        params.push((name.to_string(), name_pos, name_len, tag_abs));
                     }
                     continue;
                 }

--- a/scripts/session/quick-pick.sh
+++ b/scripts/session/quick-pick.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# quick-pick.sh — Minimal random failure picker
+# =============================================================================
+#
+# A tiny "just give me something to work on" wrapper. Picks one random
+# conformance failure from conformance-detail.json, prints the essentials,
+# and shows the command to run it verbosely.
+#
+# Usage:
+#   scripts/session/quick-pick.sh              # any failure
+#   scripts/session/quick-pick.sh --seed 42    # reproducible
+#   scripts/session/quick-pick.sh --code TS2322  # filter by error code
+#   scripts/session/quick-pick.sh --run        # also run conformance --verbose
+#
+# For richer options, use pick-random-failure.sh / random-failure.sh.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+RUN_AFTER=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="$2"; shift 2 ;;
+        --code) CODE="$2"; shift 2 ;;
+        --run) RUN_AFTER=true; shift ;;
+        -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Ensure submodule and snapshot exist.
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initializing..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+FILTER="$(SEED="$SEED" CODE="$CODE" python3 - "$DETAIL" <<'PY'
+import json, os, random, sys
+
+detail_path = sys.argv[1]
+seed = os.environ.get("SEED") or None
+code = os.environ.get("CODE") or None
+
+with open(detail_path) as f:
+    failures = json.load(f).get("failures", {})
+
+def matches(entry):
+    if not code:
+        return True
+    all_codes = set(entry.get("e", [])) | set(entry.get("a", [])) \
+              | set(entry.get("m", [])) | set(entry.get("x", []))
+    return code in all_codes
+
+cands = [(p, e) for p, e in failures.items() if e and matches(e)]
+if not cands:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(cands)
+
+expected = entry.get("e", [])
+actual   = entry.get("a", [])
+missing  = entry.get("m", [])
+extra    = entry.get("x", [])
+
+if not expected and actual:        category = "false-positive"
+elif expected and not actual:      category = "all-missing"
+elif set(expected) == set(actual): category = "fingerprint-only"
+elif missing and not extra:        category = "only-missing"
+elif extra and not missing:        category = "only-extra"
+else:                              category = "wrong-code"
+
+filt = os.path.splitext(os.path.basename(path))[0]
+
+# Human-readable summary → stderr. Filter name → stdout (captured by caller).
+print(f"path:     {path}",                    file=sys.stderr)
+print(f"category: {category}",                file=sys.stderr)
+print(f"expected: {','.join(expected) or '-'}", file=sys.stderr)
+print(f"actual:   {','.join(actual)   or '-'}", file=sys.stderr)
+print(f"missing:  {','.join(missing)  or '-'}", file=sys.stderr)
+print(f"extra:    {','.join(extra)    or '-'}", file=sys.stderr)
+print(f"pool:     {len(cands)}",              file=sys.stderr)
+print("",                                     file=sys.stderr)
+print(f"verbose run: ./scripts/conformance/conformance.sh run --filter \"{filt}\" --verbose",
+      file=sys.stderr)
+print(filt)
+PY
+)"
+
+if $RUN_AFTER; then
+    echo
+    echo "Running: ./scripts/conformance/conformance.sh run --filter \"$FILTER\" --verbose"
+    exec "$REPO_ROOT/scripts/conformance/conformance.sh" run --filter "$FILTER" --verbose
+fi


### PR DESCRIPTION
…TS2322 messages

- sanitize_type_annotation_text: reject unbalanced-brace truncated annotations
- declared_identifier_source_display: return literal display only for declared annotation types with literal canonical props (no display_properties on declared_type)
- rewrite_source_display: skip widening for source types with direct literal canonical properties (using object_shape_for_type + is_literal_type check)

tsc preserves `length: 2` from `var z: { length: 2; }` in error messages;
our widening path was converting it to `length: number`.