### PR TITLE
fix(lsp): populate sub_to_bases and reset heritage maps on clear()

### DIFF
--- a/crates/tsz-lsp/src/symbols/symbol_index.rs
+++ b/crates/tsz-lsp/src/symbols/symbol_index.rs
@@ -542,46 +542,69 @@ impl SymbolIndex {
             }
         }
 
-        // Second pass: Build sub_to_bases mapping
-        // For each ClassDeclaration/InterfaceDeclaration, extract its heritage clauses
+        // Second pass: Build sub_to_bases mapping.
+        //
+        // For each ClassDeclaration/InterfaceDeclaration, walk its own
+        // heritage_clauses directly instead of guessing at which nearby
+        // HERITAGE_CLAUSE nodes belong to this declaration.
+        //
+        // Previously this block called `arena.get_identifier_text(node_idx)`
+        // on the declaration node itself. That helper only returns text for
+        // Identifier nodes — on a ClassDeclaration it always returns None,
+        // so the entire `sub_to_bases` map was silently empty in practice
+        // and upward-heritage lookups (go-to-implementation, upward rename)
+        // produced nothing. The fix: resolve the declaration's `name` field
+        // to get the real Identifier node before asking for its text, and
+        // use the declaration's own `heritage_clauses` list (no 50-node
+        // forward-scan heuristic — classes with large bodies between the
+        // name and heritage clauses would also have missed the window).
         for i in 0..arena.nodes.len() {
             let node_idx = tsz_parser::NodeIndex(i as u32);
-            if let Some(node) = arena.get(node_idx) {
-                let is_class_or_interface = node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || node.kind == syntax_kind_ext::INTERFACE_DECLARATION;
+            let Some(node) = arena.get(node_idx) else {
+                continue;
+            };
 
-                if is_class_or_interface
-                    && let Some(class_name) = arena.get_identifier_text(node_idx)
-                {
-                    let class_name = class_name.to_string();
+            let (name_idx, heritage_list) = match node.kind {
+                kind if kind == syntax_kind_ext::CLASS_DECLARATION => {
+                    let Some(data) = arena.get_class(node) else {
+                        continue;
+                    };
+                    (data.name, data.heritage_clauses.as_ref())
+                }
+                kind if kind == syntax_kind_ext::INTERFACE_DECLARATION => {
+                    let Some(data) = arena.get_interface(node) else {
+                        continue;
+                    };
+                    (data.name, data.heritage_clauses.as_ref())
+                }
+                _ => continue,
+            };
 
-                    // Look for HeritageClause nodes that follow this class declaration
-                    // In TypeScript AST, heritage clauses typically appear as siblings or children
-                    // We'll scan forward a reasonable number of nodes to find them
-                    let search_window = 50_usize; // Look ahead up to 50 nodes
-                    let start = i + 1;
-                    let end = (i + 1 + search_window).min(arena.nodes.len());
+            let Some(heritage_list) = heritage_list else {
+                continue;
+            };
+            let Some(class_name) = arena.get_identifier_text(name_idx) else {
+                continue;
+            };
+            let class_name = class_name.to_string();
 
-                    for j in start..end {
-                        let heritage_idx = tsz_parser::NodeIndex(j as u32);
-                        if let Some(heritage_node) = arena.get(heritage_idx)
-                            && heritage_node.kind == syntax_kind_ext::HERITAGE_CLAUSE
-                        {
-                            // Extract base types from this heritage clause
-                            if let Some(heritage_data) = arena.get_heritage_clause(heritage_node) {
-                                for type_node_idx in &heritage_data.types.nodes {
-                                    if let Some(base_name) =
-                                        self.extract_heritage_type_name(arena, *type_node_idx)
-                                    {
-                                        // Track that this class extends/implements the base type
-                                        self.sub_to_bases
-                                            .entry(class_name.clone())
-                                            .or_default()
-                                            .insert(base_name);
-                                    }
-                                }
-                            }
-                        }
+            for &heritage_idx in &heritage_list.nodes {
+                let Some(heritage_node) = arena.get(heritage_idx) else {
+                    continue;
+                };
+                if heritage_node.kind != syntax_kind_ext::HERITAGE_CLAUSE {
+                    continue;
+                }
+                let Some(heritage_data) = arena.get_heritage_clause(heritage_node) else {
+                    continue;
+                };
+                for type_node_idx in &heritage_data.types.nodes {
+                    if let Some(base_name) = self.extract_heritage_type_name(arena, *type_node_idx)
+                    {
+                        self.sub_to_bases
+                            .entry(class_name.clone())
+                            .or_default()
+                            .insert(base_name);
                     }
                 }
             }
@@ -748,6 +771,12 @@ impl SymbolIndex {
         self.importers.clear();
         self.file_symbols.clear();
         self.sorted_names.clear();
+        // Heritage relationships outlived a `clear()` previously, which
+        // leaked stale class/interface edges into any fully-rebuilt index
+        // (tests reusing an index, or a workspace re-bootstrap after a
+        // root change).
+        self.heritage_clauses.clear();
+        self.sub_to_bases.clear();
     }
 
     /// Get all symbols that start with the given prefix.

--- a/crates/tsz-lsp/tests/symbol_index_tests.rs
+++ b/crates/tsz-lsp/tests/symbol_index_tests.rs
@@ -1666,3 +1666,98 @@ fn test_index_file_remove_clears_auto_imports() {
         "importers should be cleared after remove_file"
     );
 }
+
+// ── heritage index ───────────────────────────────────────────────────
+
+#[test]
+fn test_index_file_populates_sub_to_bases_for_class() {
+    // Regression: previously the second-pass heritage builder called
+    // get_identifier_text on the ClassDeclaration node itself, which
+    // always returned None — so sub_to_bases was silently empty and
+    // upward heritage lookups returned nothing.
+    let source = r#"
+        class Base {}
+        interface I {}
+        class Sub extends Base implements I {}
+    "#;
+    let (binder, parser) = parse_and_bind("file.ts", source);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("file.ts", &binder, parser.get_arena(), source);
+
+    let bases = index.get_bases_for_class("Sub");
+    assert!(
+        bases.contains(&"Base".to_string()),
+        "expected Sub -> Base, got {bases:?}"
+    );
+    assert!(
+        bases.contains(&"I".to_string()),
+        "expected Sub -> I (implements), got {bases:?}"
+    );
+}
+
+#[test]
+fn test_index_file_populates_sub_to_bases_for_interface() {
+    let source = r#"
+        interface Base {}
+        interface Mixin {}
+        interface Derived extends Base, Mixin {}
+    "#;
+    let (binder, parser) = parse_and_bind("file.ts", source);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("file.ts", &binder, parser.get_arena(), source);
+
+    let bases = index.get_bases_for_class("Derived");
+    assert!(bases.contains(&"Base".to_string()), "got {bases:?}");
+    assert!(bases.contains(&"Mixin".to_string()), "got {bases:?}");
+}
+
+#[test]
+fn test_index_file_sub_to_bases_survives_large_class_body() {
+    // Previously the second-pass used a 50-node forward-scan to find
+    // HERITAGE_CLAUSE siblings — classes with big bodies between the
+    // name and heritage clauses would fall outside the window. The fix
+    // walks the declaration's own heritage_clauses list, so body size
+    // is irrelevant.
+    let mut body = String::new();
+    for i in 0..60 {
+        body.push_str(&format!("    m{i}() {{}}\n"));
+    }
+    let source = format!("class Base {{}}\nclass Sub extends Base {{\n{body}}}\n");
+    let (binder, parser) = parse_and_bind("file.ts", &source);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("file.ts", &binder, parser.get_arena(), &source);
+
+    assert_eq!(
+        index.get_bases_for_class("Sub"),
+        vec!["Base".to_string()],
+        "heritage lookup should work regardless of class body size"
+    );
+}
+
+#[test]
+fn test_clear_resets_heritage_and_sub_to_bases() {
+    // Regression: clear() used to leave heritage_clauses and sub_to_bases
+    // populated, so a fully-rebuilt index would see stale class edges.
+    let source = r#"class Base {} class Sub extends Base {}"#;
+    let (binder, parser) = parse_and_bind("file.ts", source);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("file.ts", &binder, parser.get_arena(), source);
+
+    assert!(!index.get_files_with_heritage("Base").is_empty());
+    assert!(!index.get_bases_for_class("Sub").is_empty());
+
+    index.clear();
+
+    assert!(
+        index.get_files_with_heritage("Base").is_empty(),
+        "heritage_clauses should be cleared"
+    );
+    assert!(
+        index.get_bases_for_class("Sub").is_empty(),
+        "sub_to_bases should be cleared"
+    );
+}


### PR DESCRIPTION
## Summary

Two latent bugs in `SymbolIndex` heritage tracking:

1. **`sub_to_bases` was always empty.** The second-pass builder called `arena.get_identifier_text(class_decl_idx)`, which only returns `Some` for Identifier nodes. On a ClassDeclaration / InterfaceDeclaration it always returned `None`, so `get_bases_for_class(...)` always returned `[]`. Upward heritage lookups (go-to-implementation, heritage-aware rename) silently did nothing. Fix: resolve the declaration's `name: NodeIndex` field to the real Identifier, and walk the declaration's own `heritage_clauses` list instead of the 50-node forward-scan heuristic (which would also have missed heritage on classes with large bodies).

2. **`clear()` leaked heritage edges.** It reset 9 maps but left `heritage_clauses` and `sub_to_bases` populated, so a fully-rebuilt index would see stale class relationships.

Part of `docs/DRY_AUDIT_2026-04-21.md` bug-shapes #4 and #5.

## Test plan
- [x] 4 new tests in `symbol_index_tests.rs` cover:
  - class with `extends` + `implements`
  - interface multi-inheritance
  - large class body (would have missed the 50-node window)
  - `clear()` wipes both heritage maps
- [x] Verified by stashing the fix and re-running — all 4 tests fail on unfixed code.
- [x] `cargo nextest run -p tsz-lsp --lib` — full suite still passes
- [x] `cargo clippy -p tsz-lsp --tests -- -D warnings` clean