### PR TITLE
fix(checker): emit TS18016 for private name assignment on JS prototype

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -39,6 +39,30 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    fn is_js_prototype_private_name_assignment_target(&self, idx: NodeIndex) -> Option<NodeIndex> {
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let outer_access = self.ctx.arena.get_access_expr(node)?;
+        let name_node = self.ctx.arena.get(outer_access.name_or_argument)?;
+        if name_node.kind != SyntaxKind::PrivateIdentifier as u16 {
+            return None;
+        }
+
+        let proto_node = self.ctx.arena.get(outer_access.expression)?;
+        if proto_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let proto_access = self.ctx.arena.get_access_expr(proto_node)?;
+        let is_prototype = self
+            .ctx
+            .arena
+            .get_identifier_at(proto_access.name_or_argument)
+            .is_some_and(|ident| ident.escaped_text == "prototype");
+        is_prototype.then_some(outer_access.name_or_argument)
+    }
+
     // =========================================================================
     // Assignment Expression Checking
     // =========================================================================
@@ -500,6 +524,17 @@ impl<'a> CheckerState<'a> {
             self.get_type_of_node(left_idx);
             self.get_type_of_node(right_idx);
             return TypeId::ANY;
+        }
+
+        if self.is_js_file()
+            && let Some(private_name_idx) =
+                self.is_js_prototype_private_name_assignment_target(left_idx)
+        {
+            self.error_at_node(
+                private_name_idx,
+                "Private identifiers are not allowed outside class bodies.",
+                diagnostic_codes::PRIVATE_IDENTIFIERS_ARE_NOT_ALLOWED_OUTSIDE_CLASS_BODIES,
+            );
         }
 
         // TS2779: The left-hand side of an assignment expression may not be an optional property access.

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -52,7 +52,15 @@ fn test_private_brands_with_codes(source: &str, expected_errors: usize, error_co
 }
 
 fn collect_private_brand_diagnostics(source: &str) -> Vec<Diagnostic> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    collect_private_brand_diagnostics_with_options(source, "test.ts", CheckerOptions::default())
+}
+
+fn collect_private_brand_diagnostics_with_options(
+    source: &str,
+    file_name: &str,
+    options: CheckerOptions,
+) -> Vec<Diagnostic> {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
     let root = parser.parse_source_file();
 
     let mut binder = BinderState::new();
@@ -63,8 +71,8 @@ fn collect_private_brand_diagnostics(source: &str) -> Vec<Diagnostic> {
         parser.get_arena(),
         &binder,
         &types,
-        "test.ts".to_string(),
-        CheckerOptions::default(),
+        file_name.to_string(),
+        options,
     );
 
     checker.check_source_file(root);
@@ -340,6 +348,28 @@ fn test_ts18016_private_id_on_any_outside_class() {
             18016,
         ),
         "Should emit TS18016 for undeclared private name on any outside class"
+    );
+}
+
+/// Private identifier on a function prototype assignment outside class body -> TS18016.
+#[test]
+fn test_ts18016_private_id_on_js_prototype_assignment_outside_class() {
+    let diagnostics = collect_private_brand_diagnostics_with_options(
+        r"
+        function A() {}
+        A.prototype.#no = 2;
+        ",
+        "test.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts18016_count = diagnostics.iter().filter(|d| d.code == 18016).count();
+    assert_eq!(
+        ts18016_count, 1,
+        "Should emit TS18016 for private name assignment on a JS prototype outside class, got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

In `.js` files with `allowJs`+`checkJs`, the assignment

```js
function A() {}
A.prototype.#private = 1;
```

should emit **TS18016** ("Private identifiers are not allowed outside class bodies.") because private names are only legal inside a class body. TSZ previously missed the diagnostic.

The assignment checker now detects the shape `<identifier>.prototype.#privateName` on the LHS of a binary assignment and reports TS18016 anchored at the private name node.

## Target

Conformance: `privateNameJsBadAssignment` (1/1 passing after fix).

## Test plan

- [x] New unit test `test_ts18016_private_id_on_js_prototype_assignment_outside_class` in `private_brands.rs`.
- [x] `cargo nextest run -p tsz-checker --test private_brands` — 19/19 pass (18 prior + 1 new).
- [x] `cargo nextest run -p tsz-checker --lib` — 2600/2600 pass.
- [x] `./scripts/conformance/conformance.sh run --filter "privateNameJsBadAssignment" --verbose` — 1/1 passing.
- [x] Pre-commit full workspace test suite — 12925 tests passing.

## Notes

Recovered from an interrupted parallel agent worktree (codex/conformance-20260421172436-03). Full conformance suite not re-run in this session; relying on pre-commit full test run for unit-test parity.