### PR TITLE
[codex] fix(checker): align for-of object destructuring TS2322

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -855,13 +855,11 @@ impl<'a> CheckerState<'a> {
             let mut check_assignability = !is_destructuring && !suppress_for_readonly;
 
             if is_destructuring && !is_not_iterable {
-                self.report_abstract_properties_in_destructuring_assignment(left_idx, right_idx);
-                self.check_destructuring_property_accessibility(left_idx, right_type);
-                // TS2322: Check rest element assignability in object destructuring
-                // assignments. For `({ b, ...rest } = source)`, the rest type
-                // (source minus named properties) must be assignable to `rest`'s
-                // declared type.
-                self.check_object_destructuring_rest_assignability(left_idx, right_type);
+                self.check_object_destructuring_assignment_from_source_type(
+                    left_idx,
+                    right_type,
+                    Some(right_idx),
+                );
             }
 
             if check_assignability {

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -301,6 +301,32 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Shared object-destructuring validation for assignment-like contexts.
+    ///
+    /// This mirrors the object-literal branch of assignment checking without
+    /// requiring a concrete assignment-expression RHS node. Callers use it when
+    /// the source value is already available as a type, such as `for ({...} of xs)`.
+    pub(crate) fn check_object_destructuring_assignment_from_source_type(
+        &mut self,
+        pattern_idx: NodeIndex,
+        source_type: TypeId,
+        source_expr_idx: Option<NodeIndex>,
+    ) {
+        if source_type == TypeId::ANY || source_type == TypeId::ERROR {
+            return;
+        }
+
+        if let Some(source_expr_idx) = source_expr_idx {
+            self.report_abstract_properties_in_destructuring_assignment(
+                pattern_idx,
+                source_expr_idx,
+            );
+        }
+
+        self.check_destructuring_property_accessibility(pattern_idx, source_type);
+        self.check_object_destructuring_rest_assignability(pattern_idx, source_type);
+    }
+
     /// TS2322: Check assignability of the rest element in an object destructuring
     /// assignment. For `({ b, ...rest } = source)`, computes the rest type
     /// (source minus named properties) and checks it against the rest target's
@@ -804,23 +830,29 @@ impl<'a> CheckerState<'a> {
             return;
         }
         // When a default value is present, compute the effective destructured
-        // type: removeUndefined(sourcePropertyType) | typeOf(default).
+        // type. The default only contributes when the source property can
+        // actually be `undefined`; otherwise the runtime value always comes from
+        // the source property itself.
         // This matches tsc behavior:
         //   `({ x = 0 } = a)` where `a.x` is `number | undefined`:
         //     effective = number | number = number → assignable to number ✓
+        //   `({ x = 0 } = a)` where `a.x` is `boolean`:
+        //     effective = boolean → NOT assignable to number ✗
         //   `({ x = undefined } = a)` where `a.x` is `number | undefined`:
         //     effective = number | undefined → NOT assignable to number ✗
         if has_default && self.ctx.compiler_options.strict_null_checks {
-            let non_undefined = crate::query_boundaries::flow::narrow_destructuring_default(
-                self.ctx.types,
-                prop_type,
-                true,
-            );
-            let default_type = self.get_type_of_node(default_expr);
-            let factory = self.ctx.types.factory();
-            prop_type = factory.union2(non_undefined, default_type);
-            if prop_type == TypeId::ANY || prop_type == TypeId::ERROR {
-                return;
+            if crate::query_boundaries::common::type_contains_undefined(self.ctx.types, prop_type) {
+                let non_undefined = crate::query_boundaries::flow::narrow_destructuring_default(
+                    self.ctx.types,
+                    prop_type,
+                    true,
+                );
+                let default_type = self.get_type_of_node(default_expr);
+                let factory = self.ctx.types.factory();
+                prop_type = factory.union2(non_undefined, default_type);
+                if prop_type == TypeId::ANY || prop_type == TypeId::ERROR {
+                    return;
+                }
             }
         }
         let target_type = self.get_type_of_assignment_target(target_idx);

--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -384,6 +384,44 @@ var a: string, b: boolean;
 }
 
 #[test]
+fn for_of_object_destructuring_default_reports_leaf_mismatch() {
+    let source = r#"
+// @target: ES6
+var x: string, y: number;
+var array = [{ x: "", y: true }]
+enum E { x }
+for ({x, y = E.x} of array) {
+    x;
+    y;
+}
+"#;
+
+    let diagnostics = diagnostics_for(source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {diagnostics:?}"
+    );
+
+    let diag = ts2322[0];
+    let y_start = source.find("y = E.x").expect("expected defaulted binding") as u32;
+    assert_eq!(
+        diag.start, y_start,
+        "TS2322 should anchor at the defaulted binding name, not the whole pattern"
+    );
+    assert_eq!(
+        diag.length, 1,
+        "TS2322 should cover only the binding name token"
+    );
+    assert!(
+        diag.message_text
+            .contains("Type 'boolean' is not assignable to type 'number'"),
+        "TS2322 should report the source property mismatch, got: {diag:?}"
+    );
+}
+
+#[test]
 fn nested_object_literal_assignability_keeps_exact_property_anchor() {
     let source = r#"
 type Inner = { ok: string };

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -633,21 +633,33 @@ impl<'a> CheckerState<'a> {
             self.check_const_assignment(initializer);
         }
 
-        // TS2322: Check element type is assignable to the variable's declared type.
-        // Skip for destructuring patterns (array/object literal expressions) — those are
-        // checked element-by-element during destructuring assignment processing, not as
-        // a whole-type assignability check. Individual mismatches (e.g., wrong default
-        // values) are caught by the assignment expression checker on each element.
-        // Only skip for array destructuring — array literal elements like `k = false`
-        // are BinaryExpressions that trigger individual assignment checks.
-        // Object destructuring still needs the whole-type check because individual
-        // property bindings don't go through the assignment expression checker.
+        // TS2322: Expression-form `for (... of ...)` should follow the same
+        // destructuring-assignment path as `({ ... } = value)`. In particular,
+        // object-literal targets must validate each binding element separately
+        // instead of synthesizing a whole-pattern assignability error.
         let is_array_destructuring_target = self
             .ctx
             .arena
             .get(initializer)
             .is_some_and(|n| n.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION);
+        let is_object_destructuring_target = self
+            .ctx
+            .arena
+            .get(initializer)
+            .is_some_and(|n| n.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
         if is_for_of
+            && is_object_destructuring_target
+            && target_type != TypeId::ANY
+            && element_type != TypeId::ANY
+            && element_type != TypeId::ERROR
+            && !self.type_contains_error(target_type)
+        {
+            self.check_object_destructuring_assignment_from_source_type(
+                initializer,
+                element_type,
+                None,
+            );
+        } else if is_for_of
             && !is_array_destructuring_target
             && target_type != TypeId::ANY
             && element_type != TypeId::ANY


### PR DESCRIPTION
## Summary

This aligns expression-form object destructuring in `for...of` with normal destructuring assignment checking.

Root cause: `for ({ ... } of iterable)` was applying a synthetic whole-pattern assignability check for object-literal targets instead of routing through the existing elementwise destructuring-assignment path, so `tsz` reported a pattern-level `TS2322` where `tsc` reports a leaf diagnostic on the failing binding.

## Repro

```ts
// @target: ES6
var x: string, y: number;
var array = [{ x: "", y: true }]
enum E { x }
for ({x, y = E.x} of array) {
    x;
    y;
}
```

Expected behavior: report a single `TS2322` on `y` with `Type 'boolean' is not assignable to type 'number'.`

## What Changed

- reuse a shared object-destructuring assignment helper for assignment-like contexts
- route object-literal `for...of` targets through destructuring validation instead of whole-pattern assignability
- preserve default-value elaboration only when the source property can actually be `undefined`
- add a checker regression test for `for-of48`

## Validation

- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib -- for_of_object_destructuring_default_reports_leaf_mismatch`
- `cargo nextest run --package tsz-checker --lib -- destructuring_assignment_`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "for-of48" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
  - `FINAL RESULTS: 12060/12581 passed (95.9%)`

## Notes

- `cargo nextest run --package tsz-checker --lib` still has one unrelated pre-existing failure on current `main`:
  - `architecture_contract_tests_src::checker_files_stay_under_loc_limit`
  - `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs` is currently 2382 lines, over the 2000-line limit
