### PR TITLE
fix(cli): drop reference to undefined parallel_ds_stats

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1228,7 +1228,7 @@ pub(super) fn collect_diagnostics(
                 } else {
                     QueryCache::new(&program.type_interner)
                 };
-                let (lib_diags, lib_counters, lib_ds_stats) = check_checker_lib_file(
+                let (lib_diags, lib_counters, _lib_ds_stats) = check_checker_lib_file(
                     &checker_lib_file_env,
                     lib_idx,
                     &query_cache,
@@ -1239,7 +1239,9 @@ pub(super) fn collect_diagnostics(
                 diagnostics.extend(lib_diags);
                 request_cache_counters.merge(lib_counters);
                 parallel_qc_stats.merge(&query_cache.statistics());
-                parallel_ds_stats.merge(&lib_ds_stats);
+                // Per-lib DefinitionStore stats are discarded: libs share the
+                // same `shared_definition_store` whose aggregate is captured
+                // once below (see `aggregated_ds_stats` assignment).
             }
         }
         aggregated_qc_stats = Some(parallel_qc_stats);


### PR DESCRIPTION
## Summary

The lib-checking loop in `collect_diagnostics` references a `parallel_ds_stats` variable that doesn't exist, breaking compilation on `main`. The variable was removed in a recent refactor that moved DefinitionStore aggregation to the shared store (captured once after the loop via \`aggregated_ds_stats = project_env.shared_definition_store…\`). The per-lib `lib_ds_stats` value is no longer needed because libs share the same store.

This PR drops the dead merge call and renames the binding to `_lib_ds_stats` so the destructuring still works without an unused-variable warning.

## Repro on main

\`\`\`
\$ cargo check -p tsz-cli
error[E0425]: cannot find value \`parallel_ds_stats\` in this scope
    --> crates/tsz-cli/src/driver/check.rs:1249:17
     |
1249 |                 parallel_ds_stats.merge(&lib_ds_stats);
     |                 ^^^^^^^^^^^^^^^^^
\`\`\`

## Test plan

- [x] \`cargo check -p tsz-cli\` clean