### PR TITLE
Fix contextual this private access through callable aliases

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -76,6 +76,15 @@ impl<'a> CheckerState<'a> {
                     self.ctx
                         .definition_store
                         .register_type_to_def(instance_type, def_id);
+                    if let Some(class_idx) = self.get_class_declaration_from_symbol(sym_id) {
+                        self.ctx
+                            .class_decl_miss_cache
+                            .borrow_mut()
+                            .remove(&instance_type);
+                        self.ctx
+                            .class_instance_type_to_decl
+                            .insert(instance_type, class_idx);
+                    }
                     self.ctx
                         .register_class_instance_in_envs(def_id, instance_type);
 
@@ -634,6 +643,15 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .definition_store
                     .register_type_to_def(instance_type, def_id);
+                if let Some(class_idx) = self.get_class_declaration_from_symbol(member_sym_id) {
+                    self.ctx
+                        .class_decl_miss_cache
+                        .borrow_mut()
+                        .remove(&instance_type);
+                    self.ctx
+                        .class_instance_type_to_decl
+                        .insert(instance_type, class_idx);
+                }
                 self.ctx
                     .register_class_instance_in_envs(def_id, instance_type);
                 return Some(instance_type);

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -195,12 +195,13 @@ impl<'a> CheckerState<'a> {
                 ctx_type
             } else if type_application(self.ctx.types, ctx_type).is_some() {
                 self.evaluate_application_type(ctx_type)
-            } else if lazy_def_id(self.ctx.types, ctx_type).is_some()
-                || matches!(
-                    classify_for_evaluation(self.ctx.types, ctx_type),
-                    EvaluationNeeded::IndexAccess { .. } | EvaluationNeeded::KeyOf(..)
-                )
-            {
+            } else if let Some(def_id) = lazy_def_id(self.ctx.types, ctx_type) {
+                self.resolve_and_insert_def_type(def_id)
+                    .unwrap_or_else(|| self.judge_evaluate(ctx_type))
+            } else if matches!(
+                classify_for_evaluation(self.ctx.types, ctx_type),
+                EvaluationNeeded::IndexAccess { .. } | EvaluationNeeded::KeyOf(..)
+            ) {
                 self.judge_evaluate(ctx_type)
             } else {
                 self.evaluate_contextual_type(ctx_type)
@@ -1418,6 +1419,8 @@ impl<'a> CheckerState<'a> {
                     })
             }
         });
+
+        let implicit_this = implicit_this.map(|tt| self.resolve_lazy_type(tt));
 
         let mut pushed_this_type_early = false;
         if let Some(tt) = implicit_this {

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -1657,6 +1657,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
     /// Get parameter name from a binding name node.
     fn get_param_name(&self, name_idx: NodeIndex) -> String {
+        if self
+            .ctx
+            .arena
+            .get(name_idx)
+            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
+        {
+            return "this".to_string();
+        }
         if let Some(ident) = self.ctx.arena.get_identifier_at(name_idx) {
             return ident.escaped_text.to_string();
         }

--- a/crates/tsz-checker/tests/contextual_typing_tests.rs
+++ b/crates/tsz-checker/tests/contextual_typing_tests.rs
@@ -814,6 +814,42 @@ let obj: HasGreet = {
     );
 }
 
+/// Function expressions contextually typed by a callable `this` parameter should
+/// use that `this` type while checking the body.
+#[test]
+fn test_function_expression_contextual_this_enforces_private_access() {
+    let source = r#"
+declare function use(value: string): void;
+
+class Foo {
+    protected protec = "ok";
+    private privat = "";
+    copy!: string;
+}
+
+type BindingFunction = (this: Foo) => void;
+const bindCopy: BindingFunction = function () {
+    this.copy = this.protec;
+    use(this.privat);
+};
+"#;
+    let diagnostics = check_default(source);
+    let private_errors = diagnostics
+        .iter()
+        .filter(|d| d.code == 2341 && d.message_text.contains("'privat'"))
+        .count();
+    assert_eq!(
+        private_errors, 1,
+        "Expected exactly one TS2341 for contextual private access, got diagnostics={diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !(d.code == 2445 && d.message_text.contains("'protec'"))),
+        "Expected protected contextual this access to be allowed, got diagnostics={diagnostics:?}"
+    );
+}
+
 /// Object literal with getter and setter pair should not be a duplicate property error.
 #[test]
 fn test_object_literal_getter_setter_pair_no_duplicate() {


### PR DESCRIPTION
## Summary

Root cause: callable type aliases preserved and resolved their explicit `this` parameter incompletely, so a function expression contextually typed as `(this: Foo) => void` could check `this` as a lazy class reference instead of the resolved `Foo` instance and miss the TS2341 private-member fingerprint.

Fixed conformance target: `TypeScript/tests/cases/compiler/protectedAccessThroughContextualThis.ts`.

Added unit coverage in `crates/tsz-checker/tests/contextual_typing_tests.rs` for a function expression assigned to `(this: Foo) => void`, asserting protected access through contextual `this` is allowed while private access reports TS2341.

## Verification

Post-rebase on latest `origin/main`:

- `scripts/session/verify-all.sh`
  - formatting: passed
  - clippy: passed
  - unit tests: passed (`21086` tests)
  - conformance: improved to `12091` vs baseline `12089` (`+2`), including `protectedAccessThroughContextualThis.ts`
  - emit tests: no change (`JS=12324`, `DTS=1247`)
  - fourslash/LSP sample: no change (`50` passed)

Earlier focused checks also passed before the final full gate:

- `cargo nextest run --package tsz-checker --lib test_function_expression_contextual_this_enforces_private_access`
- `./scripts/conformance/conformance.sh run --filter "protectedAccessThroughContextualThis" --verbose`