### PR TITLE
Fix generic remapped mapped type diagnostics

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -528,6 +528,7 @@ impl<'a> CheckerState<'a> {
         // Check excess properties on fresh object types BEFORE the assignability
         // check. Fresh types from chained assignments (e.g., `return obj = { x: 1, y: 2 }`)
         // are structurally assignable but should still trigger TS2353.
+        let mut had_excess_property_error = false;
         {
             let is_direct_literal = self
                 .ctx
@@ -535,16 +536,23 @@ impl<'a> CheckerState<'a> {
                 .get(source_idx)
                 .is_some_and(|n| n.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
             if is_direct_literal {
+                let diags_before = self.ctx.diagnostics.len();
                 self.check_object_literal_excess_properties(source, target, source_idx);
+                had_excess_property_error = self.ctx.diagnostics.len() > diags_before;
             } else if crate::query_boundaries::common::is_fresh_object_type(self.ctx.types, source)
             {
                 let literal_idx = self.find_rhs_object_literal(source_idx);
+                let diags_before = self.ctx.diagnostics.len();
                 self.check_object_literal_excess_properties(
                     source,
                     target,
                     literal_idx.unwrap_or(source_idx),
                 );
+                had_excess_property_error = self.ctx.diagnostics.len() > diags_before;
             }
+        }
+        if had_excess_property_error {
+            return false;
         }
 
         // Canonical relation path: execute a RelationRequest to get both the

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -744,6 +744,36 @@ impl<'a> CheckerState<'a> {
         ty
     }
 
+    fn finite_mapped_target_property_type(
+        &mut self,
+        target_type: TypeId,
+        prop_name: &str,
+    ) -> Option<TypeId> {
+        if let Some(mapped_id) = query_common::mapped_type_id(self.ctx.types, target_type) {
+            return crate::query_boundaries::state::checking::get_finite_mapped_property_type(
+                self.ctx.types,
+                mapped_id,
+                prop_name,
+            );
+        }
+
+        let (base, args) = query_common::application_info(self.ctx.types, target_type)?;
+        let sym_id = self.ctx.resolve_type_to_symbol_id(base)?;
+        let (body_type, type_params) = self.type_reference_symbol_type_with_params(sym_id);
+        let mapped_id = query_common::mapped_type_id(self.ctx.types, body_type)?;
+        let substitution =
+            query_common::TypeSubstitution::from_args(self.ctx.types, &type_params, &args);
+        let instantiated = query_common::instantiate_type(self.ctx.types, body_type, &substitution);
+        let instantiated_mapped_id =
+            query_common::mapped_type_id(self.ctx.types, instantiated).unwrap_or(mapped_id);
+
+        crate::query_boundaries::state::checking::get_finite_mapped_property_type(
+            self.ctx.types,
+            instantiated_mapped_id,
+            prop_name,
+        )
+    }
+
     pub(in crate::error_reporter) fn object_literal_target_property_type(
         &mut self,
         target_type: TypeId,
@@ -771,6 +801,12 @@ impl<'a> CheckerState<'a> {
             if let tsz_solver::operations::property::PropertyAccessResult::Success {
                 type_id, ..
             } = self.resolve_property_access_with_env(candidate, prop_name)
+                && self.should_prefer_property_target_type(env_property_type, type_id)
+            {
+                env_property_type = Some(type_id);
+            }
+
+            if let Some(type_id) = self.finite_mapped_target_property_type(candidate, prop_name)
                 && self.should_prefer_property_target_type(env_property_type, type_id)
             {
                 env_property_type = Some(type_id);

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -903,7 +903,12 @@ impl<'a> CheckerState<'a> {
         // Without this guard, widened property types (e.g., a string literal `'name'`
         // widened to `string`) can produce false TS2322 errors like
         // `Type '"name"' is not assignable to type '"name"'`.
-        if self.target_has_missing_required_properties_from_source(&obj, effective_param_type) {
+        let mapped_surface_names =
+            self.generic_mapped_receiver_explicit_property_names(effective_param_type);
+        if self.target_has_missing_required_properties_from_source(&obj, effective_param_type)
+            && mapped_surface_names.is_empty()
+            && !self.target_has_named_property_for_any_source_prop(arg_idx, effective_param_type)
+        {
             return false;
         }
 
@@ -1667,6 +1672,14 @@ impl<'a> CheckerState<'a> {
 
         // When the target type is `never`, don't elaborate into element-level TS2322 errors.
         if param_type == TypeId::NEVER {
+            return false;
+        }
+
+        if self
+            .generic_mapped_receiver_explicit_property_names(param_type)
+            .is_empty()
+            && self.generic_mapped_receiver_lacks_explicit_property(param_type, "0")
+        {
             return false;
         }
 

--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -94,6 +94,13 @@ pub(crate) fn get_finite_mapped_property_type(
     tsz_solver::type_queries::get_finite_mapped_property_type(db, mapped_id, property_name)
 }
 
+pub(crate) fn is_identity_name_mapping(
+    db: &dyn TypeDatabase,
+    mapped: &tsz_solver::MappedType,
+) -> bool {
+    tsz_solver::type_queries::is_identity_name_mapping(db, mapped)
+}
+
 #[cfg(test)]
 #[path = "../../../tests/state_checking.rs"]
 mod tests;

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -1,4 +1,5 @@
 use crate::state::CheckerState;
+use tsz_common::interner::Atom;
 use tsz_solver::{MappedTypeId, TypeDatabase, TypeId};
 
 pub(crate) use super::super::common::{
@@ -90,6 +91,14 @@ pub(crate) fn is_identity_name_mapping(
     mapped: &tsz_solver::MappedType,
 ) -> bool {
     tsz_solver::type_queries::is_identity_name_mapping(db, mapped)
+}
+
+pub(crate) fn literal_string(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Atom> {
+    tsz_solver::visitor::literal_string(db, type_id)
+}
+
+pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Vec<TypeId>> {
+    tsz_solver::type_queries::get_union_members(db, type_id)
 }
 
 /// Compute modifier values for a mapped-type property.

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -185,6 +185,49 @@ impl<'a> CheckerState<'a> {
         let effective_target = self.normalized_target_for_excess_properties(target);
         let resolved_target = self.prune_impossible_object_union_members_with_env(effective_target);
 
+        let mut generic_mapped_excess: Option<(tsz_common::interner::Atom, NodeIndex, u32)> = None;
+        for source_prop in source_props {
+            if explicit_property_names.is_some()
+                && !explicit_property_names
+                    .as_ref()
+                    .is_some_and(|names| names.contains(&source_prop.name))
+            {
+                continue;
+            }
+
+            let prop_name = self.ctx.types.resolve_atom(source_prop.name);
+            if [target, effective_target, resolved_target]
+                .into_iter()
+                .any(|candidate| {
+                    self.generic_mapped_receiver_lacks_explicit_property(
+                        candidate,
+                        prop_name.as_ref(),
+                    )
+                })
+            {
+                let report_idx = self
+                    .find_object_literal_property_element(idx, source_prop.name)
+                    .unwrap_or(idx);
+                let pos = self
+                    .ctx
+                    .arena
+                    .get(report_idx)
+                    .map_or(u32::MAX, |node| node.pos);
+                if generic_mapped_excess.is_none_or(|(_, _, best_pos)| pos < best_pos) {
+                    generic_mapped_excess = Some((source_prop.name, report_idx, pos));
+                }
+            }
+        }
+        if let Some((prop_name_atom, report_idx, _)) = generic_mapped_excess {
+            let prop_name = self.object_literal_property_display_name(
+                report_idx,
+                self.ctx.types.resolve_atom(prop_name_atom).as_ref(),
+            );
+            self.error_excess_property_at(&prop_name, target, report_idx);
+            self.check_excess_property_initializer_implicit_any(report_idx, target);
+            return;
+        }
+
         // Handle union targets first using type_queries
         if let Some(members) = query::union_members(self.ctx.types, resolved_target) {
             let mut target_shapes = Vec::new();

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -774,6 +774,7 @@ impl<'a> CheckerState<'a> {
         type_id: TypeId,
         mapped_id: MappedTypeId,
     ) -> TypeId {
+        use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
         use tsz_solver::PropertyInfo;
         let factory = self.ctx.types.factory();
 
@@ -856,16 +857,10 @@ impl<'a> CheckerState<'a> {
         // This handles homomorphic mapped types and deferred types with constraints
         // the solver can't resolve even with the CheckerContext resolver.
 
-        // Prefer the shared finite-key collector once the constraint has been
-        // resolved. This keeps mapped expansion aligned with property access and
-        // exact `keyof` key-space semantics.
-        let string_keys: Vec<_> = if let Some(names) =
-            query::collect_finite_mapped_property_names(self.ctx.types, resolved_mapped_id)
-        {
-            names.into_iter().collect()
-        } else {
-            query::extract_string_literal_keys(self.ctx.types, keys)
-        };
+        // Iterate the source keys. Name remapping is applied per key below so
+        // generic `as` clauses that cannot produce exact property names keep the
+        // mapped type deferred instead of expanding to the original key space.
+        let string_keys: Vec<_> = query::extract_string_literal_keys(self.ctx.types, keys);
         if string_keys.is_empty() {
             // Can't evaluate - return original
             return type_id;
@@ -884,6 +879,36 @@ impl<'a> CheckerState<'a> {
         // Build the resulting object properties using solver-centralized modifier logic.
         let mut properties = Vec::new();
         for key_name in string_keys {
+            let remapped_names: Vec<Atom> = if let Some(name_type) = mapped.name_type {
+                let key_literal = self.ctx.types.literal_string_atom(key_name);
+                let mut subst = TypeSubstitution::new();
+                subst.insert(mapped.type_param.name, key_literal);
+                let instantiated_name = instantiate_type(self.ctx.types, name_type, &subst);
+                let remapped = self.evaluate_type_with_env(instantiated_name);
+                if remapped == TypeId::NEVER {
+                    continue;
+                }
+                if let Some(name) = query::literal_string(self.ctx.types, remapped) {
+                    vec![name]
+                } else if let Some(members) = query::union_members(self.ctx.types, remapped) {
+                    let mut names = Vec::with_capacity(members.len());
+                    for member in members {
+                        let Some(name) = query::literal_string(self.ctx.types, member) else {
+                            return type_id;
+                        };
+                        names.push(name);
+                    }
+                    if names.is_empty() {
+                        return type_id;
+                    }
+                    names
+                } else {
+                    return type_id;
+                }
+            } else {
+                vec![key_name]
+            };
+
             // Use env-evaluated template instantiation (needed for Lazy/DefId resolution).
             let mut property_type =
                 self.instantiate_mapped_property_template_with_env(&mapped, key_name);
@@ -911,19 +936,21 @@ impl<'a> CheckerState<'a> {
                 property_type = *declared_type;
             }
 
-            properties.push(PropertyInfo {
-                name: key_name,
-                type_id: property_type,
-                write_type: property_type,
-                optional,
-                readonly,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-            });
+            for remapped_name in remapped_names {
+                properties.push(PropertyInfo {
+                    name: remapped_name,
+                    type_id: property_type,
+                    write_type: property_type,
+                    optional,
+                    readonly,
+                    is_method: false,
+                    is_class_prototype: false,
+                    visibility: Visibility::Public,
+                    parent_id: None,
+                    declaration_order: 0,
+                    is_string_named: false,
+                });
+            }
         }
 
         factory.object(properties)

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -557,13 +557,20 @@ impl<'a> CheckerState<'a> {
             .map(|name| self.ctx.types.resolve_atom(name))
             .collect();
 
-        for name in crate::query_boundaries::state::checking::extract_string_literal_keys(
-            self.ctx.types,
-            mapped.constraint,
-        ) {
-            let name = self.ctx.types.resolve_atom(name);
-            if !names.iter().any(|existing| existing == &name) {
-                names.push(name);
+        let preserves_source_names = mapped.name_type.is_none()
+            || crate::query_boundaries::state::checking::is_identity_name_mapping(
+                self.ctx.types,
+                &mapped,
+            );
+        if preserves_source_names {
+            for name in crate::query_boundaries::state::checking::extract_string_literal_keys(
+                self.ctx.types,
+                mapped.constraint,
+            ) {
+                let name = self.ctx.types.resolve_atom(name);
+                if !names.iter().any(|existing| existing == &name) {
+                    names.push(name);
+                }
             }
         }
 
@@ -574,6 +581,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         object_type: TypeId,
         prop_name: &str,
+        use_known_finite_names: bool,
     ) -> Option<bool> {
         use crate::query_boundaries::common::{
             TypeSubstitution, application_info, instantiate_type,
@@ -595,13 +603,25 @@ impl<'a> CheckerState<'a> {
         let instantiated = instantiate_type(self.ctx.types, body_type, &substitution);
         let instantiated_mapped_id =
             crate::query_boundaries::common::mapped_type_id(self.ctx.types, instantiated)?;
-        Some(
-            !self
-                .mapped_explicit_property_names(instantiated_mapped_id)
-                .iter()
-                .any(|name| name == prop_name)
-                && !self.mapped_type_has_explicit_property(instantiated_mapped_id, prop_name),
-        )
+        let instantiated_mapped = self.ctx.types.mapped_type(instantiated_mapped_id);
+        let names = self.mapped_explicit_property_names(instantiated_mapped_id);
+        let has_explicit_name = names.iter().any(|name| name == prop_name)
+            || self.mapped_type_has_explicit_property(instantiated_mapped_id, prop_name);
+        if has_explicit_name {
+            return Some(false);
+        }
+        let preserves_source_names = instantiated_mapped.name_type.is_none()
+            || crate::query_boundaries::state::checking::is_identity_name_mapping(
+                self.ctx.types,
+                &instantiated_mapped,
+            );
+        if preserves_source_names {
+            if use_known_finite_names && !names.is_empty() {
+                return Some(true);
+            }
+            return None;
+        }
+        Some(true)
     }
 
     pub(crate) fn generic_mapped_receiver_explicit_property_names(
@@ -656,7 +676,38 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common as common_query;
 
         if let Some(lacks_explicit_property) =
-            self.generic_mapped_application_lacks_explicit_property(object_type, prop_name)
+            self.generic_mapped_application_lacks_explicit_property(object_type, prop_name, false)
+        {
+            return lacks_explicit_property;
+        }
+
+        let resolved = self.resolve_type_for_property_access(object_type);
+        let evaluated = self.evaluate_type_with_env(resolved);
+
+        for candidate in [resolved, evaluated] {
+            if !common_query::contains_type_parameters(self.ctx.types, candidate) {
+                continue;
+            }
+
+            let Some(mapped_id) = common_query::mapped_type_id(self.ctx.types, candidate) else {
+                continue;
+            };
+
+            return !self.mapped_type_has_explicit_property(mapped_id, prop_name);
+        }
+
+        false
+    }
+
+    pub(crate) fn generic_mapped_receiver_lacks_property_access_name(
+        &mut self,
+        object_type: TypeId,
+        prop_name: &str,
+    ) -> bool {
+        use crate::query_boundaries::common as common_query;
+
+        if let Some(lacks_explicit_property) =
+            self.generic_mapped_application_lacks_explicit_property(object_type, prop_name, true)
         {
             return lacks_explicit_property;
         }

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -624,7 +624,7 @@ impl<'a> CheckerState<'a> {
                         from_index_signature,
                     } => {
                         let generic_mapped_missing_named_property = from_index_signature
-                            && self.generic_mapped_receiver_lacks_explicit_property(
+                            && self.generic_mapped_receiver_lacks_property_access_name(
                                 original_object_type,
                                 property_name,
                             );
@@ -1759,7 +1759,7 @@ impl<'a> CheckerState<'a> {
 
                     if skip_flow_narrowing
                         && from_index_signature
-                        && self.generic_mapped_receiver_lacks_explicit_property(
+                        && self.generic_mapped_receiver_lacks_property_access_name(
                             original_object_type,
                             property_name,
                         )

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -1554,7 +1554,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Try to expand a Mapped type to its structural form.
     /// Returns None if the mapped type cannot be expanded (unresolvable constraint).
     pub(crate) fn try_expand_mapped(&mut self, mapped_id: MappedTypeId) -> Option<TypeId> {
-        use crate::{MappedModifier, PropertyInfo, TypeSubstitution, instantiate_type};
+        use crate::{
+            LiteralValue, MappedModifier, PropertyInfo, TypeSubstitution, instantiate_type,
+        };
 
         let mapped = self.interner.get_mapped(mapped_id);
 
@@ -1592,7 +1594,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             (false, false)
         };
 
-        // Build properties by instantiating template for each key
+        // Build properties by instantiating template for each key.
+        //
+        // If the mapped type has an `as` clause, the expanded property names must
+        // come from the remapped key, not from the original constraint key. When
+        // the remapped name is still generic (for example `${K}${T}`), the mapped
+        // type is not concretely expandable and must stay deferred.
         let mut properties = Vec::new();
         for key_name in keys {
             // Convert atom to the correct TypeId for substitution.
@@ -1610,6 +1617,37 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
             let mut subst = TypeSubstitution::new();
             subst.insert(mapped.type_param.name, key_literal);
+
+            let remapped_names: Vec<tsz_common::interner::Atom> = if let Some(name_type) =
+                mapped.name_type
+            {
+                let remapped =
+                    self.evaluate_type(instantiate_type(self.interner, name_type, &subst));
+                if remapped == TypeId::NEVER {
+                    continue;
+                }
+                if let Some(LiteralValue::String(name)) = literal_value(self.interner, remapped) {
+                    vec![name]
+                } else if let Some(list_id) = union_list_id(self.interner, remapped) {
+                    let members = self.interner.type_list(list_id);
+                    let mut names = Vec::with_capacity(members.len());
+                    for &member in members.iter() {
+                        let Some(LiteralValue::String(name)) = literal_value(self.interner, member)
+                        else {
+                            return None;
+                        };
+                        names.push(name);
+                    }
+                    if names.is_empty() {
+                        return None;
+                    }
+                    names
+                } else {
+                    return None;
+                }
+            } else {
+                vec![key_name]
+            };
 
             let instantiated_type = instantiate_type(self.interner, mapped.template, &subst);
             let property_type = self.evaluate_type(instantiated_type);
@@ -1639,19 +1677,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             };
 
-            properties.push(PropertyInfo {
-                name: key_name,
-                type_id: property_type,
-                write_type: property_type,
-                optional,
-                readonly,
-                is_method: false,
-                is_class_prototype: false,
-                visibility: Visibility::Public,
-                parent_id: None,
-                declaration_order: 0,
-                is_string_named: false,
-            });
+            for remapped_name in remapped_names {
+                properties.push(PropertyInfo {
+                    name: remapped_name,
+                    type_id: property_type,
+                    write_type: property_type,
+                    optional,
+                    readonly,
+                    is_method: false,
+                    is_class_prototype: false,
+                    visibility: Visibility::Public,
+                    parent_id: None,
+                    declaration_order: 0,
+                    is_string_named: false,
+                });
+            }
         }
 
         Some(self.interner.object(properties))

--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -44,6 +44,75 @@ fn test_any_top_bottom_subtyping() {
 }
 
 #[test]
+fn test_generic_remapped_mapped_type_does_not_expand_to_source_keys() {
+    let interner = TypeInterner::new();
+    let atom_a = interner.intern_string("a");
+    let atom_b = interner.intern_string("b");
+
+    let model = interner.object(vec![
+        PropertyInfo {
+            name: atom_a,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 0,
+            is_string_named: false,
+        },
+        PropertyInfo {
+            name: atom_b,
+            type_id: TypeId::NUMBER,
+            write_type: TypeId::NUMBER,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 1,
+            is_string_named: false,
+        },
+    ]);
+
+    let key_param = TypeParamInfo {
+        name: interner.intern_string("K"),
+        constraint: Some(interner.keyof(model)),
+        default: None,
+        is_const: false,
+    };
+    let key_type = interner.type_param(key_param);
+    let suffix_param = TypeParamInfo {
+        name: interner.intern_string("Suffix"),
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    };
+    let suffix_type = interner.type_param(suffix_param);
+    let remapped_name = interner.template_literal(vec![
+        crate::types::TemplateSpan::Type(key_type),
+        crate::types::TemplateSpan::Type(suffix_type),
+    ]);
+    let mapped = interner.mapped(MappedType {
+        type_param: key_param,
+        constraint: interner.keyof(model),
+        name_type: Some(remapped_name),
+        template: interner.index_access(model, key_type),
+        readonly_modifier: None,
+        optional_modifier: None,
+    });
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(model, mapped),
+        "generic remapped mapped types must not expand to the original source keys"
+    );
+}
+
+#[test]
 fn test_legacy_null_undefined_subtyping() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);


### PR DESCRIPTION
Root cause: generic `as`-remapped mapped types were expanded and diagnosed through their source keys when the remapped names were still generic, so `MappedModel<T>` incorrectly looked like `Model` in assignability, excess-property, and elaboration paths.

Fixed conformance target: `TypeScript/tests/cases/compiler/genericMappedTypeAsClause.ts` (`genericMappedTypeAsClause`).

Unit test: added `test_generic_remapped_mapped_type_does_not_expand_to_source_keys` in `crates/tsz-solver/tests/subtype_tests.rs`.

Verification:
- `./scripts/conformance/conformance.sh run --filter "genericMappedTypeAsClause" --verbose` -> 1/1 passed
- `scripts/session/verify-all.sh` after rebasing on latest `origin/main` -> all suites passed; conformance 12066 vs baseline 12015 (+51), emit JS +4 and DTS +25, fourslash 50/50
