### PR TITLE
[codex] suppress parenthesized recovery cascade

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2682,7 +2682,9 @@ impl ParserState {
             self.parse_expected(SyntaxKind::CloseParenToken);
         } else {
             use tsz_common::diagnostics::diagnostic_codes;
-            self.parse_error_at_current_token("')' expected.", diagnostic_codes::EXPECTED);
+            if self.should_report_error() {
+                self.parse_error_at_current_token("')' expected.", diagnostic_codes::EXPECTED);
+            }
             self.recover_parenthesized_expression_typed_arrow_tail();
         }
         self.context_flags = saved_context_flags;

--- a/crates/tsz-parser/tests/state_expression_tests.rs
+++ b/crates/tsz-parser/tests/state_expression_tests.rs
@@ -104,6 +104,41 @@ abstract class C1 {
 }
 
 #[test]
+fn malformed_equality_tail_in_parens_does_not_emit_close_paren_cascade() {
+    let (parser, _root) = parse_source("export = } x = ( y = z ==== 'function') {");
+    let diags = parser.get_diagnostics();
+
+    assert!(
+        diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPRESSION_EXPECTED && diag.start == 9),
+        "expected TS1109 at the invalid export-assignment expression, got {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPRESSION_EXPECTED && diag.start == 26),
+        "expected TS1109 at the stray equality token, got {diags:?}"
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPECTED
+                && diag.start == 28
+                && diag.message == "')' expected."),
+        "should suppress the cascading missing-paren diagnostic at the string literal, got {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPECTED
+                && diag.start == 38
+                && diag.message == "';' expected."),
+        "expected statement recovery to report the missing semicolon at the close paren, got {diags:?}"
+    );
+}
+
+#[test]
 fn type_predicate_assertions_report_syntax_errors_instead_of_parsing_as_types() {
     let (parser, _root) = parse_source(
         r#"


### PR DESCRIPTION
## Summary

Suppress the cascading missing-close-paren diagnostic when parenthesized expression recovery has already reported a nearby parse error.

Root cause: `parse_parenthesized_expression` always emitted `TS1005 ")' expected."` on a missing close paren, even when the parser had just reported the malformed `====` tail in `export = } x = ( y = z ==== 'function') {`, which made tsz report an extra fingerprint that TypeScript suppresses.

Fixed conformance target: `TypeScript/tests/cases/compiler/parserUnparsedTokenCrash2.ts`.

Unit test: `malformed_equality_tail_in_parens_does_not_emit_close_paren_cascade` in `crates/tsz-parser/tests/state_expression_tests.rs`.

## Verification

- `cargo nextest run --package tsz-parser malformed_equality_tail_in_parens_does_not_emit_close_paren_cascade`
- `./scripts/conformance/conformance.sh run --filter "parserUnparsedTokenCrash2" --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`
- `scripts/session/verify-all.sh` -> all suites passed; conformance `12086` vs baseline `12061`, emit tests improved `JS +4, DTS +25`, fourslash/LSP `50/50`.
- Commit hook passed formatting, clippy, wasm warning gate, architecture guardrails, and affected tests: `19173 passed, 56 skipped`.
