### PR TITLE
[codex] Fix primitive object-union assignability

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -884,6 +884,12 @@ impl<'a> CheckerState<'a> {
             if let Some(members) =
                 crate::query_boundaries::common::union_members(self.ctx.types, type_id)
             {
+                if members.iter().any(|&member| {
+                    crate::query_boundaries::common::is_type_parameter(self.ctx.types, member)
+                }) {
+                    return false;
+                }
+
                 let has_indexed_access = members.iter().any(|&member| {
                     crate::query_boundaries::common::is_index_access_type(self.ctx.types, member)
                 });

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3565,3 +3565,51 @@ const t = f({ a: 1, b: "c", d: ["e", 2] });
         "Should not emit TS2322 for const type parameter with multiple type params"
     );
 }
+
+#[test]
+fn non_primitive_conditional_with_type_params_matches_tsc_errors() {
+    let source = r#"
+type A<T, V> = { [P in keyof T]: T[P] extends V ? 1 : 0; };
+type B<T, V> = { [P in keyof T]: T[P] extends V | object ? 1 : 0; };
+
+let a: A<{ a: 0 | 1 }, 0> = { a: 0 };
+let b: B<{ a: 0 | 1 }, 0> = { a: 0 };
+
+function foo<T, U>(x: T) {
+    let a: object = x;
+    let b: U | object = x;
+}
+"#;
+
+    let diagnostics = get_all_diagnostics(source);
+    let ts2322_messages = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .map(|(_, message)| message.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ts2322_messages.len(),
+        2,
+        "expected only the two generic assignment errors, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322_messages
+            .iter()
+            .any(|message| message.contains("Type 'T' is not assignable to type 'object'.")),
+        "missing T to object diagnostic, got: {ts2322_messages:?}"
+    );
+    assert!(
+        ts2322_messages.iter().any(|message| {
+            message.contains("Type 'T' is not assignable to type 'object | U'.")
+                || message.contains("Type 'T' is not assignable to type 'U | object'.")
+        }),
+        "missing T to U | object diagnostic, got: {ts2322_messages:?}"
+    );
+    assert!(
+        !ts2322_messages
+            .iter()
+            .any(|message| message.contains("B<{")),
+        "mapped conditional assignment should not fail, got: {ts2322_messages:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -15,7 +15,7 @@ use crate::def::resolver::TypeResolver;
 use crate::relations::subtype::{SubtypeChecker, SubtypeResult, is_disjoint_unit_type};
 use crate::types::{IntrinsicKind, TypeApplicationId, TypeData, TypeId};
 use crate::visitor::{
-    application_id, contains_this_type, enum_components, lazy_def_id, union_list_id,
+    application_id, contains_this_type, enum_components, lazy_def_id, literal_value, union_list_id,
 };
 
 // Global thread-local fuel counter for cross-instance subtype check termination.
@@ -685,6 +685,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
         } else {
+            let literal_against_object_union = literal_value(self.interner, source).is_some()
+                && union_list_id(self.interner, target).is_some_and(|members| {
+                    self.interner.type_list(members).contains(&TypeId::OBJECT)
+                });
+            if literal_against_object_union {
+                let result = self.check_subtype_inner(source, target);
+                if let Some(dp) = def_entered {
+                    self.def_guard.leave(dp);
+                }
+                self.guard.leave(pair);
+                leave_global!();
+                return result;
+            }
+
             let source_raw = self.evaluate_type(source);
             let target_raw = self.evaluate_type(target);
             let source_eval = self.guard_compound_collapse(source, source_raw);

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -466,6 +466,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // comparison that fails (the apparent shape of `string` doesn't structurally match `String`).
         if let Some(s_kind) = intrinsic_kind(self.interner, source)
             && let Some(kind) = boxable_intrinsic_kind(s_kind)
+            && union_list_id(self.interner, target).is_none()
             && self.is_target_boxed_type(target, kind)
         {
             return SubtypeResult::True;
@@ -480,6 +481,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 LiteralValue::BigInt(_) => Some(IntrinsicKind::Bigint),
             };
             if let Some(kind) = kind
+                && union_list_id(self.interner, target).is_none()
                 && self.is_target_boxed_type(target, kind)
             {
                 return SubtypeResult::True;
@@ -508,6 +510,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // boxed type which includes merged heritage from global augmentations.
                 // Use apparent_primitive_kind to also handle literals (e.g., "test" <: Iterable<string>).
                 if let Some(kind) = self.apparent_primitive_kind(source)
+                    && union_list_id(self.interner, target).is_none()
                     && self.is_boxed_primitive_subtype(kind, target)
                 {
                     return SubtypeResult::True;
@@ -569,6 +572,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // Guard: skip for `object` type — primitives must NOT be subtypes of
             // `object` even though their boxed wrappers (Number, String, etc.) are.
             if target != TypeId::OBJECT
+                && union_list_id(self.interner, target).is_none()
                 && let Some(kind) = self.apparent_primitive_kind(source)
                 && self.is_boxed_primitive_subtype(kind, target)
             {

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -17,6 +17,7 @@ use crate::visitor::{
     TypeVisitor, array_element_type, callable_shape_id, enum_components, function_shape_id,
     intrinsic_kind, literal_value, object_shape_id, object_with_index_shape_id,
     readonly_inner_type, string_intrinsic_components, tuple_list_id, type_param_info,
+    union_list_id,
 };
 
 // =============================================================================
@@ -62,7 +63,9 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         if let Some(t_kind) = intrinsic_kind(self.checker.interner, self.target) {
             return self.checker.check_intrinsic_subtype(kind, t_kind);
         }
-        if self.checker.is_boxed_primitive_subtype(kind, self.target) {
+        if union_list_id(self.checker.interner, self.target).is_none()
+            && self.checker.is_boxed_primitive_subtype(kind, self.target)
+        {
             SubtypeResult::True
         } else {
             SubtypeResult::False
@@ -70,14 +73,27 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
     }
 
     fn visit_literal(&mut self, value: &LiteralValue) -> Self::Output {
-        let evaluated_target = self.checker.evaluate_type(self.target);
-        if evaluated_target != self.target
-            && self
-                .checker
-                .check_subtype(self.source, evaluated_target)
-                .is_true()
-        {
-            return SubtypeResult::True;
+        if let Some(t_kind) = intrinsic_kind(self.checker.interner, self.target) {
+            return self.checker.check_literal_to_intrinsic(value, t_kind);
+        }
+
+        let target_contains_object_keyword = union_list_id(self.checker.interner, self.target)
+            .is_some_and(|members| {
+                self.checker
+                    .interner
+                    .type_list(members)
+                    .contains(&TypeId::OBJECT)
+            });
+        if !target_contains_object_keyword {
+            let evaluated_target = self.checker.evaluate_type(self.target);
+            if evaluated_target != self.target
+                && self
+                    .checker
+                    .check_subtype(self.source, evaluated_target)
+                    .is_true()
+            {
+                return SubtypeResult::True;
+            }
         }
 
         if let Some(target_operand) =
@@ -117,9 +133,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             }
         }
 
-        if let Some(t_kind) = intrinsic_kind(self.checker.interner, self.target) {
-            return self.checker.check_literal_to_intrinsic(value, t_kind);
-        }
         if let LiteralValue::String(_) = value
             && let Some((kind, type_arg)) =
                 string_intrinsic_components(self.checker.interner, self.target)

--- a/crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 use crate::intern::TypeInterner;
-use crate::types::{TypeData, TypeParamInfo};
+use crate::types::{FunctionShape, IntrinsicKind, PropertyInfo, TypeData, TypeParamInfo};
 
 // =============================================================================
 // Basic Type Parameter Construction Tests
@@ -666,4 +666,101 @@ fn test_function_with_multiple_type_parameters() {
     } else {
         panic!("Expected function type");
     }
+}
+
+#[test]
+fn unconstrained_type_parameter_not_assignable_to_unrelated_param_or_object_union() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let u_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("U"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let target = interner.union2(u_param, TypeId::OBJECT);
+
+    assert!(
+        !checker.is_assignable(t_param, target),
+        "unconstrained T must not be assignable to U | object"
+    );
+}
+
+#[test]
+fn numeric_literal_union_not_subtype_of_literal_or_object() {
+    let interner = TypeInterner::new();
+    let to_fixed = interner.function(FunctionShape {
+        params: Vec::new(),
+        this_type: None,
+        return_type: TypeId::STRING,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let number_interface = interner.object(vec![PropertyInfo::method(
+        interner.intern_string("toFixed"),
+        to_fixed,
+    )]);
+    interner.set_boxed_type(IntrinsicKind::Number, number_interface);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut subtype_checker = crate::relations::subtype::SubtypeChecker::new(&interner);
+
+    let zero = interner.literal_number(0.0);
+    let one = interner.literal_number(1.0);
+    let zero_or_one = interner.union2(zero, one);
+    let zero_or_object = interner.union2(zero, TypeId::OBJECT);
+
+    assert!(
+        !subtype_checker.is_subtype_of(one, TypeId::OBJECT),
+        "numeric literals must not satisfy the lowercase object keyword"
+    );
+    assert!(
+        !subtype_checker.is_subtype_of(one, zero),
+        "numeric literal 1 must not satisfy literal 0"
+    );
+    assert!(
+        !subtype_checker.is_subtype_of(one, zero_or_object),
+        "numeric literal 1 must not satisfy 0 | object"
+    );
+    assert!(
+        !subtype_checker.is_subtype_of(zero_or_one, zero_or_object),
+        "1 is a primitive and must not satisfy the lowercase object member"
+    );
+    assert!(
+        !checker.is_assignable(zero_or_one, zero_or_object),
+        "1 is a primitive and must not satisfy the lowercase object member"
+    );
+}
+
+#[test]
+fn conditional_union_literal_extends_literal_or_object_takes_false_branch() {
+    let interner = TypeInterner::new();
+
+    let zero = interner.literal_number(0.0);
+    let one = interner.literal_number(1.0);
+    let zero_or_one = interner.union2(zero, one);
+    let zero_or_object = interner.union2(zero, TypeId::OBJECT);
+    let conditional = interner.conditional(crate::types::ConditionalType {
+        check_type: zero_or_one,
+        extends_type: zero_or_object,
+        true_type: one,
+        false_type: zero,
+        is_distributive: false,
+    });
+
+    let evaluated = crate::evaluation::evaluate::evaluate_type(&interner, conditional);
+
+    assert_eq!(
+        evaluated, zero,
+        "0 | 1 should not be treated as extending 0 | object"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes lowercase `object` handling when object appears in a union target for primitive/literal subtype checks, while preserving the required generic assignment errors for unrelated type parameters.

Root cause: subtype evaluation was letting primitive apparent/boxed object paths satisfy union targets containing the lowercase `object` keyword, so `0 | 1` incorrectly satisfied `0 | object` and the mapped conditional in `nonPrimitiveAndTypeVariables.ts` took the wrong branch; separately, TS2322 suppression hid `T -> U | object` when the union included a type parameter.

Fixed conformance target: `TypeScript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts`.

## Tests

Added unit coverage for:

- `non_primitive_conditional_with_type_params_matches_tsc_errors` in `crates/tsz-checker/tests/ts2322_tests.rs`
- `unconstrained_type_parameter_not_assignable_to_unrelated_param_or_object_union` in `crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs`
- `numeric_literal_union_not_subtype_of_literal_or_object` in `crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs`
- `conditional_union_literal_extends_literal_or_object_takes_false_branch` in `crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs`

## Verification

- `cargo nextest run -p tsz-solver --lib numeric_literal_union_not_subtype_of_literal_or_object conditional_union_literal_extends_literal_or_object_takes_false_branch unconstrained_type_parameter_not_assignable_to_unrelated_param_or_object_union`
- `cargo nextest run -p tsz-checker --test ts2322_tests non_primitive_conditional_with_type_params_matches_tsc_errors`
- `cargo check --package tsz-checker && cargo check --package tsz-solver && cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib && cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "nonPrimitiveAndTypeVariables" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/session/verify-all.sh` after rebasing on latest `origin/main`: all suites passed; conformance `12085` vs baseline `12061` (`+24`), emit JS `+4`, emit DTS `+25`, fourslash `50/50`.
