### PR TITLE
fix(checker): fall back to catch-policy type for invalid JSDoc @type on catch

### DIFF
--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -371,6 +371,37 @@ impl<'a> CheckerState<'a> {
         result
     }
 
+    pub(crate) fn jsdoc_type_expression_span_for_node(&self, idx: NodeIndex) -> Option<(u32, u32)> {
+        if !self.ctx.should_resolve_jsdoc() {
+            return None;
+        }
+        let idx = self.normalized_jsdoc_lookup_node(idx);
+        let sf = self.source_file_data_for_node(idx)?;
+        if sf.comments.is_empty() || !sf.comments.iter().any(|c| c.is_multi_line) {
+            return None;
+        }
+        let source_text: String = sf.text.to_string();
+        let comments = sf.comments.clone();
+        let (jsdoc, comment_pos) =
+            self.try_jsdoc_with_ancestor_walk_and_pos(idx, &comments, &source_text)?;
+        let type_expr = Self::extract_jsdoc_type_expression(&jsdoc)?.trim();
+        if type_expr.is_empty() {
+            return None;
+        }
+        let tag_pos = jsdoc.find("@type")?;
+        let after_tag = tag_pos + "@type".len();
+        let rest = &jsdoc[after_tag..];
+        let rest_ws = rest.len() - rest.trim_start().len();
+        let rest_trimmed = rest.trim_start();
+        let expr_offset = if let Some(after_open) = rest_trimmed.strip_prefix('{') {
+            let brace_ws = after_open.len() - after_open.trim_start().len();
+            after_tag + rest_ws + 1 + brace_ws
+        } else {
+            after_tag + rest_ws
+        };
+        Some((comment_pos + expr_offset as u32 + 4, type_expr.len() as u32))
+    }
+
     /// Emit TS2694 for JSDoc qualified type names `A.B` whose root `A` is
     /// a plain value (not a namespace/module/type container). tsc's JSDoc
     /// checker treats this as "Namespace 'A' has no exported member 'B'";

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -606,20 +606,36 @@ impl<'a> CheckerState<'a> {
             {
                 // TS1196: Catch clause variable type annotation must be 'any' or 'unknown'
                 // This also applies to JSDoc @type annotations on catch variables in JS files.
-                if is_catch_variable
+                let is_invalid_catch_jsdoc = is_catch_variable
                     && jsdoc_type != TypeId::ANY
                     && jsdoc_type != TypeId::UNKNOWN
-                    && !checker.type_contains_error(jsdoc_type)
-                {
+                    && !checker.type_contains_error(jsdoc_type);
+                if is_invalid_catch_jsdoc {
                     use crate::diagnostics::diagnostic_codes;
-                    checker.error_at_node(
-                        decl_idx,
-                        "Catch clause variable type annotation must be 'any' or 'unknown' if specified.",
-                        diagnostic_codes::CATCH_CLAUSE_VARIABLE_TYPE_ANNOTATION_MUST_BE_ANY_OR_UNKNOWN_IF_SPECIFIED,
-                    );
+                    let jsdoc_type_span = checker.jsdoc_type_expression_span_for_node(decl_idx);
+                    if let Some((start, length)) = jsdoc_type_span {
+                        checker.error_at_position(
+                            start,
+                            length,
+                            "Catch clause variable type annotation must be 'any' or 'unknown' if specified.",
+                            diagnostic_codes::CATCH_CLAUSE_VARIABLE_TYPE_ANNOTATION_MUST_BE_ANY_OR_UNKNOWN_IF_SPECIFIED,
+                        );
+                    } else {
+                        checker.error_at_node(
+                            decl_idx,
+                            "Catch clause variable type annotation must be 'any' or 'unknown' if specified.",
+                            diagnostic_codes::CATCH_CLAUSE_VARIABLE_TYPE_ANNOTATION_MUST_BE_ANY_OR_UNKNOWN_IF_SPECIFIED,
+                        );
+                    }
                 }
-                declared_type = jsdoc_type;
-                jsdoc_declared_type = Some(jsdoc_type);
+                declared_type = if is_invalid_catch_jsdoc {
+                    flow_boundary::resolve_catch_variable_type(
+                        checker.ctx.use_unknown_in_catch_variables(),
+                    )
+                } else {
+                    jsdoc_type
+                };
+                jsdoc_declared_type = Some(declared_type);
                 has_type_annotation = true;
             }
             if !has_type_annotation
@@ -2280,6 +2296,8 @@ impl<'a> CheckerState<'a> {
             // binding element symbols created by the binder.
             let pattern_type = if var_decl.type_annotation.is_some() {
                 self.get_type_from_type_node(var_decl.type_annotation)
+            } else if let Some(jsdoc_type) = jsdoc_declared_type {
+                jsdoc_type
             } else if let Some(inferred) =
                 self.cached_inferred_variable_type(decl_idx, var_decl.name)
             {

--- a/crates/tsz-checker/tests/binding_pattern_inference_tests.rs
+++ b/crates/tsz-checker/tests/binding_pattern_inference_tests.rs
@@ -29,6 +29,31 @@ fn compile_and_get_diagnostics(source: &str, options: CheckerOptions) -> Vec<(u3
         .collect()
 }
 
+fn compile_js_and_get_diagnostics(source: &str, options: CheckerOptions) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.js".to_string(),
+        options,
+    );
+
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
 #[test]
 fn test_unknown_binding_patterns_match_tsc_split_diagnostics() {
     let source = r#"
@@ -57,6 +82,49 @@ const [e1, e2] = f();
         codes,
         vec![2571, 2339, 2488, 2571, 2488],
         "Expected TypeScript-style unknown destructuring diagnostics. Actual diagnostics: {relevant:#?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_catch_variable_invalid_type_falls_back_to_catch_policy() {
+    let source = r#"
+function fn() {
+    // @ts-ignore
+    try {} catch (/** @type {number} */ err) {
+        err.toLowerCase();
+    }
+    try {} catch (/** @type {unknown} */ { x }) {
+        console.log(x);
+    }
+}
+"#;
+
+    let diagnostics = compile_js_and_get_diagnostics(
+        source,
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            no_implicit_any: true,
+            use_unknown_in_catch_variables: false,
+            target: ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    let relevant: Vec<(u32, String)> = diagnostics
+        .into_iter()
+        .filter(|(code, _)| *code != 2318)
+        .collect();
+
+    assert!(
+        relevant.iter().any(|(code, message)| *code == 2339
+            && message == "Property 'x' does not exist on type 'unknown'."),
+        "Expected TS2339 for destructuring from unknown catch JSDoc. Actual diagnostics: {relevant:#?}"
+    );
+    assert!(
+        !relevant
+            .iter()
+            .any(|(code, message)| *code == 2339 && message.contains("toLowerCase")),
+        "Invalid catch JSDoc must not make err a number. Actual diagnostics: {relevant:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

When a catch clause has an invalid JSDoc `@type` annotation (anything other than `any` or `unknown`), TSZ previously reported TS1196 but then let the invalid declared type flow through as the variable's type. That allowed `err.toLowerCase()` to pass checking after `/** @type {number} */ err`, even though tsc rejects the property access because the catch variable must fall back to the catch policy.

This change:

1. Falls back to `flow_boundary::resolve_catch_variable_type(useUnknownInCatchVariables)` when the JSDoc type is rejected, so downstream checking sees `any` / `unknown` instead of the invalid declared type.
2. Adds `jsdoc_type_expression_span_for_node` to anchor TS1196 at the JSDoc type expression (matching tsc's column).

## Target

Conformance: `jsdocCatchClauseWithTypeAnnotation` (1/1 passing after fix).

## Test plan

- [x] `cargo nextest run -p tsz-checker --test binding_pattern_inference_tests` — new regression test `test_jsdoc_catch_variable_invalid_type_falls_back_to_catch_policy` passes.
- [x] `cargo nextest run -p tsz-checker --lib` — 2598 tests still pass.
- [x] `./scripts/conformance/conformance.sh run --filter "jsdocCatchClauseWithTypeAnnotation" --verbose` — 1/1 passing.
- [x] Pre-commit full workspace test suite — 12924 tests passing.

## Notes

Recovered from an interrupted parallel agent worktree (codex/conformance-20260421172436-02). Full conformance suite not re-run in this session due to time; relying on pre-commit full test run for unit-test parity.