### PR TITLE
fix(cli): respect outDir in --build --clean tsbuildinfo path

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -3106,15 +3106,17 @@ fn handle_build_clean(
     verbose: bool,
 ) -> Result<()> {
     use std::fs;
-    use tsz_cli::config::resolve_compiler_options;
+    use tsz_cli::incremental::default_build_info_path;
 
     let mut deleted_count = 0;
 
     for project in graph.projects() {
-        let base_dir = &project.root_dir;
-
-        // Delete .tsbuildinfo file
-        let buildinfo_path = project.config_path.with_extension("tsbuildinfo");
+        // Use the same build-info path logic as the build/driver paths so that
+        // `--clean` removes the file the build actually wrote. Previously this
+        // always wrote next to the tsconfig, which missed the case where
+        // `outDir` relocates the .tsbuildinfo file.
+        let buildinfo_path =
+            default_build_info_path(&project.config_path, project.out_dir.as_deref());
         if buildinfo_path.exists() {
             fs::remove_file(&buildinfo_path)?;
             if verbose {
@@ -3123,31 +3125,27 @@ fn handle_build_clean(
             deleted_count += 1;
         }
 
-        // Get resolved options to find output directories
-        let resolved = resolve_compiler_options(project.config.base.compiler_options.as_ref())?;
-
-        // Delete outDir
-        if let Some(ref out_dir) = resolved.out_dir {
-            let full_out_dir = base_dir.join(out_dir);
-            if full_out_dir.exists() {
-                fs::remove_dir_all(&full_out_dir)?;
-                if verbose {
-                    println!("Deleted: {}", full_out_dir.display());
-                }
-                deleted_count += 1;
+        // `ResolvedProject` already stores absolute out/declaration dirs
+        // resolved against `root_dir`, so re-running `resolve_compiler_options`
+        // only duplicates work and risks drifting from the build path.
+        if let Some(ref out_dir) = project.out_dir
+            && out_dir.exists()
+        {
+            fs::remove_dir_all(out_dir)?;
+            if verbose {
+                println!("Deleted: {}", out_dir.display());
             }
+            deleted_count += 1;
         }
 
-        // Delete declarationDir
-        if let Some(ref declaration_dir) = resolved.declaration_dir {
-            let full_decl_dir = base_dir.join(declaration_dir);
-            if full_decl_dir.exists() {
-                fs::remove_dir_all(&full_decl_dir)?;
-                if verbose {
-                    println!("Deleted: {}", full_decl_dir.display());
-                }
-                deleted_count += 1;
+        if let Some(ref declaration_dir) = project.declaration_dir
+            && declaration_dir.exists()
+        {
+            fs::remove_dir_all(declaration_dir)?;
+            if verbose {
+                println!("Deleted: {}", declaration_dir.display());
             }
+            deleted_count += 1;
         }
     }
 

--- a/crates/tsz-cli/src/bin/tsz/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz/tests.rs
@@ -228,3 +228,85 @@ fn preprocess_non_boolean_false_not_consumed() {
     assert!(result.iter().any(|a| a == "--outDir"));
     assert!(result.iter().any(|a| a == "false"));
 }
+
+// ==================== handle_build_clean respects outDir ====================
+
+#[test]
+fn build_clean_removes_buildinfo_under_out_dir() {
+    use std::fs;
+    use tsz_cli::project_refs::ProjectReferenceGraph;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let tsconfig_path = root.join("tsconfig.json");
+    fs::write(
+        &tsconfig_path,
+        r#"{"compilerOptions":{"composite":true,"outDir":"dist","declaration":true}}"#,
+    )
+    .expect("write tsconfig");
+
+    let src_dir = root.join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::write(src_dir.join("index.ts"), "export const x = 1;\n").expect("write entry");
+
+    let dist_dir = root.join("dist");
+    fs::create_dir_all(&dist_dir).expect("mkdir dist");
+    let buildinfo = dist_dir.join("tsconfig.tsbuildinfo");
+    fs::write(&buildinfo, "{}").expect("write buildinfo");
+
+    // Also drop a stray .tsbuildinfo next to the tsconfig so we verify the
+    // fix is deleting the correct file (the one under outDir) and not the
+    // legacy sibling location.
+    let sibling_buildinfo = root.join("tsconfig.tsbuildinfo");
+    fs::write(&sibling_buildinfo, "{}").expect("write sibling buildinfo");
+
+    let graph = ProjectReferenceGraph::load(&tsconfig_path).expect("load graph");
+    handle_build_clean(&graph, false).expect("clean");
+
+    assert!(
+        !buildinfo.exists(),
+        "dist/tsconfig.tsbuildinfo should have been deleted"
+    );
+    assert!(
+        !dist_dir.exists(),
+        "dist/ directory should have been deleted"
+    );
+    // The sibling file lives at the legacy location; it is not the build
+    // output, so leave it untouched.
+    assert!(
+        sibling_buildinfo.exists(),
+        "sibling tsconfig.tsbuildinfo at project root should be left alone"
+    );
+}
+
+#[test]
+fn build_clean_removes_buildinfo_next_to_tsconfig_when_no_out_dir() {
+    use std::fs;
+    use tsz_cli::project_refs::ProjectReferenceGraph;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    let tsconfig_path = root.join("tsconfig.json");
+    fs::write(
+        &tsconfig_path,
+        r#"{"compilerOptions":{"composite":true}}"#,
+    )
+    .expect("write tsconfig");
+
+    let src_dir = root.join("src");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::write(src_dir.join("index.ts"), "export const x = 1;\n").expect("write entry");
+
+    let buildinfo = root.join("tsconfig.tsbuildinfo");
+    fs::write(&buildinfo, "{}").expect("write buildinfo");
+
+    let graph = ProjectReferenceGraph::load(&tsconfig_path).expect("load graph");
+    handle_build_clean(&graph, false).expect("clean");
+
+    assert!(
+        !buildinfo.exists(),
+        "tsconfig.tsbuildinfo next to tsconfig should be deleted when no outDir is set"
+    );
+}

--- a/crates/tsz-cli/src/bin/tsz/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz/tests.rs
@@ -289,11 +289,7 @@ fn build_clean_removes_buildinfo_next_to_tsconfig_when_no_out_dir() {
     let root = tmp.path();
 
     let tsconfig_path = root.join("tsconfig.json");
-    fs::write(
-        &tsconfig_path,
-        r#"{"compilerOptions":{"composite":true}}"#,
-    )
-    .expect("write tsconfig");
+    fs::write(&tsconfig_path, r#"{"compilerOptions":{"composite":true}}"#).expect("write tsconfig");
 
     let src_dir = root.join("src");
     fs::create_dir_all(&src_dir).expect("mkdir src");


### PR DESCRIPTION
## Summary

- When a tsconfig sets `outDir`, the TypeScript build writes `.tsbuildinfo` under that directory. The `--build --clean` handler was computing `config_path.with_extension(\"tsbuildinfo\")`, which targets a sibling file next to the tsconfig that never exists in an outDir-based project — leaving the real buildinfo behind.
- Route clean through `default_build_info_path`, the same helper the build writes through, using the already-resolved absolute `out_dir` / `declaration_dir` that `ResolvedProject` carries. Drops the redundant `resolve_compiler_options` call inside the clean loop.

Part of `docs/DRY_AUDIT_2026-04-21.md` bug-shape #11.

## Test plan
- [x] `cargo nextest run -p tsz-cli --bin tsz build_clean` — both new tests pass
- [x] Verified by stashing the fix and re-running: `build_clean_removes_buildinfo_under_out_dir` fails on unfixed code (sibling was deleted, outDir file untouched) — so the test catches the regression.
- [x] `cargo clippy -p tsz-cli --bin tsz --tests -- -D warnings` clean