### PR TITLE
Fix boolean literal display in invalid assignment diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -2048,6 +2048,10 @@ impl<'a> CheckerState<'a> {
         {
             return Some(display);
         }
+        if let Some(display) = self.identifier_literal_initializer_source_display(expr_idx, target)
+        {
+            return Some(display);
+        }
         if let Some(display) = self.rebuilt_array_source_display(declared_type, target) {
             return Some(display);
         }
@@ -2179,87 +2183,6 @@ impl<'a> CheckerState<'a> {
         }
 
         replaced_object_member.then(|| displays.join(" & "))
-    }
-
-    pub(in crate::error_reporter) fn identifier_array_object_literal_source_display(
-        &mut self,
-        expr_idx: NodeIndex,
-        target: TypeId,
-    ) -> Option<String> {
-        let node = self.ctx.arena.get(expr_idx)?;
-        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
-            return None;
-        }
-        let sym_id = self.resolve_identifier_symbol(expr_idx)?;
-        let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if (symbol.flags & tsz_binder::symbol_flags::VARIABLE) == 0 {
-            return None;
-        }
-        let &decl_idx = symbol.declarations.first()?;
-        let decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
-        let init_idx = decl.initializer.into_option()?;
-        let init_idx = self.ctx.arena.skip_parenthesized_and_assertions(init_idx);
-        let init_node = self.ctx.arena.get(init_idx)?;
-        if init_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
-            return None;
-        }
-        let literal = self.ctx.arena.get_literal_expr(init_node)?;
-        if literal.elements.nodes.is_empty() {
-            return None;
-        }
-
-        let mut ordered_names = Vec::new();
-        let mut property_values: Vec<Vec<TypeId>> = Vec::new();
-        for (element_index, &element_idx) in literal.elements.nodes.iter().enumerate() {
-            let element_node = self.ctx.arena.get(element_idx)?;
-            if element_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
-                return None;
-            }
-            let object = self.ctx.arena.get_literal_expr(element_node)?;
-            if element_index == 0 {
-                for &child_idx in &object.elements.nodes {
-                    let child = self.ctx.arena.get(child_idx)?;
-                    let prop = self.ctx.arena.get_property_assignment(child)?;
-                    let name = self.get_property_name(prop.name)?;
-                    ordered_names.push(name);
-                    property_values.push(vec![self.get_type_of_node(prop.initializer)]);
-                }
-                continue;
-            }
-
-            if object.elements.nodes.len() != ordered_names.len() {
-                return None;
-            }
-            for (prop_index, &child_idx) in object.elements.nodes.iter().enumerate() {
-                let child = self.ctx.arena.get(child_idx)?;
-                let prop = self.ctx.arena.get_property_assignment(child)?;
-                let name = self.get_property_name(prop.name)?;
-                if name != ordered_names[prop_index] {
-                    return None;
-                }
-                property_values[prop_index].push(self.get_type_of_node(prop.initializer));
-            }
-        }
-
-        let fields = ordered_names
-            .into_iter()
-            .zip(property_values)
-            .map(|(name, value_types)| {
-                let widened_types = value_types
-                    .into_iter()
-                    .map(|ty| self.widen_type_for_display(ty))
-                    .collect::<Vec<_>>();
-                let value_type = if widened_types.len() == 1 {
-                    widened_types[0]
-                } else {
-                    self.ctx.types.factory().union(widened_types)
-                };
-                let display = self.format_assignability_type_for_message(value_type, target);
-                format!("{name}: {display}")
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        Some(format!("{{ {fields}; }}[]"))
     }
 
     pub(in crate::error_reporter) fn has_more_specific_diagnostic_at_span(

--- a/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
@@ -1,0 +1,122 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(in crate::error_reporter) fn identifier_array_object_literal_source_display(
+        &mut self,
+        expr_idx: NodeIndex,
+        target: TypeId,
+    ) -> Option<String> {
+        let node = self.ctx.arena.get(expr_idx)?;
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.resolve_identifier_symbol(expr_idx)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if (symbol.flags & tsz_binder::symbol_flags::VARIABLE) == 0 {
+            return None;
+        }
+        let &decl_idx = symbol.declarations.first()?;
+        let decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
+        let init_idx = decl.initializer.into_option()?;
+        let init_idx = self.ctx.arena.skip_parenthesized_and_assertions(init_idx);
+        let init_node = self.ctx.arena.get(init_idx)?;
+        if init_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            return None;
+        }
+        let literal = self.ctx.arena.get_literal_expr(init_node)?;
+        if literal.elements.nodes.is_empty() {
+            return None;
+        }
+
+        let mut ordered_names = Vec::new();
+        let mut property_values: Vec<Vec<TypeId>> = Vec::new();
+        for (element_index, &element_idx) in literal.elements.nodes.iter().enumerate() {
+            let element_node = self.ctx.arena.get(element_idx)?;
+            if element_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                return None;
+            }
+            let object = self.ctx.arena.get_literal_expr(element_node)?;
+            if element_index == 0 {
+                for &child_idx in &object.elements.nodes {
+                    let child = self.ctx.arena.get(child_idx)?;
+                    let prop = self.ctx.arena.get_property_assignment(child)?;
+                    let name = self.get_property_name(prop.name)?;
+                    ordered_names.push(name);
+                    property_values.push(vec![self.get_type_of_node(prop.initializer)]);
+                }
+                continue;
+            }
+
+            if object.elements.nodes.len() != ordered_names.len() {
+                return None;
+            }
+            for (prop_index, &child_idx) in object.elements.nodes.iter().enumerate() {
+                let child = self.ctx.arena.get(child_idx)?;
+                let prop = self.ctx.arena.get_property_assignment(child)?;
+                let name = self.get_property_name(prop.name)?;
+                if name != ordered_names[prop_index] {
+                    return None;
+                }
+                property_values[prop_index].push(self.get_type_of_node(prop.initializer));
+            }
+        }
+
+        let fields = ordered_names
+            .into_iter()
+            .zip(property_values)
+            .map(|(name, value_types)| {
+                let widened_types = value_types
+                    .into_iter()
+                    .map(|ty| self.widen_type_for_display(ty))
+                    .collect::<Vec<_>>();
+                let value_type = if widened_types.len() == 1 {
+                    widened_types[0]
+                } else {
+                    self.ctx.types.factory().union(widened_types)
+                };
+                let display = self.format_assignability_type_for_message(value_type, target);
+                format!("{name}: {display}")
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        Some(format!("{{ {fields}; }}[]"))
+    }
+
+    pub(in crate::error_reporter) fn identifier_literal_initializer_source_display(
+        &mut self,
+        expr_idx: NodeIndex,
+        target: TypeId,
+    ) -> Option<String> {
+        let target = self.evaluate_type_for_assignability(target);
+        if target != TypeId::UNDEFINED
+            && crate::query_boundaries::common::enum_def_id(self.ctx.types, target).is_none()
+        {
+            return None;
+        }
+        let node = self.ctx.arena.get(expr_idx)?;
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.resolve_identifier_symbol(expr_idx)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if (symbol.flags & tsz_binder::symbol_flags::VARIABLE) == 0 {
+            return None;
+        }
+        let &decl_idx = symbol.declarations.first()?;
+        let decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
+        if decl.type_annotation.is_some() || decl.initializer.is_none() {
+            return None;
+        }
+
+        let init_idx = self.ctx.arena.skip_parenthesized(decl.initializer);
+        let init_node = self.ctx.arena.get(init_idx)?;
+        match init_node.kind {
+            k if k == tsz_scanner::SyntaxKind::TrueKeyword as u16 => Some("true".to_string()),
+            k if k == tsz_scanner::SyntaxKind::FalseKeyword as u16 => Some("false".to_string()),
+            _ => None,
+        }
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/core/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/core/mod.rs
@@ -5,4 +5,5 @@
 //! - `diagnostic_source`: diagnostic source/target expression analysis
 
 mod diagnostic_source;
+mod identifier_source_display;
 mod type_display;

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -134,6 +134,59 @@ fn get_all_diagnostics(source: &str) -> Vec<(u32, String)> {
     with_lib_contexts(source, "test.ts", CheckerOptions::default())
 }
 
+#[test]
+fn test_ts2322_identifier_literal_initializer_display_for_literal_sensitive_targets() {
+    let diagnostics = get_all_diagnostics(
+        r#"
+var x = true;
+var n: number = x;
+var u: typeof undefined = x;
+enum E { A }
+var e: E = x;
+var s = "value";
+var su: typeof undefined = s;
+var i = 1;
+var iu: typeof undefined = i;
+"#,
+    );
+    let ts2322 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .map(|(_, message)| message.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        ts2322
+            .iter()
+            .any(|message| message.contains("Type 'boolean' is not assignable to type 'number'.")),
+        "expected widened boolean display for non-literal target, got: {ts2322:#?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|message| message.contains("Type 'true' is not assignable to type 'undefined'.")),
+        "expected literal initializer display for undefined target, got: {ts2322:#?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|message| message.contains("Type 'true' is not assignable to type 'E'.")),
+        "expected literal initializer display for enum target, got: {ts2322:#?}"
+    );
+    assert!(
+        ts2322.iter().any(
+            |message| message.contains("Type 'string' is not assignable to type 'undefined'.")
+        ),
+        "expected string initializer display to remain widened, got: {ts2322:#?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|message| message.contains("Type 'number' is not assignable to type 'undefined'.")),
+        "expected numeric initializer display to remain widened, got: {ts2322:#?}"
+    );
+}
+
 fn compile_with_options(
     source: &str,
     file_name: &str,


### PR DESCRIPTION
## Summary

Root cause: TS2322 diagnostic rendering widened unannotated boolean identifier initializers before checking literal-sensitive targets, so `var x = true` reported `boolean` instead of TypeScript's `true` display when assigned to `undefined` or an enum.

Fixed conformance target: `TypeScript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts`.

The fix keeps ordinary widened boolean displays, such as `var n: number = x`, while preserving `true`/`false` initializer display for `undefined` and enum targets.

## Unit Test

Added `test_ts2322_identifier_literal_initializer_display_for_literal_sensitive_targets` in `crates/tsz-checker/tests/ts2322_tests.rs`.

## Verification

Post-rebase `scripts/session/verify-all.sh` passed:

- formatting: passed
- clippy: passed
- unit tests: passed, 20963 tests
- conformance: passed, 12071 vs 12015 baseline (+56), including `invalidBooleanAssignments`
- emit tests: passed, JS +4 and DTS +25 vs baseline
- fourslash/LSP: passed, 50/50
