### PR TITLE
fix(checker): finish per-binder alias_partners + declared_modules migration

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1052,6 +1052,29 @@ impl<'a> CheckerContext<'a> {
         binder.alias_partners.contains_key(&sym_id)
     }
 
+    /// Reverse lookup: find the TYPE_ALIAS partner that points at
+    /// `alias_sym_id`. Used by the type-position symbol resolver to redirect
+    /// an ALIAS symbol back to its merged TYPE_ALIAS counterpart. Prefers
+    /// the project-wide map; falls back to the per-binder map for
+    /// standalone callers.
+    pub fn alias_partner_reverse(
+        &self,
+        binder: &tsz_binder::BinderState,
+        alias_sym_id: SymbolId,
+    ) -> Option<SymbolId> {
+        if let Some(ref ap) = self.program_alias_partners {
+            return ap.iter().find_map(|(&type_alias_id, &alias_id)| {
+                (alias_id == alias_sym_id).then_some(type_alias_id)
+            });
+        }
+        binder
+            .alias_partners
+            .iter()
+            .find_map(|(&type_alias_id, &alias_id)| {
+                (alias_id == alias_sym_id).then_some(type_alias_id)
+            })
+    }
+
     /// Resolve an import specifier to its target file index.
     /// Uses the `resolved_module_paths` map populated by the driver.
     /// Returns None if the import cannot be resolved (e.g., external module).

--- a/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module_helpers.rs
@@ -102,19 +102,38 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
     pub(crate) fn matches_ambient_module_pattern(&self, module_name: &str) -> bool {
         let module_name = module_name.trim().trim_matches('"').trim_matches('\'');
 
-        for patterns in [
-            &self.ctx.binder.declared_modules,
-            &self.ctx.binder.shorthand_ambient_modules,
-        ] {
-            for pattern in patterns {
+        // Prefer the project-wide pattern list built once on `ProjectEnv`. The
+        // per-binder `declared_modules` / `shorthand_ambient_modules` sets are
+        // intentionally empty after the per-binder map empty-out; their
+        // contents now live in `global_declared_modules.patterns`. The local
+        // sets are still scanned as a fallback for tests/standalone callers
+        // without a `ProjectEnv`.
+        if let Some(ref dm) = self.ctx.global_declared_modules {
+            for pattern in &dm.patterns {
                 let pattern = pattern.trim().trim_matches('"').trim_matches('\'');
-                if pattern.contains('*')
-                    && let Ok(glob) = globset::GlobBuilder::new(pattern)
-                        .literal_separator(false)
-                        .build()
+                if let Ok(glob) = globset::GlobBuilder::new(pattern)
+                    .literal_separator(false)
+                    .build()
                     && glob.compile_matcher().is_match(module_name)
                 {
                     return true;
+                }
+            }
+        } else {
+            for patterns in [
+                &self.ctx.binder.declared_modules,
+                &self.ctx.binder.shorthand_ambient_modules,
+            ] {
+                for pattern in patterns {
+                    let pattern = pattern.trim().trim_matches('"').trim_matches('\'');
+                    if pattern.contains('*')
+                        && let Ok(glob) = globset::GlobBuilder::new(pattern)
+                            .literal_separator(false)
+                            .build()
+                        && glob.compile_matcher().is_match(module_name)
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -1373,7 +1373,9 @@ impl<'a> CheckerState<'a> {
                     if !is_side_effect_import
                         && (!binder.is_external_module || target_is_global_augmentation_dts)
                         && !self.is_ambient_module_match(module_name)
-                        && !binder.declared_modules.contains(normalized_module_name)
+                        && !self
+                            .ctx
+                            .declared_modules_contains(binder, normalized_module_name)
                         && let Some(source_file) = source_file
                     {
                         let file_name = source_file.file_name.as_str();

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -292,10 +292,8 @@ impl<'a> CheckerState<'a> {
                     //    be emitted instead during statement checking).
                     let has_import_partner = self
                         .ctx
-                        .binder
-                        .alias_partners
-                        .get(&sym_id)
-                        .and_then(|&partner_id| self.ctx.binder.get_symbol(partner_id))
+                        .alias_partner_for(self.ctx.binder, sym_id)
+                        .and_then(|partner_id| self.ctx.binder.get_symbol(partner_id))
                         .is_some_and(|partner| partner.flags & symbol_flags::ALIAS != 0);
                     // tsc's hasParseDiagnostics() checks ALL parse diagnostics
                     // (including grammar checks like TS1359) to suppress TS2456.

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -1029,10 +1029,8 @@ impl<'a> CheckerState<'a> {
                             // is from the name conflict (TS2440), not a real cycle.
                             let has_import_partner = self
                                 .ctx
-                                .binder
-                                .alias_partners
-                                .get(&sym_id)
-                                .and_then(|&pid| self.ctx.binder.get_symbol(pid))
+                                .alias_partner_for(self.ctx.binder, sym_id)
+                                .and_then(|pid| self.ctx.binder.get_symbol(pid))
                                 .is_some_and(|p| p.flags & tsz_binder::symbol_flags::ALIAS != 0);
                             // Suppress TS2456 when the type alias has type
                             // parameters and the body is a bare self-reference.

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -1077,12 +1077,9 @@ impl<'a> CheckerState<'a> {
             if let Some(symbol) = self.ctx.binder.get_symbol(local_sym_id)
                 && symbol.flags & symbol_flags::ALIAS != 0
             {
-                if let Some((&type_alias_id, _)) = self
+                if let Some(type_alias_id) = self
                     .ctx
-                    .binder
-                    .alias_partners
-                    .iter()
-                    .find(|&(_, &alias_id)| alias_id == local_sym_id)
+                    .alias_partner_reverse(self.ctx.binder, local_sym_id)
                 {
                     return TypeSymbolResolution::Type(type_alias_id);
                 }

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -1453,10 +1453,9 @@ impl<'a> CheckerState<'a> {
                 // the name has both a TYPE meaning and a value NAMESPACE
                 // meaning. If the partner aliases a module whose exports
                 // include any runtime value, this name IS usable as a value.
-                let has_namespace_alias_partner = target_binder
-                    .alias_partners
-                    .get(&sym_id)
-                    .copied()
+                let has_namespace_alias_partner = self
+                    .ctx
+                    .alias_partner_for(target_binder, sym_id)
                     .is_some_and(|partner_id| {
                         target_binder
                             .get_symbol(partner_id)

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -56,10 +56,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     // the member through the ALIAS symbol's import chain
                     let alias_id = self
                         .ctx
-                        .binder
-                        .alias_partners
-                        .get(&current_sym)
-                        .copied()
+                        .alias_partner_for(self.ctx.binder, current_sym)
                         .or_else(|| {
                             let resolved = self.ctx.binder.resolve_import_symbol(current_sym)?;
                             self.ctx.alias_partner_for(self.ctx.binder, resolved)

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -888,13 +888,45 @@ pub(super) fn collect_diagnostics(
     // This avoids re-scanning all binders for declared/ambient module names in
     // each checker's `set_all_binders` call — the skeleton captured this data
     // during the parallel parse/bind phase.
+    //
+    // When no skeleton exists (small projects, sequential mode, tests), fall
+    // back to the merged program-wide `declared_modules` set. This is the
+    // same merged data the (now-empty) per-binder `declared_modules` used to
+    // hold; consumers route through `ctx.declared_modules_contains` which
+    // prefers `global_declared_modules`. Without this fallback, ambient
+    // module suppression in `import_declaration` regresses (TS2307 false
+    // positives on declared modules) for non-skeleton paths.
     let skeleton_declared_modules: Option<Arc<tsz::checker::context::GlobalDeclaredModules>> =
-        program.skeleton_index.as_ref().map(|skel| {
+        if let Some(skel) = program.skeleton_index.as_ref() {
             let (exact, patterns) = skel.build_declared_module_sets();
-            Arc::new(tsz::checker::context::GlobalDeclaredModules::from_skeleton(
-                exact, patterns,
+            Some(Arc::new(
+                tsz::checker::context::GlobalDeclaredModules::from_skeleton(exact, patterns),
             ))
-        });
+        } else if !program.declared_modules.is_empty()
+            || !program.shorthand_ambient_modules.is_empty()
+        {
+            let mut exact: FxHashSet<String> = FxHashSet::default();
+            let mut patterns: Vec<String> = Vec::new();
+            for name in program
+                .declared_modules
+                .iter()
+                .chain(program.shorthand_ambient_modules.iter())
+            {
+                let normalized = name.trim_matches('"').trim_matches('\'');
+                if normalized.contains('*') {
+                    patterns.push(normalized.to_string());
+                } else {
+                    exact.insert(normalized.to_string());
+                }
+            }
+            patterns.sort();
+            patterns.dedup();
+            Some(Arc::new(
+                tsz::checker::context::GlobalDeclaredModules::from_skeleton(exact, patterns),
+            ))
+        } else {
+            None
+        };
 
     // Pre-compute expando index from skeleton when available.
     // This avoids re-scanning all binders for expando property assignments.


### PR DESCRIPTION
## Summary

The previous empty-out commit (`870257e0`) was effectively merged via the alias_partners ProjectEnv work that just landed in main, but it left **5 unmigrated direct reads** of the per-binder maps. With the maps now empty, those sites silently failed:

- **`mergeWithImportedType.ts`**: TS2456 false-positive ("Type alias 'E' circularly references itself"). The TS2456 suppressor in `computed_helpers.rs` and `type_alias_variable_alias.rs` was reading `binder.alias_partners` directly and missed the import partner the project-wide map holds.
- **`importAssertionsDeprecatedIgnored.ts`**: TS2307 false-positive on declared modules. The ambient-module suppression in `import/declaration.rs:1376` was reading `binder.declared_modules` (now empty).
- The reverse alias-partner lookup in `symbol_resolver.rs` (TYPE_ALIAS → ALIAS for type-position resolution) had no project-wide accessor at all.

## Changes

- **`check.rs`**: when `program.skeleton_index` is `None`, build `global_declared_modules` from `program.declared_modules` + `shorthand_ambient_modules` so non-skeleton paths (small projects, tests, sequential mode) still get a populated set. The accessor prefers this over the (empty) per-binder map.
- **`context/core.rs`**: add `alias_partner_reverse(binder, sym_id)` for the TYPE_ALIAS reverse lookup; mirrors the existing forward accessor's project-wide-then-per-binder fallback.
- Migrate 5 unmigrated direct reads to the accessors:
  - `types/type_node_resolution.rs`
  - `types/queries/type_only.rs` (target_binder partner check)
  - `state/type_analysis/computed_helpers.rs` (TS2456 suppression)
  - `state/type_analysis/computed/type_alias_variable_alias.rs` (TS2456)
  - `symbols/symbol_resolver.rs` (reverse lookup)
- **`declarations/declarations_module_helpers.rs`**: prefer `global_declared_modules.patterns` when available; only fall back to per-binder for standalone callers.
- **`declarations/import/declaration.rs`**: route the TS2307 suppression through `ctx.declared_modules_contains`.

## Test plan
- [x] `mergeWithImportedType.ts`: PASS (was: TS2456 false positive — locally reproduced and verified)
- [x] `importAssertionsDeprecatedIgnored.ts`: PASS (was: TS2307 false positives — locally reproduced and verified)
- [x] `cargo nextest run -p tsz-checker --lib`: 2638/2638 pass
- [x] Pre-commit hook: all suites pass (clippy, wasm warnings gate, arch guard, full tests)
- [ ] CI: full conformance, no regressions