### PR TITLE
fix(checker): skip JSDoc target-annotation as source display in TS2322

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -775,6 +775,11 @@ impl<'a> CheckerState<'a> {
                 .node_info(current)
                 .and_then(|info| self.ctx.arena.get(info.parent))
                 .is_some_and(|parent| {
+                    // Skip when the anchor is the *name* or *declaration* side of a
+                    // declaration-like construct. In those cases any leading JSDoc
+                    // `@type` describes the declared (target) type, not the source
+                    // expression — so reading it here would display the target type
+                    // as the source, producing "Type 'X' is not assignable to type 'X'".
                     matches!(
                         parent.kind,
                         syntax_kind_ext::PROPERTY_ASSIGNMENT
@@ -782,6 +787,10 @@ impl<'a> CheckerState<'a> {
                             | syntax_kind_ext::METHOD_DECLARATION
                             | syntax_kind_ext::GET_ACCESSOR
                             | syntax_kind_ext::SET_ACCESSOR
+                            | syntax_kind_ext::PROPERTY_DECLARATION
+                            | syntax_kind_ext::VARIABLE_DECLARATION
+                            | syntax_kind_ext::PARAMETER
+                            | syntax_kind_ext::BINDING_ELEMENT
                     )
                 })
             {


### PR DESCRIPTION
## Summary

For JS class private fields (and similar declarations) with JSDoc `@type {X}`, the target annotation was being rendered as the **source** type in TS2322 messages, producing nonsensical output like `Type 'boolean' is not assignable to type 'boolean'` instead of tsc's `Type 'number' is not assignable to type 'boolean'`.

Root cause: `jsdoc_annotated_expression_display` in `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs` walks up from the diagnostic anchor and returns the first leading `@type` it finds as the source-expression display. When the anchor is the declared name of a `PropertyDeclaration`, `VariableDeclaration`, `Parameter`, or `BindingElement`, that annotation describes the target type, not the source expression — so reading it produced a tautological message.

Fix: extend the parent-kind exclusion list in `jsdoc_annotated_expression_display` to include those four declaration node kinds. Only true source-position casts (`/** @type {T} */(expr)`) now drive the source display.

## Target test

`TypeScript/tests/cases/conformance/jsdoc/jsdocPrivateName1.ts`:
```js
class A {
    /** @type {boolean} some number value */
    #foo = 3 // Error because not assignable to boolean
}
```
- Before: `Type 'boolean' is not assignable to type 'boolean'`
- After:  `Type 'number' is not assignable to type 'boolean'` (matches tsc)

## Test plan

- [x] Target test `jsdocPrivateName1` flipped to passing
- [x] `cargo fmt --check`, clippy clean, `cargo nextest run` clean
- [x] Adjacent JSDoc cast test still passes (`test_jsdoc_arrow_return_cast_reports_cast_type_in_message`)
- [x] Full conformance: 12041/12581 (+12 tests vs baseline 12029, 0 regressions)
- [x] Improvements include: `jsdocPrivateName1`, `classAbstractClinterfaceAssignability`, `optionalChainWithInstantiationExpression1`, `jsdocFunctionTypeFalsePositive`, `typedefDuplicateTypeDeclaration`, and others