### PR TITLE
[codex] fix template literal numeric infer

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -336,7 +336,33 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let candidate = self.format_type_for_assignability_message(raw_constraint);
+        let evaluated_number_literal_union = if let Some(members) =
+            query_common::union_members(self.ctx.types, evaluated_constraint)
+        {
+            !members.is_empty()
+                && members.iter().all(|&member| {
+                    matches!(
+                        query_common::literal_value(self.ctx.types, member),
+                        Some(query_common::LiteralValue::Number(_))
+                    )
+                })
+        } else {
+            matches!(
+                query_common::literal_value(self.ctx.types, evaluated_constraint),
+                Some(query_common::LiteralValue::Number(_))
+            )
+        };
+        let candidate_display_type =
+            if query_common::type_application(self.ctx.types, raw_constraint).is_some()
+                && evaluated_constraint != raw_constraint
+                && evaluated_constraint != TypeId::ERROR
+                && evaluated_number_literal_union
+            {
+                evaluated_constraint
+            } else {
+                raw_constraint
+            };
+        let candidate = self.format_type_for_assignability_message(candidate_display_type);
         if display
             .as_ref()
             .is_some_and(|existing| existing != &candidate)

--- a/crates/tsz-checker/tests/infer_extends_constraint_substitution_tests.rs
+++ b/crates/tsz-checker/tests/infer_extends_constraint_substitution_tests.rs
@@ -126,6 +126,80 @@ let c: "no_match" = r;  // should error: R is "hello"
     );
 }
 
+/// Template literal `infer N extends number` should parse matching string
+/// captures into numeric literals. This keeps tuple string keys like "0" and
+/// "1" usable as ordinal indices.
+#[test]
+fn test_template_literal_infer_extends_number_extracts_tuple_indices() {
+    let source = r#"
+type IndexFor<S extends string> = S extends `${infer N extends number}` ? N : never;
+type Extract<T, U> = T extends U ? T : never;
+type IndicesOf<T> = IndexFor<Extract<keyof T, string>>;
+
+declare function getIndex<I extends IndicesOf<[{ name: "x" }, { name: "y" }]>>(index: I): void;
+
+getIndex(0);
+getIndex(1);
+getIndex(2);
+"#;
+    let diags = check_strict(source);
+    let ts2345 = diags.iter().filter(|d| d.code == 2345).count();
+    assert_eq!(
+        ts2345, 1,
+        "Expected only getIndex(2) to emit TS2345; valid tuple indices 0 and 1 should be accepted. Got: {diags:#?}"
+    );
+    let message = diags
+        .iter()
+        .find(|d| d.code == 2345)
+        .map(|d| d.message_text.as_str())
+        .unwrap_or("");
+    assert!(
+        message.contains("parameter of type '0 | 1'"),
+        "Expected invalid tuple index diagnostic to display the evaluated index union, got: {message}"
+    );
+}
+
+#[test]
+fn test_template_literal_infer_extends_number_direct_union() {
+    let source = r#"
+type IndexFor<S extends string> = S extends `${infer N extends number}` ? N : never;
+type R = IndexFor<"0" | "1">;
+
+declare function getIndex<I extends R>(index: I): void;
+
+getIndex(0);
+getIndex(1);
+getIndex(2);
+"#;
+    let diags = check_strict(source);
+    let ts2345 = diags.iter().filter(|d| d.code == 2345).count();
+    assert_eq!(
+        ts2345, 1,
+        "Expected only getIndex(2) to emit TS2345 for direct string numeric keys. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn test_template_literal_infer_extends_number_after_extract() {
+    let source = r#"
+type IndexFor<S extends string> = S extends `${infer N extends number}` ? N : never;
+type Extract<T, U> = T extends U ? T : never;
+type R = IndexFor<Extract<"0" | "1" | "length", string>>;
+
+declare function getIndex<I extends R>(index: I): void;
+
+getIndex(0);
+getIndex(1);
+getIndex(2);
+"#;
+    let diags = check_strict(source);
+    let ts2345 = diags.iter().filter(|d| d.code == 2345).count();
+    assert_eq!(
+        ts2345, 1,
+        "Expected only getIndex(2) to emit TS2345 after Extract. Got: {diags:#?}"
+    );
+}
+
 /// When infer constraint fails (value doesn't match keyof T), should get false branch.
 #[test]
 fn test_infer_extends_keyof_constraint_fails_correctly() {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -11,8 +11,8 @@
 
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
-    CallableShapeId, FunctionShape, FunctionShapeId, ObjectShapeId, ParamInfo, TemplateSpan,
-    TupleElement, TypeData, TypeId, TypeListId, TypeParamInfo,
+    CallableShapeId, FunctionShape, FunctionShapeId, IntrinsicKind, ObjectShapeId, ParamInfo,
+    TemplateSpan, TupleElement, TypeData, TypeId, TypeListId, TypeParamInfo,
 };
 use crate::utils;
 use crate::{TypeSubstitution, instantiate_type};
@@ -22,6 +22,108 @@ use tsz_common::interner::Atom;
 use super::super::evaluate::TypeEvaluator;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    fn parse_template_number_capture(&self, captured: &str) -> Option<TypeId> {
+        let value = if let Some(digits) = captured.strip_prefix("0x") {
+            u64::from_str_radix(digits, 16).ok().map(|n| n as f64)?
+        } else if let Some(digits) = captured.strip_prefix("0X") {
+            u64::from_str_radix(digits, 16).ok().map(|n| n as f64)?
+        } else if let Some(digits) = captured.strip_prefix("0o") {
+            u64::from_str_radix(digits, 8).ok().map(|n| n as f64)?
+        } else if let Some(digits) = captured.strip_prefix("0O") {
+            u64::from_str_radix(digits, 8).ok().map(|n| n as f64)?
+        } else if let Some(digits) = captured.strip_prefix("0b") {
+            u64::from_str_radix(digits, 2).ok().map(|n| n as f64)?
+        } else if let Some(digits) = captured.strip_prefix("0B") {
+            u64::from_str_radix(digits, 2).ok().map(|n| n as f64)?
+        } else {
+            captured.parse::<f64>().ok()?
+        };
+
+        if !value.is_finite() {
+            return None;
+        }
+
+        let literal = self.interner().literal_number(value);
+        let round_trips = match value {
+            v if v.fract() == 0.0 && v.abs() < 1e15 => (v as i64).to_string() == captured,
+            v => format!("{v}") == captured,
+        };
+        Some(if round_trips { literal } else { TypeId::NUMBER })
+    }
+
+    fn parse_template_bigint_capture(&self, captured: &str) -> Option<TypeId> {
+        let (negative, digits) = captured
+            .strip_prefix('-')
+            .map_or((false, captured), |rest| (true, rest));
+        if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+
+        Some(self.interner().literal_bigint_with_sign(negative, digits))
+    }
+
+    fn template_capture_for_constraint(
+        &self,
+        captured: &str,
+        captured_type: TypeId,
+        constraint: TypeId,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> Option<TypeId> {
+        if checker.is_subtype_of(captured_type, constraint) {
+            return Some(captured_type);
+        }
+
+        match self.interner().lookup(constraint) {
+            Some(TypeData::Intrinsic(IntrinsicKind::Number)) => self
+                .parse_template_number_capture(captured)
+                .filter(|&ty| checker.is_subtype_of(ty, constraint)),
+            Some(TypeData::Intrinsic(IntrinsicKind::Bigint)) => self
+                .parse_template_bigint_capture(captured)
+                .filter(|&ty| checker.is_subtype_of(ty, constraint)),
+            Some(TypeData::Intrinsic(IntrinsicKind::Boolean)) => match captured {
+                "true" => Some(self.interner().literal_boolean(true)),
+                "false" => Some(self.interner().literal_boolean(false)),
+                _ => None,
+            },
+            Some(TypeData::Intrinsic(IntrinsicKind::Null)) if captured == "null" => {
+                Some(TypeId::NULL)
+            }
+            Some(TypeData::Intrinsic(IntrinsicKind::Undefined)) if captured == "undefined" => {
+                Some(TypeId::UNDEFINED)
+            }
+            Some(TypeData::Union(members_id)) => {
+                let members = self.interner().type_list(members_id);
+                members.iter().find_map(|&member| {
+                    self.template_capture_for_constraint(captured, captured_type, member, checker)
+                        .filter(|&ty| checker.is_subtype_of(ty, constraint))
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn bind_template_infer_capture(
+        &self,
+        info: &TypeParamInfo,
+        captured: &str,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
+        let captured_type = self.interner().literal_string(captured);
+        let inferred = if let Some(constraint) = info.constraint {
+            let Some(converted) =
+                self.template_capture_for_constraint(captured, captured_type, constraint, checker)
+            else {
+                return false;
+            };
+            converted
+        } else {
+            captured_type
+        };
+
+        self.bind_infer(info, inferred, bindings, checker)
+    }
+
     fn erase_type_params_to_constraints(
         &self,
         type_params: &[TypeParamInfo],
@@ -1921,7 +2023,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     let captured_type = self.interner().literal_string(captured);
 
                     if let Some(TypeData::Infer(info)) = self.interner().lookup(type_id) {
-                        if !self.bind_infer(&info, captured_type, bindings, checker) {
+                        if !self.bind_template_infer_capture(&info, captured, bindings, checker) {
                             return false;
                         }
                     } else if !checker.is_subtype_of(captured_type, type_id) {


### PR DESCRIPTION
## Summary
- Convert constrained template-literal infer captures into primitive literal types for numeric/primitive constraints.
- Display evaluated numeric tuple-index unions for generic constraint argument diagnostics.
- Add regression coverage for `IndexFor<Extract<keyof T, string>>` tuple indices and direct numeric template infer cases.

## Root Cause
Template literal infer matching always bound captures as string literals. For `infer N extends number`, tuple string keys like `"0" | "1"` failed the numeric constraint and collapsed `IndicesOf<T>` to `never`.

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo nextest run --package tsz-checker --test infer_extends_constraint_substitution_tests 'test_template_literal_infer_extends_number' --failure-output immediate-final --success-output never`
- `.target/dist-fast/tsz-conformance --test-dir TypeScript/tests/cases --cache-file scripts/conformance/tsc-cache-full.json --tsz-binary .target/dist-fast/tsz --workers 4 --print-fingerprints --verbose --filter templateLiteralTypes4`

Notes: `scripts/session/verify-all.sh` was attempted. It passed formatting/clippy before the unit phase hit an unrelated existing LOC guard failure in `error_reporter/core/diagnostic_source.rs`; the same verifier also surfaced baseline conformance issues that reproduced on main during this automation run.