### PR TITLE
[codex] fix export type star collisions with value star reexports

### DIFF
--- a/crates/tsz-checker/src/declarations/import/exports.rs
+++ b/crates/tsz-checker/src/declarations/import/exports.rs
@@ -184,8 +184,15 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Check file_locals
-        if target_binder.file_locals.get(export_name).is_some() {
+        // Check direct exported file locals. In merged binders, `file_locals`
+        // can contain symbols declared by other files, so keep only locals that
+        // originate in the file being traced.
+        if let Some(sym_id) = target_binder.file_locals.get(export_name)
+            && let Some(symbol) = target_binder.symbols.get(sym_id)
+            && symbol.is_exported
+            && symbol.import_module.is_none()
+            && (symbol.decl_file_idx == file_idx as u32 || symbol.decl_file_idx == u32::MAX)
+        {
             return Some(file_idx);
         }
 
@@ -232,6 +239,26 @@ impl<'a> CheckerState<'a> {
                 }
                 names.insert(name.to_string());
             }
+        }
+
+        // Direct `export const` / `export type` declarations can be represented
+        // as exported file locals even when the module_exports table has no
+        // direct entry in lightweight checker contexts. They still participate
+        // in `export *` ambiguity checks, including type-only star exports.
+        for (name, &sym_id) in binder.file_locals.iter() {
+            if binder.lib_symbol_ids.contains(&sym_id) {
+                continue;
+            }
+            let Some(symbol) = binder.symbols.get(sym_id) else {
+                continue;
+            };
+            if !symbol.is_exported
+                || symbol.import_module.is_some()
+                || (symbol.decl_file_idx != file_idx as u32 && symbol.decl_file_idx != u32::MAX)
+            {
+                continue;
+            }
+            names.insert(name.to_string());
         }
 
         // Named re-exports (export { X } from './module')

--- a/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
@@ -860,6 +860,31 @@ fn test_export_type_star_as_namespace_emits_ts1362_in_value_context() {
 }
 
 #[test]
+fn test_export_type_star_collides_with_value_star_reexport() {
+    let files = [
+        ("a.ts", "export type A = number;\n"),
+        ("b.ts", "export type * from './a';\n"),
+        ("e.ts", "export const A = 1;\n"),
+        ("f.ts", "export * from './e';\nexport type * from './a';\n"),
+    ];
+    let options = CheckerOptions {
+        module: tsz_common::common::ModuleKind::CommonJS,
+        target: ScriptTarget::ES2015,
+        no_lib: true,
+        ..CheckerOptions::default()
+    };
+
+    let diagnostics = compile_named_files_get_diagnostics_with_options(&files, "f.ts", options);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, msg)| { *code == 2308 && msg.contains("\"./e\"") && msg.contains("'A'") }),
+        "Expected TS2308 for type-only star export colliding with value star export. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_export_equals_typeof_import_namespace_import_exposes_referenced_named_exports() {
     let diagnostics = compile_named_files_get_diagnostics_with_options(
         &[


### PR DESCRIPTION
## Summary

Detect TS2308 collisions when a module combines a value `export *` with an `export type *` that contributes the same exported name.

## Root Cause

The wildcard export collision collector missed direct exported file-local declarations in lightweight checker contexts where `module_exports` had no direct entry, so type-only star exports could avoid colliding with value star reexports.

## Validation

- `cargo test -p tsz-checker test_export_type_star_collides_with_value_star_reexport`