### PR TITLE
fix(checker): suppress TS2345 after TS2558 for non-generic signature with type args

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -523,10 +523,12 @@ impl<'a> CheckerState<'a> {
                     crate::diagnostics::diagnostic_codes::EXPECTED_TYPE_ARGUMENTS_BUT_GOT,
                     &["0", &got.to_string()],
                 );
-                // For non-generic functions (0 type params), tsc still proceeds with argument
-                // type checking against the original signature. Return false (not a count mismatch)
-                // so the caller continues to check argument types.
-                return false;
+                // tsc suppresses argument type checking when explicit type args are
+                // supplied to a non-generic signature: the signature is rejected by
+                // `hasCorrectTypeArgumentArity` and the call falls through to the
+                // "failed candidate" path which does not re-emit TS2345. Return
+                // `true` so the caller also skips argument type checking.
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
## Summary

When a non-generic signature (0 type parameters) is called with explicit
type arguments, tsc emits `TS2558` and rejects the signature via
`hasCorrectTypeArgumentArity`; the call falls through to the failed-
candidate path which does not re-check argument types, so no `TS2345`
is emitted for mismatched arguments on that call.

Commit `3394589f40` previously flipped this path in
`validate_call_type_arguments` to `return false` (continue with argument
checking), which produced spurious `TS2345` diagnostics on top of the
already-correct `TS2558`. This change restores `return true` so the
caller in `types/computation/call/inner.rs` also skips argument type
checking (mirroring what the generic-signature wrong-arity branch below
already does).

## Root cause

The "0 type params + got > 0" branch was the only TS2558-emitting branch
in `validate_call_type_arguments` that did not signal "signature
rejected" to the caller. The caller, seeing `type_arg_count_mismatch =
false`, proceeded to generic inference and emitted `TS2345` against an
uninstantiated signature.

## Conformance delta

+4 PASS:
- `compiler/genericWithOpenTypeParameters1.ts` (the target)
- `compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts`
- `compiler/jsxRuntimePragma.ts`
- `compiler/privacyTopLevelAmbientExternalModuleImportWithExport.ts`

Net conformance: 12046 -> 12050 (+4). No regressions in verify-all
--quick (formatting, clippy, unit tests, conformance all pass).

## Test plan

- [x] `cargo build --target-dir .target --profile dist-fast -p tsz-cli -p tsz-conformance`
- [x] `./scripts/conformance/conformance.sh run --filter genericWithOpenTypeParameters1 --verbose` -> PASS
- [x] `./scripts/conformance/conformance.sh run --filter typeArgumentsOnFunctionsWithNoTypeParameters --verbose` -> PASS
- [x] `./scripts/conformance/conformance.sh run --filter callNonGenericFunctionWithTypeArguments --verbose` -> PASS
- [x] `scripts/session/verify-all.sh --quick` -> all suites pass, +4 conformance