### PR TITLE
refactor(solver): route walker type-predicate sites through shared helper

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -302,7 +302,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     /// predicate with a concrete type, infer with `source_is_type_annotation`
     /// set so that literal predicate types (e.g. `x is 'B'`) are not marked
     /// fresh and won't be widened during candidate collection.
-    fn constrain_type_predicates(
+    pub(super) fn constrain_type_predicates(
         &mut self,
         ctx: &mut InferenceContext,
         var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1225,21 +1225,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // Constrain type predicates if both functions have them
                     // Example: source `(x: any) => x is number` vs target `(value: T) => value is S`
                     // Should infer S = number from the predicates
-                    if let (Some(s_pred), Some(t_pred)) =
-                        (&s_fn.type_predicate, &t_fn.type_predicate)
-                    {
-                        // Only constrain if both predicates have type annotations
-                        if let (Some(s_pred_type), Some(t_pred_type)) =
-                            (s_pred.type_id, t_pred.type_id)
-                        {
-                            // Type predicates are covariant: source_pred_type <: target_pred_type
-                            // Mark as type annotation source to prevent literal widening.
-                            let was = ctx.source_is_type_annotation;
-                            ctx.source_is_type_annotation = true;
-                            self.constrain_types(ctx, var_map, s_pred_type, t_pred_type, priority);
-                            ctx.source_is_type_annotation = was;
-                        }
-                    }
+                    self.constrain_type_predicates(
+                        ctx,
+                        var_map,
+                        s_fn.type_predicate.as_ref(),
+                        t_fn.type_predicate.as_ref(),
+                        priority,
+                    );
                 } else {
                     // Generic source function - instantiate with fresh inference variables
                     // This allows inferring the source function's type parameters from the target
@@ -1425,24 +1417,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
 
                     // Constrain type predicates if both functions have them
-                    if let (Some(s_pred), Some(t_pred)) =
-                        (&instantiated_predicate, &t_fn.type_predicate)
-                        && let (Some(s_pred_type), Some(t_pred_type)) =
-                            (s_pred.type_id, t_pred.type_id)
-                    {
-                        // Type predicates are covariant: source_pred_type <: target_pred_type
-                        // Mark as type annotation source to prevent literal widening.
-                        let was = ctx.source_is_type_annotation;
-                        ctx.source_is_type_annotation = true;
-                        self.constrain_types(
-                            ctx,
-                            &combined_var_map,
-                            s_pred_type,
-                            t_pred_type,
-                            priority,
-                        );
-                        ctx.source_is_type_annotation = was;
-                    }
+                    self.constrain_type_predicates(
+                        ctx,
+                        &combined_var_map,
+                        instantiated_predicate.as_ref(),
+                        t_fn.type_predicate.as_ref(),
+                        priority,
+                    );
                 }
             }
             (Some(TypeData::Function(s_fn_id)), Some(TypeData::Callable(t_callable_id))) => {


### PR DESCRIPTION
## Summary
- Follow-up to #784, which introduced `constrain_type_predicates` in `signatures.rs` but kept it file-private. Bump it to `pub(super)` and route the two remaining type-predicate save/restore blocks in `walker.rs` through the shared helper.
- Sites covered: `walker.rs:1228` (monomorphic Function/Function arm) and `walker.rs:1419` (generic-source-instantiated Function/Function arm). Both were open-coding the same `source_is_type_annotation` save/constrain/restore dance.
- Matches DRY audit targets `walker.rs:1237/1435` (`docs/DRY_AUDIT_2026-04-21.md:545`).
- Net -19 lines.

## Non-goals / preserved behavior
- Identical invariant preserved: when both source and target signatures carry a type predicate with a concrete `type_id`, inference runs with `source_is_type_annotation = true` so literal predicate types (`x is 'B'`) are not marked fresh.
- The generic-source arm keeps its own `instantiated_predicate: Option<TypePredicate>` computed from `instantiate_type`; only the post-instantiation constraint call changes.

## Test plan
- [x] `cargo clippy -p tsz-solver --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-solver --lib` — 5256 passed, 7 skipped
- [x] Pre-commit full pipeline: 18353 tests passed