### PR TITLE
[codex] fix parser recovery for Flow-style type parameter bounds

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1047,6 +1047,9 @@ impl ParserState {
             params.push(param);
 
             if !self.parse_optional(SyntaxKind::CommaToken) {
+                if self.is_js_file() && self.is_token(SyntaxKind::ColonToken) {
+                    self.error_comma_expected();
+                }
                 break;
             }
             // If the next token is `>`, the comma we just consumed was trailing.

--- a/crates/tsz-parser/tests/state_type_tests.rs
+++ b/crates/tsz-parser/tests/state_type_tests.rs
@@ -7,6 +7,12 @@ fn parse_source(source: &str) -> (ParserState, NodeIndex) {
     (parser, root)
 }
 
+fn parse_source_named(file_name: &str, source: &str) -> (ParserState, NodeIndex) {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    (parser, root)
+}
+
 #[test]
 fn parse_complex_type_expressions_have_no_errors() {
     let (parser, _root) = parse_source(
@@ -26,6 +32,27 @@ fn parse_conditional_and_infer_types_emit_expected_members() {
 fn parse_invalid_type_member_reports_diagnostics() {
     let (parser, _root) = parse_source("type T = <; ");
     assert!(!parser.get_diagnostics().is_empty());
+}
+
+#[test]
+fn parse_flow_style_type_parameter_bound_reports_comma_expected() {
+    let source = "export default class B<T: BaseA> {}";
+    let (parser, _root) = parse_source_named("test.js", source);
+    let diagnostics = parser.get_diagnostics();
+    let colon_pos = source.find(':').expect("expected colon") as u32;
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| { d.code == 1005 && d.start == colon_pos && d.message == "',' expected." }),
+        "Expected TS1005 comma diagnostic at Flow-style type parameter bound, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !(d.code == 1005 && d.start == colon_pos && d.message == "'>' expected.")),
+        "Type parameter list recovery should not report a closing `>` at the same colon, got {diagnostics:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix parser recovery for Flow-style type parameter bounds in JavaScript files. When a JS type parameter list sees `T: Base`, tsz now reports TypeScript's comma-expected recovery diagnostic instead of treating the colon as a missing closing `>`.

## Root Cause

In a malformed type-parameter list using Flow-style `T: BaseA`, tsc reports the missing list separator `',' expected` at the colon, while tsz parsed `T` then immediately asked for the closing `>`, producing `'> expected` at the same colon.

## Conformance Target

`TypeScript/tests/cases/compiler/fillInMissingTypeArgsOnJSConstructCalls.ts`

## Unit Test

`crates/tsz-parser/tests/state_type_tests.rs::parse_flow_style_type_parameter_bound_reports_comma_expected`

## Verification

- `cargo nextest run --package tsz-parser parse_flow_style_type_parameter_bound_reports_comma_expected`
- `./scripts/conformance/conformance.sh run --filter "fillInMissingTypeArgsOnJSConstructCalls" --verbose`
- `./scripts/emit/run.sh --filter=isolatedDeclarationErrorsDefault --dts-only --verbose --json-out=/tmp/isolatedDeclarationErrorsDefault-branch-after.json`
- `scripts/session/verify-all.sh` after final rebase onto `origin/main`: all suites passed; conformance 12083 vs baseline 12038 (+45); emit unchanged JS=12324 DTS=1247; fourslash unchanged 50.