### PR TITLE
perf(checker): route declared_modules.contains through accessor

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1009,6 +1009,21 @@ impl<'a> CheckerContext<'a> {
         binder.cross_file_node_symbols.get(&arena_ptr)
     }
 
+    /// Test whether `module_name` is declared as an ambient module anywhere
+    /// in the project. Prefers the project-wide `global_declared_modules`
+    /// index built from the skeleton; falls back to the per-binder
+    /// `declared_modules` set for tests / standalone callers.
+    pub fn declared_modules_contains(
+        &self,
+        binder: &tsz_binder::BinderState,
+        module_name: &str,
+    ) -> bool {
+        if let Some(ref dm) = self.global_declared_modules {
+            return dm.exact.contains(module_name);
+        }
+        binder.declared_modules.contains(module_name)
+    }
+
     /// Resolve an import specifier to its target file index.
     /// Uses the `resolved_module_paths` map populated by the driver.
     /// Returns None if the import cannot be resolved (e.g., external module).

--- a/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
@@ -73,7 +73,10 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
         }
 
         // Check ambient module declarations (`declare module "X" { ... }`)
-        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
+        if self
+            .ctx
+            .declared_modules_contains(self.ctx.binder, module_name)
+        {
             return true;
         }
 

--- a/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
@@ -73,7 +73,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
         }
 
         // Check ambient module declarations (`declare module "X" { ... }`)
-        if self.ctx.binder.declared_modules.contains(module_name) {
+        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
             return true;
         }
 

--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -493,7 +493,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check declared modules (regular ambient modules with body)
-        if self.ctx.binder.declared_modules.contains(module_name) {
+        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
             return; // Declared module exists
         }
 

--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -493,7 +493,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check declared modules (regular ambient modules with body)
-        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
+        if self
+            .ctx
+            .declared_modules_contains(self.ctx.binder, module_name)
+        {
             return; // Declared module exists
         }
 

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -875,7 +875,10 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
+        if self
+            .ctx
+            .declared_modules_contains(self.ctx.binder, module_name)
+        {
             return;
         }
 

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -293,7 +293,7 @@ impl<'a> CheckerState<'a> {
             if inside_namespace {
                 let module_is_ambient = require_module_specifier.as_deref().is_some_and(|spec| {
                     // Check current file's declared ambient modules
-                    self.ctx.binder.declared_modules.contains(spec)
+                    self.ctx.declared_modules_contains(self.ctx.binder, spec)
                             // Check cross-file ambient modules via global index
                             || self
                                 .ctx
@@ -875,7 +875,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.ctx.binder.declared_modules.contains(module_name) {
+        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
             return;
         }
 

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -152,7 +152,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.ctx.binder.declared_modules.contains(module_name) {
+        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
             self.ctx.import_resolution_stack.pop();
             return;
         }

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -152,7 +152,10 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.ctx.declared_modules_contains(self.ctx.binder, module_name) {
+        if self
+            .ctx
+            .declared_modules_contains(self.ctx.binder, module_name)
+        {
             self.ctx.import_resolution_stack.pop();
             return;
         }

--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1828,13 +1828,14 @@ impl<'a> CheckerState<'a> {
                 if let Some((module_specifier, _segments)) =
                     Self::parse_jsdoc_typeof_import_query(expr)
                 {
-                    let has_ambient_module =
-                        self.ctx.declared_modules_contains(self.ctx.binder, &module_specifier)
-                            || self
-                                .ctx
-                                .binder
-                                .shorthand_ambient_modules
-                                .contains(&module_specifier);
+                    let has_ambient_module = self
+                        .ctx
+                        .declared_modules_contains(self.ctx.binder, &module_specifier)
+                        || self
+                            .ctx
+                            .binder
+                            .shorthand_ambient_modules
+                            .contains(&module_specifier);
                     let rooted_specifier = module_specifier.starts_with('/');
                     let resolves = self
                         .ctx

--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1829,7 +1829,7 @@ impl<'a> CheckerState<'a> {
                     Self::parse_jsdoc_typeof_import_query(expr)
                 {
                     let has_ambient_module =
-                        self.ctx.binder.declared_modules.contains(&module_specifier)
+                        self.ctx.declared_modules_contains(self.ctx.binder, &module_specifier)
                             || self
                                 .ctx
                                 .binder

--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -913,7 +913,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // 4. Declared modules (ambient modules with body)
-        if self.ctx.declared_modules_contains(self.ctx.binder, &module_name) {
+        if self
+            .ctx
+            .declared_modules_contains(self.ctx.binder, &module_name)
+        {
             // Check if there's already a resolution error (TS2307) - don't emit TS2694 as a cascading error
             if self
                 .ctx

--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -913,7 +913,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // 4. Declared modules (ambient modules with body)
-        if self.ctx.binder.declared_modules.contains(&module_name) {
+        if self.ctx.declared_modules_contains(self.ctx.binder, &module_name) {
             // Check if there's already a resolution error (TS2307) - don't emit TS2694 as a cascading error
             if self
                 .ctx

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -441,7 +441,9 @@ impl<'a> CheckerState<'a> {
                         .binder
                         .shorthand_ambient_modules
                         .contains(module_name)
-                    && !self.ctx.declared_modules_contains(self.ctx.binder, module_name)
+                    && !self
+                        .ctx
+                        .declared_modules_contains(self.ctx.binder, module_name)
                     && !self
                         .ctx
                         .resolved_modules

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -441,7 +441,7 @@ impl<'a> CheckerState<'a> {
                         .binder
                         .shorthand_ambient_modules
                         .contains(module_name)
-                    && !self.ctx.binder.declared_modules.contains(module_name)
+                    && !self.ctx.declared_modules_contains(self.ctx.binder, module_name)
                     && !self
                         .ctx
                         .resolved_modules


### PR DESCRIPTION
## Summary

Adds \`CheckerContext::declared_modules_contains(binder, module_name)\` that prefers the project-wide \`global_declared_modules.exact\` set (skeleton-derived, populated once on every per-file context via \`set_declared_modules_from_skeleton\`) and falls back to the per-binder \`declared_modules\` set for tests and standalone callers.

Migrates 8 checker sites that did \`self.ctx.binder.declared_modules.contains(...)\` directly. Two remaining sites in \`import/declaration.rs\` already gate on \`global_declared_modules\` themselves and only fall back to per-binder when the global isn't populated; left as-is.

This is a **no-op behavior change today** (both paths return the same data on the parallel CLI path where the global index is always populated). It sets up a future PR that empties per-binder \`declared_modules\` in the CLI driver factories, mirroring the pattern from the already-merged \`module_exports\` (#762) and \`cross_file_node_symbols\` (#766) migrations.

## Why route through the accessor first?

Splitting the migration into two PRs keeps the per-binder/global routing change reviewable in isolation and lets the empty-per-binder follow-up land cleanly without cross-cutting concerns. The previous two ProjectEnv migrations followed exactly this pattern (#758 → #762 for \`module_exports\`).

## Changes

- New accessor: \`CheckerContext::declared_modules_contains\` (~15 lines, prefers global, falls back to per-binder).
- 8 checker call-site migrations across \`module_checker.rs\`, \`declarations_module_helpers.rs\`, \`dynamic_import_checker.rs\`, \`import/equals.rs\` (×2), \`state/type_resolution/import_type.rs\`, \`jsdoc/diagnostics.rs\`, \`symbols/symbol_resolver_utils.rs\`.

## Test plan

- [x] \`cargo nextest run -p tsz-checker\` — 4918 passed (no regressions)
- [x] \`cargo check -p tsz-checker\` clean