### PR TITLE
refactor(lowering): drop numeric-parse dupes, reuse tsz_common helper

### DIFF
--- a/crates/tsz-common/src/primitives/numeric.rs
+++ b/crates/tsz-common/src/primitives/numeric.rs
@@ -42,6 +42,7 @@ fn parse_radix_digits(text: &str, base: u32) -> Option<f64> {
 
     let mut value = 0.0;
     let base_float = base as f64;
+    let mut saw_digit = false;
 
     for byte in text.bytes() {
         if byte == b'_' {
@@ -59,7 +60,13 @@ fn parse_radix_digits(text: &str, base: u32) -> Option<f64> {
             return None; // Digit too large for base
         }
 
+        saw_digit = true;
         value = value * base_float + (digit as f64);
+    }
+
+    if !saw_digit {
+        // Stripped body contained only separators (e.g. "0x_") — no digits, invalid.
+        return None;
     }
 
     Some(value)
@@ -94,6 +101,19 @@ mod tests {
         assert_eq!(parse_numeric_literal_value("0x"), None);
         assert_eq!(parse_numeric_literal_value("0b"), None);
         assert_eq!(parse_numeric_literal_value("0o"), None);
+    }
+
+    #[test]
+    fn test_parse_numeric_literal_value_rejects_separator_only_radix_body() {
+        // A radix body consisting only of separators has zero digits, which is
+        // invalid per spec. Regression for the previous behavior where
+        // `0x_` / `0b_` / `0o_` silently returned `Some(0.0)`.
+        assert_eq!(parse_numeric_literal_value("0x_"), None);
+        assert_eq!(parse_numeric_literal_value("0X__"), None);
+        assert_eq!(parse_numeric_literal_value("0b_"), None);
+        assert_eq!(parse_numeric_literal_value("0B_"), None);
+        assert_eq!(parse_numeric_literal_value("0o_"), None);
+        assert_eq!(parse_numeric_literal_value("0O___"), None);
     }
 
     #[test]

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -237,66 +237,6 @@ impl<'a> TypeLowering<'a> {
         std::borrow::Cow::Owned(out)
     }
 
-    pub(super) fn parse_numeric_literal_value(
-        &self,
-        value: Option<f64>,
-        text: &str,
-    ) -> Option<f64> {
-        if let Some(value) = value {
-            return Some(value);
-        }
-
-        if let Some(rest) = text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
-            return Self::parse_radix_digits(rest, 16);
-        }
-        if let Some(rest) = text.strip_prefix("0b").or_else(|| text.strip_prefix("0B")) {
-            return Self::parse_radix_digits(rest, 2);
-        }
-        if let Some(rest) = text.strip_prefix("0o").or_else(|| text.strip_prefix("0O")) {
-            return Self::parse_radix_digits(rest, 8);
-        }
-
-        if text.as_bytes().contains(&b'_') {
-            let cleaned = Self::strip_numeric_separators(text);
-            return cleaned.as_ref().parse::<f64>().ok();
-        }
-
-        text.parse::<f64>().ok()
-    }
-
-    pub(super) fn parse_radix_digits(text: &str, base: u32) -> Option<f64> {
-        if text.is_empty() {
-            return None;
-        }
-
-        let mut value = 0f64;
-        let base_value = base as f64;
-        let mut saw_digit = false;
-        for &byte in text.as_bytes() {
-            if byte == b'_' {
-                continue;
-            }
-
-            let digit = match byte {
-                b'0'..=b'9' => (byte - b'0') as u32,
-                b'a'..=b'f' => (byte - b'a' + 10) as u32,
-                b'A'..=b'F' => (byte - b'A' + 10) as u32,
-                _ => return None,
-            };
-            if digit >= base {
-                return None;
-            }
-            saw_digit = true;
-            value = value * base_value + digit as f64;
-        }
-
-        if !saw_digit {
-            return None;
-        }
-
-        Some(value)
-    }
-
     pub(super) fn normalize_bigint_literal<'b>(
         &self,
         text: &'b str,
@@ -409,9 +349,9 @@ impl<'a> TypeLowering<'a> {
                     }
                     k if k == SyntaxKind::NumericLiteral as u16 => {
                         if let Some(lit_data) = self.arena.get_literal(literal_node) {
-                            if let Some(value) =
-                                self.parse_numeric_literal_value(lit_data.value, &lit_data.text)
-                            {
+                            if let Some(value) = lit_data.value.or_else(|| {
+                                tsz_common::numeric::parse_numeric_literal_value(&lit_data.text)
+                            }) {
                                 self.interner.literal_number(value)
                             } else {
                                 TypeId::NUMBER
@@ -445,10 +385,11 @@ impl<'a> TypeLowering<'a> {
                             match operand_node.kind {
                                 k if k == SyntaxKind::NumericLiteral as u16 => {
                                     if let Some(lit_data) = self.arena.get_literal(operand_node) {
-                                        if let Some(value) = self.parse_numeric_literal_value(
-                                            lit_data.value,
-                                            &lit_data.text,
-                                        ) {
+                                        if let Some(value) = lit_data.value.or_else(|| {
+                                            tsz_common::numeric::parse_numeric_literal_value(
+                                                &lit_data.text,
+                                            )
+                                        }) {
                                             let value = if op == SyntaxKind::MinusToken as u16 {
                                                 -value
                                             } else {


### PR DESCRIPTION
## Summary

- `tsz-lowering` carried a private copy of `parse_numeric_literal_value` + `parse_radix_digits` that duplicated `tsz_common::numeric`. Two call sites in `lower/advanced.rs` (plain numeric literal and negated-prefix-unary numeric) used the local pair; everything else in the workspace already routes through `tsz_common`.
- Swap both call sites to `lit.value.or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))` and delete the two local methods. Net -67 / +28 lines.
- `strip_numeric_separators` stays put — it's still used by `normalize_bigint_literal` / `bigint_to_decimal_text`.

## Latent bug surfaced during the merge

The local lowering version tracked `saw_digit` and rejected `"0x_"` / `"0b_"` / `"0o_"` as `None`. `tsz_common::numeric` silently returned `Some(0.0)` for the same inputs because its `parse_radix_digits` loop accepted zero digits once the prefix was stripped.

Rather than regress the stricter behavior during the dedupe, promote it into `tsz_common`:
- `parse_radix_digits` now tracks `saw_digit` and returns `None` when the stripped body contains no digits.
- New regression test (`test_parse_numeric_literal_value_rejects_separator_only_radix_body`) locks this in against `0x_`, `0X__`, `0b_`, `0B_`, `0o_`, `0O___`.

Flagged in `docs/DRY_AUDIT_2026-04-21.md` §tsz-common ("`parse_numeric_literal_value` exists but checker and emitter paths still parse numeric strings locally"). Checker, emitter, and declaration-emitter still have their own copies — this PR is scoped to lowering so each rollout is independently reviewable.

## Test plan

- [x] `cargo nextest run -p tsz-common` → 304 / 304 passed (incl. new separator-only regression).
- [x] `cargo nextest run -p tsz-lowering` → 114 / 114 passed.
- [x] Pre-commit suite passed cleanly before push.