### PR TITLE
[codex] Fix template literal overlap diagnostics

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -70,6 +70,24 @@ fn no_duplicate_ts2367_for_same_type_comparison() {
 }
 
 #[test]
+fn ts2367_template_literal_prefix_and_suffix_overlap() {
+    let diags = check_source_diagnostics(
+        r#"
+function f(x: `foo-${string}`, y: `${string}-bar`, z: `baz-${string}`) {
+    if (x === y) {}
+    if (x === z) {}
+}
+"#,
+    );
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        1,
+        "Expected TS2367 only for the disjoint `baz-${{string}}` comparison, got: {relevant:?}"
+    );
+}
+
+#[test]
 fn ts2367_typeof_vs_invalid_typeof_string() {
     // typeof x returns "string"|"number"|"bigint"|"boolean"|"symbol"|"undefined"|"object"|"function"
     // Comparing with "Object" (capital O) should trigger TS2367 — no overlap.

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1035,6 +1035,22 @@ impl<'a> CheckerState<'a> {
             return !has_overlap;
         }
 
+        if crate::query_boundaries::common::is_template_literal_type(self.ctx.types, effective_left)
+            || crate::query_boundaries::common::is_template_literal_type(
+                self.ctx.types,
+                effective_right,
+            )
+        {
+            let env = self.ctx.type_env.borrow();
+            return !crate::query_boundaries::assignability::are_types_overlapping_with_env(
+                self.ctx.types,
+                &env,
+                effective_left,
+                effective_right,
+                self.ctx.strict_null_checks(),
+            );
+        }
+
         // Check union types: if any member of one union overlaps with the other, they overlap
         if let query::UnionMembersKind::Union(left_members) =
             query::classify_for_union_members(self.ctx.types, effective_left)

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -92,7 +92,7 @@ impl TypeInterner {
     fn get_string_literal_values(&self, type_id: TypeId) -> Option<Vec<String>> {
         // Handle BOOLEAN intrinsic (expands to two string literals)
         if type_id == TypeId::BOOLEAN {
-            return Some(vec!["true".to_string(), "false".to_string()]);
+            return Some(vec!["false".to_string(), "true".to_string()]);
         }
 
         // Helper to convert a single type to a string value if possible

--- a/crates/tsz-solver/src/relations/subtype/overlap.rs
+++ b/crates/tsz-solver/src/relations/subtype/overlap.rs
@@ -306,10 +306,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         loop {
             // Skip type holes in both templates
+            let mut a_skipped_type = false;
+            let mut b_skipped_type = false;
             while a_idx < a_len && matches!(a_spans[a_idx], TemplateSpan::Type(_)) {
+                a_skipped_type = true;
                 a_idx += 1;
             }
             while b_idx < b_len && matches!(b_spans[b_idx], TemplateSpan::Type(_)) {
+                b_skipped_type = true;
                 b_idx += 1;
             }
 
@@ -343,6 +347,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // They must have at least one common prefix
                     let min_len = a_str.len().min(b_str.len());
                     if a_str[..min_len] != b_str[..min_len] {
+                        if a_skipped_type != b_skipped_type {
+                            return true;
+                        }
                         // Incompatible prefixes - templates are disjoint
                         return false;
                     }

--- a/crates/tsz-solver/tests/template_literal_comprehensive_test.rs
+++ b/crates/tsz-solver/tests/template_literal_comprehensive_test.rs
@@ -302,7 +302,7 @@ fn test_template_literal_with_boolean() {
     let interner = TypeInterner::new();
 
     // Create template literal with boolean type: `is-${boolean}`
-    // TypeScript expands this to "is-true" | "is-false"
+    // TypeScript expands this to "is-false" | "is-true"
     let template = interner.template_literal(vec![
         TemplateSpan::Text(interner.intern_string("is-")),
         TemplateSpan::Type(TypeId::BOOLEAN),
@@ -313,6 +313,16 @@ fn test_template_literal_with_boolean() {
         Some(TypeData::Union(list_id)) => {
             let members = interner.type_list(list_id);
             assert_eq!(members.len(), 2);
+            let strings: Vec<_> = members
+                .iter()
+                .map(|member| match interner.lookup(*member) {
+                    Some(TypeData::Literal(LiteralValue::String(atom))) => {
+                        interner.resolve_atom_ref(atom).to_string()
+                    }
+                    other => panic!("Expected string literal member, got {other:?}"),
+                })
+                .collect();
+            assert_eq!(strings, vec!["is-false", "is-true"]);
         }
         other => panic!("Expected Union for `is-${{boolean}}`, got {other:?}"),
     }

--- a/crates/tsz-solver/tests/template_literal_subtype_tests.rs
+++ b/crates/tsz-solver/tests/template_literal_subtype_tests.rs
@@ -249,6 +249,26 @@ fn test_template_literal_overlap_detection() {
 }
 
 #[test]
+fn test_template_literal_leading_hole_overlap_is_conservative() {
+    // `foo-${string}` and `${string}-bar` overlap because the leading string
+    // hole can absorb the fixed prefix from the other template.
+    let interner = TypeInterner::new();
+
+    let template1 = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("foo-")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+
+    let template2 = interner.template_literal(vec![
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Text(interner.intern_string("-bar")),
+    ]);
+
+    let checker = SubtypeChecker::new(&interner);
+    assert!(checker.are_types_overlapping(template1, template2));
+}
+
+#[test]
 fn test_template_literal_disjointness_different_suffix() {
     // `a${string}b` and `a${string}c` should be disjoint
     let interner = TypeInterner::new();


### PR DESCRIPTION
## Summary

Fixes template-literal diagnostics for `TypeScript/tests/cases/conformance/types/literal/templateLiteralTypes3.ts`.

Root cause: template-literal boolean expansion used the opposite member order from TypeScript, and the checker's TS2367 overlap path bypassed the solver's template-literal overlap logic, so `foo-${string}` and `${string}-bar` were treated as disjoint.

The solver now emits boolean template members in TypeScript order, treats fixed-text comparisons after a skipped template hole conservatively as overlapping, and the checker delegates template-literal no-overlap checks to the solver-backed overlap query.

Example now accepted without a false TS2367:

```ts
function f(x: `foo-${string}`, y: `${string}-bar`) {
  if (x === y) {}
}
```

## Tests

- `cargo nextest run --package tsz-checker --lib ts2367_template_literal_prefix_and_suffix_overlap`
- `cargo nextest run --package tsz-solver --lib template_literal_leading_hole_overlap_is_conservative template_literal_with_boolean`
- `./scripts/conformance/conformance.sh run --filter "templateLiteralTypes3" --verbose`
- `scripts/session/verify-all.sh` after rebasing on latest `origin/main`: passed all suites; conformance `12061` vs baseline `12015` (+46), emit JS +4/DTS +25, fourslash/LSP 50/50
