### PR TITLE
perf(checker): share program-wide alias_partners via ProjectEnv

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -240,6 +240,7 @@ impl<'a> CheckerContext<'a> {
             program_wildcard_reexports_type_only: None,
             program_module_exports: None,
             program_cross_file_node_symbols: None,
+            program_alias_partners: None,
             resolved_module_paths: None,
             resolved_module_request_paths: None,
             current_file_idx: 0,

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -417,6 +417,7 @@ impl<'a> CheckerContext<'a> {
             parent.program_wildcard_reexports_type_only.clone();
         self.program_module_exports = parent.program_module_exports.clone();
         self.program_cross_file_node_symbols = parent.program_cross_file_node_symbols.clone();
+        self.program_alias_partners = parent.program_alias_partners.clone();
         self.global_symbol_file_index = parent.global_symbol_file_index.clone();
         self.resolved_module_paths = parent.resolved_module_paths.clone();
         self.resolved_module_errors = parent.resolved_module_errors.clone();
@@ -1022,6 +1023,33 @@ impl<'a> CheckerContext<'a> {
             return dm.exact.contains(module_name);
         }
         binder.declared_modules.contains(module_name)
+    }
+
+    /// Resolve `sym_id` to its alias partner. Prefers the project-wide
+    /// `program_alias_partners` map installed by `ProjectEnv::apply_to`;
+    /// falls back to per-binder `alias_partners` for tests/standalone callers.
+    pub fn alias_partner_for(
+        &self,
+        binder: &tsz_binder::BinderState,
+        sym_id: SymbolId,
+    ) -> Option<SymbolId> {
+        if let Some(ref ap) = self.program_alias_partners {
+            return ap.get(&sym_id).copied();
+        }
+        binder.alias_partners.get(&sym_id).copied()
+    }
+
+    /// Test whether `sym_id` has an alias partner. Prefers the project-wide
+    /// map; falls back to per-binder.
+    pub fn alias_partners_contains(
+        &self,
+        binder: &tsz_binder::BinderState,
+        sym_id: SymbolId,
+    ) -> bool {
+        if let Some(ref ap) = self.program_alias_partners {
+            return ap.contains_key(&sym_id);
+        }
+        binder.alias_partners.contains_key(&sym_id)
     }
 
     /// Resolve an import specifier to its target file index.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1040,6 +1040,10 @@ pub struct CheckerContext<'a> {
     /// `program.cross_file_node_symbols` in a single `Arc` so N per-file
     /// binders don't each deep-clone the outer `FxHashMap<usize, Arc<…>>`.
     pub program_cross_file_node_symbols: Option<Arc<tsz_binder::CrossFileNodeSymbols>>,
+    /// Program-wide alias-partners map; consulted by
+    /// `ctx.alias_partner_for` in preference to per-binder `alias_partners`.
+    /// Driver wraps `program.alias_partners` in a single `Arc`.
+    pub program_alias_partners: Option<Arc<FxHashMap<SymbolId, SymbolId>>>,
 
     /// Resolved module paths map: (`source_file_idx`, specifier) -> `target_file_idx`.
     /// Used by `get_type_of_symbol` to resolve imports to their target file and symbol.
@@ -1310,6 +1314,8 @@ pub struct ProjectEnv {
     /// Program-wide cross-file node-symbol map; see
     /// `CheckerContext::program_cross_file_node_symbols`.
     pub program_cross_file_node_symbols: Option<Arc<tsz_binder::CrossFileNodeSymbols>>,
+    /// see `CheckerContext::program_alias_partners`.
+    pub program_alias_partners: Option<Arc<FxHashMap<SymbolId, SymbolId>>>,
     /// Resolved module paths: (`source_file_idx`, specifier) -> `target_file_idx`.
     pub resolved_module_paths: Arc<ResolvedModulePathMap>,
     /// Resolved module paths keyed by (`source_file_idx`, specifier, resolution-mode override).
@@ -1359,6 +1365,7 @@ impl Default for ProjectEnv {
             program_wildcard_reexports_type_only: None,
             program_module_exports: None,
             program_cross_file_node_symbols: None,
+            program_alias_partners: None,
             resolved_module_paths: Arc::new(FxHashMap::default()),
             resolved_module_request_paths: Arc::new(FxHashMap::default()),
             resolved_module_errors: Arc::new(FxHashMap::default()),
@@ -1435,6 +1442,9 @@ impl ProjectEnv {
         }
         if let Some(ref m) = self.program_cross_file_node_symbols {
             ctx.program_cross_file_node_symbols = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = self.program_alias_partners {
+            ctx.program_alias_partners = Some(Arc::clone(m));
         }
         // Install the shared DefinitionStore before gating expensive semantic-def
         // prepopulation so `is_fully_populated()` reflects project-wide state.

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1601,7 +1601,9 @@ impl<'a> CheckerState<'a> {
 
                     // TYPE_ALIAS + ALIAS merge: cache type alias body for type contexts,
                     // return namespace type for value contexts.
-                    if let Some(&alias_id) = self.ctx.binder.alias_partners.get(&export_sym_id) {
+                    if let Some(alias_id) =
+                        self.ctx.alias_partner_for(self.ctx.binder, export_sym_id)
+                    {
                         let ta_type = self.get_type_of_symbol(export_sym_id);
                         self.ctx.import_type_alias_types.insert(sym_id, ta_type);
                         self.record_cross_file_symbol_if_needed(alias_id, export_name, module_name);

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -410,10 +410,10 @@ impl<'a> CheckerState<'a> {
                         // errors exist, as the qualified name may be malformed.
                         let is_alias = (symbol.flags & symbol_flags::ALIAS) != 0;
                         let has_alias_partner =
-                            self.ctx.binder.alias_partners.contains_key(&sym_id)
+                            self.ctx.alias_partners_contains(self.ctx.binder, sym_id)
                                 || self.ctx.binder.resolve_import_symbol(sym_id).is_some_and(
                                     |resolved| {
-                                        self.ctx.binder.alias_partners.contains_key(&resolved)
+                                        self.ctx.alias_partners_contains(self.ctx.binder, resolved)
                                     },
                                 );
                         if (symbol.flags & valid_namespace_flags) == 0
@@ -549,16 +549,13 @@ impl<'a> CheckerState<'a> {
                     // TYPE_ALIAS+ALIAS merge: look up alias_partner and
                     // resolve the member through the ALIAS symbol's namespace
                     if result.is_none() {
-                        let alias_id = self
-                            .ctx
-                            .binder
-                            .alias_partners
-                            .get(&sym_id)
-                            .copied()
-                            .or_else(|| {
-                                let resolved = self.ctx.binder.resolve_import_symbol(sym_id)?;
-                                self.ctx.binder.alias_partners.get(&resolved).copied()
-                            });
+                        let alias_id =
+                            self.ctx
+                                .alias_partner_for(self.ctx.binder, sym_id)
+                                .or_else(|| {
+                                    let resolved = self.ctx.binder.resolve_import_symbol(sym_id)?;
+                                    self.ctx.alias_partner_for(self.ctx.binder, resolved)
+                                });
                         if let Some(alias_id) = alias_id
                             && let Some(alias_sym) =
                                 self.ctx.binder.get_symbol_with_libs(alias_id, &lib_binders)

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -1454,7 +1454,7 @@ impl<'a> CheckerState<'a> {
                     // ALIAS, so we only skip when ALIAS+VALUE are both present.
                     let has_value_flags = sym.flags & symbol_flags::ALIAS != 0
                         && sym.flags & symbol_flags::VALUE != 0;
-                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                    let has_value_partner = target_binder.alias_partners.contains_key(&sym_id)
                         || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     if !has_value_flags && !has_value_partner {
                         return true;
@@ -1488,7 +1488,7 @@ impl<'a> CheckerState<'a> {
                     // the module_exports entry holds the TYPE_ALIAS but the binder records
                     // the value-providing ALIAS as an alias_partner. If such a partner
                     // exists, the merged name provides runtime value and is NOT type-only.
-                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                    let has_value_partner = target_binder.alias_partners.contains_key(&sym_id)
                         || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     // When the symbol also has ALIAS flag (e.g., `import * as B` merged
                     // with `interface B`), the alias part may provide runtime value. Don't
@@ -1791,7 +1791,7 @@ impl<'a> CheckerState<'a> {
                 if sym.is_type_only {
                     let has_value_flags = sym.flags & symbol_flags::ALIAS != 0
                         && sym.flags & symbol_flags::VALUE != 0;
-                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                    let has_value_partner = target_binder.alias_partners.contains_key(&sym_id)
                         || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     if !has_value_flags && !has_value_partner {
                         return true;

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -1454,11 +1454,8 @@ impl<'a> CheckerState<'a> {
                     // ALIAS, so we only skip when ALIAS+VALUE are both present.
                     let has_value_flags = sym.flags & symbol_flags::ALIAS != 0
                         && sym.flags & symbol_flags::VALUE != 0;
-                    let has_value_partner = target_binder
-                        .alias_partners
-                        .get(&sym_id)
-                        .or_else(|| self.ctx.binder.alias_partners.get(&sym_id))
-                        .is_some();
+                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                        || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     if !has_value_flags && !has_value_partner {
                         return true;
                     }
@@ -1491,11 +1488,8 @@ impl<'a> CheckerState<'a> {
                     // the module_exports entry holds the TYPE_ALIAS but the binder records
                     // the value-providing ALIAS as an alias_partner. If such a partner
                     // exists, the merged name provides runtime value and is NOT type-only.
-                    let has_value_partner = target_binder
-                        .alias_partners
-                        .get(&sym_id)
-                        .or_else(|| self.ctx.binder.alias_partners.get(&sym_id))
-                        .is_some();
+                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                        || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     // When the symbol also has ALIAS flag (e.g., `import * as B` merged
                     // with `interface B`), the alias part may provide runtime value. Don't
                     // declare type-only here — let the alias-chain-following logic below
@@ -1797,11 +1791,8 @@ impl<'a> CheckerState<'a> {
                 if sym.is_type_only {
                     let has_value_flags = sym.flags & symbol_flags::ALIAS != 0
                         && sym.flags & symbol_flags::VALUE != 0;
-                    let has_value_partner = target_binder
-                        .alias_partners
-                        .get(&sym_id)
-                        .or_else(|| self.ctx.binder.alias_partners.get(&sym_id))
-                        .is_some();
+                    let has_value_partner = target_binder.alias_partners.get(&sym_id).is_some()
+                        || self.ctx.alias_partners_contains(self.ctx.binder, sym_id);
                     if !has_value_flags && !has_value_partner {
                         return true;
                     }

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -62,7 +62,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         .copied()
                         .or_else(|| {
                             let resolved = self.ctx.binder.resolve_import_symbol(current_sym)?;
-                            self.ctx.binder.alias_partners.get(&resolved).copied()
+                            self.ctx.alias_partner_for(self.ctx.binder, resolved)
                         })?;
                     let alias_sym = self
                         .ctx
@@ -940,7 +940,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             }
 
             // TYPE_ALIAS+ALIAS merge: resolve member through ALIAS partner
-            if let Some(&alias_id) = self.ctx.binder.alias_partners.get(&resolved_sym_id)
+            if let Some(alias_id) = self.ctx.alias_partner_for(self.ctx.binder, resolved_sym_id)
                 && let Some(alias_sym) =
                     self.ctx.binder.get_symbol_with_libs(alias_id, &lib_binders)
             {

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -34,6 +34,7 @@ fn empty_project_env() -> ProjectEnv {
         program_wildcard_reexports_type_only: None,
         program_module_exports: None,
         program_cross_file_node_symbols: None,
+        program_alias_partners: None,
         resolved_module_paths: Arc::new(FxHashMap::default()),
         resolved_module_request_paths: Arc::new(FxHashMap::default()),
         resolved_module_errors: Arc::new(FxHashMap::default()),

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -922,6 +922,9 @@ pub(super) fn collect_diagnostics(
     // binders scales outer-map allocation with N². Wrap once here and
     // route consumers through `ctx.cross_file_node_symbols_for_arena`.
     let program_cross_file_node_symbols = Arc::new(program.cross_file_node_symbols.clone());
+    // Same rationale for `program.alias_partners`: a single shared
+    // FxHashMap<SymbolId, SymbolId> beats N per-binder deep-clones.
+    let program_alias_partners = Arc::new(program.alias_partners.clone());
 
     let mut project_env = tsz::checker::context::ProjectEnv {
         lib_contexts: std::sync::Arc::new(checker_libs.contexts.clone()),
@@ -943,6 +946,7 @@ pub(super) fn collect_diagnostics(
         program_wildcard_reexports_type_only: Some(program_wildcard_reexports_type_only),
         program_module_exports: Some(program_module_exports),
         program_cross_file_node_symbols: Some(program_cross_file_node_symbols),
+        program_alias_partners: Some(program_alias_partners),
         ..Default::default()
     };
     // Use fingerprint-aware rebuild when a skeleton index is available.


### PR DESCRIPTION
## Summary

Adds \`program_alias_partners: Option<Arc<FxHashMap<SymbolId, SymbolId>>>\` to \`CheckerContext\` and \`ProjectEnv\`. The driver wraps \`program.alias_partners\` once and \`apply_to\` shares it via \`Arc\` to every per-file checker context.

New accessors \`CheckerContext::alias_partner_for\` and \`alias_partners_contains\` prefer the project-wide map and fall back to per-binder for tests / standalone callers. Migrates 6 call sites in \`types/type_node_resolution.rs\`, \`state/type_analysis/core.rs\`, \`state/type_analysis/computed/type_alias_variable_alias.rs\`, and \`types/queries/type_only.rs\` (×3) that did \`self.ctx.binder.alias_partners.get/contains_key\` on the per-file binder.

\`copy_cross_file_state_from\` propagates the new field to nested child checkers, mirroring the fix landed in #766 to avoid the JSDoc-resolution-path crash regression.

Three remaining call sites (\`target_binder.alias_partners.get\`, \`resolved_binder.alias_partners.get\`) are intentionally untouched — they query a specific non-\`self.ctx.binder\` binder for cross-file lookups.

This is a **no-op behavior change today**. Once consumers all route through the accessor (as they do here), a follow-up PR can empty the per-binder \`alias_partners\` in the CLI driver factories, mirroring the pattern in #758/#762/#766.

## Test plan

- [x] \`cargo nextest run -p tsz-checker\` — 4923 passed (no regressions)
- [x] \`cargo fmt --all --check\` clean
- [x] \`python3 scripts/arch/arch_guard.py\` clean