### PR TITLE
Add VS Code LSP dev client and completion regression fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run TSZ VS Code Client",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/scripts/vscode-tsz-lsp"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/scripts/vscode-tsz-lsp/out/**/*.js"
+      ],
+      "preLaunchTask": "prepare tsz vscode demo"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build tsz-lsp",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "build",
+        "-p",
+        "tsz-cli",
+        "--bin",
+        "tsz-lsp"
+      ],
+      "group": "build"
+    },
+    {
+      "label": "build tsz vscode client",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "compile"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/scripts/vscode-tsz-lsp"
+      },
+      "group": "build",
+      "problemMatcher": [
+        "$tsc"
+      ]
+    },
+    {
+      "label": "prepare tsz vscode demo",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "build tsz-lsp",
+        "build tsz vscode client"
+      ]
+    }
+  ]
+}

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -229,14 +229,16 @@ impl<'a> Completions<'a> {
         // 3. Contextual string-literal completions for call arguments.
         // This path intentionally runs before no-completion suppression, because
         // ordinary string literals are suppressed by default.
-        if self.interner.is_some()
+        if !self.is_member_context(offset)
+            && self.interner.is_some()
             && self.file_name.is_some()
             && let Some(items) =
                 self.get_string_literal_completions(node_idx, offset, type_cache.as_deref_mut())
         {
             return if items.is_empty() { None } else { Some(items) };
         }
-        if self.interner.is_some()
+        if !self.is_member_context(offset)
+            && self.interner.is_some()
             && self.file_name.is_some()
             && let Some(items) = self.get_contextual_string_literal_completions(
                 node_idx,
@@ -1094,6 +1096,32 @@ impl<'a> Completions<'a> {
 
             let ext = self.arena.get_extended(current)?;
             current = ext.parent;
+        }
+
+        if self.is_member_context(offset) && offset >= 2 {
+            let mut current = crate::utils::find_node_at_offset(self.arena, offset - 2);
+            let mut best = None;
+
+            while current.is_some() {
+                let Some(node) = self.arena.get(current) else {
+                    break;
+                };
+                if node.end == offset - 1 {
+                    best = Some(current);
+                }
+
+                let Some(ext) = self.arena.get_extended(current) else {
+                    break;
+                };
+                if ext.parent == current {
+                    break;
+                }
+                current = ext.parent;
+            }
+
+            if best.is_some() {
+                return best;
+            }
         }
 
         None

--- a/crates/tsz-lsp/tests/completions_tests.rs
+++ b/crates/tsz-lsp/tests/completions_tests.rs
@@ -181,6 +181,52 @@ fn test_completions_member_string_literal() {
 }
 
 #[test]
+fn test_completions_member_access_wins_over_prior_string_literal_context() {
+    let source = "let x: string = 42;\n\nfunction greet(name: string): string {\n  return \"Hello, \" + name;\n}\n\ngreet(123);\n\ninterface User {\n  name: string;\n  age: number;\n}\n\nconst user: User = {\n  name: \"Alice\",\n  age: \"thirty\",\n};\n\nuser.";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let line_map = LineMap::build(source);
+    let interner = TypeInterner::new();
+    let completions = Completions::new_with_types(
+        arena,
+        &binder,
+        &line_map,
+        &interner,
+        source,
+        "test.ts".to_string(),
+    );
+
+    let position = Position::new(18, 5);
+    let mut cache = None;
+    let items = completions.get_completions_with_cache(root, position, &mut cache);
+
+    assert!(
+        items.is_some(),
+        "Should have member completions for 'user.'"
+    );
+    let items = items.unwrap();
+    let names: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        names.contains(&"name"),
+        "Should suggest property 'name', got: {names:?}"
+    );
+    assert!(
+        names.contains(&"age"),
+        "Should suggest property 'age', got: {names:?}"
+    );
+    assert!(
+        !names.contains(&"\"Hello, \""),
+        "Member access should not be hijacked by prior string literal completions, got: {names:?}"
+    );
+}
+
+#[test]
 fn test_completions_contextual_string_literal_argument_keyof() {
     let source = "interface Events {\n  click: any;\n  drag: any;\n}\n\ndeclare function addListener<K extends keyof Events>(type: K, listener: (ev: Events[K]) => any): void;\n\naddListener(\"\");\n";
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());

--- a/docs/site/benchmarks.md
+++ b/docs/site/benchmarks.md
@@ -21,15 +21,3 @@ tsz is compiled with `--profile dist` (LTO enabled, single codegen unit). tsgo i
 ## Category Breakdown
 
 {{ benchmark_charts | safe }}
-
-## Running Benchmarks Locally
-
-To generate benchmark data yourself:
-
-```
-./scripts/bench/bench-vs-tsgo.sh --json
-```
-
-This produces a JSON file in `artifacts/` that the website build script uses to generate charts. Use `--quick` for faster results with fewer iterations.
-
-See [bench-vs-tsgo.sh](https://github.com/mohsen1/tsz/blob/main/scripts/bench/bench-vs-tsgo.sh) for full usage.

--- a/scripts/vscode-tsz-lsp/.gitignore
+++ b/scripts/vscode-tsz-lsp/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+out/

--- a/scripts/vscode-tsz-lsp/README.md
+++ b/scripts/vscode-tsz-lsp/README.md
@@ -1,0 +1,22 @@
+## TSZ VS Code LSP Dev Client
+
+This is a minimal local VS Code extension that launches `tsz-lsp` over stdio.
+
+### One-time setup
+
+```bash
+cargo build -p tsz-cli --bin tsz-lsp
+cd scripts/vscode-tsz-lsp
+npm install
+npm run compile
+```
+
+### Run in VS Code
+
+1. Open the repo in VS Code.
+2. Run the launch configuration `Run TSZ VS Code Client`.
+3. In the Extension Development Host, open a `.ts` or `.js` file.
+4. Use `TSZ: Restart Language Server` after rebuilding the Rust binary.
+
+By default the extension looks for `target/debug/tsz-lsp` in the first workspace folder. You can override this with the `tsz.lsp.path` setting.
+By default in this repo that resolves to `.target/debug/tsz-lsp`, because Cargo is configured to build into `.target`.

--- a/scripts/vscode-tsz-lsp/package.json
+++ b/scripts/vscode-tsz-lsp/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "tsz-vscode-lsp-dev",
+  "displayName": "TSZ LSP Dev Client",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Minimal VS Code client for running tsz-lsp locally during development.",
+  "engines": {
+    "vscode": "^1.98.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "tsz.restartLanguageServer",
+        "title": "TSZ: Restart Language Server"
+      }
+    ],
+    "configuration": {
+      "title": "TSZ",
+      "properties": {
+        "tsz.lsp.path": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the tsz-lsp binary. If empty, the extension uses <first workspace folder>/.target/debug/tsz-lsp or /.target/release/tsz-lsp."
+        },
+        "tsz.lsp.args": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Extra arguments passed to tsz-lsp."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.50",
+    "@types/vscode": "^1.98.0",
+    "typescript": "^5.8.3",
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/scripts/vscode-tsz-lsp/src/extension.ts
+++ b/scripts/vscode-tsz-lsp/src/extension.ts
@@ -1,0 +1,155 @@
+import * as cp from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("tsz.restartLanguageServer", async () => {
+      await restartClient(context, true);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("tsz.lsp.path") || event.affectsConfiguration("tsz.lsp.args")) {
+        await restartClient(context, false);
+      }
+    }),
+  );
+
+  await startClient(context, true);
+}
+
+export async function deactivate(): Promise<void> {
+  if (client) {
+    await client.stop();
+    client = undefined;
+  }
+}
+
+async function restartClient(context: vscode.ExtensionContext, userRequested: boolean): Promise<void> {
+  if (client) {
+    await client.stop();
+    client = undefined;
+  }
+
+  await startClient(context, userRequested);
+}
+
+async function startClient(context: vscode.ExtensionContext, userRequested: boolean): Promise<void> {
+  const resolution = resolveServerCommand(context);
+  const resolvedCommand = resolution.command;
+  if (!resolvedCommand) {
+    const message = [
+      "Could not find tsz-lsp.",
+      "Build it with: cargo build -p tsz-cli --bin tsz-lsp, or set tsz.lsp.path.",
+      `Checked: ${resolution.checkedPaths.join(", ")}`,
+    ].join(" ");
+    if (userRequested) {
+      void vscode.window.showErrorMessage(message);
+    }
+    return;
+  }
+
+  const args = vscode.workspace.getConfiguration("tsz").get<string[]>("lsp.args", []);
+  const outputChannel = vscode.window.createOutputChannel("TSZ LSP");
+  const traceOutputChannel = vscode.window.createOutputChannel("TSZ LSP Trace");
+
+  const serverOptions: ServerOptions = () => {
+    const serverArgs = ensureStdioMode(args);
+    const serverProcess = cp.spawn(resolvedCommand, serverArgs, {
+      cwd: resolution.workingDirectory,
+      stdio: "pipe",
+    });
+
+    return Promise.resolve(serverProcess);
+  };
+
+  const watcher = vscode.workspace.createFileSystemWatcher("**/*.{ts,tsx,js,jsx,mjs,cjs}");
+  context.subscriptions.push(watcher);
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      { scheme: "file", language: "typescript" },
+      { scheme: "file", language: "typescriptreact" },
+      { scheme: "file", language: "javascript" },
+      { scheme: "file", language: "javascriptreact" },
+    ],
+    outputChannel,
+    traceOutputChannel,
+    synchronize: {
+      fileEvents: watcher,
+    },
+  };
+
+  client = new LanguageClient("tsz-lsp", "TSZ LSP", serverOptions, clientOptions);
+  context.subscriptions.push(client);
+  await client.start();
+}
+
+function resolveServerCommand(context: vscode.ExtensionContext): {
+  command: string | undefined;
+  checkedPaths: string[];
+  workingDirectory: string;
+} {
+  const configuredPath = vscode.workspace.getConfiguration("tsz").get<string>("lsp.path", "").trim();
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const extensionRepoRoot = path.resolve(context.extensionPath, "..", "..");
+  const workingDirectory = workspaceFolder ?? extensionRepoRoot;
+
+  if (configuredPath) {
+    return {
+      command: fs.existsSync(configuredPath) ? configuredPath : undefined,
+      checkedPaths: [configuredPath],
+      workingDirectory,
+    };
+  }
+
+  const roots = new Set<string>();
+  if (workspaceFolder) {
+    roots.add(workspaceFolder);
+  }
+
+  roots.add(extensionRepoRoot);
+
+  const checkedPaths: string[] = [];
+  for (const root of roots) {
+    for (const candidate of binaryCandidates(root)) {
+      checkedPaths.push(candidate);
+      if (fs.existsSync(candidate)) {
+        return { command: candidate, checkedPaths, workingDirectory };
+      }
+    }
+  }
+
+  return { command: undefined, checkedPaths, workingDirectory };
+}
+
+function binaryName(): string {
+  return process.platform === "win32" ? "tsz-lsp.exe" : "tsz-lsp";
+}
+
+function binaryCandidates(root: string): string[] {
+  return [
+    path.join(root, ".target", "debug", binaryName()),
+    path.join(root, ".target", "release", binaryName()),
+    path.join(root, "target", "debug", binaryName()),
+    path.join(root, "target", "release", binaryName()),
+  ];
+}
+
+function ensureStdioMode(args: string[]): string[] {
+  if (args.includes("--mode")) {
+    return args;
+  }
+
+  return ["--mode", "stdio", ...args];
+}

--- a/scripts/vscode-tsz-lsp/tsconfig.json
+++ b/scripts/vscode-tsz-lsp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "target": "ES2022",
+    "lib": [
+      "ES2022"
+    ],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "sourceMap": true,
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a minimal local VS Code extension under scripts/vscode-tsz-lsp for running tsz-lsp in an Extension Development Host
- add repo-local VS Code launch/tasks to build and run the dev client against the repos .target output
- fix the member-access completion regression where `user.` could be hijacked by earlier string-literal completion context
- add a regression test for that completion case
- trim the local benchmark page by removing the duplicated local benchmark instructions section

## Verification
- cargo nextest run -p tsz-lsp -- test_completions_member_access_wins_over_prior_string_literal_context test_completions_contextual_string_literal_argument_keyof
- pre-commit hook during commit: cargo fmt, clippy, wasm32 warnings gate, architecture guardrails, and tsz-lsp test suite all passed

## Notes
- the VS Code dev client lives under scripts/ to avoid introducing a new top-level directory
- .vscode/launch.json is force-added because the repo ignore rules exclude .vscode files by default
