### PR TITLE
Fix parser recovery for postfix optional method signatures

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -561,6 +561,23 @@ impl ParserState {
         self.parse_expected(SyntaxKind::OpenParenToken);
         let parameters = self.parse_parameter_list();
         self.parse_expected(SyntaxKind::CloseParenToken);
+
+        // TS1005: method signatures cannot place `?` after the parameter list.
+        // tsc reports that at `?`, then reports TS1131 at a following `:`.
+        if self.is_token(SyntaxKind::QuestionToken) {
+            self.parse_error_at_current_token(
+                "';' expected.",
+                tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+            );
+            self.next_token();
+            if self.is_token(SyntaxKind::ColonToken) {
+                self.parse_error_at_current_token(
+                    tsz_common::diagnostics::diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+                    tsz_common::diagnostics::diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+                );
+            }
+        }
+
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
             self.parse_return_type()
         } else {

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -2605,6 +2605,54 @@ type T = {
 }
 
 #[test]
+fn test_postfix_optional_method_signature_recovers_with_semicolon_expected() {
+    let source = r"
+type T = { x()?: number; };
+interface I { y()?: string; }
+";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let x_question = source.find("x()?").expect("x method") as u32 + 3;
+    let y_question = source.find("y()?").expect("y method") as u32 + 3;
+    let question_positions = vec![x_question, y_question];
+    let colon_positions = vec![x_question + 1, y_question + 1];
+
+    let actual_positions: Vec<u32> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == diagnostic_codes::EXPECTED && diag.message == "';' expected.")
+        .map(|diag| diag.start)
+        .collect();
+    assert_eq!(
+        actual_positions, question_positions,
+        "Expected TS1005 ';' expected at postfix optional method markers, got {diagnostics:?}",
+    );
+
+    let actual_ts1131_positions: Vec<u32> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED)
+        .map(|diag| diag.start)
+        .collect();
+    assert_eq!(
+        actual_ts1131_positions, colon_positions,
+        "Expected TS1131 at the colon following postfix optional method markers: {diagnostics:?}",
+    );
+
+    let ts1131_at_question = diagnostics
+        .iter()
+        .filter(|diag| {
+            diag.code == diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED
+                && question_positions.contains(&diag.start)
+        })
+        .count();
+    assert_eq!(
+        ts1131_at_question, 0,
+        "Postfix optional method markers should not fall through to TS1131: {diagnostics:?}",
+    );
+}
+
+#[test]
 fn test_type_literal_statement_recovery_matches_interface_extending_class2() {
     let source = r"
 class Foo {


### PR DESCRIPTION
## Summary
- Fix parser recovery for invalid postfix optional method signatures like `x()?: T` in type members.
- Add a parser improvement unit test covering both type literal and interface method signatures.

## Root Cause
`parse_type_member_method_signature` accepted the method signature through `)` and left the misplaced postfix `?` for the outer type-member recovery loop, so tsz reported TS1131 at `?` instead of tsc's TS1005 at `?` followed by TS1131 at the following `:`.

## Fixed Conformance Target
`TypeScript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/objectTypesWithOptionalProperties2.ts`

## Unit Test
`test_postfix_optional_method_signature_recovers_with_semicolon_expected` in `crates/tsz-parser/tests/parser_improvement_tests.rs`

## Verification
- `cargo nextest run --package tsz-parser test_postfix_optional_method_signature_recovers_with_semicolon_expected`
- `./scripts/conformance/conformance.sh run --filter "objectTypesWithOptionalProperties2" --verbose`
- `./scripts/conformance/conformance.sh run --filter "importAssertionsDeprecatedIgnored" --verbose` (checked the transient PASS->FAIL report; target passes and the flip did not reproduce)
- `scripts/session/verify-all.sh` after rebasing onto latest `origin/main`: all suites passed; conformance 12090 vs baseline 12089 (+1), emit unchanged JS=12324/DTS=1247, fourslash unchanged 50/50
