### PR TITLE
fix(checker): detect invalid CommonJS export property assignment earlier

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -684,6 +684,10 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        if !is_const && self.error_invalid_commonjs_export_property_assignment(left_idx) {
+            return self.get_type_of_node(right_idx);
+        }
+
         if !is_const && self.is_commonjs_exports_property_declaration(left_idx) {
             // In JS files, `exports.X = value` is a declaration, not an assignment.
             // The type is inferred from the union of all assigned values, so individual
@@ -840,10 +844,6 @@ impl<'a> CheckerState<'a> {
         let suppress_for_readonly = is_readonly_target && !is_element_access;
 
         if !is_const && self.error_top_level_js_this_computed_element_assignment(left_idx) {
-            return right_type;
-        }
-
-        if !is_const && self.error_invalid_commonjs_export_property_assignment(left_idx) {
             return right_type;
         }
 

--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -722,9 +722,9 @@ impl<'a> CheckerState<'a> {
         }
 
         let surface = self.resolve_js_export_surface(self.ctx.current_file_idx);
-        let Some(direct_export_type) = surface.direct_export_type else {
-            return false;
-        };
+        let direct_export_type = surface
+            .direct_export_type
+            .unwrap_or_else(|| self.get_type_of_node(access.expression));
         if crate::query_boundaries::js_exports::commonjs_direct_export_supports_named_props(
             self.ctx.types,
             direct_export_type,

--- a/crates/tsz-checker/tests/js_export_surface_tests.rs
+++ b/crates/tsz-checker/tests/js_export_surface_tests.rs
@@ -1922,10 +1922,7 @@ mod1.f();
     );
 }
 
-// TODO: the prelude-based test environment doesn't provide enough global types
-// (Object, RegExp, etc.), causing TS2318 floods that mask the actual TS2339.
 #[test]
-#[ignore = "regressed after remote changes: TS2318 floods from missing global types mask actual TS2339"]
 fn test_primitive_module_exports_assignment_reports_same_file_property_error_with_prelude() {
     let diagnostics = check_commonjs_file_with_prelude(
         "requires.d.ts",


### PR DESCRIPTION
## Summary

Two related fixes so invalid CommonJS export property assignments surface a TS2339 instead of being masked:

1. In `assignment_ops`, call `error_invalid_commonjs_export_property_assignment` **before** the general assignability flow so the diagnostic fires and the expression returns the RHS type immediately, rather than after the non-const assignability branch that previously shadowed it.
2. In `commonjs_assignment`, when the JS export surface doesn't yet have a `direct_export_type` (seen when primitive `module.exports = …` is later mutated via `exports.X = …`), fall back to the access expression's actual type instead of bailing out of the check. Lets the "cannot add property on primitive" path fire consistently.

## Target

Unignores the regression test `test_primitive_module_exports_assignment_reports_same_file_property_error_with_prelude`, which was marked `#[ignore]` because "TS2318 floods from missing global types mask actual TS2339" — the ordering fix resolves that masking.

## Test plan

- [x] Previously-ignored test now passes: `cargo nextest run -p tsz-checker --test js_export_surface_tests -E 'test(test_primitive_module_exports_assignment_reports_same_file_property_error_with_prelude)'` — 1/1 pass.
- [x] `cargo nextest run -p tsz-checker --test js_export_surface_tests` — 65/65 pass.
- [x] `cargo nextest run -p tsz-checker --lib` — 2598/2598 pass.
- [x] Pre-commit full workspace test suite — 12925+ tests passing.

## Notes

Recovered from an interrupted parallel agent worktree (codex/conformance-20260421172436-09). Full conformance suite not re-run in this session; relying on pre-commit full test run for unit-test parity.