### PR TITLE
[codex] fix constrained generic call null diagnostics

### DIFF
--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -452,6 +452,22 @@ id<number>("hello");
     );
 }
 
+#[test]
+fn generic_call_rechecks_null_arg_against_constrained_inference() {
+    let source = r#"
+class Base { x!: string; }
+function f3<T extends Base>(y: (a: T) => T, x: T) { return y(null); }
+let r = f3(x => x, null);
+"#;
+    let diagnostics = get_diagnostics(source);
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2345 && message.contains("parameter of type 'Base'")
+        }),
+        "Generic call should reject null against the inferred constrained argument type. Diagnostics: {diagnostics:?}"
+    );
+}
+
 // ============================================================================
 // Contextual callback typing through calls
 // ============================================================================

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -793,6 +793,39 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         &mut placeholder_visited,
                     ));
                 }
+
+                // A naked inference placeholder still carries its declared
+                // constraint. Validate nullish arguments against that
+                // constraint before inference fallback can turn an invalid
+                // `null`/`undefined` candidate into the constraint type itself.
+                if contextual_arg_type.is_nullish()
+                    && let Some(TypeData::TypeParameter(tp)) = self.interner.lookup(target_type)
+                    && let Some(check_type_id) = tp.constraint
+                {
+                    let inst_check_type = instantiate_call_type(
+                        self.interner,
+                        check_type_id,
+                        &substitution,
+                        actual_this_type,
+                    );
+                    placeholder_visited.clear();
+                    if !self.type_contains_placeholder(
+                        inst_check_type,
+                        &var_map,
+                        &mut placeholder_visited,
+                    ) && !self
+                        .checker
+                        .is_assignable_to(contextual_arg_type, inst_check_type)
+                        && !self.is_function_union_compat(contextual_arg_type, inst_check_type)
+                    {
+                        return CallResult::ArgumentTypeMismatch {
+                            index: i,
+                            expected: inst_check_type,
+                            actual: contextual_arg_type,
+                            fallback_return: TypeId::ERROR,
+                        };
+                    }
+                }
             }
 
             // When the target is a bare type parameter placeholder whose constraint


### PR DESCRIPTION
## Summary

Reject nullish arguments passed to a naked generic type parameter when that type parameter has a non-null constraint. This preserves the expected TS2345 diagnostic for calls like `f3<T extends Base>(..., x: T)` with `null` arguments.

## Root Cause

Generic call inference could let an invalid `null` candidate fall back to the declared constraint type, which hid the argument mismatch instead of reporting it against the constraint.

## Validation

- `cargo test -p tsz-checker generic_call_rechecks_null_arg_against_constrained_inference`