### PR TITLE
fix(checker): emit TS2420 for interface-side private/protected member mismatch

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1089,6 +1089,7 @@ impl<'a> CheckerState<'a> {
                                 (sym_flags & tsz_binder::symbol_flags::PRIVATE) != 0;
                             let is_class_member_protected =
                                 (sym_flags & tsz_binder::symbol_flags::PROTECTED) != 0;
+                            let interface_visibility = prop.visibility;
                             if is_class_member_private {
                                 self.error_at_node(
                                         class_error_idx,
@@ -1101,6 +1102,36 @@ impl<'a> CheckerState<'a> {
                                 self.error_at_node(
                                         class_error_idx,
                                         &format!("Class '{class_name}' incorrectly implements interface '{interface_display_name}'.\n  Property '{member_name}' is protected in type '{class_name}' but not in type '{interface_display_name}'."),
+                                        diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
+                                    );
+                                continue;
+                            }
+                            // Interface-side private/protected: an interface may inherit a
+                            // private/protected member from a base class (e.g., `interface I
+                            // extends Foo`). A class implementing that interface with a
+                            // non-private same-named property breaks nominal compatibility.
+                            //
+                            // For *protected*, if the class also extends the same base (so it
+                            // has the inherited protected brand), tsc allows the widened
+                            // public redeclaration. Skip the error in that case.
+                            //
+                            // For *private*, no such leniency — redeclaring a private member
+                            // is always a nominal mismatch even when the class extends the
+                            // declaring base.
+                            if interface_visibility == tsz_solver::Visibility::Private {
+                                self.error_at_node(
+                                        class_error_idx,
+                                        &format!("Class '{class_name}' incorrectly implements interface '{interface_display_name}'.\n  Property '{member_name}' is private in type '{interface_display_name}' but not in type '{class_name}'."),
+                                        diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
+                                    );
+                                continue;
+                            }
+                            if interface_visibility == tsz_solver::Visibility::Protected
+                                && !inherited_non_public_members.contains_key(&member_name)
+                            {
+                                self.error_at_node(
+                                        class_error_idx,
+                                        &format!("Class '{class_name}' incorrectly implements interface '{interface_display_name}'.\n  Property '{member_name}' is protected in type '{interface_display_name}' but not in type '{class_name}'."),
                                         diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
                                     );
                                 continue;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1614,6 +1614,7 @@ fn checker_files_stay_under_loc_limit() {
         ("assignability/assignment_checker.rs", 2083),
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
+        ("error_reporter/core/diagnostic_source.rs", 2009),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1614,7 +1614,6 @@ fn checker_files_stay_under_loc_limit() {
         ("assignability/assignment_checker.rs", 2083),
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
-        ("error_reporter/core/diagnostic_source.rs", 2009),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),


### PR DESCRIPTION
## Summary

Fingerprint-only pickup from `implementingAnInterfaceExtendingClassWithPrivates2.ts`: tsz was missing a TS2420 diagnostic at `test.ts:13:7` for `class Bar2 extends Foo implements I` where Foo has `private x` and Bar2 redeclares `x!: string` as public.

`class_implements_checker::core` only emitted TS2420 when the *class* side declared a `private`/`protected` member. The mirror case — when the *interface* has a private or protected property (typically via `interface I extends Foo` inheriting it) and the class's corresponding member is public — was silently accepted. Added the mirror-visibility branches after the class-side checks.

Two subtleties in the new branches:

- **Private**: always emit. Redeclaring a `private` member is a nominal mismatch even when the class extends the declaring base. tsc: *"Property 'x' is private in type 'I' but not in type 'Bar2'."*
- **Protected**: skip when the class inherits the same-named private/protected member through its own `extends` chain — tsc treats the redeclaration as a widening-visibility override in that case (e.g., `class Bar8 extends Foo implements I { x: string; ... }` where Foo has `protected x`). `inherited_non_public_members` is already computed upstream; the new branch consults it.

## Test plan

- [x] `./scripts/conformance/conformance.sh run --filter "implementingAnInterfaceExtendingClass"` → 3/3 PASS (was 2/3; `WithPrivates2.ts` fingerprint-only failure resolved, `WithProtecteds.ts` preserved).
- [x] `./scripts/conformance/conformance.sh run --filter "implement"` → 12/12 PASS.
- [x] `cargo nextest run -p tsz-checker` → 4835 tests run, 4835 passed.