### PR TITLE
[codex] Keep constructor inequality guards positive-only

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1,5 +1,7 @@
 //! Diagnostic source/target expression analysis and formatting.
 
+mod compound_assignment_context;
+
 use crate::diagnostics::diagnostic_codes;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -8,75 +10,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    /// Returns true when `anchor_idx` sits inside an arithmetic/bitwise
-    /// compound assignment (`+=`, `-=`, `*=`, `&=`, etc.) — as the LHS/RHS of
-    /// the compound binary, the binary itself, or the enclosing expression
-    /// statement.
-    ///
-    /// For such contexts tsc widens literal types in the TS2322 message
-    /// because the effective source of `x op= y` is the binary result `x op y`,
-    /// which tsc reports with literal widening applied. Logical compound
-    /// assignments (`&&=`, `||=`, `??=`) preserve the narrow RHS type and are
-    /// deliberately excluded.
-    fn in_arithmetic_compound_assignment_context(&self, anchor_idx: NodeIndex) -> bool {
-        use tsz_scanner::SyntaxKind;
-
-        let is_arith_compound_op = |op: u16| -> bool {
-            crate::query_boundaries::common::is_compound_assignment_operator(op)
-                && !matches!(
-                    op,
-                    k if k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                        || k == SyntaxKind::BarBarEqualsToken as u16
-                        || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-                )
-        };
-
-        let node_is_arith_compound_bin = |idx: NodeIndex| -> bool {
-            self.ctx.arena.get(idx).is_some_and(|node| {
-                node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                    && self
-                        .ctx
-                        .arena
-                        .get_binary_expr(node)
-                        .is_some_and(|bin| is_arith_compound_op(bin.operator_token))
-            })
-        };
-
-        if node_is_arith_compound_bin(anchor_idx) {
-            return true;
-        }
-
-        if let Some(node) = self.ctx.arena.get(anchor_idx)
-            && node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
-            && let Some(stmt) = self.ctx.arena.get_expression_statement(node)
-            && node_is_arith_compound_bin(stmt.expression)
-        {
-            return true;
-        }
-
-        let Some(ext) = self.ctx.arena.get_extended(anchor_idx) else {
-            return false;
-        };
-        node_is_arith_compound_bin(ext.parent)
-    }
-
-    fn is_property_assignment_initializer(&self, anchor_idx: NodeIndex) -> bool {
-        let current = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
-        let Some(ext) = self.ctx.arena.get_extended(current) else {
-            return false;
-        };
-        let parent_idx = ext.parent;
-        let Some(parent) = self.ctx.arena.get(parent_idx) else {
-            return false;
-        };
-        parent.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
-            && self
-                .ctx
-                .arena
-                .get_property_assignment(parent)
-                .is_some_and(|prop| prop.initializer == current)
-    }
-
     pub(crate) fn object_literal_initializer_anchor_for_type(
         &mut self,
         object_idx: NodeIndex,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/compound_assignment_context.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/compound_assignment_context.rs
@@ -1,0 +1,73 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    /// Returns true when `anchor_idx` sits inside an arithmetic/bitwise
+    /// compound assignment (`+=`, `-=`, `*=`, `&=`, etc.) — as the LHS/RHS of
+    /// the compound binary, the binary itself, or the enclosing expression
+    /// statement.
+    ///
+    /// For such contexts tsc widens literal types in the TS2322 message
+    /// because the effective source of `x op= y` is the binary result `x op y`,
+    /// which tsc reports with literal widening applied. Logical compound
+    /// assignments (`&&=`, `||=`, `??=`) preserve the narrow RHS type and are
+    /// deliberately excluded.
+    pub(super) fn in_arithmetic_compound_assignment_context(&self, anchor_idx: NodeIndex) -> bool {
+        let is_arith_compound_op = |op: u16| -> bool {
+            crate::query_boundaries::common::is_compound_assignment_operator(op)
+                && !matches!(
+                    op,
+                    k if k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
+                        || k == SyntaxKind::BarBarEqualsToken as u16
+                        || k == SyntaxKind::QuestionQuestionEqualsToken as u16
+                )
+        };
+
+        let node_is_arith_compound_bin = |idx: NodeIndex| -> bool {
+            self.ctx.arena.get(idx).is_some_and(|node| {
+                node.kind == syntax_kind_ext::BINARY_EXPRESSION
+                    && self
+                        .ctx
+                        .arena
+                        .get_binary_expr(node)
+                        .is_some_and(|bin| is_arith_compound_op(bin.operator_token))
+            })
+        };
+
+        if node_is_arith_compound_bin(anchor_idx) {
+            return true;
+        }
+
+        if let Some(node) = self.ctx.arena.get(anchor_idx)
+            && node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
+            && let Some(stmt) = self.ctx.arena.get_expression_statement(node)
+            && node_is_arith_compound_bin(stmt.expression)
+        {
+            return true;
+        }
+
+        let Some(ext) = self.ctx.arena.get_extended(anchor_idx) else {
+            return false;
+        };
+        node_is_arith_compound_bin(ext.parent)
+    }
+
+    pub(super) fn is_property_assignment_initializer(&self, anchor_idx: NodeIndex) -> bool {
+        let current = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
+        let Some(ext) = self.ctx.arena.get_extended(current) else {
+            return false;
+        };
+        let parent_idx = ext.parent;
+        let Some(parent) = self.ctx.arena.get(parent_idx) else {
+            return false;
+        };
+        parent.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
+            && self
+                .ctx
+                .arena
+                .get_property_assignment(parent)
+                .is_some_and(|prop| prop.initializer == current)
+    }
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1,5 +1,7 @@
 //! Function, method, and arrow function type resolution.
+mod function_name_diagnostics;
 mod js_prototype;
+mod jsx_body_context;
 
 use crate::computation::complex::{
     expression_needs_contextual_return_type, is_contextually_sensitive,
@@ -15,23 +17,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{TypeId, TypeParamInfo};
 impl<'a> CheckerState<'a> {
-    fn is_jsx_body_child_closure(&self, func_idx: NodeIndex) -> bool {
-        let mut current = func_idx;
-        while let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent) {
-            let Some(parent_node) = self.ctx.arena.get(parent) else {
-                break;
-            };
-            match parent_node.kind {
-                k if k == syntax_kind_ext::JSX_ATTRIBUTE => return false,
-                k if k == syntax_kind_ext::JSX_ELEMENT || k == syntax_kind_ext::JSX_FRAGMENT => {
-                    return true;
-                }
-                _ => current = parent,
-            }
-        }
-        false
-    }
-
     /// Get type of function declaration/expression/arrow.
     pub(crate) fn get_type_of_function(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_function_impl(idx, &TypingRequest::NONE)
@@ -144,57 +129,12 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TS1100: `eval` or `arguments` used as a function expression name in strict mode.
-        if node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            && let Some(name_idx) = name_node
-            && let Some(name_n) = self.ctx.arena.get(name_idx)
-            && let Some(ident) = self.ctx.arena.get_identifier(name_n)
-        {
-            let name = &ident.escaped_text;
-            if self.is_strict_mode_for_node(name_idx)
-                && crate::state_checking::is_eval_or_arguments(name)
-                && !(self.ctx.enclosing_class.is_some() && name.as_str() == "arguments")
-            {
-                self.emit_eval_or_arguments_strict_mode_error(name_idx, name);
-            }
-        }
-
-        // TS1212: Reserved word used as function expression name in strict mode.
-        // This check is for function expressions (declarations are checked in check_function_declaration_callback).
-        if node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            && let Some(name_idx) = name_node
-            && let Some(name_n) = self.ctx.arena.get(name_idx)
-            && let Some(ident) = self.ctx.arena.get_identifier(name_n)
-        {
-            let name = &ident.escaped_text;
-            if self.is_strict_mode_for_node(name_idx)
-                && !self.ctx.is_ambient_declaration(idx)
-                && crate::state_checking::is_strict_mode_reserved_name(name)
-            {
-                self.emit_strict_mode_reserved_word_error(name_idx, name, true);
-            }
-        }
-
-        // TS1359: 'await' used as function name in async context.
-        // Async functions create an implicit async context where 'await' is reserved.
-        // Skip for async generators — the parser handles `await` as a name there (TS1109).
-        if node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            && function_is_async
-            && !function_is_generator
-            && let Some(name_idx) = name_node
-            && let Some(name_n) = self.ctx.arena.get(name_idx)
-            && let Some(ident) = self.ctx.arena.get_identifier(name_n)
-        {
-            let name = &ident.escaped_text;
-            if name == "await" {
-                use crate::diagnostics::diagnostic_codes;
-                self.error_at_node(
-                    name_idx,
-                    "Identifier expected. 'await' is a reserved word that cannot be used here.",
-                    diagnostic_codes::IDENTIFIER_EXPECTED_IS_A_RESERVED_WORD_THAT_CANNOT_BE_USED_HERE,
-                );
-            }
-        }
+        self.check_function_expression_name_diagnostics(
+            idx,
+            name_node,
+            function_is_async,
+            function_is_generator,
+        );
 
         // Push enclosing type parameters so nested functions can reference outer generic scopes.
         let enclosing_type_param_updates = self.push_enclosing_type_parameters(idx);

--- a/crates/tsz-checker/src/types/function_type/function_name_diagnostics.rs
+++ b/crates/tsz-checker/src/types/function_type/function_name_diagnostics.rs
@@ -1,0 +1,55 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn check_function_expression_name_diagnostics(
+        &mut self,
+        idx: NodeIndex,
+        name_node: Option<NodeIndex>,
+        function_is_async: bool,
+        function_is_generator: bool,
+    ) {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return;
+        };
+
+        if node.kind != syntax_kind_ext::FUNCTION_EXPRESSION {
+            return;
+        }
+
+        let Some(name_idx) = name_node else {
+            return;
+        };
+        let Some(name_n) = self.ctx.arena.get(name_idx) else {
+            return;
+        };
+        let Some(ident) = self.ctx.arena.get_identifier(name_n) else {
+            return;
+        };
+        let name = &ident.escaped_text;
+
+        if self.is_strict_mode_for_node(name_idx)
+            && crate::state_checking::is_eval_or_arguments(name)
+            && !(self.ctx.enclosing_class.is_some() && name.as_str() == "arguments")
+        {
+            self.emit_eval_or_arguments_strict_mode_error(name_idx, name);
+        }
+
+        if self.is_strict_mode_for_node(name_idx)
+            && !self.ctx.is_ambient_declaration(idx)
+            && crate::state_checking::is_strict_mode_reserved_name(name)
+        {
+            self.emit_strict_mode_reserved_word_error(name_idx, name, true);
+        }
+
+        if function_is_async && !function_is_generator && name == "await" {
+            use crate::diagnostics::diagnostic_codes;
+            self.error_at_node(
+                name_idx,
+                "Identifier expected. 'await' is a reserved word that cannot be used here.",
+                diagnostic_codes::IDENTIFIER_EXPECTED_IS_A_RESERVED_WORD_THAT_CANNOT_BE_USED_HERE,
+            );
+        }
+    }
+}

--- a/crates/tsz-checker/src/types/function_type/jsx_body_context.rs
+++ b/crates/tsz-checker/src/types/function_type/jsx_body_context.rs
@@ -1,0 +1,22 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn is_jsx_body_child_closure(&self, func_idx: NodeIndex) -> bool {
+        let mut current = func_idx;
+        while let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent) {
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                break;
+            };
+            match parent_node.kind {
+                k if k == syntax_kind_ext::JSX_ATTRIBUTE => return false,
+                k if k == syntax_kind_ext::JSX_ELEMENT || k == syntax_kind_ext::JSX_FRAGMENT => {
+                    return true;
+                }
+                _ => current = parent,
+            }
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -78,7 +78,16 @@ impl<'a> CheckerState<'a> {
             }
             // For rest parameters aligned with the contextual rest, preserve the
             // original type (including type parameters like `Args extends any[]`).
-            return Some(rest_param.type_id);
+            if crate::query_boundaries::common::is_type_parameter_like(
+                self.ctx.types,
+                rest_param.type_id,
+            ) || crate::query_boundaries::common::contains_type_parameters(
+                self.ctx.types,
+                rest_param.type_id,
+            ) {
+                return Some(rest_param.type_id);
+            }
+            return None;
         }
         let rest_param_type = self.contextual_rest_parameter_source_type(rest_param.type_id);
 

--- a/crates/tsz-checker/tests/conformance_issues/features/import_aliases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/import_aliases.rs
@@ -697,7 +697,7 @@ if (x.constructor === C8) {
 }
 
 #[test]
-fn test_constructor_narrowing_false_branch() {
+fn test_constructor_identity_false_branch_keeps_original_union() {
     let diagnostics = compile_and_get_diagnostics(
         r"
 class A { a!: string; }
@@ -705,15 +705,19 @@ class B { b!: number; }
 
 declare let x: A | B;
 if (x.constructor !== A) {
-    x; // should be B (A excluded)
-    x.b; // OK
+    x; // A | B
+    x.b; // TS2339: constructor inequality does not exclude A
 }
         ",
     );
+    let ts2339: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, message)| *code == 2339 && message.contains("A | B"))
+        .collect();
     assert!(
-        !has_error(&diagnostics, 2339),
-        "Constructor narrowing false branch: x.constructor !== A should \
-         exclude A from the union, leaving B. Got: {diagnostics:?}"
+        !ts2339.is_empty(),
+        "Constructor identity inequality should keep the original union in \
+         the false branch, matching tsc. Got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -882,6 +882,8 @@ fn evaluate_rest_like_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Typ
             | TypeData::Mapped(_)
             | TypeData::Conditional(_)
             | TypeData::IndexAccess(_, _)
+            | TypeData::TypeQuery(_)
+            | TypeData::KeyOf(_)
             | TypeData::Application(_),
         ) => {
             let evaluated = crate::evaluation::evaluate::evaluate_type(db, type_id);

--- a/crates/tsz-solver/src/narrowing/instanceof.rs
+++ b/crates/tsz-solver/src/narrowing/instanceof.rs
@@ -875,42 +875,23 @@ impl<'a> NarrowingContext<'a> {
 
     /// Narrow by `x.constructor !== SomeClass` (false branch).
     ///
-    /// Excludes the exact instance type from the union.
+    /// TypeScript treats constructor identity as a positive-only guard. The
+    /// true branch can narrow to the exact class, but the negative branch keeps
+    /// the original type rather than excluding the class.
     pub fn narrow_by_constructor_false(
         &self,
         source_type: TypeId,
-        instance_type: TypeId,
+        _instance_type: TypeId,
     ) -> TypeId {
         let _span = span!(
             Level::TRACE,
             "narrow_by_constructor_false",
             source = source_type.0,
-            instance = instance_type.0
+            instance = _instance_type.0
         )
         .entered();
 
-        if source_type == TypeId::ANY {
-            return source_type;
-        }
-
-        let resolved_instance = self.resolve_type(instance_type);
-
-        if let Some(members_list) = union_list_id(self.db, source_type) {
-            let members = self.db.type_list(members_list);
-            let filtered: Vec<TypeId> = members
-                .iter()
-                .copied()
-                .filter(|&m| !self.types_match_nominally(m, instance_type, resolved_instance))
-                .collect();
-            trace!(kept = filtered.len(), total = members.len());
-            return super::union_or_single_preserve(self.db, filtered);
-        }
-
-        if self.types_match_nominally(source_type, instance_type, resolved_instance) {
-            TypeId::NEVER
-        } else {
-            source_type
-        }
+        source_type
     }
 
     /// Check if two types refer to the same nominal declaration.

--- a/crates/tsz-solver/tests/narrowing_tests.rs
+++ b/crates/tsz-solver/tests/narrowing_tests.rs
@@ -229,6 +229,27 @@ fn test_narrow_excluding_discriminant() {
     assert_eq!(narrowed, expected);
 }
 
+#[test]
+fn test_constructor_identity_false_branch_does_not_exclude_instance() {
+    let interner = TypeInterner::new();
+    let prop = interner.intern_string("property1");
+    let class_instance = interner.object(vec![PropertyInfo::new(prop, TypeId::STRING)]);
+    let source = interner.union(vec![class_instance, TypeId::NUMBER]);
+    let ctx = NarrowingContext::new(&interner);
+
+    let narrowed = ctx.narrow_type(
+        source,
+        &TypeGuard::Constructor(class_instance),
+        GuardSense::Negative,
+    );
+
+    assert_eq!(
+        narrowed, source,
+        "constructor identity inequality is a positive-only guard; \
+         `x.constructor !== C` must not remove C from the source union"
+    );
+}
+
 // =============================================================================
 // Typeof Narrowing Tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes constructor identity narrowing so `x.constructor !== C` keeps the source type unchanged, matching TypeScript's positive-only treatment of constructor identity guards. The randomly selected conformance target was `TypeScript/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts`.

Root cause: the solver treated `x.constructor !== C` as the complement of the exact constructor type, so `number | C1` was narrowed to `number` and TS2339 rendered the actual type as `number` instead of TypeScript's `number | C1`.

This also includes a small verifier-uncovered rest-context repair for concrete `typeof` tuple rest callbacks, while preserving generic rest parameter identity, and mechanical checker helper splits/formatting needed to keep local guardrails green.

## Tests

- Added solver unit test: `test_constructor_identity_false_branch_does_not_exclude_instance`
- Updated checker unit expectation: `test_constructor_identity_false_branch_keeps_original_union`
- Existing verifier-covered unit: `test_contextual_tuple_rest_callbacks_accept_variadic_typeof_tuple_shapes`

## Verification

- `./scripts/conformance/conformance.sh run --filter "typeGuardConstructorClassAndNumber" --verbose` passed: 1/1
- `scripts/session/verify-all.sh` passed all suites:
  - formatting
  - clippy
  - unit tests
  - conformance: 12062 vs 12015 baseline (+47)
  - emit tests: JS +4, DTS +25
  - fourslash/LSP: 50 passed, 0 failed

Final rebase check before push: `git fetch origin --prune && git rebase origin/main` was up to date; HEAD stayed at `12230c4c90145df96f68a459bfccec99f9573264` before applying the commit.
