### PR TITLE
fix(parser): reject assignment to update expression per tsc LHS gate

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -194,7 +194,28 @@ impl ParserState {
                             == SyntaxKind::InKeyword
                     })
             });
-            if left_is_jsx_expression || left_is_await_expression || left_is_in_expression {
+            // Update expressions (`x++`, `x--`, `++x`, `--x`) are not
+            // LeftHandSideExpressions and therefore cannot be targets of
+            // assignment. Preserve the parsed update expression so
+            // statement-level recovery reports `';' expected` at `=`, matching
+            // tsc's parseAssignmentExpressionOrHigher LHS gate.
+            let left_is_update_expression =
+                self.arena.get(left).is_some_and(|node| match node.kind {
+                    syntax_kind_ext::POSTFIX_UNARY_EXPRESSION => true,
+                    syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
+                        self.arena.get_unary_expr(node).is_some_and(|data| {
+                            let op = SyntaxKind::try_from_u16(data.operator)
+                                .unwrap_or(SyntaxKind::Unknown);
+                            matches!(op, SyntaxKind::PlusPlusToken | SyntaxKind::MinusMinusToken)
+                        })
+                    }
+                    _ => false,
+                });
+            if left_is_jsx_expression
+                || left_is_await_expression
+                || left_is_in_expression
+                || left_is_update_expression
+            {
                 if deferred_failed_async_arrow_colon_recovery
                     && !self.is_token(SyntaxKind::ColonToken)
                 {


### PR DESCRIPTION
## Summary

- `x++ = 4`, `++x = 4`, etc. are not valid assignments in JavaScript because `UpdateExpression` is not a `LeftHandSideExpression`.
- Mirror tsc's `parseAssignmentExpressionOrHigher` LHS gate: when the parsed left is a postfix/prefix `++`/`--` update expression, return `left` without consuming `=` so the enclosing expression statement emits `';' expected` at `=`.
- Fixes fingerprint parity for `conformance/expressions/operators/incrementAndDecrement.ts` (and keeps the existing `++x++`-style TS1005/TS1109 recovery intact).

## Test plan

- [x] `./scripts/conformance/conformance.sh run --filter incrementAndDecrement` passes (previously fingerprint-only FAIL).
- [x] `./scripts/conformance/conformance.sh run --filter increment` — 15/15 pass.
- [x] `./scripts/conformance/conformance.sh run --filter decrement` — 9/9 pass.
- [x] `./scripts/conformance/conformance.sh run --filter unary` — 67/69 pass (pre-existing failures unrelated).
- [x] `cargo nextest run -p tsz-parser` — 531/531 pass.
- [x] `scripts/safe-run.sh scripts/session/verify-all.sh --quick` — net conformance +3 tests (12048 → 12051); the other verify-all "regressions" are stale-snapshot flakes that also fail on `origin/main`.