### PR TITLE
fix(lsp): preserve quotes when rewriting imports for file rename

### DIFF
--- a/crates/tsz-lsp/src/project/core.rs
+++ b/crates/tsz-lsp/src/project/core.rs
@@ -2414,7 +2414,6 @@ impl Project {
         new_path: &Path,
         result: &mut WorkspaceEdit,
     ) {
-        use crate::rename::TextEdit;
         use crate::rename::file_rename::FileRenameProvider;
         use crate::utils::calculate_new_relative_path;
         use std::path::Path;
@@ -2454,11 +2453,13 @@ impl Project {
                     new_path,
                     &import_loc.current_specifier,
                 ) {
-                    // Create a TextEdit for this import
-                    let text_edit = TextEdit::new(import_loc.range, new_specifier);
-
-                    // Add to the result
-                    result.add_edit(dependent_path.clone(), text_edit);
+                    // `import_loc.range` spans the surrounding quotes; use the
+                    // helper so the rewrite replaces only the inner content
+                    // and the original quote style is preserved.
+                    result.add_edit(
+                        dependent_path.clone(),
+                        import_loc.specifier_text_edit(new_specifier),
+                    );
                 }
             }
         }

--- a/crates/tsz-lsp/src/project/features.rs
+++ b/crates/tsz-lsp/src/project/features.rs
@@ -1097,33 +1097,11 @@ impl Project {
                 let resolved_base = strip_ext(&resolved);
 
                 if resolved_base == old_base {
-                    // Compute the new relative specifier
                     let new_specifier = self.compute_relative_specifier(file_name, &new_base);
-
-                    // The range includes quotes, so build the edit with quotes
-                    let quote = if loc.current_specifier.contains('\'') {
-                        '\''
-                    } else {
-                        '"'
-                    };
-                    // Adjust range to only replace the content inside quotes
-                    let inner_range = tsz_common::position::Range::new(
-                        tsz_common::position::Position::new(
-                            loc.range.start.line,
-                            loc.range.start.character + 1,
-                        ),
-                        tsz_common::position::Position::new(
-                            loc.range.end.line,
-                            loc.range.end.character.saturating_sub(1),
-                        ),
-                    );
-                    let _ = quote; // suppress unused warning, quote is in original text
-                    workspace_edits.entry(file_name.clone()).or_default().push(
-                        crate::rename::TextEdit {
-                            range: inner_range,
-                            new_text: new_specifier,
-                        },
-                    );
+                    workspace_edits
+                        .entry(file_name.clone())
+                        .or_default()
+                        .push(loc.specifier_text_edit(new_specifier));
                 }
             }
         }

--- a/crates/tsz-lsp/src/rename/file_rename.rs
+++ b/crates/tsz-lsp/src/rename/file_rename.rs
@@ -3,9 +3,10 @@
 //! Provides support for `workspace/willRenameFiles` to update import statements
 //! when files are renamed or moved.
 
-use tsz_common::position::Range;
+use tsz_common::position::{Position, Range};
 use tsz_parser::{NodeIndex, syntax_kind_ext};
 
+use crate::rename::TextEdit;
 use crate::utils::{is_import_keyword, is_require_identifier};
 
 /// Information about an import/export that needs to be updated.
@@ -13,10 +14,31 @@ use crate::utils::{is_import_keyword, is_require_identifier};
 pub struct ImportLocation {
     /// The node containing the module specifier string
     pub specifier_node: NodeIndex,
-    /// The range of the specifier text (for `TextEdit`)
+    /// Full range of the string literal, **including the surrounding quotes**.
+    ///
+    /// Callers rewriting the specifier should prefer [`Self::specifier_text_edit`]
+    /// so the quote characters are preserved without needing to re-detect the
+    /// original quote style.
     pub range: Range,
-    /// The current specifier value (e.g., "./utils" or "../types")
+    /// The current specifier value with the quotes stripped (e.g. `./utils`).
     pub current_specifier: String,
+}
+
+impl ImportLocation {
+    /// Build a `TextEdit` that replaces the specifier content between the
+    /// surrounding quotes with `new_specifier`. The original quote characters
+    /// are untouched, so the rewrite preserves the file's quote style without
+    /// the caller having to recreate them.
+    pub const fn specifier_text_edit(&self, new_specifier: String) -> TextEdit {
+        let inner = Range::new(
+            Position::new(self.range.start.line, self.range.start.character + 1),
+            Position::new(
+                self.range.end.line,
+                self.range.end.character.saturating_sub(1),
+            ),
+        );
+        TextEdit::new(inner, new_specifier)
+    }
 }
 
 define_lsp_provider!(minimal FileRenameProvider, "Provider for finding imports/exports that reference a renamed file.");

--- a/crates/tsz-lsp/tests/project_tests.rs
+++ b/crates/tsz-lsp/tests/project_tests.rs
@@ -3915,6 +3915,50 @@ fn test_project_handle_will_rename_files() {
 }
 
 #[test]
+fn test_project_handle_will_rename_files_preserves_quotes() {
+    // Regression: `process_file_rename` used to pair the outer quoted range
+    // with a bare specifier, so applying the edit overwrote the surrounding
+    // quotes. Verify that the produced edit targets only the inner content
+    // and that applying it re-yields a quoted import (for both quote styles).
+    for (quote, name) in [('\"', "double"), ('\'', "single")] {
+        let source = format!("import {{ x }} from {quote}./old{quote};\n");
+        let mut project = Project::new();
+        project.set_file("old.ts".to_string(), "export const x = 1;\n".to_string());
+        project.set_file("consumer.ts".to_string(), source.clone());
+
+        let workspace_edit = project.handle_will_rename_files(&[FileRename {
+            old_uri: "old.ts".to_string(),
+            new_uri: "new.ts".to_string(),
+        }]);
+
+        let edits = workspace_edit
+            .changes
+            .get("consumer.ts")
+            .unwrap_or_else(|| panic!("{name}-quote variant should produce edits for consumer.ts"));
+        assert_eq!(edits.len(), 1, "{name}-quote variant: one edit expected");
+        let edit = &edits[0];
+        assert!(
+            !edit.new_text.contains(quote),
+            "{name}-quote variant: edit text must not contain quotes (got {:?})",
+            edit.new_text
+        );
+
+        // Apply the edit and assert the result is still a quoted import.
+        // The extension handling is a separate concern (`calculate_new_relative_path`
+        // retains `new_path`'s extension); here we just confirm the surrounding
+        // quote characters survive the rewrite.
+        let line_map = tsz_common::position::LineMap::build(&source);
+        let applied = apply_text_edits(&source, &line_map, edits);
+        let prefix = format!("import {{ x }} from {quote}");
+        let suffix = format!("{quote};\n");
+        assert!(
+            applied.starts_with(&prefix) && applied.ends_with(&suffix),
+            "{name}-quote variant: applying the rename edit should preserve quotes, got {applied:?}"
+        );
+    }
+}
+
+#[test]
 fn test_project_subtypes_returns_empty_for_missing_file() {
     let project = Project::new();
     let result = project.subtypes("nonexistent.ts", Position::new(0, 0));


### PR DESCRIPTION
## Summary
- Fixes bug-shape #7 from `docs/DRY_AUDIT_2026-04-21.md`: `Project::handle_will_rename_files` built a `TextEdit` with the outer *quoted* range and a *bare* specifier from `calculate_new_relative_path`. Applying that edit wiped the surrounding quote characters (`import { x } from "./old";` → `import { x } from ./new.ts;`).
- Roots the range-vs-content invariant in `ImportLocation::specifier_text_edit`: shrinks the range to the inner content span and leaves the quote characters untouched, so callers no longer need to re-detect single vs double quotes.
- Replaces both call sites (`project/core.rs::process_file_rename` and `project/features.rs::get_file_rename_edits`). The latter's hand-rolled inner-range construction (plus a dead `quote` variable) is gone.

## Test plan
- [x] New regression `test_project_handle_will_rename_files_preserves_quotes` — runs the full `handle_will_rename_files` path for both `"..."` and `'...'` imports, applies the resulting edits, and asserts the rewritten text still starts and ends with the original quote.
- [x] Verified the test catches the bug: stashing the `core.rs` change reproduces `import { x } from ./new.ts;` (quotes gone).
- [x] `cargo nextest run -p tsz-lsp --lib -E 'test(rename) + test(file_rename)'` — 129 tests pass.
- [x] `cargo clippy -p tsz-lsp --lib --tests -- -D warnings` — clean (needed `const fn` on the helper).
- [x] Full pre-commit suite (3707 tests) green.