### PR TITLE
fix(checker): preserve raw mixed contextual function types

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1682,6 +1682,15 @@ impl<'a> CheckerState<'a> {
             };
 
             let elem_type = self.elaboration_source_expression_type(elem_idx);
+            let contextual_request =
+                crate::context::TypingRequest::with_contextual_type(target_element_type);
+            let contextual_elem_type =
+                self.get_type_of_node_with_request(elem_idx, &contextual_request);
+            let contextual_elem_assignable = contextual_elem_type != TypeId::ERROR
+                && contextual_elem_type != TypeId::ANY
+                && target_element_type != TypeId::ERROR
+                && target_element_type != TypeId::ANY
+                && self.is_assignable_to(contextual_elem_type, target_element_type);
 
             // When the target element type is an index-signature-only type
             // (e.g., `NamedTransform { [name: string]: Transform3D }`),
@@ -1697,6 +1706,10 @@ impl<'a> CheckerState<'a> {
                 && !self
                     .target_has_named_property_for_any_source_prop(elem_idx, target_element_type);
 
+            if contextual_elem_assignable {
+                continue;
+            }
+
             // For object/array literal elements, use contextually-typed type
             // to decide whether to elaborate (avoids false positives from widening).
             // Pass the target element type as contextual type so literal types
@@ -1707,19 +1720,6 @@ impl<'a> CheckerState<'a> {
                 syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                     | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
             ) {
-                let contextual_request =
-                    crate::context::TypingRequest::with_contextual_type(target_element_type);
-                let contextual_elem_type =
-                    self.get_type_of_node_with_request(elem_idx, &contextual_request);
-                if contextual_elem_type != TypeId::ERROR
-                    && contextual_elem_type != TypeId::ANY
-                    && target_element_type != TypeId::ERROR
-                    && target_element_type != TypeId::ANY
-                    && self.is_assignable_to(contextual_elem_type, target_element_type)
-                {
-                    // Element is contextually assignable — no error needed.
-                    continue;
-                }
                 if !skip_deep_elaboration
                     && self.try_elaborate_assignment_source_error(elem_idx, target_element_type)
                 {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -631,6 +631,26 @@ impl<'a> CheckerState<'a> {
         if let Some(module_name) = self.ctx.namespace_module_names.get(&ty) {
             return format!("typeof import(\"{module_name}\")");
         }
+        let application_display = crate::query_boundaries::common::type_application(
+            self.ctx.types,
+            ty,
+        )
+        .map(|_| ty)
+        .or_else(|| {
+            self.ctx.types.get_display_alias(ty).filter(|&alias| {
+                crate::query_boundaries::common::type_application(self.ctx.types, alias).is_some()
+            })
+        });
+        if let Some(application_display) = application_display {
+            let display_ty =
+                self.normalize_property_receiver_application_display_type(application_display);
+            let mut formatter = self
+                .ctx
+                .create_diagnostic_type_formatter()
+                .with_display_properties()
+                .with_skip_application_alias_names();
+            return formatter.format(display_ty).into_owned();
+        }
         let has_object_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty).is_some();
         let has_def = self.ctx.definition_store.find_def_for_type(ty).is_some();

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -271,6 +271,134 @@ impl<'a> CheckerState<'a> {
         self.ctx.types.factory().object_with_index(widened_shape)
     }
 
+    pub(crate) fn normalize_property_receiver_application_display_type(
+        &mut self,
+        ty: TypeId,
+    ) -> TypeId {
+        let Some(app) = query::type_application(self.ctx.types, ty) else {
+            return ty;
+        };
+
+        let args: Vec<_> = app
+            .args
+            .iter()
+            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+            .collect();
+
+        if args == app.args {
+            ty
+        } else {
+            self.ctx.types.factory().application(app.base, args)
+        }
+    }
+
+    fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
+        let evaluated = self.evaluate_type_with_env(ty);
+        if evaluated != ty {
+            return self.normalize_property_receiver_application_display_arg(evaluated);
+        }
+
+        if let Some(app) = query::type_application(self.ctx.types, ty) {
+            let args: Vec<_> = app
+                .args
+                .iter()
+                .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+                .collect();
+            return if args == app.args {
+                ty
+            } else {
+                self.ctx.types.factory().application(app.base, args)
+            };
+        }
+
+        if let Some(members) = query::union_members(self.ctx.types, ty) {
+            let normalized: Vec<_> = members
+                .iter()
+                .map(|&member| self.normalize_property_receiver_application_display_arg(member))
+                .collect();
+            return if normalized == members {
+                ty
+            } else {
+                self.ctx.types.factory().union_preserve_members(normalized)
+            };
+        }
+
+        if let Some(members) = query::intersection_members(self.ctx.types, ty) {
+            let normalized: Vec<_> = members
+                .iter()
+                .map(|&member| self.normalize_property_receiver_application_display_arg(member))
+                .collect();
+            return if normalized == members {
+                ty
+            } else {
+                self.ctx.types.factory().intersection(normalized)
+            };
+        }
+
+        let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
+        else {
+            return ty;
+        };
+        let should_widen_properties =
+            crate::query_boundaries::common::is_fresh_object_type(self.ctx.types, ty)
+                || (self.ctx.types.get_display_properties(ty).is_some() && shape.symbol.is_none());
+        if !should_widen_properties {
+            return ty;
+        }
+
+        let mut normalized_shape = shape.as_ref().clone();
+        let mut changed = self.ctx.types.get_display_properties(ty).is_some();
+
+        for prop in &mut normalized_shape.properties {
+            let normalized_read =
+                self.normalize_property_receiver_application_display_arg(prop.type_id);
+            let normalized_write =
+                self.normalize_property_receiver_application_display_arg(prop.write_type);
+            let widened_read =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized_read);
+            let widened_write = crate::query_boundaries::common::widen_literal_type(
+                self.ctx.types,
+                normalized_write,
+            );
+
+            if widened_read != prop.type_id || widened_write != prop.write_type {
+                changed = true;
+            }
+
+            prop.type_id = widened_read;
+            prop.write_type = widened_write;
+        }
+
+        if let Some(index) = normalized_shape.string_index.as_mut() {
+            let normalized =
+                self.normalize_property_receiver_application_display_arg(index.value_type);
+            let widened =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized);
+            if widened != index.value_type {
+                changed = true;
+                index.value_type = widened;
+            }
+        }
+
+        if let Some(index) = normalized_shape.number_index.as_mut() {
+            let normalized =
+                self.normalize_property_receiver_application_display_arg(index.value_type);
+            let widened =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, normalized);
+            if widened != index.value_type {
+                changed = true;
+                index.value_type = widened;
+            }
+        }
+
+        if changed {
+            self.ctx.types.factory().object_with_index(normalized_shape)
+        } else {
+            ty
+        }
+    }
+
     fn terminal_assignment_source_expression(&self, expr_idx: NodeIndex) -> NodeIndex {
         let mut current = expr_idx;
         let mut guard = 0;

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -20,7 +20,7 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    fn raw_contextual_signature_available(&self, type_id: TypeId) -> bool {
+    pub(crate) fn raw_contextual_signature_available(&self, type_id: TypeId) -> bool {
         let helper = tsz_solver::ContextualTypeContext::with_expected_and_options(
             self.ctx.types,
             type_id,

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -347,7 +347,17 @@ impl<'a> CheckerState<'a> {
                     // (e.g. { [K in keyof Props]: Props[K] } after generic inference),
                     // evaluate them with the full resolver first so the solver can
                     // extract property types from the resulting concrete object type.
-                    let property_context_type = if let Some(ctx_type) = contextual_type {
+                    let function_property_lookup_context = if initializer_is_function_like
+                        && original_contextual_type
+                            .is_some_and(|ctx_type| self.primitive_union_member_has_property(ctx_type, &name))
+                    {
+                        original_contextual_type.or(contextual_type)
+                    } else {
+                        contextual_type
+                    };
+                    let property_context_type = if let Some(ctx_type) =
+                        function_property_lookup_context
+                    {
                         let lookup_type = self.contextual_lookup_type(ctx_type);
                         let lookup_presence =
                             self.named_contextual_property_presence(lookup_type, &name);
@@ -398,7 +408,7 @@ impl<'a> CheckerState<'a> {
                             Some(jsdoc_callable_context_type)
                         } else if jsdoc_declared_type.is_none() {
                             self.function_initializer_context_type(
-                                contextual_type,
+                                function_property_lookup_context,
                                 &name,
                                 property_context_type,
                                 prop.initializer,
@@ -424,7 +434,7 @@ impl<'a> CheckerState<'a> {
                         && initializer_context_type.is_none()
                         && initializer_is_function_like
                         && original_contextual_type.is_some_and(|ctx_type| {
-                            self.contextual_type_has_primitive_union_member(ctx_type)
+                            self.primitive_union_member_has_property(ctx_type, &name)
                         });
                     let resolved_prop_ctx = self.substitute_contextual_this_type(
                         jsdoc_declared_type.or(initializer_context_type).or(

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -308,27 +308,59 @@ impl<'a> CheckerState<'a> {
         };
         use crate::query_boundaries::common::PropertyAccessResult;
 
+        let resolved = self.resolve_type_for_property_access(type_id);
         let evaluated = self.evaluate_type_with_env(type_id);
+        let evaluated = self.resolve_type_for_property_access(evaluated);
         let evaluated = self.resolve_lazy_type(evaluated);
+        let evaluated = self.evaluate_application_type(evaluated);
 
-        let members = match classify_for_excess_properties(self.ctx.types, evaluated) {
-            ExcessPropertiesKind::Union(members) => members,
-            _ => return false,
+        let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)
+            .or_else(|| crate::query_boundaries::common::union_members(self.ctx.types, resolved))
+            .or_else(|| crate::query_boundaries::common::union_members(self.ctx.types, evaluated))
+            .or_else(|| match classify_for_excess_properties(self.ctx.types, type_id) {
+                ExcessPropertiesKind::Union(members) => Some(members),
+                _ => None,
+            })
+            .or_else(|| match classify_for_excess_properties(self.ctx.types, resolved) {
+                ExcessPropertiesKind::Union(members) => Some(members),
+                _ => None,
+            })
+            .or_else(|| match classify_for_excess_properties(self.ctx.types, evaluated) {
+                ExcessPropertiesKind::Union(members) => Some(members),
+                _ => None,
+            });
+
+        let Some(members) = members
+        else {
+            return false;
         };
 
         for member in members {
             if self.ctx.types.is_nullish_type(member) {
                 continue;
             }
-            let is_primitive = matches!(
-                classify_for_excess_properties(self.ctx.types, member),
-                ExcessPropertiesKind::NotObject
-            );
+            let evaluated_member = self.evaluate_type_with_env(member);
+            let evaluated_member = self.resolve_lazy_type(evaluated_member);
+            let evaluated_member = self.evaluate_application_type(evaluated_member);
+            let resolved_member = self.resolve_type_for_property_access(member);
+            let resolved_evaluated_member = self.resolve_type_for_property_access(evaluated_member);
+            let is_primitive =
+                crate::query_boundaries::common::is_primitive_type(self.ctx.types, member)
+                    || crate::query_boundaries::common::is_primitive_type(
+                        self.ctx.types,
+                        evaluated_member,
+                    );
             if is_primitive
-                && matches!(
+                && (matches!(
                     self.resolve_property_access_with_env(member, property_name),
                     PropertyAccessResult::Success { .. }
-                )
+                ) || matches!(
+                    self.resolve_property_access_with_env(resolved_member, property_name),
+                    PropertyAccessResult::Success { .. }
+                ) || matches!(
+                    self.resolve_property_access_with_env(resolved_evaluated_member, property_name),
+                    PropertyAccessResult::Success { .. }
+                ))
             {
                 return true;
             }
@@ -368,6 +400,42 @@ impl<'a> CheckerState<'a> {
             .then_some(type_id)
     }
 
+    fn callable_context_type_from_mixed_union(&mut self, type_id: TypeId) -> Option<TypeId> {
+        let type_id = crate::query_boundaries::common::remove_undefined(self.ctx.types, type_id);
+        if type_id == TypeId::UNDEFINED {
+            return None;
+        }
+
+        if crate::query_boundaries::common::is_callable_type(self.ctx.types, type_id) {
+            return Some(type_id);
+        }
+
+        let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, type_id)
+        else {
+            return None;
+        };
+
+        let callable_members: Vec<_> = members
+            .into_iter()
+            .filter_map(|member| {
+                if crate::query_boundaries::common::is_callable_type(self.ctx.types, member) {
+                    return Some(member);
+                }
+                let evaluated = self.evaluate_type_with_env(member);
+                let evaluated = self.resolve_lazy_type(evaluated);
+                let evaluated = self.evaluate_application_type(evaluated);
+                crate::query_boundaries::common::is_callable_type(self.ctx.types, evaluated)
+                    .then_some(evaluated)
+            })
+            .collect();
+
+        match callable_members.len() {
+            0 => None,
+            1 => Some(callable_members[0]),
+            _ => Some(self.ctx.types.factory().union_preserve_members(callable_members)),
+        }
+    }
+
     pub(crate) fn function_initializer_context_type(
         &mut self,
         contextual_type: Option<TypeId>,
@@ -390,6 +458,11 @@ impl<'a> CheckerState<'a> {
             self.primitive_union_member_has_property(ctx_type, property_name)
         }) {
             return None;
+        }
+
+        if let Some(callable_only) = self.callable_context_type_from_mixed_union(property_context_type)
+        {
+            return Some(callable_only);
         }
 
         if !crate::query_boundaries::common::type_contains_undefined(
@@ -435,10 +508,6 @@ impl<'a> CheckerState<'a> {
         } else {
             Some(property_context_type)
         }
-    }
-
-    pub(crate) fn contextual_type_has_primitive_union_member(&mut self, type_id: TypeId) -> bool {
-        self.union_with_non_nullish_non_object_member(type_id, 6)
     }
 
     fn contextual_property_presence(

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -231,7 +231,29 @@ impl<'a> CheckerState<'a> {
                 EvaluationNeeded, classify_for_evaluation, lazy_def_id, type_application,
             };
 
-            let evaluated_type = if type_application(self.ctx.types, ctx_type).is_some() {
+            let preserve_raw_mixed_context =
+                crate::query_boundaries::common::union_members(self.ctx.types, ctx_type)
+                    .is_some_and(|members| {
+                        let has_callable = members.iter().any(|&member| {
+                            crate::query_boundaries::common::is_callable_type(
+                                self.ctx.types,
+                                member,
+                            )
+                        });
+                        let has_non_callable = members.iter().any(|&member| {
+                            !crate::query_boundaries::common::is_callable_type(
+                                self.ctx.types,
+                                member,
+                            )
+                        });
+                        has_callable && has_non_callable
+                    });
+            let preserve_raw_signature_context =
+                preserve_raw_mixed_context || self.raw_contextual_signature_available(ctx_type);
+
+            let evaluated_type = if preserve_raw_signature_context {
+                ctx_type
+            } else if type_application(self.ctx.types, ctx_type).is_some() {
                 self.evaluate_application_type(ctx_type)
             } else if lazy_def_id(self.ctx.types, ctx_type).is_some()
                 || matches!(
@@ -257,7 +279,11 @@ impl<'a> CheckerState<'a> {
                     self.ctx.types,
                     evaluated_type,
                 );
-            let evaluated_type = self.normalize_contextual_signature_with_env(evaluated_type);
+            let evaluated_type = if preserve_raw_signature_context {
+                evaluated_type
+            } else {
+                self.normalize_contextual_signature_with_env(evaluated_type)
+            };
             let helper_probe = ContextualTypeContext::with_expected_and_options(
                 self.ctx.types,
                 evaluated_type,
@@ -627,6 +653,16 @@ impl<'a> CheckerState<'a> {
                     } else {
                         helper.get_parameter_type(contextual_index)
                     };
+                    let preserve_direct_from_mixed_context = helper.expected().is_some_and(|expected| {
+                        crate::query_boundaries::common::union_members(self.ctx.types, expected)
+                            .is_some_and(|members| {
+                                let has_callable =
+                                    members.iter().any(|&member| crate::query_boundaries::common::is_callable_type(self.ctx.types, member));
+                                let has_non_callable =
+                                    members.iter().any(|&member| !crate::query_boundaries::common::is_callable_type(self.ctx.types, member));
+                                has_callable && has_non_callable
+                            })
+                    });
 
                     if let Some(extracted) = direct {
                         if let Some(from_expected) = expected_contextual_type {
@@ -666,10 +702,21 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.types,
                                     from_expected,
                                 );
+                            let preserve_mixed_context_direct = preserve_direct_from_mixed_context
+                                && !direct_is_placeholderish
+                                && !crate::query_boundaries::common::contains_type_parameters(
+                                    self.ctx.types,
+                                    extracted,
+                                );
                             let direct_is_strict_subtype = extracted != from_expected
                                 && self.is_subtype_of(extracted, from_expected)
                                 && !self.is_subtype_of(from_expected, extracted);
-                            if direct_is_rest_tuple_container
+                            let expected_is_strict_subtype = extracted != from_expected
+                                && self.is_subtype_of(from_expected, extracted)
+                                && !self.is_subtype_of(extracted, from_expected);
+                            if preserve_mixed_context_direct {
+                                Some(extracted)
+                            } else if direct_is_rest_tuple_container
                                 || (direct_is_placeholderish && expected_is_more_informative)
                                 || direct_is_constrained_type_param
                                 || direct_is_strict_subtype
@@ -678,7 +725,9 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 let resolved = self.resolve_type_query_type(extracted);
                                 let evaluated = self.evaluate_type_with_env(resolved);
-                                if evaluated != extracted {
+                                if expected_is_strict_subtype {
+                                    Some(extracted)
+                                } else if evaluated != extracted {
                                     expected_contextual_type.or(Some(extracted))
                                 } else {
                                     Some(extracted)

--- a/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
@@ -232,6 +232,111 @@ let p: Passport = passport.use();
 }
 
 #[test]
+fn test_keyof_array_elaboration_reports_only_invalid_literal_element() {
+    let source = r#"
+function foo<T extends { a: string, b: string }>() {
+    let b: (keyof T)[] = ["a", "b", "c"];
+}
+"#;
+
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "test.ts",
+        source,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    let ts2322: Vec<_> = diagnostics.iter().filter(|diag| diag.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected only one TS2322 for the invalid array element.\nActual: {diagnostics:#?}"
+    );
+
+    let expected_start = source.find("\"c\"").expect("expected c literal") as u32;
+    assert_eq!(
+        ts2322[0].start,
+        expected_start,
+        "Expected TS2322 to anchor at the invalid \"c\" element.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        ts2322[0]
+            .message_text
+            .contains("Type 'string' is not assignable to type 'keyof T'"),
+        "Expected widened keyof-target TS2322 text.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_property_receiver_display_widens_fresh_object_application_args() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyPick<T, K extends keyof T> = { [P in K]: T[P] };
+declare function pick<T, K extends keyof T>(obj: T, propNames: K[]): MyPick<T, K>;
+
+const x = pick({ a: 10, b: 20, c: 30 }, ["a", "c"]);
+x.b;
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    let ts2339: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2339)
+        .collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected exactly one TS2339 for the missing property access.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    let message = diagnostic_message(&diagnostics, 2339).expect("expected TS2339");
+    assert_eq!(
+        message,
+        "Property 'b' does not exist on type 'MyPick<{ a: number; b: number; c: number; }, \"a\" | \"c\">'."
+    );
+}
+
+#[test]
+fn test_property_receiver_display_preserves_annotated_application_literals() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyPick<T, K extends keyof T> = { [P in K]: T[P] };
+
+declare const x: MyPick<{ a: 10; b: 20; c: 30 }, "a" | "c">;
+x.b;
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    let ts2339: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2339)
+        .collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected exactly one TS2339 for the annotated missing property access.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    let message = diagnostic_message(&diagnostics, 2339).expect("expected TS2339");
+    assert_eq!(
+        message,
+        "Property 'b' does not exist on type 'MyPick<{ a: 10; b: 20; c: 30; }, \"a\" | \"c\">'."
+    );
+}
+
+#[test]
 fn test_cross_binder_symbol_id_collision_emits_ts2322_for_this_return() {
     let passport_dts = r#"
 declare module 'passport' {

--- a/crates/tsz-checker/tests/conformance_issues/types/defaults.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/defaults.rs
@@ -872,6 +872,10 @@ const obj: {field: Rule} = {
         has_error(&diagnostics, 7006),
         "Expected TS7006 when optional callback property comes from a primitive-containing union.\nActual diagnostics: {diagnostics:#?}"
     );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "Should NOT emit outer TS2322 when the callback loses contextual typing from a primitive-containing union.\nActual diagnostics: {diagnostics:#?}"
+    );
 }
 
 // TS7022: Variable implicitly has type 'any' because it does not have a type annotation


### PR DESCRIPTION
## Summary
- preserve raw callable aliases for mixed contextual unions like `string | Validate` so callback parameters keep the alias surface instead of being eagerly rewritten to the narrowed object member
- suppress contextual typing for object-literal function properties only when a primitive union member exposes the same property via its wrapper type
- strengthen the existing regression test to require `TS7006` and reject the outer `TS2322`

Root cause: tsz was eagerly evaluating mixed function-property contextual types from `string | FullRule`, so `Validate` was rewritten to a callable signature with `self: FullRule`, and the primitive-wrapper `normalize` overload was ignored, producing a false outer `TS2322` instead of only `TS7006`.

## Repro
```ts
type Validate = (text: string, pos: number, self: Rule) => number | boolean;
interface FullRule {
    validate: string | RegExp | Validate;
    normalize?: (match: {x: string}) => void;
}

type Rule = string | FullRule;

const obj: {field: Rule} = {
    field: {
        validate: (_t, _p, _s) => false,
        normalize: match => match.x,
    }
};
```

Expected: `TS7006` on `match` only.

## Verification
- `cargo check --package tsz-checker`
- `cargo nextest run -p tsz-checker 'types::defaults::test_optional_function_property_in_union_with_primitive_does_not_contextually_type_callback' --nocapture`
- `cargo nextest run -p tsz-checker 'types::defaults::test_contextual_typing_property_in_union_with_null' --nocapture`
- `./scripts/conformance/conformance.sh run --filter "contextualOverloadListFromUnionWithPrimitiveNoImplicitAny" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
