### PR TITLE
[codex] Preserve typeof function comma recovery in parser

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -2044,7 +2044,19 @@ impl ParserState {
                 }
 
                 // No ASI - emit ',' expected for the unexpected token and stop.
-                self.error_comma_expected();
+                // Use position-only dedup for normal tokens, not the broader
+                // distance heuristic: tsc still reports adjacent declaration-list
+                // comma errors like `var x: typeof function f() { };` at both
+                // `f` and `(`. Keep Unknown tokens on the scanner-shaped TS1127
+                // path instead of forcing TS1005.
+                if self.is_token(SyntaxKind::Unknown) {
+                    self.parse_error_at_current_token(
+                        tsz_common::diagnostics::diagnostic_messages::INVALID_CHARACTER,
+                        diagnostic_codes::INVALID_CHARACTER,
+                    );
+                } else {
+                    self.parse_error_at_current_token("',' expected.", diagnostic_codes::EXPECTED);
+                }
 
                 // Otherwise stop the list. We break instead of continuing to avoid
                 // cascading TS1134 errors when the recovery eats into what tsc

--- a/crates/tsz-parser/tests/state_statement_tests.rs
+++ b/crates/tsz-parser/tests/state_statement_tests.rs
@@ -629,6 +629,35 @@ fn member_call_tail_after_missing_comma_in_type_annotation_emits_second_comma_er
 }
 
 #[test]
+fn typeof_function_type_query_tail_emits_second_comma_error() {
+    let source = "var x7: typeof function f() { };";
+    let (parser, _root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+
+    let name_pos = source.find(" f(").expect("function name") as u32 + 1;
+    let open_paren_pos = source.find("f(").expect("function call tail") as u32 + 1;
+
+    let comma_diags: Vec<_> = diags
+        .iter()
+        .filter(|diag| diag.code == diagnostic_codes::EXPECTED && diag.message == "',' expected.")
+        .collect();
+
+    assert_eq!(
+        comma_diags.len(),
+        2,
+        "Expected exactly two TS1005 ',' expected diagnostics, got {diags:?}"
+    );
+    assert!(
+        comma_diags.iter().any(|diag| diag.start == name_pos),
+        "Expected TS1005 ',' expected at the recovered declarator name, got {diags:?}"
+    );
+    assert!(
+        comma_diags.iter().any(|diag| diag.start == open_paren_pos),
+        "Expected TS1005 ',' expected at the opening paren after the recovered declarator, got {diags:?}"
+    );
+}
+
+#[test]
 fn class_field_initializer_does_not_asi_before_computed_member() {
     let (parser, _root) = parse_source("class C {\n    [e]: number = 0\n    [e2]: number\n}");
     let diags = parser.get_diagnostics();


### PR DESCRIPTION
## Summary
- preserve the second TS1005 comma recovery when malformed `typeof function f() {}` is reparsed as a second declarator
- keep `Unknown` tokens on the existing TS1127 invalid-character recovery path instead of forcing TS1005
- add a parser regression test that locks in the `typeof function` recovery shape

## Root Cause
`tsc` emits two adjacent TS1005 comma diagnostics when malformed `typeof function f() {}` recovery turns `f` into a second declarator, while `tsz` was routing the follow-up `(` through distance-based suppression and dropping that second comma diagnostic.

## Impact
This removes the fingerprint-only mismatch in `invalidTypeOfTarget` without broadening parser recovery in unrelated invalid-character cases.

## TypeScript Snippet
```ts
var x7: typeof function f() { };
```

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-parser --lib`
- `./scripts/conformance/conformance.sh run --filter "invalidTypeOfTarget" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
