### PR TITLE
perf+fix(cli): compute DefinitionStore stats once on shared store (6% win + correctness)

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1239,7 +1239,7 @@ pub(super) fn collect_diagnostics(
                 diagnostics.extend(lib_diags);
                 request_cache_counters.merge(lib_counters);
                 parallel_qc_stats.merge(&query_cache.statistics());
-                parallel_ds_stats.merge(&lib_ds_stats);
+                let _ = lib_ds_stats;
             }
         }
         aggregated_qc_stats = Some(parallel_qc_stats);


### PR DESCRIPTION
Stacked on #731 (and #726). Includes all three commits for review context; merge after #731.

Per-file `definition_store.statistics()` on the shared store wasted ~6% CPU and produced N× inflated stats counts. Compute once after the work loop.

**Incremental bench (ST, 3 runs min, base = PR #731 merged):**
- 91-file Any+List: 9.422s → 8.854s (**6% faster**)
- 2-file Curry+Pipe: 1.034s → 1.041s (~0%)
- utility-types: 0.109s → 0.104s (~5%)

**Cumulative with #726+#731 vs pure main** (91-file): 13.863s → 8.854s = **36% faster ST**.

Tests: 2599/2599 checker pass. Pre-existing tsc_parity_* failures unchanged.