### PR TITLE
fix(parser): recover bare try blocks in class bodies

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -867,6 +867,14 @@ impl ParserState {
         while !self.is_token(SyntaxKind::CloseBraceToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
         {
+            if self.is_token(SyntaxKind::TryKeyword) && self.look_ahead_is_try_block_same_line() {
+                self.parse_error_at_current_token(
+                    "Unexpected token. A constructor, method, accessor, or property was expected.",
+                    diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
+                );
+                break;
+            }
+
             let member = self.parse_class_member();
             if member.is_some() {
                 // Don't consume trailing semicolon if the member itself is a
@@ -903,6 +911,17 @@ impl ParserState {
         }
 
         self.make_node_list(members)
+    }
+
+    fn look_ahead_is_try_block_same_line(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        self.next_token();
+        let is_try_block =
+            self.is_token(SyntaxKind::OpenBraceToken) && !self.scanner.has_preceding_line_break();
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_try_block
     }
 
     /// Parse a single class member

--- a/crates/tsz-parser/tests/state_statement_tests.rs
+++ b/crates/tsz-parser/tests/state_statement_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for statement parsing in the parser.
 use crate::parser::{NodeIndex, ParserState};
 use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
 
 fn parse_source(source: &str) -> (ParserState, NodeIndex) {
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
@@ -730,6 +731,62 @@ fn modifier_led_try_block_in_class_body_prefers_ts1068() {
     assert!(
         !codes.contains(&diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER),
         "should not emit TS1434 for modifier-led try recovery, got {diags:?}"
+    );
+}
+
+#[test]
+fn bare_try_block_in_class_body_reparses_as_outer_statement() {
+    let source = "class Foo {\n\n    try {\n\n        public bar = someInitThatMightFail();\n\n    } catch(e) {}\n\n\n\n    public baz() {\n\n        return this.bar;\n\n    }\n\n}\n";
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    let diagnostics: Vec<_> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (
+                diag.code,
+                pos.line + 1,
+                pos.character + 1,
+                diag.message.as_str(),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        diagnostics,
+        vec![
+            (
+                diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
+                3,
+                5,
+                "Unexpected token. A constructor, method, accessor, or property was expected.",
+            ),
+            (
+                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                5,
+                9,
+                "Declaration or statement expected.",
+            ),
+            (
+                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                11,
+                5,
+                "Declaration or statement expected.",
+            ),
+            (
+                diagnostic_codes::EXPECTED,
+                11,
+                18,
+                "';' expected.",
+            ),
+            (
+                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                17,
+                1,
+                "Declaration or statement expected.",
+            ),
+        ],
     );
 }
 


### PR DESCRIPTION
## Root cause

In class member lists, tsz parsed a bare `try { ... }` as a malformed class member and consumed enough tokens to cascade into the wrong recovery path, producing an extra orphan-catch diagnostic instead of matching tsc's `TS1068` at `try` and reparsing the `try` block as an outer statement.

## Fixed conformance target

`TypeScript/tests/cases/compiler/propertyWrappedInTry.ts`

```ts
class Foo {
    try {
        public bar = someInitThatMightFail();
    } catch (e) {}

    public baz() {
        return this.bar;
    }
}
```

## Fix

Detect a bare `try` followed by `{` in a class body, emit `TS1068` at the `try` token, and leave the token unconsumed so normal statement recovery reparses the block and matches tsc's diagnostic sequence.

## Unit test

Added `bare_try_block_in_class_body_reparses_as_outer_statement` in `crates/tsz-parser/tests/state_statement_tests.rs`.

## Verification

- `cargo nextest run -p tsz-parser --lib bare_try_block_in_class_body_reparses_as_outer_statement`
- `./scripts/conformance/conformance.sh run --filter "propertyWrappedInTry" --verbose`
- `scripts/session/verify-all.sh`
  - formatting: passed
  - clippy: passed
  - unit tests: passed
  - conformance: improved, `12083` vs baseline `12061` (`+22`), includes `propertyWrappedInTry.ts`
  - emit tests: improved, JS `+5`, DTS `+25`
  - fourslash/LSP: no change, 50/50 passed

Final rebase against `origin/main` was a no-op before push.
