### PR TITLE
emit: preserve global utility alias applications in d.ts output

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -36,6 +36,56 @@ pub(crate) struct ResolvedDeclarationTypeText {
 }
 
 impl<'a> DeclarationEmitter<'a> {
+    fn symbol_is_nameable_type_for_emit(&self, sym_id: SymbolId) -> bool {
+        self.binder
+            .and_then(|binder| binder.symbols.get(sym_id))
+            .is_none_or(|symbol| {
+                symbol.flags
+                    & (symbol_flags::CLASS | symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)
+                    != 0
+            })
+    }
+
+    fn should_preserve_named_application_for_emit(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        interner: &tsz_solver::TypeInterner,
+    ) -> bool {
+        let Some(app_id) = tsz_solver::visitor::application_id(interner, type_id) else {
+            return false;
+        };
+        let app = interner.type_application(app_id);
+        if app.args.is_empty() {
+            return false;
+        }
+        if let Some(sym_ref) = tsz_solver::visitor::type_query_symbol(interner, app.base) {
+            return self.symbol_is_nameable_type_for_emit(SymbolId(sym_ref.0));
+        }
+        if let Some(def_id) = tsz_solver::visitor::lazy_def_id(interner, app.base)
+            && let Some(cache) = self.type_cache.as_ref()
+        {
+            if cache.def_to_name.contains_key(&def_id) {
+                return true;
+            }
+            if let Some(sym_id) = cache.def_to_symbol.get(&def_id).copied() {
+                return self.symbol_is_nameable_type_for_emit(sym_id);
+            }
+        }
+
+        false
+    }
+
+    fn display_alias_for_declaration_emit(
+        &self,
+        type_id: tsz_solver::types::TypeId,
+        interner: &tsz_solver::TypeInterner,
+    ) -> tsz_solver::types::TypeId {
+        interner
+            .get_display_alias(type_id)
+            .filter(|&alias| self.should_preserve_named_application_for_emit(alias, interner))
+            .unwrap_or(type_id)
+    }
+
     pub(crate) fn get_node_type_or_names(
         &self,
         node_ids: &[NodeIndex],
@@ -189,19 +239,24 @@ impl<'a> DeclarationEmitter<'a> {
     /// Print a `TypeId` as TypeScript syntax using `TypePrinter`.
     pub(crate) fn print_type_id(&self, type_id: tsz_solver::types::TypeId) -> String {
         if let Some(interner) = self.type_interner {
+            let type_id = self.display_alias_for_declaration_emit(type_id, interner);
             // Evaluate the type before printing to expand mapped types over
             // literal union constraints (e.g., `{[k in "ar"|"bg"]?: T}` becomes
             // `{ar?: T; bg?: T}`).  This matches tsc's behavior in declaration
             // emit where mapped types are fully resolved.
-            let type_id = if let Some(cache) = &self.type_cache {
+            let type_id = if self.should_preserve_named_application_for_emit(type_id, interner) {
+                type_id
+            } else if let Some(cache) = &self.type_cache {
                 let resolver = DtsCacheResolver { cache };
                 let mut evaluator = tsz_solver::TypeEvaluator::with_resolver(interner, &resolver);
                 evaluator.set_max_mapped_keys(1_024);
-                evaluator.evaluate(type_id)
+                let evaluated = evaluator.evaluate(type_id);
+                self.display_alias_for_declaration_emit(evaluated, interner)
             } else {
                 let mut evaluator = tsz_solver::TypeEvaluator::new(interner);
                 evaluator.set_max_mapped_keys(1_024);
-                evaluator.evaluate(type_id)
+                let evaluated = evaluator.evaluate(type_id);
+                self.display_alias_for_declaration_emit(evaluated, interner)
             };
 
             let module_path_resolver = |sym_id| self.resolve_symbol_module_path(sym_id);
@@ -282,15 +337,20 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(interner) = self.type_interner else {
             return "any".to_string();
         };
-        let type_id = if let Some(cache) = &self.type_cache {
+        let type_id = self.display_alias_for_declaration_emit(type_id, interner);
+        let type_id = if self.should_preserve_named_application_for_emit(type_id, interner) {
+            type_id
+        } else if let Some(cache) = &self.type_cache {
             let resolver = DtsCacheResolver { cache };
             let mut evaluator = tsz_solver::TypeEvaluator::with_resolver(interner, &resolver);
             evaluator.set_max_mapped_keys(1_024);
-            evaluator.evaluate(type_id)
+            let evaluated = evaluator.evaluate(type_id);
+            self.display_alias_for_declaration_emit(evaluated, interner)
         } else {
             let mut evaluator = tsz_solver::TypeEvaluator::new(interner);
             evaluator.set_max_mapped_keys(1_024);
-            evaluator.evaluate(type_id)
+            let evaluated = evaluator.evaluate(type_id);
+            self.display_alias_for_declaration_emit(evaluated, interner)
         };
         let mut outer_names = Vec::new();
         for &param_idx in &outer_type_params.nodes {

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -440,6 +440,7 @@ impl<'a> TypePrinter<'a> {
 
         if !needs_typeof
             && !self.symbol_is_import_qualifiable(sym_id)
+            && !self.is_global_like_symbol(sym_id)
             && let Some(symbol_type) = self.non_qualifiable_symbol_inline_fallback(sym_id)
         {
             let mut nested = self.clone();
@@ -471,6 +472,18 @@ impl<'a> TypePrinter<'a> {
         }
 
         symbol.is_exported || symbol.has_any_flags(symbol_flags::EXPORT_VALUE)
+    }
+
+    pub(crate) fn is_global_like_symbol(&self, sym_id: SymbolId) -> bool {
+        let Some(arena) = self.symbol_arena else {
+            return false;
+        };
+        let Some(symbol) = arena.get(sym_id) else {
+            return false;
+        };
+        symbol.parent == SymbolId::NONE
+            && self.resolve_symbol_module_path(sym_id).is_none()
+            && !self.is_local_import_alias(sym_id)
     }
 
     pub(crate) fn print_namespace_reference(&self, sym_id: SymbolId) -> Option<String> {

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -1142,6 +1142,7 @@ impl<'a> TypePrinter<'a> {
             );
             if !needs_typeof
                 && !self.symbol_is_import_qualifiable(sym_id)
+                && !self.is_global_like_symbol(sym_id)
                 && let Some(symbol_type) = self
                     .def_type_fallback(def_id)
                     .or_else(|| self.symbol_type_fallback(sym_id))
@@ -1155,14 +1156,9 @@ impl<'a> TypePrinter<'a> {
             if let Some(name) = self.print_named_symbol_reference(sym_id, needs_typeof) {
                 return name;
             }
-            // Some lib-global generic bases (notably Promise/PromiseLike)
-            // may fail visibility heuristics in mixed multi-file contexts.
-            // Preserve their canonical global names instead of degrading to
-            // `any<...>` in declaration emit.
-            if symbol.parent == SymbolId::NONE
-                && self.resolve_symbol_module_path(sym_id).is_none()
-                && matches!(symbol.escaped_name.as_str(), "Promise" | "PromiseLike")
-            {
+            // Preserve canonical names for global-like symbols when visibility
+            // heuristics fail (e.g. utility aliases like `Extract`, `FlatArray`).
+            if !needs_typeof && self.is_global_like_symbol(sym_id) {
                 return symbol.escaped_name.clone();
             }
         }
@@ -1170,7 +1166,6 @@ impl<'a> TypePrinter<'a> {
         if let Some(name) = self
             .type_cache
             .and_then(|cache| cache.def_to_name.get(&def_id))
-            && matches!(name.as_str(), "Promise" | "PromiseLike")
         {
             return name.clone();
         }


### PR DESCRIPTION
## Summary
- preserve display aliases for nameable generic applications during declaration type printing, including TYPE_ALIAS bases
- avoid inlining non-import-qualifiable global-like lazy defs when printing type references
- generalize lazy-def name fallback from Promise-only to all known def_to_name entries

## Why
conditionalTypes2 regressed from Extract<T, Function> to T extends U ? T : never<T, Function> because the emitter inlined the lazy Extract alias body instead of preserving the named application form.

## Validation
- scripts/emit/run.sh --dts-only --filter=conditionalTypes2 --verbose
- cargo test -p tsz-emitter test_foreign_global_lazy_type_application_keeps_alias_name -- --nocapture
- cargo test -p tsz-emitter exact_tsc_extract_type -- --nocapture