### PR TITLE
[codex] align rest inference TS2345 diagnostics with TS 6.0.2

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1084,6 +1084,12 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
+        if self.call_target_preserves_literal_argument_surface(param_type, arg_idx)
+            && let Some(display) = self.literal_call_argument_display(arg_idx)
+        {
+            return display;
+        }
+
         let mut display_type = if param_type == TypeId::NEVER {
             if let Some(display) = self.zero_argument_call_list_display(arg_idx) {
                 return display;
@@ -1114,6 +1120,19 @@ impl<'a> CheckerState<'a> {
         self.rewrite_source_display_for_non_literal_target_assignability(
             arg_type, param_type, display,
         )
+    }
+
+    fn call_target_preserves_literal_argument_surface(
+        &mut self,
+        param_type: TypeId,
+        arg_idx: NodeIndex,
+    ) -> bool {
+        if self.enclosing_call_parameter_is_optional_non_rest(arg_idx) {
+            return false;
+        }
+        let evaluated = self.evaluate_type_for_assignability(param_type);
+        query_common::union_members(self.ctx.types, param_type).is_some()
+            || query_common::union_members(self.ctx.types, evaluated).is_some()
     }
 
     fn contextual_function_argument_display(
@@ -1467,11 +1486,13 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
-        // Use format_assignability_type_for_message to strip `| undefined` from
-        // optional parameter types when the argument is non-nullable.  tsc shows
-        // the declared parameter type without `| undefined` in TS2345 messages
-        // when the user actually provided an argument.
-        self.format_assignability_type_for_message(param_type, arg_type)
+        if self.enclosing_call_parameter_is_optional_non_rest(arg_idx) {
+            // tsc elides the synthetic optional `| undefined` surface once a
+            // regular argument definitely fills an optional non-rest slot.
+            return self.format_assignability_type_for_message(param_type, arg_type);
+        }
+
+        self.format_assignability_type_for_message_preserving_nullish(param_type, arg_type)
     }
 
     /// When the argument is a non-tuple spread (e.g. `...mixed` where
@@ -1510,28 +1531,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let (callee_type, arg_pos) = self.enclosing_call_arg_position(arg_idx)?;
-
-        let param_is_optional_non_rest = |params: &[tsz_solver::ParamInfo]| {
-            params
-                .get(arg_pos)
-                .map(|p| p.optional && !p.rest)
-                .unwrap_or(false)
-        };
-
-        let mut optional = false;
-        if let Some(shape) = query_common::function_shape_for_type(self.ctx.types, callee_type) {
-            optional = param_is_optional_non_rest(&shape.params);
-        }
-        if !optional
-            && let Some(signatures) =
-                query_common::call_signatures_for_type(self.ctx.types, callee_type)
-        {
-            optional = signatures
-                .iter()
-                .any(|sig| param_is_optional_non_rest(&sig.params));
-        }
-        if !optional {
+        if !self.enclosing_call_parameter_is_optional_non_rest(arg_idx) {
             return None;
         }
         // The solver typically widens optional-param types to include `undefined`
@@ -1551,6 +1551,33 @@ impl<'a> CheckerState<'a> {
         };
 
         Some(self.format_type_for_assignability_message(widened))
+    }
+
+    fn enclosing_call_parameter_is_optional_non_rest(&mut self, arg_idx: NodeIndex) -> bool {
+        let Some((callee_type, arg_pos)) = self.enclosing_call_arg_position(arg_idx) else {
+            return false;
+        };
+
+        let param_is_optional_non_rest = |params: &[tsz_solver::ParamInfo]| {
+            params
+                .get(arg_pos)
+                .map(|p| p.optional && !p.rest)
+                .unwrap_or(false)
+        };
+
+        if let Some(shape) = query_common::function_shape_for_type(self.ctx.types, callee_type)
+            && param_is_optional_non_rest(&shape.params)
+        {
+            return true;
+        }
+
+        query_common::call_signatures_for_type(self.ctx.types, callee_type).is_some_and(
+            |signatures| {
+                signatures
+                    .iter()
+                    .any(|sig| param_is_optional_non_rest(&sig.params))
+            },
+        )
     }
 
     fn enclosing_call_arg_position(&mut self, arg_idx: NodeIndex) -> Option<(TypeId, usize)> {

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -294,6 +294,106 @@ _.all([true, 1, null, 'yes'], _.identity);
 }
 
 #[test]
+fn ts2345_call_parameter_display_preserves_semantic_nullable_union() {
+    let source = r#"
+declare function takes(value: boolean | null | undefined): void;
+takes(0);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text.contains("Argument of type '0'"),
+        "TS2345 should preserve direct literal call-argument display, got: {diag:?}"
+    );
+    assert!(
+        diag.message_text
+            .contains("parameter of type 'boolean | null | undefined'"),
+        "TS2345 should preserve semantic nullable unions in parameter display, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("parameter of type 'boolean'."),
+        "TS2345 should not strip nullable union members from non-optional parameters, got: {diag:?}"
+    );
+}
+
+#[test]
+fn ts2345_call_argument_display_normalizes_negative_zero_literal() {
+    let source = r#"
+declare function takes(value: boolean | null | undefined): void;
+takes(-0);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text.contains("Argument of type '0'"),
+        "TS2345 should normalize -0 to 0 in literal call-argument display, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("Argument of type '-0'"),
+        "TS2345 should not preserve -0 text once the literal type normalizes to 0, got: {diag:?}"
+    );
+}
+
+#[test]
+fn ts2345_call_argument_display_widens_literal_for_non_union_target() {
+    let source = r#"
+declare function takes(value: string): void;
+takes(2);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text.contains("Argument of type 'number'"),
+        "TS2345 should widen direct numeric literals for non-union parameter targets, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("Argument of type '2'"),
+        "TS2345 should not preserve literal numeric text for non-union parameter targets, got: {diag:?}"
+    );
+}
+
+#[test]
+fn ts2345_call_argument_display_widens_literal_for_optional_parameter_target() {
+    let source = r#"
+interface Item {
+    name: string;
+}
+declare function takes(value?: Item): void;
+takes("abc");
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text.contains("Argument of type 'string'"),
+        "TS2345 should widen direct literals for optional parameter targets, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("Argument of type '\"abc\"'"),
+        "TS2345 should not preserve literal text when the union comes only from optionality, got: {diag:?}"
+    );
+}
+
+#[test]
 fn ts2322_optional_function_property_target_display_omits_synthetic_undefined() {
     let source = r#"
 interface Stuff {

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -1754,6 +1754,9 @@ impl<'a> CheckerState<'a> {
                 let operand = self.literal_expression_display(unary.operand)?;
                 match unary.operator {
                     k if k == tsz_scanner::SyntaxKind::MinusToken as u16 => {
+                        if operand.parse::<f64>().is_ok_and(|value| value == 0.0) {
+                            return Some("0".to_string());
+                        }
                         Some(format!("-{operand}"))
                     }
                     k if k == tsz_scanner::SyntaxKind::PlusToken as u16 => Some(operand),

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -678,6 +678,23 @@ impl<'a> CheckerState<'a> {
         ty: TypeId,
         other: TypeId,
     ) -> String {
+        self.format_assignability_type_for_message_internal(ty, other, true)
+    }
+
+    pub(crate) fn format_assignability_type_for_message_preserving_nullish(
+        &mut self,
+        ty: TypeId,
+        other: TypeId,
+    ) -> String {
+        self.format_assignability_type_for_message_internal(ty, other, false)
+    }
+
+    fn format_assignability_type_for_message_internal(
+        &mut self,
+        ty: TypeId,
+        other: TypeId,
+        strip_top_level_nullish: bool,
+    ) -> String {
         if self.target_preserves_literal_surface(other) {
             return self.format_type_diagnostic(ty);
         }
@@ -703,7 +720,9 @@ impl<'a> CheckerState<'a> {
         // strip null/undefined from the top-level union to match tsc's behavior.
         // tsc only shows the non-nullable part of the target since null/undefined
         // are not relevant to the structural mismatch.
-        if let Some(stripped) = self.strip_nullish_for_assignability_display(ty, other) {
+        if strip_top_level_nullish
+            && let Some(stripped) = self.strip_nullish_for_assignability_display(ty, other)
+        {
             return self.format_type_for_assignability_message(stripped);
         }
 

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -140,8 +140,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let actual_count = arg_types.len();
         // Track single count-compatible overload that fails on types (see resolve_callable_call).
         let mut type_mismatch_count: usize = 0;
-        let mut first_type_mismatch: Option<(usize, TypeId, TypeId)> = None;
+        let mut first_type_mismatch: Option<(usize, TypeId, TypeId, TypeId)> = None;
         let mut all_mismatches_identical = true;
+        let mut all_mismatch_fallbacks_identical = true;
         let mut has_non_count_non_type_failure = false;
         // Also track this-type mismatches for TS2345 optimization (tsc reports TS2345 not TS2769
         // when all failures are identical this-type mismatches)
@@ -169,14 +170,26 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     index,
                     expected,
                     actual,
-                    ..
+                    fallback_return,
                 } => {
                     all_arg_count_mismatches = false;
                     type_mismatch_count += 1;
                     if type_mismatch_count == 1 {
-                        first_type_mismatch = Some((index, expected, actual));
-                    } else if first_type_mismatch != Some((index, expected, actual)) {
-                        all_mismatches_identical = false;
+                        first_type_mismatch = Some((index, expected, actual, fallback_return));
+                    } else if let Some((
+                        first_index,
+                        first_expected,
+                        first_actual,
+                        first_fallback,
+                    )) = first_type_mismatch
+                    {
+                        if (first_index, first_expected, first_actual) != (index, expected, actual)
+                        {
+                            all_mismatches_identical = false;
+                        }
+                        if first_fallback != fallback_return {
+                            all_mismatch_fallbacks_identical = false;
+                        }
                     }
                     failures.push(
                         crate::diagnostics::PendingDiagnosticBuilder::argument_not_assignable(
@@ -248,13 +261,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         if !has_non_count_non_type_failure
             && type_mismatch_count > 0
             && all_mismatches_identical
-            && let Some((index, expected, actual)) = first_type_mismatch
+            && let Some((index, expected, actual, fallback_return)) = first_type_mismatch
         {
             return CallResult::ArgumentTypeMismatch {
                 index,
                 expected,
                 actual,
-                fallback_return: TypeId::ERROR,
+                fallback_return: if all_mismatch_fallbacks_identical {
+                    fallback_return
+                } else {
+                    TypeId::ERROR
+                },
             };
         }
 

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -32,6 +32,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Direct arguments should stay narrow when there are heterogeneous candidates.
         // Otherwise TypeScript-style checks can get masked by a broad union result.
         if all_mergeable {
+            // Preserve tsc's nullable-envelope inference for direct rest parameters.
+            // `foo<T>(...s: T[])` called as `foo(false, undefined, null, "x")`
+            // infers `T = boolean | null | undefined`; the later string should
+            // fail against that type rather than forcing T back to the first
+            // boolean candidate and reporting the earlier `undefined` mismatch.
+            if self.should_preserve_nullable_direct_inference_result(lower_bounds, inferred) {
+                return crate::operations::widening::widen_literal_type(self.interner, inferred);
+            }
             // Guard: if lower bounds contain literals with different primitive bases
             // (e.g., "" and 3 → string vs number), fall back to the first candidate.
             // tsc keeps the first candidate in those cases so later argument checks
@@ -59,6 +67,56 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .copied()
             .find(|ty| !matches!(*ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
             .unwrap_or(lower_bounds[0])
+    }
+
+    fn should_preserve_nullable_direct_inference_result(
+        &self,
+        lower_bounds: &[TypeId],
+        inferred: TypeId,
+    ) -> bool {
+        if !lower_bounds
+            .iter()
+            .copied()
+            .any(|bound| self.type_includes_nullish_member(bound))
+        {
+            return false;
+        }
+
+        let Some(TypeData::Union(members)) = self.interner.lookup(inferred) else {
+            return false;
+        };
+
+        let mut has_nullish = false;
+        let mut non_nullish_count = 0;
+
+        for &member in self.interner.type_list(members).iter() {
+            if member.is_nullish() {
+                has_nullish = true;
+            } else {
+                non_nullish_count += 1;
+                if non_nullish_count > 1 {
+                    return false;
+                }
+            }
+        }
+
+        has_nullish && non_nullish_count == 1
+    }
+
+    fn type_includes_nullish_member(&self, ty: TypeId) -> bool {
+        if ty.is_nullish() {
+            return true;
+        }
+
+        match self.interner.lookup(ty) {
+            Some(TypeData::Union(members)) => self
+                .interner
+                .type_list(members)
+                .iter()
+                .copied()
+                .any(TypeId::is_nullish),
+            _ => false,
+        }
     }
 
     fn preferred_specific_tuple_inference_candidate(

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -1996,6 +1996,134 @@ fn test_property_access_array_entries_returns_tuple_array() {
 }
 
 #[test]
+fn test_property_access_array_indexof_preserves_nullable_element_type() {
+    let interner = TypeInterner::new();
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+
+    let index_of = interner.function(FunctionShape {
+        params: vec![
+            ParamInfo {
+                name: Some(interner.intern_string("searchElement")),
+                type_id: t_type,
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("fromIndex")),
+                type_id: TypeId::NUMBER,
+                optional: true,
+                rest: false,
+            },
+        ],
+        return_type: TypeId::NUMBER,
+        type_params: vec![],
+        this_type: None,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let array_interface = interner.object(vec![PropertyInfo::method(
+        interner.intern_string("indexOf"),
+        index_of,
+    )]);
+    interner.set_array_base_type(array_interface, vec![t_param]);
+
+    let evaluator = PropertyAccessEvaluator::new(&interner);
+    let element = interner.union(vec![TypeId::BOOLEAN, TypeId::UNDEFINED, TypeId::NULL]);
+    let array = interner.array(element);
+
+    let result = evaluator.resolve_property_access(array, "indexOf");
+    match result {
+        PropertyAccessResult::Success { type_id, .. } => match interner.lookup(type_id) {
+            Some(TypeData::Function(func_id)) => {
+                let func = interner.function_shape(func_id);
+                assert_eq!(
+                    func.params[0].type_id, element,
+                    "indexOf should use the full nullable element type"
+                );
+            }
+            other => panic!("Expected function, got {other:?}"),
+        },
+        _ => panic!("Expected success, got {result:?}"),
+    }
+}
+
+#[test]
+fn test_property_access_callable_array_indexof_preserves_nullable_element_type() {
+    let interner = TypeInterner::new();
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+
+    let index_of = interner.function(FunctionShape {
+        params: vec![
+            ParamInfo {
+                name: Some(interner.intern_string("searchElement")),
+                type_id: t_type,
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("fromIndex")),
+                type_id: TypeId::NUMBER,
+                optional: true,
+                rest: false,
+            },
+        ],
+        return_type: TypeId::NUMBER,
+        type_params: vec![],
+        this_type: None,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: true,
+    });
+
+    let array_callable = interner.callable(CallableShape {
+        symbol: None,
+        is_abstract: false,
+        call_signatures: Vec::new(),
+        construct_signatures: Vec::new(),
+        properties: vec![PropertyInfo::method(
+            interner.intern_string("indexOf"),
+            index_of,
+        )],
+        string_index: None,
+        number_index: None,
+    });
+    interner.set_array_base_type(array_callable, vec![t_param]);
+
+    let evaluator = PropertyAccessEvaluator::new(&interner);
+    let element = interner.union(vec![TypeId::BOOLEAN, TypeId::UNDEFINED, TypeId::NULL]);
+    let array = interner.array(element);
+
+    let result = evaluator.resolve_property_access(array, "indexOf");
+    match result {
+        PropertyAccessResult::Success { type_id, .. } => match interner.lookup(type_id) {
+            Some(TypeData::Function(func_id)) => {
+                let func = interner.function_shape(func_id);
+                assert_eq!(
+                    func.params[0].type_id, element,
+                    "callable-backed Array#indexOf should keep the full nullable element type"
+                );
+            }
+            other => panic!("Expected function, got {other:?}"),
+        },
+        _ => panic!("Expected success, got {result:?}"),
+    }
+}
+
+#[test]
 fn test_property_access_array_reduce_callable() {
     let interner = TypeInterner::new();
     let (_env, _) = make_array_test_env(&interner);
@@ -7451,6 +7579,167 @@ fn test_rest_param_spreading_heterogeneous_args() {
         &[TypeId::NUMBER, TypeId::STRING, TypeId::BOOLEAN],
     );
     assert_ne!(result, TypeId::ERROR, "Expected union result, not ERROR");
+}
+
+#[test]
+fn test_rest_param_nullable_prefix_reports_later_incompatible_argument() {
+    let interner = TypeInterner::new();
+    let mut subtype = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut subtype);
+
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    let array_t = interner.array(t_type);
+
+    let func = interner.function(FunctionShape {
+        type_params: vec![t_param],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("args")),
+            type_id: array_t,
+            optional: false,
+            rest: true,
+        }],
+        this_type: None,
+        return_type: t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let bad_string = interner.literal_string("x");
+    let expected = interner.union(vec![TypeId::BOOLEAN, TypeId::UNDEFINED, TypeId::NULL]);
+
+    let result = evaluator.resolve_call(
+        func,
+        &[
+            TypeId::BOOLEAN_FALSE,
+            TypeId::UNDEFINED,
+            TypeId::NULL,
+            bad_string,
+        ],
+    );
+
+    match result {
+        CallResult::ArgumentTypeMismatch {
+            index,
+            expected: actual_expected,
+            actual,
+            ..
+        } => {
+            assert_eq!(index, 3, "expected the later incompatible rest arg to fail");
+            assert_eq!(
+                actual_expected, expected,
+                "expected nullable boolean inference for the rest element type"
+            );
+            assert_eq!(actual, bad_string);
+        }
+        _ => panic!("Expected ArgumentTypeMismatch, got {result:?}"),
+    }
+}
+
+#[test]
+fn test_array_constructor_rest_mismatch_keeps_nullable_fallback_array() {
+    let interner = TypeInterner::new();
+    let mut subtype = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut subtype);
+
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    let array_t = interner.array(t_type);
+
+    let array_ctor = interner.callable(CallableShape {
+        symbol: None,
+        is_abstract: false,
+        call_signatures: Vec::new(),
+        construct_signatures: vec![
+            CallSignature {
+                type_params: Vec::new(),
+                params: vec![ParamInfo {
+                    name: Some(interner.intern_string("arrayLength")),
+                    type_id: TypeId::NUMBER,
+                    optional: true,
+                    rest: false,
+                }],
+                this_type: None,
+                return_type: interner.array(TypeId::ANY),
+                type_predicate: None,
+                is_method: false,
+            },
+            CallSignature {
+                type_params: vec![t_param],
+                params: vec![ParamInfo {
+                    name: Some(interner.intern_string("arrayLength")),
+                    type_id: TypeId::NUMBER,
+                    optional: false,
+                    rest: false,
+                }],
+                this_type: None,
+                return_type: array_t,
+                type_predicate: None,
+                is_method: false,
+            },
+            CallSignature {
+                type_params: vec![t_param],
+                params: vec![ParamInfo {
+                    name: Some(interner.intern_string("items")),
+                    type_id: array_t,
+                    optional: false,
+                    rest: true,
+                }],
+                this_type: None,
+                return_type: array_t,
+                type_predicate: None,
+                is_method: false,
+            },
+        ],
+        properties: Vec::new(),
+        ..Default::default()
+    });
+
+    let bad_string = interner.literal_string("x");
+    let expected_elem = interner.union(vec![TypeId::BOOLEAN, TypeId::UNDEFINED, TypeId::NULL]);
+    let expected_array = interner.array(expected_elem);
+
+    let result = evaluator.resolve_new(
+        array_ctor,
+        &[
+            TypeId::BOOLEAN_FALSE,
+            TypeId::UNDEFINED,
+            TypeId::NULL,
+            bad_string,
+        ],
+    );
+
+    match result {
+        CallResult::ArgumentTypeMismatch {
+            index,
+            expected,
+            actual,
+            fallback_return,
+        } => {
+            assert_eq!(
+                index, 3,
+                "expected the rest overload to fail on the string item"
+            );
+            assert_eq!(expected, expected_elem);
+            assert_eq!(actual, bad_string);
+            assert_eq!(
+                fallback_return, expected_array,
+                "expected recovery to keep the nullable element type"
+            );
+        }
+        _ => panic!("Expected ArgumentTypeMismatch, got {result:?}"),
+    }
 }
 
 /// Test rest parameter with leading fixed parameters


### PR DESCRIPTION
## Summary

Align TS2345 diagnostics for generic rest inference with the pinned TypeScript 6.0.2 conformance baseline.

The invariant is: for `new Array<T>(...items: T[])`, TypeScript 6.0.2 preserves the nullable prefix candidate during rest inference and reports later call mismatches against that recovered union element type, while `tsz` was collapsing recovery/display to the wrong primitive surface.

This change fixes that in the owning layers:
- preserve nullable direct-rest inference results in `tsz-solver`
- keep recovered constructor fallback types when overload mismatches collapse
- preserve TS 6.0.2 call-parameter and call-argument display rules for union targets, including `-0 -> 0`

## Minimal Repro

```ts
var a = new Array(false, undefined, null, "0");
a.indexOf(0);
a.indexOf(-0);
```

Expected TS 6.0.2 diagnostics include:
- `"0"` not assignable to `boolean | null | undefined`
- `0` not assignable to `boolean | null | undefined`
- `-0` displayed as `0`

## Validation

- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "parser15.4.4.14-9-2" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
  - `199/200 passed`; the remaining `allowImportClausesToMergeWithTypes` mismatch is already present in `scripts/conformance/conformance-detail.json`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
  - `FINAL RESULTS: 12038/12581 passed (95.7%)`
- `./scripts/conformance/conformance.sh diff`
  - `2 improvements, 0 regressions`
