### PR TITLE
fix(checker): preserve union-of-literals receiver in TS2339 display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -667,11 +667,24 @@ impl<'a> CheckerState<'a> {
         }
         // Only widen object-like types (to convert literal properties to primitives).
         // For literal/primitive receiver types (e.g., `""`, `42`), tsc preserves the
-        // literal in TS2339 messages (e.g., `'""'` not `'string'`).
+        // literal in TS2339 messages (e.g., `'""'` not `'string'`).  Unions whose
+        // every member is a literal are also preserved (e.g., `"foo" | "bar"`) —
+        // widening them to `string` loses discriminative information tsc keeps in
+        // property-existence diagnostics.
         let is_literal_or_primitive =
             crate::query_boundaries::common::literal_value(self.ctx.types, ty).is_some()
                 || crate::query_boundaries::common::is_primitive_type(self.ctx.types, ty);
-        let ty = if is_literal_or_primitive {
+        let is_union_of_literals = !is_literal_or_primitive
+            && crate::query_boundaries::common::union_members(self.ctx.types, ty).is_some_and(
+                |members| {
+                    !members.is_empty()
+                        && members.iter().all(|&m| {
+                            crate::query_boundaries::common::literal_value(self.ctx.types, m)
+                                .is_some()
+                        })
+                },
+            );
+        let ty = if is_literal_or_primitive || is_union_of_literals {
             ty
         } else {
             self.widen_type_for_display(ty)


### PR DESCRIPTION
## Summary

When a property access fails on a union whose members are all literal types (e.g., `x: \"foo\" | \"bar\"`), tsc preserves the literal union in the TS2339 message (`Property 'nope' does not exist on type '\"foo\" | \"bar\"'`) rather than widening to the common primitive (`string`).

`format_property_receiver_type_for_diagnostic` previously widened anything that wasn't a bare literal or primitive, collapsing literal unions to their base type. Extend the literal/primitive guard to also skip widening when every union member is a literal — that form is already as narrow as it gets, and widening loses the discriminative information users need to diagnose the issue.

## Conformance delta

+4 tests, 0 real regressions. `unionPropertyExistence.ts` is the intended target; the other three improvements are bonus fingerprint parity in nearby tests.

## Test plan

- [x] Target test `unionPropertyExistence.ts` passes with tsc-matching display `'\"foo\" | \"bar\"'`.
- [x] `scripts/session/verify-all.sh --quick` — fmt, clippy, unit tests, conformance +3 (net of flaky tests).
- [x] Full conformance run: 12052/12581 (95.8%), +4 improvements, 0 true regressions.