### PR TITLE
fix(checker): emit TS2395 for interfaces/types in non-ambient namespaces

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -209,8 +209,14 @@ impl<'a> CheckerState<'a> {
                     // declare module "..." -- NOT a pure namespace
                     return false;
                 }
-                // Found an identifier-named module declaration (namespace)
-                found_ambient_namespace = true;
+                // Identifier-named module declaration. Only treat as "ambient
+                // namespace" when the namespace itself is in an ambient
+                // context (declare-prefixed or inside a .d.ts file). A regular
+                // `namespace N { ... }` produces runtime code and its members
+                // still participate in TS2395 export/local consistency checks.
+                if self.ctx.arena.is_in_ambient_context(parent) {
+                    found_ambient_namespace = true;
+                }
             }
             if parent_node.kind == syntax_kind_ext::SOURCE_FILE {
                 break;


### PR DESCRIPTION
## Summary
- `is_in_ambient_namespace_not_module` incorrectly treated **every** identifier-named `MODULE_DECLARATION` as ambient while walking up the AST, suppressing TS2395 for runtime namespaces.
- Gate the "found ambient namespace" flip on `arena.is_in_ambient_context(parent)` so only `declare namespace` (or namespaces inside `.d.ts`) qualify — plain `namespace N { ... }` lowers to an IIFE and must still enforce TS2395 consistency.
- Net +1 conformance (`duplicateSymbolsExportMatching.ts` FAIL → PASS); other deltas in verify-all were pre-existing parallel-run flakes (confirmed by stash + re-run in isolation).

## Test plan
- [x] `./scripts/conformance/conformance.sh run --filter duplicateSymbolsExportMatching.ts` → PASS
- [x] `./scripts/conformance/conformance.sh run --filter typeAliasesDoNotMerge.ts` → PASS (declare-namespace suppression still works)
- [x] `./scripts/conformance/conformance.sh run --filter mergedDeclarationExports.ts` → PASS
- [x] `scripts/safe-run.sh scripts/session/verify-all.sh --quick` → ALL SUITES PASSED (net +3)