### PR TITLE
chore(website): run full benchmark suite (drop --quick)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,8 +25,11 @@ permissions:
   id-token: write
 
 concurrency:
+  # Full benchmark suite is ~75 minutes — never cancel one in flight.
+  # Newer triggers wait for the running deploy to finish (GitHub auto-
+  # coalesces queued pending runs so we don't pile up duplicates).
   group: pages-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,8 +26,8 @@ permissions:
 
 concurrency:
   # Full benchmark suite is ~75 minutes — never cancel one in flight.
-  # Newer triggers wait for the running deploy to finish (GitHub auto-
-  # coalesces queued pending runs so we don't pile up duplicates).
+  # The `check` job below also early-exits if another deploy is already
+  # running, so in-between commits during a run are dropped (not queued).
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
@@ -41,9 +41,38 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Skip if another deploy is already running
+        id: in_flight
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Bench is ~75 min. If another run is already in_progress we
+          # ignore this trigger entirely — when the running one finishes,
+          # the next *new* trigger gets to start fresh.
+          IN_FLIGHT=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/gh-pages.yml/runs?status=in_progress&per_page=20" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
+          QUEUED=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/gh-pages.yml/runs?status=queued&per_page=20" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .id < ${{ github.run_id }})] | length")
+          BUSY=$((IN_FLIGHT + QUEUED))
+          echo "Other deploy runs in_progress=${IN_FLIGHT} queued_before_us=${QUEUED}"
+          if [ "$BUSY" -gt 0 ]; then
+            echo "another deploy is busy — skipping this trigger"
+            echo "in_flight=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "in_flight=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for changes since last deploy
         id: diff
         run: |
+          # If another run is already busy, drop this trigger entirely.
+          if [ "${{ steps.in_flight.outputs.in_flight }}" = "true" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Always deploy for non-schedule triggers
           if [ "${{ github.event_name }}" != "schedule" ]; then
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -84,8 +84,10 @@ jobs:
           sudo dpkg -i hyperfine_1.18.0_amd64.deb
 
       - name: Run benchmarks
-        run: ./scripts/bench/bench-vs-tsgo.sh --quick --json
-        timeout-minutes: 15
+        # Run the full benchmark suite (no --quick) so the website renders
+        # all categories instead of the ~16-entry quick subset.
+        run: ./scripts/bench/bench-vs-tsgo.sh --json
+        timeout-minutes: 75
 
       - name: Upload benchmark data
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The website's benchmarks page only shows ~16 results because the deploy workflow was running \`bench-vs-tsgo.sh --quick --json\`. Quick mode trims:

- utility-types: 4 → 1 file
- ts-toolbelt: 4 → 1 file
- ts-essentials: 4 → 1 file
- XL stress tests: 4 → 1 file
- Medium files (3) and small files: skipped entirely

This PR drops \`--quick\` so the published site renders the canonical full suite. Bumps \`timeout-minutes\` from 15 → 75 to fit the longer run; the daily Benchmark workflow already runs the full suite without \`--quick\` and completes well within that window.

## Why not pull from the daily Benchmark workflow's artifact

That artifact lives in a separate workflow run with no cross-workflow handoff. Running the bench inline keeps the deploy self-contained.

## Test plan

- [x] Diff is one-line + comment.
- [ ] Next gh-pages deploy renders all categories. Will verify after merge.