### PR TITLE
fix(lsp): count code-lens references correctly at project level

### DIFF
--- a/crates/tsz-lsp/src/project/features.rs
+++ b/crates/tsz-lsp/src/project/features.rs
@@ -477,16 +477,16 @@ impl Project {
                 let position = data.position;
                 let references = self.find_references(file_name, position)?;
 
-                // Count references (subtract 1 if declaration is included)
-                let ref_count = if references.is_empty() {
-                    0
-                } else {
-                    // Check if any reference is at the same position as the declaration
-                    let has_decl_reference = references
-                        .iter()
-                        .any(|r| r.range.start == position && r.range.end == position);
-                    references.len() - usize::from(has_decl_reference)
-                };
+                // `find_references` always appends the symbol's declarations to
+                // the result (see navigation/references.rs), so one entry is the
+                // declaration and the rest are uses. The previous point-vs-span
+                // equality check never matched — `position` is zero-width (it
+                // points at the declaration node's start offset, e.g. the
+                // `function` keyword), while location ranges cover the name
+                // identifier span (start != end) — so the count was inflated
+                // by 1 for every symbol. Mirror `code_lens::resolve_references_lens`
+                // and subtract 1 unconditionally when we have any results.
+                let ref_count = references.len().saturating_sub(1);
 
                 let title = if ref_count == 1 {
                     "1 reference".to_string()

--- a/crates/tsz-lsp/tests/project_tests.rs
+++ b/crates/tsz-lsp/tests/project_tests.rs
@@ -4137,6 +4137,43 @@ fn test_project_code_lens_returns_none_for_missing_file() {
 }
 
 #[test]
+fn test_project_resolve_code_lens_reference_count_excludes_declaration() {
+    // Regression: the project-level resolve_code_lens path used to compare a
+    // zero-width declaration position against full identifier-span reference
+    // ranges, so it never recognized the declaration and reported N+1
+    // references for N real uses. See project/features.rs.
+    let mut project = Project::new();
+    project.set_file(
+        "test.ts".to_string(),
+        "function foo() {}\nfoo();\nfoo();\nfoo();\n".to_string(),
+    );
+
+    let lenses = project
+        .get_code_lenses("test.ts")
+        .expect("code lenses for file");
+    let func_lens = lenses
+        .iter()
+        .find(|l| {
+            l.data
+                .as_ref()
+                .is_some_and(|d| d.kind == editor_decorations::code_lens::CodeLensKind::References)
+        })
+        .expect("references lens for function");
+
+    let resolved = project
+        .resolve_code_lens("test.ts", func_lens)
+        .expect("resolve produces a lens");
+    let command = resolved.command.expect("resolved lens has a command");
+    // Three call sites; declaration is appended by find_references and must
+    // be subtracted out.
+    assert_eq!(
+        command.title, "3 references",
+        "declaration must be excluded from the reference count (got: {})",
+        command.title
+    );
+}
+
+#[test]
 fn test_project_semantic_tokens_for_interface() {
     let mut project = Project::new();
     project.set_file(


### PR DESCRIPTION
## Summary
- Fixes bug-shape #6 from `docs/DRY_AUDIT_2026-04-21.md`: the project-level `resolve_code_lens` reference counter was inflated by 1 for every symbol.
- The old code compared a zero-width declaration `position` (the `function`-keyword offset) against full identifier-span reference ranges, so `has_decl_reference` was never true and the count never subtracted the declaration that `find_references` always appends.
- Mirrors the in-file path (`code_lens::resolve_references_lens`): `let ref_count = references.len().saturating_sub(1);`.

## Test plan
- [x] `cargo nextest run -p tsz-lsp --lib` — all 115 code-lens tests pass, including the new `test_project_resolve_code_lens_reference_count_excludes_declaration` that verifies 3 real call sites report `"3 references"` (not `"4 references"`).
- [x] Reverified by stashing the fix: the regression test reports `left: "4 references"`, confirming it catches the bug.
- [x] `cargo clippy -p tsz-lsp --lib --tests -- -D warnings` — clean.
- [x] Pre-commit suite (3707 tests, clippy, arch guard) all green.