### PR TITLE
[codex] fix generic indexed readonly write diagnostics

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -591,7 +591,11 @@ impl<'a> CheckerState<'a> {
     /// - The index is `keyof T` — constrains to the receiver's own key space
     /// - The index is `K extends keyof T` — a type parameter constrained to keyof
     /// - The constraint has no index signature (e.g., `{ a: string, b: number }`)
-    fn is_generic_indexed_write(&mut self, object_type: TypeId, index_type: TypeId) -> bool {
+    pub(crate) fn is_generic_indexed_write(
+        &mut self,
+        object_type: TypeId,
+        index_type: TypeId,
+    ) -> bool {
         use crate::query_boundaries::common as common_query;
         use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
 
@@ -649,6 +653,12 @@ impl<'a> CheckerState<'a> {
         // E.g., Record<string, any> is stored as Application(Mapped) and needs
         // evaluation to produce { [key: string]: any }.
         let resolved = self.evaluate_type_with_env(constraint);
+        if crate::query_boundaries::common::is_generic_mapped_type(self.ctx.types, resolved)
+            || crate::query_boundaries::common::is_mapped_type(self.ctx.types, resolved)
+        {
+            return true;
+        }
+
         let resolver = IndexSignatureResolver::new(self.ctx.types);
 
         // Check if the constraint has an index signature matching the broad index type
@@ -668,10 +678,49 @@ impl<'a> CheckerState<'a> {
     ///
     /// Returns `true` for: `string`, `number`, `symbol`, or unions of these.
     /// Returns `false` for: literals, `keyof T`, type parameters, etc.
-    fn is_broad_index_type(&self, type_id: TypeId) -> bool {
+    fn is_broad_index_type(&mut self, type_id: TypeId) -> bool {
         // Direct primitive types — these go through index signatures
         if type_id == TypeId::STRING || type_id == TypeId::NUMBER || type_id == TypeId::SYMBOL {
             return true;
+        }
+
+        let resolved = self.resolve_lazy_type(type_id);
+        if resolved != type_id && resolved != TypeId::ERROR {
+            return self.is_broad_index_type(resolved);
+        }
+
+        let evaluated = self.evaluate_type_with_env(type_id);
+        if evaluated != type_id && evaluated != TypeId::ERROR {
+            return self.is_broad_index_type(evaluated);
+        }
+
+        let display = self.format_type(type_id);
+        if display
+            .split(" | ")
+            .all(|part| matches!(part, "string" | "number" | "symbol"))
+        {
+            return true;
+        }
+
+        // A concrete `keyof` can reduce to a broad primitive key space. Keep
+        // generic `keyof T` out of this path because writes through `T[keyof T]`
+        // are checked as assignment compatibility errors instead.
+        if let Some(inner) =
+            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, type_id)
+            && !crate::query_boundaries::common::contains_type_parameters(self.ctx.types, inner)
+        {
+            let evaluated = self.ctx.types.evaluate_keyof(inner);
+            return evaluated != type_id && self.is_broad_index_type(evaluated);
+        }
+
+        // Aliases such as `keyof Record<string, number>` may arrive wrapped in
+        // an application. Evaluate non-recursively through the environment and
+        // classify the resulting key space.
+        if crate::query_boundaries::common::is_generic_application(self.ctx.types, type_id) {
+            let evaluated = self.evaluate_type_with_env(type_id);
+            return evaluated != type_id
+                && evaluated != TypeId::ERROR
+                && self.is_broad_index_type(evaluated);
         }
 
         // Check if it's a union where ALL members are broad index types

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1255,6 +1255,16 @@ impl<'a> CheckerState<'a> {
                 pre_resolution_object_type,
             ) && self.is_generic_index_type(index_type)
             {
+                if request.flow.skip_flow_narrowing()
+                    && self.is_generic_indexed_write(pre_resolution_object_type, index_type)
+                {
+                    return self
+                        .ctx
+                        .types
+                        .factory()
+                        .index_access(pre_resolution_object_type, index_type);
+                }
+
                 // When indexing a type parameter T with keys from a different type
                 // parameter (e.g., `keyof U` where `U extends T`), tsc emits TS2536.
                 // We should not defer this case to IndexAccess(T, ...).

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -717,6 +717,16 @@ impl<'a> CheckerState<'a> {
                 .is_some()
             && let Some(raw_object_text) = self.node_text(data.object_type)
         {
+            let nested_base_type = self
+                .ctx
+                .arena
+                .get_indexed_access_type(object_node)
+                .map(|nested| self.get_type_from_type_node(nested.object_type));
+            if let Some(base_type) = nested_base_type
+                && self.indexed_access_constraint_values_allow_index(base_type, index_type)
+            {
+                return;
+            }
             // Clean up object type text: strip enclosing parens and any trailing
             // index access syntax that may leak from the object_type node span.
             let object_type_str = {
@@ -1586,6 +1596,11 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types,
                 object_type_for_check,
             ) {
+                if self.indexed_access_constraint_values_allow_index(base_obj, index_type_for_check)
+                {
+                    return;
+                }
+
                 let eval_base = self.evaluate_type_with_env(base_obj);
                 let is_concrete = !crate::query_boundaries::common::is_type_parameter_like(
                     self.ctx.types,
@@ -1637,6 +1652,13 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                 }
+            }
+            if object_type != object_type_for_check
+                && let Some((base_obj, _base_idx)) =
+                    crate::query_boundaries::common::index_access_types(self.ctx.types, object_type)
+                && self.indexed_access_constraint_values_allow_index(base_obj, index_type_for_check)
+            {
+                return;
             }
 
             let message_2536 = format_message(

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -89,6 +89,38 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    pub(super) fn indexed_access_constraint_values_allow_index(
+        &mut self,
+        base_type: TypeId,
+        index_type: TypeId,
+    ) -> bool {
+        if let Some(mapped_id) =
+            crate::query_boundaries::common::mapped_type_id(self.ctx.types, base_type)
+        {
+            let mapped = self.ctx.types.mapped_type(mapped_id);
+            let template_keyof = self.ctx.types.evaluate_keyof(mapped.template);
+            return self.is_assignable_to(index_type, template_keyof);
+        }
+
+        let Some(constraint) =
+            crate::query_boundaries::common::type_parameter_constraint(self.ctx.types, base_type)
+        else {
+            return false;
+        };
+        let constraint = self.evaluate_type_with_env(constraint);
+        if matches!(constraint, TypeId::ERROR | TypeId::ANY) {
+            return false;
+        }
+
+        let key_space = self.ctx.types.evaluate_keyof(constraint);
+        let values = self
+            .evaluate_type_with_env(self.ctx.types.factory().index_access(constraint, key_space));
+        if matches!(values, TypeId::ERROR | TypeId::UNDEFINED) {
+            return false;
+        }
+        self.is_assignable_to(index_type, self.ctx.types.evaluate_keyof(values))
+    }
+
     pub(super) fn simple_type_reference_name(&self, node_idx: NodeIndex) -> Option<String> {
         let node = self.ctx.arena.get(node_idx)?;
         if node.kind == syntax_kind_ext::TYPE_REFERENCE {

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -342,6 +342,64 @@ function foo<T>() {
 }
 
 #[test]
+fn test_readonly_generic_write_with_concrete_keyof_reports_ts2862_not_ts2536() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r#"
+type Dict = { readonly [key: string]: number };
+
+function f<T extends Dict, K extends keyof T>(
+    obj: T,
+    k1: keyof Dict,
+    k2: keyof T,
+    k3: K,
+) {
+    obj.foo = 123;
+    obj[k1] = 123;
+    obj[k2] = 123;
+    obj[k3] = 123;
+}
+"#,
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| { *code == 2862 && message.contains("Type 'T' is generic") }),
+        "Expected TS2862 for concrete keyof write through readonly generic constraint.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 2536),
+        "Did not expect TS2536 to preempt TS2862 for readonly generic write.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_mapped_tuple_value_index_access_does_not_emit_ts2536() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r##"
+type Bar<T> = { [K in keyof T]: [K] };
+type Wrapped<T> = { [key: string]: { [K in keyof T]: [K] }[keyof T] };
+type Qux<T, Q extends Wrapped<T>> = { [K in keyof Q]: T[Q[K]["0"]] };
+"##,
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_error(&diagnostics, 2536),
+        "Did not expect TS2536 for indexing mapped tuple values with \"0\".\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_return_diagnostic_preserves_literal_for_generic_indexed_target() {
     let diagnostics = compile_and_get_diagnostics(
         r#"


### PR DESCRIPTION
## Summary

Fixes the `keyofAndIndexedAccess2.ts` wrong-code conformance mismatch where tsz emitted an extra TS2536 and missed TS2862 for generic indexed readonly writes.

## Root cause

The checker was classifying some generic writes through concrete broad `keyof` keys as ordinary indexed access failures before the readonly generic-write path could produce TS2862. A nested mapped tuple value access (`Q[K]["0"]`) also lost enough constraint value-space information to emit TS2536 even though the mapped value constraint guarantees a tuple-like value.

## Changes

- Treat mapped/generic mapped constraints as eligible for generic indexed readonly write diagnostics.
- Defer generic indexed writes in element access so TS2862 can be produced instead of TS2536.
- Allow nested indexed access validation through mapped tuple constraint value spaces.
- Add focused regression tests for both the TS2862 and mapped tuple value access cases.

## Validation

- `cargo fmt --all --check`
- `cargo check --package tsz-checker`
- `cargo nextest run --package tsz-checker --test conformance_issues test_mapped_tuple_value_index_access_does_not_emit_ts2536 test_readonly_generic_write_with_concrete_keyof_reports_ts2862_not_ts2536`
- `./scripts/conformance/conformance.sh run --filter "keyofAndIndexedAccess2" --verbose`
  - Diagnostic code sets now match: `[TS2322, TS2339, TS2739, TS2862, TS7053]`.
  - The file still has fingerprint-only message/position drift outside this fix.

## Notes

`verify-all.sh` was attempted during the automation run. Earlier formatting issues were fixed, and main has since unblocked one LOC guard, but the full verifier was not completed in the original worktree because it hit existing full-suite failures and conformance dependency setup behavior.
