### PR TITLE
fix(checker): narrow union target for object literal diagnostics

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -447,6 +447,53 @@ const value: Outer = { inner: { ok: 42 } };
 }
 
 #[test]
+fn discriminated_union_object_literal_reports_matching_member_property_mismatch() {
+    let source = r#"
+type A = {
+    type: 'a',
+    data: { a: string }
+};
+
+type B = {
+    type: 'b',
+    data: null
+};
+
+type C = {
+    type: 'c',
+    payload: string
+};
+
+type Union = A | B | C;
+
+const foo: Union = {
+    type: 'a',
+    data: null
+};
+"#;
+
+    let diagnostics = strict_diagnostics_for(source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {diagnostics:?}"
+    );
+
+    let diag = ts2322[0];
+    let data_start = source.rfind("data: null").expect("expected data property") as u32;
+    assert_eq!(
+        diag.start, data_start,
+        "TS2322 should anchor at the discriminant-selected property, got: {diag:?}"
+    );
+    assert!(
+        diag.message_text
+            .contains("Type 'null' is not assignable to type '{ a: string; }'."),
+        "TS2322 should report the matching union member property mismatch, got: {diag:?}"
+    );
+}
+
+#[test]
 fn numeric_property_assignment_reports_nested_value_mismatch() {
     let source = r#"
 interface A {

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -856,7 +856,7 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::union_members(self.ctx.types, param_type).is_some();
 
         // Normalize optional/nullish wrappers (e.g., `{...} | undefined`).
-        let effective_param_type = if let (Some(non_nullish), Some(_nullish_cause)) =
+        let mut effective_param_type = if let (Some(non_nullish), Some(_nullish_cause)) =
             self.split_nullish_type(param_type)
         {
             non_nullish
@@ -888,6 +888,33 @@ impl<'a> CheckerState<'a> {
             Some(obj) => obj.clone(),
             None => return false,
         };
+
+        let resolved_param_type = self.resolve_type_for_property_access(effective_param_type);
+        let evaluated_param_type = self.judge_evaluate(resolved_param_type);
+        let contextual_param_type = self.evaluate_contextual_type(effective_param_type);
+        let lazy_resolved_param_type = self.resolve_lazy_type(effective_param_type);
+        let lazy_evaluated_param_type = self.evaluate_contextual_type(lazy_resolved_param_type);
+        let assignability_param_type = self.evaluate_type_for_assignability(effective_param_type);
+        let lazy_member_param_type = self.resolve_lazy_members_in_union(assignability_param_type);
+        for candidate in [
+            effective_param_type,
+            contextual_param_type,
+            evaluated_param_type,
+            resolved_param_type,
+            lazy_resolved_param_type,
+            lazy_evaluated_param_type,
+            assignability_param_type,
+            lazy_member_param_type,
+        ] {
+            let narrowed = self.narrow_contextual_union_via_object_literal_discriminants(
+                candidate,
+                &obj.elements.nodes,
+            );
+            if narrowed != candidate {
+                effective_param_type = narrowed;
+                break;
+            }
+        }
 
         // When the source object literal is missing required properties from the
         // target, don't elaborate into per-property TS2322 errors. tsc reports

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1351,19 +1351,46 @@ impl<'a> CheckerState<'a> {
             return ctx_type;
         }
 
+        unit_discriminants.retain(|(prop_name, _)| {
+            let mut unit_member_count = 0;
+            for &member in &members {
+                let lazy_member = self.resolve_lazy_type(member);
+                let resolved_member = self.resolve_type_for_property_access(lazy_member);
+                let evaluated_member = self.evaluate_contextual_type(resolved_member);
+                let member_candidates = [evaluated_member, resolved_member, lazy_member, member];
+                let member_prop_type = member_candidates.iter().find_map(|&candidate| {
+                    self.ctx
+                        .types
+                        .contextual_property_type(candidate, prop_name)
+                });
+                let Some(member_prop_type) = member_prop_type else {
+                    continue;
+                };
+                if !crate::query_boundaries::common::is_unit_type(self.ctx.types, member_prop_type)
+                {
+                    return false;
+                }
+                unit_member_count += 1;
+            }
+            unit_member_count >= 2
+        });
+
         // For each union member, check if all discriminant values are compatible
         // AND no present property maps to `never` in that member.
         let mut matching_members: Vec<TypeId> = Vec::new();
         for &member in &members {
-            let resolved_member = self.resolve_type_for_property_access(member);
+            let lazy_member = self.resolve_lazy_type(member);
+            let resolved_member = self.resolve_type_for_property_access(lazy_member);
+            let evaluated_member = self.evaluate_contextual_type(resolved_member);
+            let member_candidates = [evaluated_member, resolved_member, lazy_member, member];
 
             // Check unit-type discriminants: literal must be subtype of member's prop type.
             let unit_match = unit_discriminants.iter().all(|(prop_name, lit_type)| {
-                let member_prop_type = self
-                    .ctx
-                    .types
-                    .contextual_property_type(resolved_member, prop_name)
-                    .or_else(|| self.ctx.types.contextual_property_type(member, prop_name));
+                let member_prop_type = member_candidates.iter().find_map(|&candidate| {
+                    self.ctx
+                        .types
+                        .contextual_property_type(candidate, prop_name)
+                });
                 match member_prop_type {
                     Some(target_type) => {
                         if *lit_type == target_type || self.is_subtype_of(*lit_type, target_type) {
@@ -1377,13 +1404,14 @@ impl<'a> CheckerState<'a> {
                         // properties).
                         if *lit_type == TypeId::UNDEFINED {
                             let prop_name_atom = self.ctx.types.intern_string(prop_name);
-                            let is_optional =
+                            let is_optional = member_candidates.iter().any(|&candidate| {
                                 crate::query_boundaries::common::find_property_in_object(
                                     self.ctx.types,
-                                    resolved_member,
+                                    candidate,
                                     prop_name_atom,
                                 )
-                                .is_some_and(|p| p.optional);
+                                .is_some_and(|p| p.optional)
+                            });
                             if is_optional {
                                 return true;
                             }
@@ -1403,11 +1431,13 @@ impl<'a> CheckerState<'a> {
             let never_match = present_property_names.iter().all(|prop_name| {
                 let prop_name_atom = self.ctx.types.intern_string(prop_name);
                 // Look up the raw property type from the member's object shape.
-                let raw_prop_type = crate::query_boundaries::common::raw_property_type(
-                    self.ctx.types,
-                    resolved_member,
-                    prop_name_atom,
-                );
+                let raw_prop_type = member_candidates.iter().find_map(|&candidate| {
+                    crate::query_boundaries::common::raw_property_type(
+                        self.ctx.types,
+                        candidate,
+                        prop_name_atom,
+                    )
+                });
                 match raw_prop_type {
                     Some(type_id) => type_id != TypeId::NEVER,
                     // Property not in object shape; don't eliminate.
@@ -1423,12 +1453,16 @@ impl<'a> CheckerState<'a> {
             //   type A = { disc: true; cb: (x: string) => void }
             //   type B = { disc?: false; cb: (x: number) => void }
             //   f({ cb: n => ... })  // disc is required in A but optional in B
-            let absent_required_match = {
+            let absent_required_match = if unit_discriminants.is_empty() {
+                true
+            } else {
                 let mut ok = true;
-                if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
-                    self.ctx.types,
-                    resolved_member,
-                ) {
+                if let Some(shape) = member_candidates.iter().find_map(|&candidate| {
+                    crate::query_boundaries::common::object_shape_for_type(
+                        self.ctx.types,
+                        candidate,
+                    )
+                }) {
                     for prop in &shape.properties {
                         if prop.optional {
                             continue;
@@ -1444,13 +1478,18 @@ impl<'a> CheckerState<'a> {
                             if other == member {
                                 return false;
                             }
-                            let resolved_other = self.resolve_type_for_property_access(other);
-                            let other_prop =
+                            let lazy_other = self.resolve_lazy_type(other);
+                            let resolved_other = self.resolve_type_for_property_access(lazy_other);
+                            let evaluated_other = self.evaluate_contextual_type(resolved_other);
+                            let other_candidates =
+                                [evaluated_other, resolved_other, lazy_other, other];
+                            let other_prop = other_candidates.iter().find_map(|&candidate| {
                                 crate::query_boundaries::common::find_property_in_object(
                                     self.ctx.types,
-                                    resolved_other,
+                                    candidate,
                                     prop.name,
-                                );
+                                )
+                            });
                             match other_prop {
                                 None => true,          // other member doesn't have it at all
                                 Some(p) => p.optional, // other member has it as optional


### PR DESCRIPTION
Root cause: object-literal diagnostic elaboration reused the broad contextual union instead of the discriminant-selected member, and the existing narrowing helper could treat any unit-valued source property such as `data: null` as a discriminant even when the target property was not a unit discriminant across the union.

Fixed conformance target: `TypeScript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts`

Unit test: `discriminated_union_object_literal_reports_matching_member_property_mismatch` in `crates/tsz-checker/src/assignability/assignment_checker_tests.rs`

Representative case:

```ts
type A = { type: "a"; data: { a: string } };
type B = { type: "b"; data: null };
type Union = A | B;

const foo: Union = { type: "a", data: null };
```

Verification:
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib discriminated_union_object_literal_reports_matching_member_property_mismatch`
- `cargo nextest run --package tsz-checker --test ts2353_tests indirect_discriminant_variable_does_not_trigger_excess_property_narrowing`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "unionErrorMessageOnMatchingDiscriminant" --verbose` -> 1/1 passed
- `./scripts/conformance/conformance.sh run --max 200` -> 200/200 passed
- `scripts/session/verify-all.sh` -> all suites passed; conformance 12085 vs 12061 baseline (+24), emit JS +4/DTS +25, fourslash unchanged

Final rebase: `git fetch origin --prune && git rebase origin/main` reported the branch was up to date.