### PR TITLE
[codex] Preserve generic class aliases in declaration emit

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -36,6 +36,35 @@ pub(crate) struct ResolvedDeclarationTypeText {
 }
 
 impl<'a> DeclarationEmitter<'a> {
+    fn should_preserve_named_application_for_emit(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        interner: &tsz_solver::TypeInterner,
+    ) -> bool {
+        let Some(app_id) = tsz_solver::visitor::application_id(interner, type_id) else {
+            return false;
+        };
+        let app = interner.type_application(app_id);
+        if app.args.is_empty() {
+            return false;
+        }
+        let Some(def_id) = tsz_solver::visitor::lazy_def_id(interner, app.base) else {
+            return false;
+        };
+        let Some(sym_id) = self
+            .type_cache
+            .as_ref()
+            .and_then(|cache| cache.def_to_symbol.get(&def_id).copied())
+        else {
+            return false;
+        };
+        self.binder
+            .and_then(|binder| binder.symbols.get(sym_id))
+            .is_some_and(|symbol| {
+                symbol.flags & (symbol_flags::CLASS | symbol_flags::INTERFACE) != 0
+            })
+    }
+
     pub(crate) fn get_node_type_or_names(
         &self,
         node_ids: &[NodeIndex],
@@ -189,11 +218,17 @@ impl<'a> DeclarationEmitter<'a> {
     /// Print a `TypeId` as TypeScript syntax using `TypePrinter`.
     pub(crate) fn print_type_id(&self, type_id: tsz_solver::types::TypeId) -> String {
         if let Some(interner) = self.type_interner {
+            let type_id = interner
+                .get_display_alias(type_id)
+                .filter(|&alias| self.should_preserve_named_application_for_emit(alias, interner))
+                .unwrap_or(type_id);
             // Evaluate the type before printing to expand mapped types over
             // literal union constraints (e.g., `{[k in "ar"|"bg"]?: T}` becomes
             // `{ar?: T; bg?: T}`).  This matches tsc's behavior in declaration
             // emit where mapped types are fully resolved.
-            let type_id = if let Some(cache) = &self.type_cache {
+            let type_id = if self.should_preserve_named_application_for_emit(type_id, interner) {
+                type_id
+            } else if let Some(cache) = &self.type_cache {
                 let resolver = DtsCacheResolver { cache };
                 let mut evaluator = tsz_solver::TypeEvaluator::with_resolver(interner, &resolver);
                 evaluator.set_max_mapped_keys(1_024);
@@ -282,7 +317,13 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(interner) = self.type_interner else {
             return "any".to_string();
         };
-        let type_id = if let Some(cache) = &self.type_cache {
+        let type_id = interner
+            .get_display_alias(type_id)
+            .filter(|&alias| self.should_preserve_named_application_for_emit(alias, interner))
+            .unwrap_or(type_id);
+        let type_id = if self.should_preserve_named_application_for_emit(type_id, interner) {
+            type_id
+        } else if let Some(cache) = &self.type_cache {
             let resolver = DtsCacheResolver { cache };
             let mut evaluator = tsz_solver::TypeEvaluator::with_resolver(interner, &resolver);
             evaluator.set_max_mapped_keys(1_024);

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
@@ -924,6 +924,55 @@ export const value = null as any;
 }
 
 #[test]
+fn test_display_alias_preserves_generic_class_type_arguments() {
+    let source = r#"
+export namespace C {
+    export class A<T> {}
+    export class B {}
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let c_sym = binder
+        .file_locals
+        .get("C")
+        .expect("missing namespace symbol");
+    let c_symbol = binder.symbols.get(c_sym).expect("missing namespace data");
+    let exports = c_symbol
+        .exports
+        .as_ref()
+        .expect("expected namespace exports");
+    let a_sym = exports.get("A").expect("missing class A symbol");
+    let b_sym = exports.get("B").expect("missing class B symbol");
+
+    let interner = TypeInterner::new();
+    let a_def = tsz_solver::DefId(9201);
+    let b_def = tsz_solver::DefId(9202);
+    let app_type = interner.application(interner.lazy(a_def), vec![interner.lazy(b_def)]);
+    let evaluated_type = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::default(),
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: Some(a_sym),
+    });
+    interner.store_display_alias(evaluated_type, app_type);
+
+    let mut type_cache = crate::type_cache_view::TypeCacheView::default();
+    type_cache.def_to_symbol.insert(a_def, a_sym);
+    type_cache.def_to_symbol.insert(b_def, b_sym);
+
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let printed = emitter.print_type_id(evaluated_type);
+
+    assert_eq!(printed, "C.A<C.B>");
+}
+
+#[test]
 fn test_object_literal_enum_values_preserve_typeof_and_widen_members() {
     let output = emit_dts_with_binding(
         r#"


### PR DESCRIPTION
## Summary

Preserve display aliases for evaluated generic class/interface applications during declaration type printing. This keeps inferred declaration types such as `C.A<C.B>` from collapsing to the bare class name `C.A` after the checker evaluates the application to a nominal object shape.

## Impact

Improves declaration emit fidelity for inferred values returned from generic calls with explicit class type arguments, including the `declFileGenericType` baseline.

## Validation

- `cargo test -p tsz-emitter declaration_emitter::tests::type_info::test_display_alias_preserves_generic_class_type_arguments --lib`
- `scripts/emit/run.sh --dts-only --filter=declFileGenericType --skip-build --verbose --json-out=/tmp/declFileGenericType.rebased.json`
- pre-commit hook: fmt, clippy, wasm rustc warnings, architecture guardrail, affected nextest profile
