### PR TITLE
fix(solver): ignore generic construct args for outer inference

### DIFF
--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -323,6 +323,33 @@ const test1 = authorPromise.then(mapper);
 }
 
 #[test]
+fn generic_construct_signature_argument_does_not_infer_outer_return_type() {
+    let diags = check_source_diagnostics(
+        r#"
+interface GenericCtor {
+    new <T>(x: T): T;
+}
+
+declare const ctor: GenericCtor;
+
+function foo<T, U>(x: T, cb: new(a: T) => U, y: U) {
+    return new cb(x);
+}
+
+foo(null, ctor, "");
+"#,
+    );
+
+    let errors: Vec<_> = diags.iter().filter(|d| d.code == 2345).collect();
+    assert_eq!(
+        errors.len(),
+        0,
+        "Expected generic construct signature argument not to infer U from T, got: {:?}",
+        errors.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn generic_call_preserves_outer_type_param_in_contravariant_object_member() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -861,6 +861,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         };
         let source_fn = self.normalize_function_shape_params_for_context(&source_fn);
         let target_fn = self.normalize_function_shape_params_for_context(&target_fn);
+
+        // TypeScript does not use generic construct-signature arguments to infer
+        // type parameters for the outer constructor-typed parameter. Leave the
+        // callable intact so the shared constraint walker erases the source
+        // signature's own type parameters instead of contextually instantiating
+        // them into the outer placeholders.
+        if source_fn.is_constructor && !source_fn.type_params.is_empty() {
+            return source_ty;
+        }
+
         if source_fn.type_params.is_empty() {
             let source_has_calls = crate::type_queries::get_call_signatures(
                 self.interner.as_type_database(),


### PR DESCRIPTION
## Root Cause

tsc erases generic construct-signature arguments before they contribute to outer generic constructor-parameter inference, but tsz contextually instantiated `new <T>(x: T) => T` against `new(a: OuterT) => OuterU`, incorrectly inferring `OuterU = OuterT` and rejecting the later `y` argument.

## Fixed Conformance Target

`TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithFunctionTypedArguments2.ts`

```ts
interface GenericCtor {
    new <T>(x: T): T;
}

declare const ctor: GenericCtor;

function foo<T, U>(x: T, cb: new(a: T) => U, y: U) {
    return new cb(x);
}

foo(null, ctor, ""); // no TS2345
```

## Unit Test

`generic_construct_signature_argument_does_not_infer_outer_return_type` in `crates/tsz-checker/src/tests/call_architecture_tests.rs`.

## Verification

Post-rebase `scripts/session/verify-all.sh` passed:

- formatting: passed
- clippy: passed
- unit tests: passed
- conformance: +19, `12080` vs `12061` baseline
- emit tests: JS +4, DTS +25
- fourslash/LSP: no change, 50/50

Targeted checks passed:

- `cargo nextest run --package tsz-checker --lib generic_construct_signature_argument_does_not_infer_outer_return_type`
- `./scripts/conformance/conformance.sh run --filter "genericCallWithFunctionTypedArguments2" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`

Note: `verify-all` reported stale-baseline PASS->FAIL entries, including the JSX runtime diagnostic cases and JS declaration emit case. The same original stale-baseline cases reproduced on clean `origin/main` with this patch stashed during investigation, so they are not introduced by this change.
