### PR TITLE
refactor(emitter): drop dead module_counter in CommonJS transforms

### DIFF
--- a/crates/tsz-emitter/src/transforms/module_commonjs.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs.rs
@@ -19,10 +19,7 @@
 //! exports.default = myFunc;
 //! ```
 
-use crate::transforms::emit_utils::{
-    identifier_text as get_identifier_text, sanitize_module_name, specifier_name_text,
-    string_literal_text,
-};
+use crate::transforms::emit_utils::{identifier_text as get_identifier_text, specifier_name_text};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
@@ -1167,35 +1164,6 @@ pub fn emit_exports_init(
     }
 
     Ok(())
-}
-
-/// Transform an import declaration to `CommonJS` require
-///
-/// ```typescript
-/// import { foo, bar } from "./module";
-/// ```
-/// Becomes:
-/// ```javascript
-/// var module_1 = require("./module");
-/// ```
-pub fn transform_import_to_require(
-    arena: &NodeArena,
-    node: &Node,
-    module_counter: &mut u32,
-) -> Option<(String, String)> {
-    let import = arena.get_import_decl(node)?;
-
-    // Get module specifier text
-    let module_spec = string_literal_text(arena, import.module_specifier)?;
-
-    // Generate module variable name (e.g., module_1, module_2)
-    *module_counter += 1;
-    let var_name = format!("{}_1", sanitize_module_name(&module_spec));
-
-    // Return (var_name, require_statement)
-    let require_stmt = format!("var {var_name} = require(\"{module_spec}\");");
-
-    Some((var_name, require_stmt))
 }
 
 /// Transform import bindings to variable declarations

--- a/crates/tsz-emitter/src/transforms/module_commonjs_ir.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs_ir.rs
@@ -32,7 +32,6 @@ use tsz_scanner::SyntaxKind;
 /// Context for `CommonJS` transformation
 pub struct CommonJsTransformContext<'a> {
     arena: &'a NodeArena,
-    module_counter: u32,
     preserve_const_enums: bool,
 }
 
@@ -40,7 +39,6 @@ impl<'a> CommonJsTransformContext<'a> {
     pub const fn new(arena: &'a NodeArena) -> Self {
         Self {
             arena,
-            module_counter: 0,
             preserve_const_enums: false,
         }
     }
@@ -133,9 +131,6 @@ impl<'a> CommonJsTransformContext<'a> {
         }
 
         let module_var = sanitize_module_name(&module_spec);
-
-        // Generate module variable name
-        self.module_counter += 1;
         let var_name = format!("{module_var}_1");
 
         let mut statements = Vec::new();
@@ -252,8 +247,6 @@ impl<'a> CommonJsTransformContext<'a> {
     ) -> Option<IRNode> {
         let module_spec = string_literal_text(self.arena, export_data.module_specifier)?;
         let module_var = sanitize_module_name(&module_spec);
-
-        self.module_counter += 1;
         let var_name = format!("{module_var}_1");
 
         let mut statements = Vec::new();


### PR DESCRIPTION
## Summary

- `CommonJsTransformContext.module_counter` and the `&mut u32 module_counter` parameter on `transform_import_to_require` were incremented at three call sites but the emitted variable name always hardcoded `_1`. The counter tracked nothing, and the docstring advertising "e.g., `module_1`, `module_2`" was misleading.
- `transform_import_to_require` itself has zero in-repo callers. Remove the dead API surface alongside the dead counter so the CommonJS transform reflects what the emitter actually does.
- No behavioral change: emitted JS is byte-identical (every site was producing `{module}_1` before and after).

If per-module collision numbering is ever needed, tsc solves it with a unique-name pass keyed by declared identifiers — a stateless counter on the transform context isn't the right place to reintroduce it.

Flagged in `docs/DRY_AUDIT_2026-04-21.md` bug-shape #10 and the `tsz-emitter` section ("module temp naming may always select `{module}_1`").

## Test plan

- [x] `cargo check -p tsz-emitter` → clean, no warnings.
- [x] `cargo nextest run -p tsz-emitter` → 1429 / 1429 passed.
- [x] `cargo nextest run -p tsz-emitter -E 'test(module_commonjs)'` → 31 / 31 passed.
- [x] Pre-commit suite (19,808 tests across 10 crates) passed cleanly before push.