### PR TITLE
fix(checker): preserve typed-array generic display in TS2322 top-level message

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -14,6 +14,44 @@ fn diagnostics_for(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
     check_source(source, "test.ts", CheckerOptions::default())
 }
 
+#[test]
+fn typed_array_cross_assignment_preserves_generic_display() {
+    let diagnostics = diagnostics_for(
+        r#"
+interface ArrayBuffer {}
+interface ArrayBufferLike {}
+interface Int8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    readonly tag: "Int8Array";
+}
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    readonly tag: "Uint8Array";
+}
+declare var Int8Array: {
+    new (length: number): Int8Array<ArrayBuffer>;
+};
+declare var Uint8Array: {
+    new (length: number): Uint8Array<ArrayBuffer>;
+};
+
+let arr_Int8Array = new Int8Array(1);
+let arr_Uint8Array = new Uint8Array(1);
+
+arr_Int8Array = arr_Uint8Array;
+"#,
+    );
+
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for incompatible typed array assignment");
+    assert!(
+        diag.message_text.contains(
+            "Type 'Uint8Array<ArrayBuffer>' is not assignable to type 'Int8Array<ArrayBuffer>'."
+        ),
+        "typed array TS2322 should preserve generic type arguments, got: {diag:?}"
+    );
+}
+
 fn strict_diagnostics_for(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
     check_source(
         source,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1609,22 +1609,35 @@ impl<'a> CheckerState<'a> {
             target_property_type
         };
 
-        if depth == 0
-            && let Some(tsz_solver::SubtypeFailureReason::LiteralTypeMismatch { .. }) =
-                nested_reason
-        {
-            return self.render_failure_reason(
-                nested_reason.expect("checked above"),
-                source_property_type,
-                target_property_type,
-                idx,
-                depth,
-            );
-        }
-
         if depth == 0 {
             let (source_str, target_str) =
                 self.format_top_level_assignability_message_types(source, target);
+            if let Some(tsz_solver::SubtypeFailureReason::LiteralTypeMismatch { .. }) =
+                nested_reason
+            {
+                let is_typed_array_display = |display: &str| {
+                    display.starts_with("Int8Array<")
+                        || display.starts_with("Uint8Array<")
+                        || display.starts_with("Uint8ClampedArray<")
+                        || display.starts_with("Int16Array<")
+                        || display.starts_with("Uint16Array<")
+                        || display.starts_with("Int32Array<")
+                        || display.starts_with("Uint32Array<")
+                        || display.starts_with("Float32Array<")
+                        || display.starts_with("Float64Array<")
+                        || display.starts_with("BigInt64Array<")
+                        || display.starts_with("BigUint64Array<")
+                };
+                if !(is_typed_array_display(&source_str) && is_typed_array_display(&target_str)) {
+                    return self.render_failure_reason(
+                        nested_reason.expect("checked above"),
+                        source_property_type,
+                        target_property_type,
+                        idx,
+                        depth,
+                    );
+                }
+            }
             let base = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&source_str, &target_str],


### PR DESCRIPTION
## Summary

When rendering a TS2322 whose nested subtype-failure reason is `LiteralTypeMismatch` (e.g. differing branded `tag: "Int8Array" | "Uint8Array"` literals), the checker previously always recursed into the nested reason and rendered the literal-property comparison, dropping the outer type-to-type message.

For typed-array cross-assignments this produced diagnostics that referenced the internal `tag` brand literals instead of the intended `Type 'Uint8Array<ArrayBuffer>' is not assignable to type 'Int8Array<ArrayBuffer>'.` shape that tsc emits.

This change detects when both the formatted source and target are typed-array generics (`Int8Array<…>` through `BigUint64Array<…>`) and keeps the top-level type-to-type message. All other shapes continue to descend into the nested literal-mismatch reason as before.

## Test plan

- [x] New unit test `typed_array_cross_assignment_preserves_generic_display` asserts the outer message format.
- [x] `cargo nextest run -p tsz-checker --lib` — 2600/2600 pass.
- [x] Pre-commit full workspace test suite — 12925+ tests passing.

## Notes

Recovered from an interrupted parallel agent worktree (codex/conformance-20260421172436-04). This is a diagnostic-display-only carve-out — no type-system semantics changed. The hardcoded TypedArray prefix list is localized to the render path; a solver-side classification would be a cleaner home if this pattern grows.