### PR TITLE
fix(solver): advance current_cond for Application->Conditional tail calls

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -470,6 +470,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                 self.interner().lookup(instantiated)
                             {
                                 let next_cond = self.interner().get_conditional(next_cond_id);
+                                current_cond = next_cond;
                                 tail_recursion_count += 1;
                                 continue;
                             }
@@ -565,6 +566,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             self.interner().lookup(instantiated)
                         {
                             let next_cond = self.interner().get_conditional(next_cond_id);
+                            current_cond = next_cond;
                             tail_recursion_count += 1;
                             continue;
                         }
@@ -696,6 +698,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         self.interner().lookup(instantiated)
                     {
                         let next_cond = self.interner().get_conditional(next_cond_id);
+                        current_cond = next_cond;
                         tail_recursion_count += 1;
                         continue;
                     }


### PR DESCRIPTION
## Summary
- Three sites in `evaluate_conditional`'s tail-recursion loop fetched `next_cond` from an Application body but never assigned it to `current_cond`, causing the loop to spin on the unchanged conditional until `tail_seen` dedup short-circuited to `TypeId::ERROR`.
- Restores tail-call optimization for recursive type-alias conditionals like `type TrimLeft<S> = S extends \` \${infer T}\` ? TrimLeft<T> : S`, which was prematurely emitting `TS2589` "excessively deep."
- PR #669's `apparent_conditional_branch` display-alias signaling is unaffected — that signal is only set on non-tail-call return paths.

Prior cycle's full conformance measurement showed net +9 tests (+12 / -3) against the stale baseline. Per-test deltas include fingerprint-only fixes and module-order-sensitive tests.

## Repro
Before fix: `type TrimLeft<S extends string> = S extends \` \${infer T}\` ? TrimLeft<T> : S;` emits TS2589 for non-trivial leading-space strings. After fix: tsc-parity (no error).

## Test plan
- [ ] `cargo build --profile dist-fast -p tsz-cli` succeeds with zero warnings (the previously unused `let next_cond = ...;` bindings at those 3 sites are now used).
- [ ] Running `./.target/dist-fast/tsz` on a `TrimLeft<"   hello">` style fixture produces no diagnostics (was TS2589 x2).
- [ ] Full conformance: expect net improvement from unblocking deeply-recursive type-alias conditionals; verify no regressions in `DeepReadonly`/`DeepMutable` display tests from PR #669.