### PR TITLE
fix(checker): detect CommonJS object export augmentation conflicts

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -324,6 +324,20 @@ impl<'a> CheckerState<'a> {
         file = self.ctx.file_name.as_str(),
         "compute_type_of_symbol: resolved symbol"
         );
+        if (flags & symbol_flags::ALIAS) != 0
+            && let Some(ref module_spec) = import_module
+            && let Some(imported_name) = import_name.as_deref()
+            && imported_name != "*"
+            && imported_name != "default"
+            && let Some(js_export_type) = self.resolve_js_export_named_type(
+                module_spec,
+                imported_name,
+                Some(self.ctx.current_file_idx),
+            )
+        {
+            return (js_export_type, Vec::new());
+        }
+
         // Export-value wrapper symbols should delegate to their wrapped declaration symbol.
         // This preserves the actual value type for `export var` / `export function` members
         // instead of falling back to implicit `any`.

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1552,6 +1552,18 @@ impl<'a> CheckerState<'a> {
                     return (TypeId::ANY, Vec::new());
                 }
 
+                // CommonJS object-literal/property exports are the concrete runtime
+                // export surface. A module augmentation may introduce a duplicate
+                // symbol with the same name, but it must not replace the JS export's
+                // value type.
+                if let Some(result) = self.resolve_js_export_named_type(
+                    module_name,
+                    export_name,
+                    Some(self.ctx.current_file_idx),
+                ) {
+                    return (result, Vec::new());
+                }
+
                 // First, try local binder's module_exports
                 let cross_file_result = self.resolve_cross_file_export(module_name, export_name);
                 let export_sym_id = cross_file_result
@@ -1652,15 +1664,6 @@ impl<'a> CheckerState<'a> {
                     if should_cache_on_export_symbol {
                         self.ctx.symbol_types.insert(export_sym_id, result);
                     }
-                    return (result, Vec::new());
-                }
-
-                // Use the unified JS export surface for CommonJS named export lookup.
-                if let Some(result) = self.resolve_js_export_named_type(
-                    module_name,
-                    export_name,
-                    Some(self.ctx.current_file_idx),
-                ) {
                     return (result, Vec::new());
                 }
 

--- a/crates/tsz-checker/src/types/type_checking/commonjs_object_exports.rs
+++ b/crates/tsz-checker/src/types/type_checking/commonjs_object_exports.rs
@@ -1,0 +1,165 @@
+//! CommonJS object-literal export helpers used by duplicate/conflict checks.
+
+use crate::diagnostics::diagnostic_codes;
+use crate::state::CheckerState;
+use tsz_binder::symbol_flags;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn check_target_file_commonjs_object_exports_conflicting_with_module_augmentations(
+        &mut self,
+    ) {
+        let Some(source_file) = self.ctx.arena.source_files.first() else {
+            return;
+        };
+
+        let export_names: Vec<(String, NodeIndex)> = source_file
+            .statements
+            .nodes
+            .iter()
+            .flat_map(|&stmt_idx| self.commonjs_object_literal_export_names(stmt_idx))
+            .collect();
+
+        for (export_name, name_idx) in export_names {
+            let conflict_decls =
+                self.module_augmentation_conflict_declarations_for_current_file(&export_name);
+            if conflict_decls.is_empty()
+                || conflict_decls
+                    .iter()
+                    .any(|(_, flags, _, _, _)| (*flags & symbol_flags::FUNCTION) != 0)
+            {
+                continue;
+            }
+
+            self.error_at_node_msg(
+                name_idx,
+                diagnostic_codes::DUPLICATE_IDENTIFIER,
+                &[&export_name],
+            );
+        }
+    }
+
+    pub(crate) fn commonjs_object_literal_export_declarations_in_file(
+        &self,
+        file_idx: usize,
+        name: &str,
+    ) -> Vec<(NodeIndex, u32, bool)> {
+        let arena = self.ctx.get_arena_for_file(file_idx as u32);
+        let Some(source_file) = arena.source_files.first() else {
+            return Vec::new();
+        };
+
+        let mut declarations = Vec::new();
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(rhs_expr) = self.commonjs_object_literal_export_rhs(arena, stmt_idx) else {
+                continue;
+            };
+            let Some(rhs_node) = arena.get(rhs_expr) else {
+                continue;
+            };
+            if rhs_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                continue;
+            }
+            let Some(object_lit) = arena.get_literal_expr(rhs_node) else {
+                continue;
+            };
+
+            for &element_idx in &object_lit.elements.nodes {
+                let Some(element_node) = arena.get(element_idx) else {
+                    continue;
+                };
+                let name_idx = match element_node.kind {
+                    syntax_kind_ext::PROPERTY_ASSIGNMENT => arena
+                        .get_property_assignment(element_node)
+                        .map(|prop| prop.name),
+                    syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => arena
+                        .get_shorthand_property(element_node)
+                        .map(|prop| prop.name),
+                    _ => None,
+                };
+                let Some(name_idx) = name_idx else {
+                    continue;
+                };
+                let Some(member_name) =
+                    crate::types_domain::queries::core::get_literal_property_name(arena, name_idx)
+                else {
+                    continue;
+                };
+                if member_name == name {
+                    declarations.push((name_idx, symbol_flags::FUNCTION_SCOPED_VARIABLE, true));
+                }
+            }
+        }
+
+        declarations
+    }
+
+    fn commonjs_object_literal_export_names(
+        &self,
+        stmt_idx: NodeIndex,
+    ) -> Vec<(String, NodeIndex)> {
+        let Some(rhs_expr) = self.commonjs_object_literal_export_rhs(self.ctx.arena, stmt_idx)
+        else {
+            return Vec::new();
+        };
+        let Some(rhs_node) = self.ctx.arena.get(rhs_expr) else {
+            return Vec::new();
+        };
+        if rhs_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return Vec::new();
+        }
+        let Some(object_lit) = self.ctx.arena.get_literal_expr(rhs_node) else {
+            return Vec::new();
+        };
+
+        let mut names = Vec::new();
+        for &element_idx in &object_lit.elements.nodes {
+            let Some(element_node) = self.ctx.arena.get(element_idx) else {
+                continue;
+            };
+            let name_idx = match element_node.kind {
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => self
+                    .ctx
+                    .arena
+                    .get_property_assignment(element_node)
+                    .map(|prop| prop.name),
+                syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => self
+                    .ctx
+                    .arena
+                    .get_shorthand_property(element_node)
+                    .map(|prop| prop.name),
+                _ => None,
+            };
+            let Some(name_idx) = name_idx else {
+                continue;
+            };
+            let Some(name) = crate::types_domain::queries::core::get_literal_property_name(
+                self.ctx.arena,
+                name_idx,
+            ) else {
+                continue;
+            };
+            names.push((name, name_idx));
+        }
+
+        names
+    }
+
+    fn commonjs_object_literal_export_rhs(
+        &self,
+        arena: &tsz_parser::parser::node::NodeArena,
+        stmt_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let stmt_node = arena.get(stmt_idx)?;
+        if stmt_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT {
+            arena.get_expression_statement(stmt_node).and_then(|stmt| {
+                self.direct_commonjs_module_export_assignment_rhs(arena, stmt.expression)
+            })
+        } else if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
+            self.direct_commonjs_module_export_rhs_from_variable_statement(arena, stmt_idx)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
+++ b/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
@@ -415,6 +415,8 @@ impl<'a> CheckerState<'a> {
                 );
             }
         }
+
+        self.check_target_file_commonjs_object_exports_conflicting_with_module_augmentations();
     }
 
     fn target_file_has_direct_export_named(&self, file_idx: usize, export_name: &str) -> bool {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifier_conflict_kinds.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifier_conflict_kinds.rs
@@ -1,0 +1,32 @@
+//! Small duplicate-identifier classifiers shared by large checker modules.
+
+use super::duplicate_identifiers::DuplicateDeclarationOrigin;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn has_targeted_aug(
+        &self,
+        declarations: &[(NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin)],
+    ) -> bool {
+        declarations.iter().any(|(_, _, is_local, _, origin)| {
+            !*is_local && *origin == DuplicateDeclarationOrigin::TargetedModuleAugmentation
+        })
+    }
+
+    pub(super) fn local_augmentation_decl_symbol_id(
+        &self,
+        node: NodeIndex,
+    ) -> Option<tsz_binder::SymbolId> {
+        self.ctx
+            .binder
+            .node_symbols
+            .get(&node.0)
+            .copied()
+            .or_else(|| {
+                self.get_declaration_name_node(node)
+                    .and_then(|name_idx| self.ctx.binder.node_symbols.get(&name_idx.0))
+                    .copied()
+            })
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1566,7 +1566,7 @@ impl<'a> CheckerState<'a> {
                     (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0
                 }
             });
-            let has_remote_block_scoped_alias_conflict =
+            let remote_alias_conflict =
                 declarations.iter().any(|(_, flags, is_local, _, origin)| {
                     !*is_local
                         && *origin == DuplicateDeclarationOrigin::GlobalScopeConflict
@@ -1578,6 +1578,7 @@ impl<'a> CheckerState<'a> {
 
             let has_remote_declaration =
                 declarations.iter().any(|(_, _, is_local, _, _)| !*is_local);
+            let force2300 = remote_alias_conflict || self.has_targeted_aug(&declarations);
             let has_enum_conflict = if has_remote_declaration {
                 declarations.iter().any(|(_, flags, _, _, _)| {
                     (flags & (symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM)) != 0
@@ -1628,8 +1629,7 @@ impl<'a> CheckerState<'a> {
             // TS2323: Check exported variable conflict using symbol.is_exported
             let has_exported_variable_conflict = symbol.is_exported && has_variable_conflict;
 
-            let (message, code) = if (!has_non_block_scoped
-                && !has_remote_block_scoped_alias_conflict)
+            let (message, code) = if !has_non_block_scoped && !force2300
                 || has_umd_global_value_conflict
             {
                 (
@@ -1643,7 +1643,7 @@ impl<'a> CheckerState<'a> {
                 && has_variable_conflict
                 && !has_non_variable_conflict
                 && !has_accessor_conflict
-                && !has_remote_block_scoped_alias_conflict
+                && !force2300
             {
                 (
                     format_message(
@@ -1688,7 +1688,7 @@ impl<'a> CheckerState<'a> {
                     // Cross-file mixed conflicts generally use TS2451, except for
                     // synthetic default-import alias collisions where tsc reports
                     // TS2300 (for example impliedNodeFormatInterop1.ts).
-                    !has_remote_block_scoped_alias_conflict
+                    !force2300
                 } else if has_block_scoped_conflict && has_function_conflict {
                     // When a function declaration conflicts with a block-scoped
                     // variable (let/const) at the same scope, tsc uses TS2300.
@@ -1823,7 +1823,7 @@ impl<'a> CheckerState<'a> {
             // the same name (e.g. allowImportClausesToMergeWithTypes.ts),
             // don't produce a false TS2300 at the `default` export site.
             if code == diagnostic_codes::DUPLICATE_IDENTIFIER
-                && has_remote_block_scoped_alias_conflict
+                && remote_alias_conflict
                 && self.is_js_file()
                 && self.ctx.should_resolve_jsdoc()
                 && let Some(default_export_ident) =

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -23,7 +23,7 @@ impl<'a> CheckerState<'a> {
                 if !std::ptr::eq(arena, self.ctx.arena) {
                     continue;
                 }
-                if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&augmentation.node.0) {
+                if let Some(sym_id) = self.local_augmentation_decl_symbol_id(augmentation.node) {
                     symbol_ids.insert(sym_id);
                 }
             }
@@ -35,7 +35,7 @@ impl<'a> CheckerState<'a> {
                 if !std::ptr::eq(arena, self.ctx.arena) {
                     continue;
                 }
-                if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&augmentation.node.0) {
+                if let Some(sym_id) = self.local_augmentation_decl_symbol_id(augmentation.node) {
                     symbol_ids.insert(sym_id);
                 }
             }
@@ -382,7 +382,7 @@ impl<'a> CheckerState<'a> {
         name: &str,
     ) -> Vec<(NodeIndex, u32, bool)> {
         let Some(binder) = self.ctx.get_binder_for_file(file_idx) else {
-            return Vec::new();
+            return self.commonjs_object_literal_export_declarations_in_file(file_idx, name);
         };
         let arena = self.ctx.get_arena_for_file(file_idx as u32);
         let file_name = arena
@@ -533,10 +533,14 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
+                if declarations.is_empty() {
+                    return self
+                        .commonjs_object_literal_export_declarations_in_file(file_idx, name);
+                }
                 return declarations;
             }
 
-            return Vec::new();
+            return self.commonjs_object_literal_export_declarations_in_file(file_idx, name);
         };
         let Some(symbol) = binder.get_symbol(sym_id) else {
             return Vec::new();
@@ -667,6 +671,10 @@ impl<'a> CheckerState<'a> {
             }
 
             return merged;
+        }
+
+        if declarations.is_empty() {
+            return self.commonjs_object_literal_export_declarations_in_file(file_idx, name);
         }
 
         declarations

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -10,11 +10,13 @@
 //! - `type_alias_checking` — type alias declaration checking, type node validation
 //! - `unused` — unused variable/parameter detection
 
+mod commonjs_object_exports;
 mod core;
 mod core_statement_checks;
 mod cross_file_conflicts;
 mod declarations;
 mod declarations_utils;
+mod duplicate_identifier_conflict_kinds;
 mod duplicate_identifiers;
 mod duplicate_identifiers_constructor;
 mod duplicate_identifiers_helpers;

--- a/crates/tsz-checker/tests/js_export_surface_tests.rs
+++ b/crates/tsz-checker/tests/js_export_surface_tests.rs
@@ -11,6 +11,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 use tsz_binder::BinderState;
 use tsz_checker::context::CheckerOptions;
+use tsz_checker::module_resolution::build_module_resolution_maps;
 use tsz_checker::state::CheckerState;
 use tsz_parser::parser::ParserState;
 use tsz_solver::TypeInterner;
@@ -128,6 +129,62 @@ fn check_commonjs_single_file(file_name: &str, source: &str) -> Vec<(u32, String
         .ctx
         .diagnostics
         .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn check_named_files_entry(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+) -> Vec<(u32, String)> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let entry_idx = file_names
+        .iter()
+        .position(|name| name == entry_file)
+        .expect("entry file should exist");
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[entry_idx]);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code != 2318)
         .map(|d| (d.code, d.message_text.clone()))
         .collect()
 }
@@ -399,6 +456,50 @@ lib.b;
     assert!(
         ts2339.is_empty(),
         "Expected no TS2339 for valid module.exports properties, got: {ts2339:#?}"
+    );
+}
+
+#[test]
+fn test_module_exports_object_literal_member_conflicts_with_module_augmentation() {
+    let files = [
+        (
+            "/test.js",
+            r#"module.exports = {
+  a: "ok"
+};"#,
+        ),
+        (
+            "/index.ts",
+            r#"import { a } from "./test";
+
+declare module "./test" {
+  export const a: number;
+}
+
+const n: number = a;"#,
+        ),
+    ];
+    let diagnostics = check_named_files_entry(
+        &files,
+        "/index.ts",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            no_lib: true,
+            module: tsz_common::common::ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2300 && message.contains("Duplicate identifier 'a'")
+        }),
+        "Expected TS2300 for module augmentation colliding with CommonJS object export, got: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2322),
+        "Expected imported `a` to keep the JS object export type, got: {diagnostics:#?}"
     );
 }
 


### PR DESCRIPTION
## Root cause

tsc treats direct CommonJS object-literal members like `module.exports = { a: ... }` as the concrete export surface, so a module augmentation exporting the same value name is a duplicate while imports still see the JS value type; tsz did not expose those object-literal members to augmentation duplicate detection and could resolve named imports through the augmentation symbol instead.

## Fixed conformance target

`TypeScript/tests/cases/compiler/jsExportMemberMergedWithModuleAugmentation2.ts`

```ts
// test.js
module.exports = { a: "ok" };

// index.ts
import { a } from "./test";
declare module "./test" { export const a: number; }
a.toFixed();
```

## Unit test

`test_module_exports_object_literal_member_conflicts_with_module_augmentation`

## Verification

Post-rebase `scripts/session/verify-all.sh` passed:

- formatting: passed
- clippy: passed
- unit tests: passed
- conformance: improved +17 (`12078` vs baseline `12061`), including the selected target
- emit tests: improved (`JS +4`, `DTS +25`)
- fourslash/LSP: no change (`50` passed)
- summary: `ALL SUITES PASSED — safe to push`

Targeted checks also passed:

- `cargo nextest run --package tsz-checker --test js_export_surface_tests test_module_exports_object_literal_member_conflicts_with_module_augmentation`
- `./scripts/conformance/conformance.sh run --filter "jsExportMemberMergedWithModuleAugmentation2" --verbose`
