### PR TITLE
fix(tsz-common): dedupe "error" in COMMON_STRINGS pre-intern list

### DIFF
--- a/crates/tsz-common/src/interner/mod.rs
+++ b/crates/tsz-common/src/interner/mod.rs
@@ -150,7 +150,6 @@ const COMMON_STRINGS: &[&str] = &[
     "console",
     "log",
     "warn",
-    "error",
     "info",
     "debug",
     "document",

--- a/crates/tsz-common/tests/interner_tests.rs
+++ b/crates/tsz-common/tests/interner_tests.rs
@@ -974,3 +974,19 @@ fn estimated_size_bytes_grows_with_content() {
         "estimated_size_bytes should grow after interning strings: {before} -> {after}"
     );
 }
+
+#[test]
+fn common_strings_has_no_duplicates() {
+    use std::collections::HashSet;
+    let mut seen: HashSet<&'static str> = HashSet::new();
+    let mut dupes: Vec<&'static str> = Vec::new();
+    for &s in super::COMMON_STRINGS {
+        if !seen.insert(s) {
+            dupes.push(s);
+        }
+    }
+    assert!(
+        dupes.is_empty(),
+        "COMMON_STRINGS contains duplicate entries: {dupes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `COMMON_STRINGS` listed `"error"` twice (line 120 under common identifiers and line 153 in the console-methods cluster). Drop the second occurrence so the pre-interned slice matches the curated intent.
- Add a regression test (`common_strings_has_no_duplicates`) that walks the slice through a `HashSet` and fails if any entry repeats, so future additions can't silently reintroduce a dupe.

Functionally harmless at runtime — `Interner::intern()` dedups by key, so the second `"error"` just wasted a slot — but flagged in `docs/DRY_AUDIT_2026-04-21.md §tsz-common` and fixing it locks in the invariant.

## Test plan

- [x] `cargo nextest run -p tsz-common` → 304 / 304 passed.
- [x] Stash-revert regression check: with the duplicate restored, the new test fails with ``COMMON_STRINGS contains duplicate entries: ["error"]``; with the fix applied it passes.
- [x] Pre-commit suite (19,808 tests across 10 crates) passed cleanly before push.