### PR TITLE
[codex] recheck merged default libs

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -84,7 +84,8 @@ impl<'a> CheckerState<'a> {
                 // assignable to `string`.
                 let type_arg_contains_type_parameters =
                     query::contains_type_parameters(self.ctx.types, type_arg);
-                let base_constraint_type = type_arg_contains_type_parameters
+                let mut base_constraint_from_indexed_access_ast = false;
+                let mut base_constraint_type = type_arg_contains_type_parameters
                     .then(|| self.constraint_check_base_type(type_arg))
                     .filter(|&base| base != type_arg)
                     // Discard degenerate base constraints (undefined, null, never)
@@ -99,6 +100,16 @@ impl<'a> CheckerState<'a> {
                             && base != TypeId::NEVER
                             && base != TypeId::VOID
                     });
+                if type_arg_contains_type_parameters
+                    && base_constraint_type
+                        .is_none_or(|base| query::contains_type_parameters(self.ctx.types, base))
+                    && let Some(&arg_idx) = type_args_list.nodes.get(i)
+                    && let Some(ast_base) =
+                        self.ast_indexed_access_property_union_from_declaration(type_arg, arg_idx)
+                {
+                    base_constraint_type = Some(ast_base);
+                    base_constraint_from_indexed_access_ast = true;
+                }
                 if type_arg_contains_type_parameters {
                     let is_bare_type_param =
                         query::is_bare_type_parameter(self.ctx.types.as_type_database(), type_arg);
@@ -113,6 +124,14 @@ impl<'a> CheckerState<'a> {
                             && base != TypeId::UNKNOWN
                             && base != type_arg
                         {
+                            let mut base = base;
+                            if !base_constraint_from_indexed_access_ast
+                                && query::contains_free_type_parameters(self.ctx.types, base)
+                                && let Some(concrete_indexed_base) =
+                                    self.concrete_indexed_access_property_union(base)
+                            {
+                                base = concrete_indexed_base;
+                            }
                             // Base constraint still contains type parameters.
                             // For most cases, defer to instantiation time. However,
                             // when the required constraint is a callable signature
@@ -121,7 +140,9 @@ impl<'a> CheckerState<'a> {
                             // provably callable (e.g. generic indexed access types
                             // like `DataFetchFns[T][F]` are not callable). This
                             // matches tsc behavior for ReturnType/Parameters/etc.
-                            if query::contains_type_parameters(self.ctx.types, base) {
+                            if !base_constraint_from_indexed_access_ast
+                                && query::contains_free_type_parameters(self.ctx.types, base)
+                            {
                                 let constraint_resolved = self.resolve_lazy_type(constraint);
                                 let db = self.ctx.types.as_type_database();
 
@@ -512,7 +533,8 @@ impl<'a> CheckerState<'a> {
                                     &subst,
                                 )
                             };
-                            if query::contains_type_parameters(self.ctx.types, inst_constraint) {
+                            if query::contains_free_type_parameters(self.ctx.types, inst_constraint)
+                            {
                                 continue;
                             }
                             let db = self.ctx.types.as_type_database();
@@ -558,7 +580,7 @@ impl<'a> CheckerState<'a> {
                             // preserves T's index signatures, but constraint resolution
                             // may produce inconsistent index signatures). For non-callable
                             // constraints, defer to instantiation time to match tsc.
-                            if !query::contains_type_parameters(self.ctx.types, base)
+                            if !query::contains_free_type_parameters(self.ctx.types, base)
                                 && !query::is_callable_type(db, inst_constraint)
                                 && !self.is_function_constraint(original_constraint)
                             {
@@ -1020,7 +1042,7 @@ impl<'a> CheckerState<'a> {
                 if !is_satisfied
                     && let Some(base) = base_constraint_type
                     && base != TypeId::UNKNOWN
-                    && !query::contains_type_parameters(self.ctx.types, base)
+                    && !query::contains_free_type_parameters(self.ctx.types, base)
                 {
                     is_satisfied = self.is_assignable_to(base, instantiated_constraint)
                         || self.satisfies_array_like_constraint(base, instantiated_constraint);
@@ -1073,8 +1095,29 @@ impl<'a> CheckerState<'a> {
         let db = self.ctx.types.as_type_database();
         // For TypeParameter: returns constraint or UNKNOWN; for non-TypeParameter: returns type_id
         let base = query::base_constraint_of_type(db, type_id);
+        if base == TypeId::UNKNOWN
+            && query::is_bare_type_parameter(db, type_id)
+            && let Some(name_atom) = query::type_parameter_name(db, type_id)
+        {
+            let name = self.ctx.types.resolve_atom(name_atom);
+            if let Some(&scoped_type_id) = self.ctx.type_parameter_scope.get(&name)
+                && scoped_type_id != type_id
+            {
+                let scoped_base = query::base_constraint_of_type(db, scoped_type_id);
+                if scoped_base != TypeId::UNKNOWN && scoped_base != scoped_type_id {
+                    return self.constraint_check_base_type(scoped_base);
+                }
+            }
+        }
         if base != type_id {
-            return self.evaluate_type_for_assignability(base);
+            let base = self.evaluate_type_for_assignability(base);
+            if let Some(keyof_operand) = query::keyof_operand(db, base) {
+                let normalized = self.get_keyof_type(keyof_operand);
+                if normalized != self.ctx.types.keyof(keyof_operand) {
+                    return normalized;
+                }
+            }
+            return base;
         }
         if let Some((object_type, index_type)) = query::index_access_components(db, type_id) {
             let constrained_object_type =
@@ -1114,14 +1157,59 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn ast_indexed_access_property_union_from_declaration(
+        &mut self,
+        type_arg: TypeId,
+        arg_idx: tsz_parser::parser::NodeIndex,
+    ) -> Option<TypeId> {
+        let node = self.ctx.arena.get(arg_idx)?;
+        let indexed = self.ctx.arena.get_indexed_access_type(node)?;
+
+        let db = self.ctx.types.as_type_database();
+        let (object_type, _index_type) = query::index_access_components(db, type_arg)?;
+        if matches!(object_type, TypeId::ERROR | TypeId::UNKNOWN) {
+            return None;
+        }
+
+        let object_type_for_check = self.evaluate_type_for_assignability(object_type);
+        let object_type_for_check = self.resolve_lazy_type(object_type_for_check);
+        let index_constraint = self
+            .resolve_index_constraint_from_declaration(indexed.index_type, indexed.object_type)?;
+
+        if !self.is_keyof_for_current_object(index_constraint, object_type, object_type_for_check) {
+            return None;
+        }
+
+        let key_space = if let Some(keyof_operand) = query::keyof_operand(db, index_constraint) {
+            self.get_keyof_type(keyof_operand)
+        } else {
+            self.evaluate_type_for_assignability(index_constraint)
+        };
+        let key_space = self.resolve_lazy_type(key_space);
+        let value_type =
+            self.constraint_check_indexed_access_value_type(object_type_for_check, key_space)?;
+        let value_type = self.evaluate_type_for_assignability(value_type);
+        let value_type = self.resolve_lazy_type(value_type);
+        (!query::contains_free_type_parameters(self.ctx.types, value_type)).then_some(value_type)
+    }
+
     fn constraint_check_indexed_access_value_type(
         &mut self,
         object_type: TypeId,
         index_type: TypeId,
     ) -> Option<TypeId> {
-        let db = self.ctx.types.as_type_database();
         let object_type = self.evaluate_type_for_assignability(object_type);
+        let mut object_type = self.resolve_lazy_type(object_type);
+        if query::get_object_shape(self.ctx.types.as_type_database(), object_type).is_none()
+            && let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(object_type)
+        {
+            object_type = self.type_reference_symbol_type(sym_id);
+            object_type = self.evaluate_type_for_assignability(object_type);
+            object_type = self.resolve_lazy_type(object_type);
+        }
         let key_type = self.evaluate_type_for_assignability(index_type);
+        let key_type = self.resolve_lazy_type(key_type);
+        let db = self.ctx.types.as_type_database();
         let key_kind = query::classify_index_key(db, key_type);
 
         if let Some(shape) = query::get_object_shape(db, object_type) {
@@ -1157,7 +1245,53 @@ impl<'a> CheckerState<'a> {
             return Some(template);
         }
 
+        // For concrete object maps like `HTMLElementTagNameMap`, an indexed access
+        // `Map[K]` with `K extends keyof Map` has a base constraint equal to the
+        // union of all mapped property value types. tsc eagerly uses that union for
+        // TS2344 checks on `HTMLCollectionOf<HTMLElementTagNameMap[K]>` /
+        // `NodeListOf<HTMLElementTagNameMap[K]>` instead of deferring the relation.
+        let keyed_object_type = if query::is_bare_type_parameter(db, key_type) {
+            let key_base = self.constraint_check_base_type(key_type);
+            if key_base == TypeId::UNKNOWN {
+                key_type
+            } else {
+                key_base
+            }
+        } else {
+            key_type
+        };
+
+        if let Some(shape) = query::get_object_shape(db, object_type)
+            && !shape.properties.is_empty()
+            && let Some(object_keys) =
+                crate::query_boundaries::common::keyof_object_properties(db, object_type)
+        {
+            let keys_assignable = self.is_assignable_to(keyed_object_type, object_keys);
+            if !keys_assignable {
+                return None;
+            }
+            let property_types: Vec<TypeId> =
+                shape.properties.iter().map(|prop| prop.type_id).collect();
+            return match property_types.len() {
+                0 => None,
+                1 => property_types.first().copied(),
+                _ => Some(self.ctx.types.union(property_types)),
+            };
+        }
+
         None
+    }
+
+    fn concrete_indexed_access_property_union(&mut self, type_id: TypeId) -> Option<TypeId> {
+        let evaluated = self.evaluate_type_for_assignability(type_id);
+        let evaluated = self.resolve_lazy_type(evaluated);
+        let db = self.ctx.types.as_type_database();
+        let (object_type, index_type) = query::index_access_components(db, evaluated)?;
+        let value_type =
+            self.constraint_check_indexed_access_value_type(object_type, index_type)?;
+        let value_type = self.evaluate_type_for_assignability(value_type);
+        let value_type = self.resolve_lazy_type(value_type);
+        (!query::contains_free_type_parameters(self.ctx.types, value_type)).then_some(value_type)
     }
 
     /// Check if a type represents the global `Function` interface from lib.d.ts.

--- a/crates/tsz-checker/src/classes/class_chain_lookup.rs
+++ b/crates/tsz-checker/src/classes/class_chain_lookup.rs
@@ -1,0 +1,212 @@
+//! Class-chain member lookup and visibility helpers.
+
+use crate::class_checker::{ClassMemberInfo, MemberVisibility};
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    /// Find a member by name in a class, searching up the inheritance chain.
+    /// Returns the member info if found, or None.
+    /// Uses cycle detection to handle circular inheritance safely.
+    pub(crate) fn find_member_in_class_chain(
+        &mut self,
+        class_idx: NodeIndex,
+        target_name: &str,
+        target_is_static: bool,
+        _depth: usize,
+        skip_private: bool,
+    ) -> Option<ClassMemberInfo> {
+        self.summarize_class_chain(class_idx)
+            .member_info(target_name, target_is_static, skip_private)
+            .cloned()
+    }
+
+    /// Internal implementation of `find_member_in_class_chain` with recursion guard.
+    #[allow(dead_code)]
+    fn find_member_in_class_chain_impl(
+        &mut self,
+        class_idx: NodeIndex,
+        target_name: &str,
+        target_is_static: bool,
+        skip_private: bool,
+        guard: &mut tsz_solver::recursion::RecursionGuard<NodeIndex>,
+    ) -> Option<ClassMemberInfo> {
+        use tsz_solver::recursion::RecursionResult;
+
+        // Check for cycles using the recursion guard
+        match guard.enter(class_idx) {
+            RecursionResult::Cycle
+            | RecursionResult::DepthExceeded
+            | RecursionResult::IterationExceeded => {
+                // Circular inheritance/depth/iteration limits detected - return None gracefully
+                // Exceeded limits - bail out
+                return None;
+            }
+            RecursionResult::Entered => {
+                // Proceed with the search
+            }
+        }
+        let result = (|| {
+            let class_node = self.ctx.arena.get(class_idx)?;
+            let class_data = self.ctx.arena.get_class(class_node)?;
+
+            // Search direct members
+            for &member_idx in &class_data.members.nodes {
+                if let Some(info) = self.extract_class_member_info(member_idx, skip_private)
+                    && info.name == target_name
+                    && info.is_static == target_is_static
+                {
+                    return Some(info);
+                }
+
+                if !target_is_static
+                    && let Some(member_node) = self.ctx.arena.get(member_idx)
+                    && member_node.kind == tsz_parser::parser::syntax_kind_ext::CONSTRUCTOR
+                    && let Some(ctor) = self.ctx.arena.get_constructor(member_node)
+                {
+                    for &param_idx in &ctor.parameters.nodes {
+                        if let Some(param_node) = self.ctx.arena.get(param_idx)
+                            && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                            && self.has_parameter_property_modifier(&param.modifiers)
+                            && let Some(name) = self.get_property_name(param.name)
+                            && name == target_name
+                        {
+                            if skip_private && self.has_private_modifier(&param.modifiers) {
+                                continue;
+                            }
+                            let visibility = if self.has_private_modifier(&param.modifiers) {
+                                MemberVisibility::Private
+                            } else if self.has_protected_modifier(&param.modifiers) {
+                                MemberVisibility::Protected
+                            } else {
+                                MemberVisibility::Public
+                            };
+                            let prop_type = if param.type_annotation.is_some() {
+                                self.get_type_from_type_node(param.type_annotation)
+                            } else {
+                                tsz_solver::TypeId::ANY
+                            };
+                            let info = ClassMemberInfo {
+                                name,
+                                type_id: prop_type,
+                                name_idx: param.name,
+                                visibility,
+                                is_method: false,
+                                is_static: false,
+                                is_accessor: false,
+                                is_abstract: false,
+                                has_override: self.has_override_modifier(&param.modifiers)
+                                    || self.has_jsdoc_override_tag(param_idx),
+                                is_jsdoc_override: !self.has_override_modifier(&param.modifiers)
+                                    && self.has_jsdoc_override_tag(param_idx),
+                                has_dynamic_name: false,
+                                has_computed_non_literal_name: false,
+                                from_interface: false,
+                            };
+                            return Some(info);
+                        }
+                    }
+                }
+            }
+
+            // Walk up to base class
+            let heritage_clauses = class_data.heritage_clauses.as_ref()?;
+
+            for &clause_idx in &heritage_clauses.nodes {
+                let clause_node = self.ctx.arena.get(clause_idx)?;
+                let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
+                if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                    continue;
+                }
+                let type_idx = *heritage.types.nodes.first()?;
+                let type_node = self.ctx.arena.get(type_idx)?;
+                let expr_idx =
+                    if let Some(expr_type_args) = self.ctx.arena.get_expr_type_args(type_node) {
+                        expr_type_args.expression
+                    } else {
+                        type_idx
+                    };
+                let expr_node = self.ctx.arena.get(expr_idx)?;
+                let ident = self.ctx.arena.get_identifier(expr_node)?;
+                let base_name = &ident.escaped_text;
+                let sym_id = self.ctx.binder.file_locals.get(base_name)?;
+                let symbol = self.ctx.binder.get_symbol(sym_id)?;
+                let base_idx = if symbol.value_declaration.is_some() {
+                    symbol.value_declaration
+                } else {
+                    *symbol.declarations.first()?
+                };
+
+                return self.find_member_in_class_chain_impl(
+                    base_idx,
+                    target_name,
+                    target_is_static,
+                    skip_private,
+                    guard,
+                );
+            }
+
+            None
+        })();
+
+        guard.leave(class_idx);
+        result
+    }
+
+    pub(crate) const fn class_member_visibility_conflicts(
+        &self,
+        derived_visibility: MemberVisibility,
+        base_visibility: MemberVisibility,
+    ) -> bool {
+        matches!(
+            (derived_visibility, base_visibility),
+            (
+                MemberVisibility::Private,
+                MemberVisibility::Private | MemberVisibility::Protected | MemberVisibility::Public
+            ) | (
+                MemberVisibility::Protected,
+                MemberVisibility::Public | MemberVisibility::Private
+            ) | (MemberVisibility::Public, MemberVisibility::Private)
+        )
+    }
+
+    /// Count required (non-optional, non-rest, no-initializer) parameters in a
+    /// method/function signature node, excluding `this` parameters.
+    pub(crate) fn count_required_params_from_signature_node(&self, node_idx: NodeIndex) -> usize {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return 0;
+        };
+        let Some(sig) = self.ctx.arena.get_signature(node) else {
+            return 0;
+        };
+        let Some(ref params) = sig.parameters else {
+            return 0;
+        };
+        let mut count = 0;
+        for &param_idx in &params.nodes {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                continue;
+            };
+            // Skip `this` pseudo-parameter
+            if let Some(name_node) = self.ctx.arena.get(param.name)
+                && name_node.kind == SyntaxKind::ThisKeyword as u16
+            {
+                continue;
+            }
+            // Rest parameters are not counted as required
+            if param.dot_dot_dot_token {
+                continue;
+            }
+            // Optional or has-default parameters are not required
+            if param.question_token || param.initializer.is_some() {
+                continue;
+            }
+            count += 1;
+        }
+        count
+    }
+}

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1,7 +1,7 @@
 //! Class and interface compatibility checking (TS2415, TS2430), member lookup
 //! in class chains, and visibility conflict detection.
 
-use crate::class_checker::{ClassMemberInfo, MemberVisibility};
+use crate::class_checker::MemberVisibility;
 use crate::diagnostics::diagnostic_codes;
 use crate::query_boundaries::class::{
     should_report_member_type_mismatch, should_report_property_type_mismatch,
@@ -180,21 +180,31 @@ impl<'a> CheckerState<'a> {
             CALL_SIGNATURE, INDEX_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
 
+        fn decl_arena_for<'a>(
+            binder: &'a tsz_binder::BinderState,
+            current_arena: &'a tsz_parser::parser::node::NodeArena,
+            sym_id: tsz_binder::SymbolId,
+            decl_idx: NodeIndex,
+        ) -> &'a tsz_parser::parser::node::NodeArena {
+            binder
+                .get_arena_for_declaration(sym_id, decl_idx)
+                .map_or(current_arena, |arena| arena.as_ref())
+        }
+
+        let iface_sym_id = self.ctx.binder.node_symbols.get(&_iface_idx.0).copied();
+
         // Get heritage clauses (extends) — must have at least one across all declarations
         if iface_data.heritage_clauses.is_none() {
             // Check if other declarations of this interface have heritage clauses
-            let has_heritage_elsewhere = self
-                .ctx
-                .binder
-                .node_symbols
-                .get(&_iface_idx.0)
-                .and_then(|&sym_id| self.ctx.binder.symbols.get(sym_id))
-                .is_some_and(|sym| {
+            let has_heritage_elsewhere = iface_sym_id
+                .and_then(|sym_id| self.ctx.binder.symbols.get(sym_id).map(|sym| (sym_id, sym)))
+                .is_some_and(|(sym_id, sym)| {
                     sym.declarations.iter().any(|&decl_idx| {
+                        let decl_arena =
+                            decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
                         decl_idx != _iface_idx
-                            && self.ctx.arena.get(decl_idx).is_some_and(|n| {
-                                self.ctx
-                                    .arena
+                            && decl_arena.get(decl_idx).is_some_and(|n| {
+                                decl_arena
                                     .get_interface(n)
                                     .is_some_and(|iface| iface.heritage_clauses.is_some())
                             })
@@ -236,16 +246,19 @@ impl<'a> CheckerState<'a> {
             .binder
             .node_symbols
             .get(&_iface_idx.0)
-            .and_then(|&sym_id| self.ctx.binder.symbols.get(sym_id))
+            .copied()
+            .and_then(|sym_id| self.ctx.binder.symbols.get(sym_id).map(|sym| (sym_id, sym)))
             .map(|sym| {
+                let (sym_id, sym) = sym;
                 sym.declarations
                     .iter()
                     .copied()
                     .filter(|&decl_idx| {
-                        self.ctx
-                            .arena
+                        let decl_arena =
+                            decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+                        decl_arena
                             .get(decl_idx)
-                            .is_some_and(|n| self.ctx.arena.get_interface(n).is_some())
+                            .is_some_and(|n| decl_arena.get_interface(n).is_some())
                     })
                     .collect()
             })
@@ -258,22 +271,33 @@ impl<'a> CheckerState<'a> {
         }
 
         for &decl_idx in &all_iface_decls {
-            if let Some(decl_node) = self.ctx.arena.get(decl_idx)
-                && let Some(decl_iface) = self.ctx.arena.get_interface(decl_node)
+            let Some(sym_id) = iface_sym_id else {
+                continue;
+            };
+            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            if let Some(decl_node) = decl_arena.get(decl_idx)
+                && let Some(decl_iface) = decl_arena.get_interface(decl_node)
             {
                 for &member_idx in &decl_iface.members.nodes {
-                    let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    let Some(member_node) = decl_arena.get(member_idx) else {
                         continue;
                     };
                     if member_node.kind == CALL_SIGNATURE {
                         derived_member_names.insert(String::from("__call__"));
                     } else if (member_node.kind == METHOD_SIGNATURE
                         || member_node.kind == PROPERTY_SIGNATURE)
-                        && let Some(sig) = self.ctx.arena.get_signature(member_node)
-                        && let Some(name) = self.get_property_name(sig.name)
+                        && let Some(sig) = decl_arena.get_signature(member_node)
+                        && let Some(name) =
+                            crate::types_domain::queries::core::get_literal_property_name(
+                                decl_arena, sig.name,
+                            )
                     {
                         derived_member_names.insert(name.clone());
-                        let type_id = self.get_type_of_interface_member(member_idx);
+                        let type_id = self
+                            .delegate_cross_arena_interface_member_simple_type(
+                                decl_idx, member_idx, decl_arena, None,
+                            )
+                            .unwrap_or_else(|| self.get_type_of_interface_member(member_idx));
                         derived_members.push((
                             name,
                             type_id,
@@ -353,30 +377,42 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        let mut derived_method_counts: rustc_hash::FxHashMap<String, usize> =
+            rustc_hash::FxHashMap::default();
+        for (name, _, _, kind, _) in &derived_members {
+            if *kind == METHOD_SIGNATURE {
+                *derived_method_counts.entry(name.clone()).or_insert(0) += 1;
+            }
+        }
+
         // Collect derived interface index signatures across all declarations.
         // These are checked against base index signatures for TS2430 compatibility.
         let mut derived_string_index_type: Option<TypeId> = None;
         let mut derived_number_index_type: Option<TypeId> = None;
         for &decl_idx in &all_iface_decls {
-            if let Some(decl_node) = self.ctx.arena.get(decl_idx)
-                && let Some(decl_iface) = self.ctx.arena.get_interface(decl_node)
+            let Some(sym_id) = iface_sym_id else {
+                continue;
+            };
+            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            if let Some(decl_node) = decl_arena.get(decl_idx)
+                && let Some(decl_iface) = decl_arena.get_interface(decl_node)
             {
                 for &member_idx in &decl_iface.members.nodes {
-                    let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    let Some(member_node) = decl_arena.get(member_idx) else {
                         continue;
                     };
                     if member_node.kind != INDEX_SIGNATURE {
                         continue;
                     }
-                    if let Some(index_sig) = self.ctx.arena.get_index_signature(member_node) {
+                    if let Some(index_sig) = decl_arena.get_index_signature(member_node) {
                         let param_idx = index_sig
                             .parameters
                             .nodes
                             .first()
                             .copied()
                             .unwrap_or(NodeIndex::NONE);
-                        let key_type = if let Some(param_node) = self.ctx.arena.get(param_idx)
-                            && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                        let key_type = if let Some(param_node) = decl_arena.get(param_idx)
+                            && let Some(param) = decl_arena.get_parameter(param_node)
                             && param.type_annotation.is_some()
                         {
                             self.get_type_from_type_node(param.type_annotation)
@@ -423,23 +459,21 @@ impl<'a> CheckerState<'a> {
         let mut all_heritage_types: Vec<(NodeIndex, NodeIndex)> = Vec::new(); // (clause_idx, type_idx)
 
         // First: collect heritage from merged class declaration (if any)
-        if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&_iface_idx.0)
+        if let Some(sym_id) = iface_sym_id
             && let Some(sym) = self.ctx.binder.symbols.get(sym_id)
         {
             for &decl_idx in &sym.declarations {
-                if let Some(node) = self.ctx.arena.get(decl_idx)
-                    && self.ctx.arena.get_class(node).is_some()
+                let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+                if let Some(node) = decl_arena.get(decl_idx)
+                    && decl_arena.get_class(node).is_some()
                 {
-                    let class_data = self
-                        .ctx
-                        .arena
+                    let class_data = decl_arena
                         .get_class(node)
                         .expect("get_class guard above ensures Some");
                     if let Some(ref heritage_clauses) = class_data.heritage_clauses {
                         for &clause_idx in &heritage_clauses.nodes {
-                            if let Some(clause_node) = self.ctx.arena.get(clause_idx)
-                                && let Some(heritage) =
-                                    self.ctx.arena.get_heritage_clause(clause_node)
+                            if let Some(clause_node) = decl_arena.get(clause_idx)
+                                && let Some(heritage) = decl_arena.get_heritage_clause(clause_node)
                                 && heritage.token == SyntaxKind::ExtendsKeyword as u16
                             {
                                 for &type_idx in &heritage.types.nodes {
@@ -455,13 +489,17 @@ impl<'a> CheckerState<'a> {
 
         // Then: collect heritage from all interface declarations
         for &decl_idx in &all_iface_decls {
-            if let Some(decl_node) = self.ctx.arena.get(decl_idx)
-                && let Some(decl_iface) = self.ctx.arena.get_interface(decl_node)
+            let Some(sym_id) = iface_sym_id else {
+                continue;
+            };
+            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            if let Some(decl_node) = decl_arena.get(decl_idx)
+                && let Some(decl_iface) = decl_arena.get_interface(decl_node)
                 && let Some(ref heritage_clauses) = decl_iface.heritage_clauses
             {
                 for &clause_idx in &heritage_clauses.nodes {
-                    if let Some(clause_node) = self.ctx.arena.get(clause_idx)
-                        && let Some(heritage) = self.ctx.arena.get_heritage_clause(clause_node)
+                    if let Some(clause_node) = decl_arena.get(clause_idx)
+                        && let Some(heritage) = decl_arena.get_heritage_clause(clause_node)
                         && heritage.token == SyntaxKind::ExtendsKeyword as u16
                     {
                         for &type_idx in &heritage.types.nodes {
@@ -473,7 +511,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Process each extended type across all heritage clauses
-        for &(_clause_idx, type_idx) in &all_heritage_types {
+        'heritage_type_loop: for &(_clause_idx, type_idx) in &all_heritage_types {
             let Some(type_node) = self.ctx.arena.get(type_idx) else {
                 continue;
             };
@@ -521,16 +559,20 @@ impl<'a> CheckerState<'a> {
 
             let mut base_iface_indices = Vec::new();
             for &decl_idx in &base_symbol.declarations {
-                if let Some(node) = self.ctx.arena.get(decl_idx)
-                    && self.ctx.arena.get_interface(node).is_some()
+                let decl_arena =
+                    decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                if let Some(node) = decl_arena.get(decl_idx)
+                    && decl_arena.get_interface(node).is_some()
                 {
                     base_iface_indices.push(decl_idx);
                 }
             }
             if base_iface_indices.is_empty() && base_symbol.value_declaration.is_some() {
                 let decl_idx = base_symbol.value_declaration;
-                if let Some(node) = self.ctx.arena.get(decl_idx)
-                    && self.ctx.arena.get_interface(node).is_some()
+                let decl_arena =
+                    decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                if let Some(node) = decl_arena.get(decl_idx)
+                    && decl_arena.get_interface(node).is_some()
                 {
                     base_iface_indices.push(decl_idx);
                 }
@@ -538,8 +580,9 @@ impl<'a> CheckerState<'a> {
 
             // Collect ALL members from this base (direct + inherited from ancestors).
             // Use a worklist to walk the interface hierarchy without recursion.
-            // Each entry: (interface_decl_idx, type_args_for_this_level)
-            let mut worklist: Vec<(NodeIndex, Option<Vec<TypeId>>)> = Vec::new();
+            // Each entry: (interface_sym_id, interface_decl_idx, type_args_for_this_level)
+            let mut worklist: Vec<(tsz_binder::SymbolId, NodeIndex, Option<Vec<TypeId>>)> =
+                Vec::new();
             for &idx in &base_iface_indices {
                 let initial_args = type_arguments.map(|args| {
                     args.nodes
@@ -547,7 +590,7 @@ impl<'a> CheckerState<'a> {
                         .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
                         .collect::<Vec<_>>()
                 });
-                worklist.push((idx, initial_args));
+                worklist.push((base_sym_id, idx, initial_args));
             }
 
             // Track which member keys we've already seen from THIS base entry.
@@ -555,20 +598,31 @@ impl<'a> CheckerState<'a> {
             let mut seen_member_keys: rustc_hash::FxHashSet<String> =
                 rustc_hash::FxHashSet::default();
             // Prevent cycles in the interface hierarchy.
-            let mut visited_ifaces: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+            let mut visited_ifaces: rustc_hash::FxHashSet<(u32, u32, usize)> =
+                rustc_hash::FxHashSet::default();
 
-            while let Some((iface_decl_idx, level_type_args)) = worklist.pop() {
-                if !visited_ifaces.insert(iface_decl_idx.0) {
+            while let Some((iface_sym_id, iface_decl_idx, level_type_args)) = worklist.pop() {
+                let iface_arena = decl_arena_for(
+                    self.ctx.binder,
+                    self.ctx.arena,
+                    iface_sym_id,
+                    iface_decl_idx,
+                );
+                let visit_key = (
+                    iface_sym_id.0,
+                    iface_decl_idx.0,
+                    iface_arena as *const tsz_parser::parser::node::NodeArena as usize,
+                );
+                if !visited_ifaces.insert(visit_key) {
                     continue; // Already visited — cycle guard
                 }
 
-                let Some(iface_node) = self.ctx.arena.get(iface_decl_idx) else {
+                let Some(iface_node) = iface_arena.get(iface_decl_idx) else {
                     continue;
                 };
-                let Some(iface) = self.ctx.arena.get_interface(iface_node) else {
+                let Some(iface) = iface_arena.get_interface(iface_node) else {
                     continue;
                 };
-
                 let (level_type_params, level_type_param_updates) =
                     self.push_type_parameters(&iface.type_parameters);
 
@@ -592,9 +646,30 @@ impl<'a> CheckerState<'a> {
                     &substitution_args,
                 );
 
+                let mut base_method_counts: rustc_hash::FxHashMap<String, usize> =
+                    rustc_hash::FxHashMap::default();
+                for &member_idx in &iface.members.nodes {
+                    let Some(member_node) = iface_arena.get(member_idx) else {
+                        continue;
+                    };
+                    if member_node.kind != METHOD_SIGNATURE {
+                        continue;
+                    }
+                    let Some(sig) = iface_arena.get_signature(member_node) else {
+                        continue;
+                    };
+                    let Some(name) = crate::types_domain::queries::core::get_literal_property_name(
+                        iface_arena,
+                        sig.name,
+                    ) else {
+                        continue;
+                    };
+                    *base_method_counts.entry(name).or_insert(0) += 1;
+                }
+
                 // Process direct members of this interface level
                 for &member_idx in &iface.members.nodes {
-                    let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    let Some(member_node) = iface_arena.get(member_idx) else {
                         continue;
                     };
 
@@ -612,19 +687,32 @@ impl<'a> CheckerState<'a> {
                         } else if member_node.kind == METHOD_SIGNATURE
                             || member_node.kind == PROPERTY_SIGNATURE
                         {
-                            let Some(sig) = self.ctx.arena.get_signature(member_node) else {
+                            let Some(sig) = iface_arena.get_signature(member_node) else {
                                 continue;
                             };
-                            let Some(name) = self.get_property_name(sig.name) else {
+                            let Some(name) =
+                                crate::types_domain::queries::core::get_literal_property_name(
+                                    iface_arena,
+                                    sig.name,
+                                )
+                            else {
                                 continue;
                             };
                             (
                                 name,
-                                instantiate_type(
-                                    self.ctx.types,
-                                    self.get_type_of_interface_member_simple(member_idx),
-                                    &substitution,
-                                ),
+                                self.delegate_cross_arena_interface_member_simple_type(
+                                    iface_decl_idx,
+                                    member_idx,
+                                    iface_arena,
+                                    Some(&substitution_args),
+                                )
+                                .unwrap_or_else(|| {
+                                    instantiate_type(
+                                        self.ctx.types,
+                                        self.get_type_of_interface_member_simple(member_idx),
+                                        &substitution,
+                                    )
+                                }),
                                 sig.question_token,
                             )
                         } else {
@@ -636,7 +724,58 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
 
-                    if derived_member_names.contains(&member_key) {
+                    if let Some((
+                        _derived_name,
+                        derived_member_type,
+                        derived_member_idx,
+                        _derived_kind,
+                        _derived_optional,
+                    )) = derived_members
+                        .iter()
+                        .find(|(derived_name, _, _, _, _)| derived_name == &member_key)
+                    {
+                        let overloaded_method_compare = *_derived_kind == METHOD_SIGNATURE
+                            && member_node.kind == METHOD_SIGNATURE
+                            && (derived_method_counts.get(&member_key).copied().unwrap_or(0) > 1
+                                || base_method_counts.get(&member_key).copied().unwrap_or(0) > 1);
+                        if overloaded_method_compare {
+                            continue;
+                        }
+
+                        let derived_prop_type =
+                            crate::query_boundaries::common::find_property_by_str(
+                                self.ctx.types,
+                                *derived_member_type,
+                                &member_key,
+                            )
+                            .map(|p| p.type_id)
+                            .unwrap_or(*derived_member_type);
+                        let base_prop_type = crate::query_boundaries::common::find_property_by_str(
+                            self.ctx.types,
+                            member_type,
+                            &member_key,
+                        )
+                        .map(|p| p.type_id)
+                        .unwrap_or(member_type);
+
+                        if should_report_member_type_mismatch(
+                            self,
+                            derived_prop_type,
+                            base_prop_type,
+                            *derived_member_idx,
+                        ) {
+                            let derived_type_str = self.format_type(derived_prop_type);
+                            let base_type_str = self.format_type(base_prop_type);
+                            self.error_at_node(
+                                iface_data.name,
+                                &format!(
+                                    "Interface '{derived_name}' incorrectly extends interface '{base_name}'.\n  Types of property '{member_key}' are incompatible.\n    Type '{derived_type_str}' is not assignable to type '{base_type_str}'."
+                                ),
+                                diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
+                            );
+                            self.pop_type_parameters(level_type_param_updates);
+                            continue 'heritage_type_loop;
+                        }
                         continue;
                     }
 
@@ -678,21 +817,21 @@ impl<'a> CheckerState<'a> {
                 // Process index signatures from this base level.
                 // Check for cross-base index signature conflicts (TS2430).
                 for &member_idx in &iface.members.nodes {
-                    let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    let Some(member_node) = iface_arena.get(member_idx) else {
                         continue;
                     };
                     if member_node.kind != INDEX_SIGNATURE {
                         continue;
                     }
-                    if let Some(idx_sig) = self.ctx.arena.get_index_signature(member_node) {
+                    if let Some(idx_sig) = iface_arena.get_index_signature(member_node) {
                         let param_idx = idx_sig
                             .parameters
                             .nodes
                             .first()
                             .copied()
                             .unwrap_or(NodeIndex::NONE);
-                        let key_type = if let Some(param_node) = self.ctx.arena.get(param_idx)
-                            && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                        let key_type = if let Some(param_node) = iface_arena.get(param_idx)
+                            && let Some(param) = iface_arena.get_parameter(param_node)
                             && param.type_annotation.is_some()
                         {
                             self.get_type_from_type_node(param.type_annotation)
@@ -746,10 +885,10 @@ impl<'a> CheckerState<'a> {
                 // Enqueue this interface's own bases (grandparent interfaces)
                 if let Some(ref heritage_clauses) = iface.heritage_clauses {
                     for &hc_idx in &heritage_clauses.nodes {
-                        let Some(hc_node) = self.ctx.arena.get(hc_idx) else {
+                        let Some(hc_node) = iface_arena.get(hc_idx) else {
                             continue;
                         };
-                        let Some(hc) = self.ctx.arena.get_heritage_clause(hc_node) else {
+                        let Some(hc) = iface_arena.get_heritage_clause(hc_node) else {
                             continue;
                         };
                         if hc.token != SyntaxKind::ExtendsKeyword as u16 {
@@ -757,8 +896,8 @@ impl<'a> CheckerState<'a> {
                         }
                         for &ancestor_type_idx in &hc.types.nodes {
                             let (ancestor_expr, ancestor_type_args_opt) = if let Some(ancestor_node) =
-                                self.ctx.arena.get(ancestor_type_idx)
-                                && let Some(eat) = self.ctx.arena.get_expr_type_args(ancestor_node)
+                                iface_arena.get(ancestor_type_idx)
+                                && let Some(eat) = iface_arena.get_expr_type_args(ancestor_node)
                             {
                                 let args: Vec<TypeId> = eat
                                     .type_arguments
@@ -781,16 +920,26 @@ impl<'a> CheckerState<'a> {
                                 (ancestor_type_idx, None)
                             };
 
-                            if let Some(ancestor_sym_id) =
-                                self.resolve_heritage_symbol(ancestor_expr)
+                            let ancestor_resolution = self.resolve_heritage_symbol(ancestor_expr);
+                            if let Some(ancestor_sym_id) = ancestor_resolution
                                 && let Some(ancestor_sym) =
                                     self.ctx.binder.get_symbol(ancestor_sym_id)
                             {
                                 for &decl_idx in &ancestor_sym.declarations {
-                                    if let Some(dn) = self.ctx.arena.get(decl_idx)
-                                        && self.ctx.arena.get_interface(dn).is_some()
+                                    let decl_arena = decl_arena_for(
+                                        self.ctx.binder,
+                                        self.ctx.arena,
+                                        ancestor_sym_id,
+                                        decl_idx,
+                                    );
+                                    if let Some(dn) = decl_arena.get(decl_idx)
+                                        && decl_arena.get_interface(dn).is_some()
                                     {
-                                        worklist.push((decl_idx, ancestor_type_args_opt.clone()));
+                                        worklist.push((
+                                            ancestor_sym_id,
+                                            decl_idx,
+                                            ancestor_type_args_opt.clone(),
+                                        ));
                                     }
                                 }
                             }
@@ -805,7 +954,9 @@ impl<'a> CheckerState<'a> {
             if base_iface_indices.is_empty() {
                 let mut base_class_idx = None;
                 for &decl_idx in &base_symbol.declarations {
-                    if let Some(node) = self.ctx.arena.get(decl_idx)
+                    let decl_arena =
+                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    if let Some(node) = decl_arena.get(decl_idx)
                         && node.kind == syntax_kind_ext::CLASS_DECLARATION
                     {
                         base_class_idx = Some(decl_idx);
@@ -815,7 +966,9 @@ impl<'a> CheckerState<'a> {
 
                 if base_class_idx.is_none() && base_symbol.value_declaration.is_some() {
                     let decl_idx = base_symbol.value_declaration;
-                    if let Some(node) = self.ctx.arena.get(decl_idx)
+                    let decl_arena =
+                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    if let Some(node) = decl_arena.get(decl_idx)
                         && node.kind == syntax_kind_ext::CLASS_DECLARATION
                     {
                         base_class_idx = Some(decl_idx);
@@ -823,8 +976,12 @@ impl<'a> CheckerState<'a> {
                 }
 
                 if let Some(class_idx) = base_class_idx
-                    && let Some(class_node) = self.ctx.arena.get(class_idx)
-                    && let Some(class_data) = self.ctx.arena.get_class(class_node)
+                    && let Some(class_node) =
+                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, class_idx)
+                            .get(class_idx)
+                    && let Some(class_data) =
+                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, class_idx)
+                            .get_class(class_node)
                 {
                     // Build type parameter substitution for generic class bases
                     // e.g. `extends C<string>` where `class C<T> { a: T; }` → a: string
@@ -1739,209 +1896,5 @@ impl<'a> CheckerState<'a> {
 
             self.pop_type_parameters(base_type_param_updates);
         }
-    }
-
-    /// Find a member by name in a class, searching up the inheritance chain.
-    /// Returns the member info if found, or None.
-    /// Uses cycle detection to handle circular inheritance safely.
-    pub(crate) fn find_member_in_class_chain(
-        &mut self,
-        class_idx: NodeIndex,
-        target_name: &str,
-        target_is_static: bool,
-        _depth: usize,
-        skip_private: bool,
-    ) -> Option<ClassMemberInfo> {
-        self.summarize_class_chain(class_idx)
-            .lookup(target_name, target_is_static, skip_private)
-            .cloned()
-    }
-
-    /// Internal implementation of `find_member_in_class_chain` with recursion guard.
-    #[allow(dead_code)]
-    fn find_member_in_class_chain_impl(
-        &mut self,
-        class_idx: NodeIndex,
-        target_name: &str,
-        target_is_static: bool,
-        skip_private: bool,
-        guard: &mut tsz_solver::recursion::RecursionGuard<NodeIndex>,
-    ) -> Option<ClassMemberInfo> {
-        use tsz_solver::recursion::RecursionResult;
-
-        // Check for cycles using the recursion guard
-        match guard.enter(class_idx) {
-            RecursionResult::Cycle
-            | RecursionResult::DepthExceeded
-            | RecursionResult::IterationExceeded => {
-                // Circular inheritance/depth/iteration limits detected - return None gracefully
-                // Exceeded limits - bail out
-                return None;
-            }
-            RecursionResult::Entered => {
-                // Proceed with the search
-            }
-        }
-        let result = (|| {
-            let class_node = self.ctx.arena.get(class_idx)?;
-            let class_data = self.ctx.arena.get_class(class_node)?;
-
-            // Search direct members
-            for &member_idx in &class_data.members.nodes {
-                if let Some(info) = self.extract_class_member_info(member_idx, skip_private)
-                    && info.name == target_name
-                    && info.is_static == target_is_static
-                {
-                    return Some(info);
-                }
-
-                if !target_is_static
-                    && let Some(member_node) = self.ctx.arena.get(member_idx)
-                    && member_node.kind == tsz_parser::parser::syntax_kind_ext::CONSTRUCTOR
-                    && let Some(ctor) = self.ctx.arena.get_constructor(member_node)
-                {
-                    for &param_idx in &ctor.parameters.nodes {
-                        if let Some(param_node) = self.ctx.arena.get(param_idx)
-                            && let Some(param) = self.ctx.arena.get_parameter(param_node)
-                            && self.has_parameter_property_modifier(&param.modifiers)
-                            && let Some(name) = self.get_property_name(param.name)
-                            && name == target_name
-                        {
-                            if skip_private && self.has_private_modifier(&param.modifiers) {
-                                continue;
-                            }
-                            let visibility = if self.has_private_modifier(&param.modifiers) {
-                                MemberVisibility::Private
-                            } else if self.has_protected_modifier(&param.modifiers) {
-                                MemberVisibility::Protected
-                            } else {
-                                MemberVisibility::Public
-                            };
-                            let prop_type = if param.type_annotation.is_some() {
-                                self.get_type_from_type_node(param.type_annotation)
-                            } else {
-                                tsz_solver::TypeId::ANY
-                            };
-                            let info = ClassMemberInfo {
-                                name,
-                                type_id: prop_type,
-                                name_idx: param.name,
-                                visibility,
-                                is_method: false,
-                                is_static: false,
-                                is_accessor: false,
-                                is_abstract: false,
-                                has_override: self.has_override_modifier(&param.modifiers)
-                                    || self.has_jsdoc_override_tag(param_idx),
-                                is_jsdoc_override: !self.has_override_modifier(&param.modifiers)
-                                    && self.has_jsdoc_override_tag(param_idx),
-                                has_dynamic_name: false,
-                                has_computed_non_literal_name: false,
-                                from_interface: false,
-                            };
-                            return Some(info);
-                        }
-                    }
-                }
-            }
-
-            // Walk up to base class
-            let heritage_clauses = class_data.heritage_clauses.as_ref()?;
-
-            for &clause_idx in &heritage_clauses.nodes {
-                let clause_node = self.ctx.arena.get(clause_idx)?;
-                let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
-                if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
-                    continue;
-                }
-                let type_idx = *heritage.types.nodes.first()?;
-                let type_node = self.ctx.arena.get(type_idx)?;
-                let expr_idx =
-                    if let Some(expr_type_args) = self.ctx.arena.get_expr_type_args(type_node) {
-                        expr_type_args.expression
-                    } else {
-                        type_idx
-                    };
-                let expr_node = self.ctx.arena.get(expr_idx)?;
-                let ident = self.ctx.arena.get_identifier(expr_node)?;
-                let base_name = &ident.escaped_text;
-                let sym_id = self.ctx.binder.file_locals.get(base_name)?;
-                let symbol = self.ctx.binder.get_symbol(sym_id)?;
-                let base_idx = if symbol.value_declaration.is_some() {
-                    symbol.value_declaration
-                } else {
-                    *symbol.declarations.first()?
-                };
-
-                return self.find_member_in_class_chain_impl(
-                    base_idx,
-                    target_name,
-                    target_is_static,
-                    skip_private,
-                    guard,
-                );
-            }
-
-            None
-        })();
-
-        guard.leave(class_idx);
-        result
-    }
-
-    pub(crate) const fn class_member_visibility_conflicts(
-        &self,
-        derived_visibility: MemberVisibility,
-        base_visibility: MemberVisibility,
-    ) -> bool {
-        matches!(
-            (derived_visibility, base_visibility),
-            (
-                MemberVisibility::Private,
-                MemberVisibility::Private | MemberVisibility::Protected | MemberVisibility::Public
-            ) | (
-                MemberVisibility::Protected,
-                MemberVisibility::Public | MemberVisibility::Private
-            ) | (MemberVisibility::Public, MemberVisibility::Private)
-        )
-    }
-
-    /// Count required (non-optional, non-rest, no-initializer) parameters in a
-    /// method/function signature node, excluding `this` parameters.
-    fn count_required_params_from_signature_node(&self, node_idx: NodeIndex) -> usize {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return 0;
-        };
-        let Some(sig) = self.ctx.arena.get_signature(node) else {
-            return 0;
-        };
-        let Some(ref params) = sig.parameters else {
-            return 0;
-        };
-        let mut count = 0;
-        for &param_idx in &params.nodes {
-            let Some(param_node) = self.ctx.arena.get(param_idx) else {
-                continue;
-            };
-            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
-                continue;
-            };
-            // Skip `this` pseudo-parameter
-            if let Some(name_node) = self.ctx.arena.get(param.name)
-                && name_node.kind == SyntaxKind::ThisKeyword as u16
-            {
-                continue;
-            }
-            // Rest parameters are not counted as required
-            if param.dot_dot_dot_token {
-                continue;
-            }
-            // Optional or has-default parameters are not required
-            if param.question_token || param.initializer.is_some() {
-                continue;
-            }
-            count += 1;
-        }
-        count
     }
 }

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -93,6 +93,15 @@ impl ClassChainSummary {
         target_is_static: bool,
         skip_private: bool,
     ) -> Option<&ClassMemberInfo> {
+        self.member_info(target_name, target_is_static, skip_private)
+    }
+
+    pub(crate) fn member_info(
+        &self,
+        target_name: &str,
+        target_is_static: bool,
+        skip_private: bool,
+    ) -> Option<&ClassMemberInfo> {
         let map = if target_is_static {
             &self.static_members
         } else {

--- a/crates/tsz-checker/src/classes/mod.rs
+++ b/crates/tsz-checker/src/classes/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod class_abstract_checker;
+pub(crate) mod class_chain_lookup;
 pub mod class_checker;
 pub(crate) mod class_checker_compat;
 pub(crate) mod class_helpers;

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -27,6 +27,11 @@ pub(crate) fn index_access_components(
     tsz_solver::type_queries::get_index_access_types(db, type_id)
 }
 
+/// Get the operand of a `keyof T` type.
+pub(crate) fn keyof_operand(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    tsz_solver::type_queries::keyof_inner_type(db, type_id)
+}
+
 /// Get the extends type and false type of a conditional type.
 ///
 /// Returns `Some((extends_type, false_type))` if the type is a `Conditional`.
@@ -111,6 +116,14 @@ pub(crate) fn get_type_parameter_constraint(
     type_id: TypeId,
 ) -> Option<TypeId> {
     tsz_solver::type_queries::get_type_parameter_constraint(db, type_id)
+}
+
+/// Get the declared name of a type parameter or infer variable.
+pub(crate) fn type_parameter_name(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_common::Atom> {
+    tsz_solver::type_queries::get_type_parameter_name(db, type_id)
 }
 
 /// Check if a type is a primitive (string, number, boolean, bigint, etc.).

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -6,6 +6,7 @@
 use crate::context::{TypingRequest, is_declaration_file_name};
 use crate::state::CheckerState;
 use crate::statements::StatementChecker;
+use rustc_hash::FxHashSet;
 use tracing::{Level, span};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -24,26 +25,15 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    /// Check a source file and populate diagnostics (main entry point).
-    ///
-    /// This is the primary entry point for type checking after parsing and binding.
-    /// It traverses the entire AST and performs all type checking operations.
-    pub fn check_source_file(&mut self, root_idx: NodeIndex) {
-        let _span = span!(Level::INFO, "check_source_file", idx = ?root_idx).entered();
-
+    fn prepare_source_file_for_checking(&mut self, root_idx: NodeIndex) -> Option<NodeIndex> {
         // Reset per-file flags
         self.ctx.is_in_ambient_declaration_file = false;
 
-        let Some(node) = self.ctx.arena.get(root_idx) else {
-            return;
-        };
-
-        let Some(sf) = self.ctx.arena.get_source_file(node) else {
-            return;
-        };
+        let node = self.ctx.arena.get(root_idx)?;
+        let sf = self.ctx.arena.get_source_file(node)?;
         self.resolve_compiler_options_from_source(&sf.text);
         if self.has_ts_nocheck_pragma(&sf.text) {
-            return;
+            return None;
         }
 
         // `type_env` is rebuilt per file, so drop per-file symbol-resolution memoization.
@@ -112,19 +102,194 @@ impl<'a> CheckerState<'a> {
             self.register_boxed_types();
         }
 
-        // Type check each top-level statement
         // Mark that we're now in the checking phase. During build_type_environment,
         // closures may be type-checked without contextual types, which would cause
         // premature TS7006 errors. The checking phase ensures contextual types are available.
         self.ctx.is_checking_statements = true;
 
+        // In .d.ts files, the entire file is an ambient context.
+        if self.ctx.is_declaration_file() {
+            self.ctx.is_in_ambient_declaration_file = true;
+        }
+
+        Some(root_idx)
+    }
+
+    fn check_interface_declarations_recursively(
+        &mut self,
+        statements: &[NodeIndex],
+        reset_fuel_between_interfaces: bool,
+        interface_filter: Option<&FxHashSet<String>>,
+    ) {
+        for &stmt_idx in statements {
+            let Some(stmt_node) = self.ctx.arena.get(stmt_idx) else {
+                continue;
+            };
+
+            if stmt_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+                if let Some(filter) = interface_filter {
+                    let Some(name) = self
+                        .ctx
+                        .arena
+                        .get_interface(stmt_node)
+                        .and_then(|iface| self.ctx.arena.get(iface.name))
+                        .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                        .map(|ident| ident.escaped_text.as_str())
+                    else {
+                        continue;
+                    };
+                    if !filter.contains(name) {
+                        continue;
+                    }
+                }
+                if self.ctx.binder.node_symbols.contains_key(&stmt_idx.0) {
+                    if reset_fuel_between_interfaces {
+                        self.ctx
+                            .type_resolution_fuel
+                            .set(crate::state::MAX_TYPE_RESOLUTION_OPS);
+                        crate::state_domain::type_environment::lazy::reset_global_resolution_fuel();
+                        self.check_lib_interface_declaration_post_merge(stmt_idx);
+                    } else {
+                        self.check_interface_declaration(stmt_idx);
+                    }
+                }
+                continue;
+            }
+
+            if stmt_node.kind != syntax_kind_ext::MODULE_DECLARATION {
+                continue;
+            }
+
+            let Some(module_decl) = self.ctx.arena.get_module(stmt_node) else {
+                continue;
+            };
+            if module_decl.body.is_none() {
+                continue;
+            }
+            let Some(body_node) = self.ctx.arena.get(module_decl.body) else {
+                continue;
+            };
+            if body_node.kind != syntax_kind_ext::MODULE_BLOCK {
+                continue;
+            }
+            let Some(block) = self.ctx.arena.get_module_block(body_node) else {
+                continue;
+            };
+            let Some(inner) = &block.statements else {
+                continue;
+            };
+            self.check_interface_declarations_recursively(
+                &inner.nodes,
+                reset_fuel_between_interfaces,
+                interface_filter,
+            );
+        }
+    }
+
+    /// Check only interface declarations in a source file after full environment setup.
+    ///
+    /// This is used for post-merge standard library validation so interface-specific
+    /// diagnostics like TS2344/TS2430 are re-evaluated without running the full lib
+    /// statement pipeline.
+    pub fn check_source_file_interfaces_only(&mut self, root_idx: NodeIndex) {
+        let _span =
+            span!(Level::INFO, "check_source_file_interfaces_only", idx = ?root_idx).entered();
+
+        let Some(root_idx) = self.prepare_source_file_for_checking(root_idx) else {
+            return;
+        };
+
+        let Some(node) = self.ctx.arena.get(root_idx) else {
+            return;
+        };
+        let Some(sf) = self.ctx.arena.get_source_file(node) else {
+            return;
+        };
+
+        self.check_interface_declarations_recursively(&sf.statements.nodes, false, None);
+    }
+
+    /// Check only interface declarations, refreshing type-resolution fuel between declarations.
+    ///
+    /// This is reserved for post-merge standard library validation, where a synthetic
+    /// lib file may contain many independent affected interfaces and an early DOM
+    /// interface must not exhaust the budget for later diagnostics.
+    pub fn check_source_file_interfaces_only_with_fresh_interface_fuel(
+        &mut self,
+        root_idx: NodeIndex,
+    ) {
+        let _span = span!(
+            Level::INFO,
+            "check_source_file_interfaces_only_with_fresh_interface_fuel",
+            idx = ?root_idx
+        )
+        .entered();
+
+        let Some(root_idx) = self.prepare_source_file_for_checking(root_idx) else {
+            return;
+        };
+
+        let Some(node) = self.ctx.arena.get(root_idx) else {
+            return;
+        };
+        let Some(sf) = self.ctx.arena.get_source_file(node) else {
+            return;
+        };
+
+        self.check_interface_declarations_recursively(&sf.statements.nodes, true, None);
+    }
+
+    /// Check selected interfaces with the minimal post-merge lib validation path.
+    pub fn check_source_file_interfaces_only_filtered_post_merge(
+        &mut self,
+        root_idx: NodeIndex,
+        interface_filter: &FxHashSet<String>,
+    ) {
+        let _span = span!(
+            Level::INFO,
+            "check_source_file_interfaces_only_filtered_post_merge",
+            idx = ?root_idx
+        )
+        .entered();
+
+        let Some(root_idx) = self.prepare_source_file_for_checking(root_idx) else {
+            return;
+        };
+
+        let Some(node) = self.ctx.arena.get(root_idx) else {
+            return;
+        };
+        let Some(sf) = self.ctx.arena.get_source_file(node) else {
+            return;
+        };
+
+        self.check_interface_declarations_recursively(
+            &sf.statements.nodes,
+            true,
+            Some(interface_filter),
+        );
+    }
+
+    /// Check a source file and populate diagnostics (main entry point).
+    ///
+    /// This is the primary entry point for type checking after parsing and binding.
+    /// It traverses the entire AST and performs all type checking operations.
+    pub fn check_source_file(&mut self, root_idx: NodeIndex) {
+        let _span = span!(Level::INFO, "check_source_file", idx = ?root_idx).entered();
+        let Some(root_idx) = self.prepare_source_file_for_checking(root_idx) else {
+            return;
+        };
+        let Some(node) = self.ctx.arena.get(root_idx) else {
+            return;
+        };
+        let Some(sf) = self.ctx.arena.get_source_file(node) else {
+            return;
+        };
+
         // In .d.ts files, emit TS1036 for non-declaration top-level statements.
         // The entire file is an ambient context, so statements like break, continue,
         // return, debugger, if, while, for, etc. are not allowed.
         let is_dts = self.ctx.is_declaration_file();
-        if is_dts {
-            self.ctx.is_in_ambient_declaration_file = true;
-        }
 
         // TS2563: In tsc, this is emitted when flow analysis recursion depth
         // exceeds 2000 during getTypeAtFlowNode, NOT as a pre-check on total

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -120,6 +120,7 @@ impl<'a> CheckerState<'a> {
         statements: &[NodeIndex],
         reset_fuel_between_interfaces: bool,
         interface_filter: Option<&FxHashSet<String>>,
+        extension_filter: Option<&FxHashSet<String>>,
     ) {
         for &stmt_idx in statements {
             let Some(stmt_node) = self.ctx.arena.get(stmt_idx) else {
@@ -127,15 +128,15 @@ impl<'a> CheckerState<'a> {
             };
 
             if stmt_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+                let interface_name = self
+                    .ctx
+                    .arena
+                    .get_interface(stmt_node)
+                    .and_then(|iface| self.ctx.arena.get(iface.name))
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .map(|ident| ident.escaped_text.as_str());
                 if let Some(filter) = interface_filter {
-                    let Some(name) = self
-                        .ctx
-                        .arena
-                        .get_interface(stmt_node)
-                        .and_then(|iface| self.ctx.arena.get(iface.name))
-                        .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                        .map(|ident| ident.escaped_text.as_str())
-                    else {
+                    let Some(name) = interface_name else {
                         continue;
                     };
                     if !filter.contains(name) {
@@ -148,7 +149,16 @@ impl<'a> CheckerState<'a> {
                             .type_resolution_fuel
                             .set(crate::state::MAX_TYPE_RESOLUTION_OPS);
                         crate::state_domain::type_environment::lazy::reset_global_resolution_fuel();
-                        self.check_lib_interface_declaration_post_merge(stmt_idx);
+                        let check_extension_compatibility = match extension_filter {
+                            Some(filter) => {
+                                interface_name.is_some_and(|name| filter.contains(name))
+                            }
+                            None => true,
+                        };
+                        self.check_lib_interface_declaration_post_merge(
+                            stmt_idx,
+                            check_extension_compatibility,
+                        );
                     } else {
                         self.check_interface_declaration(stmt_idx);
                     }
@@ -182,6 +192,7 @@ impl<'a> CheckerState<'a> {
                 &inner.nodes,
                 reset_fuel_between_interfaces,
                 interface_filter,
+                extension_filter,
             );
         }
     }
@@ -206,7 +217,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        self.check_interface_declarations_recursively(&sf.statements.nodes, false, None);
+        self.check_interface_declarations_recursively(&sf.statements.nodes, false, None, None);
     }
 
     /// Check only interface declarations, refreshing type-resolution fuel between declarations.
@@ -236,7 +247,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        self.check_interface_declarations_recursively(&sf.statements.nodes, true, None);
+        self.check_interface_declarations_recursively(&sf.statements.nodes, true, None, None);
     }
 
     /// Check selected interfaces with the minimal post-merge lib validation path.
@@ -244,6 +255,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         root_idx: NodeIndex,
         interface_filter: &FxHashSet<String>,
+        extension_filter: &FxHashSet<String>,
     ) {
         let _span = span!(
             Level::INFO,
@@ -267,6 +279,7 @@ impl<'a> CheckerState<'a> {
             &sf.statements.nodes,
             true,
             Some(interface_filter),
+            Some(extension_filter),
         );
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -19,7 +19,11 @@ impl<'a> CheckerState<'a> {
     /// unrelated to user-induced global merges. For lib rechecks we only need member
     /// type annotations to trigger generic constraint diagnostics (TS2344) and
     /// heritage compatibility to catch broken merged inheritance (TS2430).
-    pub(crate) fn check_lib_interface_declaration_post_merge(&mut self, stmt_idx: NodeIndex) {
+    pub(crate) fn check_lib_interface_declaration_post_merge(
+        &mut self,
+        stmt_idx: NodeIndex,
+        check_extension_compatibility: bool,
+    ) {
         let Some(node) = self.ctx.arena.get(stmt_idx) else {
             return;
         };
@@ -68,7 +72,9 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        self.check_interface_extension_compatibility(stmt_idx, iface);
+        if check_extension_compatibility {
+            self.check_interface_extension_compatibility(stmt_idx, iface);
+        }
         self.pop_type_parameters(type_param_updates);
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -13,6 +13,65 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Minimal interface validation used by post-merge standard library checks.
+    ///
+    /// The normal interface checker runs many declaration-file diagnostics that are
+    /// unrelated to user-induced global merges. For lib rechecks we only need member
+    /// type annotations to trigger generic constraint diagnostics (TS2344) and
+    /// heritage compatibility to catch broken merged inheritance (TS2430).
+    pub(crate) fn check_lib_interface_declaration_post_merge(&mut self, stmt_idx: NodeIndex) {
+        let Some(node) = self.ctx.arena.get(stmt_idx) else {
+            return;
+        };
+
+        let Some(iface) = self.ctx.arena.get_interface(node) else {
+            return;
+        };
+
+        let (_type_params, type_param_updates) = self.push_type_parameters(&iface.type_parameters);
+
+        for &member_idx in &iface.members.nodes {
+            let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+
+            if let Some(sig) = self.ctx.arena.get_signature(member_node) {
+                let (_type_params, method_type_param_updates) =
+                    self.push_type_parameters(&sig.type_parameters);
+                if sig.type_annotation.is_some() {
+                    self.get_type_from_type_node(sig.type_annotation);
+                }
+                for &param_idx in sig.parameters.as_ref().map_or(&[][..], |p| &p.nodes) {
+                    if let Some(param_node) = self.ctx.arena.get(param_idx)
+                        && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                        && param.type_annotation.is_some()
+                    {
+                        self.get_type_from_type_node(param.type_annotation);
+                    }
+                }
+                self.pop_type_parameters(method_type_param_updates);
+                continue;
+            }
+
+            if let Some(accessor) = self.ctx.arena.get_accessor(member_node) {
+                if accessor.type_annotation.is_some() {
+                    self.get_type_from_type_node(accessor.type_annotation);
+                }
+                for &param_idx in &accessor.parameters.nodes {
+                    if let Some(param_node) = self.ctx.arena.get(param_idx)
+                        && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                        && param.type_annotation.is_some()
+                    {
+                        self.get_type_from_type_node(param.type_annotation);
+                    }
+                }
+            }
+        }
+
+        self.check_interface_extension_compatibility(stmt_idx, iface);
+        self.pop_type_parameters(type_param_updates);
+    }
+
     /// Check an interface declaration.
     pub(crate) fn check_interface_declaration(&mut self, stmt_idx: NodeIndex) {
         use crate::diagnostics::diagnostic_codes;

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1007,6 +1007,20 @@ impl<'a> CheckerState<'a> {
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to(&mut checker.ctx);
         checker.ctx.current_file_idx = delegate_file_idx.unwrap_or(self.ctx.current_file_idx);
+        let parent_is_declaration_file = self.ctx.file_name.ends_with(".d.ts")
+            || self.ctx.file_name.ends_with(".d.cts")
+            || self.ctx.file_name.ends_with(".d.mts");
+        let delegate_is_declaration_file = interface_arena
+            .source_files
+            .first()
+            .is_some_and(|source_file| source_file.is_declaration_file);
+        if parent_is_declaration_file && !delegate_is_declaration_file {
+            checker
+                .ctx
+                .type_resolution_fuel
+                .set(crate::state::MAX_TYPE_RESOLUTION_OPS);
+            crate::state_domain::type_environment::lazy::reset_global_resolution_fuel();
+        }
         // DefId ↔ SymbolId mappings are resolved via DefinitionStore fallback
         // on cache miss — no parent-to-child copy needed.
 

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -171,7 +171,6 @@ impl<'a> CheckerState<'a> {
                                 .any(|param| param.default.is_some())
                         })
                     });
-
                 // Recovery path: a type reference can appear where an expression statement is expected
                 // (e.g. malformed `this.x: any;` parses through a labeled statement).
                 // In value position, primitive type keywords should emit TS2693.

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -298,7 +298,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn is_keyof_for_current_object(
+    pub(crate) fn is_keyof_for_current_object(
         &mut self,
         ty: TypeId,
         object_type: TypeId,
@@ -322,7 +322,7 @@ impl<'a> CheckerState<'a> {
     /// Resolve a type parameter's constraint from its AST declaration when the TypeId
     /// doesn't carry one. This handles cases where type parameters lose their constraints
     /// during type application argument resolution (e.g., `M[Event]` inside `Id<M[Event]>`).
-    fn resolve_index_constraint_from_declaration(
+    pub(crate) fn resolve_index_constraint_from_declaration(
         &mut self,
         index_node_idx: NodeIndex,
         _object_node_idx: NodeIndex,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -63,6 +63,12 @@ pub(super) struct CollectDiagnosticsResult {
     pub module_dep_stats: Option<super::ModuleDependencyStats>,
 }
 
+#[derive(Default)]
+pub(super) struct CheckerLibSet {
+    pub(super) files: Vec<Arc<LibFile>>,
+    pub(super) contexts: Vec<LibContext>,
+}
+
 /// Check if a filename is a TypeScript declaration file (.d.ts, .d.cts, .d.mts).
 fn is_declaration_file(name: &str) -> bool {
     tsz::module_resolver::ModuleExtension::from_path(std::path::Path::new(name)).is_declaration()
@@ -74,35 +80,35 @@ fn should_apply_duplicate_package_redirect(importing_file: &Path) -> bool {
         .any(|component| component.as_os_str() == "node_modules")
 }
 
-/// Load lib.d.ts files and create `LibContext` objects for the checker.
+/// Clone lib.d.ts files and create fresh checker-facing `LibContext` objects.
 ///
 /// The binding pipeline mutates per-file binder state while injecting lib symbols into the
 /// unified program. Reusing those same `LibFile` binders as checker lib contexts leaks that
 /// binding-phase state into lib type resolution and can corrupt structural relations between
 /// recursive lib types like `RegExpMatchArray`, `Promise<T>`, and `PromiseLike<T>`.
 ///
-/// Build a fresh checker-facing lib context set from the same on-disk lib files so program
-/// binding and checker lib resolution stay isolated.
-pub(super) fn load_lib_files_for_contexts(lib_files: &[Arc<LibFile>]) -> Vec<LibContext> {
-    if lib_files.is_empty() {
-        return Vec::new();
-    }
-
-    let lib_paths: Vec<PathBuf> = lib_files
-        .iter()
-        .map(|lib| PathBuf::from(&lib.file_name))
-        .collect();
-    let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
-    let fresh_lib_files = parallel::load_lib_files_for_binding_strict(&lib_path_refs)
-        .expect("failed to reload lib files for checker contexts");
-
-    fresh_lib_files
+/// Build a fresh checker-facing lib set from the already-loaded lib sources so program
+/// binding and checker lib resolution stay isolated without requiring disk reloads.
+pub(super) fn load_checker_libs(lib_files: &[Arc<LibFile>]) -> CheckerLibSet {
+    let files = parallel::clone_lib_files_for_checker(lib_files);
+    let contexts = files
         .iter()
         .map(|lib| LibContext {
             arena: Arc::clone(&lib.arena),
             binder: Arc::clone(&lib.binder),
         })
-        .collect()
+        .collect();
+
+    CheckerLibSet { files, contexts }
+}
+
+fn should_skip_type_checking_for_file(
+    file_name: &str,
+    options: &ResolvedCompilerOptions,
+    is_default_lib: bool,
+) -> bool {
+    (options.skip_lib_check && is_declaration_file(file_name))
+        || (options.skip_default_lib_check && is_default_lib)
 }
 
 fn program_has_real_syntax_errors(program: &MergedProgram) -> bool {
@@ -539,7 +545,7 @@ pub(super) fn collect_diagnostics(
     options: &ResolvedCompilerOptions,
     base_dir: &Path,
     cache: Option<&mut CompilationCache>,
-    lib_contexts: &[LibContext],
+    checker_libs: &CheckerLibSet,
     typescript_dom_replacement_globals: (bool, bool, bool),
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
     has_deprecation_diagnostics: bool,
@@ -568,6 +574,7 @@ pub(super) fn collect_diagnostics(
 
     // Pre-compute merged augmentations once for all binder reconstruction paths.
     let merged_augmentations = MergedAugmentations::from_program(program);
+    let affected_lib_interfaces = affected_lib_interface_names(program, checker_libs);
 
     // Pre-create all binders for cross-file resolution
     let all_binders: Arc<Vec<Arc<BinderState>>> = Arc::new({
@@ -890,7 +897,7 @@ pub(super) fn collect_diagnostics(
     // build_global_indices computes the 4 binder-derived indices once here so that
     // per-file checker creation via apply_to skips the O(N) binder scans.
     let mut project_env = tsz::checker::context::ProjectEnv {
-        lib_contexts: std::sync::Arc::new(lib_contexts.to_vec()),
+        lib_contexts: std::sync::Arc::new(checker_libs.contexts.clone()),
         all_arenas: Arc::clone(&all_arenas),
         all_binders: Arc::clone(&all_binders),
         skeleton_declared_modules,
@@ -938,7 +945,7 @@ pub(super) fn collect_diagnostics(
 
     // Prime Array<T> base type with global augmentations before any file checks.
     // The prime checker uses the shared DefinitionStore (via project_env.apply_to).
-    if !program.files.is_empty() && !lib_contexts.is_empty() {
+    if !program.files.is_empty() && !checker_libs.contexts.is_empty() {
         let prime_idx = 0;
         let file = &program.files[prime_idx];
         let binder = parallel::create_binder_from_bound_file(file, program, prime_idx);
@@ -952,6 +959,17 @@ pub(super) fn collect_diagnostics(
         project_env.apply_to(&mut checker.ctx);
         checker.prime_boxed_types();
     }
+
+    let baseline_lib_diagnostics = if !options.no_check && !checker_libs.files.is_empty() {
+        collect_checker_lib_baseline_fingerprints(
+            program,
+            options,
+            checker_libs,
+            &affected_lib_interfaces,
+        )
+    } else {
+        FxHashSet::default()
+    };
 
     // --- SMART INVALIDATION: Work Queue Algorithm ---
     // Only type-check files that have changed or depend on files with changed export signatures
@@ -990,6 +1008,15 @@ pub(super) fn collect_diagnostics(
     let mut aggregated_qc_stats: Option<tsz_solver::QueryCacheStatistics> = None;
     #[allow(unused_assignments)]
     let mut aggregated_ds_stats: Option<tsz_solver::StoreStatistics> = None;
+    let checker_lib_file_env = CheckerLibFileCheckEnv {
+        program,
+        options,
+        checker_libs,
+        affected_interfaces: &affected_lib_interfaces,
+        merged_augmentations: &merged_augmentations,
+        project_env: &project_env,
+        program_has_real_syntax_errors,
+    };
 
     if cache.is_none() {
         // --- PARALLEL PATH: No cache, check all files concurrently ---
@@ -1158,6 +1185,27 @@ pub(super) fn collect_diagnostics(
                     let file_path = PathBuf::from(&program.files[file_idx].file_name);
                     tc_out.insert(file_path, tc);
                 }
+            }
+        }
+        if !options.no_check {
+            for lib_idx in 0..checker_libs.files.len() {
+                let query_cache = if let Some(shared) = shared_query_cache.as_ref() {
+                    QueryCache::new_with_shared(&program.type_interner, shared)
+                } else {
+                    QueryCache::new(&program.type_interner)
+                };
+                let (lib_diags, lib_counters, lib_ds_stats) = check_checker_lib_file(
+                    &checker_lib_file_env,
+                    lib_idx,
+                    &query_cache,
+                    Some(Arc::clone(&shared_lib_cache)),
+                );
+                let mut lib_diags = lib_diags;
+                retain_program_induced_lib_diagnostics(&mut lib_diags, &baseline_lib_diagnostics);
+                diagnostics.extend(lib_diags);
+                request_cache_counters.merge(lib_counters);
+                parallel_qc_stats.merge(&query_cache.statistics());
+                parallel_ds_stats.merge(&lib_ds_stats);
             }
         }
         aggregated_qc_stats = Some(parallel_qc_stats);
@@ -1454,6 +1502,17 @@ pub(super) fn collect_diagnostics(
                 diagnostics.extend(file_diagnostics);
             }
             request_cache_counters.merge(checker_counters);
+        }
+        if !options.no_check {
+            for lib_idx in 0..checker_libs.files.len() {
+                let (lib_diags, lib_counters, lib_ds_stats) =
+                    check_checker_lib_file(&checker_lib_file_env, lib_idx, &query_cache, None);
+                let mut lib_diags = lib_diags;
+                retain_program_induced_lib_diagnostics(&mut lib_diags, &baseline_lib_diagnostics);
+                diagnostics.extend(lib_diags);
+                request_cache_counters.merge(lib_counters);
+                sequential_ds_stats.merge(&lib_ds_stats);
+            }
         }
         // Sequential path: single shared QueryCache — capture stats after all files.
         aggregated_qc_stats = Some(query_cache.statistics());
@@ -2001,6 +2060,726 @@ pub(super) fn check_file_for_parallel<'a>(
     )
 }
 
+struct CheckerLibFileCheckEnv<'a> {
+    program: &'a MergedProgram,
+    options: &'a ResolvedCompilerOptions,
+    checker_libs: &'a CheckerLibSet,
+    affected_interfaces: &'a FxHashSet<String>,
+    merged_augmentations: &'a MergedAugmentations,
+    project_env: &'a tsz::checker::context::ProjectEnv,
+    program_has_real_syntax_errors: bool,
+}
+
+fn check_checker_lib_file(
+    env: &CheckerLibFileCheckEnv<'_>,
+    lib_idx: usize,
+    query_cache: &QueryCache,
+    shared_lib_cache: Option<Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>>>,
+) -> (
+    Vec<Diagnostic>,
+    RequestCacheCounters,
+    tsz_solver::StoreStatistics,
+) {
+    let program = env.program;
+    let options = env.options;
+    let checker_libs = env.checker_libs;
+    let lib_file = &checker_libs.files[lib_idx];
+    if should_skip_type_checking_for_file(&lib_file.file_name, options, true) {
+        return (
+            Vec::new(),
+            RequestCacheCounters::default(),
+            tsz_solver::StoreStatistics::default(),
+        );
+    }
+
+    let lib_bound_file =
+        build_lib_bound_file_for_interface_checks(program, lib_file, env.affected_interfaces);
+    let binder = create_binder_from_bound_file_with_augmentations(
+        &lib_bound_file,
+        program,
+        program.files.len(),
+        env.merged_augmentations,
+    );
+
+    let mut checker = CheckerState::with_options(
+        &lib_bound_file.arena,
+        &binder,
+        query_cache,
+        lib_bound_file.file_name.clone(),
+        &options.checker,
+    );
+    env.project_env.apply_to(&mut checker.ctx);
+    if let Some(shared_lib_cache) = shared_lib_cache {
+        checker.ctx.shared_lib_type_cache = Some(shared_lib_cache);
+    }
+
+    // The current lib file is already the primary binder for this checker. Exclude it from the
+    // fallback lib contexts to avoid duplicate lib declarations during cross-file lookup while
+    // still preserving the total count used for capability checks.
+    let other_lib_contexts: Vec<LibContext> = checker_libs
+        .contexts
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| *idx != lib_idx)
+        .map(|(_, ctx)| ctx.clone())
+        .collect();
+    checker.ctx.set_lib_contexts(other_lib_contexts);
+    checker
+        .ctx
+        .set_actual_lib_file_count(checker_libs.contexts.len());
+    checker.prime_boxed_types();
+
+    // Lib files have no parser diagnostics in the checker pass, but semantic diagnostics from
+    // them should still respect tsc's global syntax-error suppression policy.
+    checker.ctx.has_parse_errors = env.program_has_real_syntax_errors;
+    tsz::checker::reset_stack_overflow_flag();
+    checker.check_source_file_interfaces_only_with_fresh_interface_fuel(lib_bound_file.source_file);
+
+    let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
+    if env.program_has_real_syntax_errors {
+        diagnostics
+            .retain(|diag| keep_checker_diagnostic_when_program_has_real_syntax_errors(diag.code));
+    }
+    diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+    diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
+
+    (
+        diagnostics,
+        checker.ctx.request_cache_counters,
+        checker.ctx.definition_store.statistics(),
+    )
+}
+
+fn check_checker_lib_file_baseline(
+    options: &ResolvedCompilerOptions,
+    checker_libs: &CheckerLibSet,
+    lib_idx: usize,
+    affected_interfaces: &FxHashSet<String>,
+    query_cache: &QueryCache,
+) -> (
+    Vec<Diagnostic>,
+    RequestCacheCounters,
+    tsz_solver::StoreStatistics,
+) {
+    let lib_file = &checker_libs.files[lib_idx];
+    if should_skip_type_checking_for_file(&lib_file.file_name, options, true) {
+        return (
+            Vec::new(),
+            RequestCacheCounters::default(),
+            tsz_solver::StoreStatistics::default(),
+        );
+    }
+
+    let mut checker = CheckerState::with_options(
+        &lib_file.arena,
+        lib_file.binder.as_ref(),
+        query_cache,
+        lib_file.file_name.clone(),
+        &options.checker,
+    );
+    let other_lib_contexts: Vec<LibContext> = checker_libs
+        .contexts
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| *idx != lib_idx)
+        .map(|(_, ctx)| ctx.clone())
+        .collect();
+    checker.ctx.set_lib_contexts(other_lib_contexts);
+    checker
+        .ctx
+        .set_actual_lib_file_count(checker_libs.contexts.len());
+    checker.prime_boxed_types();
+    tsz::checker::reset_stack_overflow_flag();
+    checker.check_source_file_interfaces_only_filtered_post_merge(
+        lib_file.root_index,
+        affected_interfaces,
+    );
+
+    let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
+    diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+    diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
+
+    (
+        diagnostics,
+        checker.ctx.request_cache_counters,
+        checker.ctx.definition_store.statistics(),
+    )
+}
+
+fn collect_lib_interface_node_symbols(
+    arena: &NodeArena,
+    statements: &[NodeIndex],
+    globals: &SymbolTable,
+    affected_interfaces: &FxHashSet<String>,
+    node_symbols: &mut FxHashMap<u32, tsz::binder::SymbolId>,
+) {
+    for &stmt_idx in statements {
+        let Some(stmt_node) = arena.get(stmt_idx) else {
+            continue;
+        };
+
+        if stmt_node.kind == tsz::parser::syntax_kind_ext::INTERFACE_DECLARATION {
+            if let Some(interface) = arena.get_interface(stmt_node)
+                && let Some(name) = arena.get_identifier_at(interface.name)
+                && affected_interfaces.contains(&name.escaped_text)
+                && let Some(sym_id) = globals.get(&name.escaped_text)
+            {
+                node_symbols.insert(stmt_idx.0, sym_id);
+                node_symbols.insert(interface.name.0, sym_id);
+                if let Some(heritage_clauses) = &interface.heritage_clauses {
+                    for &clause_idx in &heritage_clauses.nodes {
+                        let Some(clause_node) = arena.get(clause_idx) else {
+                            continue;
+                        };
+                        let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+                            continue;
+                        };
+                        if heritage.token != tsz_scanner::SyntaxKind::ExtendsKeyword as u16 {
+                            continue;
+                        }
+                        for &type_idx in &heritage.types.nodes {
+                            let Some(type_node) = arena.get(type_idx) else {
+                                continue;
+                            };
+                            let expr_idx = if let Some(expr_type_args) =
+                                arena.get_expr_type_args(type_node)
+                            {
+                                expr_type_args.expression
+                            } else if type_node.kind == tsz::parser::syntax_kind_ext::TYPE_REFERENCE
+                            {
+                                arena
+                                    .get_type_ref(type_node)
+                                    .map_or(type_idx, |type_ref| type_ref.type_name)
+                            } else {
+                                type_idx
+                            };
+                            if let Some(base_name) = entity_name_text_in_arena(arena, expr_idx)
+                                && let Some(base_sym_id) = globals.get(&base_name)
+                            {
+                                node_symbols.insert(expr_idx.0, base_sym_id);
+                            }
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if stmt_node.kind != tsz::parser::syntax_kind_ext::MODULE_DECLARATION {
+            continue;
+        }
+
+        let Some(module_decl) = arena.get_module(stmt_node) else {
+            continue;
+        };
+        if module_decl.body.is_none() {
+            continue;
+        }
+        let Some(body_node) = arena.get(module_decl.body) else {
+            continue;
+        };
+        if body_node.kind != tsz::parser::syntax_kind_ext::MODULE_BLOCK {
+            continue;
+        }
+        let Some(block) = arena.get_module_block(body_node) else {
+            continue;
+        };
+        let Some(inner) = &block.statements else {
+            continue;
+        };
+        collect_lib_interface_node_symbols(
+            arena,
+            &inner.nodes,
+            globals,
+            affected_interfaces,
+            node_symbols,
+        );
+    }
+}
+
+fn interface_name_text(arena: &NodeArena, stmt_idx: NodeIndex) -> Option<String> {
+    let node = arena.get(stmt_idx)?;
+    let interface = arena.get_interface(node)?;
+    let ident = arena.get_identifier_at(interface.name)?;
+    Some(ident.escaped_text.clone())
+}
+
+fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    let node = arena.get(idx)?;
+    if node.kind == tsz::parser::syntax_kind_ext::TYPE_REFERENCE
+        && let Some(type_ref) = arena.get_type_ref(node)
+    {
+        return entity_name_text_in_arena(arena, type_ref.type_name);
+    }
+    if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+        return arena
+            .get_identifier(node)
+            .map(|ident| ident.escaped_text.clone());
+    }
+    if node.kind == tsz::parser::syntax_kind_ext::QUALIFIED_NAME {
+        let qn = arena.get_qualified_name(node)?;
+        let left = entity_name_text_in_arena(arena, qn.left)?;
+        let right = entity_name_text_in_arena(arena, qn.right)?;
+        return Some(format!("{left}.{right}"));
+    }
+    if node.kind == tsz::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        && let Some(access) = arena.get_access_expr(node)
+    {
+        let left = entity_name_text_in_arena(arena, access.expression)?;
+        let right = arena
+            .get(access.name_or_argument)
+            .and_then(|right_node| arena.get_identifier(right_node))?;
+        return Some(format!("{left}.{}", right.escaped_text));
+    }
+    None
+}
+
+fn collect_direct_base_names(
+    arena: &NodeArena,
+    interface: &tsz_parser::parser::node::InterfaceData,
+) -> Vec<String> {
+    let Some(heritage_clauses) = &interface.heritage_clauses else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    for &clause_idx in &heritage_clauses.nodes {
+        let Some(clause_node) = arena.get(clause_idx) else {
+            continue;
+        };
+        let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+            continue;
+        };
+        if heritage.token != tsz_scanner::SyntaxKind::ExtendsKeyword as u16 {
+            continue;
+        }
+        for &type_idx in &heritage.types.nodes {
+            let Some(type_node) = arena.get(type_idx) else {
+                continue;
+            };
+            let expr_idx = if let Some(expr_type_args) = arena.get_expr_type_args(type_node) {
+                expr_type_args.expression
+            } else if type_node.kind == tsz::parser::syntax_kind_ext::TYPE_REFERENCE {
+                arena
+                    .get_type_ref(type_node)
+                    .map_or(type_idx, |type_ref| type_ref.type_name)
+            } else {
+                type_idx
+            };
+            if let Some(name) = entity_name_text_in_arena(arena, expr_idx) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn collect_user_global_interface_seeds(program: &MergedProgram) -> FxHashSet<String> {
+    let mut seeds = FxHashSet::default();
+
+    for file in &program.files {
+        if !file.is_external_module
+            && let Some(source_file) = file.arena.get_source_file_at(file.source_file)
+        {
+            for &stmt_idx in &source_file.statements.nodes {
+                if let Some(name) = interface_name_text(file.arena.as_ref(), stmt_idx) {
+                    seeds.insert(name);
+                }
+            }
+        }
+
+        for name in file.global_augmentations.keys() {
+            seeds.insert(name.clone());
+        }
+    }
+
+    seeds
+}
+
+fn member_name_text(arena: &NodeArena, member_idx: NodeIndex) -> Option<String> {
+    let member_node = arena.get(member_idx)?;
+    if let Some(sig) = arena.get_signature(member_node) {
+        return arena
+            .get(sig.name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.clone());
+    }
+    if let Some(accessor) = arena.get_accessor(member_node) {
+        return arena
+            .get(accessor.name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.clone());
+    }
+    None
+}
+
+fn collect_user_global_interface_member_names(program: &MergedProgram) -> FxHashSet<String> {
+    let mut member_names = FxHashSet::default();
+
+    for file in &program.files {
+        if file.is_external_module {
+            continue;
+        }
+        let Some(source_file) = file.arena.get_source_file_at(file.source_file) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = file.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = file.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            for &member_idx in &interface.members.nodes {
+                if let Some(name) = member_name_text(file.arena.as_ref(), member_idx) {
+                    member_names.insert(name);
+                }
+            }
+        }
+    }
+
+    member_names
+}
+
+fn add_user_global_interface_declaration_arenas(
+    program: &MergedProgram,
+    declaration_arenas: &mut tsz::binder::state::DeclarationArenaMap,
+) {
+    for file in &program.files {
+        if file.is_external_module {
+            continue;
+        }
+        let Some(source_file) = file.arena.get_source_file_at(file.source_file) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(name) = interface_name_text(file.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            let Some(sym_id) = program.globals.get(&name) else {
+                continue;
+            };
+            let target = declaration_arenas.entry((sym_id, stmt_idx)).or_default();
+            if !target.iter().any(|arena| Arc::ptr_eq(arena, &file.arena)) {
+                target.push(Arc::clone(&file.arena));
+            }
+        }
+    }
+}
+
+fn type_node_contains_tag_name_map_indexed_access(
+    arena: &NodeArena,
+    type_idx: NodeIndex,
+    fuel: &mut u32,
+) -> bool {
+    if type_idx == NodeIndex::NONE || *fuel == 0 {
+        return false;
+    }
+    *fuel -= 1;
+
+    let Some(node) = arena.get(type_idx) else {
+        return false;
+    };
+    if node.kind == tsz::parser::syntax_kind_ext::INDEXED_ACCESS_TYPE {
+        return arena
+            .get_indexed_access_type(node)
+            .and_then(|indexed| entity_name_text_in_arena(arena, indexed.object_type))
+            .is_some_and(|name| name.contains("TagNameMap"));
+    }
+
+    if let Some(type_ref) = arena.get_type_ref(node) {
+        return type_ref.type_arguments.as_ref().is_some_and(|args| {
+            args.nodes
+                .iter()
+                .any(|&arg| type_node_contains_tag_name_map_indexed_access(arena, arg, fuel))
+        });
+    }
+    if let Some(composite) = arena.get_composite_type(node) {
+        return composite
+            .types
+            .nodes
+            .iter()
+            .any(|&ty| type_node_contains_tag_name_map_indexed_access(arena, ty, fuel));
+    }
+    if let Some(array) = arena.get_array_type(node) {
+        return type_node_contains_tag_name_map_indexed_access(arena, array.element_type, fuel);
+    }
+    if let Some(wrapped) = arena.get_wrapped_type(node) {
+        return type_node_contains_tag_name_map_indexed_access(arena, wrapped.type_node, fuel);
+    }
+    if let Some(type_operator) = arena.get_type_operator(node) {
+        return type_node_contains_tag_name_map_indexed_access(
+            arena,
+            type_operator.type_node,
+            fuel,
+        );
+    }
+    if let Some(function_type) = arena.get_function_type(node) {
+        if type_node_contains_tag_name_map_indexed_access(
+            arena,
+            function_type.type_annotation,
+            fuel,
+        ) {
+            return true;
+        }
+        for &param_idx in &function_type.parameters.nodes {
+            let Some(param_node) = arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = arena.get_parameter(param_node) else {
+                continue;
+            };
+            if type_node_contains_tag_name_map_indexed_access(arena, param.type_annotation, fuel) {
+                return true;
+            }
+        }
+    }
+    if let Some(conditional) = arena.get_conditional_type(node) {
+        return [
+            conditional.check_type,
+            conditional.extends_type,
+            conditional.true_type,
+            conditional.false_type,
+        ]
+        .into_iter()
+        .any(|ty| type_node_contains_tag_name_map_indexed_access(arena, ty, fuel));
+    }
+
+    false
+}
+
+fn interface_declares_member_named(
+    arena: &NodeArena,
+    interface: &tsz_parser::parser::node::InterfaceData,
+    member_names: &FxHashSet<String>,
+) -> bool {
+    !member_names.is_empty()
+        && interface.members.nodes.iter().any(|&member_idx| {
+            member_name_text(arena, member_idx).is_some_and(|name| member_names.contains(&name))
+        })
+}
+
+fn interface_has_indexed_access_member_type(
+    arena: &NodeArena,
+    interface: &tsz_parser::parser::node::InterfaceData,
+) -> bool {
+    for &member_idx in &interface.members.nodes {
+        let Some(member_node) = arena.get(member_idx) else {
+            continue;
+        };
+        if let Some(sig) = arena.get_signature(member_node) {
+            let mut fuel = 256;
+            if type_node_contains_tag_name_map_indexed_access(arena, sig.type_annotation, &mut fuel)
+            {
+                return true;
+            }
+            for &param_idx in sig.parameters.as_ref().map_or(&[][..], |p| &p.nodes) {
+                let Some(param_node) = arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = arena.get_parameter(param_node) else {
+                    continue;
+                };
+                let mut fuel = 256;
+                if type_node_contains_tag_name_map_indexed_access(
+                    arena,
+                    param.type_annotation,
+                    &mut fuel,
+                ) {
+                    return true;
+                }
+            }
+        }
+        if let Some(accessor) = arena.get_accessor(member_node) {
+            let mut fuel = 256;
+            if type_node_contains_tag_name_map_indexed_access(
+                arena,
+                accessor.type_annotation,
+                &mut fuel,
+            ) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn affected_lib_interface_names(
+    program: &MergedProgram,
+    checker_libs: &CheckerLibSet,
+) -> FxHashSet<String> {
+    let seed_interfaces = collect_user_global_interface_seeds(program);
+    let mut affected = seed_interfaces.clone();
+    let user_member_names = collect_user_global_interface_member_names(program);
+    let mut inheritance_graph: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+
+    for lib in &checker_libs.files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            let bases = collect_direct_base_names(lib.arena.as_ref(), interface);
+            inheritance_graph
+                .entry(name)
+                .or_default()
+                .extend(bases.into_iter());
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, bases) in &inheritance_graph {
+            if affected.contains(name) {
+                continue;
+            }
+            if bases.iter().any(|base| affected.contains(base)) {
+                changed = affected.insert(name.clone());
+            }
+        }
+    }
+
+    let mut relevant = FxHashSet::default();
+    for lib in &checker_libs.files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            if !affected.contains(&name) {
+                continue;
+            }
+            if interface_declares_member_named(lib.arena.as_ref(), interface, &user_member_names)
+                || interface_has_indexed_access_member_type(lib.arena.as_ref(), interface)
+            {
+                relevant.insert(name);
+            }
+        }
+    }
+
+    relevant.extend(seed_interfaces);
+    let mut ancestor_queue: Vec<String> = relevant.iter().cloned().collect();
+    while let Some(name) = ancestor_queue.pop() {
+        let Some(bases) = inheritance_graph.get(&name) else {
+            continue;
+        };
+        for base in bases {
+            if relevant.insert(base.clone()) {
+                ancestor_queue.push(base.clone());
+            }
+        }
+    }
+
+    if relevant.is_empty() {
+        affected
+    } else {
+        relevant
+    }
+}
+
+fn build_lib_bound_file_for_interface_checks(
+    program: &MergedProgram,
+    lib_file: &Arc<LibFile>,
+    affected_interfaces: &FxHashSet<String>,
+) -> tsz::parallel::BoundFile {
+    let mut node_symbols = FxHashMap::default();
+    if let Some(source_file) = lib_file.arena.get_source_file_at(lib_file.root_index) {
+        collect_lib_interface_node_symbols(
+            lib_file.arena.as_ref(),
+            &source_file.statements.nodes,
+            &program.globals,
+            affected_interfaces,
+            &mut node_symbols,
+        );
+    }
+
+    let mut declaration_arenas = program.declaration_arenas.clone();
+    add_user_global_interface_declaration_arenas(program, &mut declaration_arenas);
+
+    tsz::parallel::BoundFile {
+        file_name: lib_file.file_name.clone(),
+        source_file: lib_file.root_index,
+        arena: Arc::clone(&lib_file.arena),
+        node_symbols,
+        symbol_arenas: program.symbol_arenas.clone(),
+        declaration_arenas,
+        module_declaration_exports_publicly: FxHashMap::default(),
+        scopes: Vec::new(),
+        node_scope_ids: FxHashMap::default(),
+        parse_diagnostics: Vec::new(),
+        global_augmentations: FxHashMap::default(),
+        module_augmentations: FxHashMap::default(),
+        augmentation_target_modules: FxHashMap::default(),
+        flow_nodes: tsz::binder::FlowNodeArena::default(),
+        node_flow: FxHashMap::default(),
+        switch_clause_to_switch: FxHashMap::default(),
+        is_external_module: lib_file.binder.is_external_module,
+        expando_properties: FxHashMap::default(),
+        file_features: tsz::binder::FileFeatures::NONE,
+        lib_symbol_reverse_remap: FxHashMap::default(),
+        semantic_defs: FxHashMap::default(),
+    }
+}
+
+type LibDiagnosticFingerprint = (String, u32, u32, String);
+
+fn lib_diagnostic_fingerprint(diag: &Diagnostic) -> LibDiagnosticFingerprint {
+    (
+        diag.file.clone(),
+        diag.start,
+        diag.code,
+        diag.message_text.clone(),
+    )
+}
+
+fn collect_checker_lib_baseline_fingerprints(
+    program: &MergedProgram,
+    options: &ResolvedCompilerOptions,
+    checker_libs: &CheckerLibSet,
+    affected_interfaces: &FxHashSet<String>,
+) -> FxHashSet<LibDiagnosticFingerprint> {
+    let mut fingerprints = FxHashSet::default();
+
+    for lib_idx in 0..checker_libs.files.len() {
+        let query_cache = QueryCache::new(&program.type_interner);
+        let (diagnostics, _, _) = check_checker_lib_file_baseline(
+            options,
+            checker_libs,
+            lib_idx,
+            affected_interfaces,
+            &query_cache,
+        );
+        fingerprints.extend(diagnostics.iter().map(lib_diagnostic_fingerprint));
+    }
+
+    fingerprints
+}
+
+fn retain_program_induced_lib_diagnostics(
+    diagnostics: &mut Vec<Diagnostic>,
+    baseline_fingerprints: &FxHashSet<LibDiagnosticFingerprint>,
+) {
+    diagnostics.retain(|diag| !baseline_fingerprints.contains(&lib_diagnostic_fingerprint(diag)));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2024,7 +2803,7 @@ mod tests {
             &ResolvedCompilerOptions::default(),
             std::path::Path::new("/"),
             None,
-            &[],
+            &CheckerLibSet::default(),
             (false, false, false),
             &type_cache_output,
             false,
@@ -2051,7 +2830,7 @@ mod tests {
             options,
             base_dir,
             None,
-            &[],
+            &CheckerLibSet::default(),
             (false, false, false),
             &type_cache_output,
             false,
@@ -2270,7 +3049,7 @@ const elem = <div className={class1, class2}/>;
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2291,7 +3070,7 @@ const elem = <div className={class1, class2}/>;
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2388,7 +3167,7 @@ const q: PromiseLike<number> = p;
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2409,7 +3188,7 @@ const q: PromiseLike<number> = p;
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2467,7 +3246,7 @@ async function f() {
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2488,7 +3267,7 @@ async function f() {
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2549,7 +3328,7 @@ type Recurse2 = {
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2570,7 +3349,7 @@ type Recurse2 = {
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2641,7 +3420,7 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let direct_lib_contexts: Vec<LibContext> = lib_files
             .iter()
             .map(|lib| LibContext {
@@ -2649,6 +3428,10 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
                 binder: Arc::clone(&lib.binder),
             })
             .collect();
+        let direct_checker_libs = CheckerLibSet {
+            files: lib_files.clone(),
+            contexts: direct_lib_contexts.clone(),
+        };
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2777,7 +3560,7 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
             &resolved,
             dir.path(),
             None,
-            &direct_lib_contexts,
+            &direct_checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2797,7 +3580,7 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2879,7 +3662,7 @@ export const x = foo();
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -2899,7 +3682,7 @@ export const x = foo();
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -2980,7 +3763,7 @@ export type RowToColumns<TColumns> = {
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3000,7 +3783,7 @@ export type RowToColumns<TColumns> = {
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3484,7 +4267,7 @@ let x2: string = f;
             &resolved,
             dir.path(),
             None,
-            &[],
+            &CheckerLibSet::default(),
             (false, false, false),
             &type_cache_output,
             false,
@@ -3580,7 +4363,7 @@ const onSomeEvent = <T extends keyof TypesMap>(p: P<T>) => typeHandlers[p.t]?.(p
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3601,7 +4384,7 @@ const onSomeEvent = <T extends keyof TypesMap>(p: P<T>) => typeHandlers[p.t]?.(p
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3677,7 +4460,7 @@ const nestedTuple = type([["ark", "|>", (x) => x.length]])
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3698,7 +4481,7 @@ const nestedTuple = type([["ark", "|>", (x) => x.length]])
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3764,7 +4547,7 @@ m(item => item.id < 5);
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3785,7 +4568,7 @@ m(item => item.id < 5);
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3845,7 +4628,7 @@ interface Buzz { id: number; buzz: string }
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3866,7 +4649,7 @@ interface Buzz { id: number; buzz: string }
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3934,7 +4717,7 @@ const obj: {field: Rule} = {
         let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
         let lib_files =
             parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
-        let lib_contexts = load_lib_files_for_contexts(&lib_files);
+        let checker_libs = load_checker_libs(&lib_files);
         let compile_inputs: Vec<_> = sources
             .into_iter()
             .map(|source| {
@@ -3955,7 +4738,7 @@ const obj: {field: Rule} = {
             &resolved,
             dir.path(),
             None,
-            &lib_contexts,
+            &checker_libs,
             (false, false, false),
             &type_cache_output,
             false,
@@ -3992,6 +4775,202 @@ const obj: {field: Rule} = {
                 .iter()
                 .any(|diag| diag.file == "/b.ts" && diag.code == 2322),
             "did not expect TS2322 when another file has a real syntax error: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn collect_diagnostics_reports_default_lib_breakage_from_global_node_merge() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(
+            &file_path,
+            r#"
+const enum SyntaxKind {
+    Modifier,
+    Decorator,
+}
+
+interface Node {
+    kind: SyntaxKind;
+}
+
+interface Modifier extends Node { kind: SyntaxKind.Modifier; }
+interface Decorator extends Node { kind: SyntaxKind.Decorator; }
+
+declare function isModifier(node: Node): node is Modifier;
+declare function isDecorator(node: Node): node is Decorator;
+
+declare function every<T, U extends T>(array: readonly T[], callback: (element: T) => element is U): array is readonly U[];
+
+declare const modifiers: readonly Decorator[] | readonly Modifier[];
+
+function foo() {
+    every(modifiers, isModifier);
+    every(modifiers, isDecorator);
+}
+"#,
+        )
+        .expect("write source");
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        let diagnostics = collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics;
+
+        let lib_dom_diagnostics = diagnostics
+            .iter()
+            .filter(|diag| diag.file.ends_with("lib.dom.d.ts"))
+            .collect::<Vec<_>>();
+        let ts2344_count = lib_dom_diagnostics
+            .iter()
+            .filter(|diag| diag.code == diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT)
+            .count();
+        let ts2430_count = lib_dom_diagnostics
+            .iter()
+            .filter(|diag| diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE)
+            .count();
+
+        assert_eq!(
+            ts2344_count, 3,
+            "Expected three TS2344 diagnostics from lib.dom.d.ts after merging Node.kind, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            ts2430_count, 1,
+            "Expected one TS2430 diagnostic from lib.dom.d.ts after merging Node.kind, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn collect_diagnostics_respects_skip_default_lib_check_for_global_node_merge() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(
+            &file_path,
+            r#"
+const enum SyntaxKind {
+    Modifier,
+    Decorator,
+}
+
+interface Node {
+    kind: SyntaxKind;
+}
+"#,
+        )
+        .expect("write source");
+
+        let mut resolved = resolved_options_for_es2015_strict_test();
+        resolved.skip_default_lib_check = true;
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        let diagnostics = collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics;
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && matches!(
+                        diag.code,
+                        diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT
+                            | diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+                    )
+            }),
+            "Did not expect lib.dom.d.ts TS2344/TS2430 diagnostics when skipDefaultLibCheck is enabled, got: {diagnostics:?}"
         );
     }
 

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -575,6 +575,8 @@ pub(super) fn collect_diagnostics(
     // Pre-compute merged augmentations once for all binder reconstruction paths.
     let merged_augmentations = MergedAugmentations::from_program(program);
     let affected_lib_interfaces = affected_lib_interface_names(program, checker_libs);
+    let affected_lib_extension_interfaces =
+        affected_lib_extension_interface_names(program, checker_libs, &affected_lib_interfaces);
 
     // Pre-create all binders for cross-file resolution
     let all_binders: Arc<Vec<Arc<BinderState>>> = Arc::new({
@@ -966,6 +968,7 @@ pub(super) fn collect_diagnostics(
             options,
             checker_libs,
             &affected_lib_interfaces,
+            &affected_lib_extension_interfaces,
         )
     } else {
         FxHashSet::default()
@@ -1013,6 +1016,7 @@ pub(super) fn collect_diagnostics(
         options,
         checker_libs,
         affected_interfaces: &affected_lib_interfaces,
+        extension_interfaces: &affected_lib_extension_interfaces,
         merged_augmentations: &merged_augmentations,
         project_env: &project_env,
         program_has_real_syntax_errors,
@@ -2065,6 +2069,7 @@ struct CheckerLibFileCheckEnv<'a> {
     options: &'a ResolvedCompilerOptions,
     checker_libs: &'a CheckerLibSet,
     affected_interfaces: &'a FxHashSet<String>,
+    extension_interfaces: &'a FxHashSet<String>,
     merged_augmentations: &'a MergedAugmentations,
     project_env: &'a tsz::checker::context::ProjectEnv,
     program_has_real_syntax_errors: bool,
@@ -2133,7 +2138,11 @@ fn check_checker_lib_file(
     // them should still respect tsc's global syntax-error suppression policy.
     checker.ctx.has_parse_errors = env.program_has_real_syntax_errors;
     tsz::checker::reset_stack_overflow_flag();
-    checker.check_source_file_interfaces_only_with_fresh_interface_fuel(lib_bound_file.source_file);
+    checker.check_source_file_interfaces_only_filtered_post_merge(
+        lib_bound_file.source_file,
+        env.affected_interfaces,
+        env.extension_interfaces,
+    );
 
     let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
     if env.program_has_real_syntax_errors {
@@ -2155,6 +2164,7 @@ fn check_checker_lib_file_baseline(
     checker_libs: &CheckerLibSet,
     lib_idx: usize,
     affected_interfaces: &FxHashSet<String>,
+    extension_interfaces: &FxHashSet<String>,
     query_cache: &QueryCache,
 ) -> (
     Vec<Diagnostic>,
@@ -2193,6 +2203,7 @@ fn check_checker_lib_file_baseline(
     checker.check_source_file_interfaces_only_filtered_post_merge(
         lib_file.root_index,
         affected_interfaces,
+        extension_interfaces,
     );
 
     let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
@@ -2695,6 +2706,43 @@ fn affected_lib_interface_names(
     }
 }
 
+fn affected_lib_extension_interface_names(
+    program: &MergedProgram,
+    checker_libs: &CheckerLibSet,
+    affected_interfaces: &FxHashSet<String>,
+) -> FxHashSet<String> {
+    let user_member_names = collect_user_global_interface_member_names(program);
+    let mut extension_interfaces = FxHashSet::default();
+
+    for lib in &checker_libs.files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            if affected_interfaces.contains(&name)
+                && interface_declares_member_named(
+                    lib.arena.as_ref(),
+                    interface,
+                    &user_member_names,
+                )
+            {
+                extension_interfaces.insert(name);
+            }
+        }
+    }
+
+    extension_interfaces
+}
+
 fn build_lib_bound_file_for_interface_checks(
     program: &MergedProgram,
     lib_file: &Arc<LibFile>,
@@ -2755,6 +2803,7 @@ fn collect_checker_lib_baseline_fingerprints(
     options: &ResolvedCompilerOptions,
     checker_libs: &CheckerLibSet,
     affected_interfaces: &FxHashSet<String>,
+    extension_interfaces: &FxHashSet<String>,
 ) -> FxHashSet<LibDiagnosticFingerprint> {
     let mut fingerprints = FxHashSet::default();
 
@@ -2765,6 +2814,7 @@ fn collect_checker_lib_baseline_fingerprints(
             checker_libs,
             lib_idx,
             affected_interfaces,
+            extension_interfaces,
             &query_cache,
         );
         fingerprints.extend(diagnostics.iter().map(lib_diagnostic_fingerprint));

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1512,7 +1512,7 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
     file_idx: usize,
     augmentations: &MergedAugmentations,
 ) -> BinderState {
-    let declaration_arenas: tsz::binder::state::DeclarationArenaMap = program
+    let mut declaration_arenas: tsz::binder::state::DeclarationArenaMap = program
         .declaration_arenas
         .iter()
         .filter_map(|(&(sym_id, decl_idx), arenas)| {
@@ -1520,6 +1520,16 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
             has_non_local_arena.then(|| ((sym_id, decl_idx), arenas.clone()))
         })
         .collect();
+    for (&(sym_id, decl_idx), arenas) in &file.declaration_arenas {
+        let target = declaration_arenas.entry((sym_id, decl_idx)).or_default();
+        for arena in arenas {
+            if !Arc::ptr_eq(arena, &file.arena)
+                && !target.iter().any(|existing| Arc::ptr_eq(existing, arena))
+            {
+                target.push(Arc::clone(arena));
+            }
+        }
+    }
 
     let symbols_with_non_local_declarations: rustc_hash::FxHashSet<tsz::binder::SymbolId> =
         declaration_arenas

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1297,7 +1297,7 @@ fn compile_inner(
     let load_libs_duration = load_libs_start.elapsed();
     perf_log_phase("load_libs", load_libs_start);
 
-    // PERF: Start loading checker lib contexts in a background thread while we
+    // PERF: Start cloning checker lib binders in a background thread while we
     // build the user program. The checker needs fresh binder state (separate from
     // the binding-phase libs) because it mutates during declaration merging.
     // By overlapping this with user file parsing+binding, we save ~100ms on
@@ -1305,7 +1305,7 @@ fn compile_inner(
     let checker_lib_handle = if !resolved.no_check {
         let lib_files_clone = lib_files.clone();
         Some(std::thread::spawn(move || {
-            load_lib_files_for_contexts(&lib_files_clone)
+            load_checker_libs(&lib_files_clone)
         }))
     } else {
         None
@@ -1338,11 +1338,11 @@ fn compile_inner(
         update_import_symbol_ids(&program, &resolved, &base_dir, c);
     }
 
-    // Wait for checker lib contexts (already running in background)
+    // Wait for checker lib clones (already running in background)
     let build_lib_contexts_start = Instant::now();
-    let lib_contexts = match checker_lib_handle {
+    let checker_libs = match checker_lib_handle {
         Some(handle) => handle.join().expect("checker lib loading panicked"),
-        None => Vec::new(),
+        None => check::CheckerLibSet::default(),
     };
     perf_log_phase("build_lib_contexts", build_lib_contexts_start);
 
@@ -1353,7 +1353,7 @@ fn compile_inner(
         &resolved,
         &base_dir,
         effective_cache,
-        &lib_contexts,
+        &checker_libs,
         typescript_dom_replacement_globals,
         &parallel_type_caches,
         has_deprecation_diagnostics,
@@ -2305,7 +2305,7 @@ pub(crate) use sources::{
 mod check;
 #[path = "check_utils.rs"]
 mod check_utils;
-use check::{collect_diagnostics, load_lib_files_for_contexts};
+use check::{collect_diagnostics, load_checker_libs};
 
 pub fn apply_cli_overrides(options: &mut ResolvedCompilerOptions, args: &CliArgs) -> Result<()> {
     if let Some(target) = args.target {
@@ -2508,6 +2508,9 @@ pub fn apply_cli_overrides(options: &mut ResolvedCompilerOptions, args: &CliArgs
     }
     if args.skip_lib_check {
         options.skip_lib_check = true;
+    }
+    if args.skip_default_lib_check {
+        options.skip_default_lib_check = true;
     }
     if args.allow_js {
         options.allow_js = true;

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -224,6 +224,9 @@ pub struct CompilerOptions {
     /// Skip type checking of declaration files (.d.ts)
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub skip_lib_check: Option<bool>,
+    /// Skip type checking of default library declaration files (.d.ts)
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub skip_default_lib_check: Option<bool>,
     /// Disable emitting declarations that have '@internal' in their JSDoc comments
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub strip_internal: Option<bool>,
@@ -430,6 +433,8 @@ pub struct ResolvedCompilerOptions {
     pub explicit_check_js_false: bool,
     /// Skip type checking of declaration files (.d.ts)
     pub skip_lib_check: bool,
+    /// Skip type checking of default library declaration files (.d.ts)
+    pub skip_default_lib_check: bool,
     /// Disable emitting declarations that have '@internal' in their JSDoc comments
     pub strip_internal: bool,
     /// Maximum folder depth for checking JS files from `node_modules`.
@@ -1092,6 +1097,9 @@ pub fn resolve_compiler_options(
     }
     if let Some(skip_lib_check) = options.skip_lib_check {
         resolved.skip_lib_check = skip_lib_check;
+    }
+    if let Some(skip_default_lib_check) = options.skip_default_lib_check {
+        resolved.skip_default_lib_check = skip_default_lib_check;
     }
     if let Some(isolated_declarations) = options.isolated_declarations {
         resolved.isolated_declarations = isolated_declarations;

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -3824,6 +3824,43 @@ fn affected_lib_interface_names(
     }
 }
 
+fn affected_lib_extension_interface_names(
+    program: &MergedProgram,
+    checker_lib_files: &[Arc<LibFile>],
+    affected_interfaces: &FxHashSet<String>,
+) -> FxHashSet<String> {
+    let user_member_names = collect_user_global_interface_member_names(program);
+    let mut extension_interfaces = FxHashSet::default();
+
+    for lib in checker_lib_files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            if affected_interfaces.contains(&name)
+                && interface_declares_member_named(
+                    lib.arena.as_ref(),
+                    interface,
+                    &user_member_names,
+                )
+            {
+                extension_interfaces.insert(name);
+            }
+        }
+    }
+
+    extension_interfaces
+}
+
 fn build_lib_bound_file_for_interface_checks(
     program: &MergedProgram,
     lib_file: &Arc<LibFile>,
@@ -4382,6 +4419,11 @@ pub fn check_files_parallel(
     };
 
     let affected_lib_interfaces = affected_lib_interface_names(program, &checker_lib_files);
+    let affected_lib_extension_interfaces = affected_lib_extension_interface_names(
+        program,
+        &checker_lib_files,
+        &affected_lib_interfaces,
+    );
 
     let check_one_lib = |lib_idx: usize, lib_file: &Arc<LibFile>| -> FileCheckResult {
         let query_cache = if let Some(ref shared) = shared_query_cache {
@@ -4432,8 +4474,10 @@ pub fn check_files_parallel(
         checker.ctx.set_actual_lib_file_count(lib_contexts.len());
         checker.prime_boxed_types();
 
-        checker.check_source_file_interfaces_only_with_fresh_interface_fuel(
+        checker.check_source_file_interfaces_only_filtered_post_merge(
             lib_bound_file.source_file,
+            &affected_lib_interfaces,
+            &affected_lib_extension_interfaces,
         );
 
         let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
@@ -4470,6 +4514,7 @@ pub fn check_files_parallel(
         checker.check_source_file_interfaces_only_filtered_post_merge(
             lib_file.root_index,
             &affected_lib_interfaces,
+            &affected_lib_extension_interfaces,
         );
 
         let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -1033,6 +1033,30 @@ pub fn load_lib_files_for_binding_strict(
     results.into_iter().collect()
 }
 
+/// Clone lib files into fresh checker-only binders using the already-loaded source text.
+///
+/// The binders used during program construction are mutated while merging lib symbols into
+/// user-file binders. Checker-facing lib contexts and lib-file checks need fresh binder state
+/// so declaration merging and semantic lookups run against clean lib binders.
+#[must_use]
+pub fn clone_lib_files_for_checker(
+    lib_files: &[Arc<lib_loader::LibFile>],
+) -> Vec<Arc<lib_loader::LibFile>> {
+    lib_files
+        .iter()
+        .map(|lib| {
+            let source = lib
+                .arena
+                .get_source_file_at(lib.root_index)
+                .unwrap_or_else(|| panic!("missing source text for lib file {}", lib.file_name));
+            Arc::new(lib_loader::LibFile::from_source(
+                lib.file_name.clone(),
+                source.text.to_string(),
+            ))
+        })
+        .collect()
+}
+
 /// Parse and bind a single lib file, returning a `LibFile` or error.
 fn parse_and_bind_lib_file(
     file_name: String,
@@ -1088,18 +1112,20 @@ fn collect_lib_files_recursive_cached(
         return Ok(());
     }
 
-    // Priority: embedded (comment-stripped, 58% smaller) > disk cache > disk read.
-    // Embedded libs contain the same declarations as disk files but with comments
-    // removed at build time, reducing parse work by ~58%. This is safe because
-    // declaration files don't use comments for semantics.
+    // Prefer physical lib files when they exist so diagnostic offsets match the
+    // TypeScript lib baselines. Fall back to embedded libs only when running
+    // without an on-disk TypeScript lib directory.
     let basename = lib_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     let embedded_key = basename.strip_prefix("lib.").unwrap_or(basename);
-    let source_text = if let Some(embedded) = crate::embedded_libs::get_lib_content(embedded_key) {
-        // Built-in embedded content — zero I/O, comment-stripped for faster parsing
-        embedded.to_string()
-    } else if let Some(cached) = file_cache.get(&lib_path) {
+    let source_text = if let Some(cached) = file_cache.get(&lib_path) {
         // File was read from disk (custom lib dir with non-standard files) — use it
         cached.clone()
+    } else if lib_path.exists() {
+        std::fs::read_to_string(&lib_path)
+            .with_context(|| format!("failed to read lib file {}", lib_path.display()))?
+    } else if let Some(embedded) = crate::embedded_libs::get_lib_content(embedded_key) {
+        // Built-in embedded content — zero I/O, comment-stripped for faster parsing
+        embedded.to_string()
     } else {
         // Fallback to disk read
         std::fs::read_to_string(&lib_path)
@@ -3299,6 +3325,7 @@ pub struct FunctionCheckResult {
 }
 
 /// Result of type checking all function bodies in a file
+#[derive(Debug)]
 pub struct FileCheckResult {
     /// File index
     pub file_idx: usize,
@@ -3310,7 +3337,539 @@ pub struct FileCheckResult {
     pub diagnostics: Vec<Diagnostic>,
 }
 
+fn collect_lib_interface_node_symbols(
+    arena: &NodeArena,
+    statements: &[NodeIndex],
+    globals: &SymbolTable,
+    affected_interfaces: &FxHashSet<String>,
+    node_symbols: &mut FxHashMap<u32, SymbolId>,
+) {
+    for &stmt_idx in statements {
+        let Some(stmt_node) = arena.get(stmt_idx) else {
+            continue;
+        };
+
+        if stmt_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            if let Some(interface) = arena.get_interface(stmt_node)
+                && let Some(name) = arena.get_identifier_at(interface.name)
+                && affected_interfaces.contains(&name.escaped_text)
+                && let Some(sym_id) = globals.get(&name.escaped_text)
+            {
+                node_symbols.insert(stmt_idx.0, sym_id);
+                node_symbols.insert(interface.name.0, sym_id);
+                if let Some(heritage_clauses) = &interface.heritage_clauses {
+                    for &clause_idx in &heritage_clauses.nodes {
+                        let Some(clause_node) = arena.get(clause_idx) else {
+                            continue;
+                        };
+                        let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+                            continue;
+                        };
+                        if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                            continue;
+                        }
+                        for &type_idx in &heritage.types.nodes {
+                            let Some(type_node) = arena.get(type_idx) else {
+                                continue;
+                            };
+                            let expr_idx =
+                                if let Some(expr_type_args) = arena.get_expr_type_args(type_node) {
+                                    expr_type_args.expression
+                                } else if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+                                    arena
+                                        .get_type_ref(type_node)
+                                        .map_or(type_idx, |type_ref| type_ref.type_name)
+                                } else {
+                                    type_idx
+                                };
+                            if let Some(base_name) = entity_name_text_in_arena(arena, expr_idx)
+                                && let Some(base_sym_id) = globals.get(&base_name)
+                            {
+                                node_symbols.insert(expr_idx.0, base_sym_id);
+                            }
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if stmt_node.kind != syntax_kind_ext::MODULE_DECLARATION {
+            continue;
+        }
+
+        let Some(module_decl) = arena.get_module(stmt_node) else {
+            continue;
+        };
+        if module_decl.body.is_none() {
+            continue;
+        }
+        let Some(body_node) = arena.get(module_decl.body) else {
+            continue;
+        };
+        if body_node.kind != syntax_kind_ext::MODULE_BLOCK {
+            continue;
+        }
+        let Some(block) = arena.get_module_block(body_node) else {
+            continue;
+        };
+        let Some(inner) = &block.statements else {
+            continue;
+        };
+        collect_lib_interface_node_symbols(
+            arena,
+            &inner.nodes,
+            globals,
+            affected_interfaces,
+            node_symbols,
+        );
+    }
+}
+
+fn interface_name_text(arena: &NodeArena, stmt_idx: NodeIndex) -> Option<String> {
+    let node = arena.get(stmt_idx)?;
+    let interface = arena.get_interface(node)?;
+    let ident = arena.get_identifier_at(interface.name)?;
+    Some(ident.escaped_text.clone())
+}
+
+fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    let node = arena.get(idx)?;
+    if node.kind == syntax_kind_ext::TYPE_REFERENCE
+        && let Some(type_ref) = arena.get_type_ref(node)
+    {
+        return entity_name_text_in_arena(arena, type_ref.type_name);
+    }
+    if node.kind == SyntaxKind::Identifier as u16 {
+        return arena
+            .get_identifier(node)
+            .map(|ident| ident.escaped_text.clone());
+    }
+    if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+        let qn = arena.get_qualified_name(node)?;
+        let left = entity_name_text_in_arena(arena, qn.left)?;
+        let right = entity_name_text_in_arena(arena, qn.right)?;
+        return Some(format!("{left}.{right}"));
+    }
+    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        && let Some(access) = arena.get_access_expr(node)
+    {
+        let left = entity_name_text_in_arena(arena, access.expression)?;
+        let right = arena
+            .get(access.name_or_argument)
+            .and_then(|right_node| arena.get_identifier(right_node))?;
+        return Some(format!("{left}.{}", right.escaped_text));
+    }
+    None
+}
+
+fn collect_direct_base_names(
+    arena: &NodeArena,
+    interface: &crate::parser::node::InterfaceData,
+) -> Vec<String> {
+    let Some(heritage_clauses) = &interface.heritage_clauses else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    for &clause_idx in &heritage_clauses.nodes {
+        let Some(clause_node) = arena.get(clause_idx) else {
+            continue;
+        };
+        let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+            continue;
+        };
+        if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+            continue;
+        }
+        for &type_idx in &heritage.types.nodes {
+            let Some(type_node) = arena.get(type_idx) else {
+                continue;
+            };
+            let expr_idx = if let Some(expr_type_args) = arena.get_expr_type_args(type_node) {
+                expr_type_args.expression
+            } else if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+                arena
+                    .get_type_ref(type_node)
+                    .map_or(type_idx, |type_ref| type_ref.type_name)
+            } else {
+                type_idx
+            };
+            if let Some(name) = entity_name_text_in_arena(arena, expr_idx) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn collect_user_global_interface_seeds(program: &MergedProgram) -> FxHashSet<String> {
+    let mut seeds = FxHashSet::default();
+
+    for file in &program.files {
+        if !file.is_external_module
+            && let Some(source_file) = file.arena.get_source_file_at(file.source_file)
+        {
+            for &stmt_idx in &source_file.statements.nodes {
+                if let Some(name) = interface_name_text(file.arena.as_ref(), stmt_idx) {
+                    seeds.insert(name);
+                }
+            }
+        }
+
+        for name in file.global_augmentations.keys() {
+            seeds.insert(name.clone());
+        }
+    }
+
+    seeds
+}
+
+fn member_name_text(arena: &NodeArena, member_idx: NodeIndex) -> Option<String> {
+    let member_node = arena.get(member_idx)?;
+    if let Some(sig) = arena.get_signature(member_node) {
+        return arena
+            .get(sig.name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.clone());
+    }
+    if let Some(accessor) = arena.get_accessor(member_node) {
+        return arena
+            .get(accessor.name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.clone());
+    }
+    None
+}
+
+fn collect_user_global_interface_member_names(program: &MergedProgram) -> FxHashSet<String> {
+    let mut member_names = FxHashSet::default();
+
+    for file in &program.files {
+        if file.is_external_module {
+            continue;
+        }
+        let Some(source_file) = file.arena.get_source_file_at(file.source_file) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = file.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = file.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            for &member_idx in &interface.members.nodes {
+                if let Some(name) = member_name_text(file.arena.as_ref(), member_idx) {
+                    member_names.insert(name);
+                }
+            }
+        }
+    }
+
+    member_names
+}
+
+fn add_user_global_interface_declaration_arenas(
+    program: &MergedProgram,
+    declaration_arenas: &mut DeclarationArenaMap,
+) {
+    for file in &program.files {
+        if file.is_external_module {
+            continue;
+        }
+        let Some(source_file) = file.arena.get_source_file_at(file.source_file) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(name) = interface_name_text(file.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            let Some(sym_id) = program.globals.get(&name) else {
+                continue;
+            };
+            let target = declaration_arenas.entry((sym_id, stmt_idx)).or_default();
+            if !target.iter().any(|arena| Arc::ptr_eq(arena, &file.arena)) {
+                target.push(Arc::clone(&file.arena));
+            }
+        }
+    }
+}
+
+fn type_node_contains_tag_name_map_indexed_access(
+    arena: &NodeArena,
+    type_idx: NodeIndex,
+    fuel: &mut u32,
+) -> bool {
+    if type_idx == NodeIndex::NONE || *fuel == 0 {
+        return false;
+    }
+    *fuel -= 1;
+
+    let Some(node) = arena.get(type_idx) else {
+        return false;
+    };
+    if node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
+        return arena
+            .get_indexed_access_type(node)
+            .and_then(|indexed| entity_name_text_in_arena(arena, indexed.object_type))
+            .is_some_and(|name| name.contains("TagNameMap"));
+    }
+
+    if let Some(type_ref) = arena.get_type_ref(node) {
+        return type_ref.type_arguments.as_ref().is_some_and(|args| {
+            args.nodes
+                .iter()
+                .any(|&arg| type_node_contains_tag_name_map_indexed_access(arena, arg, fuel))
+        });
+    }
+    if let Some(composite) = arena.get_composite_type(node) {
+        return composite
+            .types
+            .nodes
+            .iter()
+            .any(|&ty| type_node_contains_tag_name_map_indexed_access(arena, ty, fuel));
+    }
+    if let Some(array) = arena.get_array_type(node) {
+        return type_node_contains_tag_name_map_indexed_access(arena, array.element_type, fuel);
+    }
+    if let Some(wrapped) = arena.get_wrapped_type(node) {
+        return type_node_contains_tag_name_map_indexed_access(arena, wrapped.type_node, fuel);
+    }
+    if let Some(type_operator) = arena.get_type_operator(node) {
+        return type_node_contains_tag_name_map_indexed_access(
+            arena,
+            type_operator.type_node,
+            fuel,
+        );
+    }
+    if let Some(function_type) = arena.get_function_type(node) {
+        if type_node_contains_tag_name_map_indexed_access(
+            arena,
+            function_type.type_annotation,
+            fuel,
+        ) {
+            return true;
+        }
+        for &param_idx in &function_type.parameters.nodes {
+            let Some(param_node) = arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = arena.get_parameter(param_node) else {
+                continue;
+            };
+            if type_node_contains_tag_name_map_indexed_access(arena, param.type_annotation, fuel) {
+                return true;
+            }
+        }
+    }
+    if let Some(conditional) = arena.get_conditional_type(node) {
+        return [
+            conditional.check_type,
+            conditional.extends_type,
+            conditional.true_type,
+            conditional.false_type,
+        ]
+        .into_iter()
+        .any(|ty| type_node_contains_tag_name_map_indexed_access(arena, ty, fuel));
+    }
+
+    false
+}
+
+fn interface_declares_member_named(
+    arena: &NodeArena,
+    interface: &crate::parser::node::InterfaceData,
+    member_names: &FxHashSet<String>,
+) -> bool {
+    !member_names.is_empty()
+        && interface.members.nodes.iter().any(|&member_idx| {
+            member_name_text(arena, member_idx).is_some_and(|name| member_names.contains(&name))
+        })
+}
+
+fn interface_has_indexed_access_member_type(
+    arena: &NodeArena,
+    interface: &crate::parser::node::InterfaceData,
+) -> bool {
+    for &member_idx in &interface.members.nodes {
+        let Some(member_node) = arena.get(member_idx) else {
+            continue;
+        };
+        if let Some(sig) = arena.get_signature(member_node) {
+            let mut fuel = 256;
+            if type_node_contains_tag_name_map_indexed_access(arena, sig.type_annotation, &mut fuel)
+            {
+                return true;
+            }
+            for &param_idx in sig.parameters.as_ref().map_or(&[][..], |p| &p.nodes) {
+                let Some(param_node) = arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = arena.get_parameter(param_node) else {
+                    continue;
+                };
+                let mut fuel = 256;
+                if type_node_contains_tag_name_map_indexed_access(
+                    arena,
+                    param.type_annotation,
+                    &mut fuel,
+                ) {
+                    return true;
+                }
+            }
+        }
+        if let Some(accessor) = arena.get_accessor(member_node) {
+            let mut fuel = 256;
+            if type_node_contains_tag_name_map_indexed_access(
+                arena,
+                accessor.type_annotation,
+                &mut fuel,
+            ) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn affected_lib_interface_names(
+    program: &MergedProgram,
+    checker_lib_files: &[Arc<LibFile>],
+) -> FxHashSet<String> {
+    let seed_interfaces = collect_user_global_interface_seeds(program);
+    let mut affected = seed_interfaces.clone();
+    let user_member_names = collect_user_global_interface_member_names(program);
+    let mut inheritance_graph: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+
+    for lib in checker_lib_files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            let bases = collect_direct_base_names(lib.arena.as_ref(), interface);
+            inheritance_graph
+                .entry(name)
+                .or_default()
+                .extend(bases.into_iter());
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, bases) in &inheritance_graph {
+            if affected.contains(name) {
+                continue;
+            }
+            if bases.iter().any(|base| affected.contains(base)) {
+                changed = affected.insert(name.clone());
+            }
+        }
+    }
+
+    let mut relevant = FxHashSet::default();
+    for lib in checker_lib_files {
+        let Some(source_file) = lib.arena.get_source_file_at(lib.root_index) else {
+            continue;
+        };
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = lib.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(interface) = lib.arena.get_interface(stmt_node) else {
+                continue;
+            };
+            let Some(name) = interface_name_text(lib.arena.as_ref(), stmt_idx) else {
+                continue;
+            };
+            if !affected.contains(&name) {
+                continue;
+            }
+            if interface_declares_member_named(lib.arena.as_ref(), interface, &user_member_names)
+                || interface_has_indexed_access_member_type(lib.arena.as_ref(), interface)
+            {
+                relevant.insert(name);
+            }
+        }
+    }
+
+    relevant.extend(seed_interfaces);
+    let mut ancestor_queue: Vec<String> = relevant.iter().cloned().collect();
+    while let Some(name) = ancestor_queue.pop() {
+        let Some(bases) = inheritance_graph.get(&name) else {
+            continue;
+        };
+        for base in bases {
+            if relevant.insert(base.clone()) {
+                ancestor_queue.push(base.clone());
+            }
+        }
+    }
+
+    if relevant.is_empty() {
+        affected
+    } else {
+        relevant
+    }
+}
+
+fn build_lib_bound_file_for_interface_checks(
+    program: &MergedProgram,
+    lib_file: &Arc<LibFile>,
+    affected_interfaces: &FxHashSet<String>,
+) -> BoundFile {
+    let mut node_symbols = FxHashMap::default();
+    if let Some(source_file) = lib_file.arena.get_source_file_at(lib_file.root_index) {
+        collect_lib_interface_node_symbols(
+            lib_file.arena.as_ref(),
+            &source_file.statements.nodes,
+            &program.globals,
+            affected_interfaces,
+            &mut node_symbols,
+        );
+    }
+
+    let mut declaration_arenas = program.declaration_arenas.clone();
+    add_user_global_interface_declaration_arenas(program, &mut declaration_arenas);
+
+    BoundFile {
+        file_name: lib_file.file_name.clone(),
+        source_file: lib_file.root_index,
+        arena: Arc::clone(&lib_file.arena),
+        node_symbols,
+        symbol_arenas: program.symbol_arenas.clone(),
+        declaration_arenas,
+        module_declaration_exports_publicly: FxHashMap::default(),
+        scopes: Vec::new(),
+        node_scope_ids: FxHashMap::default(),
+        parse_diagnostics: Vec::new(),
+        global_augmentations: FxHashMap::default(),
+        module_augmentations: FxHashMap::default(),
+        augmentation_target_modules: FxHashMap::default(),
+        flow_nodes: FlowNodeArena::default(),
+        node_flow: FxHashMap::default(),
+        switch_clause_to_switch: FxHashMap::default(),
+        is_external_module: lib_file.binder.is_external_module,
+        expando_properties: FxHashMap::default(),
+        file_features: crate::binder::FileFeatures::NONE,
+        lib_symbol_reverse_remap: FxHashMap::default(),
+        semantic_defs: FxHashMap::default(),
+    }
+}
+
 /// Result of parallel type checking
+#[derive(Debug)]
 pub struct CheckResult {
     /// Per-file check results
     pub file_results: Vec<FileCheckResult>,
@@ -3662,11 +4221,13 @@ pub fn check_files_parallel(
         crate::checker::module_resolution::build_module_resolution_maps(&file_names);
     let resolved_module_paths = Arc::new(resolved_module_paths);
 
-    // Create lib_contexts from lib_files (contains both arena and binder).
+    let checker_lib_files = clone_lib_files_for_checker(lib_files);
+
+    // Create fresh checker lib contexts from cloned lib files (contains both arena and binder).
     // Wrapped in Arc so that per-file checkers and child delegations share
     // the same Vec with O(1) clone cost (single atomic refcount increment).
     let lib_contexts: Arc<Vec<LibContext>> = Arc::new(
-        lib_files
+        checker_lib_files
             .iter()
             .map(|lib| LibContext {
                 arena: Arc::clone(&lib.arena),
@@ -3820,11 +4381,135 @@ pub fn check_files_parallel(
         }
     };
 
+    let affected_lib_interfaces = affected_lib_interface_names(program, &checker_lib_files);
+
+    let check_one_lib = |lib_idx: usize, lib_file: &Arc<LibFile>| -> FileCheckResult {
+        let query_cache = if let Some(ref shared) = shared_query_cache {
+            tsz_solver::QueryCache::new_with_shared(&program.type_interner, shared)
+        } else {
+            tsz_solver::QueryCache::new(&program.type_interner)
+        };
+
+        let lib_bound_file =
+            build_lib_bound_file_for_interface_checks(program, lib_file, &affected_lib_interfaces);
+        let mut binder =
+            create_binder_from_bound_file(&lib_bound_file, program, program.files.len());
+        let mut composed_semantic_defs = program.semantic_defs.clone();
+        for (sym_id, entry) in &lib_bound_file.semantic_defs {
+            composed_semantic_defs.insert(*sym_id, entry.clone());
+        }
+        binder.semantic_defs = composed_semantic_defs;
+
+        let mut checker = CheckerState::with_options(
+            &lib_bound_file.arena,
+            &binder,
+            &query_cache,
+            lib_bound_file.file_name.clone(),
+            checker_options,
+        );
+        checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+        if let Some(ref modules) = shared_declared_modules {
+            checker
+                .ctx
+                .set_declared_modules_from_skeleton(Arc::clone(modules));
+        }
+        checker.ctx.set_all_binders(Arc::clone(&all_binders));
+        checker
+            .ctx
+            .set_resolved_module_paths(Arc::clone(&resolved_module_paths));
+        checker.ctx.set_resolved_modules(resolved_modules.clone());
+        checker
+            .ctx
+            .set_global_symbol_file_index(Arc::clone(&global_symbol_file_index));
+
+        let other_lib_contexts: Vec<LibContext> = lib_contexts
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != lib_idx)
+            .map(|(_, ctx)| ctx.clone())
+            .collect();
+        checker.ctx.set_lib_contexts(other_lib_contexts);
+        checker.ctx.set_actual_lib_file_count(lib_contexts.len());
+        checker.prime_boxed_types();
+
+        checker.check_source_file_interfaces_only_with_fresh_interface_fuel(
+            lib_bound_file.source_file,
+        );
+
+        let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
+        diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
+
+        FileCheckResult {
+            file_idx: program.files.len() + lib_idx,
+            file_name: lib_file.file_name.clone(),
+            function_results: Vec::new(),
+            diagnostics,
+        }
+    };
+
+    let check_one_lib_baseline = |lib_idx: usize, lib_file: &Arc<LibFile>| -> FileCheckResult {
+        let query_cache = tsz_solver::QueryCache::new(&program.type_interner);
+
+        let mut checker = CheckerState::with_options(
+            &lib_file.arena,
+            lib_file.binder.as_ref(),
+            &query_cache,
+            lib_file.file_name.clone(),
+            checker_options,
+        );
+        let other_lib_contexts: Vec<LibContext> = lib_contexts
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != lib_idx)
+            .map(|(_, ctx)| ctx.clone())
+            .collect();
+        checker.ctx.set_lib_contexts(other_lib_contexts);
+        checker.ctx.set_actual_lib_file_count(lib_contexts.len());
+        checker.prime_boxed_types();
+        checker.check_source_file_interfaces_only_filtered_post_merge(
+            lib_file.root_index,
+            &affected_lib_interfaces,
+        );
+
+        let mut diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
+        diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
+        diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
+
+        FileCheckResult {
+            file_idx: program.files.len() + lib_idx,
+            file_name: lib_file.file_name.clone(),
+            function_results: Vec::new(),
+            diagnostics,
+        }
+    };
+
+    let fingerprint = |file_name: &str, diag: &Diagnostic| {
+        (
+            file_name.to_owned(),
+            diag.start,
+            diag.code,
+            diag.message_text.clone(),
+        )
+    };
+    let baseline_lib_diagnostics: FxHashSet<(String, u32, u32, String)> = checker_lib_files
+        .iter()
+        .enumerate()
+        .flat_map(|(lib_idx, lib_file)| {
+            let file_result = check_one_lib_baseline(lib_idx, lib_file);
+            let file_name = file_result.file_name.clone();
+            file_result
+                .diagnostics
+                .into_iter()
+                .map(move |diag| fingerprint(&file_name, &diag))
+        })
+        .collect();
+
     // Single-file optimization: skip Rayon overhead when there's only one file.
     // For multi-file projects, use parallel iteration via Rayon's work-stealing
     // scheduler. `par_iter().enumerate()` preserves input ordering (file_idx) so
     // results are deterministic regardless of which thread completes first.
-    let file_results: Vec<FileCheckResult> = if program.files.len() <= 1 {
+    let mut file_results: Vec<FileCheckResult> = if program.files.len() <= 1 {
         program
             .files
             .iter()
@@ -3837,6 +4522,20 @@ pub fn check_files_parallel(
             .map(|(file_idx, file)| check_one_file(file_idx, file))
             .collect()
     };
+
+    file_results.extend(
+        checker_lib_files
+            .iter()
+            .enumerate()
+            .map(|(lib_idx, lib_file)| {
+                let mut file_result = check_one_lib(lib_idx, lib_file);
+                let file_name = file_result.file_name.clone();
+                file_result.diagnostics.retain(|diag| {
+                    !baseline_lib_diagnostics.contains(&fingerprint(&file_name, diag))
+                });
+                file_result
+            }),
+    );
 
     let diagnostic_count: usize = file_results.iter().map(|r| r.diagnostics.len()).sum();
 

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -3,6 +3,8 @@ use crate::parallel::residency::{MemoryPressure, ResidencyBudget};
 use crate::parallel::skeleton::diff_skeletons;
 use std::fs;
 use std::path::Path;
+use tsz_common::common::ModuleKind;
+use tsz_common::diagnostics::diagnostic_codes;
 
 #[test]
 fn test_parse_single_file() {
@@ -434,6 +436,67 @@ fn test_merge_preserves_file_locals() {
     assert!(program.file_locals[0].has("a2"));
     assert!(program.file_locals[1].has("b1"));
     assert!(program.file_locals[1].has("b2"));
+}
+
+#[test]
+fn check_files_parallel_reports_default_lib_breakage_from_global_node_merge() {
+    let files = vec![(
+        "main.ts".to_string(),
+        r#"
+const enum SyntaxKind {
+    Track,
+}
+
+interface Node {
+    kind: SyntaxKind;
+}
+"#
+        .to_string(),
+    )];
+
+    let lib_files = vec![std::sync::Arc::new(
+        crate::lib_loader::LibFile::from_source(
+            "lib.dom.d.ts".to_string(),
+            r#"
+interface Node {
+    kind: string;
+}
+
+interface Element extends Node {}
+interface HTMLElement extends Element {}
+interface HTMLTrackElement extends HTMLElement {
+    kind: string;
+}
+"#
+            .to_string(),
+        ),
+    )];
+    let program = merge_bind_results(parse_and_bind_parallel_with_libs(files, &lib_files));
+    let options = CheckerOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::ES2015,
+        strict: true,
+        no_implicit_any: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+
+    let result = check_files_parallel(&program, &options, &lib_files);
+    let lib_dom_diagnostics = result
+        .file_results
+        .iter()
+        .filter(|file| file.file_name.ends_with("lib.dom.d.ts"))
+        .flat_map(|file| file.diagnostics.iter())
+        .collect::<Vec<_>>();
+    let ts2430_count = lib_dom_diagnostics
+        .iter()
+        .filter(|diag| diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE)
+        .count();
+
+    assert_eq!(
+        ts2430_count, 1,
+        "Expected one post-merge lib TS2430 diagnostic after merging Node.kind, got: {result:#?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This fixes the `coAndContraVariantInferences4` conformance gap where `tsz` resolved default-lib symbols in the merged program state but did not re-check affected default-lib interfaces after user global interface merges.

The motivating case is a user merge like:

```ts
interface Node { kind: SyntaxKind }
```

That merge can make `lib.dom.d.ts` invalid. `tsc` reports the resulting `TS2344` and `TS2430` diagnostics from the lib file; `tsz` previously emitted none because lib files were lookup contexts only during the main check pass.

## Changes

- Recheck affected default-lib interface declarations in merged-program state when `skipLibCheck` / `skipDefaultLibCheck` do not suppress them.
- Route merged-lib diagnostics through the existing sorting and baseline fingerprint dedup flow.
- Narrow extension-compatibility rechecks to affected lib interfaces that declare user-merged member names, while still checking affected member type annotations needed for indexed-access `TS2344` diagnostics.
- Add regressions for default-lib breakage caused by a global `Node` merge, including `skipDefaultLibCheck` coverage.
- Split class-chain lookup helpers out of `class_checker_compat.rs` to stay within architecture guardrails.

## Validation

- Pre-commit hook passed: format, clippy, wasm rustc warnings, architecture guardrails, and `12902` nextest tests.
- `./scripts/conformance/conformance.sh run --filter "coAndContraVariantInferences4" --verbose` -> `1/1 passed`.
- `cargo nextest run --profile conformance --package tsz-cli --lib collect_diagnostics_reports_default_lib_breakage_from_global_node_merge collect_diagnostics_respects_skip_default_lib_check_for_global_node_merge --status-level fail` -> `2 passed`.
- `./scripts/conformance/conformance.sh run --max 200` -> `200/200 passed`.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep "FINAL RESULTS"` -> `FINAL RESULTS: 12048/12581 passed (95.8%)`.
