### PR TITLE
refactor(checker): route enum numeric fallback through tsz_common parser

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -97,7 +97,11 @@ impl<'a> CheckerState<'a> {
                                 .unwrap_or(TypeId::STRING),
                             k if k == SyntaxKind::NumericLiteral as u16 => enum_arena
                                 .get_literal(init_node)
-                                .and_then(|lit| lit.value.or_else(|| lit.text.parse::<f64>().ok()))
+                                .and_then(|lit| {
+                                    lit.value.or_else(|| {
+                                        tsz_common::numeric::parse_numeric_literal_value(&lit.text)
+                                    })
+                                })
                                 .map(|value| factory.literal_number(value))
                                 .unwrap_or(TypeId::NUMBER),
                             _ => TypeId::NUMBER,

--- a/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
+++ b/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
@@ -55,7 +55,8 @@ pub(crate) fn evaluate_const_enum_initializer(
     match node.kind {
         k if k == SyntaxKind::NumericLiteral as u16 => {
             let lit = arena.get_literal(node)?;
-            lit.value.or_else(|| lit.text.parse::<f64>().ok())
+            lit.value
+                .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
         }
         k if k == SyntaxKind::Identifier as u16 => {
             let name = arena.get_identifier_text(expr_idx)?;

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -307,16 +307,12 @@ impl<'a> CheckerState<'a> {
                     }
                 }
                 k if k == SyntaxKind::NumericLiteral as u16 => {
-                    // Get the numeric literal value
-                    if let Some(lit) = self.ctx.arena.get_literal(init_node) {
-                        // lit.value is Option<f64>, use it if available
-                        if let Some(value) = lit.value {
-                            return factory.literal_number(value);
-                        }
-                        // Fallback: parse from text
-                        if let Ok(value) = lit.text.parse::<f64>() {
-                            return factory.literal_number(value);
-                        }
+                    if let Some(lit) = self.ctx.arena.get_literal(init_node)
+                        && let Some(value) = lit
+                            .value
+                            .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
+                    {
+                        return factory.literal_number(value);
                     }
                 }
                 _ => {
@@ -371,7 +367,8 @@ impl<'a> CheckerState<'a> {
         match node.kind {
             k if k == SyntaxKind::NumericLiteral as u16 => {
                 let lit = self.ctx.arena.get_literal(node)?;
-                lit.value.or_else(|| lit.text.parse::<f64>().ok())
+                lit.value
+                    .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
             }
             k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
                 let unary = self.ctx.arena.get_unary_expr(node)?;


### PR DESCRIPTION
## Summary
Four enum-evaluation sites used `lit.text.parse::<f64>().ok()` as a fallback when `lit.value` is `None`. The parser already populates `lit.value` by calling `tsz_common::numeric::parse_numeric_literal_value` on every numeric literal (see `tsz-parser/src/parser/state_expressions_literals.rs:569`), so these fallbacks are by construction dead for well-formed nodes.

Route the fallbacks through the same common primitive so behavior stays identical if the fallback ever fires — rather than silently downgrading hex/bin/oct/underscore literals to base `number`. Addresses DRY audit recommendation in `tsz-common` (docs/DRY_AUDIT_2026-04-21.md:321: "Replace local numeric parsing in checker/emitter/lowering with the common primitive").

Sites updated:
- `types/utilities/const_enum_eval.rs:58` — `evaluate_const_enum_initializer` NumericLiteral arm
- `types/utilities/enum_utils.rs:317` — enum member type resolution NumericLiteral arm
- `types/utilities/enum_utils.rs:374` — `evaluate_constant_expression` NumericLiteral arm
- `state/type_environment/core.rs:100` — cross-arena enum member literal type

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p tsz-checker --lib` → 2637 passed
- [x] Full pre-commit pipeline (fmt, arch-guard, nextest precommit profile 12984 tests) passed