### PR TITLE
[codex] fix parser diagnostics for empty template spans at EOF

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -74,6 +74,10 @@ pub const CONTEXT_FLAG_IN_TUPLE_ELEMENT: u32 = 65536;
 /// Suppresses TS1213 for `yield` in computed property names of generator methods
 /// (tsc does not emit TS1213 in this position).
 pub const CONTEXT_FLAG_GENERATOR_MEMBER_NAME: u32 = 131072;
+/// Context flag: parsing a `${...}` template span expression.
+/// Empty spans at EOF report TS1109 from template-span recovery so the
+/// expression error can anchor before trailing trivia while TS1005 anchors at EOF.
+pub const CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION: u32 = 262144;
 
 // =============================================================================
 // Parse Diagnostic

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -2808,7 +2808,12 @@ impl ParserState {
                 if self.is_token(SyntaxKind::EndOfFileToken) {
                     // At EOF while expecting an expression: emit TS1109 to match tsc.
                     // Examples: `[#abc]=` or `var x =` at end of file.
-                    self.error_expression_expected();
+                    if (self.context_flags
+                        & crate::parser::state::CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION)
+                        == 0
+                    {
+                        self.error_expression_expected();
+                    }
                     return NodeIndex::NONE;
                 }
                 if self.is_at_expression_end()

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2511,7 +2511,10 @@ impl ParserState {
     }
 
     fn parse_template_expression_span(&mut self) -> (u32, NodeIndex, bool) {
+        let saved_flags = self.context_flags;
+        self.context_flags |= crate::parser::state::CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION;
         let expression = self.parse_expression();
+        self.context_flags = saved_flags;
         if expression.is_none() {
             // Emit TS1109 "Expression expected." for empty template expressions.
             // Position depends on the current token:

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -2821,6 +2821,33 @@ fn template_with_substitution() {
     );
 }
 
+#[test]
+fn template_empty_span_at_eof_anchors_expression_before_missing_brace() {
+    let source = "f `123qdawdrqw${ 1 }${ 2 }${ ";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    let ts1109 = diagnostics
+        .iter()
+        .find(|diag| diag.code == diagnostic_codes::EXPRESSION_EXPECTED)
+        .expect("expected TS1109 for empty template span expression");
+    assert_eq!(
+        ts1109.start,
+        source.len() as u32 - 1,
+        "TS1109 should anchor at trailing trivia before EOF: {diagnostics:?}"
+    );
+
+    let missing_brace = diagnostics
+        .iter()
+        .find(|diag| diag.code == diagnostic_codes::EXPECTED && diag.message == "'}' expected.")
+        .expect("expected TS1005 for the missing template span close brace");
+    assert_eq!(
+        missing_brace.start,
+        source.len() as u32,
+        "TS1005 should anchor at EOF: {diagnostics:?}"
+    );
+}
+
 // =============================================================================
 // 12. Using / Await Using Declarations
 // =============================================================================


### PR DESCRIPTION
## Summary

Fix parser recovery for an empty template substitution at EOF so TS1109 anchors on the empty expression before the missing-brace TS1005 diagnostic at EOF.

## Root Cause

`parse_primary_expression` emitted its own EOF expression-expected diagnostic while template-span recovery also emitted one, causing the expression diagnostic to anchor incorrectly relative to the missing `}` recovery.

## Validation

- Full pre-commit hook passed while creating the salvage commit: formatting, clippy, wasm rustc warnings gate, architecture guardrails, and 19,218 nextest tests.
- `cargo test -p tsz-parser template_empty_span_at_eof_anchors_expression_before_missing_brace` in the rebased branch.