### PR TITLE
[codex] align tagged template generic inference with call resolution

### DIFF
--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -6,9 +6,9 @@
 
 use super::complex::is_contextually_sensitive;
 use crate::context::TypingRequest;
-use crate::query_boundaries::assignability::contains_type_parameters;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::common::instantiate_type;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -33,10 +33,7 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         request: &TypingRequest,
     ) -> TypeId {
-        use crate::query_boundaries::checkers::iterable::{
-            call_signatures_for_type, function_shape_for_type,
-        };
-        use crate::query_boundaries::common::instantiate_type;
+        use crate::query_boundaries::checkers::iterable::function_shape_for_type;
 
         let Some(node) = self.ctx.arena.get(idx) else {
             return TypeId::ERROR;
@@ -140,17 +137,6 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|s| !s.type_params.is_empty())
             && tagged.type_arguments.is_none();
 
-        // Determine whether to check argument assignability (TS2345).
-        // For overloaded functions, tsc performs full overload resolution and reports
-        // TS2769 ("No overload matches this call") instead of TS2345 per argument.
-        // We only check arguments when the tag has a single call signature.
-        let is_overloaded = crate::query_boundaries::common::callable_shape_for_type(
-            self.ctx.types,
-            resolved_tag_type,
-        )
-        .is_some_and(|callable| callable.call_signatures.len() > 1);
-        let should_check_args = !is_overloaded;
-
         // Apply explicit type arguments to the tag type (e.g., tag<Stuff>`...`).
         // This instantiates type parameters in the function signature so that
         // contextual typing of substitution expressions and the return type
@@ -164,6 +150,26 @@ impl<'a> CheckerState<'a> {
             resolved_tag_type
         };
 
+        let callee_type_for_context = self.evaluate_application_type(resolved_tag_type);
+        let callee_type_for_context = self.resolve_lazy_type(callee_type_for_context);
+        let callee_type_for_context = self.evaluate_contextual_type(callee_type_for_context);
+        let mut call_target_type = self.resolve_lazy_members_in_union(callee_type_for_context);
+        call_target_type = self.replace_function_type_for_call(tag_type, call_target_type);
+        if call_target_type == TypeId::ANY {
+            self.type_check_template_substitutions_no_context(&tagged, request);
+            return TypeId::ANY;
+        }
+
+        let unwrapped_tag = self.ctx.arena.skip_parenthesized_and_assertions(tagged.tag);
+        let force_bivariant_callbacks = matches!(
+            self.ctx.arena.get(unwrapped_tag).map(|n| n.kind),
+            Some(
+                syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                    | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+            )
+        );
+        let actual_this_type = self.actual_this_type_for_tagged_template_call(unwrapped_tag);
+
         // For tagged templates, the tag function parameters are:
         //   param[0] = TemplateStringsArray (always)
         //   param[1..] = substitution expressions
@@ -172,7 +178,7 @@ impl<'a> CheckerState<'a> {
         // Create contextual context from tag function type
         let ctx_helper = ContextualTypeContext::with_expected_and_options(
             self.ctx.types,
-            resolved_tag_type,
+            callee_type_for_context,
             self.ctx.compiler_options.no_implicit_any,
         );
 
@@ -190,10 +196,9 @@ impl<'a> CheckerState<'a> {
             if !needs_two_pass {
                 // === Single-pass inference: no contextually-sensitive args ===
                 // All arguments are concrete, so we can infer type parameters directly.
-                let template_strings_type = TypeId::ANY;
                 let total_args = 1 + substitution_exprs.len();
                 let mut arg_types: Vec<TypeId> = Vec::with_capacity(total_args);
-                arg_types.push(template_strings_type);
+                arg_types.push(TypeId::ANY);
 
                 for (i, &expr_idx) in substitution_exprs.iter().enumerate() {
                     let ctx_type = ctx_helper.get_parameter_type_for_call(i + 1, total_args);
@@ -202,105 +207,16 @@ impl<'a> CheckerState<'a> {
                     arg_types.push(arg_type);
                 }
 
-                // Perform inference
-                let evaluated_shape = {
-                    let new_params: Vec<_> = shape
-                        .params
-                        .iter()
-                        .map(|p| tsz_solver::ParamInfo {
-                            name: p.name,
-                            type_id: self.evaluate_type_with_env(p.type_id),
-                            optional: p.optional,
-                            rest: p.rest,
-                        })
-                        .collect();
-                    tsz_solver::FunctionShape {
-                        params: new_params,
-                        return_type: shape.return_type,
-                        this_type: shape.this_type,
-                        type_params: shape.type_params.clone(),
-                        type_predicate: shape.type_predicate,
-                        is_constructor: shape.is_constructor,
-                        is_method: shape.is_method,
-                    }
-                };
-                let mut substitution = {
-                    let env = self.ctx.type_env.borrow();
-                    call_checker::compute_contextual_types_with_context(
-                        self.ctx.types,
-                        &self.ctx,
-                        &env,
-                        &evaluated_shape,
-                        &arg_types,
-                        request.contextual_type,
-                    )
-                };
-
-                // Post-process: replace __infer_N placeholders with their constraint
-                // or `unknown`. compute_contextual_types uses placeholders for
-                // unresolved type params (designed for two-pass contextual typing),
-                // but in the single-pass case we need concrete types for argument
-                // checking—matching resolve_generic_call_inner which defaults to
-                // `unknown` for unconstrained, uninferred type params.
-                for tp in &shape.type_params {
-                    if let Some(resolved) = substitution.get(tp.name)
-                        && let Some(info) = crate::query_boundaries::common::type_param_info(
-                            self.ctx.types,
-                            resolved,
-                        )
-                    {
-                        let name_str = self.ctx.types.resolve_atom(info.name);
-                        if name_str.as_str().starts_with("__infer_") {
-                            let fallback = if let Some(constraint) = tp.constraint {
-                                let inst =
-                                    instantiate_type(self.ctx.types, constraint, &substitution);
-                                if !contains_type_parameters(self.ctx.types, inst) {
-                                    inst
-                                } else {
-                                    TypeId::UNKNOWN
-                                }
-                            } else {
-                                TypeId::UNKNOWN
-                            };
-                            substitution.insert(tp.name, fallback);
-                        }
-                    }
-                }
-
-                // Check argument assignability with instantiated parameter types
-                let mut reported_arg_error = false;
-                for (i, &expr_idx) in substitution_exprs.iter().enumerate() {
-                    let ctx_type = ctx_helper
-                        .get_parameter_type_for_call(i + 1, total_args)
-                        .map(|pt| {
-                            let instantiated = instantiate_type(self.ctx.types, pt, &substitution);
-                            self.evaluate_type_with_env(instantiated)
-                        });
-                    let actual_type = arg_types[i + 1]; // already computed above
-
-                    if should_check_args
-                        && !reported_arg_error
-                        && let Some(expected) = ctx_type
-                        && actual_type != TypeId::ERROR
-                        && actual_type != TypeId::UNKNOWN
-                        && expected != TypeId::ERROR
-                        && expected != TypeId::UNKNOWN
-                        && !contains_type_parameters(self.ctx.types, expected)
-                        && !self.should_defer_contextual_argument_mismatch(actual_type, expected)
-                        && !self.check_argument_assignable_or_report(
-                            actual_type,
-                            expected,
-                            expr_idx,
-                        )
-                    {
-                        reported_arg_error = true;
-                    }
-                }
-
-                // Return instantiated return type
-                let return_type =
-                    instantiate_type(self.ctx.types, shape.return_type, &substitution);
-                return self.evaluate_type_with_env(return_type);
+                return self.finish_tagged_template_call(
+                    idx,
+                    &tagged,
+                    &substitution_exprs,
+                    call_target_type,
+                    arg_types,
+                    force_bivariant_callbacks,
+                    request.contextual_type,
+                    actual_this_type,
+                );
             }
 
             if needs_two_pass {
@@ -322,10 +238,9 @@ impl<'a> CheckerState<'a> {
                 // Build argument types for Round 1: TemplateStringsArray + substitutions
                 // Use ANY as stand-in for TemplateStringsArray since it's a fixed
                 // non-generic type that doesn't affect type parameter inference.
-                let template_strings_type = TypeId::ANY;
                 let mut round1_arg_types: Vec<TypeId> =
                     Vec::with_capacity(1 + substitution_exprs.len());
-                round1_arg_types.push(template_strings_type);
+                round1_arg_types.push(TypeId::ANY);
 
                 for (i, &expr_idx) in substitution_exprs.iter().enumerate() {
                     if sensitive_args[i] {
@@ -375,7 +290,8 @@ impl<'a> CheckerState<'a> {
 
                 // === Round 2: Type-check all substitutions with contextual types ===
                 let total_args = 1 + substitution_exprs.len();
-                let mut reported_arg_error = false;
+                let mut arg_types = Vec::with_capacity(total_args);
+                arg_types.push(TypeId::ANY);
                 for (i, &expr_idx) in substitution_exprs.iter().enumerate() {
                     let ctx_type = ctx_helper
                         .get_parameter_type_for_call(i + 1, total_args)
@@ -389,80 +305,98 @@ impl<'a> CheckerState<'a> {
                         request.read().contextual_opt(None)
                     };
                     let actual_type = self.get_type_of_node_with_request(expr_idx, &arg_request);
-
-                    // Check argument assignability against expected parameter type (TS2345).
-                    // tsc reports only the first argument mismatch per tagged template call.
-                    // Skip for overloaded functions (handled via overload resolution / TS2769).
-                    // Skip when expected type still contains unresolved type parameters
-                    // (generic inference may not have fully instantiated the signature).
-                    if should_check_args
-                        && !reported_arg_error
-                        && let Some(expected) = ctx_type
-                        && actual_type != TypeId::ERROR
-                        && actual_type != TypeId::UNKNOWN
-                        && expected != TypeId::ERROR
-                        && expected != TypeId::UNKNOWN
-                        && !contains_type_parameters(self.ctx.types, expected)
-                        && !self.should_defer_contextual_argument_mismatch(actual_type, expected)
-                        && !self.check_argument_assignable_or_report(
-                            actual_type,
-                            expected,
-                            expr_idx,
-                        )
-                    {
-                        reported_arg_error = true;
-                    }
+                    arg_types.push(actual_type);
                 }
 
-                // Return instantiated return type
-                let return_type =
-                    instantiate_type(self.ctx.types, shape.return_type, &substitution);
-                return self.evaluate_type_with_env(return_type);
+                return self.finish_tagged_template_call(
+                    idx,
+                    &tagged,
+                    &substitution_exprs,
+                    call_target_type,
+                    arg_types,
+                    force_bivariant_callbacks,
+                    request.contextual_type,
+                    actual_this_type,
+                );
             }
         }
 
         // Single-pass: type-check substitutions with contextual types from tag signature
         let total_args = 1 + substitution_exprs.len();
-        let mut reported_arg_error = false;
+        let mut arg_types = Vec::with_capacity(total_args);
+        arg_types.push(TypeId::ANY);
         for (i, &expr_idx) in substitution_exprs.iter().enumerate() {
             let ctx_type = ctx_helper.get_parameter_type_for_call(i + 1, total_args);
             let arg_request = request.read().contextual_opt(ctx_type);
             let actual_type = self.get_type_of_node_with_request(expr_idx, &arg_request);
-
-            // Check argument assignability against expected parameter type (TS2345).
-            // tsc reports only the first argument mismatch per tagged template call,
-            // so stop checking after the first error.
-            // Skip for overloaded functions (handled via overload resolution / TS2769).
-            // Skip when expected type still contains unresolved type parameters
-            // (generic inference may not have fully instantiated the signature).
-            if should_check_args
-                && !reported_arg_error
-                && let Some(expected) = ctx_type
-                && actual_type != TypeId::ERROR
-                && actual_type != TypeId::UNKNOWN
-                && expected != TypeId::ERROR
-                && expected != TypeId::UNKNOWN
-                && !contains_type_parameters(self.ctx.types, expected)
-                && !self.should_defer_contextual_argument_mismatch(actual_type, expected)
-                && !self.check_argument_assignable_or_report(actual_type, expected, expr_idx)
-            {
-                reported_arg_error = true;
-            }
+            arg_types.push(actual_type);
         }
 
-        // Get the return type from the tag function's call signature.
-        // Use resolved_tag_type which has explicit type arguments applied.
-        if let Some(sig) = function_shape_for_type(self.ctx.types, resolved_tag_type) {
-            return sig.return_type;
-        }
-        if let Some(call_sigs) = call_signatures_for_type(self.ctx.types, resolved_tag_type)
-            && let Some(first_sig) = call_sigs.first()
+        self.finish_tagged_template_call(
+            idx,
+            &tagged,
+            &substitution_exprs,
+            call_target_type,
+            arg_types,
+            force_bivariant_callbacks,
+            request.contextual_type,
+            actual_this_type,
+        )
+    }
+
+    fn actual_this_type_for_tagged_template_call(
+        &mut self,
+        unwrapped_tag: NodeIndex,
+    ) -> Option<TypeId> {
+        let tag_node = self.ctx.arena.get(unwrapped_tag)?;
+        if tag_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && tag_node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
         {
-            return first_sig.return_type;
+            return None;
         }
 
-        // If tag is Function type, return any
-        TypeId::ANY
+        let access = self.ctx.arena.get_access_expr(tag_node)?;
+        Some(self.get_type_of_node(access.expression))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn finish_tagged_template_call(
+        &mut self,
+        idx: NodeIndex,
+        tagged: &tsz_parser::parser::node::TaggedTemplateData,
+        substitution_exprs: &[NodeIndex],
+        callee_type: TypeId,
+        arg_types: Vec<TypeId>,
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+    ) -> TypeId {
+        let mut args = Vec::with_capacity(1 + substitution_exprs.len());
+        args.push(tagged.template);
+        args.extend_from_slice(substitution_exprs);
+
+        let (result, _instantiated_predicate, _instantiated_params) = self
+            .resolve_call_with_checker_adapter(
+                callee_type,
+                &arg_types,
+                force_bivariant_callbacks,
+                contextual_type,
+                actual_this_type,
+            );
+
+        self.handle_call_result(
+            result,
+            super::call_result::CallResultContext {
+                callee_expr: tagged.tag,
+                call_idx: idx,
+                args: &args,
+                arg_types: &arg_types,
+                callee_type,
+                is_super_call: false,
+                is_optional_chain: false,
+                allow_contextual_mismatch_deferral: true,
+            },
+        )
     }
 
     /// Collect template substitution expression `NodeIndex` values from a tagged template.

--- a/crates/tsz-checker/tests/conformance_issues/features/templates.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/templates.rs
@@ -971,3 +971,99 @@ tag `${ x => x }`;
         "Should NOT emit TS7006 - 'x' should be contextually typed from tag parameter.\nActual errors: {relevant:#?}"
     );
 }
+
+#[test]
+fn test_tagged_template_generic_literal_argument_uses_call_inference() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+function someGenerics9<T>(strs: TemplateStringsArray, a: T, b: T, c: T): T {
+    return null as any;
+}
+var a9a = someGenerics9 `${ "" }${ 0 }${ [] }`;
+var a9a: {};
+        "#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2345
+                && message
+                    .contains("Argument of type '0' is not assignable to parameter of type '\"\"'")
+        }),
+        "Expected tagged-template TS2345 to match normal generic call inference. Actual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2403
+                && message.contains("Variable 'a9a' must be of type 'string'")
+                && !message.contains("\"\" | 0")
+        }),
+        "Expected tagged-template result display to widen to string. Actual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_tagged_template_generic_object_union_result_is_widened() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+function someGenerics9<T>(strs: TemplateStringsArray, a: T, b: T, c: T): T {
+    return null as any;
+}
+var a9e = someGenerics9 `${ undefined }${ { x: 6, z: new Date() } }${ { x: 6, y: "" } }`;
+var a9e: {};
+        "#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2403
+                && message.contains("Variable 'a9e' must be of type")
+                && message.contains("x: number")
+                && message.contains("z: Date")
+                && message.contains("z?: undefined")
+                && message.contains("y: string")
+                && message.contains("y?: undefined")
+                && !message.contains("x: 6")
+                && !message.contains("y: \"\"")
+        }),
+        "Expected tagged-template object union result display to widen literals. Actual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_tagged_template_generic_unresolved_type_params_display_as_unknown() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+function someGenerics4<T, U>(strs: TemplateStringsArray, n: T, f: (x: U) => void) { }
+someGenerics4 `${ null }${ null }`;
+
+function someGenerics7<A, B, C>(strs: TemplateStringsArray, a: (a: A) => A, b: (b: B) => B, c: (c: C) => C) { }
+function someGenerics8<T>(strs: TemplateStringsArray, n: T): T { return n; }
+var x = someGenerics8 `${ someGenerics7 }`;
+x `${ null }${ null }${ null }`;
+        "#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2345
+                && message
+                    .contains("Argument of type 'null' is not assignable to parameter of type '(x: unknown) => void'")
+        }),
+        "Expected unresolved callback parameter type to display as unknown. Actual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2345
+                && message
+                    .contains("Argument of type 'null' is not assignable to parameter of type '(a: unknown) => unknown'")
+        }),
+        "Expected returned generic tag parameter type to display as unknown. Actual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|(_, message)| !message.contains("(x: U)") && !message.contains("(a: A)")),
+        "Tagged-template generic diagnostics should not leak unresolved type parameter names. Actual: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -3,7 +3,7 @@
 use crate::inference::infer::{InferenceContext, InferenceVar};
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
-use crate::types::{FunctionShape, ParamInfo, TypeData, TypeId, TypePredicate};
+use crate::types::{FunctionShape, ObjectFlags, ParamInfo, TypeData, TypeId, TypePredicate};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
@@ -1224,6 +1224,23 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         .iter()
                         .all(|member| self.is_mergeable_direct_inference_candidate(*member))
             }
+            _ => false,
+        }
+    }
+
+    pub(super) fn inference_type_contains_fresh_object_or_array(&self, ty: TypeId) -> bool {
+        match self.interner.lookup(ty) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => self
+                .interner
+                .object_shape(shape_id)
+                .flags
+                .contains(ObjectFlags::FRESH_LITERAL),
+            Some(TypeData::Array(_) | TypeData::Tuple(_)) => true,
+            Some(TypeData::Union(members)) => self
+                .interner
+                .type_list(members)
+                .iter()
+                .any(|&member| self.inference_type_contains_fresh_object_or_array(member)),
             _ => false,
         }
     }

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1,6 +1,5 @@
 //! Core generic call resolution (`resolve_generic_call_inner`).
 
-use crate::contains_type_by_id;
 use crate::inference::infer::{InferenceContext, InferenceError, InferenceVar};
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::widening;
@@ -1550,18 +1549,26 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     self.normalize_inferred_placeholder_type(ty, infer_subst)
                 } else if !tp.is_const
                     && !contra_only
-                    && infer_ctx.all_candidates_are_fresh_literals(var)
                     && !tp
                         .constraint
                         .is_some_and(|c| constraint_is_primitive_type(self.interner, c))
                 {
-                    // Only widen when all covariant candidates are fresh literals
-                    // (from expressions, not type annotations) AND the type parameter
-                    // does NOT have a primitive constraint (string, number, bigint).
+                    // Widen fresh inference results from expressions when the type
+                    // parameter does NOT have a primitive constraint (string, number,
+                    // bigint).
                     // tsc preserves literal types when the constraint is a primitive:
                     //   <T extends string>(a: T) => T  -- T="z" preserved
                     //   <T>(a: T) => T                  -- T="z" widened to string
-                    crate::widen_literal_type(self.interner.as_type_database(), ty)
+                    if infer_ctx.all_candidates_are_fresh_literals(var) {
+                        crate::widen_literal_type(self.interner.as_type_database(), ty)
+                    } else if self.inference_type_contains_fresh_object_or_array(ty) {
+                        crate::operations::widening::widen_type_for_inference(
+                            self.interner.as_type_database(),
+                            ty,
+                        )
+                    } else {
+                        ty
+                    }
                 } else {
                     ty
                 }
@@ -2066,27 +2073,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         return CallResult::Success(return_type);
                     }
 
-                    let expected = self
-                        .param_type_for_arg_index(&func.params, index, final_args.len())
-                        .filter(|raw_expected| {
-                            crate::type_queries::contains_type_parameters_db(
-                                self.interner,
-                                *raw_expected,
-                            ) && contains_type_by_id(
-                                self.interner.as_type_database(),
-                                expected,
-                                TypeId::UNKNOWN,
-                            )
-                        })
-                        .filter(|raw_expected| {
-                            instantiate_call_type(
-                                self.interner,
-                                *raw_expected,
-                                &final_subst,
-                                actual_this_type,
-                            ) == expected
-                        })
-                        .unwrap_or(expected);
                     CallResult::ArgumentTypeMismatch {
                         index,
                         expected,

--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -347,9 +347,7 @@ fn widen_type_cached(
                     };
 
                 // Carry forward display properties from the original TypeId.
-                if !strip_fresh_display
-                    && let Some(display_props) = db.get_display_properties(type_id)
-                {
+                if let Some(display_props) = db.get_display_properties(type_id) {
                     db.store_display_properties(widened_type_id, display_props.as_ref().clone());
                 }
                 propagate_display_alias(db, type_id, widened_type_id);

--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -14,7 +14,7 @@
 //! - **Type parameters**: Never widened
 //! - **Unique symbols**: Never widened
 
-use crate::types::{TypeData, TypeId};
+use crate::types::{ObjectFlags, TypeData, TypeId};
 
 /// Propagate `display_alias` from the original type to the widened type.
 ///
@@ -79,7 +79,7 @@ pub fn widen_type(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId {
     // still contain widenable data, so they must go through the full path.
     use rustc_hash::FxHashMap;
     let mut cache = FxHashMap::default();
-    widen_type_cached(db, type_id, &mut cache, true, true)
+    widen_type_cached(db, type_id, &mut cache, true, true, false)
 }
 
 /// Widen for diagnostic display: like `widen_type` but preserves boolean
@@ -92,7 +92,7 @@ pub fn widen_type(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId {
 pub fn widen_type_for_display(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId {
     use rustc_hash::FxHashMap;
     let mut cache = FxHashMap::default();
-    widen_type_cached(db, type_id, &mut cache, false, false)
+    widen_type_cached(db, type_id, &mut cache, false, false, false)
 }
 
 /// Widen type for inference resolution: like `widen_type` but does NOT
@@ -106,7 +106,7 @@ pub fn widen_type_for_display(db: &dyn crate::TypeDatabase, type_id: TypeId) -> 
 pub(crate) fn widen_type_for_inference(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId {
     use rustc_hash::FxHashMap;
     let mut cache = FxHashMap::default();
-    widen_type_cached(db, type_id, &mut cache, true, false)
+    widen_type_cached(db, type_id, &mut cache, true, false, true)
 }
 
 /// Deep-widen a type including inside function/callable signatures.
@@ -145,7 +145,7 @@ pub fn widen_type_deep(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId 
     }
     use rustc_hash::FxHashMap;
     let mut cache = FxHashMap::default();
-    widen_type_cached(db, type_id, &mut cache, true, true)
+    widen_type_cached(db, type_id, &mut cache, true, true, false)
 }
 
 fn widen_type_cached(
@@ -154,6 +154,7 @@ fn widen_type_cached(
     cache: &mut rustc_hash::FxHashMap<TypeId, TypeId>,
     widen_boolean_intrinsics: bool,
     widen_functions: bool,
+    widen_object_union_members: bool,
 ) -> TypeId {
     // Fast path: most intrinsic types are never widened, but boolean
     // literal intrinsics (BOOLEAN_TRUE / BOOLEAN_FALSE) must widen to BOOLEAN.
@@ -208,17 +209,69 @@ fn widen_type_cached(
             let is_passthrough_intrinsic = |m: TypeId| -> bool {
                 m == TypeId::UNDEFINED || m == TypeId::NULL || m == TypeId::VOID
             };
+            let is_fresh_object_member = |m: TypeId| -> bool {
+                match db.lookup(m) {
+                    Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => db
+                        .object_shape(shape_id)
+                        .flags
+                        .contains(ObjectFlags::FRESH_LITERAL),
+                    _ => false,
+                }
+            };
+            let is_fresh_object_or_array_member = |m: TypeId| -> bool {
+                match db.lookup(m) {
+                    Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_)) => {
+                        is_fresh_object_member(m)
+                    }
+                    Some(TypeData::Array(_) | TypeData::Tuple(_)) => true,
+                    _ => false,
+                }
+            };
             let has_literal = members.iter().any(|&m| is_fresh_member(m));
             let small_fresh_union = has_literal
                 && members.len() <= 3
                 && members
                     .iter()
                     .all(|&m| is_fresh_member(m) || is_passthrough_intrinsic(m));
-            if small_fresh_union {
-                let widened_members: Vec<TypeId> = members
+            let has_fresh_object_or_array_member =
+                members.iter().any(|&m| is_fresh_object_or_array_member(m));
+            if small_fresh_union || (widen_object_union_members && has_fresh_object_or_array_member)
+            {
+                let mut members_to_widen = members.to_vec();
+                if widen_object_union_members {
+                    let fresh_object_members: Vec<TypeId> = members
+                        .iter()
+                        .copied()
+                        .filter(|&member| is_fresh_object_member(member))
+                        .collect();
+                    if let Some(normalized_objects) =
+                        super::expression_ops::normalize_fresh_object_literal_union_members(
+                            db,
+                            &fresh_object_members,
+                        )
+                    {
+                        let mut normalized = normalized_objects.into_iter();
+                        for member in &mut members_to_widen {
+                            if is_fresh_object_member(*member)
+                                && let Some(normalized_member) = normalized.next()
+                            {
+                                *member = normalized_member;
+                            }
+                        }
+                    }
+                }
+
+                let widened_members: Vec<TypeId> = members_to_widen
                     .iter()
                     .map(|&m| {
-                        widen_type_cached(db, m, cache, widen_boolean_intrinsics, widen_functions)
+                        widen_type_cached(
+                            db,
+                            m,
+                            cache,
+                            widen_boolean_intrinsics,
+                            widen_functions,
+                            widen_object_union_members,
+                        )
                     })
                     .collect();
                 let widened = db.union(widened_members);
@@ -234,6 +287,8 @@ fn widen_type_cached(
             let shape = db.object_shape(shape_id);
             let mut new_props = Vec::with_capacity(shape.properties.len());
             let mut changed = false;
+            let strip_fresh_display =
+                widen_object_union_members && shape.flags.contains(ObjectFlags::FRESH_LITERAL);
 
             for prop in &shape.properties {
                 // Rule: Readonly properties are NOT widened
@@ -246,6 +301,7 @@ fn widen_type_cached(
                         cache,
                         widen_boolean_intrinsics,
                         widen_functions,
+                        widen_object_union_members,
                     )
                 };
 
@@ -259,6 +315,7 @@ fn widen_type_cached(
                         cache,
                         widen_boolean_intrinsics,
                         widen_functions,
+                        widen_object_union_members,
                     )
                 };
 
@@ -271,21 +328,28 @@ fn widen_type_cached(
                 new_props.push(new_prop);
             }
 
-            if changed {
+            if changed || strip_fresh_display {
+                let mut flags = shape.flags;
+                if strip_fresh_display {
+                    flags.remove(ObjectFlags::FRESH_LITERAL);
+                }
+
                 let widened_type_id =
-                    // If we have index signatures, we must preserve them using object_with_index
                     if shape.string_index.is_some() || shape.number_index.is_some() {
                         let mut new_shape = (*shape).clone();
                         new_shape.properties = new_props;
+                        new_shape.flags = flags;
                         db.object_with_index(new_shape)
                     } else {
                         // Preserve symbol and flags so named types (interfaces,
                         // classes) retain their identity through widening.
-                        db.object_with_flags_and_symbol(new_props, shape.flags, shape.symbol)
+                        db.object_with_flags_and_symbol(new_props, flags, shape.symbol)
                     };
 
                 // Carry forward display properties from the original TypeId.
-                if let Some(display_props) = db.get_display_properties(type_id) {
+                if !strip_fresh_display
+                    && let Some(display_props) = db.get_display_properties(type_id)
+                {
                     db.store_display_properties(widened_type_id, display_props.as_ref().clone());
                 }
                 propagate_display_alias(db, type_id, widened_type_id);
@@ -304,6 +368,7 @@ fn widen_type_cached(
                 cache,
                 widen_boolean_intrinsics,
                 widen_functions,
+                widen_object_union_members,
             );
             if widened != element_type {
                 let widened_arr = db.array(widened);
@@ -326,6 +391,7 @@ fn widen_type_cached(
                     cache,
                     widen_boolean_intrinsics,
                     widen_functions,
+                    widen_object_union_members,
                 );
                 if widened != elem.type_id {
                     changed = true;
@@ -359,6 +425,7 @@ fn widen_type_cached(
                         cache,
                         widen_boolean_intrinsics,
                         widen_functions,
+                        widen_object_union_members,
                     );
                     if widened.type_id != param.type_id {
                         changed = true;
@@ -373,6 +440,7 @@ fn widen_type_cached(
                     cache,
                     widen_boolean_intrinsics,
                     widen_functions,
+                    widen_object_union_members,
                 );
                 if widened != this_ty {
                     changed = true;
@@ -385,6 +453,7 @@ fn widen_type_cached(
                 cache,
                 widen_boolean_intrinsics,
                 widen_functions,
+                widen_object_union_members,
             );
             if widened_return != widened_shape.return_type {
                 changed = true;
@@ -421,6 +490,7 @@ fn widen_type_cached(
                                 cache,
                                 widen_boolean_intrinsics,
                                 widen_functions,
+                                widen_object_union_members,
                             );
                             if widened.type_id != param.type_id {
                                 changed = true;
@@ -435,6 +505,7 @@ fn widen_type_cached(
                             cache,
                             widen_boolean_intrinsics,
                             widen_functions,
+                            widen_object_union_members,
                         );
                         if widened != this_ty {
                             changed = true;
@@ -447,6 +518,7 @@ fn widen_type_cached(
                         cache,
                         widen_boolean_intrinsics,
                         widen_functions,
+                        widen_object_union_members,
                     );
                     if widened_return != widened_sig.return_type {
                         changed = true;

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -430,6 +430,174 @@ fn test_generic_call_widening_applies_when_constraint_satisfied() {
 }
 
 #[test]
+fn test_generic_call_widens_fresh_object_union_inferred_type() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let t_param = TypeParamInfo {
+        is_const: false,
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+    };
+    let t_type = interner.type_param(t_param);
+    let func = interner.function(FunctionShape {
+        params: vec![
+            ParamInfo::unnamed(t_type),
+            ParamInfo::unnamed(t_type),
+            ParamInfo::unnamed(t_type),
+        ],
+        this_type: None,
+        return_type: t_type,
+        type_params: vec![t_param],
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let x = interner.intern_string("x");
+    let y = interner.intern_string("y");
+    let z = interner.intern_string("z");
+    let six = interner.literal_number(6.0);
+    let seven = interner.literal_number(7.0);
+    let empty = interner.literal_string("");
+
+    let left = interner.object_fresh(vec![PropertyInfo::new(x, six), PropertyInfo::new(z, seven)]);
+    let right = interner.object_fresh(vec![PropertyInfo::new(x, six), PropertyInfo::new(y, empty)]);
+
+    let result = evaluator.resolve_call(func, &[TypeId::UNDEFINED, left, right]);
+    let ret = match result {
+        CallResult::Success(ret) => ret,
+        other => panic!("Expected Success for fresh-object generic inference, got {other:?}"),
+    };
+
+    let Some(TypeData::Union(list_id)) = interner.lookup(ret) else {
+        panic!("Expected union return type, got {:?}", interner.lookup(ret));
+    };
+    let members = interner.type_list(list_id);
+    assert!(
+        members.contains(&TypeId::UNDEFINED),
+        "Expected undefined in inferred union, got {members:?}"
+    );
+
+    let mut saw_left_shape = false;
+    let mut saw_right_shape = false;
+
+    for &member in members.iter() {
+        let shape = match interner.lookup(member) {
+            Some(TypeData::Object(shape_id)) | Some(TypeData::ObjectWithIndex(shape_id)) => {
+                interner.object_shape(shape_id)
+            }
+            _ => continue,
+        };
+
+        assert!(
+            !shape
+                .flags
+                .contains(crate::types::ObjectFlags::FRESH_LITERAL),
+            "Widened inference result should not retain fresh-object flags"
+        );
+
+        let find_prop = |name| shape.properties.iter().find(|prop| prop.name == name);
+        let x_prop = find_prop(x).expect("normalized member should keep x");
+        assert_eq!(x_prop.type_id, TypeId::NUMBER);
+        assert!(!x_prop.optional);
+
+        let y_prop = find_prop(y).expect("normalized member should include y");
+        let z_prop = find_prop(z).expect("normalized member should include z");
+
+        if !z_prop.optional {
+            saw_left_shape = true;
+            assert_eq!(z_prop.type_id, TypeId::NUMBER);
+            assert!(y_prop.optional);
+            assert_eq!(y_prop.type_id, TypeId::UNDEFINED);
+        } else if !y_prop.optional {
+            saw_right_shape = true;
+            assert_eq!(y_prop.type_id, TypeId::STRING);
+            assert!(z_prop.optional);
+            assert_eq!(z_prop.type_id, TypeId::UNDEFINED);
+        }
+    }
+
+    assert!(
+        saw_left_shape,
+        "Expected widened left object member in inferred union"
+    );
+    assert!(
+        saw_right_shape,
+        "Expected widened right object member in inferred union"
+    );
+}
+
+#[test]
+fn test_generic_call_uninferred_callback_param_mismatch_uses_unknown() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let t_param = TypeParamInfo {
+        is_const: false,
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+    };
+    let u_param = TypeParamInfo {
+        is_const: false,
+        name: interner.intern_string("U"),
+        constraint: None,
+        default: None,
+    };
+    let t_type = interner.type_param(t_param);
+    let u_type = interner.type_param(u_param);
+
+    let callback = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(u_type)],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: vec![],
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let func = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(t_type), ParamInfo::unnamed(callback)],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: vec![t_param, u_param],
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let result = evaluator.resolve_call(func, &[TypeId::NULL, TypeId::NULL]);
+    match result {
+        CallResult::ArgumentTypeMismatch {
+            index,
+            expected,
+            actual,
+            ..
+        } => {
+            assert_eq!(index, 1);
+            assert_eq!(actual, TypeId::NULL);
+
+            let Some(TypeData::Function(shape_id)) = interner.lookup(expected) else {
+                panic!(
+                    "Expected instantiated callback type in mismatch, got {:?}",
+                    interner.lookup(expected)
+                );
+            };
+            let shape = interner.function_shape(shape_id);
+            assert!(shape.type_params.is_empty());
+            assert_eq!(shape.params.len(), 1);
+            assert_eq!(shape.params[0].type_id, TypeId::UNKNOWN);
+            assert_eq!(shape.return_type, TypeId::VOID);
+        }
+        other => panic!("Expected callback mismatch with unknown parameter, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_get_contextual_signature_with_compat_checker_matches_call_evaluator() {
     let interner = TypeInterner::new();
     let contextual = interner.function(FunctionShape {


### PR DESCRIPTION
## Summary
- route final tagged-template resolution through the shared call resolver while keeping the initial tagged-template pass only for contextual typing
- remove the checker-local tagged-template TS2345 loop and let solver-backed call resolution own generic mismatch selection
- widen fresh object and array generic inference results in the solver, and lock the solver behavior in unit tests
- add focused tagged-template conformance issue coverage for literal mismatch, widened object-union display, and unresolved callback parameter display

## Root cause
TypeScript resolves generic tagged templates through the same call-resolution path as normal calls, but `tsz` finalized tagged templates with checker-local inference and argument checking, so generic mismatch reporting and inferred-type widening diverged from normal call behavior.

## Impact
Tagged-template generic inference now matches normal generic call behavior for:
- first-mismatch TS2345 selection
- widened return display for fresh object and array inference results
- `unknown` display for unresolved callback type parameters in mismatch diagnostics

## Example
```ts
function someGenerics9<T>(strs: TemplateStringsArray, a: T, b: T, c: T): T {
  return null as any;
}

var a9a = someGenerics9 `${""}${0}${[]}`;
var a9a: {};
```

Expected parity with `tsc`:
- TS2345 reports `0` against parameter type `""`
- the redeclaration display for `a9a` widens to `string`

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `cargo nextest run --package tsz-solver test_generic_call_widens_fresh_object_union_inferred_type test_generic_call_uninferred_callback_param_mismatch_uses_unknown`
- `./scripts/conformance/conformance.sh run --filter "taggedTemplateStringsTypeArgumentInference" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
