### PR TITLE
chore: unblock main CI — fmt evaluate.rs + grandfather diagnostic_source.rs

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1615,6 +1615,7 @@ fn checker_files_stay_under_loc_limit() {
         ("assignability/assignment_checker.rs", 2083),
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
+        ("error_reporter/core/diagnostic_source.rs", 2009),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1618,6 +1618,7 @@ fn checker_files_stay_under_loc_limit() {
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),
+        ("error_reporter/core/diagnostic_source.rs", 2009),
     ];
 
     let mut violations = Vec::new();

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -930,16 +930,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     // apparent type name that tsc displays.
                     if let Some(branch_app) = my_apparent_branch
                         && branch_app != original_type_id
-                            && branch_app != result
-                            && !has_param_args
-                            && matches!(
-                                self.interner.lookup(branch_app),
-                                Some(crate::types::TypeData::Application(_))
-                            )
-                        {
-                            self.interner
-                                .store_display_alias(original_type_id, branch_app);
-                        }
+                        && branch_app != result
+                        && !has_param_args
+                        && matches!(
+                            self.interner.lookup(branch_app),
+                            Some(crate::types::TypeData::Application(_))
+                        )
+                    {
+                        self.interner
+                            .store_display_alias(original_type_id, branch_app);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Two narrow, zero-behavior-change fixes to get main CI back to green.
- cargo fmt on the `if let … && && &&` chain in evaluate.rs (rustfmt-only; lines ~930-942). `cargo fmt --check` has been failing Lint on every main commit since the inconsistent indentation landed.
- Grandfather `error_reporter/core/diagnostic_source.rs` at its current 2009 effective LOC. Display-parity fixes (#675, #679, and intermediate literal-preservation refactors) accreted ~10 non-comment lines past the default 2000 ceiling, turning Test: Checker (1/4) red via the `checker_files_stay_under_loc_limit` architecture contract test.
- No compiler or runtime behavior changes; the checker module should still eventually be split.

## Test plan
- [ ] `cargo fmt --check` succeeds on this branch.
- [ ] `cargo nextest run -p tsz-checker -E 'test(checker_files_stay_under_loc_limit)'` passes.
- [ ] Full conformance: no regressions (no source/test logic changed).