### PR TITLE
[codex] align default import type meaning with tsc

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -51,7 +51,6 @@ use tsz_binder::{BinderState, ModuleAugmentation};
 pub use tsz_common::checker_options::CheckerOptions;
 pub use tsz_common::common::ScriptTarget;
 use tsz_parser::parser::node::NodeArena;
-
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.
 ///
 /// Prevents stack overflow when resolving deeply recursive or circular

--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -141,8 +141,17 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn current_file_emit_resolution_mode(&self) -> crate::context::ResolutionModeOverride {
-        let file_name = self.ctx.file_name.as_str();
+    pub(crate) fn current_file_emit_resolution_mode(
+        &self,
+    ) -> crate::context::ResolutionModeOverride {
+        let file_name = self
+            .ctx
+            .all_arenas
+            .as_ref()
+            .and_then(|arenas| arenas.get(self.ctx.current_file_idx))
+            .and_then(|arena| arena.source_files.first())
+            .map(|source_file| source_file.file_name.as_str())
+            .unwrap_or(self.ctx.file_name.as_str());
         if file_name.ends_with(".mts") || file_name.ends_with(".mjs") {
             return crate::context::ResolutionModeOverride::Import;
         }

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -154,11 +154,16 @@ impl<'a> CheckerState<'a> {
         let quoted_module = format!("\"{module_name}\"");
         let has_json_default_export =
             self.module_has_json_default_export(module_name, Some(self.ctx.current_file_idx));
+        let has_module_exports_binding =
+            self.module_uses_module_exports_interop(module_name, resolution_mode);
         let has_default_binding = has_json_default_export
+            || has_module_exports_binding
             || self.module_has_default_binding_fast_path(module_name, resolution_mode)
-            || exports_table
-                .as_ref()
-                .is_some_and(|table| table.has("default") || table.has("export="));
+            || exports_table.as_ref().is_some_and(|table| {
+                table.has("default")
+                    || table.has("export=")
+                    || (has_module_exports_binding && table.has("module.exports"))
+            });
 
         // TS2497: Module with `export =` targeting a non-module/non-variable symbol
         // can only be referenced via default import. Applies to namespace imports
@@ -594,6 +599,7 @@ impl<'a> CheckerState<'a> {
                                 );
                             }
                         } else if has_json_default_export
+                            || has_module_exports_binding
                             || exports_table.has("default")
                             || exports_table.has("export=")
                         {
@@ -1286,6 +1292,10 @@ impl<'a> CheckerState<'a> {
         module_name: &str,
         resolution_mode: Option<crate::context::ResolutionModeOverride>,
     ) -> bool {
+        if self.module_uses_module_exports_interop(module_name, resolution_mode) {
+            return true;
+        }
+
         let resolved_target = if resolution_mode.is_some() {
             self.ctx.resolve_import_target_from_file_with_mode(
                 self.ctx.current_file_idx,

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -353,6 +353,10 @@ impl<'a> CheckerState<'a> {
     fn get_type_only_import_export_kind(&self, idx: NodeIndex) -> Option<TypeOnlyKind> {
         use tsz_binder::symbol_flags;
 
+        if let Some(kind) = self.require_call_bound_identifier_type_only_kind(idx) {
+            return Some(kind);
+        }
+
         let sym_id = self.resolve_identifier_symbol(idx)?;
         let mut visited = AliasCycleTracker::new();
         let target = self.resolve_alias_symbol(sym_id, &mut visited);
@@ -423,19 +427,18 @@ impl<'a> CheckerState<'a> {
             // object itself is a value even if the module's exports are type-only.
             // Individual type-only members surface as TS2339 via property lookup.
             if let Some(module_specifier) = symbol.import_module.as_deref() {
-                let is_namespace_binding =
-                    symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*");
-                let export_name = symbol
-                    .import_name
-                    .as_deref()
-                    .unwrap_or(&symbol.escaped_name);
+                let Some((export_name, is_namespace_binding)) =
+                    self.effective_import_binding_name(symbol)
+                else {
+                    continue;
+                };
                 if !is_namespace_binding
-                    && self.is_export_type_only_across_binders(module_specifier, export_name)
+                    && self.is_export_type_only_across_binders(module_specifier, &export_name)
                 {
                     // Determine whether the type-only came from `import type` or `export type`
                     // in the target module. Resolve the export symbol and walk its declarations.
                     if let Some(kind) =
-                        self.classify_cross_file_type_only_kind(module_specifier, export_name)
+                        self.classify_cross_file_type_only_kind(module_specifier, &export_name)
                     {
                         return Some(kind);
                     }
@@ -526,6 +529,53 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    pub(crate) fn require_call_bound_identifier_type_only_kind(
+        &self,
+        idx: NodeIndex,
+    ) -> Option<TypeOnlyKind> {
+        use crate::context::ResolutionModeOverride;
+
+        if !self.is_require_call_bound_identifier(idx) {
+            return None;
+        }
+
+        let sym_id = self
+            .ctx
+            .binder
+            .get_node_symbol(idx)
+            .or_else(|| self.ctx.binder.resolve_identifier(self.ctx.arena, idx))?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+
+        for &decl_idx in &symbol.declarations {
+            if decl_idx.is_none() {
+                continue;
+            }
+            let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            let Some(module_specifier) = self.get_require_module_specifier(var_decl.initializer)
+            else {
+                continue;
+            };
+            let uses_module_exports = self.module_uses_module_exports_interop(
+                &module_specifier,
+                Some(ResolutionModeOverride::Require),
+            );
+            let kind = self.classify_cross_file_type_only_kind(&module_specifier, "module.exports");
+            if !uses_module_exports {
+                continue;
+            }
+            if let Some(kind) = kind {
+                return Some(kind);
+            }
+        }
+
+        None
+    }
+
     /// Determine whether a cross-file type-only export came from `import type`
     /// (TS1361) or `export type` (TS1362) by resolving the target module and
     /// walking the export symbol's declarations.
@@ -543,16 +593,16 @@ impl<'a> CheckerState<'a> {
             .ctx
             .module_exports_for_module(target_binder, &target_file_name)?;
         let sym_id = exports_table.get(export_name)?;
-        let sym = self.ctx.binder.get_symbol(sym_id)?;
+        let sym = target_binder
+            .get_symbol(sym_id)
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
 
         if !sym.is_type_only {
             return None;
         }
 
         // Walk the symbol's declarations to find the import/export that made it type-only
-        let decl_arena = self
-            .ctx
-            .binder
+        let decl_arena = target_binder
             .symbol_arenas
             .get(&sym_id)
             .map(|arc| &**arc)

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -3,6 +3,8 @@
 //! Constructor type operations have been extracted to
 //! `type_resolution/constructors.rs`.
 
+mod interop;
+
 use crate::module_resolution::module_specifier_candidates;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
@@ -1987,33 +1989,6 @@ impl<'a> CheckerState<'a> {
         name.ends_with(".mjs") || name.ends_with(".mts")
     }
 
-    /// Check if the target module is a pure ESM module (from a package with
-    /// `"type": "module"` or using `.mjs`/`.mts` extension).
-    pub(crate) fn module_is_esm(&self, module_specifier: &str) -> bool {
-        let Some(target_idx) = self.ctx.resolve_import_target(module_specifier) else {
-            return false;
-        };
-        let arena = self.ctx.get_arena_for_file(target_idx as u32);
-        let Some(source_file) = arena.source_files.first() else {
-            return false;
-        };
-        let file_name = source_file.file_name.as_str();
-
-        if file_name.ends_with(".mjs") || file_name.ends_with(".mts") {
-            return true;
-        }
-        if file_name.ends_with(".cjs") || file_name.ends_with(".cts") {
-            return false;
-        }
-
-        self.ctx
-            .file_is_esm_map
-            .as_ref()
-            .and_then(|map| map.get(file_name))
-            .copied()
-            .unwrap_or(false)
-    }
-
     pub(crate) fn module_has_export_equals(&self, module_specifier: &str) -> bool {
         if self
             .ctx
@@ -2412,7 +2387,12 @@ impl<'a> CheckerState<'a> {
 
         let has_default =
             if let Some(exports_table) = self.resolve_effective_module_exports(module_specifier) {
-                exports_table.has("default") || exports_table.has("export=")
+                exports_table.has("default")
+                    || exports_table.has("export=")
+                    || self.module_uses_module_exports_interop(
+                        module_specifier,
+                        Some(self.current_file_emit_resolution_mode()),
+                    )
             } else {
                 false
             };

--- a/crates/tsz-checker/src/state/type_resolution/module/interop.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/interop.rs
@@ -1,0 +1,87 @@
+use crate::context::ResolutionModeOverride;
+use crate::state::CheckerState;
+use tsz_common::common::ModuleKind;
+
+impl<'a> CheckerState<'a> {
+    /// Check if the target module is a pure ESM module (from a package with
+    /// `"type": "module"` or using `.mjs`/`.mts` extension).
+    pub(crate) fn module_is_esm(&self, module_specifier: &str) -> bool {
+        let Some(target_idx) = self.ctx.resolve_import_target(module_specifier) else {
+            return false;
+        };
+        let arena = self.ctx.get_arena_for_file(target_idx as u32);
+        let Some(source_file) = arena.source_files.first() else {
+            return false;
+        };
+        let file_name = source_file.file_name.as_str();
+
+        if file_name.ends_with(".mjs") || file_name.ends_with(".mts") {
+            return true;
+        }
+        if file_name.ends_with(".cjs") || file_name.ends_with(".cts") {
+            return false;
+        }
+
+        self.ctx
+            .file_is_esm_map
+            .as_ref()
+            .and_then(|map| map.get(file_name))
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// In Node20/NodeNext require-style consumers, a target ESM file can
+    /// expose a CommonJS-facing binding via `export type { X as "module.exports" }`.
+    /// Callers use this to treat `"module.exports"` like a default/export-equals
+    /// binding for diagnostics and type-only classification.
+    pub(crate) fn module_uses_module_exports_interop(
+        &self,
+        module_specifier: &str,
+        resolution_mode: Option<ResolutionModeOverride>,
+    ) -> bool {
+        if !matches!(
+            self.ctx.compiler_options.module,
+            ModuleKind::Node20 | ModuleKind::NodeNext
+        ) {
+            return false;
+        }
+
+        if resolution_mode != Some(ResolutionModeOverride::Require) {
+            return false;
+        }
+
+        let Some(target_idx) = self.ctx.resolve_import_target_from_file_with_mode(
+            self.ctx.current_file_idx,
+            module_specifier,
+            Some(ResolutionModeOverride::Require),
+        ) else {
+            return false;
+        };
+
+        let arena = self.ctx.get_arena_for_file(target_idx as u32);
+        let Some(source_file) = arena.source_files.first() else {
+            return false;
+        };
+        let file_name = source_file.file_name.as_str();
+        let target_is_esm = if file_name.ends_with(".mjs") || file_name.ends_with(".mts") {
+            true
+        } else if file_name.ends_with(".cjs") || file_name.ends_with(".cts") {
+            false
+        } else {
+            self.lookup_file_is_esm(file_name).unwrap_or(false)
+        };
+
+        let mut visited = rustc_hash::FxHashSet::default();
+        let has_module_exports = self
+            .resolve_export_in_file(target_idx, "module.exports", &mut visited)
+            .is_some()
+            || self
+                .resolve_effective_module_exports_with_mode(
+                    module_specifier,
+                    Some(ResolutionModeOverride::Require),
+                )
+                .is_some_and(|exports| exports.has("module.exports"));
+
+        target_is_esm && has_module_exports
+    }
+}

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -851,6 +851,90 @@ impl<'a> CheckerState<'a> {
         };
 
         let resolve_alias_type_position_result = |sym_id: SymbolId| {
+            let classify_target_resolution = |target_sym_id: SymbolId| {
+                let mut effective_target_id = target_sym_id;
+                let target_symbol_has_declared_type_meaning = |sym_id: SymbolId| {
+                    let Some(symbol) = self
+                        .get_cross_file_symbol(sym_id)
+                        .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))
+                    else {
+                        return false;
+                    };
+
+                    if (symbol.flags & symbol_flags::ALIAS) == 0
+                        && (symbol.flags & symbol_flags::TYPE) != 0
+                    {
+                        return true;
+                    }
+
+                    symbol.declarations.iter().copied().any(|decl_idx| {
+                        let arena = self
+                            .ctx
+                            .resolve_symbol_file_index(sym_id)
+                            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+                            .and_then(|binder| binder.get_arena_for_declaration(sym_id, decl_idx))
+                            .or_else(|| self.ctx.binder.get_arena_for_declaration(sym_id, decl_idx))
+                            .map_or(self.ctx.arena, |arena| arena.as_ref());
+
+                        arena.get(decl_idx).is_some_and(|node| {
+                            node.kind == syntax_kind_ext::INTERFACE_DECLARATION
+                                || node.kind == syntax_kind_ext::CLASS_DECLARATION
+                                || node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                                || node.kind == syntax_kind_ext::ENUM_DECLARATION
+                        })
+                    })
+                };
+                let mut target_flags = self
+                    .get_cross_file_symbol(effective_target_id)
+                    .or_else(|| {
+                        self.ctx
+                            .binder
+                            .get_symbol_with_libs(effective_target_id, &lib_binders)
+                    })
+                    .map_or(0, |s| s.flags);
+
+                // Synthetic default-export symbols often exist as bare aliases
+                // with no direct TYPE/VALUE flags. Follow the alias before
+                // deciding whether the import is usable in type position.
+                if (target_flags & symbol_flags::ALIAS) != 0 {
+                    if target_symbol_has_declared_type_meaning(effective_target_id) {
+                        return TypeSymbolResolution::Type(effective_target_id);
+                    }
+                    let mut visited_target_aliases = AliasCycleTracker::new();
+                    if let Some(alias_target_id) =
+                        self.resolve_alias_symbol(effective_target_id, &mut visited_target_aliases)
+                        && alias_target_id != effective_target_id
+                    {
+                        effective_target_id = alias_target_id;
+                        target_flags = self
+                            .get_cross_file_symbol(effective_target_id)
+                            .or_else(|| {
+                                self.ctx
+                                    .binder
+                                    .get_symbol_with_libs(effective_target_id, &lib_binders)
+                            })
+                            .map_or(0, |s| s.flags);
+                    }
+                }
+
+                let target_is_namespace_module = (target_flags
+                    & (symbol_flags::MODULE
+                        | symbol_flags::NAMESPACE_MODULE
+                        | symbol_flags::VALUE_MODULE))
+                    != 0;
+                let target_has_type =
+                    (target_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
+                let target_has_value = (target_flags & symbol_flags::VALUE) != 0;
+                let target_is_value_only =
+                    target_has_value && !target_has_type && !target_is_namespace_module;
+
+                if target_is_value_only {
+                    TypeSymbolResolution::ValueOnly(effective_target_id)
+                } else {
+                    TypeSymbolResolution::Type(effective_target_id)
+                }
+            };
+
             if let Some(alias_symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
                 && let Some(module_name) = alias_symbol.import_module.as_ref()
                 && alias_symbol.import_name.is_some()
@@ -868,39 +952,43 @@ impl<'a> CheckerState<'a> {
                     expected_name,
                     Some(source_file_idx),
                 ) {
+                    let export_surface_meanings = (expected_name != "*")
+                        .then(|| {
+                            self.ctx
+                                .resolve_import_target_from_file(source_file_idx, module_name)
+                        })
+                        .flatten()
+                        .map(|target_file_idx| {
+                            let declarations = self.export_surface_declarations_in_file(
+                                target_file_idx,
+                                expected_name,
+                            );
+                            let has_type_position_meaning =
+                                declarations.iter().any(|(_, flags, _)| {
+                                    (*flags
+                                        & (symbol_flags::TYPE
+                                            | symbol_flags::NAMESPACE_MODULE
+                                            | symbol_flags::VALUE_MODULE))
+                                        != 0
+                                });
+                            let has_runtime_value = declarations
+                                .iter()
+                                .any(|(_, flags, _)| (*flags & symbol_flags::VALUE) != 0);
+                            (has_type_position_meaning, has_runtime_value)
+                        });
+                    if let Some((has_type_position_meaning, has_runtime_value)) =
+                        export_surface_meanings
+                        && !has_type_position_meaning
+                        && has_runtime_value
+                    {
+                        return Some(TypeSymbolResolution::ValueOnly(target_sym_id));
+                    }
                     // Use get_cross_file_symbol first, then fall back to
                     // get_symbol_with_libs. When the target comes from a
                     // different binder (ambient module, cross-file export),
                     // SymbolId values can collide with the current binder's
                     // symbols, causing incorrect flag lookups.
-                    let target_flags = self
-                        .get_cross_file_symbol(target_sym_id)
-                        .or_else(|| {
-                            self.ctx
-                                .binder
-                                .get_symbol_with_libs(target_sym_id, &lib_binders)
-                        })
-                        .map_or(0, |s| s.flags);
-                    let target_is_namespace_module = (target_flags
-                        & (symbol_flags::MODULE
-                            | symbol_flags::NAMESPACE_MODULE
-                            | symbol_flags::VALUE_MODULE))
-                        != 0;
-                    // Use the already-resolved target_flags for value-only
-                    // classification. The internal symbol_is_value_only /
-                    // alias_resolves_to_value_only helpers use lookup_symbol_with_name
-                    // which searches the current binder — that can return a
-                    // WRONG symbol when SymbolIds collide across binders.
-                    let target_has_type =
-                        (target_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
-                    let target_has_value = (target_flags & symbol_flags::VALUE) != 0;
-                    let target_is_value_only =
-                        target_has_value && !target_has_type && !target_is_namespace_module;
-                    return Some(if target_is_value_only {
-                        TypeSymbolResolution::ValueOnly(target_sym_id)
-                    } else {
-                        TypeSymbolResolution::Type(target_sym_id)
-                    });
+                    return Some(classify_target_resolution(target_sym_id));
                 }
             }
             let mut visited_aliases = AliasCycleTracker::new();
@@ -920,31 +1008,7 @@ impl<'a> CheckerState<'a> {
                             module_name,
                         );
                     }
-                    // Use get_cross_file_symbol to avoid SymbolId collision
-                    // across binders (same fix as the first branch above).
-                    let target_flags = self
-                        .get_cross_file_symbol(target_sym_id)
-                        .or_else(|| {
-                            self.ctx
-                                .binder
-                                .get_symbol_with_libs(target_sym_id, &lib_binders)
-                        })
-                        .map_or(0, |s| s.flags);
-                    let target_is_namespace_module = (target_flags
-                        & (symbol_flags::MODULE
-                            | symbol_flags::NAMESPACE_MODULE
-                            | symbol_flags::VALUE_MODULE))
-                        != 0;
-                    let target_has_type =
-                        (target_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
-                    let target_has_value = (target_flags & symbol_flags::VALUE) != 0;
-                    let target_is_value_only =
-                        target_has_value && !target_has_type && !target_is_namespace_module;
-                    if target_is_value_only {
-                        TypeSymbolResolution::ValueOnly(target_sym_id)
-                    } else {
-                        TypeSymbolResolution::Type(target_sym_id)
-                    }
+                    classify_target_resolution(target_sym_id)
                 })
         };
 

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -414,6 +414,15 @@ impl<'a> CheckerState<'a> {
             }
 
             if !self.is_identifier_in_type_position(idx)
+                && self.is_require_call_bound_identifier(idx)
+                && self
+                    .require_call_bound_identifier_type_only_kind(idx)
+                    .is_some()
+            {
+                self.error_type_only_value_at(name, idx);
+            }
+
+            if !self.is_identifier_in_type_position(idx)
                 && self.alias_resolves_to_uninstantiated_namespace(sym_id)
             {
                 self.report_wrong_meaning(

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -15,6 +15,28 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    pub(crate) fn effective_import_binding_name(
+        &self,
+        symbol: &tsz_binder::Symbol,
+    ) -> Option<(String, bool)> {
+        let module_specifier = symbol.import_module.as_deref()?;
+        let import_name = symbol.import_name.as_deref();
+        let is_namespace_binding = import_name.is_none() || import_name == Some("*");
+
+        if self.module_uses_module_exports_interop(
+            module_specifier,
+            Some(self.current_file_emit_resolution_mode()),
+        ) && (is_namespace_binding || import_name == Some("default"))
+        {
+            return Some(("module.exports".to_string(), false));
+        }
+
+        Some((
+            import_name.unwrap_or(&symbol.escaped_name).to_string(),
+            is_namespace_binding,
+        ))
+    }
+
     pub(crate) fn file_has_jsdoc_typedef_named(&self, file_idx: usize, export_name: &str) -> bool {
         use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
 
@@ -708,19 +730,14 @@ impl<'a> CheckerState<'a> {
             return true;
         }
         if let Some(module_specifier) = symbol.import_module.as_deref() {
-            // Namespace imports (import * as ns) and namespace re-exports
-            // (export * as ns from) create value bindings — the namespace object.
-            // They should not be treated as type-only even if the target module
-            // only has type-only exports. Individual members surface as TS2339.
-            let is_namespace_binding =
-                symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*");
-            let export_name = symbol
-                .import_name
-                .as_deref()
-                .unwrap_or(&symbol.escaped_name);
+            let Some((export_name, is_namespace_binding)) =
+                self.effective_import_binding_name(symbol)
+            else {
+                return false;
+            };
             // Check across all binders for transitive type-only export chains
             if !is_namespace_binding
-                && self.is_export_type_only_across_binders(module_specifier, export_name)
+                && self.is_export_type_only_across_binders(module_specifier, &export_name)
             {
                 return true;
             }

--- a/crates/tsz-checker/tests/conformance_issues/features/import_aliases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/import_aliases.rs
@@ -513,6 +513,96 @@ new Foo();
 }
 
 #[test]
+fn test_esm_module_exports_type_only_in_node20_cts_reports_ts1362_and_ts2614() {
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &[
+            (
+                "exporter.mts",
+                r#"
+export default class Foo {}
+export type { Foo as "module.exports" };
+                "#,
+            ),
+            (
+                "importer.cts",
+                r#"
+import Foo = require("./exporter.mjs");
+new Foo();
+
+import Foo2 from "./exporter.mjs";
+new Foo2();
+
+import * as Foo3 from "./exporter.mjs";
+new Foo3();
+
+import { Oops } from "./exporter.mjs";
+                "#,
+            ),
+        ],
+        "importer.cts",
+        CheckerOptions {
+            module: tsz_common::ModuleKind::Node20,
+            target: tsz_common::common::ScriptTarget::ES2023,
+            ..Default::default()
+        },
+    );
+    let ts1362_count = diagnostics.iter().filter(|(code, _)| *code == 1362).count();
+    let ts2614_count = diagnostics.iter().filter(|(code, _)| *code == 2614).count();
+
+    assert_eq!(
+        ts1362_count, 3,
+        "Expected TS1362 for require/default/namespace value use of a type-only \
+         \"module.exports\" binding. Got diagnostics: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2614_count, 1,
+        "Expected TS2614 for named import from a module with only a default-like \
+         Node20 CommonJS interop binding. Got diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 2305),
+        "TS2305 should not be emitted when Node20 require interop sees a \
+         default-like \"module.exports\" binding. Got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_esm_module_exports_type_only_in_node20_cjs_require_reports_ts1362() {
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &[
+            (
+                "exporter.mts",
+                r#"
+export default class Foo {}
+export type { Foo as "module.exports" };
+                "#,
+            ),
+            (
+                "importer.cjs",
+                r#"
+const Foo = require("./exporter.mjs");
+new Foo();
+                "#,
+            ),
+        ],
+        "importer.cjs",
+        CheckerOptions {
+            module: tsz_common::ModuleKind::Node20,
+            target: tsz_common::common::ScriptTarget::ES2023,
+            allow_js: true,
+            check_js: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 1362),
+        "Expected TS1362 when a CommonJS require() binding resolves to a type-only \
+         \"module.exports\" export. Got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_no_false_ts2339_on_generic_class_computed_property_self_reference() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -169,6 +169,12 @@ fn post_process_checker_diagnostics(
     // Only keep TS1xxx codes that tsc is known to emit for JS files.
     if is_js {
         checker_diagnostics.retain(|diag| {
+            // TS1361/TS1362 are semantic type-only value-use diagnostics, not
+            // parser grammar errors. Keep them for checked JS files even
+            // though their codes live in the TS1xxx range.
+            if !should_filter_type_errors && matches!(diag.code, 1361 | 1362) {
+                return true;
+            }
             if tsz::checker::diagnostics::is_parser_grammar_diagnostic(diag.code) {
                 return is_ts1xxx_allowed_in_js(diag.code);
             }
@@ -4177,6 +4183,63 @@ let x2: string = f;
         assert!(
             f_diags.iter().all(|diag| diag.code != 2339),
             "did not expect follow-on TS2339 once TS1361 fired, got: {f_diags:?}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_collect_diagnostics_keeps_ts1362_for_checked_js_module_exports_type_only_require() {
+        let dir = std::env::temp_dir().join("tsz_check_js_module_exports_type_only_require");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let importer_path = dir.join("importer.cjs");
+        let exporter_path = dir.join("exporter.mts");
+
+        let importer_source = "const Foo = require(\"./exporter.mjs\");\nnew Foo();\n";
+        let exporter_source =
+            "export default class Foo {}\nexport type { Foo as \"module.exports\" };\n";
+
+        fs::write(&importer_path, importer_source).unwrap();
+        fs::write(&exporter_path, exporter_source).unwrap();
+
+        let options = ResolvedCompilerOptions {
+            allow_js: true,
+            check_js: true,
+            module_resolution: Some(crate::config::ModuleResolutionKind::NodeNext),
+            module_suffixes: vec![String::new()],
+            printer: tsz::emitter::PrinterOptions {
+                module: ModuleKind::Node20,
+                target: tsz_common::common::ScriptTarget::ES2023,
+                ..Default::default()
+            },
+            checker: tsz::checker::context::CheckerOptions {
+                module: ModuleKind::Node20,
+                target: tsz_common::common::ScriptTarget::ES2023,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (importer_path.to_str().unwrap(), importer_source),
+                (exporter_path.to_str().unwrap(), exporter_source),
+            ],
+            &options,
+            &dir,
+        );
+
+        let importer_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|diag| Path::new(&diag.file) == importer_path.as_path())
+            .collect();
+
+        assert!(
+            importer_diags.iter().any(|diag| diag.code == 1362),
+            "expected TS1362 for checked CommonJS require() of a type-only \
+             \"module.exports\" binding, got: {importer_diags:?}"
         );
 
         let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary
- treat `"module.exports"` type-only exports in Node20/NodeNext as default-like for type/value diagnostics
- preserve value-only default imports by classifying the target file's normalized export surface before trusting synthetic `default` aliases
- keep `TS1361`/`TS1362` for checked JS in CLI post-processing and add regressions for both the original conformance case and the merged-default regression
- factor a repeated checker-context wildcard re-export type into a shared alias to satisfy the current clippy gate on this tree

## Root cause
`tsc` decides whether a default import has type meaning from the imported module's effective export surface. `tsz` was classifying cross-file default imports from the synthetic `default` alias symbol alone, which dropped merged default-export type meaning in one direction and incorrectly let plain value-only defaults flow through type position in the other.

## Repro
```ts
// mod.ts
interface A {}
export type { A as "module.exports" };

// main.cts
import foo = require("./mod");
foo; // TS1362
import { A } from "./mod"; // TS2614
```

```ts
// b.ts
export const zzz = 123;
export default zzz;

// a.ts
export default interface zzz { x: string; }
import zzz from "./b";
export { zzz as default };

// index.ts
import zzz from "./a";
const x: zzz = { x: "" };

import originalZZZ from "./b";
const y: originalZZZ = x; // TS2749
```

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "esmModuleExports3" --verbose`
- `./scripts/conformance/conformance.sh run --filter "allowImportClausesToMergeWithTypes" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
