### PR TITLE
fix(solver): merge intersection properties for object-like targets

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1006,6 +1006,18 @@ impl<'a> CheckerState<'a> {
             return self.format_assignability_type_for_message(source, target);
         }
 
+        // Generic intersection source reduction: when the source is an intersection
+        // containing type parameters (e.g., `T & U`), tsc displays the reduced base
+        // constraint instead of the raw generic intersection.  For example,
+        // `T extends string | number | undefined` and `U extends string | null | undefined`
+        // display as `string | undefined` rather than `T & U`.
+        //
+        // This matches tsc's `getBaseConstraintOfType` behavior for intersection types
+        // in error messages.
+        if let Some(reduced) = self.generic_intersection_source_display_substitution(source) {
+            return self.format_type_for_assignability_message(reduced);
+        }
+
         // For Lazy(DefId) source types representing named interfaces (non-generic),
         // return the interface name directly. This prevents get_type_of_node from
         // resolving the Lazy to its structural form, losing the name (e.g., showing
@@ -2246,5 +2258,43 @@ impl<'a> CheckerState<'a> {
             .diagnostics
             .iter()
             .any(|diag| diag.code == code && diag.start >= start && diag.start < end)
+    }
+
+    /// When the source of an assignment is a generic intersection (e.g., `T & U`
+    /// where at least one member is a type parameter with a constraint), return
+    /// the reduced base-constraint form for display.  Returns `None` when no
+    /// reduction applies (source is not an intersection, or no members have
+    /// usable constraints, or the reduction yields the same type).
+    ///
+    /// This matches tsc's `getBaseConstraintOfType` behavior for intersection
+    /// types: the base constraint of `T & U` is `constraint(T) & constraint(U)`,
+    /// which the interner further simplifies via distribution.
+    pub(in crate::error_reporter) fn generic_intersection_source_display_substitution(
+        &self,
+        source: TypeId,
+    ) -> Option<TypeId> {
+        let members = crate::query_boundaries::common::intersection_members(
+            self.ctx.types.as_type_database(),
+            source,
+        )?;
+        // Only rewrite when at least one member is a bare type parameter with a
+        // constraint — otherwise there's no reduction and this would just hide
+        // the intersection unnecessarily.
+        let has_constrained_type_param = members.iter().any(|&m| {
+            crate::query_boundaries::common::type_param_info(self.ctx.types.as_type_database(), m)
+                .and_then(|info| info.constraint)
+                .is_some()
+        });
+        if !has_constrained_type_param {
+            return None;
+        }
+        let reduced = crate::query_boundaries::common::get_base_constraint_for_display(
+            self.ctx.types.as_type_database(),
+            source,
+        );
+        if reduced == source {
+            return None;
+        }
+        Some(reduced)
     }
 }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -743,6 +743,30 @@ impl<'a> CheckerState<'a> {
         {
             return None;
         }
+        // When `other` is a generic type (type parameter or intersection of type
+        // parameters), reduce it to its base constraint and check if that
+        // contains null/undefined.  tsc preserves the full target union when
+        // the source's base constraint is nullable.  Example:
+        //   source `T & U` where constraints are `string | ... | undefined`
+        //   target `string | null` must stay `string | null` (not `string`).
+        let other_base = crate::query_boundaries::common::get_base_constraint_for_display(
+            self.ctx.types.as_type_database(),
+            other,
+        );
+        if other_base != other
+            && let Some(other_base_members) =
+                crate::query_boundaries::common::union_members(self.ctx.types, other_base)
+            && other_base_members
+                .iter()
+                .any(|&m| m == TypeId::NULL || m == TypeId::UNDEFINED)
+        {
+            return None;
+        }
+        // Also handle direct TypeId::NULL/UNDEFINED in the reduced base (e.g.,
+        // T extends undefined reduces to `undefined`).
+        if other_base == TypeId::NULL || other_base == TypeId::UNDEFINED {
+            return None;
+        }
         let filtered: Vec<TypeId> = members
             .iter()
             .copied()

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1359,6 +1359,18 @@ pub(crate) fn get_base_constraint_of_type(db: &dyn TypeDatabase, type_id: TypeId
     tsz_solver::type_queries::get_base_constraint_of_type(db, type_id)
 }
 
+/// Recursively reduce a type to its base constraint for display purposes.
+///
+/// Handles type parameters, intersections, and unions: for an intersection
+/// like `T & U` where the members have constraints, returns the intersection
+/// of the constraints (further simplified via the interner). This matches
+/// tsc's `getBaseConstraintOfType` for instantiable intersections and is used
+/// in error messages to display the reduced form instead of the raw generic
+/// intersection.
+pub(crate) fn get_base_constraint_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::type_queries::get_base_constraint_for_display(db, type_id)
+}
+
 pub(crate) fn get_call_signatures(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -810,6 +810,46 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 return SubtypeResult::True;
             }
 
+            // Source intersection base-constraint reduction:
+            // When source is an intersection containing type parameters (e.g., `T & U`
+            // where `T extends A` and `U extends B`), tsc computes the base constraint
+            // as `A & B` (set-theoretic intersection of the constraints). If the
+            // reduced constraint is assignable to the target union, the original
+            // intersection is too.
+            //
+            // This mirrors tsc's getBaseConstraintOfType for intersections:
+            //   getBaseConstraintOfType(T & U) = getIntersectionType([
+            //       getBaseConstraintOfType(T),   // = constraint of T
+            //       getBaseConstraintOfType(U),   // = constraint of U
+            //   ])
+            //
+            // Example: `T extends string | number | undefined` & `U extends string | null | undefined`
+            //   reduced constraint = `(string | number | undefined) & (string | null | undefined)`
+            //                      = `string | undefined` (after distribution).
+            //   `string | undefined <: string | undefined` → True.
+            if let Some(s_list) = intersection_list_id(self.interner, source) {
+                let s_member_list = self.interner.type_list(s_list);
+                let has_type_params = s_member_list
+                    .iter()
+                    .any(|&m| type_param_info(self.interner, m).is_some());
+                if has_type_params {
+                    let constraint_members: Vec<TypeId> = s_member_list
+                        .iter()
+                        .map(|&m| {
+                            if let Some(info) = type_param_info(self.interner, m) {
+                                info.constraint.unwrap_or(TypeId::UNKNOWN)
+                            } else {
+                                m
+                            }
+                        })
+                        .collect();
+                    let reduced = self.interner.intersection(constraint_members);
+                    if reduced != source && self.check_subtype(reduced, target).is_true() {
+                        return SubtypeResult::True;
+                    }
+                }
+            }
+
             // Trace: Source is not a subtype of any union member
             if let Some(tracer) = &mut self.tracer
                 && !tracer.on_mismatch_dyn(SubtypeFailureReason::NoUnionMemberMatches {
@@ -836,8 +876,29 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Note: property merging (e.g., { a: string } & { b: number } <: { a: string; b: number })
         // is still handled by the visitor's visit_intersection (reached when no individual
         // member matches and no type-specific handler intercepts).
+        //
+        // Exception: for direct object-like targets, skip this shortcut so that
+        // property merging (visit_intersection) can catch conflicting concrete
+        // members. Without this, `T & { a: boolean } <: { a?: string }` would
+        // incorrectly pass because `T <: { a?: string }` succeeds under generic
+        // weak-type generosity, even though the `{ a: boolean }` member forces a
+        // concrete property conflict. tsc reports TS2322 here by property-merging
+        // the intersection source before comparing against the object target.
         if let Some(members) = intersection_list_id(self.interner, source) {
             let member_list = self.interner.type_list(members);
+            // When target is object-like, skip type-parameter members from the
+            // shortcut: a type parameter may "generously" pass a weak-type target
+            // via type-parameter relaxation, but concrete members of the same
+            // intersection (e.g., `{ a: boolean }` in `T & { a: boolean }`) may
+            // have properties that conflict with the target. In that case the
+            // intersection as a whole must fail, not silently pass via the
+            // generic member. Concrete members keep the shortcut so cases like
+            // `{ a: string } & { b: number } <: { a: string }` still pass.
+            // When target is not object-like (e.g., type parameter, primitive,
+            // union, application), keep all members — those targets don't have
+            // the weak-type generosity concern.
+            let target_is_object_like = object_shape_id(self.interner, target).is_some()
+                || object_with_index_shape_id(self.interner, target).is_some();
             // Reset `in_intersection_member_check` for source member checks.
             // When we reach here from a target intersection loop, the flag is true
             // which suppresses weak type checks (TS2559). But the source member checks
@@ -849,6 +910,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let saved_intersection_check = self.in_intersection_member_check;
             self.in_intersection_member_check = false;
             for &member in member_list.iter() {
+                if target_is_object_like && type_param_info(self.interner, member).is_some() {
+                    continue;
+                }
                 if self.check_subtype(member, target).is_true() {
                     self.in_intersection_member_check = saved_intersection_check;
                     return SubtypeResult::True;

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -328,7 +328,17 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // This handles patterns like `T & {} <: string` where `T extends string | undefined`:
         // The constraint intersection `(string | undefined) & {}` simplifies to `string`,
         // and `string <: string` succeeds.
-        {
+        //
+        // Skip this fallback when the target is object-like: substituting the
+        // constraint (e.g., `object` or an interface) can introduce a "generous"
+        // member that would generously satisfy the weak-type/object target even
+        // though the original intersection has a concrete conflicting property
+        // (e.g., `T extends object & { a: boolean } <: { a?: string }` must fail
+        // because `{ a: boolean }` conflicts with `a?: string`, but substituting
+        // T → object yields `object & { a: boolean }` and `object` alone passes
+        // the weak target, making the recursive shortcut spuriously succeed).
+        // Property merging above already handles the object-like-target case.
+        if !target_is_object_like {
             let member_list = self.checker.interner.type_list(TypeListId(list_id));
             let has_type_params = member_list
                 .iter()

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -92,6 +92,79 @@ pub fn get_base_constraint_of_type(db: &dyn TypeDatabase, type_id: TypeId) -> Ty
     }
 }
 
+/// Resolve a type to its base constraint for display purposes, recursively reducing
+/// type parameters inside unions and intersections.
+///
+/// This mirrors tsc's `getBaseConstraintOfType` for instantiable types, which for
+/// unions/intersections recursively reduces each member and then re-intersects/unions.
+/// The intersection of union constraints is simplified via the interner's normal
+/// distribution rules (e.g., `(A | B) & (A | C)` reduces to `A | (B & C)` and
+/// disjoint primitives collapse to `never`).
+///
+/// Returns the reduced type, or `type_id` unchanged when there is no simplification.
+///
+/// Example: for `T & U` where `T extends string | number | undefined` and
+/// `U extends string | null | undefined`, this returns `string | undefined`
+/// (matching tsc's getBaseConstraintOfType(T & U) output).
+pub fn get_base_constraint_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    fn go(db: &dyn TypeDatabase, type_id: TypeId, depth: u8) -> Option<TypeId> {
+        if depth > 6 {
+            return None;
+        }
+        match db.lookup(type_id)? {
+            TypeData::TypeParameter(info) => {
+                let constraint = info.constraint?;
+                // Recursively reduce the constraint to bottom out at a concrete type.
+                Some(go(db, constraint, depth + 1).unwrap_or(constraint))
+            }
+            TypeData::Intersection(list_id) => {
+                let members = db.type_list(list_id);
+                let mut reduced: Vec<TypeId> = Vec::with_capacity(members.len());
+                let mut changed = false;
+                for &m in members.iter() {
+                    match go(db, m, depth + 1) {
+                        Some(r) => {
+                            if r != m {
+                                changed = true;
+                            }
+                            reduced.push(r);
+                        }
+                        None => reduced.push(m),
+                    }
+                }
+                if changed {
+                    Some(db.intersection(reduced))
+                } else {
+                    None
+                }
+            }
+            TypeData::Union(list_id) => {
+                let members = db.type_list(list_id);
+                let mut reduced: Vec<TypeId> = Vec::with_capacity(members.len());
+                let mut changed = false;
+                for &m in members.iter() {
+                    match go(db, m, depth + 1) {
+                        Some(r) => {
+                            if r != m {
+                                changed = true;
+                            }
+                            reduced.push(r);
+                        }
+                        None => reduced.push(m),
+                    }
+                }
+                if changed {
+                    Some(db.union(reduced))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+    go(db, type_id, 0).unwrap_or(type_id)
+}
+
 /// Compute the "constituent count" of a type for relation complexity estimation.
 ///
 /// Mirrors tsc's `getConstituentCount` used to detect TS2859 before


### PR DESCRIPTION
## Summary

When the source is a generic intersection like `T & { a: boolean }` and the target is an object-like type (e.g., `{ a?: string }`), tsc rejects the assignment because the concrete member forces a property conflict. Our shortcut "any source member matches target" incorrectly passed the check via `T <: weak_target` (type-parameter weak-type generosity), bypassing the `{ a: boolean }` conflict.

Three coordinated subtype changes plus a display fix:

- **Source-intersection member shortcut** (`subtype/core.rs`): skip type-parameter members from the "any member matches" shortcut when target is object-like. Concrete members still participate so `{ a: string } & { b: number } <: { a: string }` still passes.
- **Constraint-based fallback** (`subtype/visitor.rs`): skip the constraint substitution step when target is object-like. Replacing `T` with its constraint (e.g., `object`) can re-introduce the generous match (`object <: { a?: string }`), defeating the property-merge just above.
- **Generic intersection union-target reduction** (`subtype/core.rs`): when target is a union, reduce a generic intersection source to the intersection of its constraints and re-check. Matches tsc's `getBaseConstraintOfType` for instantiable intersections.
- **Display substitution** (`error_reporter/`): show the reduced `string | undefined` form rather than raw `T & U` in TS2322 messages, matching tsc's diagnostic text.

## Conformance delta

12048 -> 12052 (+4), 0 regressions:
- `compiler/intersectionPropertyCheck.ts`
- `conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts`
- `conformance/types/intersection/intersectionWithUnionConstraint.ts`
- `transpile/jsWithSourceMapBasic.ts`

## Test plan

- [x] Target test `intersectionPropertyCheck.ts` passes (all 4 tsc diagnostics emitted).
- [x] Target test `intersectionWithUnionConstraint.ts` passes (display shows `string | undefined`).
- [x] `T & Function <: Function` still succeeds (regression check for interface-like object targets).
- [x] `{ a: string } & { b: number } <: { a: string }` still passes via member shortcut.
- [x] `scripts/session/verify-all.sh --quick` passes (fmt, clippy, unit tests, conformance +net).
- [x] Full conformance run: 12052/12581 (95.8%), +4 improvements, 0 regressions.