### PR TITLE
refactor(solver): extract constrain_object_properties helper

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -10,8 +10,8 @@ use crate::operations::core::MAX_CONSTRAINT_STEPS;
 use crate::operations::{AssignabilityChecker, CallEvaluator, MAX_CONSTRAINT_RECURSION_DEPTH};
 use crate::relations::variance::compute_type_param_variances_with_resolver;
 use crate::types::{
-    FunctionShape, ParamInfo, PropertyInfo, TemplateSpan, TupleElement, TypeData, TypeId,
-    TypeParamInfo, TypePredicate, Variance,
+    FunctionShape, ObjectShape, ParamInfo, PropertyInfo, TemplateSpan, TupleElement, TypeData,
+    TypeId, TypeParamInfo, TypePredicate, Variance,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
@@ -1559,17 +1559,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             (Some(TypeData::Object(s_shape_id)), Some(TypeData::Object(t_shape_id))) => {
                 let s_shape = self.interner.object_shape(s_shape_id);
                 let t_shape = self.interner.object_shape(t_shape_id);
-                let source_is_fresh = s_shape
-                    .flags
-                    .contains(crate::types::ObjectFlags::FRESH_LITERAL);
-                self.constrain_properties(
-                    ctx,
-                    var_map,
-                    &s_shape.properties,
-                    &t_shape.properties,
-                    priority,
-                    source_is_fresh,
-                );
+                self.constrain_object_properties(ctx, var_map, &s_shape, &t_shape, priority);
             }
             (
                 Some(TypeData::ObjectWithIndex(s_shape_id)),
@@ -1577,17 +1567,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             ) => {
                 let s_shape = self.interner.object_shape(s_shape_id);
                 let t_shape = self.interner.object_shape(t_shape_id);
-                let source_is_fresh = s_shape
-                    .flags
-                    .contains(crate::types::ObjectFlags::FRESH_LITERAL);
-                self.constrain_properties(
-                    ctx,
-                    var_map,
-                    &s_shape.properties,
-                    &t_shape.properties,
-                    priority,
-                    source_is_fresh,
-                );
+                self.constrain_object_properties(ctx, var_map, &s_shape, &t_shape, priority);
                 if let (Some(s_idx), Some(t_idx)) = (&s_shape.string_index, &t_shape.string_index) {
                     self.constrain_types(
                         ctx,
@@ -1673,17 +1653,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             (Some(TypeData::Object(s_shape_id)), Some(TypeData::ObjectWithIndex(t_shape_id))) => {
                 let s_shape = self.interner.object_shape(s_shape_id);
                 let t_shape = self.interner.object_shape(t_shape_id);
-                let source_is_fresh = s_shape
-                    .flags
-                    .contains(crate::types::ObjectFlags::FRESH_LITERAL);
-                self.constrain_properties(
-                    ctx,
-                    var_map,
-                    &s_shape.properties,
-                    &t_shape.properties,
-                    priority,
-                    source_is_fresh,
-                );
+                self.constrain_object_properties(ctx, var_map, &s_shape, &t_shape, priority);
                 self.constrain_properties_against_index_signatures(
                     ctx,
                     var_map,
@@ -1695,17 +1665,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             (Some(TypeData::ObjectWithIndex(s_shape_id)), Some(TypeData::Object(t_shape_id))) => {
                 let s_shape = self.interner.object_shape(s_shape_id);
                 let t_shape = self.interner.object_shape(t_shape_id);
-                let source_is_fresh = s_shape
-                    .flags
-                    .contains(crate::types::ObjectFlags::FRESH_LITERAL);
-                self.constrain_properties(
-                    ctx,
-                    var_map,
-                    &s_shape.properties,
-                    &t_shape.properties,
-                    priority,
-                    source_is_fresh,
-                );
+                self.constrain_object_properties(ctx, var_map, &s_shape, &t_shape, priority);
                 self.constrain_index_signatures_to_properties(
                     ctx,
                     var_map,
@@ -2146,5 +2106,33 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             _ => {}
         }
+    }
+
+    /// Constrain source properties against target properties for two object
+    /// shapes, propagating freshness from the source's `FRESH_LITERAL` flag.
+    ///
+    /// All four `Object`/`ObjectWithIndex` arms of the main walker compute
+    /// `source_is_fresh` from the same flag bit and feed it into
+    /// [`Self::constrain_properties`]; this helper keeps that shared preamble
+    /// in one place.
+    fn constrain_object_properties(
+        &mut self,
+        ctx: &mut InferenceContext,
+        var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
+        s_shape: &ObjectShape,
+        t_shape: &ObjectShape,
+        priority: crate::types::InferencePriority,
+    ) {
+        let source_is_fresh = s_shape
+            .flags
+            .contains(crate::types::ObjectFlags::FRESH_LITERAL);
+        self.constrain_properties(
+            ctx,
+            var_map,
+            &s_shape.properties,
+            &t_shape.properties,
+            priority,
+            source_is_fresh,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Collapse the shared 8-line preamble in the four `Object`/`ObjectWithIndex` arms of the main constraint walker at `crates/tsz-solver/src/operations/constraints/walker.rs:1559/1574/1673/1695` into a private helper `constrain_object_properties`.
- Each arm was reading `source_is_fresh` from `ObjectFlags::FRESH_LITERAL` and feeding it into `constrain_properties` with identical argument ordering; the freshness rule now lives in one place instead of four.
- Matches DRY audit target `walker.rs:1559/1574/1673/1695` (`docs/DRY_AUDIT_2026-04-21.md:545`).
- Net -12 lines.

## Non-goals / preserved behavior
- The two arms that need `s_shape` and `t_shape` after the initial constraint (index-signature cross inference, reverse-index inference) retain them — the helper takes `&ObjectShape` and does not consume the `Arc`.

## Test plan
- [x] `cargo clippy -p tsz-solver --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-solver --lib` — 5256 passed, 7 skipped
- [x] Pre-commit full pipeline: 18352 tests passed