### PR TITLE
fix(checker): keep tuple arity errors on assignment

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -539,6 +539,37 @@ t = (x: number) => 1;
 }
 
 #[test]
+fn tuple_arity_assignment_reports_outer_tuple_mismatch() {
+    let source = r#"
+let tup: [number, number, number] = [1, 2, 3, "string"];
+"#;
+
+    let diagnostics = diagnostics_for(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322");
+
+    let tup_start = source.find("tup").expect("expected variable name") as u32;
+    assert_eq!(
+        diag.start, tup_start,
+        "TS2322 should anchor at the variable name for tuple arity mismatch"
+    );
+    assert!(
+        diag.message_text.contains(
+            "Type '[number, number, number, string]' is not assignable to type '[number, number, number]'"
+        ),
+        "TS2322 should report the outer tuple assignment mismatch, got: {diag:?}"
+    );
+    assert!(
+        !diag
+            .message_text
+            .contains("Type 'string' is not assignable to type 'number'"),
+        "tuple arity mismatch should not collapse to the extra element mismatch, got: {diag:?}"
+    );
+}
+
+#[test]
 fn generic_default_initializer_widens_numeric_literals() {
     let source = r#"
 function foo3<T extends Number>(x: T = 1) { }

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1686,6 +1686,13 @@ impl<'a> CheckerState<'a> {
             None => return false,
         };
 
+        if let Some(target_count) =
+            crate::query_boundaries::common::get_fixed_tuple_length(self.ctx.types, param_type)
+            && arr.elements.nodes.len() > target_count
+        {
+            return false;
+        }
+
         let ctx_helper = tsz_solver::ContextualTypeContext::with_expected_and_options(
             self.ctx.types,
             param_type,


### PR DESCRIPTION
## Summary
- Keep array-literal elaboration from drilling into elements when a closed tuple target has fewer slots than the source literal.
- This preserves the outer TS2322 tuple assignment diagnostic instead of reporting the extra element as a scalar mismatch.

## Root Cause
- tsz only suppressed array-literal element elaboration for tuple arity mismatches in the variable-initializer precheck, so the fallback TS2322 path re-elaborated the same array literal and reported the extra element instead of the outer tuple assignment that tsc reports.

## Fixed Conformance Target
- TypeScript/tests/cases/conformance/expressions/contextualTyping/arrayLiteralExpressionContextualTyping.ts

## Unit Test
- tuple_arity_assignment_reports_outer_tuple_mismatch in crates/tsz-checker/src/assignability/assignment_checker_tests.rs

## Verification
- cargo nextest run --package tsz-checker --lib tuple_arity_assignment_reports_outer_tuple_mismatch
- ./scripts/conformance/conformance.sh run --filter "arrayLiteralExpressionContextualTyping" --verbose
- cargo check --package tsz-checker
- cargo check --package tsz-solver
- cargo build --profile dist-fast --bin tsz
- cargo fmt --all --check
- cargo nextest run --package tsz-checker --lib
- cargo nextest run --package tsz-solver --lib
- ./scripts/conformance/conformance.sh run --max 200
- scripts/session/verify-all.sh: ALL SUITES PASSED (conformance +26, emit JS +4/DTS +25, fourslash no change)