### PR TITLE
fix(module-resolver): classify path-mapping extension from resolved file

### DIFF
--- a/crates/tsz-core/src/module_resolver/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/path_mapping.rs
@@ -42,6 +42,13 @@ impl ModuleResolver {
                     let candidate = base.join(&substituted);
 
                     if let Some(resolved) = self.try_file_or_directory(&candidate) {
+                        // `candidate` has no extension here (we skipped
+                        // targets that already did on line 34), so classify
+                        // on the resolved path instead — otherwise the
+                        // extension is always `Unknown`, which desyncs path-
+                        // mapping-resolved modules from every other resolver
+                        // exit that sets this from the resolved file.
+                        let extension = ModuleExtension::from_path(&resolved);
                         return PathMappingAttempt {
                             resolved: Some(ResolvedModule {
                                 resolved_path: resolved,
@@ -49,7 +56,7 @@ impl ModuleResolver {
                                 is_external: false,
                                 package_name: None,
                                 original_specifier: specifier.to_string(),
-                                extension: ModuleExtension::from_path(&candidate),
+                                extension,
                             }),
                             attempted,
                         };

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -3643,6 +3643,49 @@ fn test_lookup_path_mapping_failure_produces_ts2307_via_lookup() {
 }
 
 #[test]
+fn test_path_mapping_extension_reflects_resolved_file() {
+    // Regression: path-mapping previously classified the resolved module's
+    // extension from the pre-resolution candidate (which always has no
+    // extension at this point — targets with extensions are filtered
+    // earlier). That made every path-mapping-resolved module carry
+    // `ModuleExtension::Unknown` instead of the real `.ts` / `.d.ts` / etc.,
+    // drifting from every other resolver exit (relative, node_modules,
+    // exports, self-reference) which uses the resolved path. The fix
+    // classifies on the resolved path.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_path_mapping_ext_regression");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(dir.join("src/index.ts"), "import '@app/widget';").unwrap();
+    fs::write(dir.join("src/widget.ts"), "export const w = 1;").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        base_url: Some(dir.clone()),
+        paths: Some(vec![PathMapping {
+            pattern: "@app/*".to_string(),
+            prefix: "@app/".to_string(),
+            suffix: String::new(),
+            targets: vec!["src/*".to_string()],
+        }]),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("@app/widget", &dir.join("src/index.ts"), Span::new(8, 20));
+
+    let module = result.expect("path mapping should resolve @app/widget to src/widget.ts");
+    assert_eq!(module.resolved_path, dir.join("src/widget.ts"));
+    assert_eq!(
+        module.extension,
+        ModuleExtension::Ts,
+        "path-mapping must classify extension from the resolved file, not the extensionless candidate"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn test_lookup_fallback_rescues_not_found() {
     // When primary resolution fails but fallback succeeds, lookup() should
     // return resolved with no error.


### PR DESCRIPTION
## Summary

`try_path_mappings` was passing the pre-resolution `candidate` path to `ModuleExtension::from_path`. At that point `candidate` is guaranteed to have **no** extension — targets that already carried one are filtered out a few lines earlier at `has_path_mapping_target_extension`. So every path-mapping-resolved module silently received `ModuleExtension::Unknown` instead of the real `.ts` / `.d.ts` / `.cts` / `.json` classification.

This desynced the path-mapping exit from every other resolver exit (relative, node_modules, exports, self-reference), all of which classify on the resolved file.

**Fix:** classify `ModuleExtension::from_path(&resolved)` like the rest of the resolver (15+ matching call sites across `relative_resolution.rs`, `node_modules_resolution.rs`, `exports_imports.rs`, `self_reference.rs`, `mod.rs`).

## Regression test

`test_path_mapping_extension_reflects_resolved_file` writes `src/widget.ts`, configures a `@app/*` → `src/*` path mapping, resolves `@app/widget`, and asserts `module.extension == ModuleExtension::Ts`.

Pre-fix behavior:
```
assertion `left == right` failed: path-mapping must classify extension
from the resolved file, not the extensionless candidate
  left: Unknown
 right: Ts
```

## Test plan

- [x] `cargo nextest run -p tsz-core --lib test_path_mapping_extension_reflects_resolved_file` — pass
- [x] `cargo nextest run -p tsz-core --lib module_resolver` — 147 pass
- [x] `cargo clippy -p tsz-core --lib --tests -- -D warnings` — clean
- [x] Verified the new test fails against the unfixed `path_mapping.rs`

Per DRY audit 2026-04-21 bug-shape finding #2.