### PR TITLE
fix(checker): preserve namespace and display property order

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -104,10 +104,6 @@ name = "ts1254_ambient_const_tests"
 path = "tests/ts1254_ambient_const_tests.rs"
 
 [[test]]
-name = "conformance_issues"
-path = "tests/conformance_issues.rs"
-
-[[test]]
 name = "binding_pattern_inference_tests"
 path = "tests/binding_pattern_inference_tests.rs"
 
@@ -150,6 +146,14 @@ path = "tests/type_arg_count_mismatch_tests.rs"
 [[test]]
 name = "commonjs_module_export_alias_tests"
 path = "tests/commonjs_module_export_alias_tests.rs"
+
+[[test]]
+name = "conformance_issues"
+path = "tests/conformance_issues.rs"
+
+[[test]]
+name = "export_equals_display_order_tests"
+path = "tests/export_equals_display_order_tests.rs"
 
 [[test]]
 name = "commonjs_require_value_tests"

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -595,14 +595,20 @@ impl<'a> CheckerState<'a> {
                 .get("export=")
                 .or_else(|| exports_table.get("module.exports"))
                 .map(|export_equals_sym| self.get_type_of_symbol(export_equals_sym));
+            let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
 
             // Create an object type with all module exports
             let mut props: Vec<PropertyInfo> = Vec::new();
-            for (name, &export_sym_id) in exports_table.iter() {
+            for &(name, export_sym_id) in &ordered_exports {
                 if name == "export=" {
                     continue;
                 }
                 let prop_type = self.get_type_of_symbol(export_sym_id);
+                let declaration_order = if name == "default" {
+                    1
+                } else {
+                    props.len() as u32 + 2
+                };
                 let name_atom = self.ctx.types.intern_string(name);
                 props.push(PropertyInfo {
                     name: name_atom,
@@ -614,7 +620,7 @@ impl<'a> CheckerState<'a> {
                     is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: None,
-                    declaration_order: 0,
+                    declaration_order,
                     is_string_named: false,
                 });
             }
@@ -678,12 +684,13 @@ impl<'a> CheckerState<'a> {
                         is_class_prototype: false,
                         visibility: Visibility::Public,
                         parent_id: None,
-                        declaration_order: 0,
+                        declaration_order: 1,
                         is_string_named: false,
                     });
                 }
             }
 
+            Self::normalize_namespace_export_declaration_order(&mut props);
             let factory = self.ctx.types.factory();
             let module_type = factory.object(props);
             let display_module_name =

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -327,7 +327,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.symbol_instance_types.insert(sym_id, placeholder);
         self.ctx.symbol_resolution_depth.set(depth + 1);
         let mut props: Vec<PropertyInfo> = Vec::new();
-        for (name, &member_id) in exports.iter() {
+        for (name, member_id) in self.ordered_namespace_export_entries(&exports) {
             if self.ctx.symbol_resolution_set.contains(&member_id) {
                 continue;
             }
@@ -378,6 +378,11 @@ impl<'a> CheckerState<'a> {
             {
                 member_type = self.get_enum_namespace_type_for_value(member_type);
             }
+            let declaration_order = if name == "default" {
+                1
+            } else {
+                props.len() as u32 + 2
+            };
             let name_atom = self.ctx.types.intern_string(name);
             props.push(PropertyInfo {
                 name: name_atom,
@@ -389,11 +394,12 @@ impl<'a> CheckerState<'a> {
                 is_class_prototype: false,
                 visibility: Visibility::Public,
                 parent_id: None,
-                declaration_order: 0,
+                declaration_order,
                 is_string_named: false,
             });
         }
         self.ctx.symbol_resolution_depth.set(depth);
+        Self::normalize_namespace_export_declaration_order(&mut props);
         // Use object_with_flags_and_symbol to preserve the namespace's SymbolId.
         // This enables the type formatter to detect the namespace and display
         // it as `typeof M` instead of expanding to the structural object shape.

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1,11 +1,5 @@
-//! Rendering of `SubtypeFailureReason` into diagnostics.
-//!
-//! Converts solver-produced failure reasons into user-facing diagnostic
-//! messages. Split from `assignability.rs` for maintainability.
-use super::assignability::{
-    is_builtin_wrapper_name, is_function_type_display, is_object_prototype_method,
-    is_object_prototype_method_for_array_target, is_primitive_type_name,
-};
+//! Render `SubtypeFailureReason` values into diagnostics.
+//! Split from `assignability.rs` for maintainability.
 use crate::diagnostics::{
     Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
     diagnostic_messages, format_message,
@@ -15,6 +9,11 @@ use crate::query_boundaries::type_checking_utilities as query_utils;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
+
+use super::assignability::{
+    is_builtin_wrapper_name, is_function_type_display, is_object_prototype_method,
+    is_object_prototype_method_for_array_target, is_primitive_type_name,
+};
 mod type_mismatch;
 impl<'a> CheckerState<'a> {
     /// Recursively render a `SubtypeFailureReason` into a Diagnostic.
@@ -40,10 +39,8 @@ impl<'a> CheckerState<'a> {
             });
         let file_name = self.ctx.file_name.clone();
 
-        // TS2696: When the source is the `Object` wrapper type and the failure is
-        // about property-level issues (not call/construct signatures), tsc emits
-        // "The 'Object' type is assignable to very few other types" instead of TS2322.
-        // When the target is a callable/constructable type, tsc uses TS2322 instead.
+        // TS2696: property-only failures from the `Object` wrapper use the
+        // specialized message unless the target is callable/constructable.
         if depth == 0 {
             let is_property_failure = matches!(
                 reason,
@@ -382,9 +379,8 @@ impl<'a> CheckerState<'a> {
                         self.format_type_diagnostic(target),
                     )
                 };
-                // TS2820: when the source is a string literal and a union member is
-                // close in spelling, emit "did you mean X?" instead of plain TS2322.
-                // TSC uses the expanded union form (not the alias name) in TS2820 messages.
+                // TS2820 prefers "did you mean X?" and uses the expanded union
+                // form rather than the alias name.
                 let evaluated_target_for_suggestion = self.evaluate_type_with_env(target);
                 if let Some(suggestion) = self.find_string_literal_spelling_suggestion(
                     source,
@@ -426,8 +422,7 @@ impl<'a> CheckerState<'a> {
                 source_type: _,
                 target_type: _,
             } => {
-                // Use unwidened type for TS2559/TS2560 — tsc preserves literal types
-                // (e.g., "12" not "number", "'false'" not "boolean") in
+                // Use the unwidened source: tsc preserves literal spellings in
                 // "has no properties in common" messages.
                 let mut source_str =
                     if (crate::query_boundaries::common::has_call_signatures(
@@ -446,8 +441,7 @@ impl<'a> CheckerState<'a> {
                     };
                 let target_str = self.format_type_for_assignability_message(target);
 
-                // If the source is callable/constructable and calling it would fix
-                // the mismatch, emit TS2560 ("did you mean to call it?") instead.
+                // If calling the source would fix the mismatch, emit TS2560 instead.
                 let (msg_template, code) = if self
                     .should_suggest_calling_for_weak_type(source, target)
                 {
@@ -500,7 +494,6 @@ impl<'a> CheckerState<'a> {
                 source_param,
                 target_param,
             } => {
-                // Emit the primary TS2322 diagnostic for the outer type mismatch.
                 let source_str =
                     self.format_assignment_source_type_for_diagnostic(source, target, idx);
                 let target_str = self.format_assignability_type_for_message(target, source);
@@ -516,39 +509,19 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 );
 
-                // Emit TS2328 as a separate top-level diagnostic when:
-                // 1. We're at the top-level (depth == 0)
-                // 2. The outer source/target are direct function types (not type
-                //    alias applications like `Func<T,U>` — tsc reports those via
-                //    type-argument elaboration, not TS2328)
-                // 3. The mismatched parameter types are themselves callable
-                // 4. Neither callback parameter type contains type parameters
-                //    (tsc skips TS2328 elaboration for generic signatures)
-                //
-                // tsc emits TS2328 as its own diagnostic in the error list, so it
-                // must appear as a standalone "error TS2328:" line.
-                let source_is_direct_callable =
-                    crate::query_boundaries::common::is_callable_type(self.ctx.types, source);
-                let target_is_direct_callable =
-                    crate::query_boundaries::common::is_callable_type(self.ctx.types, target);
-                let source_param_is_callable = crate::query_boundaries::common::is_callable_type(
-                    self.ctx.types,
-                    *source_param,
-                );
-                let target_param_is_callable = crate::query_boundaries::common::is_callable_type(
-                    self.ctx.types,
-                    *target_param,
-                );
-                let source_param_is_generic =
-                    crate::query_boundaries::common::contains_type_parameters(
-                        self.ctx.types,
-                        *source_param,
-                    );
-                let target_param_is_generic =
-                    crate::query_boundaries::common::contains_type_parameters(
-                        self.ctx.types,
-                        *target_param,
-                    );
+                // TS2328 is emitted separately only for top-level direct callable
+                // mismatches whose parameter types are callable and non-generic.
+                let is_callable =
+                    |ty| crate::query_boundaries::common::is_callable_type(self.ctx.types, ty);
+                let contains_type_params = |ty| {
+                    crate::query_boundaries::common::contains_type_parameters(self.ctx.types, ty)
+                };
+                let source_is_direct_callable = is_callable(source);
+                let target_is_direct_callable = is_callable(target);
+                let source_param_is_callable = is_callable(*source_param);
+                let target_param_is_callable = is_callable(*target_param);
+                let source_param_is_generic = contains_type_params(*source_param);
+                let target_param_is_generic = contains_type_params(*target_param);
 
                 if depth == 0
                     && source_is_direct_callable
@@ -620,10 +593,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    // =========================================================================
-    // Per-variant render helpers
-    // =========================================================================
-
     #[allow(clippy::too_many_arguments)]
     fn render_missing_property(
         &mut self,
@@ -639,8 +608,7 @@ impl<'a> CheckerState<'a> {
         source_type: TypeId,
         target_type: TypeId,
     ) -> Diagnostic {
-        // TSC emits TS2322 (generic assignability error) instead of TS2741
-        // when the source is a primitive type. Primitives can't have "missing properties".
+        // Primitive sources use TS2322 rather than missing-property wording.
         let display_src_str = if depth == 0 && source_type != tsz_solver::TypeId::OBJECT {
             self.format_assignment_source_type_for_diagnostic(source, target, idx)
         } else {
@@ -664,9 +632,8 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TSC emits TS2322 instead of TS2741 when the source has call signatures
-        // (pure function type, NOT class constructor) and the target does NOT have call
-        // signatures. Class constructors (construct-only) should still produce TS2741.
+        // Pure function sources against non-callable targets use TS2322; class
+        // constructors still keep the missing-property path.
         let source_eval_for_fn = self.evaluate_type_with_env(source);
         let target_eval_for_fn = self.evaluate_type_with_env(target);
         let is_source_fn =

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -106,9 +106,6 @@ mod circular_accessor_annotation_tests;
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]
-#[path = "../tests/conformance_issues.rs"]
-mod conformance_issues;
-#[cfg(test)]
 #[path = "../tests/control_flow_tests.rs"]
 mod control_flow_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -356,6 +356,10 @@ pub(crate) fn object_shape_for_type(
     tsz_solver::type_queries::get_object_shape(db, type_id)
 }
 
+pub(crate) fn normalize_display_property_order(props: &mut [tsz_solver::PropertyInfo]) {
+    tsz_solver::normalize_display_property_order(props)
+}
+
 pub(crate) fn array_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::type_queries::get_array_element_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -68,6 +68,30 @@ pub struct JsExportSurface {
 }
 
 impl JsExportSurface {
+    fn normalize_property_declaration_order(props: &mut [PropertyInfo]) {
+        props.sort_by(
+            |a, b| match (a.declaration_order > 0, b.declaration_order > 0) {
+                (true, true) => a.declaration_order.cmp(&b.declaration_order),
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                (false, false) => std::cmp::Ordering::Equal,
+            },
+        );
+
+        for (idx, prop) in props.iter_mut().enumerate() {
+            prop.declaration_order = idx as u32 + 1;
+        }
+    }
+
+    fn merged_declaration_order(existing: u32, overlay: u32) -> u32 {
+        match (existing > 0, overlay > 0) {
+            (true, true) => existing.min(overlay),
+            (true, false) => existing,
+            (false, true) => overlay,
+            (false, false) => 0,
+        }
+    }
+
     fn merge_property_info(
         checker: &mut CheckerState<'_>,
         existing: &PropertyInfo,
@@ -92,7 +116,10 @@ impl JsExportSurface {
             is_class_prototype: existing.is_class_prototype || overlay.is_class_prototype,
             visibility: existing.visibility,
             parent_id: existing.parent_id.or(overlay.parent_id),
-            declaration_order: existing.declaration_order.min(overlay.declaration_order),
+            declaration_order: Self::merged_declaration_order(
+                existing.declaration_order,
+                overlay.declaration_order,
+            ),
             is_string_named: false,
         }
     }
@@ -127,9 +154,7 @@ impl JsExportSurface {
                 }
             }
             merged_props.extend(overlay_by_name.into_values());
-            for (idx, prop) in merged_props.iter_mut().enumerate() {
-                prop.declaration_order = idx as u32;
-            }
+            Self::normalize_property_declaration_order(&mut merged_props);
             merged_shape.properties = merged_props;
             return Some(checker.ctx.types.factory().callable(merged_shape));
         }
@@ -147,9 +172,7 @@ impl JsExportSurface {
                 }
             }
             merged_props.extend(overlay_by_name.into_values());
-            for (idx, prop) in merged_props.iter_mut().enumerate() {
-                prop.declaration_order = idx as u32;
-            }
+            Self::normalize_property_declaration_order(&mut merged_props);
 
             let merged_shape = ObjectShape {
                 flags: shape.flags,
@@ -223,7 +246,9 @@ impl JsExportSurface {
         });
 
         let namespace_type = if can_merge_named_exports && !self.named_exports.is_empty() {
-            Some(factory.object(self.named_exports.clone()))
+            let mut named_exports = self.named_exports.clone();
+            Self::normalize_property_declaration_order(&mut named_exports);
+            Some(factory.object(named_exports))
         } else {
             None
         };
@@ -335,13 +360,12 @@ impl<'a> CheckerState<'a> {
             return Vec::new();
         };
 
-        shape
-            .properties
+        let mut props = shape.properties;
+        JsExportSurface::normalize_property_declaration_order(&mut props);
+        props
             .into_iter()
-            .enumerate()
-            .map(|(idx, mut prop)| {
+            .map(|mut prop| {
                 prop.optional = force_optional;
-                prop.declaration_order = idx as u32;
                 prop
             })
             .collect()
@@ -410,7 +434,7 @@ impl<'a> CheckerState<'a> {
             .enumerate()
             .filter_map(|(idx, name)| {
                 pending.remove(&name).map(|mut prop| {
-                    prop.declaration_order = idx as u32;
+                    prop.declaration_order = idx as u32 + 1;
                     prop
                 })
             })
@@ -552,6 +576,7 @@ impl<'a> CheckerState<'a> {
             &mut props,
             None,
         );
+        JsExportSurface::normalize_property_declaration_order(&mut props);
         surface.named_exports = props;
 
         // 3. Collect prototype property assignments for constructor functions
@@ -712,7 +737,7 @@ impl<'a> CheckerState<'a> {
                     is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: None,
-                    declaration_order: idx as u32,
+                    declaration_order: idx as u32 + 1,
                     is_string_named: false,
                 });
             }
@@ -763,5 +788,53 @@ impl<'a> CheckerState<'a> {
         let ctor_name = ctor_ident.escaped_text.clone();
 
         Some((ctor_name, member_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JsExportSurface;
+    use tsz_solver::{PropertyInfo, TypeId, TypeInterner, Visibility};
+
+    fn prop(db: &TypeInterner, name: &str, declaration_order: u32) -> PropertyInfo {
+        PropertyInfo {
+            name: db.intern_string(name),
+            type_id: TypeId::ANY,
+            write_type: TypeId::ANY,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order,
+            is_string_named: false,
+        }
+    }
+
+    #[test]
+    fn normalize_property_declaration_order_preserves_existing_source_order() {
+        let db = TypeInterner::new();
+        let mut props = vec![prop(&db, "configs", 3), prop(&db, "default", 1)];
+
+        JsExportSurface::normalize_property_declaration_order(&mut props);
+
+        assert_eq!(db.resolve_atom_ref(props[0].name).as_ref(), "default");
+        assert_eq!(props[0].declaration_order, 1);
+        assert_eq!(db.resolve_atom_ref(props[1].name).as_ref(), "configs");
+        assert_eq!(props[1].declaration_order, 2);
+    }
+
+    #[test]
+    fn normalize_property_declaration_order_prioritizes_explicit_members_before_unset_members() {
+        let db = TypeInterner::new();
+        let mut props = vec![prop(&db, "configs", 0), prop(&db, "default", 1)];
+
+        JsExportSurface::normalize_property_declaration_order(&mut props);
+
+        assert_eq!(db.resolve_atom_ref(props[0].name).as_ref(), "default");
+        assert_eq!(props[0].declaration_order, 1);
+        assert_eq!(db.resolve_atom_ref(props[1].name).as_ref(), "configs");
+        assert_eq!(props[1].declaration_order, 2);
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -12,6 +12,51 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::{PropertyInfo, TypeId, Visibility};
 impl<'a> CheckerState<'a> {
+    pub(crate) fn normalize_namespace_export_declaration_order(props: &mut [PropertyInfo]) {
+        props.sort_by(
+            |a, b| match (a.declaration_order > 0, b.declaration_order > 0) {
+                (true, true) => a.declaration_order.cmp(&b.declaration_order),
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                (false, false) => std::cmp::Ordering::Equal,
+            },
+        );
+
+        for (idx, prop) in props.iter_mut().enumerate() {
+            prop.declaration_order = idx as u32 + 1;
+        }
+    }
+
+    pub(crate) fn ordered_namespace_export_entries<'b>(
+        &self,
+        exports_table: &'b tsz_binder::SymbolTable,
+    ) -> Vec<(&'b str, SymbolId)> {
+        let mut entries: Vec<_> = exports_table
+            .iter()
+            .map(|(name, &sym_id)| {
+                let span = self
+                    .get_symbol_globally(sym_id)
+                    .or_else(|| self.get_cross_file_symbol(sym_id))
+                    .and_then(|symbol| {
+                        symbol
+                            .first_declaration_span
+                            .or(symbol.value_declaration_span)
+                    });
+                (name.as_str(), sym_id, span)
+            })
+            .collect();
+
+        entries.sort_by_key(|(name, sym_id, span)| {
+            let (start, end) = span.unwrap_or((u32::MAX, u32::MAX));
+            (span.is_none(), start, end, *name, sym_id.0)
+        });
+
+        entries
+            .into_iter()
+            .map(|(name, sym_id, _)| (name, sym_id))
+            .collect()
+    }
+
     pub(crate) fn type_has_unresolved_inference_holes(&self, type_id: TypeId) -> bool {
         contains_type_parameters(self.ctx.types, type_id)
             || contains_infer_types(self.ctx.types, type_id)
@@ -164,7 +209,7 @@ impl<'a> CheckerState<'a> {
             &mut nested_exports,
         );
 
-        for (name, &export_sym_id) in nested_exports.iter() {
+        for (name, export_sym_id) in self.ordered_namespace_export_entries(&nested_exports) {
             if self.should_skip_namespace_export_name(&nested_exports, name, export_sym_id) {
                 continue;
             }
@@ -1113,5 +1158,131 @@ impl<'a> CheckerState<'a> {
             &escaped_name,
             &factory,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::{QueryDatabase, TypeInterner};
+
+    fn make_prop(name: tsz_common::Atom, declaration_order: u32) -> PropertyInfo {
+        PropertyInfo {
+            name,
+            type_id: TypeId::ANY,
+            write_type: TypeId::ANY,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order,
+            is_string_named: false,
+        }
+    }
+
+    #[test]
+    fn synthetic_namespace_default_normalization_preserves_default_before_augmentations() {
+        let types = TypeInterner::new();
+        let default_atom = types.intern_string("default");
+        let configs_atom = types.intern_string("configs");
+        let mut props = vec![make_prop(configs_atom, 0), make_prop(default_atom, 1)];
+
+        CheckerState::normalize_namespace_export_declaration_order(&mut props);
+        let namespace_type = types.factory().object(props);
+        let shape = crate::query_boundaries::common::object_shape_for_type(&types, namespace_type)
+            .expect("namespace type should have an object shape");
+        let shape_props: Vec<_> = shape
+            .properties
+            .iter()
+            .map(|prop| {
+                (
+                    types.resolve_atom_ref(prop.name).to_string(),
+                    prop.declaration_order,
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            shape_props,
+            vec![("configs".to_string(), 2), ("default".to_string(), 1)]
+        );
+    }
+
+    #[test]
+    fn ordered_namespace_export_entries_follow_first_declaration_span() {
+        use tsz_binder::{BinderState, SymbolTable, symbol_flags};
+        use tsz_checker::context::{CheckerOptions, ScriptTarget};
+        use tsz_parser::parser::ParserState;
+
+        let mut parser = ParserState::new("/test.ts".to_string(), String::new());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+
+        let third = binder
+            .symbols
+            .alloc(symbol_flags::EXPORT_VALUE, "third".to_string());
+        binder
+            .symbols
+            .get_mut(third)
+            .expect("third symbol should exist")
+            .add_declaration(NodeIndex::NONE, Some((30, 31)));
+
+        let first = binder
+            .symbols
+            .alloc(symbol_flags::EXPORT_VALUE, "first".to_string());
+        binder
+            .symbols
+            .get_mut(first)
+            .expect("first symbol should exist")
+            .add_declaration(NodeIndex::NONE, Some((10, 11)));
+
+        let second = binder
+            .symbols
+            .alloc(symbol_flags::EXPORT_VALUE, "second".to_string());
+        binder
+            .symbols
+            .get_mut(second)
+            .expect("second symbol should exist")
+            .add_declaration(NodeIndex::NONE, Some((20, 21)));
+
+        let missing_span = binder
+            .symbols
+            .alloc(symbol_flags::EXPORT_VALUE, "missingSpan".to_string());
+
+        let mut exports = SymbolTable::new();
+        exports.set("third".to_string(), third);
+        exports.set("missingSpan".to_string(), missing_span);
+        exports.set("first".to_string(), first);
+        exports.set("second".to_string(), second);
+
+        let types = TypeInterner::new();
+        let checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            "/test.ts".to_string(),
+            CheckerOptions {
+                target: ScriptTarget::ES2020,
+                ..CheckerOptions::default()
+            },
+        );
+
+        let ordered = checker.ordered_namespace_export_entries(&exports);
+        let names: Vec<_> = ordered
+            .into_iter()
+            .map(|(name, _)| name.to_string())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "first".to_string(),
+                "second".to_string(),
+                "third".to_string(),
+                "missingSpan".to_string()
+            ]
+        );
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -786,9 +786,10 @@ impl<'a> CheckerState<'a> {
                         let module_is_non_module_entity = self
                             .ctx
                             .module_resolves_to_non_module_entity(&module_specifier);
+                        let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
                         // Record cross-file symbol targets so delegate_cross_arena_symbol_resolution
                         // can find the correct arena for symbols from ambient modules.
-                        for (name, &sym_id) in exports_table.iter() {
+                        for &(name, sym_id) in &ordered_exports {
                             self.record_cross_file_symbol_if_needed(
                                 sym_id,
                                 name,
@@ -796,8 +797,8 @@ impl<'a> CheckerState<'a> {
                             );
                         }
                         let exports_table_target =
-                            exports_table.iter().find_map(|(_, &export_sym_id)| {
-                                self.ctx.resolve_symbol_file_index(export_sym_id)
+                            ordered_exports.iter().find_map(|(_, export_sym_id)| {
+                                self.ctx.resolve_symbol_file_index(*export_sym_id)
                             });
                         let mut export_equals_type =
                             exports_table.get("export=").map(|export_equals_sym| {
@@ -827,9 +828,7 @@ impl<'a> CheckerState<'a> {
                                 .as_ref()
                                 .map(|s| s.named_exports.clone())
                                 .unwrap_or_default();
-                            for (order, prop) in named_exports.iter_mut().enumerate() {
-                                prop.declaration_order = order as u32;
-                            }
+                            Self::normalize_namespace_export_declaration_order(&mut named_exports);
                             if let Some(surface_direct_type) =
                                 surface.as_ref().and_then(|s| s.direct_export_type)
                             {
@@ -838,7 +837,7 @@ impl<'a> CheckerState<'a> {
                             named_exports
                         } else {
                             let mut props: Vec<PropertyInfo> = Vec::new();
-                            for (name, &sym_id) in exports_table.iter() {
+                            for &(name, sym_id) in &ordered_exports {
                                 if self.should_skip_namespace_export_name(
                                     &exports_table,
                                     name,
@@ -913,6 +912,7 @@ impl<'a> CheckerState<'a> {
                                 });
                             }
                         }
+                        Self::normalize_namespace_export_declaration_order(&mut props);
                         let namespace_has_no_runtime_props = props.is_empty();
                         let namespace_type = factory.object(props);
                         // Store display name for error messages: TSC shows namespace
@@ -1132,8 +1132,9 @@ impl<'a> CheckerState<'a> {
                         declaring_file_idx,
                     );
                     if let Some(exports_table) = exports_table {
+                        let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
                         // Record cross-file symbol targets for all symbols in the table
-                        for (name, &sym_id) in exports_table.iter() {
+                        for &(name, sym_id) in &ordered_exports {
                             self.record_cross_file_symbol_if_needed(sym_id, name, module_name);
                         }
 
@@ -1141,8 +1142,8 @@ impl<'a> CheckerState<'a> {
                         let module_is_non_module_entity =
                             self.ctx.module_resolves_to_non_module_entity(module_name);
                         let exports_table_target =
-                            exports_table.iter().find_map(|(_, &export_sym_id)| {
-                                self.ctx.resolve_symbol_file_index(export_sym_id)
+                            ordered_exports.iter().find_map(|(_, export_sym_id)| {
+                                self.ctx.resolve_symbol_file_index(*export_sym_id)
                             });
                         let mut export_equals_type =
                             exports_table.get("export=").map(|export_equals_sym| {
@@ -1174,9 +1175,7 @@ impl<'a> CheckerState<'a> {
                                 .as_ref()
                                 .map(|s| s.named_exports.clone())
                                 .unwrap_or_default();
-                            for (order, prop) in named_exports.iter_mut().enumerate() {
-                                prop.declaration_order = order as u32;
-                            }
+                            Self::normalize_namespace_export_declaration_order(&mut named_exports);
                             if export_equals_type.is_none() {
                                 export_equals_type =
                                     surface.as_ref().and_then(|s| s.direct_export_type);
@@ -1184,7 +1183,7 @@ impl<'a> CheckerState<'a> {
                             named_exports
                         } else {
                             let mut props: Vec<PropertyInfo> = Vec::new();
-                            for (name, &export_sym_id) in exports_table.iter() {
+                            for &(name, export_sym_id) in &ordered_exports {
                                 if self.should_skip_namespace_export_name(
                                     &exports_table,
                                     name,
@@ -1330,11 +1329,20 @@ impl<'a> CheckerState<'a> {
                                 props.iter().any(|p| p.name == default_atom);
                             let synthetic_default_type =
                                 if can_use_cjs_namespace_default && has_named_default_prop {
-                                    Some(factory.object(props.clone()))
+                                    let mut synthetic_props = props.clone();
+                                    Self::normalize_namespace_export_declaration_order(
+                                        &mut synthetic_props,
+                                    );
+                                    Some(factory.object(synthetic_props))
                                 } else {
                                     export_equals_type.or_else(|| {
-                                        can_use_cjs_namespace_default
-                                            .then(|| factory.object(props.clone()))
+                                        can_use_cjs_namespace_default.then(|| {
+                                            let mut synthetic_props = props.clone();
+                                            Self::normalize_namespace_export_declaration_order(
+                                                &mut synthetic_props,
+                                            );
+                                            factory.object(synthetic_props)
+                                        })
                                     })
                                 };
                             if let Some(eq_type) = synthetic_default_type {
@@ -1356,13 +1364,14 @@ impl<'a> CheckerState<'a> {
                                         is_class_prototype: false,
                                         visibility: Visibility::Public,
                                         parent_id: None,
-                                        declaration_order: 0,
+                                        declaration_order: 1,
                                         is_string_named: false,
                                     });
                                 }
                             }
                         }
 
+                        Self::normalize_namespace_export_declaration_order(&mut props);
                         let namespace_has_no_runtime_props = props.is_empty();
                         let namespace_type = factory.object(props);
                         // Store display name for error messages: TSC shows namespace
@@ -1476,6 +1485,7 @@ impl<'a> CheckerState<'a> {
 
                     if let Some(exports_table) = self.resolve_effective_module_exports(module_name)
                     {
+                        let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
                         if exports_table.has("export=")
                             && let Some(export_eq_sym) = exports_table.get("export=")
                         {
@@ -1493,7 +1503,7 @@ impl<'a> CheckerState<'a> {
 
                         use tsz_solver::PropertyInfo;
                         let mut props: Vec<PropertyInfo> = Vec::new();
-                        for (name, &export_sym_id) in exports_table.iter() {
+                        for &(name, export_sym_id) in &ordered_exports {
                             if self.should_skip_namespace_export_name(
                                 &exports_table,
                                 name,
@@ -1522,6 +1532,7 @@ impl<'a> CheckerState<'a> {
                                 is_string_named: false,
                             });
                         }
+                        Self::normalize_namespace_export_declaration_order(&mut props);
                         let module_type = factory.object(props);
                         self.ctx.namespace_module_names.insert(
                             module_type,
@@ -1726,9 +1737,11 @@ impl<'a> CheckerState<'a> {
                             let exports_table = self.resolve_effective_module_exports(module_name);
 
                             if let Some(exports_table) = exports_table {
+                                let ordered_exports =
+                                    self.ordered_namespace_export_entries(&exports_table);
                                 use tsz_solver::PropertyInfo;
                                 let mut props: Vec<PropertyInfo> = Vec::new();
-                                for (name, &export_sym_id) in exports_table.iter() {
+                                for &(name, export_sym_id) in &ordered_exports {
                                     if self.should_skip_namespace_export_name(
                                         &exports_table,
                                         name,
@@ -1757,6 +1770,7 @@ impl<'a> CheckerState<'a> {
                                         is_string_named: false,
                                     });
                                 }
+                                Self::normalize_namespace_export_declaration_order(&mut props);
                                 let module_type = factory.object(props);
                                 self.ctx.namespace_module_names.insert(
                                     module_type,

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -809,7 +809,7 @@ impl<'a> CheckerState<'a> {
                     is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: None,
-                    declaration_order: props.len() as u32,
+                    declaration_order: props.len() as u32 + 1,
                     is_string_named: false,
                 });
             }
@@ -947,7 +947,7 @@ impl<'a> CheckerState<'a> {
                 &target_arena,
                 &name,
                 descriptor_expr,
-                props.len() as u32,
+                props.len() as u32 + 1,
             ) else {
                 continue;
             };
@@ -1007,12 +1007,13 @@ impl<'a> CheckerState<'a> {
         if let Some(exports_table) = exports_table {
             let module_is_non_module_entity =
                 self.ctx.module_resolves_to_non_module_entity(module_name);
-            for (name, &sym_id) in exports_table.iter() {
+            let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
+            for &(name, sym_id) in &ordered_exports {
                 self.record_cross_file_symbol_if_needed(sym_id, name, module_name);
             }
-            let exports_table_target = exports_table
+            let exports_table_target = ordered_exports
                 .iter()
-                .find_map(|(_, &sym_id)| self.ctx.resolve_symbol_file_index(sym_id));
+                .find_map(|(_, sym_id)| self.ctx.resolve_symbol_file_index(*sym_id));
 
             let mut export_equals_type = exports_table.get("export=").map(|export_equals_sym| {
                 // When `export = C.B` resolves to a type-only symbol (e.g., `interface B` from a
@@ -1077,9 +1078,7 @@ impl<'a> CheckerState<'a> {
                     .as_ref()
                     .map(|s| s.named_exports.clone())
                     .unwrap_or_default();
-                for (order, prop) in named_exports.iter_mut().enumerate() {
-                    prop.declaration_order = order as u32;
-                }
+                Self::normalize_namespace_export_declaration_order(&mut named_exports);
                 if let Some(surface_direct_type) =
                     surface.as_ref().and_then(|s| s.direct_export_type)
                 {
@@ -1088,7 +1087,7 @@ impl<'a> CheckerState<'a> {
                 named_exports
             } else {
                 let mut props: Vec<PropertyInfo> = Vec::new();
-                for (name, &sym_id) in exports_table.iter() {
+                for &(name, sym_id) in &ordered_exports {
                     if name == "export="
                         || self.should_skip_namespace_export_name(&exports_table, name, sym_id)
                         || self.is_type_only_export_symbol(sym_id)
@@ -1101,6 +1100,11 @@ impl<'a> CheckerState<'a> {
 
                     let mut prop_type = self.get_type_of_symbol(sym_id);
                     prop_type = self.apply_module_augmentations(module_name, name, prop_type);
+                    let declaration_order = if name == "default" {
+                        1
+                    } else {
+                        props.len() as u32 + 2
+                    };
                     let name_atom = self.ctx.types.intern_string(name);
                     props.push(PropertyInfo {
                         name: name_atom,
@@ -1112,7 +1116,7 @@ impl<'a> CheckerState<'a> {
                         is_class_prototype: false,
                         visibility: Visibility::Public,
                         parent_id: None,
-                        declaration_order: props.len() as u32,
+                        declaration_order,
                         is_string_named: false,
                     });
                 }
@@ -1150,6 +1154,7 @@ impl<'a> CheckerState<'a> {
             let display_module_name = (has_named_props && preserve_namespace_display)
                 .then(|| self.resolve_namespace_display_module_name(&exports_table, module_name));
             let namespace_type = has_named_props.then(|| {
+                Self::normalize_namespace_export_declaration_order(&mut props);
                 let namespace_type = factory.object(props);
                 if let Some(display_module_name) = display_module_name.as_ref() {
                     self.ctx

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -807,12 +807,13 @@ impl<'a> CheckerState<'a> {
             module_name,
             Some(self.ctx.current_file_idx),
         ) {
-            let exports_table_target = exports_table
+            let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
+            let exports_table_target = ordered_exports
                 .iter()
-                .find_map(|(_, &export_sym_id)| self.ctx.resolve_symbol_file_index(export_sym_id))
+                .find_map(|(_, export_sym_id)| self.ctx.resolve_symbol_file_index(*export_sym_id))
                 .or(target_idx);
             let mut props = Vec::new();
-            for (name, &export_sym_id) in exports_table.iter() {
+            for &(name, export_sym_id) in &ordered_exports {
                 if let Some(owner_file_idx) = exports_table_target {
                     self.ctx
                         .register_symbol_file_target(export_sym_id, owner_file_idx);
@@ -899,6 +900,11 @@ impl<'a> CheckerState<'a> {
                 }
                 let prop_type =
                     self.namespace_import_export_property_type(module_name, export_sym_id);
+                let declaration_order = if name == "default" {
+                    1
+                } else {
+                    props.len() as u32 + 2
+                };
                 props.push(PropertyInfo {
                     name: self.ctx.types.intern_string(name),
                     type_id: prop_type,
@@ -909,7 +915,7 @@ impl<'a> CheckerState<'a> {
                     is_class_prototype: false,
                     visibility: Visibility::Public,
                     parent_id: None,
-                    declaration_order: 0,
+                    declaration_order,
                     is_string_named: false,
                 });
             }
@@ -919,6 +925,7 @@ impl<'a> CheckerState<'a> {
                 &exports_table,
                 &mut props,
             );
+            Self::normalize_namespace_export_declaration_order(&mut props);
             let namespace_type = self.ctx.types.factory().object(props);
             self.ctx.namespace_module_names.insert(
                 namespace_type,

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -272,7 +272,9 @@ impl<'a> CheckerState<'a> {
                                 }
                             })
                             .collect();
-                        display_props.sort_by_key(|a| a.name);
+                        crate::query_boundaries::common::normalize_display_property_order(
+                            &mut display_props,
+                        );
                         self.ctx
                             .types
                             .store_display_properties(type_id, display_props);

--- a/crates/tsz-checker/tests/conformance_issues/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/mod.rs
@@ -1,0 +1,10 @@
+//! Unit tests documenting known conformance test failures.
+//!
+//! These tests are marked `#[ignore]` and document specific issues found during
+//! conformance investigation.
+
+mod core;
+mod errors;
+mod features;
+mod modules;
+mod types;

--- a/crates/tsz-checker/tests/conformance_issues/modules/context.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/context.rs
@@ -1,4 +1,4 @@
-use super::super::core::*;
+use crate::core::*;
 
 #[test]
 fn test_js_constructor_branch_property_visible_cross_file() {
@@ -350,6 +350,10 @@ namedFoo.toExponential(2);
         "Expected TS2339 to report against the full export= object surface. Actual diagnostics: {diagnostics:#?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Multi-file helpers for cross-file type-only export tests
+// ---------------------------------------------------------------------------
 
 fn compile_two_files_get_diagnostics_with_options(
     a_source: &str,

--- a/crates/tsz-checker/tests/export_equals_display_order_tests.rs
+++ b/crates/tsz-checker/tests/export_equals_display_order_tests.rs
@@ -1,0 +1,330 @@
+use rustc_hash::FxHashSet;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::module_resolution::build_module_resolution_maps;
+use tsz_checker::state::CheckerState;
+use tsz_common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+struct NamespaceCheckResult {
+    formatted: String,
+    display_props: Vec<(String, u32)>,
+    shape_props: Vec<(String, u32)>,
+    diagnostics: FxHashSet<String>,
+}
+
+fn check_namespace_symbol(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    symbol_name: &str,
+    options: CheckerOptions,
+) -> NamespaceCheckResult {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let entry_idx = file_names
+        .iter()
+        .position(|name| name == entry_file)
+        .expect("entry file should exist");
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+    checker.ctx.report_unresolved_imports = true;
+
+    checker.check_source_file(roots[entry_idx]);
+
+    let sym_id = checker
+        .ctx
+        .binder
+        .file_locals
+        .get(symbol_name)
+        .expect("import symbol should exist");
+    let ty = checker.get_type_of_symbol(sym_id);
+
+    NamespaceCheckResult {
+        formatted: checker.format_type_diagnostic(ty),
+        display_props: checker
+            .ctx
+            .types
+            .get_display_properties(ty)
+            .map(|props| {
+                props
+                    .iter()
+                    .map(|prop| {
+                        (
+                            checker.ctx.types.resolve_atom_ref(prop.name).to_string(),
+                            prop.declaration_order,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+        shape_props: tsz_solver::type_queries::get_object_shape(checker.ctx.types, ty).map_or(
+            Vec::new(),
+            |shape| {
+                shape
+                    .properties
+                    .iter()
+                    .map(|prop| {
+                        (
+                            checker.ctx.types.resolve_atom_ref(prop.name).to_string(),
+                            prop.declaration_order,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            },
+        ),
+        diagnostics: checker
+            .ctx
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == 2322)
+            .map(|d| d.message_text.clone())
+            .collect(),
+    }
+}
+
+fn checker_options() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES2020,
+        no_lib: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn assert_default_before_named_exports(message: &str) {
+    assert!(
+        message.contains("Type '{ default:"),
+        "Expected TS2322 source type to render default before named exports. Actual: {message}"
+    );
+    assert!(
+        !message.contains("Type '{ configs:"),
+        "Expected TS2322 source type to avoid name-order rendering. Actual: {message}"
+    );
+}
+
+#[test]
+fn export_equals_typeof_import_namespace_preserves_default_before_named_exports() {
+    let result = check_namespace_symbol(
+        &[
+            (
+                "/pkg/index.d.ts",
+                r#"
+declare const pluginImportX: typeof import("./lib/index");
+export = pluginImportX;
+"#,
+            ),
+            (
+                "/pkg/lib/index.d.ts",
+                r#"
+interface PluginConfig {
+    parser?: string | null;
+}
+declare const configs: {
+    "stage-0": PluginConfig;
+};
+declare const _default: {
+    configs: {
+        "stage-0": PluginConfig;
+    };
+};
+export default _default;
+export { configs };
+"#,
+            ),
+            (
+                "/main.ts",
+                r#"
+import * as pluginImportX from "./pkg/index";
+interface Plugin {
+  configs?: { [key: string]: { parser: string | null } };
+}
+const p: Plugin = pluginImportX;
+"#,
+            ),
+        ],
+        "/main.ts",
+        "pluginImportX",
+        checker_options(),
+    );
+
+    assert_eq!(result.formatted, "typeof import(\"lib/index\")");
+    assert!(
+        result.display_props.is_empty(),
+        "Expected no display properties, got: {:?}",
+        result.display_props
+    );
+    assert_eq!(
+        result.shape_props,
+        vec![("configs".to_string(), 2), ("default".to_string(), 1)],
+        "Expected namespace object shape to preserve default-before-configs declaration order"
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "Expected one TS2322, got: {:#?}",
+        result.diagnostics
+    );
+    let message = result
+        .diagnostics
+        .iter()
+        .next()
+        .expect("TS2322 should exist");
+    assert_default_before_named_exports(message);
+}
+
+#[test]
+fn import_equals_commonjs_value_type_preserves_default_before_named_exports() {
+    let result = check_namespace_symbol(
+        &[
+            (
+                "/pkg/index.d.ts",
+                r#"
+declare const pluginImportX: typeof import("./lib/index");
+export = pluginImportX;
+"#,
+            ),
+            (
+                "/pkg/lib/index.d.ts",
+                r#"
+interface PluginConfig {
+    parser?: string | null;
+}
+declare const configs: {
+    "stage-0": PluginConfig;
+};
+declare const _default: {
+    configs: {
+        "stage-0": PluginConfig;
+    };
+};
+export default _default;
+export { configs };
+"#,
+            ),
+            (
+                "/main.ts",
+                r#"
+import pluginImportX = require("./pkg/index");
+interface Plugin {
+  configs?: { [key: string]: { parser: string | null } };
+}
+const p: Plugin = pluginImportX;
+"#,
+            ),
+        ],
+        "/main.ts",
+        "pluginImportX",
+        checker_options(),
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "Expected one TS2322, got: {:#?}",
+        result.diagnostics
+    );
+    let message = result
+        .diagnostics
+        .iter()
+        .next()
+        .expect("TS2322 should exist");
+    assert_default_before_named_exports(message);
+}
+
+#[test]
+fn namespace_export_shape_preserves_source_order_for_three_named_exports() {
+    let result = check_namespace_symbol(
+        &[
+            (
+                "/pkg/index.d.ts",
+                r#"
+declare const pluginImportX: typeof import("./lib/index");
+export = pluginImportX;
+"#,
+            ),
+            (
+                "/pkg/lib/index.d.ts",
+                r#"
+declare const zebra: { kind: "zebra" };
+declare const alpha: { kind: "alpha" };
+declare const middle: { kind: "middle" };
+declare const _default: {
+    zebra: typeof zebra;
+    alpha: typeof alpha;
+    middle: typeof middle;
+};
+export default _default;
+export { zebra, alpha, middle };
+"#,
+            ),
+            (
+                "/main.ts",
+                r#"
+import pluginImportX = require("./pkg/index");
+interface Plugin {
+  zebra: number;
+  alpha: number;
+  middle: number;
+}
+const p: Plugin = pluginImportX;
+"#,
+            ),
+        ],
+        "/main.ts",
+        "pluginImportX",
+        checker_options(),
+    );
+
+    assert_eq!(result.formatted, "typeof import(\"lib/index\")");
+    let mut shape_props = result.shape_props.clone();
+    shape_props.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        shape_props,
+        vec![
+            ("alpha".to_string(), 3),
+            ("default".to_string(), 1),
+            ("middle".to_string(), 4),
+            ("zebra".to_string(), 2),
+        ],
+        "Expected namespace object shape to keep named exports in source declaration order"
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "Expected one TS2322, got: {:#?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-checker/tests/js_export_surface_tests.rs
+++ b/crates/tsz-checker/tests/js_export_surface_tests.rs
@@ -270,15 +270,19 @@ fn format_commonjs_single_file_symbol_type(
     checker.format_type(symbol_type)
 }
 
-#[allow(dead_code)]
-fn format_commonjs_two_file_consumer_symbol_type(
+struct ConsumerSymbolInspection {
+    formatted: String,
+    shape_props: Vec<(String, u32)>,
+}
+
+fn inspect_commonjs_two_file_consumer_symbol(
     producer_name: &str,
     producer_source: &str,
     consumer_name: &str,
     consumer_source: &str,
     consumer_symbol_name: &str,
     module_specifier: &str,
-) -> String {
+) -> ConsumerSymbolInspection {
     let mut parser_a = ParserState::new(producer_name.to_string(), producer_source.to_string());
     let root_a = parser_a.parse_source_file();
     let mut binder_a = BinderState::new();
@@ -351,7 +355,24 @@ fn format_commonjs_two_file_consumer_symbol_type(
 
     checker.check_source_file(root_b);
     let symbol_type = checker.get_type_of_symbol(sym_id);
-    checker.format_type(symbol_type)
+
+    ConsumerSymbolInspection {
+        formatted: checker.format_type(symbol_type),
+        shape_props: tsz_solver::type_queries::get_object_shape(checker.ctx.types, symbol_type)
+            .map(|shape| {
+                shape
+                    .properties
+                    .iter()
+                    .map(|prop| {
+                        (
+                            checker.ctx.types.resolve_atom_ref(prop.name).to_string(),
+                            prop.declaration_order,
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
 }
 
 // ==========================================================================
@@ -405,6 +426,65 @@ new mod.Baz();
     assert!(
         ts2339.is_empty(),
         "Expected no TS2339 for require() of module.exports object literal class property, got: {ts2339:#?}"
+    );
+}
+
+#[test]
+fn test_js_export_surface_preserves_default_before_late_exports_assignment() {
+    let inspection = inspect_commonjs_two_file_consumer_symbol(
+        "lib.js",
+        r#"
+const defaultConfig = { parser: "babel" };
+module.exports = { default: defaultConfig };
+exports.configs = { "stage-0": defaultConfig };
+"#,
+        "consumer.ts",
+        r#"
+import lib = require("./lib.js");
+const value = lib;
+"#,
+        "value",
+        "./lib.js",
+    );
+
+    assert!(
+        inspection.formatted.starts_with("typeof import(\""),
+        "Expected require() namespace import to keep a module-style display name, got: {}",
+        inspection.formatted
+    );
+    assert_eq!(
+        inspection.shape_props,
+        vec![("configs".to_string(), 2), ("default".to_string(), 1)],
+        "Expected JS export surface namespace shape to preserve default-before-configs order"
+    );
+}
+
+#[test]
+fn test_js_export_surface_preserves_plain_exports_assignment_order() {
+    let inspection = inspect_commonjs_two_file_consumer_symbol(
+        "lib.js",
+        r#"
+exports.zzz = 1;
+exports.aaa = 2;
+"#,
+        "consumer.ts",
+        r#"
+import lib = require("./lib.js");
+const value = lib;
+"#,
+        "value",
+        "./lib.js",
+    );
+
+    assert!(
+        inspection.formatted.starts_with("typeof import(\""),
+        "Expected require() namespace import to keep a module-style display name, got: {}",
+        inspection.formatted
+    );
+    assert_eq!(
+        inspection.shape_props,
+        vec![("aaa".to_string(), 2), ("zzz".to_string(), 1)],
+        "Expected JS export surface namespace shape to preserve first-seen exports assignment order"
     );
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -1273,31 +1273,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         original_members: &[TypeId],
         result: TypeId,
     ) {
-        use tsz_common::interner::Atom;
-        let mut merged_display_props: rustc_hash::FxHashMap<Atom, crate::PropertyInfo> =
-            rustc_hash::FxHashMap::default();
-
-        for &member in original_members {
-            if let Some(props) = self.interner.get_display_properties(member) {
-                for prop in props.as_ref() {
-                    merged_display_props
-                        .entry(prop.name)
-                        .and_modify(|existing| {
-                            if existing.type_id != prop.type_id {
-                                existing.type_id = self
-                                    .interner
-                                    .intersect_types_raw2(existing.type_id, prop.type_id);
-                            }
-                        })
-                        .or_insert_with(|| prop.clone());
-                }
-            }
-        }
-
-        if !merged_display_props.is_empty() {
-            let mut display_vec: Vec<crate::PropertyInfo> =
-                merged_display_props.into_values().collect();
-            display_vec.sort_by_key(|p| p.name.0);
+        let display_vec = crate::types::merge_display_properties_for_intersection(
+            self.interner,
+            original_members,
+        );
+        if !display_vec.is_empty() {
             self.interner.store_display_properties(result, display_vec);
         }
     }

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1420,31 +1420,11 @@ impl<'a> TypeInstantiator<'a> {
         original_members: &[TypeId],
         result: TypeId,
     ) {
-        use tsz_common::interner::Atom;
-        let mut merged_display_props: rustc_hash::FxHashMap<Atom, crate::PropertyInfo> =
-            rustc_hash::FxHashMap::default();
-
-        for &member in original_members {
-            if let Some(props) = self.interner.get_display_properties(member) {
-                for prop in props.as_ref() {
-                    merged_display_props
-                        .entry(prop.name)
-                        .and_modify(|existing| {
-                            if existing.type_id != prop.type_id {
-                                existing.type_id = self
-                                    .interner
-                                    .intersect_types_raw2(existing.type_id, prop.type_id);
-                            }
-                        })
-                        .or_insert_with(|| prop.clone());
-                }
-            }
-        }
-
-        if !merged_display_props.is_empty() {
-            let mut display_vec: Vec<crate::PropertyInfo> =
-                merged_display_props.into_values().collect();
-            display_vec.sort_by_key(|p| p.name.0);
+        let display_vec = crate::types::merge_display_properties_for_intersection(
+            self.interner,
+            original_members,
+        );
+        if !display_vec.is_empty() {
             self.interner.store_display_properties(result, display_vec);
         }
     }

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -11,6 +11,7 @@ use crate::types::{
     CallableShape, ConditionalType, FunctionShape, IntrinsicKind, LiteralValue, MappedType,
     ObjectFlags, ObjectShape, ObjectShapeId, OrderedFloat, PropertyInfo, SymbolRef, TemplateSpan,
     TupleElement, TypeApplication, TypeData, TypeId, TypeParamInfo,
+    normalize_display_property_order,
 };
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
@@ -1283,14 +1284,8 @@ impl TypeInterner {
         widened_properties: Vec<PropertyInfo>,
         display_properties: Vec<PropertyInfo>,
     ) -> TypeId {
-        // Capture display property declaration order before interning
         let mut display_props = display_properties;
-        for (i, prop) in display_props.iter_mut().enumerate() {
-            if prop.declaration_order == 0 {
-                prop.declaration_order = (i + 1) as u32;
-            }
-        }
-        display_props.sort_by_key(|a| a.name);
+        normalize_display_property_order(&mut display_props);
 
         // Intern the widened properties as the canonical type
         let type_id = self.object_with_flags(widened_properties, ObjectFlags::FRESH_LITERAL);

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -720,26 +720,8 @@ impl TypeInterner {
         };
 
         // Propagate display properties from input objects to the merged result.
-        let mut merged_display_props: rustc_hash::FxHashMap<Atom, PropertyInfo> =
-            rustc_hash::FxHashMap::default();
-        for &member in members {
-            if let Some(props) = self.get_display_properties(member) {
-                for prop in props.as_ref() {
-                    merged_display_props
-                        .entry(prop.name)
-                        .and_modify(|existing| {
-                            if existing.type_id != prop.type_id {
-                                existing.type_id =
-                                    self.intersect_types_raw2(existing.type_id, prop.type_id);
-                            }
-                        })
-                        .or_insert_with(|| prop.clone());
-                }
-            }
-        }
-        if !merged_display_props.is_empty() {
-            let mut display_vec: Vec<PropertyInfo> = merged_display_props.into_values().collect();
-            display_vec.sort_by_key(|p| p.name.0);
+        let display_vec = crate::types::merge_display_properties_for_intersection(self, members);
+        if !display_vec.is_empty() {
             self.store_display_properties(result, display_vec);
         }
 

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -253,7 +253,7 @@ pub use types::{
 pub use types::{
     CallSignature, CallableShapeId, IntrinsicKind, LiteralValue, MappedModifier, ObjectShapeId,
     PropertyInfo, PropertyLookup, SymbolRef, TypeApplication, TypeApplicationId, TypeData, TypeId,
-    TypeListId, Visibility, is_compiler_managed_type,
+    TypeListId, Visibility, is_compiler_managed_type, normalize_display_property_order,
 };
 // unsoundness_audit: accessed via tsz_solver::unsoundness_audit module path
 pub use widening::*;

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1079,6 +1079,65 @@ impl PropertyInfo {
     }
 }
 
+/// Normalize display-only properties for diagnostic storage.
+///
+/// Unlike canonical object properties, display properties should preserve
+/// source-facing member order rather than name order. Explicit declaration
+/// orders come first; any unordered trailing members keep their existing
+/// sequence after the ordered segment. The final dense renumbering gives later
+/// display-time merges a stable ordering signal.
+pub fn normalize_display_property_order(props: &mut [PropertyInfo]) {
+    props.sort_by(
+        |a, b| match (a.declaration_order > 0, b.declaration_order > 0) {
+            (true, true) => a.declaration_order.cmp(&b.declaration_order),
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            (false, false) => std::cmp::Ordering::Equal,
+        },
+    );
+
+    for (idx, prop) in props.iter_mut().enumerate() {
+        prop.declaration_order = idx as u32 + 1;
+    }
+}
+
+/// Merge display-only properties from multiple intersection members while
+/// preserving first-seen source order.
+pub fn merge_display_properties_for_intersection(
+    db: &dyn crate::TypeDatabase,
+    members: &[TypeId],
+) -> Vec<PropertyInfo> {
+    let mut merged: Vec<PropertyInfo> = Vec::new();
+    let mut prop_indices: rustc_hash::FxHashMap<Atom, usize> = rustc_hash::FxHashMap::default();
+
+    for &member in members {
+        let Some(props) = db.get_display_properties(member) else {
+            continue;
+        };
+
+        for prop in props.as_ref() {
+            if let Some(&idx) = prop_indices.get(&prop.name) {
+                let existing: &mut PropertyInfo = &mut merged[idx];
+                if existing.type_id != prop.type_id {
+                    existing.type_id = db.intersect_types_raw2(existing.type_id, prop.type_id);
+                }
+                if existing.write_type != prop.write_type {
+                    existing.write_type =
+                        db.intersect_types_raw2(existing.write_type, prop.write_type);
+                }
+            } else {
+                prop_indices.insert(prop.name, merged.len());
+                merged.push(prop.clone());
+            }
+        }
+    }
+
+    for (idx, prop) in merged.iter_mut().enumerate() {
+        prop.declaration_order = idx as u32 + 1;
+    }
+    merged
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PropertyLookup {
     Found(usize),

--- a/crates/tsz-solver/tests/types_tests.rs
+++ b/crates/tsz-solver/tests/types_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::TypeInterner;
 
 #[test]
 fn test_type_id_intrinsics() {
@@ -151,6 +152,156 @@ fn test_ordered_float_infinity() {
     assert_eq!(pos_inf, OrderedFloat(f64::INFINITY));
     assert_eq!(neg_inf, OrderedFloat(f64::NEG_INFINITY));
     assert_ne!(pos_inf, neg_inf);
+}
+
+#[test]
+fn test_normalize_display_property_order_preserves_declaration_sequence() {
+    let interner = tsz_common::interner::ShardedInterner::new();
+    let default_name = interner.intern("default");
+    let configs_name = interner.intern("configs");
+
+    let mut props = vec![
+        PropertyInfo {
+            name: configs_name,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            declaration_order: 2,
+            ..PropertyInfo::new(configs_name, TypeId::STRING)
+        },
+        PropertyInfo {
+            name: default_name,
+            type_id: TypeId::NUMBER,
+            write_type: TypeId::NUMBER,
+            declaration_order: 1,
+            ..PropertyInfo::new(default_name, TypeId::NUMBER)
+        },
+    ];
+
+    normalize_display_property_order(&mut props);
+
+    assert_eq!(props[0].name, default_name);
+    assert_eq!(props[1].name, configs_name);
+    assert_eq!(props[0].declaration_order, 1);
+    assert_eq!(props[1].declaration_order, 2);
+}
+
+#[test]
+fn test_normalize_display_property_order_prioritizes_explicit_order_before_unset_members() {
+    let interner = tsz_common::interner::ShardedInterner::new();
+    let default_name = interner.intern("default");
+    let configs_name = interner.intern("configs");
+
+    let mut props = vec![
+        PropertyInfo {
+            name: configs_name,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            declaration_order: 0,
+            ..PropertyInfo::new(configs_name, TypeId::STRING)
+        },
+        PropertyInfo {
+            name: default_name,
+            type_id: TypeId::NUMBER,
+            write_type: TypeId::NUMBER,
+            declaration_order: 1,
+            ..PropertyInfo::new(default_name, TypeId::NUMBER)
+        },
+    ];
+
+    normalize_display_property_order(&mut props);
+
+    assert_eq!(props[0].name, default_name);
+    assert_eq!(props[1].name, configs_name);
+    assert_eq!(props[0].declaration_order, 1);
+    assert_eq!(props[1].declaration_order, 2);
+}
+
+#[test]
+fn test_merge_display_properties_for_intersection_preserves_first_seen_order() {
+    let interner = TypeInterner::new();
+    let default_name = interner.intern_string("default");
+    let configs_name = interner.intern_string("configs");
+
+    let mk_prop = |name, type_id, declaration_order| PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        declaration_order,
+        ..PropertyInfo::new(name, type_id)
+    };
+
+    let left = interner.object(vec![
+        mk_prop(configs_name, TypeId::STRING, 2),
+        mk_prop(default_name, TypeId::NUMBER, 1),
+    ]);
+    interner.store_display_properties(
+        left,
+        vec![
+            mk_prop(default_name, TypeId::NUMBER, 1),
+            mk_prop(configs_name, TypeId::STRING, 2),
+        ],
+    );
+
+    let right = interner.object(vec![
+        mk_prop(configs_name, TypeId::STRING, 2),
+        mk_prop(default_name, TypeId::NUMBER, 1),
+    ]);
+    interner.store_display_properties(
+        right,
+        vec![
+            mk_prop(default_name, TypeId::NUMBER, 1),
+            mk_prop(configs_name, TypeId::STRING, 2),
+        ],
+    );
+
+    let merged = merge_display_properties_for_intersection(&interner, &[left, right]);
+
+    assert_eq!(merged.len(), 2);
+    assert_eq!(merged[0].name, default_name);
+    assert_eq!(merged[1].name, configs_name);
+    assert_eq!(merged[0].declaration_order, 1);
+    assert_eq!(merged[1].declaration_order, 2);
+}
+
+#[test]
+fn test_merge_display_properties_for_intersection_keeps_left_to_right_member_sequence() {
+    let interner = TypeInterner::new();
+    let b_name = interner.intern_string("b");
+    let c_name = interner.intern_string("c");
+    let a_name = interner.intern_string("a");
+
+    let mk_prop = |name, type_id, declaration_order| PropertyInfo {
+        name,
+        type_id,
+        write_type: type_id,
+        declaration_order,
+        ..PropertyInfo::new(name, type_id)
+    };
+
+    let left = interner.object(vec![
+        mk_prop(b_name, TypeId::STRING, 2),
+        mk_prop(c_name, TypeId::BOOLEAN, 3),
+    ]);
+    interner.store_display_properties(
+        left,
+        vec![
+            mk_prop(b_name, TypeId::STRING, 2),
+            mk_prop(c_name, TypeId::BOOLEAN, 3),
+        ],
+    );
+
+    let right = interner.object(vec![mk_prop(a_name, TypeId::NUMBER, 1)]);
+    interner.store_display_properties(right, vec![mk_prop(a_name, TypeId::NUMBER, 1)]);
+
+    let merged = merge_display_properties_for_intersection(&interner, &[left, right]);
+
+    assert_eq!(merged.len(), 3);
+    assert_eq!(merged[0].name, b_name);
+    assert_eq!(merged[1].name, c_name);
+    assert_eq!(merged[2].name, a_name);
+    assert_eq!(merged[0].declaration_order, 1);
+    assert_eq!(merged[1].declaration_order, 2);
+    assert_eq!(merged[2].declaration_order, 3);
 }
 
 // ============================================================================


### PR DESCRIPTION
TS2322 parity was still unstable for CommonJS and namespace-object paths. Several namespace builders assigned declaration_order while iterating FxHashMap-backed export tables, so named exports could drift away from source order once there were 3+ properties. Merged display properties could also be re-sorted by per-member counters, which moved later intersection members ahead of earlier contributors.

Order namespace exports by declaration span, normalize default and named exports before interning, and preserve left-to-right first-seen order when merging display properties. This also normalizes JS export surfaces and adds focused regressions for export =, synthetic default namespace imports, and exports.* surfaces.

Keep conformance_issues as a real Cargo test target again and route the checker-side helper calls through query boundaries so the rebased branch continues to satisfy the architecture guards.