### PR TITLE
fix(checker): typeof/lazy in contextual rest params + raise reverse-mapped test budget

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,8 +20,16 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.default.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(reverse_mapped_union_template_definition_pattern) | test(test_ts2536_with_lib_mismatched_keyof_source)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source)'
 slow-timeout = { period = "90s", terminate-after = 2 }
+
+# Pre-existing perf hotspot: recursive reverse-mapped inference over union
+# templates (`Definition<T> = { [K in keyof T]: f(T[K]) | Definition<T[K]> }`).
+# Completes correctly but is slow; local ~120s, CI's shared runners exceed 180s.
+# Root cause tracked separately — raise the budget until a solver-side fix lands.
+[[profile.default.overrides]]
+filter = 'test(reverse_mapped_union_template_definition_pattern)'
+slow-timeout = { period = "90s", terminate-after = 3 }
 
 [profile.default.junit]
 path = "target/nextest/default/junit.xml"
@@ -35,8 +43,14 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(reverse_mapped_union_template_definition_pattern) | test(test_ts2536_with_lib_mismatched_keyof_source)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source)'
 slow-timeout = { period = "90s", terminate-after = 2 }
+
+# See note in profile.default.overrides — CI hardware needs a larger budget
+# for recursive reverse-mapped inference with union templates.
+[[profile.ci.overrides]]
+filter = 'test(reverse_mapped_union_template_definition_pattern)'
+slow-timeout = { period = "90s", terminate-after = 3 }
 
 # Quick profile for fast feedback during development
 [profile.quick]
@@ -54,8 +68,13 @@ test-threads = "num-cpus"
 status-level = "fail"
 
 [[profile.precommit.overrides]]
-filter = 'test(test_ts2536_with_lib_mismatched_keyof_source) | test(reverse_mapped_union_template_definition_pattern)'
+filter = 'test(test_ts2536_with_lib_mismatched_keyof_source)'
 slow-timeout = { period = "90s", terminate-after = 2 }
+
+# See note in profile.default.overrides.
+[[profile.precommit.overrides]]
+filter = 'test(reverse_mapped_union_template_definition_pattern)'
+slow-timeout = { period = "90s", terminate-after = 3 }
 
 # Long-running tests profile (for conformance tests)
 [profile.conformance]

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -382,12 +382,21 @@ impl<'a> CheckerState<'a> {
         updates
     }
 
-    /// Evaluate Application types in rest parameters of contextual function types.
+    /// Evaluate indirection (Application, typeof, lazy) in rest parameters of
+    /// contextual function types so that downstream contextual-typing code can
+    /// split the tuple across the callback's own parameters.
+    ///
+    /// Why: `(...args: typeof t2) => void` where `t2: [number, boolean, ...string[]]`
+    /// needs to expose the tuple shape to `(a, b, c) => {}` param matching. When
+    /// the outer context is preserved raw (#688), this helper is the only place
+    /// that resolves the rest param — so it must handle more than just Application.
     pub(crate) fn evaluate_contextual_rest_param_applications(
         &mut self,
         type_id: TypeId,
     ) -> TypeId {
-        use crate::query_boundaries::common::function_shape_for_type;
+        use crate::query_boundaries::common::{
+            function_shape_for_type, is_generic_application, is_type_query_type, lazy_def_id,
+        };
 
         let Some(shape) = function_shape_for_type(self.ctx.types, type_id) else {
             return type_id;
@@ -401,16 +410,16 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
-        // Only try to evaluate if the rest param type is an Application
-        if !crate::query_boundaries::common::is_generic_application(
-            self.ctx.types,
-            last_param.type_id,
-        ) {
+        let rest_tid = last_param.type_id;
+        let needs_resolution = is_generic_application(self.ctx.types, rest_tid)
+            || is_type_query_type(self.ctx.types, rest_tid)
+            || lazy_def_id(self.ctx.types, rest_tid).is_some();
+        if !needs_resolution {
             return type_id;
         }
 
-        let evaluated_rest = self.evaluate_application_type(last_param.type_id);
-        if evaluated_rest == last_param.type_id {
+        let evaluated_rest = self.evaluate_type_with_env(rest_tid);
+        if evaluated_rest == rest_tid {
             return type_id;
         }
 


### PR DESCRIPTION
## Summary

Two pre-existing regressions that were landing on `origin/main` and blocking local dev and CI:

1. **`test_contextual_tuple_rest_callbacks_accept_variadic_typeof_tuple_shapes`** was failing with TS2345 on callbacks assigned against `(...args: typeof t2) => void` where `t2: [number, boolean, ...string[]]`. Root cause: #688 ("preserve raw mixed contextual function types") stopped evaluating the outer contextual type for callable contexts, delegating rest-param resolution to `evaluate_contextual_rest_param_applications`. That helper only handled `Application` types, so `typeof t2` and `Lazy(DefId)` rest params stayed unresolved, which blocked tuple-shape splitting across the inner callback parameters. Fix extends the helper to also resolve type queries and lazy refs via `evaluate_type_with_env`, reusing existing query-boundary helpers (`is_type_query_type`, `lazy_def_id`). Still routes through the solver — no new checker-side type algorithms.

2. **`reverse_mapped_union_template_definition_pattern`** was timing out at 180s in CI's "Test: Checker (4/4)" shard. The test completes correctly (~120s locally) but CI's shared runners need more headroom. The underlying perf hotspot is recursive reverse-mapped inference over union templates (`Definition<T> = { [K in keyof T]: f(T[K]) \| Definition<T[K]> }`) and needs a separate solver-side fix. This PR gives just that one test `terminate-after = 3` (270s budget) in the default/ci/precommit profiles, split out from the other slow-test overrides so the hang-detection guarantee stays tight for every other test.

## Test plan

- [x] `cargo nextest run -p tsz-checker -E 'test(test_contextual_tuple_rest_callbacks_accept_variadic_typeof_tuple_shapes)'` — PASS
- [x] `cargo nextest run -p tsz-checker -E 'test(reverse_mapped_union_template_definition_pattern)'` — PASS in 119s
- [x] `cargo nextest run -p tsz-checker --lib -E 'test(architecture_contract)'` — 101 PASS
- [x] `cargo fmt --all -- --check` — clean
- [x] Full precommit suite (12889 tests) — clean