### PR TITLE
fix: align jsx element attributes diagnostics

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -1399,9 +1399,16 @@ impl<'a> CheckerState<'a> {
                 if let Some(eap_symbol) = self.ctx.binder.get_symbol(eap_sym_id)
                     && let Some(&decl_idx) = eap_symbol.declarations.first()
                 {
+                    let anchor_idx = self
+                        .ctx
+                        .arena
+                        .get(decl_idx)
+                        .and_then(|node| self.ctx.arena.get_interface(node))
+                        .map(|iface| iface.name)
+                        .unwrap_or(decl_idx);
                     use crate::diagnostics::diagnostic_codes;
                     self.error_at_node_msg(
-                        decl_idx,
+                        anchor_idx,
                         diagnostic_codes::THE_GLOBAL_TYPE_JSX_MAY_NOT_HAVE_MORE_THAN_ONE_PROPERTY,
                         &["ElementAttributesProperty"],
                     );

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -660,6 +660,17 @@ impl<'a> CheckerState<'a> {
                             continue;
                         }
 
+                        let props_target_has_object_shape =
+                            crate::query_boundaries::common::object_shape_for_type(
+                                self.ctx.types,
+                                props_type,
+                            )
+                            .is_some();
+                        if !props_target_has_object_shape {
+                            needs_special_attr_object_assignability = true;
+                            continue;
+                        }
+
                         // Check if the component has type parameters. This handles cases like
                         // class components with generic props where the display target is
                         // `IntrinsicAttributes & IntrinsicClassAttributes<ElemClass<T>> & { x: number; }`

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -401,6 +401,63 @@ fn jsx_element_attributes_property_multiple_members_emits_ts2608() {
     );
 }
 
+#[test]
+fn jsx_element_attributes_property_multiple_members_anchors_at_interface_name() {
+    let source = r#"
+        declare namespace JSX {
+            interface Element { }
+            interface ElementAttributesProperty { pr1: any; pr2: any; }
+            interface IntrinsicElements { }
+        }
+        interface CompType { new(n: string): {}; }
+        declare var Comp: CompType;
+        <Comp x={10} />;
+        "#;
+    let diagnostics = check_jsx(source);
+    let expected_start = source
+        .find("ElementAttributesProperty")
+        .expect("expected ElementAttributesProperty in source") as u32;
+    let ts2608 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2608)
+        .expect("expected TS2608 for invalid ElementAttributesProperty");
+    assert_eq!(
+        ts2608.start, expected_start,
+        "TS2608 should anchor at the ElementAttributesProperty name, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn jsx_invalid_element_attributes_property_props_assignability_anchors_at_tag_name() {
+    let source = r#"
+        declare namespace JSX {
+            interface Element { }
+            interface ElementAttributesProperty { pr1: any; pr2: any; }
+            interface IntrinsicElements { }
+        }
+        interface CompType { new(n: string): {}; }
+        declare var Comp: CompType;
+        <Comp x={10} />;
+        "#;
+    let diagnostics = check_jsx(source);
+    let expected_start = source
+        .find("Comp x")
+        .expect("expected JSX tag name in source") as u32;
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| {
+            diag.code == 2322
+                && diag
+                    .message_text
+                    .contains("Type '{ x: number; }' is not assignable to type 'string'.")
+        })
+        .expect("expected TS2322 for invalid JSX attributes object");
+    assert_eq!(
+        ts2322.start, expected_start,
+        "TS2322 should anchor at the JSX tag name, got: {diagnostics:?}"
+    );
+}
+
 /// TS2786 should NOT fire for generic class components whose construct
 /// signature return type contains unresolved type parameters.
 /// TSC resolves signatures before checking; we skip the check when


### PR DESCRIPTION
## Summary
- Align JSX element attribute diagnostics behavior
- Add focused JSX checker coverage
- Migrate CI configuration from CircleCI to GitHub Actions as included in this branch

## Testing
- Not run locally in this PR creation step.