### PR TITLE
fix(solver): update current_cond on instantiated-application tail calls

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -937,7 +937,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                 Some(crate::types::TypeData::Application(_))
                             )
                         {
-                            self.interner.store_display_alias(original_type_id, branch_app);
+                            self.interner
+                                .store_display_alias(original_type_id, branch_app);
                         }
                     }
                 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -470,6 +470,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                 self.interner().lookup(instantiated)
                             {
                                 let next_cond = self.interner().get_conditional(next_cond_id);
+                                current_cond = next_cond;
                                 tail_recursion_count += 1;
                                 continue;
                             }
@@ -565,6 +566,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             self.interner().lookup(instantiated)
                         {
                             let next_cond = self.interner().get_conditional(next_cond_id);
+                            current_cond = next_cond;
                             tail_recursion_count += 1;
                             continue;
                         }
@@ -696,6 +698,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         self.interner().lookup(instantiated)
                     {
                         let next_cond = self.interner().get_conditional(next_cond_id);
+                        current_cond = next_cond;
                         tail_recursion_count += 1;
                         continue;
                     }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -481,7 +481,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         }
                     }
                     // Direct Application branch.
-                    if matches!(self.interner().lookup(substituted_true), Some(TypeData::Application(_))) {
+                    if matches!(
+                        self.interner().lookup(substituted_true),
+                        Some(TypeData::Application(_))
+                    ) {
                         self.apparent_conditional_branch = Some(substituted_true);
                     }
                     return self.evaluate(substituted_true);
@@ -573,7 +576,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         self.apparent_conditional_branch = Some(cond.false_type);
                         return self.evaluate(instantiated);
                     }
-                    if matches!(self.interner().lookup(cond.false_type), Some(TypeData::Application(_))) {
+                    if matches!(
+                        self.interner().lookup(cond.false_type),
+                        Some(TypeData::Application(_))
+                    ) {
                         self.apparent_conditional_branch = Some(cond.false_type);
                     }
                 }
@@ -705,7 +711,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     self.apparent_conditional_branch = Some(result_branch);
                     return self.evaluate(instantiated);
                 }
-                if matches!(self.interner().lookup(result_branch), Some(TypeData::Application(_))) {
+                if matches!(
+                    self.interner().lookup(result_branch),
+                    Some(TypeData::Application(_))
+                ) {
                     self.apparent_conditional_branch = Some(result_branch);
                 }
             }

--- a/crates/tsz-solver/tests/compat_tests.rs
+++ b/crates/tsz-solver/tests/compat_tests.rs
@@ -5570,7 +5570,11 @@ fn test_explain_normalized_mapped_application_missing_property() {
 }
 
 #[test]
-fn test_explain_prefers_named_missing_property_over_late_bound_symbols() {
+fn test_explain_includes_late_bound_symbols_for_non_array_target() {
+    // For non-array-like targets (e.g., ArrayConstructor), tsc includes
+    // symbol-keyed names in the missing-property list alongside named
+    // properties. The checker must report all missing properties so the
+    // emitted TS2322 message matches tsc.
     let interner = TypeInterner::new();
 
     let length = interner.intern_string("length");
@@ -5588,16 +5592,16 @@ fn test_explain_prefers_named_missing_property_over_late_bound_symbols() {
     let reason = checker.explain_failure(source, target);
 
     match reason {
-        Some(SubtypeFailureReason::MissingProperty {
-            property_name,
+        Some(SubtypeFailureReason::MissingProperties {
+            property_names,
             source_type,
             target_type,
         }) => {
-            assert_eq!(property_name, length);
+            assert_eq!(property_names, vec![length, iterator, unscopables]);
             assert_eq!(source_type, source);
             assert_eq!(target_type, target);
         }
-        other => panic!("Expected MissingProperty for 'length', got {other:?}"),
+        other => panic!("Expected MissingProperties for all three, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary
- Three tail-recursion continuation sites in `evaluate_conditional` bound `next_cond` from a freshly instantiated Application but never assigned it to `current_cond`. The loop then re-processed the original conditional on the next iteration, the cycle detector on `(check, extends, true, false)` tripped on iteration 2, and TS2589 fired at the type reference site.
- Fixed all three sites (true-branch tail call, false-branch tail call, subtype-result-branch tail call) to properly update `current_cond = next_cond` before `continue`.
- Updated stale solver unit test `test_explain_prefers_named_missing_property_over_late_bound_symbols` (renamed to `test_explain_includes_late_bound_symbols_for_non_array_target`) to match post-#670 policy: for non-array-like targets (e.g. `ArrayConstructor`), symbol-keyed names are included in the missing-property list alongside named properties, so the reason is `MissingProperties { [length, [Symbol.iterator], [Symbol.unscopables]] }` rather than `MissingProperty { length }`.

## Why it matters
Patterns that tail-recurse through an Application form are common in real-world type libraries — for example:
```ts
type GetPath<T, P> =
  P extends readonly [] ? T :
  P extends readonly [infer A extends keyof T, ...infer R] ? GetPath<T[A], R> :
  never;
```
Before this fix, `GetPath<Obj, readonly ['a','b','c']>` incorrectly reported TS2589 on iteration 2 instead of resolving after 4 tail calls.

## Test plan
- [x] `cargo nextest run -p tsz-checker -E 'test(test_infer_extends_keyof_in_conditional_type) + test(test_infer_extends_keyof_tuple_pattern) + test(test_infer_extends_keyof_non_tuple) + test(test_infer_extends_concrete_constraint_still_works) + test(test_infer_extends_keyof_constraint_fails_correctly)'` — all 5 pass
- [x] `cargo nextest run -p tsz-solver -E 'test(test_explain_includes_late_bound_symbols_for_non_array_target)'` — passes
- [x] `scripts/safe-run.sh cargo nextest run` — 20919/20919 pass, 0 regressions
- [x] `cargo fmt --all --check` — clean