### PR TITLE
[codex] fix remapped keyof conformance

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -994,7 +994,62 @@ impl<'a> CheckerState<'a> {
         }
         source_str = self.canonicalize_assignment_numeric_literal_union_display(source_str);
         target_str = self.canonicalize_assignment_numeric_literal_union_display(target_str);
+        if let Some(widened) = self.rewrite_standalone_literal_source_for_keyof_display(
+            &source_str,
+            &target_str,
+            target,
+        ) {
+            source_str = widened;
+        }
         (source_str, target_str)
+    }
+
+    pub(in crate::error_reporter) fn rewrite_standalone_literal_source_for_keyof_display(
+        &mut self,
+        source_display: &str,
+        target_display: &str,
+        target: TypeId,
+    ) -> Option<String> {
+        let evaluated_target = self.evaluate_type_for_assignability(target);
+        let target_alias_origin = self
+            .ctx
+            .types
+            .get_display_alias(target)
+            .or_else(|| self.ctx.types.get_display_alias(evaluated_target));
+        let target_is_generic_keyof =
+            crate::query_boundaries::common::contains_type_parameters(self.ctx.types, target)
+                || crate::query_boundaries::common::contains_type_parameters(
+                    self.ctx.types,
+                    evaluated_target,
+                )
+                || target_alias_origin
+                    .and_then(|alias| {
+                        crate::query_boundaries::common::keyof_inner_type(self.ctx.types, alias)
+                    })
+                    .is_some_and(|operand| {
+                        crate::query_boundaries::common::contains_type_parameters(
+                            self.ctx.types,
+                            operand,
+                        ) || crate::query_boundaries::common::contains_type_parameters(
+                            self.ctx.types,
+                            self.evaluate_type_for_assignability(operand),
+                        )
+                    });
+        if !target_display.starts_with("keyof ") || !target_is_generic_keyof {
+            return None;
+        }
+
+        if source_display == "true" || source_display == "false" {
+            return Some("boolean".to_string());
+        }
+        if source_display.starts_with('"') && source_display.ends_with('"') {
+            return Some("string".to_string());
+        }
+        if source_display.parse::<f64>().is_ok() {
+            return Some("number".to_string());
+        }
+
+        None
     }
 
     pub(super) fn rewrite_source_display_for_non_literal_target_assignability(

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -357,7 +357,7 @@ impl<'a> CheckerState<'a> {
                 source_type,
                 target_union_members: _,
             } => {
-                let (source_str, target_str) = if depth == 0 {
+                let (mut source_str, target_str) = if depth == 0 {
                     let use_structural_source_display =
                         crate::query_boundaries::common::enum_def_id(self.ctx.types, source)
                             .is_none();
@@ -379,6 +379,13 @@ impl<'a> CheckerState<'a> {
                         self.format_type_diagnostic(target),
                     )
                 };
+                if let Some(widened) = self.rewrite_standalone_literal_source_for_keyof_display(
+                    &source_str,
+                    &target_str,
+                    target,
+                ) {
+                    source_str = widened;
+                }
                 // TS2820 prefers "did you mean X?" and uses the expanded union
                 // form rather than the alias name.
                 let evaluated_target_for_suggestion = self.evaluate_type_with_env(target);

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -71,6 +71,14 @@ impl<'a> CheckerState<'a> {
                 target_str =
                     self.rewrite_target_display_for_non_literal_assignability(target, target_str);
             }
+
+            if let Some(widened) = self.rewrite_standalone_literal_source_for_keyof_display(
+                &source_str,
+                &target_str,
+                target,
+            ) {
+                source_str = widened;
+            }
         }
         source_str = self.normalize_template_placeholder_spacing_for_display(&source_str);
         target_str = self.normalize_template_placeholder_spacing_for_display(&target_str);

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -448,6 +448,44 @@ function f4<T extends { [K in keyof T]: string }>(k: keyof T) {
 }
 
 #[test]
+fn test_assignment_diagnostic_widens_literal_for_named_keyof_display_target() {
+    let diagnostics = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+declare const sym: unique symbol;
+
+function g<T>() {
+    type Orig = { [k: string]: any, str: any, [sym]: any } & T;
+    type NonIndex<T extends PropertyKey> = {} extends Record<T, any> ? never : T;
+    type DistributiveNonIndex<T extends PropertyKey> = T extends unknown ? NonIndex<T> : never;
+    type Remapped = { [K in keyof Orig as DistributiveNonIndex<K>]: any };
+    let x: keyof Remapped;
+    x = "whatever";
+}
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message.contains("Type 'string' is not assignable to type 'keyof Remapped'")
+        }),
+        "Expected named `keyof` target display to widen literal source text.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message
+                    .contains("Type '\"whatever\"' is not assignable to type 'keyof Remapped'")
+        }),
+        "Did not expect literal source text for named `keyof` target display.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_generic_string_index_constraint_allows_read_but_rejects_write_via_dot_access() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -3,9 +3,13 @@
 //! Handles TypeScript's keyof operator: `keyof T`
 
 use crate::TypeDatabase;
+use crate::objects::{PropertyCollectionResult, collect_properties};
 use crate::relations::subtype::TypeResolver;
 use crate::type_queries::narrow_keyof_intersection_member_by_literal_discriminants;
-use crate::types::{IntrinsicKind, LiteralValue, TupleElement, TypeData, TypeId, TypeListId};
+use crate::types::{
+    IntrinsicKind, LiteralValue, MappedType, MappedTypeId, TupleElement, TypeData, TypeId,
+    TypeListId,
+};
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
 
@@ -70,6 +74,119 @@ impl KeyofKeySet {
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    fn property_name_atom_to_key_type(&self, name: Atom) -> TypeId {
+        let name_text = self.interner().resolve_atom_ref(name);
+        if let Some(symbol_ref) = name_text.strip_prefix("__unique_")
+            && let Ok(id) = symbol_ref.parse::<u32>()
+        {
+            return self.interner().unique_symbol(crate::types::SymbolRef(id));
+        }
+        self.interner().literal_string_atom(name)
+    }
+
+    fn push_remapped_key_type(&mut self, key_types: &mut Vec<TypeId>, remapped_key: TypeId) {
+        if remapped_key == TypeId::STRING {
+            key_types.push(TypeId::STRING);
+            key_types.push(TypeId::NUMBER);
+        } else {
+            key_types.push(remapped_key);
+        }
+    }
+
+    fn collect_keyof_for_remapped_mapped_type(
+        &mut self,
+        mapped_id: MappedTypeId,
+        mapped: &MappedType,
+    ) -> Option<TypeId> {
+        let name_type = mapped.name_type?;
+        let mut key_types = Vec::new();
+
+        let constraint_source = crate::keyof_inner_type(self.interner(), mapped.constraint)
+            .or_else(|| {
+                let evaluated = self.evaluate(mapped.constraint);
+                (evaluated != mapped.constraint)
+                    .then(|| crate::keyof_inner_type(self.interner(), evaluated))
+                    .flatten()
+            });
+
+        if let Some(source) = constraint_source {
+            let resolved_source = self.evaluate(source);
+            match collect_properties(resolved_source, self.interner(), self.resolver()) {
+                PropertyCollectionResult::Properties {
+                    properties,
+                    string_index,
+                    number_index,
+                } => {
+                    for prop in properties {
+                        let source_key = self.property_name_atom_to_key_type(prop.name);
+                        match self.remap_key_type_for_mapped(mapped, source_key) {
+                            Ok(Some(remapped_key)) => {
+                                self.push_remapped_key_type(&mut key_types, remapped_key);
+                            }
+                            Ok(None) => {}
+                            Err(()) => return None,
+                        }
+                    }
+                    if string_index.is_some() {
+                        match self.remap_key_type_for_mapped(mapped, TypeId::STRING) {
+                            Ok(Some(remapped_key)) => {
+                                self.push_remapped_key_type(&mut key_types, remapped_key);
+                            }
+                            Ok(None) => {}
+                            Err(()) => return None,
+                        }
+                    } else if number_index.is_some() {
+                        match self.remap_key_type_for_mapped(mapped, TypeId::NUMBER) {
+                            Ok(Some(remapped_key)) => key_types.push(remapped_key),
+                            Ok(None) => {}
+                            Err(()) => return None,
+                        }
+                    }
+                }
+                PropertyCollectionResult::Any => {
+                    match self.remap_key_type_for_mapped(mapped, TypeId::STRING) {
+                        Ok(Some(remapped_key)) => {
+                            self.push_remapped_key_type(&mut key_types, remapped_key);
+                        }
+                        Ok(None) => {}
+                        Err(()) => return None,
+                    }
+                    match self.remap_key_type_for_mapped(mapped, TypeId::NUMBER) {
+                        Ok(Some(remapped_key)) => key_types.push(remapped_key),
+                        Ok(None) => {}
+                        Err(()) => return None,
+                    }
+                    match self.remap_key_type_for_mapped(mapped, TypeId::SYMBOL) {
+                        Ok(Some(remapped_key)) => key_types.push(remapped_key),
+                        Ok(None) => {}
+                        Err(()) => return None,
+                    }
+                }
+                PropertyCollectionResult::NonObject => {}
+            }
+        } else if let Some(names) =
+            crate::type_queries::collect_finite_mapped_property_names(self.interner(), mapped_id)
+        {
+            let mut sorted_names: Vec<_> = names.into_iter().collect();
+            sorted_names.sort_by_key(|atom| atom.0);
+            for name in sorted_names {
+                key_types.push(self.property_name_atom_to_key_type(name));
+            }
+        }
+
+        if crate::type_queries::contains_type_parameters_db(self.interner(), mapped.constraint) {
+            key_types.push(name_type);
+        }
+
+        if key_types.is_empty() {
+            None
+        } else if key_types.len() == 1 {
+            Some(key_types[0])
+        } else {
+            Some(self.interner().union(key_types))
+        }
+    }
+
     fn should_include_keyof_property(&self, prop: &crate::PropertyInfo) -> bool {
         prop.visibility == crate::Visibility::Public
             && !self
@@ -156,8 +273,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 TypeData::Mapped(mapped_id) => {
                     let mapped = self.interner().get_mapped(mapped_id);
-                    if let Some(name_type) = mapped.name_type {
-                        self.evaluate(name_type)
+                    if mapped.name_type.is_some() {
+                        self.collect_keyof_for_remapped_mapped_type(mapped_id, &mapped)
+                            .unwrap_or_else(|| {
+                                self.evaluate(mapped.name_type.unwrap_or(TypeId::ERROR))
+                            })
                     } else {
                         self.evaluate(mapped.constraint)
                     }
@@ -210,7 +330,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .properties
                         .iter()
                         .filter(|p| self.should_include_keyof_property(p))
-                        .map(|p| self.interner().literal_string_atom(p.name))
+                        .map(|p| self.property_name_atom_to_key_type(p.name))
                         .collect();
                     if key_types.is_empty() {
                         return TypeId::NEVER;
@@ -223,7 +343,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .properties
                         .iter()
                         .filter(|p| self.should_include_keyof_property(p))
-                        .map(|p| self.interner().literal_string_atom(p.name))
+                        .map(|p| self.property_name_atom_to_key_type(p.name))
                         .collect();
 
                     if shape.string_index.is_some() {
@@ -245,7 +365,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .properties
                         .iter()
                         .filter(|p| self.should_include_keyof_property(p))
-                        .map(|p| self.interner().literal_string_atom(p.name))
+                        .map(|p| self.property_name_atom_to_key_type(p.name))
                         .collect();
 
                     if shape.string_index.is_some() {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -32,7 +32,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         key_type = key_type.0,
         has_name_type = mapped.name_type.is_some(),
     ))]
-    fn remap_key_type_for_mapped(
+    pub(crate) fn remap_key_type_for_mapped(
         &mut self,
         mapped: &MappedType,
         key_type: TypeId,

--- a/crates/tsz-solver/tests/mapped_key_remap_tests.rs
+++ b/crates/tsz-solver/tests/mapped_key_remap_tests.rs
@@ -6,6 +6,7 @@ use crate::types::*;
 use crate::{
     evaluation::evaluate::evaluate_type,
     intern::TypeInterner,
+    relations::subtype::SubtypeChecker,
     type_queries::{collect_finite_mapped_property_names, get_finite_mapped_property_type},
 };
 
@@ -913,5 +914,107 @@ fn test_finite_mapped_property_names_do_not_materialize_string_index_keys() {
     assert!(
         get_finite_mapped_property_type(&interner, mapped_id, "anything").is_none(),
         "string index constraints should not synthesize exact property types"
+    );
+}
+
+#[test]
+fn test_keyof_string_indexed_object_preserves_unique_symbol_property() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let sym_ref = crate::SymbolRef(77);
+    let sym_name = interner.intern_string("__unique_77");
+    let source = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: vec![
+            PropertyInfo::new(interner.intern_string("str"), TypeId::STRING),
+            PropertyInfo::new(sym_name, TypeId::NUMBER),
+        ],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol: None,
+    });
+
+    let keyof_source = evaluate_type(&interner, interner.keyof(source));
+
+    assert!(
+        checker.is_subtype_of(interner.literal_string("str"), keyof_source),
+        "explicit string property should remain in keyof, got {:?}",
+        interner.lookup(keyof_source)
+    );
+    assert!(
+        checker.is_subtype_of(interner.unique_symbol(sym_ref), keyof_source),
+        "explicit unique symbol property should remain in keyof, got {:?}",
+        interner.lookup(keyof_source)
+    );
+    assert!(
+        checker.is_subtype_of(TypeId::NUMBER, keyof_source),
+        "string index signature should still contribute number to keyof, got {:?}",
+        interner.lookup(keyof_source)
+    );
+}
+
+#[test]
+fn test_keyof_generic_remapped_mapped_type_keeps_concrete_lower_bound_keys() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let sym_ref = crate::SymbolRef(91);
+    let sym_name = interner.intern_string("__unique_91");
+    let concrete_source = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: vec![
+            PropertyInfo::new(interner.intern_string("str"), TypeId::STRING),
+            PropertyInfo::new(sym_name, TypeId::NUMBER),
+        ],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::ANY,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol: None,
+    });
+    let generic_tail = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let source = interner.intersection(vec![concrete_source, generic_tail]);
+
+    let key_param_info = TypeParamInfo {
+        name: interner.intern_string("K"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let key_param = interner.intern(TypeData::TypeParameter(key_param_info));
+    let mapped = interner.mapped(MappedType {
+        type_param: key_param_info,
+        constraint: interner.keyof(source),
+        name_type: Some(key_param),
+        template: TypeId::BOOLEAN,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    let keyof_mapped = evaluate_type(&interner, interner.keyof(mapped));
+
+    assert!(
+        checker.is_subtype_of(interner.literal_string("str"), keyof_mapped),
+        "lower-bound literal key should survive remapped keyof, got {:?}",
+        interner.lookup(keyof_mapped)
+    );
+    assert!(
+        checker.is_subtype_of(interner.unique_symbol(sym_ref), keyof_mapped),
+        "lower-bound unique symbol key should survive remapped keyof, got {:?}",
+        interner.lookup(keyof_mapped)
     );
 }


### PR DESCRIPTION
## Summary

- fix solver `keyof` evaluation for remapped mapped types so concrete lower-bound keys like `"str"` and unique-symbol keys survive generic remapping
- fix TS2322 source display so named `keyof` targets only widen standalone literals for generic/unresolved `keyof` cases, while concrete `keyof` targets keep exact literal spellings
- add solver and checker regressions covering the remapped `keyof` semantics and diagnostic display edge cases

## Root Cause

For remapped mapped types over generic string-indexed sources, `tsz` dropped concrete lower-bound keys during solver-side `keyof` evaluation and then widened named `keyof` diagnostics too aggressively, while `tsc` preserves those concrete keys semantically and only widens standalone literals for generic/unresolved `keyof` targets.

## TypeScript Repro

```ts
const sym = Symbol("")

function g<T>() {
  type Orig = { [k: string]: any, str: any, [sym]: any } & T;
  type NonIndex<T extends PropertyKey> = {} extends Record<T, any> ? never : T;
  type DistributiveNonIndex<T extends PropertyKey> = T extends unknown ? NonIndex<T> : never;
  type Remapped = { [K in keyof Orig as DistributiveNonIndex<K>]: any };

  let x: keyof Remapped;
  x = "whatever"; // Type string is not assignable to type keyof Remapped.
}
```

## Validation

- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "keyRemappingKeyofResult" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL` -> `FINAL RESULTS: 12079/12581 passed (96.0%)`
