### PR TITLE
refactor(solver): dedupe QueryCache constructors via with_optional_shared

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -307,25 +307,7 @@ pub struct QueryCache<'a> {
 
 impl<'a> QueryCache<'a> {
     pub fn new(interner: &'a TypeInterner) -> Self {
-        QueryCache {
-            interner,
-            eval_cache: RefCell::new(FxHashMap::default()),
-            application_eval_cache: RefCell::new(FxHashMap::default()),
-            element_access_cache: RefCell::new(FxHashMap::default()),
-            object_spread_properties_cache: RefCell::new(FxHashMap::default()),
-            subtype_cache: RefCell::new(FxHashMap::default()),
-            assignability_cache: RefCell::new(FxHashMap::default()),
-            property_cache: RefCell::new(FxHashMap::default()),
-            variance_cache: RefCell::new(FxHashMap::default()),
-            canonical_cache: RefCell::new(FxHashMap::default()),
-            intersection_merge_cache: RefCell::new(FxHashMap::default()),
-            subtype_cache_hits: Cell::new(0),
-            subtype_cache_misses: Cell::new(0),
-            assignability_cache_hits: Cell::new(0),
-            assignability_cache_misses: Cell::new(0),
-            no_unchecked_indexed_access: Cell::new(interner.no_unchecked_indexed_access()),
-            shared: None,
-        }
+        Self::with_optional_shared(interner, None)
     }
 
     /// Create a `QueryCache` backed by a shared cross-file cache.
@@ -334,6 +316,13 @@ impl<'a> QueryCache<'a> {
     /// On local miss, the shared `DashMap` cache is consulted. Results are written
     /// to both local and shared caches for cross-file benefit.
     pub fn new_with_shared(interner: &'a TypeInterner, shared: &'a SharedQueryCache) -> Self {
+        Self::with_optional_shared(interner, Some(shared))
+    }
+
+    fn with_optional_shared(
+        interner: &'a TypeInterner,
+        shared: Option<&'a SharedQueryCache>,
+    ) -> Self {
         QueryCache {
             interner,
             eval_cache: RefCell::new(FxHashMap::default()),
@@ -351,7 +340,7 @@ impl<'a> QueryCache<'a> {
             assignability_cache_hits: Cell::new(0),
             assignability_cache_misses: Cell::new(0),
             no_unchecked_indexed_access: Cell::new(interner.no_unchecked_indexed_access()),
-            shared: Some(shared),
+            shared,
         }
     }
 


### PR DESCRIPTION
## Summary
`QueryCache::new` and `QueryCache::new_with_shared` duplicated the full struct literal — 18 identical field initializers each, differing only in whether `shared` was `None` or `Some(_)`. A field added to one ctor was easy to forget in the other (exactly the drift the audit flagged).

Extracted the body into a private `with_optional_shared(interner, shared: Option<&SharedQueryCache>)` builder; both public ctors become one-line wrappers. Net +9 / −20. No behavior change.

Audit: `docs/DRY_AUDIT_2026-04-21.md` `tsz-solver` § *"Query cache constructors and clear paths are similar but not equivalent."*

## Test plan
- [x] `cargo clippy -p tsz-solver --all-targets -- -D warnings`
- [x] `cargo nextest run -p tsz-solver` — 5252 passed
- [x] Pre-commit hook full nextest (precommit profile) — 18334 passed, 55 skipped
- [x] Architecture guardrail passes