### PR TITLE
perf(checker): share program-wide cross_file_node_symbols via ProjectEnv

### DIFF
--- a/crates/tsz-binder/src/lib.rs
+++ b/crates/tsz-binder/src/lib.rs
@@ -22,8 +22,8 @@ pub use flow::{FlowNode, FlowNodeArena, FlowNodeId, flow_flags};
 pub use scopes::{ContainerKind, Scope, ScopeContext, ScopeId};
 pub use state::export_surface::{ExportSurface, ExportedSymbol, NamedReexport, WildcardReexport};
 pub use state::{
-    BinderOptions, BinderState, DeclarationArenaMap, FileFeatures, FileReexports, FileReexportsMap,
-    GlobalAugmentation, LibContext, ModuleAugmentation, ReexportTarget, SemanticDefEntry,
-    SemanticDefKind, ValidationError,
+    BinderOptions, BinderState, CrossFileNodeSymbols, DeclarationArenaMap, FileFeatures,
+    FileReexports, FileReexportsMap, GlobalAugmentation, LibContext, ModuleAugmentation,
+    ReexportTarget, SemanticDefEntry, SemanticDefKind, ValidationError,
 };
 pub use symbols::{Symbol, SymbolArena, SymbolId, SymbolTable, symbol_flags};

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -239,6 +239,7 @@ impl<'a> CheckerContext<'a> {
             program_wildcard_reexports: None,
             program_wildcard_reexports_type_only: None,
             program_module_exports: None,
+            program_cross_file_node_symbols: None,
             resolved_module_paths: None,
             resolved_module_request_paths: None,
             current_file_idx: 0,

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -993,6 +993,21 @@ impl<'a> CheckerContext<'a> {
         self.module_exports_for_module(binder, module_key).is_some()
     }
 
+    /// Resolve a node → symbol lookup by arena pointer against the
+    /// cross-file node-symbol map. Prefers the shared project-wide map
+    /// installed by `ProjectEnv::apply_to`; falls back to the per-binder
+    /// copy for tests and standalone callers.
+    pub fn cross_file_node_symbols_for_arena<'b>(
+        &'b self,
+        binder: &'b tsz_binder::BinderState,
+        arena_ptr: usize,
+    ) -> Option<&'b Arc<FxHashMap<u32, SymbolId>>> {
+        if let Some(ref idx) = self.program_cross_file_node_symbols {
+            return idx.get(&arena_ptr);
+        }
+        binder.cross_file_node_symbols.get(&arena_ptr)
+    }
+
     /// Resolve an import specifier to its target file index.
     /// Uses the `resolved_module_paths` map populated by the driver.
     /// Returns None if the import cannot be resolved (e.g., external module).

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -87,6 +87,7 @@ pub type ResolvedModuleRequestPathMap =
     FxHashMap<(usize, String, Option<ResolutionModeOverride>), usize>;
 pub type ResolvedModuleRequestErrorMap =
     FxHashMap<(usize, String, Option<ResolutionModeOverride>), ResolutionError>;
+pub type WildcardReexportsTypeOnlyMap = FxHashMap<String, Vec<(String, bool)>>;
 
 /// Represents a failed module resolution with specific error details.
 #[derive(Clone, Debug)]
@@ -1418,13 +1419,19 @@ pub struct CheckerContext<'a> {
     /// Program-wide wildcard re-exports map; see `program_reexports`.
     pub program_wildcard_reexports: Option<Arc<FxHashMap<String, Vec<String>>>>,
     /// Program-wide type-only wildcard re-exports map; see `program_reexports`.
-    pub program_wildcard_reexports_type_only: Option<Arc<FxHashMap<String, Vec<(String, bool)>>>>,
+    pub program_wildcard_reexports_type_only: Option<Arc<WildcardReexportsTypeOnlyMap>>,
     /// Program-wide module-exports index keyed by file name (or ambient
     /// module specifier). Consulted by `ctx.module_exports_for_module`
     /// in preference to per-binder `module_exports`. Driver wraps
     /// `program.module_exports` in a single `Arc` so N cross-file lookup
     /// binders don't each deep-clone the merged map.
     pub program_module_exports: Option<Arc<FxHashMap<String, tsz_binder::SymbolTable>>>,
+    /// Program-wide cross-file node-symbol map keyed by arena pointer.
+    /// Consulted by `ctx.cross_file_node_symbols_for_arena` in preference
+    /// to per-binder `cross_file_node_symbols`. Driver wraps
+    /// `program.cross_file_node_symbols` in a single `Arc` so N per-file
+    /// binders don't each deep-clone the outer `FxHashMap<usize, Arc<…>>`.
+    pub program_cross_file_node_symbols: Option<Arc<tsz_binder::CrossFileNodeSymbols>>,
 
     /// Resolved module paths map: (`source_file_idx`, specifier) -> `target_file_idx`.
     /// Used by `get_type_of_symbol` to resolve imports to their target file and symbol.
@@ -1689,9 +1696,12 @@ pub struct ProjectEnv {
     /// see `CheckerContext::program_reexports`.
     pub program_reexports: Option<Arc<tsz_binder::FileReexportsMap>>,
     pub program_wildcard_reexports: Option<Arc<FxHashMap<String, Vec<String>>>>,
-    pub program_wildcard_reexports_type_only: Option<Arc<FxHashMap<String, Vec<(String, bool)>>>>,
+    pub program_wildcard_reexports_type_only: Option<Arc<WildcardReexportsTypeOnlyMap>>,
     /// Program-wide module-exports index; see `CheckerContext::program_module_exports`.
     pub program_module_exports: Option<Arc<FxHashMap<String, tsz_binder::SymbolTable>>>,
+    /// Program-wide cross-file node-symbol map; see
+    /// `CheckerContext::program_cross_file_node_symbols`.
+    pub program_cross_file_node_symbols: Option<Arc<tsz_binder::CrossFileNodeSymbols>>,
     /// Resolved module paths: (`source_file_idx`, specifier) -> `target_file_idx`.
     pub resolved_module_paths: Arc<ResolvedModulePathMap>,
     /// Resolved module paths keyed by (`source_file_idx`, specifier, resolution-mode override).
@@ -1740,6 +1750,7 @@ impl Default for ProjectEnv {
             program_wildcard_reexports: None,
             program_wildcard_reexports_type_only: None,
             program_module_exports: None,
+            program_cross_file_node_symbols: None,
             resolved_module_paths: Arc::new(FxHashMap::default()),
             resolved_module_request_paths: Arc::new(FxHashMap::default()),
             resolved_module_errors: Arc::new(FxHashMap::default()),
@@ -1813,6 +1824,9 @@ impl ProjectEnv {
         }
         if let Some(ref m) = self.program_module_exports {
             ctx.program_module_exports = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = self.program_cross_file_node_symbols {
+            ctx.program_cross_file_node_symbols = Some(Arc::clone(m));
         }
         // Install the shared DefinitionStore before gating expensive semantic-def
         // prepopulation so `is_fully_populated()` reflects project-wide state.

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -97,9 +97,7 @@ impl<'a> CheckerState<'a> {
     fn class_declaration_symbol(&self, class_idx: NodeIndex) -> Option<SymbolId> {
         let arena_ptr = self.ctx.arena as *const _ as usize;
         self.ctx
-            .binder
-            .cross_file_node_symbols
-            .get(&arena_ptr)
+            .cross_file_node_symbols_for_arena(self.ctx.binder, arena_ptr)
             .and_then(|node_symbols| node_symbols.get(&class_idx.0).copied())
             .or_else(|| self.ctx.binder.get_node_symbol(class_idx))
     }

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -33,6 +33,7 @@ fn empty_project_env() -> ProjectEnv {
         program_wildcard_reexports: None,
         program_wildcard_reexports_type_only: None,
         program_module_exports: None,
+        program_cross_file_node_symbols: None,
         resolved_module_paths: Arc::new(FxHashMap::default()),
         resolved_module_request_paths: Arc::new(FxHashMap::default()),
         resolved_module_errors: Arc::new(FxHashMap::default()),

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -910,6 +910,12 @@ pub(super) fn collect_diagnostics(
     // authoritative cross-file exports table; wrap once, share via `Arc`
     // to avoid N deep-clones into per-file cross-file lookup binders.
     let program_module_exports = Arc::new(program.module_exports.clone());
+    // Same rationale for `program.cross_file_node_symbols`: the outer
+    // map is `FxHashMap<usize, Arc<…>>` (~24 bytes * N_files for the
+    // entries plus hash overhead). Cloning into every one of N per-file
+    // binders scales outer-map allocation with N². Wrap once here and
+    // route consumers through `ctx.cross_file_node_symbols_for_arena`.
+    let program_cross_file_node_symbols = Arc::new(program.cross_file_node_symbols.clone());
 
     let mut project_env = tsz::checker::context::ProjectEnv {
         lib_contexts: std::sync::Arc::new(checker_libs.contexts.clone()),
@@ -930,6 +936,7 @@ pub(super) fn collect_diagnostics(
         program_wildcard_reexports: Some(program_wildcard_reexports),
         program_wildcard_reexports_type_only: Some(program_wildcard_reexports_type_only),
         program_module_exports: Some(program_module_exports),
+        program_cross_file_node_symbols: Some(program_cross_file_node_symbols),
         ..Default::default()
     };
     // Use fingerprint-aware rebuild when a skeleton index is available.

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1580,7 +1580,12 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
             wildcard_reexports_type_only: program.wildcard_reexports_type_only.clone(),
             symbol_arenas,
             declaration_arenas,
-            cross_file_node_symbols: program.cross_file_node_symbols.clone(),
+            // Per-binder cross_file_node_symbols left empty intentionally.
+            // The program-wide outer map is stored once on ProjectEnv and
+            // read via `ctx.cross_file_node_symbols_for_arena`. Cloning
+            // it into every per-file binder scales outer-map allocation
+            // with N² — several hundred MB on large-ts-repo.
+            cross_file_node_symbols: Default::default(),
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: Default::default(),
             flow_nodes: file.flow_nodes.clone(),
@@ -1683,7 +1688,9 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
             // into every file binder makes all_binders setup scale with total declarations.
             symbol_arenas: Default::default(),
             declaration_arenas: Default::default(),
-            cross_file_node_symbols: program.cross_file_node_symbols.clone(),
+            // See `create_binder_from_bound_file_with_augmentations` for
+            // the rationale: the program-wide map lives on ProjectEnv.
+            cross_file_node_symbols: Default::default(),
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: Default::default(),
             flow_nodes: file.flow_nodes.clone(),


### PR DESCRIPTION
## Summary

`create_binder_from_bound_file_with_augmentations` and `create_cross_file_lookup_binder_with_augmentations` (both in `tsz-cli`) were each deep-cloning `program.cross_file_node_symbols` into every one of N per-file binders. The outer map is `FxHashMap<usize, Arc<…>>`: the arena-pointer keys and `Arc` handles dominate the per-entry cost, but the inner per-file `node_symbols` maps are already `Arc`-shared, so the whole O(N · N) outer-map allocation was redundant — every per-file binder was paying for the full project-wide outer map even though each binder's own lookups only ever touch that one shared structure.

## Changes

- Add `program_cross_file_node_symbols: Option<Arc<CrossFileNodeSymbols>>` to `CheckerContext` and `ProjectEnv`.
- `ProjectEnv::apply_to` installs the shared `Arc` on every per-file checker context.
- New accessor `CheckerContext::cross_file_node_symbols_for_arena(binder, arena_ptr)` that prefers the project-wide map and falls back to per-binder for tests / standalone callers.
- The only checker consumer (`types::class_type::class_declaration_symbol` at `crates/tsz-checker/src/types/class_type/core.rs:99`) routes through the accessor.
- Both CLI driver factories now leave per-binder `cross_file_node_symbols` empty; driver wires the `Arc` into `ProjectEnv` once.
- Re-exports `CrossFileNodeSymbols` from the `tsz_binder` crate root.
- Adds `WildcardReexportsTypeOnlyMap` type alias to clear two pre-existing `clippy::type_complexity` warnings in `context/mod.rs` that block any lint-clean commit.

## Why scope the migration to the CLI driver path

`tsz-core` also populates `cross_file_node_symbols` (in `parallel/core.rs:4697, 4788`). Those two paths stay populated: the emitter (`emit.rs:337`) and `tsz_server` (two sites) call `tsz::parallel::create_binder_from_bound_file` and consume the per-binder map directly. They don't go through `ProjectEnv`, so migrating them would require plumbing the `Arc` through each consumer's state. The CLI checker path alone is N files × N files, so it's the dominant win; the emitter path is per-emitted-file and far less load-bearing.

## Based on

This PR targets \`fix-cli-parallel-ds-stats-compile\` (#763), a one-line fix for an unrelated compile error that's currently blocking \`main\` from building. Once that lands, this can be rebased onto \`main\`.

## Test plan

- [x] \`cargo clippy -p tsz-checker -p tsz-cli -p tsz-emitter -p tsz-lsp --all-targets -- -D warnings\` — clean
- [x] \`cargo nextest run -p tsz-checker\` — 4908 passed (no regressions)
- [x] \`cargo nextest run -p tsz-cli\` — only pre-existing main failures remain (verified on base branch)

Once merged, a follow-up will add a `MergedProgram::into_project_env`-style API so `tsz-core`'s parallel checker and the emitter can adopt the same shared-`Arc` pattern without duplicating the boilerplate.