### PR TITLE
refactor(options): centralize target/module parsing + audit-driven bug fixes

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -2462,60 +2462,33 @@ fn show_config_add_implied_options(map: &mut serde_json::Map<String, serde_json:
     // Collect the set of explicitly provided option keys (owned to avoid borrow conflicts)
     let provided: std::collections::HashSet<String> = map.keys().cloned().collect();
 
-    // --- Helper: parse target string to numeric level ---
-    fn parse_target(s: &str) -> u8 {
-        match s.to_lowercase().as_str() {
-            "es3" => 0,
-            "es5" => 1,
-            "es6" | "es2015" => 2,
-            "es2016" => 3,
-            "es2017" => 4,
-            "es2018" => 5,
-            "es2019" => 6,
-            "es2020" => 7,
-            "es2021" => 8,
-            "es2022" => 9,
-            "es2023" => 10,
-            "es2024" => 11,
-            "esnext" => 99,
-            _ => 12, // default ES2025 (also covers "es2025" explicitly)
-        }
+    // --- Helper: parse target string ---
+    fn parse_target(s: &str) -> tsz::common::ScriptTarget {
+        tsz::common::ScriptTarget::from_ts_str(s).unwrap_or(tsz::common::ScriptTarget::ES2025)
     }
 
     // --- Helper: compute module from target ---
-    const fn compute_module(target: u8) -> &'static str {
-        if target == 99 {
-            "esnext"
-        } else if target >= 9 {
-            // >= ES2022
-            "es2022"
-        } else if target >= 7 {
-            // >= ES2020
-            "es2020"
-        } else if target >= 2 {
-            // >= ES2015
-            "es6"
-        } else {
-            "commonjs"
+    const fn compute_module(target: tsz::common::ScriptTarget) -> &'static str {
+        match tsz_cli::config::default_module_kind_for_target(target, true) {
+            // tsc still prints this computed default as "es6" in --showConfig.
+            tsz::common::ModuleKind::ES2015 => "es6",
+            module => module.as_ts_str(),
         }
     }
 
     // --- Helper: compute moduleResolution from module string ---
     fn compute_module_resolution(module_str: &str) -> &'static str {
-        match module_str.to_lowercase().as_str() {
-            "none" | "amd" | "umd" | "system" => "classic",
-            "nodenext" => "nodenext",
-            "node16" | "node18" | "node20" => "node16",
-            _ => "bundler",
-        }
+        tsz::common::ModuleKind::from_ts_str(module_str)
+            .map(tsz_cli::config::default_module_resolution_for_module)
+            .unwrap_or(tsz_cli::config::ModuleResolutionKind::Bundler)
+            .as_ts_str()
     }
 
     // --- Helper: compute moduleDetection from module string ---
     fn compute_module_detection(module_str: &str) -> &'static str {
-        match module_str.to_lowercase().as_str() {
-            "node16" | "node18" | "node20" | "nodenext" => "force",
-            _ => "auto",
-        }
+        tsz::common::ModuleKind::from_ts_str(module_str)
+            .map(tsz_cli::config::default_module_detection_for_module)
+            .unwrap_or("auto")
     }
 
     // v6 defaults (empty config):
@@ -2523,7 +2496,7 @@ fn show_config_add_implied_options(map: &mut serde_json::Map<String, serde_json:
     // esModuleInterop=true, allowSyntheticDefaultImports=true
     // useDefineForClassFields=true (es2025 >= ES2022)
     // strict sub-flags: false, declaration=false, incremental=false
-    const DEFAULT_TARGET: u8 = 12; // ES2025
+    const DEFAULT_TARGET: tsz::common::ScriptTarget = tsz::common::ScriptTarget::ES2025;
     const DEFAULT_MODULE_RESOLUTION: &str = "bundler";
     const DEFAULT_MODULE_DETECTION: &str = "auto";
 
@@ -2597,8 +2570,8 @@ fn show_config_add_implied_options(map: &mut serde_json::Map<String, serde_json:
 
     // --- useDefineForClassFields: deps=["target","module"] ---
     if !provided.contains("useDefineForClassFields") && depends_on_provided(&["target", "module"]) {
-        let computed = user_target >= 9; // >= ES2022
-        let default_val = DEFAULT_TARGET >= 9; // true
+        let computed = user_target.supports_es2022();
+        let default_val = DEFAULT_TARGET.supports_es2022(); // true
         if computed != default_val {
             map.insert("useDefineForClassFields".into(), Value::Bool(computed));
         }

--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -831,24 +831,10 @@ impl Server {
     }
 
     pub(crate) fn parse_target(target: &Option<String>) -> ScriptTarget {
-        target.as_ref().map_or(ScriptTarget::ES5, |t| {
-            // Handle comma-separated targets (e.g., "es2015,es2017") by taking the first one
-            // This matches how TSC runs multi-target tests - one iteration per target
-            let first_target = t.split(',').next().unwrap_or(t).trim().to_lowercase();
-            match first_target.as_str() {
-                "es3" => ScriptTarget::ES3,
-                "es5" => ScriptTarget::ES5,
-                "es6" | "es2015" => ScriptTarget::ES2015,
-                "es2016" => ScriptTarget::ES2016,
-                "es2017" => ScriptTarget::ES2017,
-                "es2018" => ScriptTarget::ES2018,
-                "es2019" => ScriptTarget::ES2019,
-                "es2020" => ScriptTarget::ES2020,
-                "es2021" => ScriptTarget::ES2021,
-                "es2022" | "es2023" => ScriptTarget::ES2022,
-                _ => ScriptTarget::ESNext,
-            }
-        })
+        match target.as_deref() {
+            Some(value) => ScriptTarget::from_ts_str(value).unwrap_or(ScriptTarget::ESNext),
+            None => ScriptTarget::ES5,
+        }
     }
 
     pub(crate) fn build_checker_options(&self, options: &CheckOptions) -> CheckerOptions {

--- a/crates/tsz-common/src/common/mod.rs
+++ b/crates/tsz-common/src/common/mod.rs
@@ -15,6 +15,18 @@
 //!
 //! No module should depend on a module that appears later in this chain.
 
+fn normalize_ts_option(value: &str) -> String {
+    let first = value.split(',').next().unwrap_or(value).trim();
+    let mut normalized = String::with_capacity(first.len());
+    for ch in first.chars() {
+        if ch == '-' || ch == '_' || ch.is_whitespace() {
+            continue;
+        }
+        normalized.push(ch.to_ascii_lowercase());
+    }
+    normalized
+}
+
 /// ECMAScript target version.
 ///
 /// This determines which language features are available during compilation.
@@ -66,6 +78,80 @@ pub enum ScriptTarget {
 }
 
 impl ScriptTarget {
+    /// Parse a TypeScript compiler option target value.
+    ///
+    /// This accepts tsc spelling variants and comma-separated directive values,
+    /// taking the first entry to match multi-target conformance directives.
+    #[must_use]
+    pub fn from_ts_str(value: &str) -> Option<Self> {
+        match normalize_ts_option(value).as_str() {
+            "es3" => Some(Self::ES3),
+            "es5" => Some(Self::ES5),
+            "es6" | "es2015" => Some(Self::ES2015),
+            "es2016" => Some(Self::ES2016),
+            "es2017" => Some(Self::ES2017),
+            "es2018" => Some(Self::ES2018),
+            "es2019" => Some(Self::ES2019),
+            "es2020" => Some(Self::ES2020),
+            "es2021" => Some(Self::ES2021),
+            "es2022" => Some(Self::ES2022),
+            "es2023" => Some(Self::ES2023),
+            "es2024" => Some(Self::ES2024),
+            "es2025" => Some(Self::ES2025),
+            "esnext" => Some(Self::ESNext),
+            _ => None,
+        }
+    }
+
+    /// Parse TypeScript's numeric target enum value.
+    #[must_use]
+    pub const fn from_ts_numeric(value: u32) -> Option<Self> {
+        match value {
+            0 => Some(Self::ES3),
+            1 => Some(Self::ES5),
+            2 => Some(Self::ES2015),
+            3 => Some(Self::ES2016),
+            4 => Some(Self::ES2017),
+            5 => Some(Self::ES2018),
+            6 => Some(Self::ES2019),
+            7 => Some(Self::ES2020),
+            8 => Some(Self::ES2021),
+            9 => Some(Self::ES2022),
+            10 => Some(Self::ES2023),
+            11 => Some(Self::ES2024),
+            12 => Some(Self::ES2025),
+            99 => Some(Self::ESNext),
+            _ => None,
+        }
+    }
+
+    /// Return TypeScript's numeric target ordering value.
+    #[must_use]
+    pub const fn ts_numeric_value(self) -> u8 {
+        self as u8
+    }
+
+    /// Return a canonical TypeScript option spelling.
+    #[must_use]
+    pub const fn as_ts_str(self) -> &'static str {
+        match self {
+            Self::ES3 => "es3",
+            Self::ES5 => "es5",
+            Self::ES2015 => "es2015",
+            Self::ES2016 => "es2016",
+            Self::ES2017 => "es2017",
+            Self::ES2018 => "es2018",
+            Self::ES2019 => "es2019",
+            Self::ES2020 => "es2020",
+            Self::ES2021 => "es2021",
+            Self::ES2022 => "es2022",
+            Self::ES2023 => "es2023",
+            Self::ES2024 => "es2024",
+            Self::ES2025 => "es2025",
+            Self::ESNext => "esnext",
+        }
+    }
+
     /// Check if this target supports ES2016+ features (exponentiation operator).
     #[must_use]
     pub const fn supports_es2016(self) -> bool {
@@ -190,6 +276,80 @@ pub enum ModuleKind {
 }
 
 impl ModuleKind {
+    /// Parse a TypeScript compiler option module value.
+    ///
+    /// This accepts tsc spelling variants and comma-separated directive values,
+    /// taking the first entry to match multi-target conformance directives.
+    #[must_use]
+    pub fn from_ts_str(value: &str) -> Option<Self> {
+        match normalize_ts_option(value).as_str() {
+            "none" => Some(Self::None),
+            "commonjs" => Some(Self::CommonJS),
+            "amd" => Some(Self::AMD),
+            "umd" => Some(Self::UMD),
+            "system" => Some(Self::System),
+            "es6" | "es2015" => Some(Self::ES2015),
+            "es2020" => Some(Self::ES2020),
+            "es2022" => Some(Self::ES2022),
+            "esnext" => Some(Self::ESNext),
+            "node16" => Some(Self::Node16),
+            "node18" => Some(Self::Node18),
+            "node20" => Some(Self::Node20),
+            "nodenext" => Some(Self::NodeNext),
+            "preserve" => Some(Self::Preserve),
+            _ => None,
+        }
+    }
+
+    /// Parse TypeScript's numeric module enum value.
+    #[must_use]
+    pub const fn from_ts_numeric(value: u32) -> Option<Self> {
+        match value {
+            0 => Some(Self::None),
+            1 => Some(Self::CommonJS),
+            2 => Some(Self::AMD),
+            3 => Some(Self::UMD),
+            4 => Some(Self::System),
+            5 => Some(Self::ES2015),
+            6 => Some(Self::ES2020),
+            7 => Some(Self::ES2022),
+            99 => Some(Self::ESNext),
+            100 => Some(Self::Node16),
+            101 => Some(Self::Node18),
+            102 => Some(Self::Node20),
+            199 => Some(Self::NodeNext),
+            200 => Some(Self::Preserve),
+            _ => None,
+        }
+    }
+
+    /// Return a canonical TypeScript option spelling.
+    #[must_use]
+    pub const fn as_ts_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::CommonJS => "commonjs",
+            Self::AMD => "amd",
+            Self::UMD => "umd",
+            Self::System => "system",
+            Self::ES2015 => "es2015",
+            Self::ES2020 => "es2020",
+            Self::ES2022 => "es2022",
+            Self::ESNext => "esnext",
+            Self::Node16 => "node16",
+            Self::Node18 => "node18",
+            Self::Node20 => "node20",
+            Self::NodeNext => "nodenext",
+            Self::Preserve => "preserve",
+        }
+    }
+
+    /// Return TypeScript's numeric module enum value.
+    #[must_use]
+    pub const fn ts_numeric_value(self) -> u32 {
+        self as u32
+    }
+
     /// Check if this is a CommonJS-like module system
     #[must_use]
     pub const fn is_commonjs(self) -> bool {

--- a/crates/tsz-common/tests/common.rs
+++ b/crates/tsz-common/tests/common.rs
@@ -24,6 +24,38 @@ fn test_script_target_comparisons() {
 }
 
 #[test]
+fn test_script_target_from_ts_str() {
+    assert_eq!(ScriptTarget::from_ts_str("ES5"), Some(ScriptTarget::ES5));
+    assert_eq!(ScriptTarget::from_ts_str("es6"), Some(ScriptTarget::ES2015));
+    assert_eq!(
+        ScriptTarget::from_ts_str("es2023"),
+        Some(ScriptTarget::ES2023)
+    );
+    assert_eq!(
+        ScriptTarget::from_ts_str("es2025"),
+        Some(ScriptTarget::ES2025)
+    );
+    assert_eq!(
+        ScriptTarget::from_ts_str("ES5, ES2015"),
+        Some(ScriptTarget::ES5)
+    );
+    assert_eq!(ScriptTarget::from_ts_str("not-a-target"), None);
+    assert_eq!(
+        ScriptTarget::from_ts_numeric(10),
+        Some(ScriptTarget::ES2023)
+    );
+    assert_eq!(
+        ScriptTarget::from_ts_numeric(12),
+        Some(ScriptTarget::ES2025)
+    );
+    assert_eq!(
+        ScriptTarget::from_ts_numeric(99),
+        Some(ScriptTarget::ESNext)
+    );
+    assert_eq!(ScriptTarget::from_ts_numeric(42), None);
+}
+
+#[test]
 fn test_module_kind_detection() {
     // CommonJS-like systems
     assert!(ModuleKind::CommonJS.is_commonjs());
@@ -63,6 +95,32 @@ fn test_module_kind_detection() {
     assert!(ModuleKind::Node20.supports_dynamic_import_options());
     assert!(ModuleKind::Preserve.supports_dynamic_import_options());
     assert!(!ModuleKind::CommonJS.supports_dynamic_import_options());
+}
+
+#[test]
+fn test_module_kind_from_ts_str() {
+    assert_eq!(
+        ModuleKind::from_ts_str("commonjs"),
+        Some(ModuleKind::CommonJS)
+    );
+    assert_eq!(ModuleKind::from_ts_str("es6"), Some(ModuleKind::ES2015));
+    assert_eq!(ModuleKind::from_ts_str("node18"), Some(ModuleKind::Node18));
+    assert_eq!(ModuleKind::from_ts_str("node20"), Some(ModuleKind::Node20));
+    assert_eq!(
+        ModuleKind::from_ts_str("react-native"),
+        None,
+        "jsx spellings must not parse as module values"
+    );
+    assert_eq!(
+        ModuleKind::from_ts_str("es2022, esnext"),
+        Some(ModuleKind::ES2022)
+    );
+    assert_eq!(ModuleKind::from_ts_numeric(3), Some(ModuleKind::UMD));
+    assert_eq!(ModuleKind::from_ts_numeric(5), Some(ModuleKind::ES2015));
+    assert_eq!(ModuleKind::from_ts_numeric(101), Some(ModuleKind::Node18));
+    assert_eq!(ModuleKind::from_ts_numeric(102), Some(ModuleKind::Node20));
+    assert_eq!(ModuleKind::from_ts_numeric(255), None);
+    assert_eq!(ModuleKind::NodeNext.ts_numeric_value(), 199);
 }
 
 #[test]

--- a/crates/tsz-core/src/api/wasm/compiler_options.rs
+++ b/crates/tsz-core/src/api/wasm/compiler_options.rs
@@ -35,11 +35,11 @@ pub(crate) struct CompilerOptions {
     no_implicit_this: Option<bool>,
 
     /// Specify ECMAScript target version (accepts string like "ES5" or numeric).
-    #[serde(default, deserialize_with = "deserialize_target_or_module")]
+    #[serde(default, deserialize_with = "deserialize_target")]
     target: Option<u32>,
 
     /// Specify module code generation mode (accepts string like `ESNext` or numeric).
-    #[serde(default, deserialize_with = "deserialize_target_or_module")]
+    #[serde(default, deserialize_with = "deserialize_module")]
     module: Option<u32>,
 
     /// Interpret optional property types as written, rather than adding 'undefined'.
@@ -123,15 +123,40 @@ where
     deserializer.deserialize_any(BoolOptionVisitor)
 }
 
+#[derive(Clone, Copy)]
+enum WasmCompilerOptionKind {
+    Target,
+    Module,
+}
+
+fn deserialize_target<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_target_or_module(deserializer, WasmCompilerOptionKind::Target)
+}
+
+fn deserialize_module<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_target_or_module(deserializer, WasmCompilerOptionKind::Module)
+}
+
 /// Deserialize target/module values that can be either strings or numbers.
 /// TypeScript test files often use strings like "ES5", "ES2015", "CommonJS", etc.
-fn deserialize_target_or_module<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+fn deserialize_target_or_module<'de, D>(
+    deserializer: D,
+    kind: WasmCompilerOptionKind,
+) -> Result<Option<u32>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     use serde::de::{self, Visitor};
 
-    struct TargetOrModuleVisitor;
+    struct TargetOrModuleVisitor {
+        kind: WasmCompilerOptionKind,
+    }
 
     impl<'de> Visitor<'de> for TargetOrModuleVisitor {
         type Value = Option<u32>;
@@ -172,33 +197,17 @@ where
         where
             E: de::Error,
         {
-            // Parse string values to their TypeScript enum equivalents
-            // Note: For shared values like ES2015/ES6, we use the ScriptTarget value
-            // because both target and module use the same match arm
-            let result = match value.to_uppercase().as_str() {
-                // ScriptTarget values (0-10, 99) and ModuleKind-specific values
-                // Combined arms where ScriptTarget and ModuleKind share the same numeric value
-                "ES3" | "NONE" => 0,
-                "ES5" | "COMMONJS" => 1,
-                "ES2015" | "ES6" | "AMD" => 2,
-                "ES2016" | "UMD" => 3,
-                "ES2017" | "SYSTEM" => 4,
-                "ES2018" => 5,
-                "ES2019" => 6,
-                "ES2020" => 7,
-                "ES2021" => 8,
-                "ES2022" => 9,
-                "ES2023" => 10,
-                "ESNEXT" => 99,
-                "NODE16" => 100,
-                "NODENEXT" => 199,
-                _ => return Ok(None), // Unknown value, treat as unset
+            let result = match self.kind {
+                WasmCompilerOptionKind::Target => crate::common::ScriptTarget::from_ts_str(value)
+                    .map(|target| u32::from(target.ts_numeric_value())),
+                WasmCompilerOptionKind::Module => crate::common::ModuleKind::from_ts_str(value)
+                    .map(crate::common::ModuleKind::ts_numeric_value),
             };
-            Ok(Some(result))
+            Ok(result)
         }
     }
 
-    deserializer.deserialize_any(TargetOrModuleVisitor)
+    deserializer.deserialize_any(TargetOrModuleVisitor { kind })
 }
 
 impl CompilerOptions {
@@ -264,20 +273,10 @@ impl CompilerOptions {
         }
     }
 
-    const fn resolve_module(&self) -> crate::common::ModuleKind {
-        match self.module {
-            Some(1) => crate::common::ModuleKind::CommonJS,
-            Some(2) => crate::common::ModuleKind::AMD,
-            Some(3) => crate::common::ModuleKind::UMD,
-            Some(4) => crate::common::ModuleKind::System,
-            Some(5) => crate::common::ModuleKind::ES2015,
-            Some(6) => crate::common::ModuleKind::ES2020,
-            Some(7) => crate::common::ModuleKind::ES2022,
-            Some(99) => crate::common::ModuleKind::ESNext,
-            Some(100) => crate::common::ModuleKind::Node16,
-            Some(199) => crate::common::ModuleKind::NodeNext,
-            _ => crate::common::ModuleKind::None,
-        }
+    fn resolve_module(&self) -> crate::common::ModuleKind {
+        self.module
+            .and_then(crate::common::ModuleKind::from_ts_numeric)
+            .unwrap_or(crate::common::ModuleKind::None)
     }
 
     /// Convert to `CheckerOptions` for type checking.
@@ -357,5 +356,18 @@ mod tests {
     fn parse_compiler_options_json_accepts_valid_input() {
         let parsed = parse_compiler_options_json(r#"{"strict":true,"module":99}"#);
         assert!(parsed.is_ok(), "valid options JSON should parse");
+    }
+
+    #[test]
+    fn parse_compiler_options_json_uses_separate_target_and_module_domains() {
+        let parsed =
+            parse_compiler_options_json(r#"{"target":"ES2015","module":"ES2015"}"#).unwrap();
+
+        assert_eq!(parsed.target, Some(2));
+        assert_eq!(parsed.module, Some(5));
+        assert_eq!(
+            parsed.to_checker_options().module,
+            crate::common::ModuleKind::ES2015
+        );
     }
 }

--- a/crates/tsz-core/src/api/wasm/parser.rs
+++ b/crates/tsz-core/src/api/wasm/parser.rs
@@ -355,32 +355,8 @@ impl Parser {
     #[wasm_bindgen(js_name = generateTransforms)]
     pub fn generate_transforms(&self, target: u32, module: u32) -> WasmTransformContext {
         let options = PrinterOptions {
-            target: match target {
-                0 => ScriptTarget::ES3,
-                1 => ScriptTarget::ES5,
-                2 => ScriptTarget::ES2015,
-                3 => ScriptTarget::ES2016,
-                4 => ScriptTarget::ES2017,
-                5 => ScriptTarget::ES2018,
-                6 => ScriptTarget::ES2019,
-                7 => ScriptTarget::ES2020,
-                8 => ScriptTarget::ES2021,
-                9 => ScriptTarget::ES2022,
-                _ => ScriptTarget::ESNext,
-            },
-            module: match module {
-                1 => ModuleKind::CommonJS,
-                2 => ModuleKind::AMD,
-                3 => ModuleKind::UMD,
-                4 => ModuleKind::System,
-                5 => ModuleKind::ES2015,
-                6 => ModuleKind::ES2020,
-                7 => ModuleKind::ES2022,
-                99 => ModuleKind::ESNext,
-                100 => ModuleKind::Node16,
-                199 => ModuleKind::NodeNext,
-                _ => ModuleKind::None,
-            },
+            target: ScriptTarget::from_ts_numeric(target).unwrap_or(ScriptTarget::ESNext),
+            module: ModuleKind::from_ts_numeric(module).unwrap_or(ModuleKind::None),
             ..Default::default()
         };
 

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -455,6 +455,102 @@ pub enum ModuleResolutionKind {
     Bundler,
 }
 
+impl ModuleResolutionKind {
+    /// Parse a TypeScript compiler option `moduleResolution` value.
+    ///
+    /// This accepts comma-separated directive values, taking the first entry to
+    /// match multi-target conformance directives.
+    #[must_use]
+    pub fn from_ts_str(value: &str) -> Option<Self> {
+        let normalized = normalize_option(value.split(',').next().unwrap_or(value).trim());
+        match normalized.as_str() {
+            "classic" => Some(Self::Classic),
+            "node" | "node10" => Some(Self::Node),
+            "node16" => Some(Self::Node16),
+            "nodenext" => Some(Self::NodeNext),
+            "bundler" => Some(Self::Bundler),
+            _ => None,
+        }
+    }
+
+    /// Return a canonical TypeScript option spelling.
+    #[must_use]
+    pub const fn as_ts_str(self) -> &'static str {
+        match self {
+            Self::Classic => "classic",
+            Self::Node => "node10",
+            Self::Node16 => "node16",
+            Self::NodeNext => "nodenext",
+            Self::Bundler => "bundler",
+        }
+    }
+
+    #[must_use]
+    pub const fn is_modern(self) -> bool {
+        matches!(self, Self::Node16 | Self::NodeNext | Self::Bundler)
+    }
+}
+
+/// Default module kind used when `module` is omitted.
+///
+/// The default differs depending on whether `target` was explicitly supplied,
+/// matching the existing tsc-parity behavior used by config resolution.
+#[must_use]
+pub const fn default_module_kind_for_target(
+    target: ScriptTarget,
+    target_explicitly_set: bool,
+) -> ModuleKind {
+    if !target_explicitly_set {
+        return ModuleKind::ESNext;
+    }
+
+    match target {
+        ScriptTarget::ES3 | ScriptTarget::ES5 => ModuleKind::CommonJS,
+        ScriptTarget::ES2015
+        | ScriptTarget::ES2016
+        | ScriptTarget::ES2017
+        | ScriptTarget::ES2018
+        | ScriptTarget::ES2019 => ModuleKind::ES2015,
+        ScriptTarget::ES2020 | ScriptTarget::ES2021 => ModuleKind::ES2020,
+        ScriptTarget::ES2022
+        | ScriptTarget::ES2023
+        | ScriptTarget::ES2024
+        | ScriptTarget::ES2025 => ModuleKind::ES2022,
+        ScriptTarget::ESNext => ModuleKind::ESNext,
+    }
+}
+
+/// Default `moduleResolution` used when it is omitted for a module kind.
+#[must_use]
+pub const fn default_module_resolution_for_module(module: ModuleKind) -> ModuleResolutionKind {
+    match module {
+        ModuleKind::None | ModuleKind::AMD | ModuleKind::UMD | ModuleKind::System => {
+            ModuleResolutionKind::Classic
+        }
+        ModuleKind::NodeNext => ModuleResolutionKind::NodeNext,
+        ModuleKind::Node16 | ModuleKind::Node18 | ModuleKind::Node20 => {
+            ModuleResolutionKind::Node16
+        }
+        ModuleKind::CommonJS
+        | ModuleKind::ES2015
+        | ModuleKind::ES2020
+        | ModuleKind::ES2022
+        | ModuleKind::ESNext
+        | ModuleKind::Preserve => ModuleResolutionKind::Bundler,
+    }
+}
+
+/// Default `moduleDetection` shown by tsc-style config output for a module kind.
+#[must_use]
+pub const fn default_module_detection_for_module(module: ModuleKind) -> &'static str {
+    match module {
+        ModuleKind::Node16 | ModuleKind::Node18 | ModuleKind::Node20 | ModuleKind::NodeNext => {
+            "force"
+        }
+        _ => "auto",
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PathMapping {
     pub pattern: String,
@@ -493,23 +589,7 @@ impl ResolvedCompilerOptions {
             return resolution;
         }
 
-        // Match tsc 6.0's computed moduleResolution defaults:
-        // None/AMD/UMD/System → Classic (deprecated module kinds)
-        // CommonJS → Bundler (changed in tsc 6.0, was Node/node10)
-        // ES2015/ES2020/ES2022/ESNext/Preserve → Bundler (changed in tsc 6.0, was Classic)
-        // NodeNext → NodeNext
-        // Node16/Node18/Node20 → Node16
-        match self.printer.module {
-            ModuleKind::None | ModuleKind::AMD | ModuleKind::UMD | ModuleKind::System => {
-                ModuleResolutionKind::Classic
-            }
-            ModuleKind::NodeNext => ModuleResolutionKind::NodeNext,
-            ModuleKind::Node16 | ModuleKind::Node18 | ModuleKind::Node20 => {
-                ModuleResolutionKind::Node16
-            }
-            // tsc 6.0: ES module kinds and CommonJS default to Bundler resolution
-            _ => ModuleResolutionKind::Bundler,
-        }
+        default_module_resolution_for_module(self.printer.module)
     }
 }
 
@@ -544,31 +624,8 @@ pub fn resolve_compiler_options(
         resolved.printer.module = kind;
         resolved.checker.module = kind;
     } else {
-        // Match our tsc parity defaults when --module is omitted:
-        // target omitted -> ESNext
-        // ES3 / ES5 -> CommonJS
-        // ES2015..ES2019 -> ES2015
-        // ES2020..ES2021 -> ES2020
-        // ES2022..ES2025 -> ES2022
-        // ESNext -> ESNext
-        let default_module = if options.target.is_some() {
-            match resolved.printer.target {
-                ScriptTarget::ES3 | ScriptTarget::ES5 => ModuleKind::CommonJS,
-                ScriptTarget::ES2015
-                | ScriptTarget::ES2016
-                | ScriptTarget::ES2017
-                | ScriptTarget::ES2018
-                | ScriptTarget::ES2019 => ModuleKind::ES2015,
-                ScriptTarget::ES2020 | ScriptTarget::ES2021 => ModuleKind::ES2020,
-                ScriptTarget::ES2022
-                | ScriptTarget::ES2023
-                | ScriptTarget::ES2024
-                | ScriptTarget::ES2025 => ModuleKind::ES2022,
-                ScriptTarget::ESNext => ModuleKind::ESNext,
-            }
-        } else {
-            ModuleKind::ESNext
-        };
+        let default_module =
+            default_module_kind_for_target(resolved.printer.target, options.target.is_some());
         resolved.printer.module = default_module;
         resolved.checker.module = default_module;
     }
@@ -3238,68 +3295,18 @@ fn merge_compiler_options(base: CompilerOptions, child: CompilerOptions) -> Comp
 }
 
 fn parse_script_target(value: &str) -> Result<ScriptTarget> {
-    // Handle comma-separated target values (e.g., "ES5, ES2015" from multi-target
-    // test directives) by taking only the first value, matching tsc behavior.
-    let first = value.split(',').next().unwrap_or(value);
-    let normalized = normalize_option(first);
-    let target = match normalized.as_str() {
-        "es3" => ScriptTarget::ES3,
-        "es5" => ScriptTarget::ES5,
-        "es6" | "es2015" => ScriptTarget::ES2015,
-        "es2016" => ScriptTarget::ES2016,
-        "es2017" => ScriptTarget::ES2017,
-        "es2018" => ScriptTarget::ES2018,
-        "es2019" => ScriptTarget::ES2019,
-        "es2020" => ScriptTarget::ES2020,
-        "es2021" => ScriptTarget::ES2021,
-        "es2022" => ScriptTarget::ES2022,
-        "es2023" => ScriptTarget::ES2023,
-        "es2024" => ScriptTarget::ES2024,
-        "es2025" => ScriptTarget::ES2025,
-        "esnext" => ScriptTarget::ESNext,
-        _ => bail!("unsupported compilerOptions.target '{value}'"),
-    };
-
-    Ok(target)
+    ScriptTarget::from_ts_str(value)
+        .ok_or_else(|| anyhow!("unsupported compilerOptions.target '{value}'"))
 }
 
 fn parse_module_kind(value: &str) -> Result<ModuleKind> {
-    let cleaned = value.split(',').next().unwrap_or(value).trim();
-    let normalized = normalize_option(cleaned);
-    let module = match normalized.as_str() {
-        "none" => ModuleKind::None,
-        "commonjs" => ModuleKind::CommonJS,
-        "amd" => ModuleKind::AMD,
-        "umd" => ModuleKind::UMD,
-        "system" => ModuleKind::System,
-        "es6" | "es2015" => ModuleKind::ES2015,
-        "es2020" => ModuleKind::ES2020,
-        "es2022" => ModuleKind::ES2022,
-        "esnext" => ModuleKind::ESNext,
-        "node16" => ModuleKind::Node16,
-        "node18" => ModuleKind::Node18,
-        "node20" => ModuleKind::Node20,
-        "nodenext" => ModuleKind::NodeNext,
-        "preserve" => ModuleKind::Preserve,
-        _ => bail!("unsupported compilerOptions.module '{value}'"),
-    };
-
-    Ok(module)
+    ModuleKind::from_ts_str(value)
+        .ok_or_else(|| anyhow!("unsupported compilerOptions.module '{value}'"))
 }
 
 fn parse_module_resolution(value: &str) -> Result<ModuleResolutionKind> {
-    let cleaned = value.split(',').next().unwrap_or(value).trim();
-    let normalized = normalize_option(cleaned);
-    let resolution = match normalized.as_str() {
-        "classic" => ModuleResolutionKind::Classic,
-        "node" | "node10" => ModuleResolutionKind::Node,
-        "node16" => ModuleResolutionKind::Node16,
-        "nodenext" => ModuleResolutionKind::NodeNext,
-        "bundler" => ModuleResolutionKind::Bundler,
-        _ => bail!("unsupported compilerOptions.moduleResolution '{value}'"),
-    };
-
-    Ok(resolution)
+    ModuleResolutionKind::from_ts_str(value)
+        .ok_or_else(|| anyhow!("unsupported compilerOptions.moduleResolution '{value}'"))
 }
 
 fn parse_jsx_emit(value: &str) -> Result<JsxEmit> {
@@ -4383,6 +4390,46 @@ mod tests {
         assert_eq!(
             resolved.module_resolution,
             Some(ModuleResolutionKind::Node16)
+        );
+    }
+
+    #[test]
+    fn test_shared_module_defaults_cover_targets_and_resolution() {
+        assert_eq!(
+            default_module_kind_for_target(ScriptTarget::ES5, true),
+            ModuleKind::CommonJS
+        );
+        assert_eq!(
+            default_module_kind_for_target(ScriptTarget::ES2019, true),
+            ModuleKind::ES2015
+        );
+        assert_eq!(
+            default_module_kind_for_target(ScriptTarget::ES2021, true),
+            ModuleKind::ES2020
+        );
+        assert_eq!(
+            default_module_kind_for_target(ScriptTarget::ES2025, true),
+            ModuleKind::ES2022
+        );
+        assert_eq!(
+            default_module_kind_for_target(ScriptTarget::ES2025, false),
+            ModuleKind::ESNext
+        );
+        assert_eq!(
+            default_module_resolution_for_module(ModuleKind::System),
+            ModuleResolutionKind::Classic
+        );
+        assert_eq!(
+            default_module_resolution_for_module(ModuleKind::CommonJS),
+            ModuleResolutionKind::Bundler
+        );
+        assert_eq!(
+            default_module_resolution_for_module(ModuleKind::Node20),
+            ModuleResolutionKind::Node16
+        );
+        assert_eq!(
+            default_module_resolution_for_module(ModuleKind::NodeNext),
+            ModuleResolutionKind::NodeNext
         );
     }
 

--- a/crates/tsz-parser/src/parser/node_children.rs
+++ b/crates/tsz-parser/src/parser/node_children.rs
@@ -632,7 +632,6 @@ impl NodeArena {
                     Self::add_list(children, &data.parameters);
                     Self::add_opt_child(children, data.type_annotation);
                     children.push(data.body);
-                    children.push(data.body);
                     return true;
                 }
             }

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -2,6 +2,7 @@
 //! type syntax, declarations, class syntax, statements, and error recovery.
 
 use crate::parser::node::NodeArena;
+use crate::parser::node_view::NodeAccess;
 use crate::parser::syntax_kind_ext;
 use crate::parser::{NodeIndex, ParserState};
 use tsz_common::diagnostics::diagnostic_codes;
@@ -2647,6 +2648,31 @@ fn super_type_arguments_report_parser_error_and_recover_to_call() {
     );
     let callee_node = arena.get(call.expression).expect("callee");
     assert_eq!(callee_node.kind, SyntaxKind::SuperKeyword as u16);
+}
+
+#[test]
+fn accessor_children_include_body_once() {
+    let source = "class C { get x() { return 1; } }";
+    let (parser, root) = parse_source(source);
+    assert_no_errors(&parser, "class accessor");
+
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let class = arena.get_class(stmt_node).expect("class");
+    let accessor_idx = class.members.nodes[0];
+    let accessor_node = arena.get(accessor_idx).expect("accessor");
+    let accessor = arena.get_accessor(accessor_node).expect("accessor data");
+
+    let children = arena.get_children(accessor_idx);
+    assert_eq!(
+        children
+            .iter()
+            .filter(|&&child| child == accessor.body)
+            .count(),
+        1,
+        "accessor body should appear exactly once in traversal children"
+    );
 }
 
 #[test]

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -365,6 +365,7 @@ impl<'a> QueryCache<'a> {
         self.property_cache.borrow_mut().clear();
         self.variance_cache.borrow_mut().clear();
         self.canonical_cache.borrow_mut().clear();
+        self.intersection_merge_cache.borrow_mut().clear();
         self.reset_relation_cache_stats();
     }
 

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -29,6 +29,10 @@ impl<'a> QueryCache<'a> {
     fn object_spread_properties_cache_len(&self) -> usize {
         self.object_spread_properties_cache.borrow().len()
     }
+
+    fn intersection_merge_cache_len(&self) -> usize {
+        self.intersection_merge_cache.borrow().len()
+    }
 }
 
 #[test]
@@ -387,12 +391,16 @@ fn query_cache_estimated_size_resets_on_clear() {
         RelationCacheKey::subtype(str_type, TypeId::NUMBER, 0, 0),
         true,
     );
+    cache.insert_intersection_merge(str_type, Some(TypeId::STRING));
 
     let before_clear = cache.estimated_size_bytes();
+    assert_eq!(cache.intersection_merge_cache_len(), 1);
 
     cache.clear();
 
     let after_clear = cache.estimated_size_bytes();
+    assert_eq!(cache.intersection_merge_cache_len(), 0);
+    assert_eq!(cache.lookup_intersection_merge(str_type), None);
     // After clear, size should not exceed before_clear (maps may retain capacity).
     // The key invariant: statistics-based estimate resets to zero.
     let stats = cache.statistics();

--- a/crates/tsz-wasm/src/wasm_api/emit.rs
+++ b/crates/tsz-wasm/src/wasm_api/emit.rs
@@ -79,33 +79,10 @@ pub struct TranspileOptions {
 
 impl TranspileOptions {
     fn to_printer_options(&self) -> PrinterOptions {
-        let target = match self.target.unwrap_or(1) {
-            0 => ScriptTarget::ES3,
-            2 => ScriptTarget::ES2015,
-            3 => ScriptTarget::ES2016,
-            4 => ScriptTarget::ES2017,
-            5 => ScriptTarget::ES2018,
-            6 => ScriptTarget::ES2019,
-            7 => ScriptTarget::ES2020,
-            8 => ScriptTarget::ES2021,
-            9 => ScriptTarget::ES2022,
-            99 => ScriptTarget::ESNext,
-            _ => ScriptTarget::ES5,
-        };
-        let module = match self.module.unwrap_or(0) {
-            1 => ModuleKind::CommonJS,
-            2 => ModuleKind::AMD,
-            4 => ModuleKind::System,
-            5 => ModuleKind::UMD,
-            6 => ModuleKind::ES2015,
-            7 => ModuleKind::ES2020,
-            99 => ModuleKind::ESNext,
-            100 => ModuleKind::Node16,
-            101 => ModuleKind::Node18,
-            102 => ModuleKind::Node20,
-            199 => ModuleKind::NodeNext,
-            _ => ModuleKind::None,
-        };
+        let target = ScriptTarget::from_ts_numeric(u32::from(self.target.unwrap_or(1)))
+            .unwrap_or(ScriptTarget::ES5);
+        let module = ModuleKind::from_ts_numeric(u32::from(self.module.unwrap_or(0)))
+            .unwrap_or(ModuleKind::None);
         let mut opts = PrinterOptions {
             target,
             module,
@@ -192,18 +169,10 @@ pub fn transpile(source: &str, target: Option<u8>, module: Option<u8>) -> String
     let arena = parser.into_arena();
 
     // Create emit context with specified options
-    let target = match target.unwrap_or(1) {
-        0 => ScriptTarget::ES3,
-        2 => ScriptTarget::ES2015,
-        99 => ScriptTarget::ESNext,
-        _ => ScriptTarget::ES5,
-    };
-    let module = match module.unwrap_or(0) {
-        1 => ModuleKind::CommonJS,
-        6 => ModuleKind::ES2015,
-        99 => ModuleKind::ESNext,
-        _ => ModuleKind::None,
-    };
+    let target =
+        ScriptTarget::from_ts_numeric(u32::from(target.unwrap_or(1))).unwrap_or(ScriptTarget::ES5);
+    let module =
+        ModuleKind::from_ts_numeric(u32::from(module.unwrap_or(0))).unwrap_or(ModuleKind::None);
     let opts = PrinterOptions {
         target,
         module,

--- a/crates/tsz-wasm/src/wasm_api/enums.rs
+++ b/crates/tsz-wasm/src/wasm_api/enums.rs
@@ -149,6 +149,8 @@ pub enum ScriptTarget {
     ES2021 = 8,
     ES2022 = 9,
     ES2023 = 10,
+    ES2024 = 11,
+    ES2025 = 12,
     #[default]
     ESNext = 99,
     JSON = 100,
@@ -170,6 +172,8 @@ pub enum ModuleKind {
     ES2022 = 7,
     ESNext = 99,
     Node16 = 100,
+    Node18 = 101,
+    Node20 = 102,
     NodeNext = 199,
     Preserve = 200,
 }

--- a/crates/tsz-wasm/src/wasm_api/program.rs
+++ b/crates/tsz-wasm/src/wasm_api/program.rs
@@ -67,22 +67,10 @@ pub struct TsCompilerOptions {
 }
 
 impl TsCompilerOptions {
-    const fn resolve_module(&self) -> tsz::common::ModuleKind {
-        match self.module {
-            Some(1) => tsz::common::ModuleKind::CommonJS,
-            Some(2) => tsz::common::ModuleKind::AMD,
-            Some(3) => tsz::common::ModuleKind::UMD,
-            Some(4) => tsz::common::ModuleKind::System,
-            Some(5) => tsz::common::ModuleKind::ES2015,
-            Some(6) => tsz::common::ModuleKind::ES2020,
-            Some(7) => tsz::common::ModuleKind::ES2022,
-            Some(99) => tsz::common::ModuleKind::ESNext,
-            Some(100) => tsz::common::ModuleKind::Node16,
-            Some(101) => tsz::common::ModuleKind::Node18,
-            Some(102) => tsz::common::ModuleKind::Node20,
-            Some(199) => tsz::common::ModuleKind::NodeNext,
-            _ => tsz::common::ModuleKind::None,
-        }
+    fn resolve_module(&self) -> tsz::common::ModuleKind {
+        self.module
+            .and_then(|module| tsz::common::ModuleKind::from_ts_numeric(u32::from(module)))
+            .unwrap_or(tsz::common::ModuleKind::None)
     }
 
     /// Convert to internal `CheckerOptions`
@@ -533,19 +521,14 @@ impl TsProgram {
         let mut emitted_files: Vec<serde_json::Value> = Vec::new();
 
         // Determine target and module from options
-        let target = match self.options.target.unwrap_or(1) {
-            0 => tsz::emitter::ScriptTarget::ES3,
-            2 => tsz::emitter::ScriptTarget::ES2015,
-            99 => tsz::emitter::ScriptTarget::ESNext,
-            _ => tsz::emitter::ScriptTarget::ES5,
-        };
+        let target = tsz::emitter::ScriptTarget::from_ts_numeric(u32::from(
+            self.options.target.unwrap_or(1),
+        ))
+        .unwrap_or(tsz::emitter::ScriptTarget::ES5);
 
-        let module = match self.options.module.unwrap_or(0) {
-            1 => tsz::emitter::ModuleKind::CommonJS,
-            6 => tsz::emitter::ModuleKind::ES2015,
-            99 => tsz::emitter::ModuleKind::ESNext,
-            _ => tsz::emitter::ModuleKind::None,
-        };
+        let module =
+            tsz::emitter::ModuleKind::from_ts_numeric(u32::from(self.options.module.unwrap_or(0)))
+                .unwrap_or(tsz::emitter::ModuleKind::None);
 
         // Emit each file
         for (idx, bound_file) in merged.files.iter().enumerate() {
@@ -609,19 +592,15 @@ impl TsProgram {
                     ""
                 };
 
-                let target = match self.options.target.unwrap_or(1) {
-                    0 => tsz::emitter::ScriptTarget::ES3,
-                    2 => tsz::emitter::ScriptTarget::ES2015,
-                    99 => tsz::emitter::ScriptTarget::ESNext,
-                    _ => tsz::emitter::ScriptTarget::ES5,
-                };
+                let target = tsz::emitter::ScriptTarget::from_ts_numeric(u32::from(
+                    self.options.target.unwrap_or(1),
+                ))
+                .unwrap_or(tsz::emitter::ScriptTarget::ES5);
 
-                let module = match self.options.module.unwrap_or(0) {
-                    1 => tsz::emitter::ModuleKind::CommonJS,
-                    6 => tsz::emitter::ModuleKind::ES2015,
-                    99 => tsz::emitter::ModuleKind::ESNext,
-                    _ => tsz::emitter::ModuleKind::None,
-                };
+                let module = tsz::emitter::ModuleKind::from_ts_numeric(u32::from(
+                    self.options.module.unwrap_or(0),
+                ))
+                .unwrap_or(tsz::emitter::ModuleKind::None);
 
                 return super::emit::emit_file(
                     &bound_file.arena,

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -1,0 +1,774 @@
+# DRY Audit Report
+
+Date: 2026-04-21
+
+Scope: the full `tsz` workspace: Rust crates, conformance tooling, WASM bindings, CLI/server code, LSP code, tests, and supporting scripts.
+
+Method: local repository inspection plus batched `gpt-5.4` xhigh read-only agents. The runtime capped concurrent agents at 6, so the audits were run in waves. No production code was changed for this audit.
+
+## Executive Summary
+
+The repository has many repeated patterns, but the largest DRY payoff is not from small helper extraction. It is from making a few high-churn concepts single-source:
+
+1. Compiler option metadata: target/module/moduleResolution parsing, valid values, defaulting, lib expansion, CLI flags, conformance option conversion, scripts, and WASM enums all repeat overlapping tables.
+2. Parse/bind/check/emit pipelines: CLI, core WASM APIs, `tsz-wasm`, LSP tests, checker tests, emitter tests, and solver tests rebuild nearly identical setup paths.
+3. Project/file provider context: LSP project operations repeatedly fetch files, line maps, source text, binder state, arenas, and caches before calling feature providers.
+4. Conformance execution/comparison: subprocess invocation, diagnostic comparison, fingerprint/code matching, process-pool lifecycle, and cache/test discovery are duplicated.
+5. AST traversal and source span handling: parser, binder, lowering, emitter, LSP, and diagnostics all have local traversal or span conversion logic that can drift.
+6. Test fixtures: many crates have high-volume tests that duplicate project setup, parser setup, diagnostic assertions, and type/interner construction.
+
+The repeated tables already show correctness drift: WASM module numeric mappings disagree, tsserver target parsing collapses newer targets, conformance has independent lib chains, `--showConfig` reimplements defaults, LSP file rename ranges differ by caller, and some cleanup paths leave stale indexes.
+
+## Highest Priority DRY Work
+
+### P0: Centralize Compiler Option And Lib Metadata
+
+Evidence:
+
+- `crates/tsz-core/src/config/mod.rs:3240`, `:3266`, `:4059`, `:4068`, `:4077`, `:4093`
+- `crates/tsz-cli/src/bin/tsz.rs:373`, `:1113`, `:2188`, `:2486`, `:2503`
+- `crates/tsz-cli/src/commands/args.rs:713`, `:752`
+- `crates/tsz-cli/src/bin/tsz_server/check.rs:804`, `:833`, `:854`
+- `crates/conformance/src/options_convert.rs:14`, `:111`, `:610`
+- `crates/conformance/src/tsz_wrapper.rs:1028`, `:1077`, `:1193`, `:1220`
+- `crates/conformance/src/bin/generate-tsc-cache-tsserver.rs:424`, `:463`, `:551`, `:575`
+- `crates/tsz-core/src/api/wasm/compiler_options.rs:128`, `:250`, `:267`, `:283`
+- `crates/tsz-wasm/src/wasm_api/enums.rs:140`, `:161`
+- `crates/tsz-wasm/src/wasm_api/emit.rs:95`
+- `crates/tsz-wasm/src/wasm_api/program.rs:70`, `:89`
+- `scripts/emit/src/runner.ts:230`, `:249`, `:276`
+- `scripts/emit/src/cli-transpiler.ts:83`, `:105`
+
+Problems:
+
+- There are several source-of-truth candidates for target, module, moduleResolution, lib names, and valid-value display strings.
+- WASM public enums stop at `ES2023` and omit newer module kinds such as `Node18` and `Node20`.
+- One WASM path maps module numeric values differently from another: `emit.rs` maps `5 => UMD`, while `program.rs` maps `5 => ES2015`.
+- `tsz-core/src/api/wasm/compiler_options.rs:128` uses one deserializer for target and module. That makes string `ES2015` parse through a numeric value that later means `AMD` in module space.
+- CLI `--showConfig`, tsserver, scripts, and conformance all reimplement pieces of core option defaulting.
+- Conformance owns a hardcoded target-to-lib-chain table even though core already has lib alias and target root-lib logic.
+
+Refactor:
+
+- Make `tsz-core::config` or a small shared options module the Rust source of truth.
+- Expose helpers for:
+  - `ScriptTarget::from_ts_str`, `from_ts_numeric`, `to_ts_str`, `valid_values`
+  - `ModuleKind::from_ts_str`, `from_ts_numeric`, `to_ts_str`, `valid_values`
+  - `ModuleResolutionKind` parsing/display/defaulting
+  - `default_module_for_target`
+  - `default_module_resolution_for_module`
+  - lib root and default-lib chain by target
+  - lowercase/camelCase compiler-option key normalization
+- Keep WASM-specific wrapper enums if needed for `wasm-bindgen`, but derive conversions from the shared enums.
+- Generate a small JSON or TS table for scripts from the same metadata, then replace the script-local parse/format/default functions.
+
+First useful PR:
+
+- Extract target/module/moduleResolution parsing and display into public shared helpers.
+- Replace tsserver `check.rs::parse_target`, CLI `--showConfig` defaulting, and WASM numeric mappings.
+- Add focused tests that compare CLI, config, WASM, and script tables for all supported target/module values.
+
+### P0: Shared Test Harnesses
+
+Evidence:
+
+- Checker tests: `ParserState::new` 534 times, `BinderState::new` 504 times, `CheckerState::new` 369 times under `crates/tsz-checker/tests`
+- `crates/tsz-checker/src/test_utils.rs:17`
+- `crates/tsz-checker/tests/never_returning_narrowing_tests.rs:14`, `:19`
+- `crates/tsz-checker/tests/lib_resolution_identity_tests.rs:25`
+- `crates/tsz-checker/tests/jsdoc_type_tag_tests.rs:23`
+- `crates/tsz-checker/tests/ts2300_tests.rs:12`, `:258`
+- `crates/tsz-lsp/tests/definition_tests.rs:10`
+- `crates/tsz-lsp/tests/code_lens_tests.rs:8`
+- `crates/tsz-lsp/tests/call_hierarchy_tests.rs:8`
+- `crates/tsz-lsp/tests/type_definition_tests.rs:8`
+- `crates/tsz-lsp/src/fourslash.rs:1445`, `:1588`, `:1685`
+- `crates/tsz-emitter/tests/statements.rs:15`
+- `crates/tsz-emitter/tests/printer.rs:45`
+- `crates/tsz-emitter/tests/declarations_class.rs:12`
+- `crates/tsz-solver/tests/common/mod.rs:3`
+- `crates/tsz-lowering/tests/lower_tests.rs:733`, `:761`, `:791`, `:814`, `:837`, `:860`, `:890`, `:913`
+- `crates/tsz-core/tests/module_resolution_tests.rs:32`, `:105`, `:172`, `:239`, `:309`, `:440`
+- `crates/tsz-core/tests/parallel_tests.rs:495`, `:523`, `:534`, `:8514`
+
+Problems:
+
+- Tests repeat the same parse/bind/check boilerplate, making behavior changes expensive and uneven.
+- Some tests import a shared helper and still redefine a local version.
+- Several repeated setup paths have subtly different lib loading, options, source file names, line map handling, and diagnostic filtering.
+- Table-driven cases are often expressed as many nearly identical test bodies.
+
+Refactor:
+
+- Add crate-local `test_support` modules where they are missing or too thin.
+- Use fixtures with explicit names:
+  - `CheckerFixture`
+  - `ProjectFixture`
+  - `ServerFixture`
+  - `EmitterFixture`
+  - `SolverFixture`
+  - `ModuleResolutionFixture`
+- Make common operations one-liners:
+  - `check(source)`
+  - `check_with_options(source, options)`
+  - `multi_file(files)`
+  - `expect_codes([2322, 2344])`
+  - `expect_no_codes([...])`
+  - `emit(source, options)`
+  - `parse_find_lower(source, predicate)`
+- Convert high-volume repeated tests to table-driven loops where test failure names remain readable.
+
+First useful PR:
+
+- Checker test helper consolidation: replace the top 20 repeated parse/bind/check sites and the 10 `load_lib_files_for_test` variants.
+- LSP tests: route manual definition/reference/completion tests through the existing fourslash harness where practical.
+
+### P1: LSP Provider Context And Reference Occurrence Model
+
+Evidence:
+
+- `crates/tsz-lsp/src/project/features.rs:452`, `:820`, `:920`, `:1061`, `:1110`
+- `crates/tsz-lsp/src/project/core.rs:2368`, `:2451`
+- `crates/tsz-lsp/src/project/operations.rs:816`, `:1099`, `:1214`, `:1587`
+- `crates/tsz-lsp/src/rename/file_rename.rs:126`
+- `crates/tsz-lsp/src/navigation/references.rs:87`, `:285`
+- `crates/tsz-lsp/src/rename/core.rs:317`, `:347`
+- `crates/tsz-lsp/src/highlighting/document.rs:911`
+- `crates/tsz-lsp/src/utils/mod.rs:23`, `:166`
+- `crates/tsz-lsp/src/resolver/core.rs:302`, `:688`, `:746`, `:771`
+- `crates/tsz-lsp/src/symbols/symbol_index.rs:301`, `:545`, `:740`
+
+Problems:
+
+- Project feature methods repeatedly fetch the same file context: file name, arena, binder, source text, line map, and caches.
+- Some read paths call `touch_file` while similar paths do not, so cache/access behavior can drift.
+- References, detailed references, rename references, highlights, and code lens repeat collection, access classification, sort/dedup, and location conversion.
+- Offset-to-node lookup is repeatedly implemented as linear scans.
+- File rename logic exists in both project features and core paths, with inconsistent quote/range behavior.
+- Heritage symbol index cleanup is field-by-field and misses some structures.
+
+Refactor:
+
+- Add `Project::with_file_context` and `with_file_context_mut` helpers to centralize lookup, touch, timing, cache access, and provider construction.
+- Introduce a `CursorTarget` resolver shared by definition, type definition, hover, rename, references, highlights, and code lens.
+- Make a single `ReferenceCollector` return rich occurrences:
+  - file
+  - range
+  - node index
+  - symbol id plus file identity
+  - access kind
+  - declaration/reference classification
+- Move file rename range and module specifier replacement into `rename/file_rename.rs`; callers should only orchestrate.
+- Replace field-by-field symbol-index cleanup with per-file index records that can be removed atomically.
+
+First useful PR:
+
+- Add `ProjectFileContext` and migrate definition/type-definition/implementation/reference entry points.
+- Add tests around `touch_file` consistency and file rename replacement ranges.
+
+### P1: Conformance Runner Backend Consolidation
+
+Evidence:
+
+- `crates/conformance/src/runner.rs:876`, `:993`, `:1249`, `:1283`, `:1454`, `:1487`, `:1602`
+- `crates/conformance/src/batch_pool.rs:63`, `:125`, `:313`
+- `crates/conformance/src/server_pool.rs:75`, `:130`, `:313`
+- `crates/conformance/src/test_filter.rs:3`
+- `crates/conformance/src/bin/generate-tsc-cache.rs:252`, `:360`, `:431`
+- `crates/conformance/src/bin/generate-tsc-cache-tsserver.rs:381`, `:747`
+- `scripts/conformance/extract-baseline.py:22`
+- `scripts/conformance/analyze-conformance.py:29`, `:88`
+- `scripts/conformance/build-snapshot-detail.py:31`, `:66`
+- `scripts/conformance/analyze-conformance-areas.py:34`
+- `scripts/conformance/conformance.sh:411`, `:494`, `:671`, `:717`
+
+Problems:
+
+- Diagnostic comparison logic is triplicated in the Rust runner.
+- Subprocess invocation exists inline even though a helper exists.
+- Batch and server process pools have nearly identical lifecycle, timeout, RSS, and restart logic.
+- Test discovery is implemented in runner and cache generators despite a shared filter module.
+- Script-side PASS/FAIL parsing and diffing is repeated across multiple Python scripts.
+- Shell runner invocation is assembled in several places.
+
+Refactor:
+
+- Define a `RunnerBackend` trait with local process, batch pool, and server pool implementations.
+- Define one comparison engine that supports strict fingerprint, diagnostic-code-only, known fail options, and UTF-16 variants.
+- Extract a shared `ProcessPool` core with backend-specific request/response adapters.
+- Make test discovery and cache discovery shared Rust modules used by runner and cache generators.
+- Add `scripts/conformance/lib/results.py` with parser, diff, code extraction, and categorization helpers.
+- Add shell helpers for conformance runner invocation and one JSON-summary extraction step.
+
+First useful PR:
+
+- Pull the three Rust comparison blocks into a single function with tests.
+- Replace script PASS/FAIL regex copies with `scripts/conformance/lib/results.py`.
+
+### P1: WASM API Surface, Options, And Diagnostics DTOs
+
+Evidence:
+
+- `crates/tsz-core/src/lib.rs:249`
+- `crates/tsz-wasm/src/lib.rs:21`, `:29`
+- `crates/tsz-core/src/api/wasm/compiler_options.rs:8`, `:70`, `:128`
+- `crates/tsz-core/src/api/wasm/program.rs:35`, `:147`, `:247`, `:301`
+- `crates/tsz-core/src/api/wasm/parser.rs:149`, `:203`, `:223`, `:244`, `:274`, `:339`, `:777`, `:853`, `:900`, `:1223`
+- `crates/tsz-wasm/src/wasm_api/program.rs:26`, `:257`, `:372`, `:405`, `:484`, `:535`, `:612`
+- `crates/tsz-wasm/src/wasm_api/language_service.rs:35`, `:277`, `:336`
+- `crates/tsz-wasm/src/wasm_api/emit.rs:17`, `:141`, `:188`, `:248`
+- `crates/tsz-wasm/src/wasm.rs:234`
+
+Problems:
+
+- There are two exported WASM API layers: core exposes bindings, and `tsz-wasm` has a separate `wasm_api`.
+- Compiler option DTOs and defaults are duplicated between core WASM and `tsz-wasm`.
+- Multi-file parse/bind/check pipelines are repeated and cache fields are invalidated without being populated in some paths.
+- Single-file checker methods rebuild `CheckerState` and apply lib contexts inconsistently.
+- Language-service wrappers parse/bind independently instead of delegating to core parser/session state.
+- Diagnostic JSON shapes drift: `message`, `message_text`, `messageText`, numeric categories, and string categories all appear.
+- Emit paths parse/lower/print separately.
+
+Refactor:
+
+- Pick one canonical WASM implementation surface. Treat the other as a compatibility facade.
+- Move WASM compiler option DTO and conversions into one shared module.
+- Extract `ensure_compiled_and_checked()` for multi-file APIs and cache `CheckResult`.
+- Extract `Parser::with_checker` for single-file APIs.
+- Introduce `DiagnosticDto` with explicit serde field names and a clear byte/UTF-16 span policy.
+- Centralize `emit_from_arena` and target/module resolver usage.
+
+First useful PR:
+
+- Fix target/module numeric mapping first, because it is correctness-sensitive.
+- Then introduce shared `DiagnosticDto` and shared option DTO conversions.
+
+### P1: AST Traversal And Span Semantics
+
+Evidence:
+
+- `crates/tsz-parser/src/parser/node_view.rs:258`
+- `crates/tsz-parser/src/parser/node_children.rs:42`, `:634`
+- `crates/tsz-parser/src/parser/node.rs:48`
+- `crates/tsz-parser/src/parser/state.rs:436`
+- `crates/tsz-scanner/src/scanner_impl.rs:6`, `:114`, `:178`
+- `crates/tsz-binder/src/names.rs:211`, `:325`, `:472`
+- `crates/tsz-binder/src/binding.rs:13`, `:99`, `:1346`, `:1422`, `:1461`, `:1565`
+- `crates/tsz-binder/src/symbols.rs:133`
+- `crates/tsz-binder/src/state/core.rs:162`, `:203`, `:206`, `:221`, `:237`, `:265`, `:291`, `:510`
+- `crates/tsz-lowering/src/transform_utils.rs:175`, `:302`
+- `crates/tsz-lowering/src/lower/core.rs:498`, `:1442`, `:1661`, `:1819`, `:1943`
+- `crates/tsz-common/src/span/mod.rs:17`
+- `crates/tsz-common/src/diagnostics/mod.rs:48`
+- `crates/tsz-lsp/src/diagnostics/mod.rs:193`, `:261`
+
+Problems:
+
+- The codebase has AST child/view infrastructure, but many crates still reimplement traversals.
+- Accessor children appear to push `data.body` twice in `node_children.rs:634`.
+- Scanner, parser, binder, and diagnostics use byte offsets, `u32` spans, raw `(u32, u32)`, and start/length shapes without a single semantic type.
+- Binder state init/reset is large and field-by-field; new fields can be missed.
+- `declare_symbol` variants repeat similar flows.
+
+Refactor:
+
+- Create shared traversal adapters for common patterns:
+  - node children
+  - binding-name extraction
+  - declaration name extraction
+  - class/interface/member walking
+  - transform traversal with enter/exit hooks
+- Introduce or enforce one text span type at boundaries, with conversions:
+  - raw byte span
+  - UTF-16 LSP range
+  - diagnostic start/length
+- Add `Diagnostic::span()` and constructors from `Span`.
+- Make binder reset derive from construction or group mutable per-file state into one resettable struct.
+
+First useful PR:
+
+- Fix `node_children.rs:634`, then migrate one lowering traversal and one binder name traversal to the shared child API.
+- Add a span conversion test matrix for byte offsets, UTF-16 positions, and diagnostic ranges.
+
+## Crate-Specific Findings
+
+### `tsz-common`
+
+Findings:
+
+- `tsz-common` owns generated diagnostic messages/codes and formatting, but `tsz-core` redefines severity, related info, diagnostic shape, and message formatting.
+- `CheckerOptions` has defaults and strict overlays in common, but callers in WASM, core, and tsserver rebuild defaults manually.
+- Target/module enums live in common, while parsing/display/defaults live elsewhere.
+- `parse_numeric_literal_value` exists but checker and emitter paths still parse numeric strings locally.
+- `Span` exists, but common diagnostics store `start` plus `length`, forcing LSP/core callers to reconstruct spans.
+- `COMMON_STRINGS` is private and includes duplicate `"error"` entries.
+
+Evidence:
+
+- `crates/tsz-common/src/diagnostics/mod.rs:48`, `:143`
+- `crates/tsz-common/src/diagnostics/data.rs:15118`
+- `crates/tsz-common/src/options/checker.rs:189`, `:253`
+- `crates/tsz-common/src/common/mod.rs:18`, `:142`
+- `crates/tsz-common/src/primitives/numeric.rs:3`
+- `crates/tsz-common/src/span/mod.rs:17`
+- `crates/tsz-common/src/interner/mod.rs:52`, `:120`, `:153`
+- `crates/tsz-core/src/diagnostics/mod.rs:36`, `:140`, `:640`
+
+Recommendations:
+
+- Move option overlay builders and target/module parse/display helpers into common or expose them from core as a canonical layer.
+- Add diagnostic constructors and accessors that use `Span`.
+- Replace local numeric parsing in checker/emitter/lowering with the common primitive.
+- Expose curated duplicate-free common interned string slices if other crates need them.
+
+### `tsz-core`
+
+Findings:
+
+- Module resolver has repeated file probing, node_modules walking, package.json reads, default module-kind calculation, and fallback ESM extension validation.
+- Config owns rich option parsing and lib metadata, but this is not consistently reused by CLI, WASM, scripts, and conformance.
+- Core WASM program APIs repeat source/lib parse+bind+check pipelines.
+- Source files own `Arc<str>`, while some program APIs clone `(String, String)` pairs.
+
+Evidence:
+
+- `crates/tsz-core/src/module_resolver/file_probing.rs:19`, `:188`
+- `crates/tsz-core/src/module_resolver/node_modules_resolution.rs:188`, `:305`, `:358`, `:423`, `:450`
+- `crates/tsz-core/src/module_resolver/relative_resolution.rs:60`, `:172`
+- `crates/tsz-core/src/module_resolver/path_mapping.rs:44`, `:52`
+- `crates/tsz-core/src/module_resolver/self_reference.rs:57`, `:96`
+- `crates/tsz-core/src/module_resolver/exports_imports.rs:29`, `:261`
+- `crates/tsz-core/src/module_resolver/mod.rs:217`, `:524`, `:740`
+- `crates/tsz-core/src/config/mod.rs:491`, `:547`, `:2991`, `:3373`, `:3446`, `:3483`, `:3527`, `:3741`, `:3795`
+- `crates/tsz-core/src/api/wasm/program.rs:36`, `:147`, `:247`, `:301`
+- `crates/tsz-core/src/parallel/core.rs:906`, `:1037`
+- `crates/tsz-core/src/source_file/mod.rs:36`
+
+Recommendations:
+
+- Extract resolver helpers for `ResolvedModule` construction, package.json load/cache, node_modules ascent, and file-extension probing.
+- Make config helper functions public enough for CLI/server/conformance/WASM reuse.
+- Audit `path_mapping.rs:52`; the extension appears to be taken from the candidate path rather than the actual resolved path.
+- Ensure `self_reference.rs:96` `AmbiguousRoot` results are either surfaced or intentionally ignored.
+- Add an `ensure_compiled_and_checked` cache for core WASM program APIs.
+
+### `tsz-cli`
+
+Findings:
+
+- CLI argument preprocessing, known option sets, valid values, `ValueEnum` conversions, semantic application, and `--showConfig` output are separate implementations.
+- Project/config discovery is reusable in `driver/sources.rs`, but `--showConfig`, `--listFilesOnly`, build, watch, and compile reassemble parts locally.
+- Driver lib resolution is richer than tsserver lib resolution.
+- Diagnostics and tsserver response construction are repeated.
+- File traversal/include/exclude logic differs between project discovery, watch, and server completions.
+- Server file reads are repeated across open-file, disk, virtual harness, and structure paths.
+
+Evidence:
+
+- `crates/tsz-cli/src/bin/tsz.rs:373`, `:1703`, `:1799`, `:1844`, `:2188`, `:2878`, `:2966`, `:3004`, `:3143`
+- `crates/tsz-cli/src/commands/args.rs:713`
+- `crates/tsz-cli/src/commands/build.rs:204`, `:223`
+- `crates/tsz-cli/src/commands/watch.rs:430`, `:548`
+- `crates/tsz-cli/src/driver/core.rs:1703`, `:1863`, `:2310`
+- `crates/tsz-cli/src/driver/sources.rs:299`
+- `crates/tsz-cli/src/project/fs.rs:9`, `:55`, `:188`, `:395`, `:542`
+- `crates/tsz-cli/src/bin/tsz_server/main.rs:667`, `:686`, `:980`
+- `crates/tsz-cli/src/bin/tsz_server/check.rs:558`, `:675`, `:804`
+- `crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs:1185`, `:1218`
+- `crates/tsz-cli/src/bin/tsz_server/handlers_diagnostics.rs:264`
+- `crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs:3397`
+- `crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs:2373`
+
+Recommendations:
+
+- Add a compiler-option registry describing canonical flag, aliases, kind, valid values, and JSON/showConfig key.
+- Add `driver::prepare_project_inputs(args, cwd)` for resolved config, options, base dir, and discovery options.
+- Extract a `lib_resolution` module returning a `LibPlan`.
+- Add `ServerFileStore` helpers: `read_file_any`, `read_config_json`, `nearest_config`, `content_for_diagnostics`.
+- Add `Server::ok`, `Server::empty_ok`, and `Server::fail`.
+- Replace build-clean build-info path logic with the same helper used by build.
+
+### `conformance`
+
+Findings:
+
+- The runner has three diagnostic comparison implementations and multiple subprocess execution paths.
+- Batch and server pools duplicate process lifecycle and RSS tracking.
+- Option conversion, list-option classification, and lowercase-to-camelCase mapping are repeated in runner, wrapper, and cache generator code.
+- Cache discovery and test discovery are repeated.
+- Production diagnostic parsing differs from test helper parsing.
+
+Evidence:
+
+- `crates/conformance/src/runner.rs:616`, `:781`, `:876`, `:993`, `:1021`, `:1089`, `:1249`, `:1283`, `:1386`, `:1454`, `:1487`, `:1602`
+- `crates/conformance/src/batch_pool.rs:63`, `:125`, `:313`
+- `crates/conformance/src/server_pool.rs:28`, `:75`, `:130`, `:313`
+- `crates/conformance/src/options_convert.rs:14`, `:106`, `:610`
+- `crates/conformance/src/tsz_wrapper.rs:667`, `:719`, `:1028`, `:1077`, `:1193`, `:1441`, `:1914`
+- `crates/conformance/src/bin/generate-tsc-cache.rs:252`, `:360`, `:431`
+- `crates/conformance/src/bin/generate-tsc-cache-tsserver.rs:381`, `:424`, `:463`, `:551`, `:747`
+- `crates/conformance/tests/tsz_wrapper.rs:5`, `:179`
+
+Recommendations:
+
+- Introduce `ComparisonMode` and a single comparison engine.
+- Make `RunnerBackend` abstract local, batch, and server execution.
+- Share process-pool lifecycle code.
+- Replace conformance-specific lib and option tables with core/config metadata.
+- Use one production parser in tests.
+
+### `tsz-wasm`
+
+Findings:
+
+- The crate exports core WASM bindings and an independent `wasm_api` surface.
+- Compiler options, target/module mappings, diagnostics DTOs, language-service plumbing, and emit pipelines are duplicated.
+- Semantic diagnostics and diagnostic-code paths rerun checking even after `ensure_compiled`.
+
+Evidence:
+
+- `crates/tsz-wasm/src/lib.rs:21`, `:29`
+- `crates/tsz-wasm/src/wasm_api/enums.rs:125`, `:136`, `:157`
+- `crates/tsz-wasm/src/wasm_api/program.rs:26`, `:70`, `:89`, `:257`, `:372`, `:405`, `:484`, `:535`, `:612`
+- `crates/tsz-wasm/src/wasm_api/language_service.rs:35`, `:277`, `:336`
+- `crates/tsz-wasm/src/wasm_api/emit.rs:17`, `:95`, `:141`, `:188`, `:248`
+- `crates/tsz-wasm/src/wasm.rs:234`
+
+Recommendations:
+
+- Keep the JS API stable, but delegate implementation to one core parser/program surface.
+- Cache `CheckResult` alongside merged program state.
+- Replace local enums with wrapper conversions from common/core enums.
+- Add shared DTOs with `From` conversions from internal diagnostics, LSP, and emit types.
+
+### `tsz-lsp`
+
+Findings:
+
+- Provider setup and file context plumbing are repeated across project features.
+- File rename logic is duplicated and inconsistent on ranges.
+- Scope enter/exit and reference resolution fallback behavior differ between resolver modes.
+- References, detailed references, rename, highlights, and code lens duplicate occurrence logic.
+- Protocol DTOs are mixed into internal models; diagnostics has a cleaner conversion pattern.
+- Fourslash helpers exist but many tests still build providers manually.
+
+Evidence:
+
+- `crates/tsz-lsp/src/project/features.rs:27`, `:452`, `:470`, `:485`, `:820`, `:920`, `:1061`, `:1110`
+- `crates/tsz-lsp/src/project/core.rs:2368`, `:2451`
+- `crates/tsz-lsp/src/project/operations.rs:816`, `:1099`, `:1214`, `:1587`
+- `crates/tsz-lsp/src/rename/file_rename.rs:126`
+- `crates/tsz-lsp/src/resolver/core.rs:254`, `:302`, `:688`, `:746`, `:771`
+- `crates/tsz-lsp/src/navigation/references.rs:87`, `:285`
+- `crates/tsz-lsp/src/rename/core.rs:317`, `:347`
+- `crates/tsz-lsp/src/highlighting/document.rs:18`, `:911`
+- `crates/tsz-lsp/src/symbols/document_symbols.rs:29`
+- `crates/tsz-lsp/src/editor_ranges/folding.rs:12`
+- `crates/tsz-lsp/src/completions/mod.rs:24`
+- `crates/tsz-lsp/src/diagnostics/mod.rs:31`
+- `crates/tsz-lsp/src/fourslash.rs:75`, `:223`, `:252`, `:365`, `:444`, `:486`, `:1445`
+
+Recommendations:
+
+- Build `ProjectFileContext`, `CursorTarget`, and `ReferenceCollector`.
+- Split internal feature models from LSP/tsserver DTOs, following diagnostics conversion.
+- Audit `project/features.rs:485`; it compares declaration reference range start and end to the same position.
+- Sort or assert semantic-token ordering before delta encoding.
+- Route manual tests through fourslash where possible.
+
+### `tsz-checker`
+
+Findings:
+
+- Keyword syntax to builtin `TypeId` mapping is repeated despite an existing lib-resolution helper.
+- Assignment operator classification is repeated across expression checking, assignment checking, usage, and variable utilities.
+- Primary declaration selection is repeated across TDZ, suggestions, type-only checks, and other paths.
+- Cross-file child checker lifecycle is repeated.
+- Heritage-clause and constructor parameter-property traversal are repeated.
+- CommonJS export LHS classification repeats across collection paths.
+- TS2322 rendering has repeated builder shapes.
+- Flow worklist defer/enqueue paths repeat.
+- Checker tests repeat setup and diagnostic assertions heavily.
+
+Evidence:
+
+- `crates/tsz-checker/src/check/assignment_fallback.rs:138`
+- `crates/tsz-checker/src/check/type_node.rs:103`
+- `crates/tsz-checker/src/check/cross_file.rs:77`
+- `crates/tsz-checker/src/check/dispatch_helpers.rs:74`
+- `crates/tsz-checker/src/types/queries/lib_resolution.rs:24`
+- `crates/tsz-checker/src/check/expressions.rs:458`
+- `crates/tsz-checker/src/check/assignment.rs:1664`
+- `crates/tsz-checker/src/check/assignment_ops.rs:20`
+- `crates/tsz-checker/src/check/var_utils.rs:713`
+- `crates/tsz-checker/src/check/usage.rs:1398`
+- `crates/tsz-checker/src/query_boundaries/common.rs:1807`
+- `crates/tsz-checker/src/check/tdz.rs:68`
+- `crates/tsz-checker/src/check/suggestions.rs:88`
+- `crates/tsz-checker/src/check/type_only.rs:183`, `:292`, `:1294`
+- `crates/tsz-checker/src/jsdoc/lookup.rs:211`
+- `crates/tsz-checker/src/jsdoc/resolution/type_construction.rs:45`
+- `crates/tsz-checker/src/state/type_resolution/import_type.rs:456`, `:509`, `:690`
+- `crates/tsz-checker/src/computed_commonjs/exports_resolution.rs:78`
+- `crates/tsz-checker/src/check/class_helpers.rs:22`
+- `crates/tsz-checker/src/check/class_implements_helpers.rs:40`, `:257`
+- `crates/tsz-checker/src/check/interface_type.rs:657`
+- `crates/tsz-checker/src/check/class.rs:1577`, `:1669`
+- `crates/tsz-checker/src/check/class_summary.rs:204`, `:264`
+- `crates/tsz-checker/src/check/class_checker.rs:704`, `:2030`
+- `crates/tsz-checker/src/check/property_init.rs:108`
+- `crates/tsz-checker/src/check/member_declaration_checks.rs:272`
+- `crates/tsz-checker/src/check/exports_collection.rs:31`, `:143`, `:272`, `:412`
+- `crates/tsz-checker/src/diagnostics/render_failure.rs:661`, `:711`, `:844`, `:883`, `:1199`, `:1472`
+- `crates/tsz-checker/src/flow/control_flow/core.rs:1218`, `:1255`, `:1298`, `:1531`, `:1579`, `:1631`
+
+Recommendations:
+
+- Add helpers for builtin type lookup from syntax kind/text, assignment-operator classification, primary declaration selection, child-checker execution, and heritage/member iteration.
+- Centralize CommonJS export LHS classification.
+- Create diagnostic builders for common assignability failure shapes.
+- Consolidate checker tests around one fixture and diagnostic assertion DSL.
+
+### `tsz-solver`
+
+Findings:
+
+- Rest parameter constraints, type predicate source annotation save/restore, mapped key substitution, and object/index constraints repeat.
+- Query cache constructors and clear paths are similar but not equivalent.
+- Subtype/assignability cache paths repeat.
+- Diagnostic eager/pending builders are duplicated.
+- Solver tests repeat type interner, subtype checker, object/property/function shape setup.
+
+Evidence:
+
+- `crates/tsz-solver/src/signatures.rs:136`, `:244`, `:275`, `:307`
+- `crates/tsz-solver/src/walker.rs:621`, `:671`, `:1167`, `:1237`, `:1361`, `:1435`, `:1559`, `:1574`, `:1673`, `:1695`
+- `crates/tsz-solver/src/query_cache.rs:309`, `:321`, `:336`, `:358`, `:1204`, `:1286`
+- `crates/tsz-solver/src/diagnostics/builders.rs:299`, `:526`, `:780`
+- `crates/tsz-solver/src/diagnostics/core.rs:844`
+- `crates/tsz-solver/tests/common/mod.rs:3`
+- `crates/tsz-solver/tests/constraint_tests.rs:27`, `:86`, `:151`
+- `crates/tsz-solver/tests/subtype_cache_tests.rs:23`, `:55`, `:154`
+- `crates/tsz-solver/tests/relation_cache_config_tests.rs:103`, `:141`, `:157`
+
+Recommendations:
+
+- Add small scoped helpers for rest-parameter constraints, temporary type predicate annotation state, mapped-key substitution, and object/index constraint handling.
+- Review `QueryCache::clear`; `intersection_merge_cache` is initialized but appears not to be cleared.
+- Replace repeated test setup with builders: `types()`, `object()`, `function()`, `assert_subtype`, `assert_not_subtype`.
+
+### `tsz-emitter`
+
+Findings:
+
+- AST-to-IR lowering and AST visitor setup repeat across transforms.
+- Temp allocator logic exists in several transforms.
+- Class member transform paths have multiple overlapping implementations.
+- Import/export classifier logic and module temp naming repeat.
+- Helper injection booleans/order, printer statement-list loops, and raw string escape hatches repeat.
+- Emitter tests repeat parser/print harness setup, `PrintOptions`, AST navigation, source strings, and `output.is_some()` assertions.
+
+Evidence:
+
+- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs:95`, `:115`, `:151`
+- `crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs:31`, `:545`
+- `crates/tsz-emitter/src/transforms/es5.rs:679`, `:760`, `:1302`
+- `crates/tsz-emitter/src/transforms/spread_es5.rs:566`
+- `crates/tsz-emitter/src/transforms/async_es5_ir.rs:1317`
+- `crates/tsz-emitter/src/transforms/block_scoping_es5.rs:336`
+- `crates/tsz-emitter/src/transforms/class_es5_ir.rs:396`, `:2580`
+- `crates/tsz-emitter/src/transforms/es_decorators.rs:162`, `:1883`
+- `crates/tsz-emitter/src/transforms/class_es5_ir_members.rs:17`, `:436`, `:456`, `:854`
+- `crates/tsz-emitter/src/emit_utils.rs:94`, `:149`, `:203`, `:459`
+- `crates/tsz-emitter/src/transforms/module_commonjs.rs:350`, `:493`, `:871`, `:1192`
+- `crates/tsz-emitter/src/transforms/module_commonjs_ir.rs:86`, `:132`, `:138`, `:256`
+- `crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs:15`, `:318`
+- `crates/tsz-emitter/src/helpers.rs:375`, `:449`, `:561`
+- `crates/tsz-emitter/src/ir_printer.rs:287`, `:348`, `:1421`, `:1956`
+- `crates/tsz-emitter/src/ir_printer_helpers.rs:136`
+- `crates/tsz-emitter/tests/statements.rs:15`, `:569`, `:990`
+- `crates/tsz-emitter/tests/printer.rs:45`, `:122`, `:138`, `:157`, `:204`, `:484`, `:554`, `:627`
+- `crates/tsz-emitter/tests/declarations_class.rs:12`, `:15`, `:212`
+- `crates/tsz-emitter/tests/module_commonjs_tests.rs:141`, `:497`, `:571`
+
+Recommendations:
+
+- Introduce shared transform context with temp allocator, helper request tracking, and module/import/export classification.
+- Replace repeated visitor skeletons with one traversal adapter.
+- Audit module temp naming; some paths always produce `{module}_1`.
+- Add `emit_test_support` with parser/print helpers and table-case macros.
+
+### `tsz-parser`, `tsz-scanner`, `tsz-binder`, `tsz-lowering`
+
+Findings:
+
+- AST traversal infrastructure exists but is bypassed by repeated local walkers.
+- Span semantics are inconsistent across byte positions, character-index comments, `u32` parser spans, binder raw tuples, and diagnostics.
+- Binder state init/reset and symbol declaration flows are repeated.
+- Scanner/parser/binder/lowering tests repeat setup heavily.
+- Numeric literal parsing is repeated outside common.
+
+Evidence:
+
+- `crates/tsz-parser/src/parser/node_view.rs:258`
+- `crates/tsz-parser/src/parser/node_children.rs:42`, `:634`
+- `crates/tsz-parser/src/parser/node_arena.rs:238`
+- `crates/tsz-scanner/src/lib.rs:592`
+- `crates/tsz-scanner/src/scanner_impl.rs:6`, `:114`, `:178`
+- `crates/tsz-binder/src/state/mod.rs:466`
+- `crates/tsz-binder/src/declaration.rs:2761`
+- `crates/tsz-binder/src/state/tests.rs:766`, `:3409`, `:3554`
+- `crates/tsz-parser/tests/parser_unit_tests.rs:14`
+- `crates/tsz-parser/tests/state_declaration_tests.rs:6`
+- `crates/tsz-parser/tests/jsx_unclosed_tag_tests.rs:5`
+- `crates/tsz-scanner/tests/scanner_comprehensive_tests.rs:8`
+- `crates/tsz-scanner/tests/scanner_impl_tests.rs:5`
+- `crates/tsz-lowering/src/lower/advanced.rs:240`
+- `crates/tsz-lowering/tests/lower_tests.rs:733`
+
+Recommendations:
+
+- Make node traversal APIs easier to use than local recursion.
+- Add explicit `TextSpan`/`ByteSpan`/`LspRange` conversions and update docs to match actual semantics.
+- Move hardcoded modifier/keyword token lengths into scanner/parser metadata.
+- Create parser/scanner/binder/lowering test fixtures.
+
+### Scripts
+
+Findings:
+
+- Emit option extraction, CLI arg conversion, target/module parsing, output path inference, cache hashing, and normalization repeat across script files.
+- Conformance result parsing, diffing, JSON querying, shell runner invocation, and summary extraction repeat across Python and shell scripts.
+- Emit and fourslash query scripts implement the same snapshot-query mechanics.
+- README metrics refresh has Node and Python implementations.
+
+Evidence:
+
+- `scripts/emit/src/runner.ts:129`, `:139`, `:189`, `:210`, `:230`, `:249`, `:276`, `:506`, `:669`, `:771`, `:833`
+- `scripts/emit/src/cli-transpiler.ts:40`, `:83`, `:105`, `:289`, `:324`, `:331`, `:422`, `:468`
+- `scripts/emit/src/baseline-parser.ts:118`, `:193`, `:376`
+- `scripts/emit/query-emit.py:40`, `:131`
+- `scripts/fourslash/query-fourslash.py:41`, `:119`
+- `scripts/fourslash/runner.cjs:621`
+- `scripts/fourslash/test-worker.cjs:120`, `:1522`, `:2220`, `:4330`
+- `scripts/fourslash/tsz-adapter.cjs:197`
+- `scripts/conformance/query-conformance.py:244`
+- `scripts/conformance/conformance.sh:411`, `:494`, `:671`, `:717`
+- `scripts/update-readme-from-ci-metrics.mjs:21`, `:44`
+- `scripts/refresh-readme.py:27`, `:36`
+
+Recommendations:
+
+- Add `scripts/emit/src/compiler-options.ts` with `extractOptions`, `toCliArgs`, and stable cache fields.
+- Add `scripts/emit/src/emit-output-paths.ts`.
+- Replace custom cache hashing with `crypto.createHash("sha256")` over stable JSON.
+- Add `scripts/conformance/lib/results.py`.
+- Add `scripts/lib/query_snapshot.py`.
+- Pick one README metrics updater or make both consume one declarative suite config.
+
+## Bug-Shaped Findings To Triage
+
+These were discovered while looking for duplication. They should be verified with targeted tests before refactoring around them.
+
+1. `crates/tsz-parser/src/parser/node_children.rs:634`: accessor child collection appears to push `data.body` twice.
+2. `crates/tsz-core/src/module_resolver/path_mapping.rs:52`: extension may be taken from the candidate path rather than the resolved path.
+3. `crates/tsz-solver/src/query_cache.rs:358`: `intersection_merge_cache` appears initialized but not cleared.
+4. `crates/tsz-lsp/src/symbols/symbol_index.rs:301`, `:740`: heritage index cleanup may leave stale class relationships.
+5. `crates/tsz-lsp/src/symbols/symbol_index.rs:545`: heritage indexing may extract identifier text from declaration nodes instead of the declaration name node.
+6. `crates/tsz-lsp/src/project/features.rs:485`: code lens range comparison compares start and end to the same position.
+7. `crates/tsz-lsp/src/rename/file_rename.rs:126` plus project callers: file rename range includes/trims quotes inconsistently.
+8. `crates/tsz-wasm/src/wasm_api/emit.rs:95` versus `program.rs:70`: module numeric mappings disagree.
+9. `crates/tsz-core/src/api/wasm/compiler_options.rs:128`: one deserializer is used for target and module strings.
+10. `crates/tsz-emitter/src/transforms/module_commonjs_ir.rs:138`, `:256` and `module_commonjs.rs:1192`: module temp naming may always select `{module}_1`.
+11. `crates/tsz-cli/src/bin/tsz.rs:3143` versus `commands/build.rs:204`: build-clean build-info path logic can drift from build path logic.
+12. `crates/conformance/src/server_pool.rs:28` and `runner.rs:1089`: server mode comparison appears code-only in one path and fingerprint-based in another.
+
+## Suggested Implementation Sequence
+
+### Phase 1: Stabilize Shared Metadata
+
+1. Extract target/module/moduleResolution parse/display/default helpers.
+2. Replace tsserver, CLI `--showConfig`, WASM, and conformance callers.
+3. Add tests that assert all public tables agree.
+4. Extract default-lib chain helpers from core config and remove conformance's duplicate table.
+
+Expected payoff: removes high-risk semantic drift across CLI, server, WASM, scripts, and conformance.
+
+### Phase 2: Consolidate Test Fixtures
+
+1. Add checker test fixture and migrate repeated parse/bind/check tests.
+2. Add LSP test fixture or push manual tests through fourslash.
+3. Add emitter and solver test fixture builders.
+4. Add core module-resolution and parallel project fixtures.
+
+Expected payoff: reduces future refactor cost and makes behavior changes easier to validate.
+
+### Phase 3: Unify LSP Project Access
+
+1. Add `ProjectFileContext`.
+2. Add `CursorTarget`.
+3. Add `ReferenceCollector`.
+4. Centralize file rename logic and occurrence conversion.
+
+Expected payoff: lowers risk in rename/references/highlights/code lens, and removes inconsistent cache/touch behavior.
+
+### Phase 4: Conformance Runner Cleanup
+
+1. Extract comparison engine.
+2. Extract backend abstraction and shared process-pool lifecycle.
+3. Share test/cache discovery.
+4. Add Python `results.py` and shell helpers.
+
+Expected payoff: reduces noise in future conformance improvements and makes server/local/batch behavior easier to compare.
+
+### Phase 5: WASM And Diagnostics DTO Cleanup
+
+1. Pick canonical WASM implementation surface.
+2. Add shared option DTO conversion.
+3. Add shared diagnostic DTO conversion.
+4. Cache compile/check results.
+
+Expected payoff: improves JS API consistency and avoids repeated expensive checking.
+
+### Phase 6: Traversal, Span, And Emitter Internals
+
+1. Fix the accessor child duplication.
+2. Extract common AST traversal adapters.
+3. Standardize span/range conversions.
+4. Share emitter transform context, temp allocation, and helper injection.
+
+Expected payoff: lowers long-term maintenance cost across parser, binder, lowering, checker, emitter, and LSP.
+
+## Verification Strategy
+
+For each DRY refactor, prefer behavior locks before broad replacement:
+
+- Snapshot current option parsing/display for every target, module, and moduleResolution value.
+- Add WASM tests for numeric target/module conversion, including newer values.
+- Add conformance runner comparison unit tests for exact fingerprint, code-only, missing diagnostic, extra diagnostic, and UTF-16 variants.
+- Add LSP tests for references/rename/highlights sharing one occurrence model.
+- Add span conversion tests for ASCII, multi-byte UTF-8, and surrogate-pair UTF-16 positions.
+- Add test fixture migration in small batches so failures identify helper mistakes rather than product behavior.
+
+## Agent Coverage
+
+The audit used read-only subagents for these areas:
+
+- Checker tests
+- Checker source
+- Solver source and tests
+- Emitter transforms
+- Emitter tests
+- Parser/scanner/binder/lowering
+- Core source
+- Core tests
+- LSP source
+- LSP tests
+- Conformance crate
+- CLI/server
+- WASM/core WASM APIs
+- Common crate and cross-crate diagnostics/options
+- Scripts
+- Cross-cutting option/lib metadata
+
+The subagent findings were then merged with local inspection into this report. The report intentionally prioritizes repeated behavior that can drift semantically over purely cosmetic duplication.


### PR DESCRIPTION
## Summary

Follow-up on the repo-wide DRY audit (committed here as `docs/DRY_AUDIT_2026-04-21.md`). This PR lands the most load-bearing findings from that audit:

1. **P0 §1 Centralize compiler option metadata** — `ScriptTarget`, `ModuleKind`, and `ModuleResolutionKind` now own their canonical parse/display/numeric round-trip in `tsz-common` / `tsz-core::config`. Six duplicated callsites (tsz-cli, tsserver check, tsz-core WASM API, tsz-wasm wasm_api x2, tsz-core config) delegate to these helpers.
2. **Bug-shape #1 (parser)** — `NodeArena::fill_accessor_children` pushed `data.body` twice; every accessor reported a duplicate body child. Fixed with a regression test.
3. **Bug-shape #3 (solver)** — `QueryCache::clear` reset every other cache field but silently skipped `intersection_merge_cache`. Fixed with an extension to the existing clear-resets test.
4. **Bug-shape #8 + #9 (WASM)** — Two concrete latent bugs:
   - `tsz-wasm::wasm_api::emit::transpile` mapped module `5 => UMD`, `6 => ES2015`, while `program.rs` used tsc's ordering (`3 => UMD`, `5 => ES2015`). Passing a numeric module through `transpile` silently picked the wrong module kind.
   - `tsz-core::api::wasm::compiler_options` used one shared deserializer for `target` and `module`, so `module: "ES2015"` mapped to numeric `2` (AMD) instead of `5` (ES2015).
   - `tsz-cli` tsserver check collapsed `"es2023"` onto ES2022 and ES2024+ values onto ESNext — silent downgrades.
   - WASM-exported `ScriptTarget` stopped at ES2023 and `ModuleKind` was missing Node18/Node20.

All callsites now route through shared `from_ts_str` / `from_ts_numeric` / `as_ts_str` / `ts_numeric_value` helpers, so the drift can't recur.

## Commits

- `docs: add DRY audit 2026-04-21` — the read-only audit report (774 lines) that motivated the rest of the PR.
- `fix(parser): emit accessor body exactly once in child traversal` — 2 files
- `fix(solver): clear intersection_merge_cache in QueryCache::clear` — 2 files
- `refactor(options): centralize target/module parsing & numeric mapping` — 10 files

## Test plan

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo nextest run -p tsz-common -p tsz-parser -p tsz-solver -p tsz-core -p tsz-cli -p tsz-wasm -p tsz-checker` — 14 851 tests pass, 65 skipped
- [x] Pre-commit hook (clippy + affected-crate nextest + architecture guardrails) ran on every commit — all green
- [x] New regression tests:
  - `accessor_children_include_body_once`
  - `query_cache_estimated_size_resets_on_clear` extension for `intersection_merge_cache`
  - `test_script_target_from_ts_str`, `test_module_kind_from_ts_str` in `tsz-common`
  - `parse_compiler_options_json_uses_separate_target_and_module_domains` in `tsz-core::api::wasm::compiler_options` — locks in the `"ES2015" → target=2, module=5` distinction
- [ ] CI must confirm conformance unaffected (the refactor is purely organizational on the `tsc` side; no diagnostic behavior was intentionally changed)

## Audit items intentionally left out of this PR

The audit's P0 §2 (shared test harnesses), P1 LSP provider context, P1 conformance runner backend, and the AST traversal / span cleanup are larger follow-ups that each want their own review. This PR picks the highest-correctness-risk subset first.