### PR TITLE
refactor(checker): route remaining keyword→TypeId sites through lib_resolution

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -3,6 +3,7 @@
 //! and cross-file interface declaration merging.
 
 use crate::state::CheckerState;
+use crate::types_domain::queries::lib_resolution::keyword_syntax_to_type_id;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -74,19 +75,8 @@ impl<'a> CheckerState<'a> {
             return TypeId::UNKNOWN;
         };
 
-        match node.kind {
-            k if k == tsz_scanner::SyntaxKind::StringKeyword as u16 => return TypeId::STRING,
-            k if k == tsz_scanner::SyntaxKind::NumberKeyword as u16 => return TypeId::NUMBER,
-            k if k == tsz_scanner::SyntaxKind::BooleanKeyword as u16 => return TypeId::BOOLEAN,
-            k if k == tsz_scanner::SyntaxKind::VoidKeyword as u16 => return TypeId::VOID,
-            k if k == tsz_scanner::SyntaxKind::UndefinedKeyword as u16 => {
-                return TypeId::UNDEFINED;
-            }
-            k if k == tsz_scanner::SyntaxKind::NullKeyword as u16 => return TypeId::NULL,
-            k if k == tsz_scanner::SyntaxKind::NeverKeyword as u16 => return TypeId::NEVER,
-            k if k == tsz_scanner::SyntaxKind::UnknownKeyword as u16 => return TypeId::UNKNOWN,
-            k if k == tsz_scanner::SyntaxKind::AnyKeyword as u16 => return TypeId::ANY,
-            _ => {}
+        if let Some(builtin) = keyword_syntax_to_type_id(node.kind) {
+            return builtin;
         }
 
         let name = if node.kind == syntax_kind_ext::TYPE_REFERENCE {

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -6,6 +6,7 @@
 //! It follows the "Check Fast, Explain Slow" pattern where we first
 //! resolve types, then use the solver to explain any failures.
 
+use super::queries::lib_resolution::keyword_syntax_to_type_id;
 use super::type_node_helpers::{
     check_duplicate_parameters_in_type, check_parameter_initializers_in_type,
 };
@@ -94,27 +95,16 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     /// Compute the type of a type node (internal, not cached).
     fn compute_type(&mut self, idx: NodeIndex) -> TypeId {
         use tsz_parser::parser::syntax_kind_ext;
-        use tsz_scanner::SyntaxKind;
 
         let Some(node) = self.ctx.arena.get(idx) else {
             return TypeId::ERROR;
         };
 
-        match node.kind {
-            // Keyword types - use compile-time constant TypeIds
-            k if k == SyntaxKind::NumberKeyword as u16 => TypeId::NUMBER,
-            k if k == SyntaxKind::StringKeyword as u16 => TypeId::STRING,
-            k if k == SyntaxKind::BooleanKeyword as u16 => TypeId::BOOLEAN,
-            k if k == SyntaxKind::VoidKeyword as u16 => TypeId::VOID,
-            k if k == SyntaxKind::AnyKeyword as u16 => TypeId::ANY,
-            k if k == SyntaxKind::NeverKeyword as u16 => TypeId::NEVER,
-            k if k == SyntaxKind::UnknownKeyword as u16 => TypeId::UNKNOWN,
-            k if k == SyntaxKind::UndefinedKeyword as u16 => TypeId::UNDEFINED,
-            k if k == SyntaxKind::NullKeyword as u16 => TypeId::NULL,
-            k if k == SyntaxKind::ObjectKeyword as u16 => TypeId::OBJECT,
-            k if k == SyntaxKind::BigIntKeyword as u16 => TypeId::BIGINT,
-            k if k == SyntaxKind::SymbolKeyword as u16 => TypeId::SYMBOL,
+        if let Some(builtin) = keyword_syntax_to_type_id(node.kind) {
+            return builtin;
+        }
 
+        match node.kind {
             // Type reference (e.g., "MyType", "Array<T>")
             k if k == syntax_kind_ext::TYPE_REFERENCE => self.get_type_from_type_reference(idx),
 


### PR DESCRIPTION
## Summary
- Follow-up to #775 — two more inline `SyntaxKind::*Keyword → TypeId::*` matches in `tsz-checker` collapsed onto the canonical `keyword_syntax_to_type_id` helper in `crates/tsz-checker/src/types/queries/lib_resolution.rs`:
  - `state/type_analysis/cross_file.rs::resolve_cross_file_heritage_type_arg` — 10-arm inline match → 3-line early return.
  - `types/type_node.rs::compute_type` — 12-arm inline match → 3-line early return; also drops the now-unused inner `use tsz_scanner::SyntaxKind;` inside `compute_type` (the module-level import is still used elsewhere).
- Net: +8 / −28 lines, no behavior change.
- Addresses `docs/DRY_AUDIT_2026-04-21.md` tsz-checker § *"Keyword syntax to builtin `TypeId` mapping is repeated despite an existing lib-resolution helper"*.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings`
- [x] `cargo nextest run -p tsz-checker --lib` — 2623 passed
- [x] Pre-commit hook full nextest (precommit profile) — 12968 passed, 48 skipped
- [x] Architecture guardrail passes