### PR TITLE
[codex] fix checker unreachable for-clause IIFE anchors

### DIFF
--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -34,6 +34,38 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    pub(crate) fn terminating_iife_unreachable_anchor(
+        &mut self,
+        expr_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let expr_node = self.ctx.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+
+        let call = self.ctx.arena.get_call_expr(expr_node)?;
+        let callee = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(call.expression);
+        let callee_node = self.ctx.arena.get(callee)?;
+        if callee_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+            && callee_node.kind != syntax_kind_ext::ARROW_FUNCTION
+        {
+            return None;
+        }
+
+        let func = self.ctx.arena.get_function(callee_node)?;
+        let body_idx = func.body;
+        let body_node = self.ctx.arena.get(body_idx)?;
+        let block = self.ctx.arena.get_block(body_node)?;
+        let statements = block.statements.nodes.clone();
+
+        statements
+            .into_iter()
+            .find(|&stmt_idx| self.statement_always_throws(stmt_idx))
+    }
+
     /// Check if a callee expression explicitly returns `never` based on its
     /// declaration's return type annotation. This avoids fully type-checking the
     /// call expression, which would cache a potentially stale result in

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -986,6 +986,21 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         );
     }
 
+    fn report_unreachable_code_at_terminating_iife_body(&mut self, node_idx: NodeIndex) -> bool {
+        if self.ctx.compiler_options.allow_unreachable_code != Some(false) {
+            return false;
+        }
+        let Some(anchor) = self.terminating_iife_unreachable_anchor(node_idx) else {
+            return false;
+        };
+        self.error_at_node(
+            anchor,
+            crate::diagnostics::diagnostic_messages::UNREACHABLE_CODE_DETECTED,
+            crate::diagnostics::diagnostic_codes::UNREACHABLE_CODE_DETECTED,
+        );
+        true
+    }
+
     fn enter_iteration_statement(&mut self) {
         self.ctx.iteration_depth += 1;
     }

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -317,6 +317,10 @@ pub trait StatementCheckCallbacks {
     /// Used for for-loop condition/incrementer that are unreachable.
     fn report_unreachable_code_at_node(&mut self, node_idx: NodeIndex);
 
+    /// Report TS7027 at the statement inside a direct throwing IIFE, if the
+    /// given expression is one.
+    fn report_unreachable_code_at_terminating_iife_body(&mut self, node_idx: NodeIndex) -> bool;
+
     /// Enter an iteration statement (for/while/do-while/for-in/for-of).
     /// Increments `iteration_depth` for break/continue validation.
     fn enter_iteration_statement(&mut self);
@@ -609,9 +613,22 @@ impl StatementChecker {
                         }
                     }
 
-                    // If the initializer always throws, the condition is unreachable
+                    // If the initializer always throws, the remaining for-clause
+                    // expressions are unreachable.
+                    // For direct throwing IIFEs, tsc anchors the unreachable
+                    // diagnostic inside the unreachable IIFE bodies, not at
+                    // the `for` clause expression starts.
                     if init_terminates && condition.is_some() {
-                        state.report_unreachable_code_at_node(condition);
+                        let reported_condition =
+                            state.report_unreachable_code_at_terminating_iife_body(condition);
+                        if !reported_condition {
+                            state.report_unreachable_code_at_node(condition);
+                        }
+                        if incrementor.is_some()
+                            && !state.report_unreachable_code_at_terminating_iife_body(incrementor)
+                        {
+                            state.report_unreachable_code_at_node(incrementor);
+                        }
                     }
 
                     let mut condition_is_false = false;
@@ -621,15 +638,15 @@ impl StatementChecker {
                         state.check_truthy_or_falsy(condition);
                         condition_is_false = state.is_false_condition(condition);
                         // Check if the condition expression itself terminates control flow
-                        if !init_terminates {
-                            condition_terminates =
-                                state.call_expression_terminates_control_flow(condition);
-                        }
+                        condition_terminates =
+                            state.call_expression_terminates_control_flow(condition);
                     }
 
                     // If the condition always throws, the incrementer is unreachable
-                    if (init_terminates || condition_terminates) && incrementor.is_some() {
-                        state.report_unreachable_code_at_node(incrementor);
+                    if !init_terminates && condition_terminates && incrementor.is_some() {
+                        if !state.report_unreachable_code_at_terminating_iife_body(incrementor) {
+                            state.report_unreachable_code_at_node(incrementor);
+                        }
                     }
 
                     let prev_unreachable = state.is_unreachable();
@@ -642,7 +659,11 @@ impl StatementChecker {
                     state.enter_iteration_statement();
                     state.check_declaration_in_statement_position(statement);
                     state.check_statement_with_request(statement, request);
-                    if incrementor.is_some() {
+                    if incrementor.is_some()
+                        && !condition_is_false
+                        && !init_terminates
+                        && !condition_terminates
+                    {
                         state.get_type_of_node_with_request(incrementor, &non_contextual_request);
                     }
                     state.leave_iteration_statement();

--- a/crates/tsz-checker/tests/never_returning_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/never_returning_narrowing_tests.rs
@@ -11,6 +11,7 @@
 
 use crate::context::CheckerOptions;
 use crate::state::CheckerState;
+use crate::test_utils::check_source;
 use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
 use tsz_solver::TypeInterner;
@@ -143,6 +144,41 @@ function f() {
     assert!(
         !codes.contains(&7027),
         "Expected no TS7027 after calling an inferred-never local identifier, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn throwing_iifes_in_for_clauses_anchor_unreachable_at_throw_statements() {
+    let source = r#"
+try {
+    for (
+        (function () { throw "1"; })();
+        (function () { throw "2"; })();
+        (function () { throw "3"; })()
+    ) {}
+} catch (e) {}
+"#;
+    let diagnostics = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            allow_unreachable_code: Some(false),
+            ..Default::default()
+        },
+    );
+    let starts: Vec<u32> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 7027)
+        .map(|diag| diag.start)
+        .collect();
+    let expected = vec![
+        source.find("throw \"2\"").unwrap() as u32,
+        source.find("throw \"3\"").unwrap() as u32,
+    ];
+
+    assert_eq!(
+        starts, expected,
+        "expected TS7027 to be anchored at the unreachable throwing IIFE bodies; diagnostics: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes TS7027 diagnostic anchoring for unreachable direct throwing IIFEs in `for` condition and incrementor clauses.

Root cause: `tsc` reports TS7027 inside unreachable direct throwing IIFE bodies in `for` condition/incrementor clauses after a never-returning initializer, but `tsz` anchored those diagnostics at the clause expression starts and could also type-check an already unreachable incrementor.

Fixed conformance target: `TypeScript/tests/cases/compiler/reachabilityChecks8.ts`

```ts
try {
    for (
        (function () { throw "1"; })();
        (function () { throw "2"; })();
        (function () { throw "3"; })()
    ) {}
} catch (e) {}
```

This now reports TS7027 at `throw "2"` and `throw "3"`, matching TypeScript diagnostic anchors.

## Tests

Unit test added: `throwing_iifes_in_for_clauses_anchor_unreachable_at_throw_statements`

Verification:

- `cargo fmt --check`
- `cargo nextest run --package tsz-checker --lib throwing_iifes_in_for_clauses_anchor_unreachable_at_throw_statements`
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "reachabilityChecks8" --verbose` passed `1/1`
- `./scripts/conformance/conformance.sh run --max 200` passed `200/200`
- `scripts/session/verify-all.sh` passed all suites: formatting, clippy, unit tests, conformance (+47), emit tests (JS +4, DTS +25), fourslash/LSP (=50)
