### PR TITLE
ci(conformance): emit per-test PASS/FAIL artifact for platform-delta diagnosis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,6 +664,7 @@ jobs:
             --max-compilations-per-worker 50 \
             --max-worker-rss-mb 1024 \
             --cache-file scripts/conformance/tsc-cache-full.json \
+            --print-test \
             2>&1 | tee "$TMPOUT" || true
           sed -E 's/\x1b\[[0-9;]*m//g' "$TMPOUT" > "$CLEANOUT"
 
@@ -674,6 +675,12 @@ jobs:
           echo "passed=${PASSED:-0}" >> "$GITHUB_OUTPUT"
           echo "total=${TOTAL:-0}" >> "$GITHUB_OUTPUT"
           echo "Shard ${{ matrix.shard }}: ${PASSED:-0}/${TOTAL:-0} passed"
+
+          # Emit per-test PASS/FAIL lines as a separate artifact for offline
+          # cross-platform diffing (investigating Mac-vs-Linux 40-test delta).
+          mkdir -p .ci-metrics
+          grep -aE '^(PASS|FAIL|CRASH|TIMEOUT) ' "$CLEANOUT" \
+            > ".ci-metrics/shard-${{ matrix.shard }}-results.txt" || true
 
       - name: Save shard results
         if: always()
@@ -691,8 +698,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: conformance-shard-${{ matrix.shard }}
-          path: .ci-metrics/shard-${{ matrix.shard }}.json
-          retention-days: 1
+          path: |
+            .ci-metrics/shard-${{ matrix.shard }}.json
+            .ci-metrics/shard-${{ matrix.shard }}-results.txt
+          retention-days: 7
 
   # ─── Conformance: Aggregate results ────────────────────────────────────────
   conformance-aggregate:


### PR DESCRIPTION
## Summary

User flagged that the macOS-local conformance snapshot (**12,049 / 12,581 passing**) disagrees with what CI measures on Linux (**12,006 / 12,581**) on the same commit — a **~43-test platform delta**.

### What I verified

| run | passed | notes |
|---|---|---|
| Local, default flags (`--workers 16`, no timeout, no recycling) | 12,049 | matches snapshot.json |
| Local, CI flags (`--workers 2 --timeout 30 --max-compilations-per-worker 50 --max-worker-rss-mb 1024`) | 12,045 | — |
| CI (Linux, same CI flags) on sha=1eece827 | 12,006 | shard totals: 1285, 1266, 1246, 1230/1297, 1233, 1269, 1246, 1203, 1239, 789/884 |

Breakdown:

- **~4 tests: config-sensitive.** Reducing workers, adding timeout, and recycling workers after 50 compilations flips a few tests that depend on intra-process state (observed local-default → local-CI-flags: 12,049 → 12,045).
- **~39 tests: platform-sensitive.** Same config, different OS: Linux fails 39 tests that Mac passes (local-CI-flags → CI: 12,045 → 12,006).

Prior commit `136dda7018 chore(ci): align conformance/fourslash baselines with CI-observed counts` already documented this exact pattern at ~42 tests. The gap has persisted.

### What this PR does

Shard runner today captures only aggregate counts. This PR:

1. Adds `--print-test` to the per-shard invocation so each test emits `PASS …` / `FAIL …` lines.
2. Writes those lines to `.ci-metrics/shard-<N>-results.txt` and uploads them in the shard artifact.
3. Raises shard artifact retention to 7 days so the per-test files survive long enough to diff across commits.

No runtime change to the binary — pure diagnostic emission.

## Follow-ups (NOT in this PR)

With this merged, a follow-up can:

- Download both sets of shard artifacts (one CI run per platform, or compare CI against `scripts/conformance/conformance-baseline.txt`).
- Diff the FAIL lists to enumerate the 39 platform-specific tests.
- Decide per-test: (a) fix the tsz-side discrepancy (probably path canonicalization on `/var` → `/private/var`, locale-specific formatting, etc.), (b) mark it skipped on one platform, or (c) adjust the baseline.

Once the 39 tests are identified and categorized, the snapshot / baseline divergence can be resolved properly instead of being papered over with a patched `summary.passed`.

## Test plan

- [x] Workflow YAML still parses (no lint error)
- [ ] After merge: inspect uploaded `shard-<N>-results.txt` artifacts