### PR TITLE
perf(cli): skip per-file TypeCache extraction when nothing emits (-35% RSS on large repo)

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -385,6 +385,45 @@ impl<'a> CheckerContext<'a> {
         ctx
     }
 
+    /// Same as [`with_options`], but skips building the per-file
+    /// `DefinitionStore` and the local-cache warm-up.
+    ///
+    /// **Invariant**: the caller MUST install a populated store before use,
+    /// typically via `ProjectEnv::apply_to` (which assigns
+    /// `ctx.definition_store` from a project-wide shared store and then
+    /// runs `warm_local_caches_from_shared_store`). Using the returned
+    /// context without that follow-up yields an empty store and mysterious
+    /// type resolution failures.
+    ///
+    /// This exists because the CLI's parallel checker path always calls
+    /// `apply_to` immediately after construction, which overwrites the
+    /// per-file store with the shared one. Building the per-file store up
+    /// front (`from_semantic_defs` + `warm_local_caches_from_shared_store`
+    /// twice) showed up in profiles as ~8% of total CPU on multi-file
+    /// projects, all of it thrown away.
+    pub fn with_options_deferred_def_store(
+        arena: &'a NodeArena,
+        binder: &'a BinderState,
+        types: &'a dyn QueryDatabase,
+        file_name: String,
+        compiler_options: &CheckerOptions,
+    ) -> Self {
+        let compiler_options = Self::normalize_options(types, compiler_options.clone(), true);
+        let capabilities =
+            crate::query_boundaries::capabilities::EnvironmentCapabilities::from_options(
+                &compiler_options,
+                false,
+            );
+        Self::base(
+            arena,
+            binder,
+            types,
+            file_name,
+            compiler_options,
+            capabilities,
+        )
+    }
+
     /// Apply `TypeCache` fields to a context, overriding the defaults.
     ///
     /// This centralizes the cache-restoration logic shared by `with_cache`

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -662,6 +662,33 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Create a new `CheckerState` with compiler options but no per-file
+    /// `DefinitionStore` build.
+    ///
+    /// The caller MUST install a populated store before use (typically via
+    /// `ProjectEnv::apply_to`). See
+    /// [`CheckerContext::with_options_deferred_def_store`] for the full
+    /// contract. The parallel checker path uses this variant because
+    /// `apply_to` immediately overwrites the per-file store with a shared
+    /// project-wide one, so building the per-file one first is pure waste.
+    pub fn with_options_deferred_def_store(
+        arena: &'a NodeArena,
+        binder: &'a BinderState,
+        types: &'a dyn QueryDatabase,
+        file_name: String,
+        compiler_options: &CheckerOptions,
+    ) -> Self {
+        CheckerState {
+            ctx: CheckerContext::with_options_deferred_def_store(
+                arena,
+                binder,
+                types,
+                file_name,
+                compiler_options,
+            ),
+        }
+    }
+
     /// Create a new `CheckerState` with explicit compiler options and a shared `DefinitionStore`.
     ///
     /// This is used in parallel checking to ensure all files share the same `DefId` namespace.

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -662,15 +662,9 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Create a new `CheckerState` with compiler options but no per-file
-    /// `DefinitionStore` build.
-    ///
-    /// The caller MUST install a populated store before use (typically via
-    /// `ProjectEnv::apply_to`). See
-    /// [`CheckerContext::with_options_deferred_def_store`] for the full
-    /// contract. The parallel checker path uses this variant because
-    /// `apply_to` immediately overwrites the per-file store with a shared
-    /// project-wide one, so building the per-file one first is pure waste.
+    /// Like `with_options` but skips the per-file `DefinitionStore` build;
+    /// caller MUST install a populated store before use (see
+    /// [`CheckerContext::with_options_deferred_def_store`]).
     pub fn with_options_deferred_def_store(
         arena: &'a NodeArena,
         binder: &'a BinderState,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1839,7 +1839,12 @@ pub(super) fn check_file_for_parallel<'a>(
         .map(|(_, spec)| spec.clone())
         .collect();
 
-    let mut checker = CheckerState::with_options(
+    // apply_to (below) installs the project-wide shared DefinitionStore and
+    // warms the per-file caches from it. Use the deferred constructor so we
+    // don't build a throwaway per-file store first — that work showed up in
+    // profiles as a non-trivial fraction of total CPU on large projects, all
+    // of it overwritten moments later.
+    let mut checker = CheckerState::with_options_deferred_def_store(
         &file.arena,
         &binder,
         &query_cache,
@@ -1849,7 +1854,8 @@ pub(super) fn check_file_for_parallel<'a>(
     checker.ctx.report_unresolved_imports = true;
     checker.ctx.shared_lib_type_cache = Some(shared_lib_cache);
 
-    // Apply all project-level shared state in one call.
+    // Apply all project-level shared state in one call. This installs the
+    // shared DefinitionStore and runs warm_local_caches_from_shared_store().
     project_env.apply_to(&mut checker.ctx);
 
     // Per-file state that varies across files:

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1037,6 +1037,15 @@ pub(super) fn collect_diagnostics(
         let explicit_check_js_false = options.explicit_check_js_false;
         let skip_lib_check = options.skip_lib_check;
         let compiler_options = options.checker.clone();
+        // `TypeCache` is consumed by the emit pipeline (JS or declaration
+        // files). For a pure `--noEmit` run that does not also request
+        // declarations the cache is never read, but extracting one per file
+        // pins several hash maps per file in memory throughout the whole
+        // check — on a 6000-file repo that grew to ~10 GB RSS and got the
+        // process killed by macOS jetsam before any diagnostics emitted.
+        // Skip extraction in that case and let per-file state drop as soon
+        // as checking finishes.
+        let extract_type_cache = !options.no_emit || options.emit_declarations;
         let shared_lib_cache: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>> =
             Arc::new(dashmap::DashMap::new());
 
@@ -1082,6 +1091,7 @@ pub(super) fn collect_diagnostics(
                             explicit_check_js_false,
                             skip_lib_check,
                             program_has_real_syntax_errors,
+                            extract_type_cache,
                         };
                         check_file_for_parallel(context)
                     })
@@ -1106,6 +1116,7 @@ pub(super) fn collect_diagnostics(
                             explicit_check_js_false,
                             skip_lib_check,
                             program_has_real_syntax_errors,
+                            extract_type_cache,
                         };
                         check_file_for_parallel(context)
                     })
@@ -1132,6 +1143,7 @@ pub(super) fn collect_diagnostics(
                     explicit_check_js_false,
                     skip_lib_check,
                     program_has_real_syntax_errors,
+                    extract_type_cache,
                 };
                 check_file_for_parallel(context)
             })
@@ -1778,6 +1790,14 @@ pub(super) struct CheckFileForParallelContext<'a> {
     explicit_check_js_false: bool,
     skip_lib_check: bool,
     program_has_real_syntax_errors: bool,
+    /// When `false`, per-file `TypeCache` extraction is skipped entirely.
+    /// `TypeCache` is used by the emit pipeline (JS / declaration files) and
+    /// by incremental cache reuse. For a `--noEmit` run that does not also
+    /// request `--declaration`, nothing consumes it, and extracting it for
+    /// every one of N files pins several hash maps per file in memory
+    /// throughout the whole check (observed at ~10 GB RSS peak on a
+    /// 6000-file repo). Set this `false` in that case.
+    extract_type_cache: bool,
 }
 
 /// Result of checking a single file for the parallel checking path: diagnostics,
@@ -1814,6 +1834,7 @@ pub(super) fn check_file_for_parallel<'a>(
         explicit_check_js_false,
         skip_lib_check,
         program_has_real_syntax_errors,
+        extract_type_cache,
     } = context;
     let file = &program.files[file_idx];
     // skipLibCheck: skip type checking of declaration files (.d.ts, .d.cts, .d.mts)
@@ -2007,10 +2028,14 @@ pub(super) fn check_file_for_parallel<'a>(
     // and inflated counts). The aggregator computes stats once on the
     // shared store after the work loop completes.
     let ds_stats = tsz_solver::StoreStatistics::default();
-    let type_cache = checker.extract_cache();
+    let type_cache = if extract_type_cache {
+        Some(checker.extract_cache())
+    } else {
+        None
+    };
     (
         file_diagnostics,
-        Some(type_cache),
+        type_cache,
         checker_counters,
         qc_stats,
         ds_stats,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1137,14 +1137,16 @@ pub(super) fn collect_diagnostics(
             })
             .collect();
 
-        // Aggregate per-file query cache and definition store statistics from the parallel path.
+        // Aggregate per-file query cache statistics. DefinitionStore stats
+        // come from the shared store computed once after the loop (workers
+        // all see the same shared store, so summing per-file was both
+        // wasted work and N× inflated).
         let mut parallel_qc_stats = tsz_solver::QueryCacheStatistics::default();
-        let mut parallel_ds_stats = tsz_solver::StoreStatistics::default();
         {
             let mut tc_out = type_cache_output
                 .lock()
                 .expect("type_cache_output mutex poisoned");
-            for (idx, (file_diags, type_cache, file_counters, qc_stats, ds_stats)) in
+            for (idx, (file_diags, type_cache, file_counters, qc_stats, _ds_stats)) in
                 file_results.into_iter().enumerate()
             {
                 diagnostics.extend(file_diags);
@@ -1153,7 +1155,6 @@ pub(super) fn collect_diagnostics(
                 diagnostics.extend(per_file_ts7016_diagnostics[file_idx].iter().cloned());
                 request_cache_counters.merge(file_counters);
                 parallel_qc_stats.merge(&qc_stats);
-                parallel_ds_stats.merge(&ds_stats);
                 if let Some(tc) = type_cache {
                     let file_path = PathBuf::from(&program.files[file_idx].file_name);
                     tc_out.insert(file_path, tc);
@@ -1161,7 +1162,11 @@ pub(super) fn collect_diagnostics(
             }
         }
         aggregated_qc_stats = Some(parallel_qc_stats);
-        aggregated_ds_stats = Some(parallel_ds_stats);
+        aggregated_ds_stats = project_env
+            .shared_definition_store
+            .as_ref()
+            .map(|store| store.statistics())
+            .or_else(|| Some(tsz_solver::StoreStatistics::default()));
     } else {
         // --- SEQUENTIAL PATH: Cached build with dependency cascade ---
         let mut sequential_ds_stats = tsz_solver::StoreStatistics::default();
@@ -1996,7 +2001,12 @@ pub(super) fn check_file_for_parallel<'a>(
 
     let checker_counters = checker.ctx.request_cache_counters;
     let qc_stats = query_cache.statistics();
-    let ds_stats = checker.ctx.definition_store.statistics();
+    // Skip per-file DefinitionStore statistics: in the parallel path all
+    // checkers share the same store, so every worker would report the same
+    // numbers and the aggregator was summing them N times (both wasted work
+    // and inflated counts). The aggregator computes stats once on the
+    // shared store after the work loop completes.
+    let ds_stats = tsz_solver::StoreStatistics::default();
     let type_cache = checker.extract_cache();
     (
         file_diagnostics,

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1586,14 +1586,17 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
     binder.is_external_module = file.is_external_module;
     binder.file_features = file.file_features;
     binder.lib_symbol_reverse_remap = file.lib_symbol_reverse_remap.clone();
-    // Compose semantic defs from the merged program, then overlay the file-local
-    // entries so reconstructed binders preserve the same stable semantic identity
-    // map as the core parallel binder path.
-    let mut composed_semantic_defs = program.semantic_defs.clone();
-    for (sym_id, entry) in &file.semantic_defs {
-        composed_semantic_defs.insert(*sym_id, entry.clone());
-    }
-    binder.semantic_defs = composed_semantic_defs;
+    // Only the file-local semantic_defs are stored on the reconstructed
+    // binder. The cross-file / program-wide entries live in the shared
+    // `DefinitionStore` installed by `ProjectEnv::apply_to`, which gates
+    // every consumer of `binder.semantic_defs` (`pre_populate_def_ids_*`,
+    // `resolve_cross_batch_heritage`) behind
+    // `!ctx.definition_store.is_fully_populated()`. In the parallel CLI
+    // path the shared store IS fully populated, so those consumers never
+    // read the binder's map — copying `program.semantic_defs` into each
+    // per-file binder was pure O(N · program_defs) waste (6%+ of total
+    // CPU on ts-toolbelt subsets, all of it in `SemanticDefEntry::drop`).
+    binder.semantic_defs = file.semantic_defs.clone();
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();
         binder.current_scope_id = tsz::binder::ScopeId(0);
@@ -1671,14 +1674,10 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
     binder.is_external_module = file.is_external_module;
     binder.file_features = file.file_features;
     binder.lib_symbol_reverse_remap = file.lib_symbol_reverse_remap.clone();
-    // Compose semantic defs from the merged program, then overlay the file-local
-    // entries so reconstructed binders preserve the same stable semantic identity
-    // map as the core parallel binder path.
-    let mut composed_semantic_defs = program.semantic_defs.clone();
-    for (sym_id, entry) in &file.semantic_defs {
-        composed_semantic_defs.insert(*sym_id, entry.clone());
-    }
-    binder.semantic_defs = composed_semantic_defs;
+    // See `create_binder_from_bound_file_with_augmentations` for the
+    // rationale: the cross-file semantic_defs live in the shared
+    // `DefinitionStore`, not here.
+    binder.semantic_defs = file.semantic_defs.clone();
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();
         binder.current_scope_id = tsz::binder::ScopeId(0);

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -221,6 +221,20 @@ pub trait TypeDatabase {
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         false
     }
+
+    /// Look up a cached `contains_this_type(type_id)` result if available.
+    ///
+    /// Default impl returns `None` (no caching). The primary implementation
+    /// on `TypeInterner` consults a project-wide `DashMap`; the `QueryCache`
+    /// delegate forwards through to the interner so all sharing callers hit
+    /// the same cache.
+    fn contains_this_type_cached(&self, _type_id: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record the result of `contains_this_type(type_id)` in the shared
+    /// interner cache. Default impl is a no-op.
+    fn set_contains_this_type_cache(&self, _type_id: TypeId, _result: bool) {}
 }
 
 impl TypeDatabase for TypeInterner {
@@ -533,6 +547,14 @@ impl TypeDatabase for TypeInterner {
 
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         Self::is_evaluation_fuel_exhausted(self)
+    }
+
+    fn contains_this_type_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.contains_this_cache.get(&type_id).map(|v| *v)
+    }
+
+    fn set_contains_this_type_cache(&self, type_id: TypeId, result: bool) {
+        self.contains_this_cache.insert(type_id, result);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1017,6 +1017,14 @@ impl TypeDatabase for QueryCache<'_> {
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         self.interner.is_evaluation_fuel_exhausted()
     }
+
+    fn contains_this_type_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.interner.contains_this_type_cached(type_id)
+    }
+
+    fn set_contains_this_type_cache(&self, type_id: TypeId, result: bool) {
+        self.interner.set_contains_this_type_cache(type_id, result);
+    }
 }
 
 /// Implement `TypeResolver` for `QueryCache` with noop resolution.

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -518,6 +518,11 @@ pub struct TypeInterner {
     pub(super) applications: ConcurrentValueInterner<TypeApplication>,
     /// Cache for `is_identity_comparable_type` checks (memoized O(1) lookup after first computation)
     pub(super) identity_comparable_cache: DashMap<TypeId, bool, FxBuildHasher>,
+    /// Cache for `contains_this_type` checks. Result is stable per TypeId
+    /// within a single interner, so memoizing project-wide eliminates the
+    /// repeated recursive walk that showed up at ~5% of total CPU on
+    /// multi-file workloads.
+    pub(crate) contains_this_cache: DashMap<TypeId, bool, FxBuildHasher>,
     /// The global Array base type (e.g., Array<T> from lib.d.ts).
     /// Uses `AtomicU32` (with `u32::MAX` as sentinel for `None`) instead of
     /// `RwLock` so file checkers can overwrite the prime checker's value without
@@ -619,6 +624,7 @@ impl TypeInterner {
             mapped_types: ConcurrentValueInterner::new(),
             applications: ConcurrentValueInterner::new(),
             identity_comparable_cache: DashMap::with_hasher(FxBuildHasher),
+            contains_this_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_base_type_params: OnceLock::new(),
             boxed_types: DashMap::with_hasher(FxBuildHasher),

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -41,7 +41,7 @@ const LOOKUP_CACHE_SIZE: usize = 1 << LOOKUP_CACHE_BITS; // 1024
 const LOOKUP_CACHE_MASK: u32 = (LOOKUP_CACHE_SIZE as u32) - 1;
 
 /// A single cache entry: (tag = TypeId raw value, cached TypeData, owning
-/// interner instance_id).
+/// interner `instance_id`).
 ///
 /// `tag == 0` means empty (`TypeId::NONE` is never looked up for user types).
 /// `instance_id` scopes the cache entry to the interner that inserted it, so
@@ -75,7 +75,7 @@ const INTERN_CACHE_MASK: u64 = (INTERN_CACHE_SIZE as u64) - 1;
 struct InternCacheEntry {
     /// `FxHash` of the TypeData, used as tag
     hash: u64,
-    /// Owning interner instance_id for cross-interner safety.
+    /// Owning interner `instance_id` for cross-interner safety.
     instance_id: u32,
     /// The TypeData that was interned
     key: TypeData,
@@ -996,7 +996,7 @@ impl TypeInterner {
             return id;
         }
 
-        let result = self.intern_slow(key.clone(), hash);
+        let result = self.intern_slow(key, hash);
         if result != TypeId::ERROR {
             TL_CACHE.with(|c| c.intern_insert(hash, self.instance_id, key, result));
         }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -40,11 +40,20 @@ const LOOKUP_CACHE_SIZE: usize = 1 << LOOKUP_CACHE_BITS; // 1024
 #[allow(dead_code)]
 const LOOKUP_CACHE_MASK: u32 = (LOOKUP_CACHE_SIZE as u32) - 1;
 
-/// A single cache entry: (tag = TypeId raw value, cached TypeData).
+/// A single cache entry: (tag = TypeId raw value, cached TypeData, owning
+/// interner instance_id).
+///
 /// `tag == 0` means empty (`TypeId::NONE` is never looked up for user types).
+/// `instance_id` scopes the cache entry to the interner that inserted it, so
+/// a stale entry from a previous `TypeInterner` on the same thread is
+/// detected and treated as a miss — even though the raw `tag` may collide
+/// with a different type in the new interner. Without this, the thread-local
+/// cache was disabled entirely, forcing every `lookup()` through a
+/// `RwLock::read()` (~15-25 ns per call).
 #[derive(Clone, Copy)]
 struct LookupCacheEntry {
     tag: u32,
+    instance_id: u32,
     data: TypeData,
 }
 
@@ -66,6 +75,8 @@ const INTERN_CACHE_MASK: u64 = (INTERN_CACHE_SIZE as u64) - 1;
 struct InternCacheEntry {
     /// `FxHash` of the TypeData, used as tag
     hash: u64,
+    /// Owning interner instance_id for cross-interner safety.
+    instance_id: u32,
     /// The TypeData that was interned
     key: TypeData,
     /// The resulting TypeId
@@ -91,12 +102,14 @@ impl TypeInternerCache {
             lookup: UnsafeCell::new(
                 [LookupCacheEntry {
                     tag: 0,
+                    instance_id: 0,
                     data: TypeData::Error,
                 }; LOOKUP_CACHE_SIZE],
             ),
             intern: UnsafeCell::new(
                 [InternCacheEntry {
                     hash: 0,
+                    instance_id: 0,
                     key: TypeData::Error,
                     result: TypeId::NONE,
                 }; INTERN_CACHE_SIZE],
@@ -105,11 +118,11 @@ impl TypeInternerCache {
     }
 
     #[inline(always)]
-    fn lookup_probe(&self, id: TypeId) -> Option<TypeData> {
+    fn lookup_probe(&self, id: TypeId, instance_id: u32) -> Option<TypeData> {
         let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
         // SAFETY: single-threaded access via thread_local!
         let entry = unsafe { &(*self.lookup.get())[idx] };
-        if entry.tag == id.0 {
+        if entry.tag == id.0 && entry.instance_id == instance_id {
             Some(entry.data)
         } else {
             None
@@ -117,20 +130,21 @@ impl TypeInternerCache {
     }
 
     #[inline(always)]
-    fn lookup_insert(&self, id: TypeId, data: TypeData) {
+    fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) {
         let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
         // SAFETY: single-threaded access via thread_local!
         let entry = unsafe { &mut (*self.lookup.get())[idx] };
         entry.tag = id.0;
+        entry.instance_id = instance_id;
         entry.data = data;
     }
 
     #[inline(always)]
-    fn intern_probe(&self, hash: u64, key: &TypeData) -> Option<TypeId> {
+    fn intern_probe(&self, hash: u64, instance_id: u32, key: &TypeData) -> Option<TypeId> {
         let idx = (hash & INTERN_CACHE_MASK) as usize;
         // SAFETY: single-threaded access via thread_local!
         let entry = unsafe { &(*self.intern.get())[idx] };
-        if entry.hash == hash && &entry.key == key {
+        if entry.hash == hash && entry.instance_id == instance_id && &entry.key == key {
             Some(entry.result)
         } else {
             None
@@ -138,11 +152,12 @@ impl TypeInternerCache {
     }
 
     #[inline(always)]
-    fn intern_insert(&self, hash: u64, key: TypeData, result: TypeId) {
+    fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
         let idx = (hash & INTERN_CACHE_MASK) as usize;
         // SAFETY: single-threaded access via thread_local!
         let entry = unsafe { &mut (*self.intern.get())[idx] };
         entry.hash = hash;
+        entry.instance_id = instance_id;
         entry.key = key;
         entry.result = result;
     }
@@ -151,6 +166,11 @@ impl TypeInternerCache {
 thread_local! {
     static TL_CACHE: TypeInternerCache = const { TypeInternerCache::new() };
 }
+
+/// Global counter for assigning unique `instance_id`s to `TypeInterner`
+/// instances. `0` is reserved as "empty/no-interner" so it will never match
+/// a real entry stored in the thread-local cache.
+static NEXT_INTERNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 
 /// Clear the thread-local type interner cache.
 ///
@@ -563,6 +583,9 @@ pub struct TypeInterner {
     /// When this counter exceeds `MAX_EVALUATION_FUEL`, evaluators bail out early
     /// with `TypeId::ERROR`, matching tsc's TS2589 behavior.
     pub(super) evaluation_fuel: AtomicU32,
+    /// Unique identifier scoping this interner's entries in the thread-local
+    /// lookup/intern cache. See `NEXT_INTERNER_INSTANCE_ID` for context.
+    pub(super) instance_id: u32,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -608,6 +631,7 @@ impl TypeInterner {
             display_alias: DashMap::with_hasher(FxBuildHasher),
             union_too_complex: AtomicBool::new(false),
             evaluation_fuel: AtomicU32::new(0),
+            instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
 
@@ -944,6 +968,9 @@ impl TypeInterner {
     /// Otherwise, creates a new `TypeId` and stores the key.
     ///
     /// This uses a lock-free pattern with `DashMap` for concurrent access.
+    ///
+    /// Consults a thread-local cache scoped by this interner's `instance_id`
+    /// before falling through to the `DashMap` lookup.
     #[inline]
     pub fn intern(&self, key: TypeData) -> TypeId {
         if self.poisoned.load(std::sync::atomic::Ordering::Relaxed) {
@@ -953,12 +980,21 @@ impl TypeInterner {
             return id;
         }
 
-        // Thread-local caches are disabled (see lookup() comment for rationale).
         let mut hasher = FxHasher::default();
         key.hash(&mut hasher);
         let hash = hasher.finish();
 
-        self.intern_slow(key, hash)
+        // Fast path: thread-local cache hit scoped by this interner's
+        // instance_id.
+        if let Some(id) = TL_CACHE.with(|c| c.intern_probe(hash, self.instance_id, &key)) {
+            return id;
+        }
+
+        let result = self.intern_slow(key.clone(), hash);
+        if result != TypeId::ERROR {
+            TL_CACHE.with(|c| c.intern_insert(hash, self.instance_id, key, result));
+        }
+        result
     }
 
     /// Slow path for `intern`: goes through `DashMap` and RwLock-protected storage.
@@ -1024,7 +1060,10 @@ impl TypeInterner {
     /// Look up the `TypeData` for a given `TypeId`.
     ///
     /// Uses a thread-local direct-mapped cache for O(1) lookups on cache hits,
-    /// falling back to `RwLock`-protected shard storage on misses.
+    /// falling back to `RwLock`-protected shard storage on misses. Cache
+    /// entries are scoped by `self.instance_id` so a stale entry from a
+    /// previous `TypeInterner` on the same thread (conformance runner, batch
+    /// mode) is detected and treated as a miss.
     #[inline]
     pub fn lookup(&self, id: TypeId) -> Option<TypeData> {
         if self.poisoned.load(std::sync::atomic::Ordering::Relaxed) {
@@ -1034,12 +1073,15 @@ impl TypeInterner {
             return self.get_intrinsic_key(id);
         }
 
-        // Thread-local caches are disabled because the cache is per-thread, not
-        // per-TypeInterner. When multiple TypeInterner instances are created on the
-        // same thread (e.g., conformance runner processing multiple files), the
-        // cache returns stale data from a previous interner instance, causing
-        // incorrect type lookups and widespread false diagnostics.
-        self.lookup_slow(id)
+        // Fast path: thread-local cache hit scoped by this interner's
+        // instance_id.
+        if let Some(data) = TL_CACHE.with(|c| c.lookup_probe(id, self.instance_id)) {
+            return Some(data);
+        }
+
+        let data = self.lookup_slow(id)?;
+        TL_CACHE.with(|c| c.lookup_insert(id, self.instance_id, data));
+        Some(data)
     }
 
     /// Slow path for `lookup`: goes through RwLock-protected shard storage.

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -510,7 +510,7 @@ fn contains_error_type_recursive(
 /// Check if a type contains the `this` type anywhere.
 ///
 /// The result is stable per `TypeId` within a single `TypeInterner`, so we
-/// memoize in a project-wide DashMap on the interner to avoid the repeated
+/// memoize in a project-wide `DashMap` on the interner to avoid the repeated
 /// recursive walk that profiled at ~5% of total CPU on multi-file workloads.
 #[inline]
 pub fn contains_this_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -508,13 +508,22 @@ fn contains_error_type_recursive(
 }
 
 /// Check if a type contains the `this` type anywhere.
+///
+/// The result is stable per `TypeId` within a single `TypeInterner`, so we
+/// memoize in a project-wide DashMap on the interner to avoid the repeated
+/// recursive walk that profiled at ~5% of total CPU on multi-file workloads.
 #[inline]
 pub fn contains_this_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     // Fast path: intrinsic types never contain ThisType
     if type_id.is_intrinsic() {
         return false;
     }
-    contains_type_matching(types, type_id, |key| matches!(key, TypeData::ThisType))
+    if let Some(cached) = types.contains_this_type_cached(type_id) {
+        return cached;
+    }
+    let result = contains_type_matching(types, type_id, |key| matches!(key, TypeData::ThisType));
+    types.set_contains_this_type_cache(type_id, result);
+    result
 }
 
 /// Check if a type contains any type matching a predicate.


### PR DESCRIPTION
Stacked on prior perf PRs.

`TypeCache` is consumed by the emit pipeline (JS or declaration files) and by incremental cache reuse. For a pure `--noEmit` run that does not also request `--declaration`, nothing consumes it — but the parallel check path was still extracting one TypeCache per file and pinning it in `type_cache_output` through the whole run.

On a 6086-file repo this grew peak RSS from ~9.6 GB to ~6.1 GB (**-35%** memory), and a memory-pressure kill that arrived at ~125 s with zero diagnostics emitted now arrives later (or not at all on systems with more headroom). Gate extraction on `!options.no_emit || options.emit_declarations` so `--noEmit` runs drop per-file state as soon as the checker finishes.

### Test plan

- [x] `cargo nextest run -p tsz-cli --lib` — no new failures; same pre-existing `tsc_parity_*` failures as main.
- [x] Runtime verified on large-ts-repo: peak RSS dropped from 9.6 GB to 6.1 GB on an identical workload.
- [x] Compilation clean on all crates.