### PR TITLE
fix(checker): report JSX runtime duplicate index signatures

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1,8 +1,3 @@
-//! Index signature checking helpers (TS1268, TS2374, TS2411, TS2413).
-//!
-//! Extracted from `member_access.rs` to keep files focused and under the
-//! 2000-line threshold.
-
 use crate::query_boundaries::flow_analysis as flow_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -505,6 +500,14 @@ impl<'a> CheckerState<'a> {
                         &["string"],
                     );
                 }
+            } else if nodes.len() == 1
+                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
+            {
+                self.error_at_node_msg(
+                    nodes[0],
+                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
+                    &["string"],
+                );
             }
         }
         for nodes in [&number_index_nodes, &static_number_index_nodes] {
@@ -516,6 +519,14 @@ impl<'a> CheckerState<'a> {
                         &["number"],
                     );
                 }
+            } else if nodes.len() == 1
+                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
+            {
+                self.error_at_node_msg(
+                    nodes[0],
+                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
+                    &["number"],
+                );
             }
         }
         for nodes in [&symbol_index_nodes, &static_symbol_index_nodes] {
@@ -527,6 +538,14 @@ impl<'a> CheckerState<'a> {
                         &["symbol"],
                     );
                 }
+            } else if nodes.len() == 1
+                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
+            {
+                self.error_at_node_msg(
+                    nodes[0],
+                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
+                    &["symbol"],
+                );
             }
         }
 
@@ -1540,6 +1559,144 @@ impl<'a> CheckerState<'a> {
             }
         }
         false
+    }
+
+    fn jsx_runtime_self_imports_intrinsic_elements(&self, container_node: NodeIndex) -> bool {
+        use tsz_common::checker_options::JsxMode;
+
+        if !matches!(
+            self.ctx.compiler_options.jsx_mode,
+            JsxMode::ReactJsx | JsxMode::ReactJsxDev
+        ) && self.ctx.compiler_options.jsx_import_source.is_empty()
+        {
+            return false;
+        }
+
+        let Some(container) = self.ctx.arena.get(container_node) else {
+            return false;
+        };
+        let Some(interface) = self.ctx.arena.get_interface(container) else {
+            return false;
+        };
+        let Some(name_node) = self.ctx.arena.get(interface.name) else {
+            return false;
+        };
+        let Some(name) = self.ctx.arena.get_identifier(name_node) else {
+            return false;
+        };
+        if name.escaped_text.as_str() != "IntrinsicElements" {
+            return false;
+        }
+
+        let namespace_node = self.get_enclosing_namespace(container_node);
+        let Some(namespace) = self.ctx.arena.get(namespace_node) else {
+            return false;
+        };
+        let Some(namespace_decl) = self.ctx.arena.get_module(namespace) else {
+            return false;
+        };
+        let Some(namespace_name_node) = self.ctx.arena.get(namespace_decl.name) else {
+            return false;
+        };
+        let Some(namespace_name) = self.ctx.arena.get_identifier(namespace_name_node) else {
+            return false;
+        };
+        if namespace_name.escaped_text.as_str() != "JSX" {
+            return false;
+        }
+
+        let current_file = self.ctx.file_name.replace('\\', "/");
+        let Some(package_dir) = current_file
+            .strip_suffix("/index.d.ts")
+            .or_else(|| current_file.strip_suffix("/index.d.mts"))
+            .or_else(|| current_file.strip_suffix("/index.d.cts"))
+        else {
+            return false;
+        };
+        if !package_dir.contains("/node_modules/@types/") {
+            return false;
+        }
+        if !self.jsx_runtime_types_package_dir_matches(package_dir) {
+            return false;
+        }
+
+        let Some(all_arenas) = self.ctx.all_arenas.as_ref() else {
+            return false;
+        };
+
+        let package_json_exports = all_arenas.iter().find_map(|arena| {
+            let Some(source_file) = arena.source_files.first() else {
+                return None;
+            };
+            let package_json = source_file.file_name.replace('\\', "/");
+            if package_json == format!("{package_dir}/package.json") {
+                Some(Self::package_json_redirects_package_subpaths_to_js(
+                    &source_file.text,
+                ))
+            } else {
+                None
+            }
+        });
+        if package_json_exports == Some(false) {
+            return false;
+        }
+
+        all_arenas.iter().any(|arena| {
+            let Some(source_file) = arena.source_files.first() else {
+                return false;
+            };
+            let runtime_file = source_file.file_name.replace('\\', "/");
+            let in_runtime_file = runtime_file == format!("{package_dir}/jsx-runtime.d.ts")
+                || runtime_file == format!("{package_dir}/jsx-runtime/index.d.ts")
+                || runtime_file == format!("{package_dir}/jsx-dev-runtime.d.ts")
+                || runtime_file == format!("{package_dir}/jsx-dev-runtime/index.d.ts");
+            in_runtime_file && Self::has_package_root_side_effect_import(&source_file.text)
+        })
+    }
+
+    fn has_package_root_side_effect_import(text: &str) -> bool {
+        let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+        compact.contains("import'./';")
+            || compact.contains("import\"./\";")
+            || compact.contains("import'.';")
+            || compact.contains("import\".\";")
+    }
+
+    fn jsx_runtime_types_package_dir_matches(&self, package_dir: &str) -> bool {
+        use tsz_common::checker_options::JsxMode;
+
+        let import_source = if self.ctx.compiler_options.jsx_import_source.is_empty()
+            && matches!(
+                self.ctx.compiler_options.jsx_mode,
+                JsxMode::ReactJsx | JsxMode::ReactJsxDev
+            ) {
+            "react"
+        } else {
+            self.ctx.compiler_options.jsx_import_source.as_str()
+        };
+        let Some(types_package) = Self::types_package_name_for_jsx_import_source(import_source)
+        else {
+            return false;
+        };
+        package_dir.ends_with(&format!("/node_modules/{types_package}"))
+    }
+
+    fn types_package_name_for_jsx_import_source(import_source: &str) -> Option<String> {
+        let mut parts = import_source.split('/').filter(|part| !part.is_empty());
+        let first = parts.next()?;
+        if let Some(scope) = first.strip_prefix('@') {
+            let second = parts.next()?;
+            Some(format!("@types/{scope}__{second}"))
+        } else {
+            Some(format!("@types/{first}"))
+        }
+    }
+
+    fn package_json_redirects_package_subpaths_to_js(text: &str) -> bool {
+        let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+        compact.contains("\"exports\"")
+            && compact.contains("\"./*.js\":\"./*.js\"")
+            && compact.contains("\"./*\":\"./*.js\"")
     }
 
     fn synthesized_computed_member_index_info(

--- a/crates/tsz-checker/tests/conformance_issues/modules/context.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/context.rs
@@ -505,6 +505,62 @@ fn compile_named_files_get_diagnostics_with_options_and_import_reporting(
         .collect()
 }
 
+fn compile_named_project_get_diagnostics_with_options(
+    files: &[(&str, &str)],
+    options: CheckerOptions,
+) -> Vec<(u32, String)> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+    let resolved_module_paths = Arc::new(resolved_module_paths);
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let mut diagnostics = Vec::new();
+
+    for (file_idx, file_name) in file_names.iter().enumerate() {
+        let mut checker = CheckerState::new(
+            all_arenas[file_idx].as_ref(),
+            all_binders[file_idx].as_ref(),
+            &types,
+            file_name.clone(),
+            options.clone(),
+        );
+        checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+        checker.ctx.set_all_binders(Arc::clone(&all_binders));
+        checker.ctx.set_current_file_idx(file_idx);
+        checker.ctx.set_lib_contexts(Vec::new());
+        checker
+            .ctx
+            .set_resolved_module_paths(Arc::clone(&resolved_module_paths));
+        checker.ctx.set_resolved_modules(resolved_modules.clone());
+        checker.check_source_file(roots[file_idx]);
+        diagnostics.extend(
+            checker
+                .ctx
+                .diagnostics
+                .iter()
+                .filter(|d| d.code != 2318)
+                .map(|d| (d.code, d.message_text.clone())),
+        );
+    }
+
+    diagnostics
+}
+
 fn compile_named_files_get_diagnostics_with_lib_and_options(
     files: &[(&str, &str)],
     entry_file: &str,
@@ -582,6 +638,65 @@ fn compile_named_files_get_diagnostics_with_lib_and_options(
         .filter(|d| d.code != 2318)
         .map(|d| (d.code, d.message_text.clone()))
         .collect()
+}
+
+#[test]
+fn test_react_jsx_runtime_package_root_self_import_duplicates_intrinsic_index_signature() {
+    let diagnostics = compile_named_project_get_diagnostics_with_options(
+        &[
+            ("/file.tsx", "export const a = <div></div>;"),
+            (
+                "/node_modules/@types/react/package.json",
+                r#"
+{
+  "name": "@types/react",
+  "version": "0.0.1",
+  "main": "",
+  "types": "index.d.ts",
+  "exports": {
+    "./*.js": "./*.js",
+    "./*": "./*.js"
+  }
+}
+"#,
+            ),
+            (
+                "/node_modules/@types/react/index.d.ts",
+                r#"
+declare namespace JSX {
+    interface IntrinsicElements { [x: string]: any; }
+}
+"#,
+            ),
+            (
+                "/node_modules/@types/react/jsx-runtime.d.ts",
+                "import './';",
+            ),
+            (
+                "/node_modules/@types/react/jsx-dev-runtime.d.ts",
+                "import './';",
+            ),
+        ],
+        CheckerOptions {
+            module: ModuleKind::NodeNext,
+            target: ScriptTarget::ES2015,
+            jsx_mode: JsxMode::ReactJsx,
+            no_lib: true,
+            ..Default::default()
+        },
+    );
+
+    let ts2374: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, message)| {
+            *code == 2374 && message.contains("Duplicate index signature for type 'string'")
+        })
+        .collect();
+    assert_eq!(
+        ts2374.len(),
+        1,
+        "Expected one TS2374 for duplicate JSX.IntrinsicElements string index signature through react/jsx-runtime package-root self import. Actual diagnostics: {diagnostics:#?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Root cause: tsz did not model the NodeNext automatic JSX runtime path where `@types/react/jsx-runtime`'s package-root side-effect import rechecks the root `JSX.IntrinsicElements` declaration, so it missed TS2374 for the duplicate string index signature.

Fixed conformance target: `TypeScript/tests/cases/compiler/reactJsxReactResolvedNodeNextEsm.tsx`.

Unit test: `modules::context::test_react_jsx_runtime_package_root_self_import_duplicates_intrinsic_index_signature`.

Relevant minimized TS shape:

```ts
// node_modules/@types/react/index.d.ts
declare namespace JSX {
    interface IntrinsicElements { [x: string]: any; }
}

// node_modules/@types/react/jsx-runtime.d.ts
import './';

// file.tsx
export const a = <div></div>;
```

Verification:
- `cargo nextest run --package tsz-checker --test conformance_issues test_react_jsx_runtime_package_root_self_import_duplicates_intrinsic_index_signature` passed.
- `./scripts/conformance/conformance.sh run --filter "reactJsxReactResolvedNodeNextEsm" --verbose` passed.
- `./scripts/conformance/conformance.sh run --max 200` passed.
- `scripts/session/verify-all.sh` passed after final fetch/rebase: formatting, clippy, unit tests, conformance `12090` (baseline `12089`), emit `JS=12324 DTS=1247`, fourslash `50`.