### PR TITLE
fix(checker): preserve generic class args in TS2322 display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1431,12 +1431,21 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_TWO_DIFFERENT_TYPES_WITH_THIS_NAME_EXIST_BUT_THEY,
                 )
             } else {
-                let source_name = if src_str.starts_with("typeof ") {
+                let source_generic_base = src_str.split_once('<').map(|(base, _)| base);
+                let target_generic_base = tgt_str.split_once('<').map(|(base, _)| base);
+                let preserve_generic_nominal_pair = src_str.contains('<')
+                    && tgt_str.contains('<')
+                    && authoritative_src == authoritative_tgt
+                    && source_generic_base == target_generic_base
+                    && authoritative_src.as_deref() == source_generic_base;
+                let source_name = if src_str.starts_with("typeof ") || preserve_generic_nominal_pair
+                {
                     src_str.as_str()
                 } else {
                     authoritative_src.as_deref().unwrap_or(&src_str)
                 };
-                let target_name = if tgt_str.starts_with("typeof ") {
+                let target_name = if tgt_str.starts_with("typeof ") || preserve_generic_nominal_pair
+                {
                     tgt_str.as_str()
                 } else {
                     authoritative_tgt.as_deref().unwrap_or(&tgt_str)

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -1094,6 +1094,80 @@ var r = foo<number>({ bar: 1, baz: '' });
 }
 
 #[test]
+fn test_ts2322_generic_private_class_assignment_preserves_type_arguments() {
+    let source = r#"
+class C<T> {
+    #foo: T;
+    #method(): T { return this.#foo; }
+    get #prop(): T { return this.#foo; }
+    set #prop(value: T) { this.#foo = value; }
+
+    bar(x: C<T>) { return x.#foo; }
+    bar2(x: C<T>) { return x.#method(); }
+    bar3(x: C<T>) { return x.#prop; }
+
+    baz(x: C<number>) { return x.#foo; }
+    baz2(x: C<number>) { return x.#method; }
+    baz3(x: C<number>) { return x.#prop; }
+
+    quux(x: C<string>) { return x.#foo; }
+    quux2(x: C<string>) { return x.#method; }
+    quux3(x: C<string>) { return x.#prop; }
+}
+
+declare let a: C<number>;
+declare let b: C<string>;
+a.#foo;
+a.#method;
+a.#prop;
+a = b;
+b = a;
+"#;
+
+    let diagnostics = compile_with_options(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            strict: true,
+            strict_property_initialization: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let messages: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .map(|(_, message)| message.as_str())
+        .collect();
+
+    assert_eq!(
+        messages.len(),
+        2,
+        "expected exactly two TS2322 assignment diagnostics, got: {diagnostics:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| !message.contains("Type 'C' is not assignable to type 'C'.")),
+        "generic class TS2322 should not erase type arguments, got: {diagnostics:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message
+                .contains("Type 'C<string>' is not assignable to type 'C<number>'.")),
+        "expected C<string> -> C<number> TS2322 display, got: {diagnostics:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message
+                .contains("Type 'C<number>' is not assignable to type 'C<string>'.")),
+        "expected C<number> -> C<string> TS2322 display, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn generic_object_assign_initializer_keeps_outer_ts2322() {
     let source = r#"
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/crates/tsz-cli/tests/tsc_compat_tests.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests.rs
@@ -203,6 +203,69 @@ fn normalize_output(s: &str) -> String {
     stripped.replace("\r\n", "\n")
 }
 
+#[test]
+fn generic_private_class_assignment_preserves_type_arguments_in_cli_output() {
+    let temp = TempDir::new("generic_private_class_assignment").expect("temp dir");
+    let source = r#"
+class C<T> {
+    #foo: T;
+    #method(): T { return this.#foo; }
+    get #prop(): T { return this.#foo; }
+    set #prop(value: T) { this.#foo = value; }
+
+    bar(x: C<T>) { return x.#foo; }
+    bar2(x: C<T>) { return x.#method(); }
+    bar3(x: C<T>) { return x.#prop; }
+
+    baz(x: C<number>) { return x.#foo; }
+    baz2(x: C<number>) { return x.#method; }
+    baz3(x: C<number>) { return x.#prop; }
+
+    quux(x: C<string>) { return x.#foo; }
+    quux2(x: C<string>) { return x.#method; }
+    quux3(x: C<string>) { return x.#prop; }
+}
+
+declare let a: C<number>;
+declare let b: C<string>;
+a.#foo;
+a.#method;
+a.#prop;
+a = b;
+b = a;
+"#;
+    write_file(&temp.path.join("test.ts"), source);
+
+    let (_, output) = run_tsz_with_exit_code(
+        &temp.path,
+        &[
+            "--pretty",
+            "false",
+            "--noEmit",
+            "--strict",
+            "--target",
+            "es6",
+            "--strictPropertyInitialization",
+            "false",
+            "test.ts",
+        ],
+    )
+    .expect("tsz should run");
+
+    assert!(
+        output.contains("Type 'C<string>' is not assignable to type 'C<number>'."),
+        "expected C<string> -> C<number> display in CLI output, got:\n{output}"
+    );
+    assert!(
+        output.contains("Type 'C<number>' is not assignable to type 'C<string>'."),
+        "expected C<number> -> C<string> display in CLI output, got:\n{output}"
+    );
+    assert!(
+        !output.contains("Type 'C' is not assignable to type 'C'."),
+        "generic class CLI diagnostic should not erase type arguments, got:\n{output}"
+    );
+}
+
 /// Strip ANSI escape sequences from a string.
 fn strip_ansi(s: &str) -> String {
     let mut result = String::with_capacity(s.len());


### PR DESCRIPTION
## Root Cause
Generic fallback TS2322 formatting computed `C<string>`/`C<number>` but then overwrote both sides with the authoritative bare class name `C`; tsc preserves the instantiated class display when same nominal generic class instances differ by type arguments.

## Fixed Conformance Target
`TypeScript/tests/cases/conformance/classes/members/privateNames/privateNamesInGenericClasses.ts`

```ts
class C<T> { #foo!: T }
declare let a: C<number>;
declare let b: C<string>;
a = b; // TS2322: Type 'C<string>' is not assignable to type 'C<number>'.
```

## Unit Tests
- `tsz-checker::ts2322_tests::test_ts2322_generic_private_class_assignment_preserves_type_arguments`
- `tsz-cli::tsc_compat_tests::generic_private_class_assignment_preserves_type_arguments_in_cli_output`

## Verification
- `./scripts/conformance/conformance.sh run --filter "privateNamesInGenericClasses" --verbose` -> `FINAL RESULTS: 1/1 passed`
- `scripts/session/verify-all.sh` after final fetch/rebase -> all suites passed
  - formatting: passed
  - clippy: passed
  - unit tests: passed (`20950` passed, `72` skipped)
  - conformance: improved to `12064/12581` (`+49` vs `12015` baseline)
  - emit tests: improved (`JS +4`, `DTS +25`)
  - fourslash/LSP: `50/50` passed
