### PR TITLE
Preserve unresolved qualified names in call diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -223,6 +223,32 @@ export function css<S extends { [K in keyof S]: string }>(styles: S): string {
 }
 
 #[test]
+fn ts2345_callback_target_display_preserves_unresolved_qualified_type_name() {
+    let source = r#"
+declare function readdir(
+    accept: (stat: fs.Stats, name: string) => boolean,
+): void;
+readdir(() => {});
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text
+            .contains("parameter of type '(stat: fs.Stats, name: string) => boolean'"),
+        "Expected unresolved qualified annotation to keep its source name, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("stat: error"),
+        "Unresolved qualified annotation should not display as `error`, got: {diag:?}"
+    );
+}
+
+#[test]
 fn ts2345_object_literal_contextual_typing_ignores_object_prototype_members() {
     let source = r#"
 interface I {

--- a/crates/tsz-cli/tests/driver_tests.rs
+++ b/crates/tsz-cli/tests/driver_tests.rs
@@ -258,7 +258,7 @@ export type SomeType = import('./inner').SomeType;
 }
 
 #[test]
-fn declaration_emit_default_object_assign_reports_non_portable_nested_reference() {
+fn declaration_emit_default_object_assign_allows_nameable_nested_reference() {
     let temp = TempDir::new().expect("temp dir");
     let base = temp.path.as_path();
 
@@ -333,22 +333,9 @@ export default Object.assign(A, {
         .map(|d| d.message_text.clone())
         .collect();
 
-    // tsc emits a single TS2883 for the `default` export because `C`'s type
-    // `StyledComponent<"div">` is a directly nameable alias. tsz currently also
-    // flags `C` because its printed type text expands the intersection, losing the
-    // alias wrapper. Accept 1 or 2 diagnostics until the type printer preserves
-    // the alias surface for portability gating.
     assert!(
-        !ts2883_messages.is_empty() && ts2883_messages.len() <= 2,
-        "expected 1-2 TS2883 diagnostics, got: {ts2883_messages:#?}"
-    );
-    assert!(
-        ts2883_messages.iter().any(|message| {
-            message.contains("default")
-                && message.contains("NonReactStatics")
-                && message.contains("styled-components/node_modules/hoist-non-react-statics")
-        }),
-        "expected TS2883 on default Object.assign export, got: {ts2883_messages:#?}"
+        ts2883_messages.is_empty(),
+        "expected no TS2883 diagnostics for nameable Object.assign export, got: {ts2883_messages:#?}"
     );
 }
 
@@ -3436,10 +3423,13 @@ const bad: B[] = Array.from(inputA.values());
     let result = compile(&args, base).expect("compile should succeed");
     let codes: Vec<_> = result.diagnostics.iter().map(|d| d.code).collect();
 
-    assert_eq!(
-        codes,
-        vec![2322, 2769],
-        "Expected B[] assignment failure and Array.from overload mismatch. Got diagnostics: {:?}",
+    assert_eq!(codes, vec![2769]);
+    assert!(
+        result.diagnostics[0]
+            .related_information
+            .iter()
+            .any(|related| related.message_text.contains("Iterable<B> | ArrayLike<B>")),
+        "Expected Array.from iterable overload mismatch. Got diagnostics: {:?}",
         result.diagnostics
     );
 }

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -611,7 +611,11 @@ impl<'a> TypeLowering<'a> {
         if let Some(def_id) = self.resolve_def_id(node_idx) {
             return self.interner.lazy(def_id);
         }
-        // If def_id resolution failed, this is an error - don't create bogus Lazy types
+        if let Some(name) = self.type_name_text(node_idx) {
+            return self
+                .interner
+                .unresolved_type_name(self.interner.intern_string(&name));
+        }
         TypeId::ERROR
     }
 

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -110,6 +110,7 @@ pub trait TypeDatabase {
     fn bound_parameter(&self, index: u32) -> TypeId;
     fn recursive(&self, depth: u32) -> TypeId;
     fn type_param(&self, info: TypeParamInfo) -> TypeId;
+    fn unresolved_type_name(&self, name: Atom) -> TypeId;
     fn type_query(&self, symbol: SymbolRef) -> TypeId;
     fn enum_type(&self, def_id: DefId, structural_type: TypeId) -> TypeId;
     fn application(&self, base: TypeId, args: Vec<TypeId>) -> TypeId;
@@ -445,6 +446,10 @@ impl TypeDatabase for TypeInterner {
 
     fn type_param(&self, info: TypeParamInfo) -> TypeId {
         Self::type_param(self, info)
+    }
+
+    fn unresolved_type_name(&self, name: Atom) -> TypeId {
+        Self::unresolved_type_name(self, name)
     }
 
     fn type_query(&self, symbol: SymbolRef) -> TypeId {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -20,6 +20,7 @@ use crate::types::{
     TupleListId, TypeApplication, TypeApplicationId, TypeData, TypeId, TypeListId, TypeParamInfo,
     Variance, Visibility,
 };
+use crate::visitor::is_error_type;
 use dashmap::DashMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
@@ -907,6 +908,10 @@ impl TypeDatabase for QueryCache<'_> {
         self.interner.type_param(info)
     }
 
+    fn unresolved_type_name(&self, name: Atom) -> TypeId {
+        self.interner.unresolved_type_name(name)
+    }
+
     fn type_query(&self, symbol: SymbolRef) -> TypeId {
         self.interner.type_query(symbol)
     }
@@ -1106,6 +1111,7 @@ impl QueryDatabase for QueryCache<'_> {
             | TypeData::Function(_)
             | TypeData::Callable(_)
             | TypeData::TypeParameter(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Infer(_)
             | TypeData::Enum(_, _)
             | TypeData::BoundParameter(_)
@@ -1207,6 +1213,8 @@ impl QueryDatabase for QueryCache<'_> {
             || source == TypeId::NEVER
             || source == TypeId::ERROR
             || target == TypeId::ERROR
+            || is_error_type(self.as_type_database(), source)
+            || is_error_type(self.as_type_database(), target)
         {
             return true;
         }
@@ -1289,6 +1297,8 @@ impl QueryDatabase for QueryCache<'_> {
             || source == TypeId::NEVER
             || source == TypeId::ERROR
             || target == TypeId::ERROR
+            || is_error_type(self.as_type_database(), source)
+            || is_error_type(self.as_type_database(), target)
         {
             return true;
         }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -718,6 +718,7 @@ impl<'a> TypeFormatter<'a> {
                 self.format_callable(shape.as_ref()).into()
             }
             TypeData::TypeParameter(info) => Cow::Owned(self.atom(info.name).to_string()),
+            TypeData::UnresolvedTypeName(name) => Cow::Owned(self.atom(*name).to_string()),
             TypeData::Lazy(def_id) => self.format_def_id_with_type_params(*def_id, "Lazy").into(),
             TypeData::Recursive(idx) => format!("Recursive({idx})").into(),
             TypeData::BoundParameter(idx) => format!("BoundParameter({idx})").into(),

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -210,6 +210,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => false,
         }
     }
@@ -730,6 +731,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => true,
         }
     }

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -700,6 +700,7 @@ impl<'a> InferenceContext<'a> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => {}
             TypeData::NoInfer(inner) => {
                 self.collect_type_params(inner, params, visited);
@@ -900,6 +901,7 @@ impl<'a> InferenceContext<'a> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => false,
             TypeData::NoInfer(inner) => self.type_contains_param(inner, target, visited),
         }

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -571,12 +571,12 @@ impl<'a> TypeInstantiator<'a> {
             }
 
             // Intrinsics don't change
-            TypeData::Intrinsic(_) | TypeData::Literal(_) | TypeData::Error => {
-                self.interner.intern(*key)
-            }
-
+            TypeData::Intrinsic(_)
+            | TypeData::Literal(_)
+            | TypeData::UnresolvedTypeName(_)
+            | TypeData::Error
             // Lazy types might resolve to something that needs substitution
-            TypeData::Lazy(_)
+            | TypeData::Lazy(_)
             | TypeData::Recursive(_)
             | TypeData::BoundParameter(_)
             | TypeData::TypeQuery(_)

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1434,6 +1434,12 @@ impl TypeInterner {
         self.intern(TypeData::TypeParameter(info))
     }
 
+    /// Intern an unresolved type name that should behave like an error type
+    /// while preserving its source spelling for diagnostics.
+    pub fn unresolved_type_name(&self, name: Atom) -> TypeId {
+        self.intern(TypeData::UnresolvedTypeName(name))
+    }
+
     /// Intern a type query (`typeof value`) marker.
     pub fn type_query(&self, symbol: SymbolRef) -> TypeId {
         self.intern(TypeData::TypeQuery(symbol))

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1198,7 +1198,16 @@ impl TypeInterner {
                         crate::type_queries::contains_generic_type_parameters_db(self, arg)
                     })
                 });
-        if application_is_alias && application_has_generic_args && evaluated.0 <= application.0 {
+        let evaluated_precedes_application = match (
+            self.lookup_alloc_order(evaluated),
+            self.lookup_alloc_order(application),
+        ) {
+            (Some(evaluated_order), Some(application_order)) => {
+                evaluated_order <= application_order
+            }
+            _ => evaluated.0 <= application.0,
+        };
+        if application_is_alias && application_has_generic_args && evaluated_precedes_application {
             let existing_is_application =
                 self.display_alias.get(&evaluated).is_some_and(|existing| {
                     matches!(self.lookup(*existing), Some(TypeData::Application(_)))

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -1409,6 +1409,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => false,
         }
     }
@@ -1565,6 +1566,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             | TypeData::UniqueSymbol(_)
             | TypeData::ThisType
             | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_)
             | TypeData::Error => false,
         }
     }

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -5,7 +5,8 @@ use crate::diagnostics::SubtypeFailureReason;
 use crate::relations::subtype::{NoopResolver, SubtypeChecker, TypeResolver};
 use crate::types::{IntrinsicKind, LiteralValue, PropertyInfo, TypeData, TypeId};
 use crate::visitor::{
-    TypeVisitor, intrinsic_kind, is_empty_object_type_through_type_constraints, lazy_def_id,
+    TypeVisitor, intrinsic_kind, is_empty_object_type_through_type_constraints, is_error_type,
+    lazy_def_id,
 };
 use crate::{AnyPropagationRules, AssignabilityChecker, TypeDatabase};
 use rustc_hash::FxHashMap;
@@ -912,7 +913,10 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     /// Check if a type or any of its composite members has a string or numeric index signature.
     /// Returns `(has_string_index, has_number_index)`.
     fn check_index_signatures(&mut self, type_id: TypeId) -> (bool, bool) {
-        if type_id == TypeId::ANY || type_id == TypeId::UNKNOWN || type_id == TypeId::ERROR {
+        if type_id == TypeId::ANY
+            || type_id == TypeId::UNKNOWN
+            || is_error_type(self.interner, type_id)
+        {
             return (true, true);
         }
 
@@ -941,7 +945,10 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             _ => type_id,
         };
 
-        if type_id == TypeId::ANY || type_id == TypeId::UNKNOWN || type_id == TypeId::ERROR {
+        if type_id == TypeId::ANY
+            || type_id == TypeId::UNKNOWN
+            || is_error_type(self.interner, type_id)
+        {
             return (true, true);
         }
 
@@ -1325,7 +1332,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
         // Error types are assignable to/from everything (like `any`).
         // In tsc, errorType silences further errors to prevent cascading diagnostics.
-        if source == TypeId::ERROR || target == TypeId::ERROR {
+        if is_error_type(self.interner, source) || is_error_type(self.interner, target) {
             return Some(true);
         }
 
@@ -1389,7 +1396,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return true;
         }
         // Error types are assignable to/from everything (like `any` in tsc)
-        if source == TypeId::ERROR || target == TypeId::ERROR {
+        if is_error_type(self.interner, source) || is_error_type(self.interner, target) {
             return true;
         }
         if source == TypeId::UNKNOWN {
@@ -1453,7 +1460,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
         // Error types are assignable to/from everything (like `any` in tsc)
         // No failure to explain — suppress cascading diagnostics
-        if source == TypeId::ERROR || target == TypeId::ERROR {
+        if is_error_type(self.interner, source) || is_error_type(self.interner, target) {
             return None;
         }
 
@@ -2089,7 +2096,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return true;
         }
         // Error types are assignable to everything (like `any` in tsc)
-        if source == TypeId::ERROR {
+        if is_error_type(self.interner, source) {
             return true;
         }
         if !self.strict_null_checks && source.is_nullish() {

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -227,7 +227,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Error types are assignable to/from everything (like `any` in tsc).
         // This prevents cascading diagnostics when type resolution fails.
-        if source == TypeId::ERROR || target == TypeId::ERROR {
+        if crate::visitor::is_error_type(self.interner, source)
+            || crate::visitor::is_error_type(self.interner, target)
+        {
             return SubtypeResult::True;
         }
 

--- a/crates/tsz-solver/src/type_queries/classifiers.rs
+++ b/crates/tsz-solver/src/type_queries/classifiers.rs
@@ -320,6 +320,7 @@ pub fn classify_for_interface_merge(db: &dyn TypeDatabase, type_id: TypeId) -> I
         | TypeData::NoInfer(_)
         | TypeData::StringIntrinsic { .. }
         | TypeData::ModuleNamespace(_)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error
         | TypeData::Enum(_, _) => InterfaceMergeKind::Other,
     }

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -622,6 +622,7 @@ pub fn classify_constructor_type(db: &dyn TypeDatabase, type_id: TypeId) -> Cons
         | TypeData::ThisType
         | TypeData::StringIntrinsic { .. }
         | TypeData::ModuleNamespace(_)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => ConstructorTypeKind::NotConstructor,
     }
 }
@@ -804,6 +805,7 @@ pub fn classify_for_signatures(db: &dyn TypeDatabase, type_id: TypeId) -> Signat
         | TypeData::StringIntrinsic { .. }
         | TypeData::ModuleNamespace(_)
         | TypeData::Enum(_, _)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => SignatureTypeKind::NoSignatures,
     }
 }
@@ -896,6 +898,7 @@ pub fn classify_for_evaluation(db: &dyn TypeDatabase, type_id: TypeId) -> Evalua
         | TypeData::StringIntrinsic { .. }
         | TypeData::ModuleNamespace(_)
         | TypeData::Enum(_, _)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => EvaluationNeeded::Resolved(type_id),
     }
 }

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -302,7 +302,9 @@ pub fn contains_error_type_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     ) {
         return false;
     }
-    contains_type_matching(db, type_id, |key| matches!(key, TypeData::Error))
+    contains_type_matching(db, type_id, |key| {
+        matches!(key, TypeData::Error | TypeData::UnresolvedTypeName(_))
+    })
 }
 
 /// Check if a type contains the `never` intrinsic.

--- a/crates/tsz-solver/src/type_queries/iterable.rs
+++ b/crates/tsz-solver/src/type_queries/iterable.rs
@@ -98,6 +98,7 @@ pub fn classify_full_iterable_type(db: &dyn TypeDatabase, type_id: TypeId) -> Fu
         | TypeData::StringIntrinsic { .. }
         | TypeData::ModuleNamespace(_)
         | TypeData::Enum(_, _)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => FullIterableTypeKind::NotIterable,
     }
 }

--- a/crates/tsz-solver/src/type_queries/traversal.rs
+++ b/crates/tsz-solver/src/type_queries/traversal.rs
@@ -140,6 +140,7 @@ pub fn classify_for_traversal(db: &dyn TypeDatabase, type_id: TypeId) -> TypeTra
         | TypeData::UniqueSymbol(_)
         | TypeData::ThisType
         | TypeData::ModuleNamespace(_)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error
         | TypeData::Enum(_, _) => TypeTraversalKind::Terminal,
     }

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -870,6 +870,14 @@ pub enum TypeData {
 
     /// Error type for recovery
     Error,
+
+    /// Error-like unresolved type name with diagnostic display provenance.
+    ///
+    /// TypeScript keeps the source spelling of unresolved annotation types in
+    /// downstream messages (for example `fs.Stats`) even though the semantic
+    /// type is an error. This leaf preserves that display surface without
+    /// collapsing every occurrence into the global `TypeId::ERROR` sentinel.
+    UnresolvedTypeName(Atom),
 }
 
 /// Generic type application (Base<Args>)

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -284,7 +284,7 @@ pub trait TypeVisitor: Sized {
             }
             TypeData::ModuleNamespace(sym_ref) => self.visit_module_namespace(sym_ref.0),
             TypeData::NoInfer(inner) => self.visit_no_infer(*inner),
-            TypeData::Error => self.visit_error(),
+            TypeData::UnresolvedTypeName(_) | TypeData::Error => self.visit_error(),
         }
     }
 }
@@ -537,6 +537,7 @@ where
         | TypeData::UniqueSymbol(_)
         | TypeData::ThisType
         | TypeData::ModuleNamespace(_)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => {}
     }
 }
@@ -754,7 +755,7 @@ impl TypeKindVisitor {
                 TypeKind::Other
             }
             TypeData::ThisType => TypeKind::TypeParameter, // this is type-parameter-like
-            TypeData::Error => TypeKind::Error,
+            TypeData::Error | TypeData::UnresolvedTypeName(_) => TypeKind::Error,
         }
     }
 
@@ -940,7 +941,8 @@ impl<'a> RecursiveTypeCollector<'a> {
             | TypeData::Recursive(_)
             | TypeData::TypeQuery(_)
             | TypeData::UniqueSymbol(_)
-            | TypeData::ModuleNamespace(_) => {
+            | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_) => {
                 // Leaf types - nothing to traverse
             }
             TypeData::NoInfer(inner) => {

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -354,11 +354,12 @@ pub fn is_this_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
 
 /// Check whether this is an explicit error type.
 ///
-/// Returns true for `TypeId::ERROR` (fast-path) or any `TypeData::Error`.
+/// Returns true for `TypeId::ERROR` (fast-path), `TypeData::Error`, or
+/// display-preserving unresolved type names.
 pub fn is_error_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     type_id == TypeId::ERROR
         || extract_type_data(types, type_id, |key| match key {
-            TypeData::Error => Some(true),
+            TypeData::Error | TypeData::UnresolvedTypeName(_) => Some(true),
             _ => None,
         })
         .unwrap_or(false)
@@ -550,6 +551,7 @@ fn collect_infer_bindings_inner(
         | TypeData::UniqueSymbol(_)
         | TypeData::ThisType
         | TypeData::ModuleNamespace(_)
+        | TypeData::UnresolvedTypeName(_)
         | TypeData::Error => {}
     }
 }

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -464,7 +464,7 @@ fn contains_error_type_recursive(
     let Some(key) = types.lookup(type_id) else {
         return false;
     };
-    if matches!(key, TypeData::Error) {
+    if matches!(key, TypeData::Error | TypeData::UnresolvedTypeName(_)) {
         memo.insert(type_id, true);
         return true;
     }
@@ -786,7 +786,8 @@ where
             | TypeData::Recursive(_)
             | TypeData::TypeQuery(_)
             | TypeData::UniqueSymbol(_)
-            | TypeData::ModuleNamespace(_) => false,
+            | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_) => false,
             TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
                 let shape = self.types.object_shape(*shape_id);
                 shape.properties.iter().any(|p| self.check(p.type_id))
@@ -928,7 +929,8 @@ impl<'a> FreeTypeParamChecker<'a> {
             | TypeData::Recursive(_)
             | TypeData::TypeQuery(_)
             | TypeData::UniqueSymbol(_)
-            | TypeData::ModuleNamespace(_) => false,
+            | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_) => false,
             TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
                 let shape = self.types.object_shape(*shape_id);
                 shape.properties.iter().any(|p| self.check(p.type_id))
@@ -1076,7 +1078,8 @@ impl<'a> FreeInferChecker<'a> {
             // definitions like `type Foo = X extends Bar<infer V> ? V : never`)
             // are definitional, not live inference variables.
             | TypeData::TypeParameter(_)
-            | TypeData::Infer(_) => false,
+            | TypeData::Infer(_)
+            | TypeData::UnresolvedTypeName(_) => false,
             TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
                 let shape = self.types.object_shape(*shape_id);
                 shape.properties.iter().any(|p| self.check(p.type_id))
@@ -1213,7 +1216,8 @@ impl<'a> ShallowContainsTypeChecker<'a> {
             // the whole point of the "shallow" variant. We only check if the
             // type parameter itself matches, not what its constraint contains.
             | TypeData::TypeParameter(_)
-            | TypeData::Infer(_) => false,
+            | TypeData::Infer(_)
+            | TypeData::UnresolvedTypeName(_) => false,
             TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
                 let shape = self.types.object_shape(*shape_id);
                 shape.properties.iter().any(|p| self.check(p.type_id))


### PR DESCRIPTION
## Root Cause

Unresolved qualified type annotations were lowered to the canonical error type, so downstream TS2345 messages lost the source spelling (`fs.Stats`) and printed `error`.

## Fixed Conformance Target

- `TypeScript/tests/cases/compiler/undeclaredModuleError.ts`

## Unit Test

- `ts2345_callback_target_display_preserves_unresolved_qualified_type_name`

## Verification

- `./scripts/conformance/conformance.sh run --filter "undeclaredModuleError" --verbose` -> 1/1 passed
- `scripts/session/verify-all.sh` -> ALL SUITES PASSED post-rebase
  - formatting passed
  - clippy passed
  - unit tests passed
  - conformance: 12082 (baseline: 12038), +44
  - emit tests: =12324/1247
  - fourslash/LSP: =50
