### PR TITLE
refactor(solver+checker): centralize is_assignment_operator in tsz-solver

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -18,25 +18,7 @@ impl<'a> CheckerState<'a> {
 
     /// Check if a token is an assignment operator (=, +=, -=, etc.)
     pub(crate) const fn is_assignment_operator(&self, operator: u16) -> bool {
-        matches!(
-            operator,
-            k if k == SyntaxKind::EqualsToken as u16
-                || k == SyntaxKind::PlusEqualsToken as u16
-                || k == SyntaxKind::MinusEqualsToken as u16
-                || k == SyntaxKind::AsteriskEqualsToken as u16
-                || k == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                || k == SyntaxKind::SlashEqualsToken as u16
-                || k == SyntaxKind::PercentEqualsToken as u16
-                || k == SyntaxKind::LessThanLessThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::AmpersandEqualsToken as u16
-                || k == SyntaxKind::BarEqualsToken as u16
-                || k == SyntaxKind::BarBarEqualsToken as u16
-                || k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-                || k == SyntaxKind::CaretEqualsToken as u16
-        )
+        crate::query_boundaries::common::is_assignment_operator(operator)
     }
 
     fn is_js_prototype_private_name_assignment_target(&self, idx: NodeIndex) -> Option<NodeIndex> {

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -7,8 +7,9 @@ use super::{FlowAnalyzer, PropertyKey};
 use crate::query_boundaries::flow_analysis::{
     array_type, enum_member_domain, evaluate_application_type, fallback_compound_assignment_result,
     get_array_element_type, get_lazy_def_id, is_assignable, is_assignable_with_env,
-    is_compound_assignment_operator, map_compound_assignment_to_binary, tuple_elements_for_type,
-    union_members_for_type, widen_literal_to_primitive,
+    is_assignment_operator as boundary_is_assignment_operator, is_compound_assignment_operator,
+    map_compound_assignment_to_binary, tuple_elements_for_type, union_members_for_type,
+    widen_literal_to_primitive,
 };
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
@@ -1662,25 +1663,7 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     pub(crate) const fn is_assignment_operator(&self, operator: u16) -> bool {
-        matches!(
-            operator,
-            k if k == SyntaxKind::EqualsToken as u16
-                || k == SyntaxKind::PlusEqualsToken as u16
-                || k == SyntaxKind::MinusEqualsToken as u16
-                || k == SyntaxKind::AsteriskEqualsToken as u16
-                || k == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                || k == SyntaxKind::SlashEqualsToken as u16
-                || k == SyntaxKind::PercentEqualsToken as u16
-                || k == SyntaxKind::LessThanLessThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::AmpersandEqualsToken as u16
-                || k == SyntaxKind::BarEqualsToken as u16
-                || k == SyntaxKind::BarBarEqualsToken as u16
-                || k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-                || k == SyntaxKind::CaretEqualsToken as u16
-        )
+        boundary_is_assignment_operator(operator)
     }
 
     pub(crate) fn narrow_assignment(&self, initial_type: TypeId, assigned_type: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
+++ b/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
@@ -456,25 +456,7 @@ impl<'a> FlowGraphBuilder<'a> {
     }
 
     pub(super) const fn is_assignment_operator_token(operator_token: u16) -> bool {
-        matches!(
-            operator_token,
-            x if x == SyntaxKind::EqualsToken as u16
-                || x == SyntaxKind::PlusEqualsToken as u16
-                || x == SyntaxKind::MinusEqualsToken as u16
-                || x == SyntaxKind::AsteriskEqualsToken as u16
-                || x == SyntaxKind::SlashEqualsToken as u16
-                || x == SyntaxKind::PercentEqualsToken as u16
-                || x == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                || x == SyntaxKind::LessThanLessThanEqualsToken as u16
-                || x == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                || x == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                || x == SyntaxKind::AmpersandEqualsToken as u16
-                || x == SyntaxKind::CaretEqualsToken as u16
-                || x == SyntaxKind::BarEqualsToken as u16
-                || x == SyntaxKind::BarBarEqualsToken as u16
-                || x == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || x == SyntaxKind::QuestionQuestionEqualsToken as u16
-        )
+        crate::query_boundaries::common::is_assignment_operator(operator_token)
     }
 
     // =============================================================================

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1808,6 +1808,10 @@ pub(crate) const fn is_compound_assignment_operator(operator_token: u16) -> bool
     tsz_solver::is_compound_assignment_operator(operator_token)
 }
 
+pub(crate) const fn is_assignment_operator(operator_token: u16) -> bool {
+    tsz_solver::is_assignment_operator(operator_token)
+}
+
 pub(crate) const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
     tsz_solver::map_compound_assignment_to_binary(operator_token)
 }

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -78,6 +78,10 @@ pub(crate) const fn is_compound_assignment_operator(operator_token: u16) -> bool
     tsz_solver::is_compound_assignment_operator(operator_token)
 }
 
+pub(crate) const fn is_assignment_operator(operator_token: u16) -> bool {
+    tsz_solver::is_assignment_operator(operator_token)
+}
+
 pub(crate) const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
     tsz_solver::map_compound_assignment_to_binary(operator_token)
 }

--- a/crates/tsz-solver/src/operations/compound_assignment.rs
+++ b/crates/tsz-solver/src/operations/compound_assignment.rs
@@ -22,6 +22,13 @@ pub const fn is_compound_assignment_operator(operator_token: u16) -> bool {
     )
 }
 
+/// Check if a token is any assignment operator: simple `=` or one of the
+/// compound forms (`+=`, `-=`, `**=`, `&&=`, `??=`, etc.).
+pub const fn is_assignment_operator(operator_token: u16) -> bool {
+    operator_token == SyntaxKind::EqualsToken as u16
+        || is_compound_assignment_operator(operator_token)
+}
+
 pub const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
     match operator_token {
         k if k == SyntaxKind::PlusEqualsToken as u16 => Some("+"),


### PR DESCRIPTION
## Summary
- Add `tsz_solver::is_assignment_operator` (`=` or any compound-assignment token) next to the existing `is_compound_assignment_operator` in `tsz-solver/operations/compound_assignment.rs`.
- Expose it through both `query_boundaries::common::is_assignment_operator` and `query_boundaries::flow_analysis::is_assignment_operator` wrappers.
- Delete three near-identical 16-arm inline matches from the checker:
  - `assignability/assignment_checker/assignment_ops.rs` (`CheckerState::is_assignment_operator`)
  - `flow/control_flow/assignment.rs` (`FlowAnalyzer::is_assignment_operator`)
  - `flow/flow_graph_builder/expressions.rs` (`FlowGraphBuilder::is_assignment_operator_token`)
- Each call site now routes through the boundary wrapper, preserving the `architecture_contract_tests` rule that forbids inline `tsz_solver::` calls outside `query_boundaries/`.

One scoped DRY fix from `docs/DRY_AUDIT_2026-04-21.md` (tsz-checker § "Assignment operator classification is repeated across expression checking, assignment checking, usage, and variable utilities"). Net: +21 / -59 lines.

## Test plan
- [x] `cargo check -p tsz-checker -p tsz-solver`
- [x] `cargo clippy -p tsz-checker -p tsz-solver --all-targets -- -D warnings`
- [x] `cargo nextest run -p tsz-checker -p tsz-solver --lib` — 7873 passed
- [x] Pre-commit hook full nextest (precommit profile) — 18332 passed, 55 skipped
- [x] Architecture guardrail (`test_no_inline_solver_function_calls_in_checker_modules`) passes