### PR TITLE
refactor: extract Symbol::primary_declaration helper

### DIFF
--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -222,6 +222,16 @@ impl Symbol {
             self.first_declaration_span = span;
         }
     }
+
+    /// Primary declaration node for this symbol: prefer `value_declaration` when
+    /// set, otherwise fall back to the first entry in `declarations`. Returns
+    /// `None` when neither is available.
+    #[must_use]
+    pub fn primary_declaration(&self) -> Option<NodeIndex> {
+        self.value_declaration
+            .into_option()
+            .or_else(|| self.declarations.first().copied())
+    }
 }
 
 // =============================================================================

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -85,11 +85,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
         let Some(class_decl) = self.ctx.arena.get_class_at(decl_idx) else {

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -2274,11 +2274,7 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(symbol) = self.binder.get_symbol(sym_id) else {
             return false;
         };
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first) = symbol.declarations.first() {
-            first
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
         self.declaration_has_never_return_type(decl_idx)

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -63,13 +63,8 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // 3. Get the declaration node
-        // Prefer value_declaration, fall back to first declaration
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        // 3. Get the declaration node (prefer value_declaration, fall back to first).
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -149,11 +144,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // 3. Get the declaration node
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -243,11 +234,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // 3. Get the declaration node
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -197,11 +197,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -204,11 +204,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -313,11 +309,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 


### PR DESCRIPTION
## Summary

Follow-up on DRY audit §Checker "Primary declaration selection is repeated across TDZ, suggestions, type-only checks, and other paths." Collapses the duplicated 6-line

\`\`\`rust
let decl_idx = if symbol.value_declaration.is_some() {
    symbol.value_declaration
} else if let Some(&first_decl) = symbol.declarations.first() {
    first_decl
} else {
    return false;
};
\`\`\`

pattern into a single method on \`Symbol\` that returns \`Option<NodeIndex>\`. Callers shrink to \`let Some(decl_idx) = symbol.primary_declaration() else { return false; };\`.

The helper leans on the existing \`NodeIndex::into_option()\` adapter so the sentinel-based \`value_declaration\` field still round-trips into \`Option\` cleanly.

## Scope

Adds \`Symbol::primary_declaration()\` in \`tsz-binder\` and routes **7 call sites** through it:

- \`tsz-checker/src/flow/flow_analysis/tdz.rs\` × 3
- \`tsz-checker/src/types/queries/type_only.rs\` × 2
- \`tsz-checker/src/error_reporter/suggestions.rs\`
- \`tsz-checker/src/flow/reachability_checker.rs\`
- \`tsz-checker/src/flow/control_flow/core.rs\` (\`symbol_declaration_returns_never\`)

Follow-up PRs will sweep the remaining ~75 instances across checker+LSP+CLI+binder; each has a different control-flow shape (\`return\`, \`return false\`, \`continue\`, \`None\`, booleans), all of which are compatible with the \`Option<NodeIndex>\` return type.

## Why this is safe

The helper is a pure data-shape accessor. It preserves the existing selection order exactly:
1. Prefer \`value_declaration\` when set.
2. Otherwise fall back to the first entry in \`declarations\`.
3. Otherwise \`None\`.

The original sentinel check (\`value_declaration.is_some()\` comparing against \`NodeIndex::NONE\`) maps to \`NodeIndex::into_option()\`, which checks the same \`u32::MAX\` sentinel.

## Architecture

Lives on \`Symbol\` in \`tsz-binder\` since it's a data-shape helper, not a type algorithm. No solver interaction, no architectural gate crossings.

Net: **+19 / −42** (6 files).

## Test plan

- [x] \`cargo clippy -p tsz-binder -p tsz-checker --lib --no-deps\` — zero warnings
- [x] \`cargo nextest run -p tsz-checker --lib\` — 2638/2638 pass
- [x] \`cargo nextest run -p tsz-binder --lib\` — 227/227 pass
- [x] Full precommit pipeline (fmt + clippy + wasm32-rustc + arch-guard + nextest precommit 18712 tests) — all green

## Follow-ups

- Sweep the remaining ~75 call sites of the same pattern across checker, LSP, CLI, and binder crates (documented in the DRY audit §tsz-checker section).