### PR TITLE
[codex] Evaluate template literal holes before matching

### DIFF
--- a/crates/tsz-checker/tests/infer_extends_constraint_substitution_tests.rs
+++ b/crates/tsz-checker/tests/infer_extends_constraint_substitution_tests.rs
@@ -6,7 +6,11 @@
 //! constraint TypeId was not substituted, causing `keyof T` to reference a stale
 //! type parameter instead of the concrete type, making the infer pattern fail.
 
+use rustc_hash::FxHashSet;
+use std::path::Path;
+use std::sync::Arc;
 use tsz_binder::BinderState;
+use tsz_binder::lib_loader::LibFile;
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::state::CheckerState;
 use tsz_parser::parser::ParserState;
@@ -33,6 +37,91 @@ fn check_strict(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
         "test.ts".to_string(),
         options,
     );
+
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.clone()
+}
+
+fn load_lib_files_for_test() -> Vec<Arc<LibFile>> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let lib_roots = [
+        manifest_dir.join("../../crates/tsz-core/src/lib-assets"),
+        manifest_dir.join("../../crates/tsz-core/src/lib-assets-stripped"),
+        manifest_dir.join("../../TypeScript/src/lib"),
+    ];
+    let lib_names = [
+        "es5.d.ts",
+        "es2015.d.ts",
+        "es2015.core.d.ts",
+        "es2015.collection.d.ts",
+        "es2015.iterable.d.ts",
+        "es2015.generator.d.ts",
+        "es2015.promise.d.ts",
+        "es2015.proxy.d.ts",
+        "es2015.reflect.d.ts",
+        "es2015.symbol.d.ts",
+        "es2015.symbol.wellknown.d.ts",
+    ];
+
+    let mut lib_files = Vec::new();
+    let mut seen_files = FxHashSet::default();
+    for file_name in lib_names {
+        for root in &lib_roots {
+            let lib_path = root.join(file_name);
+            if lib_path.exists()
+                && let Ok(content) = std::fs::read_to_string(&lib_path)
+            {
+                if !seen_files.insert(file_name.to_string()) {
+                    break;
+                }
+                lib_files.push(Arc::new(LibFile::from_source(
+                    file_name.to_string(),
+                    content,
+                )));
+                break;
+            }
+        }
+    }
+
+    lib_files
+}
+
+fn check_strict_with_libs(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let lib_files = load_lib_files_for_test();
+
+    let mut binder = BinderState::new();
+    if lib_files.is_empty() {
+        binder.bind_source_file(parser.get_arena(), root);
+    } else {
+        binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    }
+
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        strict: true,
+        ..Default::default()
+    };
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        options,
+    );
+
+    if !lib_files.is_empty() {
+        let lib_contexts: Vec<tsz_checker::context::LibContext> = lib_files
+            .iter()
+            .map(|lib| tsz_checker::context::LibContext {
+                arena: Arc::clone(&lib.arena),
+                binder: Arc::clone(&lib.binder),
+            })
+            .collect();
+        checker.ctx.set_lib_contexts(lib_contexts);
+        checker.ctx.set_actual_lib_file_count(lib_files.len());
+    }
 
     checker.check_source_file(root);
     checker.ctx.diagnostics.clone()
@@ -197,6 +286,44 @@ getIndex(2);
     assert_eq!(
         ts2345, 1,
         "Expected only getIndex(2) to emit TS2345 after Extract. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn test_path_keys_accepts_readonly_tuple_numeric_string_index() {
+    let source = r#"
+type PropType<T, Path extends string> =
+    string extends Path ? unknown :
+    Path extends keyof T ? T[Path] :
+    Path extends `${infer K}.${infer R}` ? K extends keyof T ? PropType<T[K], R> : unknown :
+    unknown;
+
+type PathKeys<T> =
+    unknown extends T ? never :
+    T extends readonly any[] ? Extract<keyof T, `${number}`> | SubKeys<T, Extract<keyof T, `${number}`>> :
+    T extends object ? Extract<keyof T, string> | SubKeys<T, Extract<keyof T, string>> :
+    never;
+
+type SubKeys<T, K extends string> = K extends keyof T ? `${K}.${PathKeys<T[K]>}` : never;
+
+declare function getProp<T, P extends PathKeys<T>>(obj: T, path: P): PropType<T, P>;
+
+const obj2 = {
+    name: 'John',
+    age: 42,
+    cars: [
+        { make: 'Ford', age: 10 },
+        { make: 'Trabant', age: 35 }
+    ]
+} as const;
+
+getProp(obj2, 'cars.1.make');
+"#;
+    let diags = check_strict_with_libs(source);
+    let ts2345: Vec<_> = diags.iter().filter(|d| d.code == 2345).collect();
+    assert!(
+        ts2345.is_empty(),
+        "Expected readonly tuple numeric string path to be accepted without TS2345. Got: {diags:#?}"
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/literals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/literals.rs
@@ -153,7 +153,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
             TemplateSpan::Type(type_id) => {
-                let type_id = *type_id;
+                let original_type_id = *type_id;
+                let evaluated_type_id = self.evaluate_type(original_type_id);
+                let type_id = if evaluated_type_id == original_type_id {
+                    original_type_id
+                } else {
+                    evaluated_type_id
+                };
                 if let Some(kind) = intrinsic_kind(self.interner, type_id) {
                     return match kind {
                         IntrinsicKind::String => {


### PR DESCRIPTION
## Summary

Evaluate template-literal type holes before matching literal strings against template literal patterns. This lets recursive conditional/application holes participate in the existing literal, union, intrinsic, and string-intrinsic matching logic.

Root cause: tsz treated non-primitive unevaluated template-literal holes such as `${PathKeys<T[K]>}` as unmatchable during literal-to-template matching, while TypeScript evaluates those recursive conditional/application holes before deciding whether a string literal fits the pattern.

Fixed conformance target: `TypeScript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts`, removing the extra `TS2345` for `getProp2(obj2, 'cars.1.make')`.

Unit test: `test_path_keys_accepts_readonly_tuple_numeric_string_index` in `crates/tsz-checker/tests/infer_extends_constraint_substitution_tests.rs`.

## Verification

- `cargo nextest run --package tsz-checker --test infer_extends_constraint_substitution_tests test_path_keys_accepts_readonly_tuple_numeric_string_index`
- `cargo nextest run --package tsz-checker --test infer_extends_constraint_substitution_tests`
- `./scripts/conformance/conformance.sh run --filter "templateLiteralTypes1" --verbose` (diagnostic code set now matches; remaining mismatch is fingerprint-only)
- `scripts/session/verify-all.sh` (passed: formatting, clippy, unit tests, conformance +23, emit JS +4/DTS +25, fourslash unchanged)
