### PR TITLE
refactor(checker): reuse tsz_common numeric parser for truthiness zero check

### DIFF
--- a/crates/tsz-checker/src/types/queries/callable_truthiness.rs
+++ b/crates/tsz-checker/src/types/queries/callable_truthiness.rs
@@ -20,30 +20,9 @@ use tsz_solver::TypeId;
 
 /// Check if a numeric literal text represents zero in any notation.
 /// Handles decimal (0.0, .0, 0e0), hex (0x0), binary (0b0), octal (0o0),
-/// and numeric separators (`0_0`).
+/// and numeric separators (`0_0`) via the shared `tsz_common` parser.
 fn is_numeric_literal_zero(text: &str) -> bool {
-    // Strip numeric separators
-    let stripped: String;
-    let s = if text.contains('_') {
-        stripped = text.replace('_', "");
-        &stripped
-    } else {
-        text
-    };
-
-    // Check hex/binary/octal prefixes
-    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-        return !rest.is_empty() && rest.chars().all(|c| c == '0');
-    }
-    if let Some(rest) = s.strip_prefix("0b").or_else(|| s.strip_prefix("0B")) {
-        return !rest.is_empty() && rest.chars().all(|c| c == '0');
-    }
-    if let Some(rest) = s.strip_prefix("0o").or_else(|| s.strip_prefix("0O")) {
-        return !rest.is_empty() && rest.chars().all(|c| c == '0');
-    }
-
-    // Decimal: parse as f64
-    s.parse::<f64>().is_ok_and(|v| v == 0.0)
+    tsz_common::numeric::parse_numeric_literal_value(text).is_some_and(|v| v == 0.0)
 }
 
 /// Result of tsc's `getSyntacticTruthySemantics` — purely syntactic truthiness.


### PR DESCRIPTION
## Summary
- Collapse the local 23-line `is_numeric_literal_zero` helper in `types/queries/callable_truthiness.rs` (the TS2872/TS2873 truthiness path) to a one-liner that delegates to `tsz_common::numeric::parse_numeric_literal_value`.
- The local version re-implemented 0x/0X/0b/0B/0o/0O prefix stripping and numeric-separator handling that already lives in the shared parser. Every input produces the same truthy-zero verdict: the parser returns `Some(0.0)` exactly when the original function returned `true`.
- Matches DRY audit recommendation: 'Replace local numeric parsing in checker/emitter/lowering with the common primitive' (`docs/DRY_AUDIT_2026-04-21.md:321`).
- Net -21 lines.

## Non-goals / preserved behavior
- Other checker sites that already route through `tsz_common::numeric::parse_numeric_literal_value` (narrowing, references) are unchanged.
- The adjacent `CheckerState::is_numeric_literal_zero` method in `types/type_checking/declarations.rs` is a different check (literal `text == \"0\"` only, stricter syntactic form) and is intentionally left alone.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-checker --lib` — 2635 passed, 9 skipped
- [x] Pre-commit full pipeline: 12982 tests passed