### PR TITLE
[codex] align keyof array conformance diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1682,6 +1682,15 @@ impl<'a> CheckerState<'a> {
             };
 
             let elem_type = self.elaboration_source_expression_type(elem_idx);
+            let contextual_request =
+                crate::context::TypingRequest::with_contextual_type(target_element_type);
+            let contextual_elem_type =
+                self.get_type_of_node_with_request(elem_idx, &contextual_request);
+            let contextual_elem_assignable = contextual_elem_type != TypeId::ERROR
+                && contextual_elem_type != TypeId::ANY
+                && target_element_type != TypeId::ERROR
+                && target_element_type != TypeId::ANY
+                && self.is_assignable_to(contextual_elem_type, target_element_type);
 
             // When the target element type is an index-signature-only type
             // (e.g., `NamedTransform { [name: string]: Transform3D }`),
@@ -1697,6 +1706,10 @@ impl<'a> CheckerState<'a> {
                 && !self
                     .target_has_named_property_for_any_source_prop(elem_idx, target_element_type);
 
+            if contextual_elem_assignable {
+                continue;
+            }
+
             // For object/array literal elements, use contextually-typed type
             // to decide whether to elaborate (avoids false positives from widening).
             // Pass the target element type as contextual type so literal types
@@ -1707,19 +1720,6 @@ impl<'a> CheckerState<'a> {
                 syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                     | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
             ) {
-                let contextual_request =
-                    crate::context::TypingRequest::with_contextual_type(target_element_type);
-                let contextual_elem_type =
-                    self.get_type_of_node_with_request(elem_idx, &contextual_request);
-                if contextual_elem_type != TypeId::ERROR
-                    && contextual_elem_type != TypeId::ANY
-                    && target_element_type != TypeId::ERROR
-                    && target_element_type != TypeId::ANY
-                    && self.is_assignable_to(contextual_elem_type, target_element_type)
-                {
-                    // Element is contextually assignable — no error needed.
-                    continue;
-                }
                 if !skip_deep_elaboration
                     && self.try_elaborate_assignment_source_error(elem_idx, target_element_type)
                 {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -631,6 +631,26 @@ impl<'a> CheckerState<'a> {
         if let Some(module_name) = self.ctx.namespace_module_names.get(&ty) {
             return format!("typeof import(\"{module_name}\")");
         }
+        let application_display = crate::query_boundaries::common::type_application(
+            self.ctx.types,
+            ty,
+        )
+        .map(|_| ty)
+        .or_else(|| {
+            self.ctx.types.get_display_alias(ty).filter(|&alias| {
+                crate::query_boundaries::common::type_application(self.ctx.types, alias).is_some()
+            })
+        });
+        if let Some(application_display) = application_display {
+            let display_ty =
+                self.normalize_property_receiver_application_display_type(application_display);
+            let mut formatter = self
+                .ctx
+                .create_diagnostic_type_formatter()
+                .with_display_properties()
+                .with_skip_application_alias_names();
+            return formatter.format(display_ty).into_owned();
+        }
         let has_object_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty).is_some();
         let has_def = self.ctx.definition_store.find_def_for_type(ty).is_some();

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -271,6 +271,134 @@ impl<'a> CheckerState<'a> {
         self.ctx.types.factory().object_with_index(widened_shape)
     }
 
+    pub(crate) fn normalize_property_receiver_application_display_type(
+        &mut self,
+        ty: TypeId,
+    ) -> TypeId {
+        let Some(app) = query::type_application(self.ctx.types, ty) else {
+            return ty;
+        };
+
+        let args: Vec<_> = app
+            .args
+            .iter()
+            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+            .collect();
+
+        if args == app.args {
+            ty
+        } else {
+            self.ctx.types.factory().application(app.base, args)
+        }
+    }
+
+    fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
+        let evaluated = self.evaluate_type_with_env(ty);
+        if evaluated != ty {
+            return self.normalize_property_receiver_application_display_arg(evaluated);
+        }
+
+        if let Some(app) = query::type_application(self.ctx.types, ty) {
+            let args: Vec<_> = app
+                .args
+                .iter()
+                .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+                .collect();
+            return if args == app.args {
+                ty
+            } else {
+                self.ctx.types.factory().application(app.base, args)
+            };
+        }
+
+        if let Some(members) = query::union_members(self.ctx.types, ty) {
+            let normalized: Vec<_> = members
+                .iter()
+                .map(|&member| self.normalize_property_receiver_application_display_arg(member))
+                .collect();
+            return if normalized == members {
+                ty
+            } else {
+                self.ctx.types.factory().union_preserve_members(normalized)
+            };
+        }
+
+        if let Some(members) = query::intersection_members(self.ctx.types, ty) {
+            let normalized: Vec<_> = members
+                .iter()
+                .map(|&member| self.normalize_property_receiver_application_display_arg(member))
+                .collect();
+            return if normalized == members {
+                ty
+            } else {
+                self.ctx.types.factory().intersection(normalized)
+            };
+        }
+
+        let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
+        else {
+            return ty;
+        };
+        let should_widen_properties =
+            crate::query_boundaries::common::is_fresh_object_type(self.ctx.types, ty)
+                || (self.ctx.types.get_display_properties(ty).is_some() && shape.symbol.is_none());
+        if !should_widen_properties {
+            return ty;
+        }
+
+        let mut normalized_shape = shape.as_ref().clone();
+        let mut changed = self.ctx.types.get_display_properties(ty).is_some();
+
+        for prop in &mut normalized_shape.properties {
+            let normalized_read =
+                self.normalize_property_receiver_application_display_arg(prop.type_id);
+            let normalized_write =
+                self.normalize_property_receiver_application_display_arg(prop.write_type);
+            let widened_read =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized_read);
+            let widened_write = crate::query_boundaries::common::widen_literal_type(
+                self.ctx.types,
+                normalized_write,
+            );
+
+            if widened_read != prop.type_id || widened_write != prop.write_type {
+                changed = true;
+            }
+
+            prop.type_id = widened_read;
+            prop.write_type = widened_write;
+        }
+
+        if let Some(index) = normalized_shape.string_index.as_mut() {
+            let normalized =
+                self.normalize_property_receiver_application_display_arg(index.value_type);
+            let widened =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized);
+            if widened != index.value_type {
+                changed = true;
+                index.value_type = widened;
+            }
+        }
+
+        if let Some(index) = normalized_shape.number_index.as_mut() {
+            let normalized =
+                self.normalize_property_receiver_application_display_arg(index.value_type);
+            let widened =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized);
+            if widened != index.value_type {
+                changed = true;
+                index.value_type = widened;
+            }
+        }
+
+        if changed {
+            self.ctx.types.factory().object_with_index(normalized_shape)
+        } else {
+            ty
+        }
+    }
+
     fn terminal_assignment_source_expression(&self, expr_idx: NodeIndex) -> NodeIndex {
         let mut current = expr_idx;
         let mut guard = 0;

--- a/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
@@ -232,6 +232,111 @@ let p: Passport = passport.use();
 }
 
 #[test]
+fn test_keyof_array_elaboration_reports_only_invalid_literal_element() {
+    let source = r#"
+function foo<T extends { a: string, b: string }>() {
+    let b: (keyof T)[] = ["a", "b", "c"];
+}
+"#;
+
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "test.ts",
+        source,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    let ts2322: Vec<_> = diagnostics.iter().filter(|diag| diag.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected only one TS2322 for the invalid array element.\nActual: {diagnostics:#?}"
+    );
+
+    let expected_start = source.find("\"c\"").expect("expected c literal") as u32;
+    assert_eq!(
+        ts2322[0].start,
+        expected_start,
+        "Expected TS2322 to anchor at the invalid \"c\" element.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        ts2322[0]
+            .message_text
+            .contains("Type 'string' is not assignable to type 'keyof T'"),
+        "Expected widened keyof-target TS2322 text.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_property_receiver_display_widens_fresh_object_application_args() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyPick<T, K extends keyof T> = { [P in K]: T[P] };
+declare function pick<T, K extends keyof T>(obj: T, propNames: K[]): MyPick<T, K>;
+
+const x = pick({ a: 10, b: 20, c: 30 }, ["a", "c"]);
+x.b;
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    let ts2339: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2339)
+        .collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected exactly one TS2339 for the missing property access.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    let message = diagnostic_message(&diagnostics, 2339).expect("expected TS2339");
+    assert_eq!(
+        message,
+        "Property 'b' does not exist on type 'MyPick<{ a: number; b: number; c: number; }, \"a\" | \"c\">'."
+    );
+}
+
+#[test]
+fn test_property_receiver_display_preserves_annotated_application_literals() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyPick<T, K extends keyof T> = { [P in K]: T[P] };
+
+declare const x: MyPick<{ a: 10; b: 20; c: 30 }, "a" | "c">;
+x.b;
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    let ts2339: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2339)
+        .collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected exactly one TS2339 for the annotated missing property access.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    let message = diagnostic_message(&diagnostics, 2339).expect("expected TS2339");
+    assert_eq!(
+        message,
+        "Property 'b' does not exist on type 'MyPick<{ a: 10; b: 20; c: 30; }, \"a\" | \"c\">'."
+    );
+}
+
+#[test]
 fn test_cross_binder_symbol_id_collision_emits_ts2322_for_this_return() {
     let passport_dts = r#"
 declare module 'passport' {


### PR DESCRIPTION
## Summary

Fix `keyofIsLiteralContexualType` by aligning both the TS2322 element elaboration and the TS2339 receiver display with `tsc`.

Root cause: tsz elaborated array literal elements using non-contextual element types and preserved display-only literal properties inside computed generic receiver applications, while `tsc` contextually rechecks array elements and widens fresh object-literal type arguments when formatting TS2339 receiver types.

## What changed

- contextually type every array literal element before deciding whether TS2322 elaboration is needed, so valid `keyof T` elements like `"a"` and `"b"` are no longer reported
- normalize property-receiver application displays so computed `Pick<{ a: 10; ... }, ...>` receivers widen fresh object-literal members to `number`/`string`/`boolean`, while explicit annotated applications still preserve literal args
- add checker regressions for:
  - the `keyof T` array elaboration anchor/count invariant
  - widening computed application receiver displays
  - preserving literal args for explicitly annotated application displays

## Repro

```ts
function foo<T extends { a: string; b: string }>() {
  let b: (keyof T)[] = ["a", "b", "c"];
}

declare function pick<T, K extends keyof T>(obj: T, propNames: K[]): Pick<T, K>;
const x = pick({ a: 10, b: 20, c: 30 }, ["a", "c"]);
x.b;
```

Expected:
- only `"c"` produces TS2322 in the array literal
- TS2339 formats the receiver as `Pick<{ a: number; b: number; c: number; }, "a" | "c">`

## Validation

- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `cargo nextest run --package tsz-checker test_keyof_array_elaboration_reports_only_invalid_literal_element`
- `cargo nextest run --package tsz-checker test_property_receiver_display_`
- `./scripts/conformance/conformance.sh run --filter "keyofIsLiteralContexualType" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`

Full-suite result from this run:
- `FINAL RESULTS: 12055/12581 passed (95.8%)`
