### PR TITLE
refactor(solver): extract constrain_type_predicates helper

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -8,7 +8,7 @@ use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{
     CallSignature, FunctionShape, ObjectShape, ObjectShapeId, ParamInfo, PropertyInfo,
-    TupleElement, TypeData, TypeId,
+    TupleElement, TypeData, TypeId, TypePredicate,
 };
 use crate::utils;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -227,26 +227,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             target_has_predicate = target.type_predicate.is_some(),
             "constrain_function_to_call_signature: checking type predicates"
         );
-        if let (Some(s_pred), Some(t_pred)) = (&source.type_predicate, &target.type_predicate) {
-            trace!(
-                source_pred_asserts = s_pred.asserts,
-                source_pred_type = ?s_pred.type_id,
-                target_pred_asserts = t_pred.asserts,
-                target_pred_type = ?t_pred.type_id,
-                "constrain_function_to_call_signature: both have predicates"
-            );
-            if let (Some(s_pred_type), Some(t_pred_type)) = (s_pred.type_id, t_pred.type_id) {
-                trace!(
-                    s_pred_type = ?s_pred_type,
-                    t_pred_type = ?t_pred_type,
-                    "constrain_function_to_call_signature: adding constraint"
-                );
-                let was = ctx.source_is_type_annotation;
-                ctx.source_is_type_annotation = true;
-                self.constrain_types(ctx, var_map, s_pred_type, t_pred_type, priority);
-                ctx.source_is_type_annotation = was;
-            }
-        }
+        self.constrain_type_predicates(
+            ctx,
+            var_map,
+            source.type_predicate.as_ref(),
+            target.type_predicate.as_ref(),
+            priority,
+        );
     }
 
     pub(super) fn constrain_call_signature_to_function(
@@ -269,14 +256,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             priority,
         );
         // Constrain type predicates if both have them
-        if let (Some(s_pred), Some(t_pred)) = (&source.type_predicate, &target.type_predicate)
-            && let (Some(s_pred_type), Some(t_pred_type)) = (s_pred.type_id, t_pred.type_id)
-        {
-            let was = ctx.source_is_type_annotation;
-            ctx.source_is_type_annotation = true;
-            self.constrain_types(ctx, var_map, s_pred_type, t_pred_type, priority);
-            ctx.source_is_type_annotation = was;
-        }
+        self.constrain_type_predicates(
+            ctx,
+            var_map,
+            source.type_predicate.as_ref(),
+            target.type_predicate.as_ref(),
+            priority,
+        );
     }
 
     pub(super) fn constrain_call_signature_to_call_signature(
@@ -301,14 +287,39 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Constrain type predicates if both have them.
         // Mark as type annotation source so literal types from predicates
         // (e.g., `x is 'B'`) are NOT marked as fresh and won't be widened.
-        if let (Some(s_pred), Some(t_pred)) = (&source.type_predicate, &target.type_predicate)
-            && let (Some(s_pred_type), Some(t_pred_type)) = (s_pred.type_id, t_pred.type_id)
-        {
-            let was = ctx.source_is_type_annotation;
-            ctx.source_is_type_annotation = true;
-            self.constrain_types(ctx, var_map, s_pred_type, t_pred_type, priority);
-            ctx.source_is_type_annotation = was;
-        }
+        self.constrain_type_predicates(
+            ctx,
+            var_map,
+            source.type_predicate.as_ref(),
+            target.type_predicate.as_ref(),
+            priority,
+        );
+    }
+
+    /// Constrain the target type parameters inside a pair of type predicates.
+    ///
+    /// Matches tsc: when both source and target signatures carry a type
+    /// predicate with a concrete type, infer with `source_is_type_annotation`
+    /// set so that literal predicate types (e.g. `x is 'B'`) are not marked
+    /// fresh and won't be widened during candidate collection.
+    fn constrain_type_predicates(
+        &mut self,
+        ctx: &mut InferenceContext,
+        var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
+        source_pred: Option<&TypePredicate>,
+        target_pred: Option<&TypePredicate>,
+        priority: crate::types::InferencePriority,
+    ) {
+        let (Some(s_pred), Some(t_pred)) = (source_pred, target_pred) else {
+            return;
+        };
+        let (Some(s_pred_type), Some(t_pred_type)) = (s_pred.type_id, t_pred.type_id) else {
+            return;
+        };
+        let was = ctx.source_is_type_annotation;
+        ctx.source_is_type_annotation = true;
+        self.constrain_types(ctx, var_map, s_pred_type, t_pred_type, priority);
+        ctx.source_is_type_annotation = was;
     }
 
     pub(super) fn function_type_from_signature(


### PR DESCRIPTION
## Summary
- Collapse three near-identical save/restore blocks around `ctx.source_is_type_annotation` in `operations/constraints/signatures.rs` into a single `constrain_type_predicates` helper.
- The blocks lived in `constrain_function_to_call_signature`, `constrain_call_signature_to_function`, and `constrain_call_signature_to_call_signature`. Each guarded on both predicates being `Some` and both having a concrete `type_id`, then flipped the flag around a call to `constrain_types`.
- Matches DRY audit target `signatures.rs:244/275/307` from `docs/DRY_AUDIT_2026-04-21.md`.

## Non-goals / preserved behavior
- The three `trace!` calls inside `constrain_function_to_call_signature` that named the direction (source→target role context) stay at the call site; only the two per-branch traces inside the guard body are dropped, which had no semantic effect. No assignability or inference behavior changes.

## Test plan
- [x] `cargo clippy -p tsz-solver --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-solver --lib` — 5252 passed, 7 skipped
- [x] Pre-commit full pipeline: 18344 tests passed