### PR TITLE
refactor: sweep primary_declaration call sites through Symbol helper

### DIFF
--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -222,6 +222,16 @@ impl Symbol {
             self.first_declaration_span = span;
         }
     }
+
+    /// Primary declaration node for this symbol: prefer `value_declaration` when
+    /// set, otherwise fall back to the first entry in `declarations`. Returns
+    /// `None` when neither is available.
+    #[must_use]
+    pub fn primary_declaration(&self) -> Option<NodeIndex> {
+        self.value_declaration
+            .into_option()
+            .or_else(|| self.declarations.first().copied())
+    }
 }
 
 // =============================================================================

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -680,13 +680,7 @@ impl<'a> CheckerState<'a> {
                         })
                         .and_then(|identifier_idx| self.resolve_identifier_symbol(identifier_idx))
                         .and_then(|sym_id| self.get_symbol_from_any_binder(sym_id))
-                        .and_then(|symbol| {
-                            if symbol.value_declaration.is_some() {
-                                Some(symbol.value_declaration)
-                            } else {
-                                symbol.declarations.first().copied()
-                            }
-                        })
+                        .and_then(|symbol| symbol.primary_declaration())
                         .and_then(|decl_idx| self.enclosing_statement_node(decl_idx))
                         .unwrap_or(left_idx);
                     self.error_at_node_msg(

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -1085,11 +1085,7 @@ impl<'a> CheckerState<'a> {
                     symbol.import_module.clone(),
                     symbol.import_name.clone(),
                     symbol.escaped_name.clone(),
-                    if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else {
-                        *symbol.declarations.first()?
-                    },
+                    symbol.primary_declaration()?,
                 )
             } else {
                 let lib_binders = self.get_lib_binders();
@@ -1101,11 +1097,7 @@ impl<'a> CheckerState<'a> {
                     symbol.import_module.clone(),
                     symbol.import_name.clone(),
                     symbol.escaped_name.clone(),
-                    if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else {
-                        *symbol.declarations.first()?
-                    },
+                    symbol.primary_declaration()?,
                 )
             };
 

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -852,11 +852,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            let decl_idx = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&decl_idx) = symbol.declarations.first() {
-                decl_idx
-            } else {
+            let Some(decl_idx) = symbol.primary_declaration() else {
                 continue;
             };
 

--- a/crates/tsz-checker/src/classes/class_chain_lookup.rs
+++ b/crates/tsz-checker/src/classes/class_chain_lookup.rs
@@ -132,11 +132,7 @@ impl<'a> CheckerState<'a> {
                 let base_name = &ident.escaped_text;
                 let sym_id = self.ctx.binder.file_locals.get(base_name)?;
                 let symbol = self.ctx.binder.get_symbol(sym_id)?;
-                let base_idx = if symbol.value_declaration.is_some() {
-                    symbol.value_declaration
-                } else {
-                    *symbol.declarations.first()?
-                };
+                let base_idx = symbol.primary_declaration()?;
 
                 return self.find_member_in_class_chain_impl(
                     base_idx,

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -368,11 +368,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(sym_id) = self.ctx.binder.file_locals.get(&base_class_name)
                         && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                     {
-                        if symbol.value_declaration.is_some() {
-                            base_class_idx = Some(symbol.value_declaration);
-                        } else if let Some(&decl_idx) = symbol.declarations.first() {
-                            base_class_idx = Some(decl_idx);
-                        }
+                        base_class_idx = symbol.primary_declaration();
                     }
                 }
             }

--- a/crates/tsz-checker/src/classes/class_implements_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_implements_helpers.rs
@@ -433,13 +433,10 @@ impl<'a> CheckerState<'a> {
                     let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                         continue;
                     };
-                    if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else if let Some(&d) = symbol.declarations.first() {
-                        d
-                    } else {
+                    let Some(d) = symbol.primary_declaration() else {
                         continue;
-                    }
+                    };
+                    d
                 };
 
                 // Cycle detection
@@ -563,13 +560,10 @@ impl<'a> CheckerState<'a> {
                     let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                         continue;
                     };
-                    if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else if let Some(&d) = symbol.declarations.first() {
-                        d
-                    } else {
+                    let Some(d) = symbol.primary_declaration() else {
                         continue;
-                    }
+                    };
+                    d
                 };
 
                 if !visited.insert(base_decl) {

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -970,13 +970,8 @@ impl<'a> CheckerState<'a> {
             Some(s) => s,
             None => return false,
         };
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            match symbol.declarations.first() {
-                Some(&d) => d,
-                None => return false,
-            }
+        let Some(decl_idx) = symbol.primary_declaration() else {
+            return false;
         };
         let Some(node) = self.ctx.arena.get(decl_idx) else {
             return false;
@@ -1019,13 +1014,8 @@ impl<'a> CheckerState<'a> {
                 None => break,
             };
 
-            let decl_idx = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else {
-                match symbol.declarations.first() {
-                    Some(&d) => d,
-                    None => break,
-                }
+            let Some(decl_idx) = symbol.primary_declaration() else {
+                break;
             };
 
             let Some(node) = self.ctx.arena.get(decl_idx) else {
@@ -1121,13 +1111,8 @@ impl<'a> CheckerState<'a> {
         };
 
         // Walk the class declarations for this symbol
-        let decl_idx = if child.value_declaration.is_some() {
-            child.value_declaration
-        } else {
-            match child.declarations.first() {
-                Some(&d) => d,
-                None => return false,
-            }
+        let Some(decl_idx) = child.primary_declaration() else {
+            return false;
         };
 
         let Some(node) = self.ctx.arena.get(decl_idx) else {

--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -403,12 +403,7 @@ impl<'a> CheckerState<'a> {
                             && let Some(default_sym) = target_binder.get_symbol(default_sym_id)
                             && (default_sym.flags & symbol_flags::ALIAS) != 0
                             && default_sym.import_module.is_none()
-                            && let Some(target_decl_idx) =
-                                if default_sym.value_declaration.is_some() {
-                                    Some(default_sym.value_declaration)
-                                } else {
-                                    default_sym.declarations.first().copied()
-                                }
+                            && let Some(target_decl_idx) = default_sym.primary_declaration()
                             && let Some(target_decl_node) = target_arena.get(target_decl_idx)
                             && let Some(target_ident) =
                                 target_arena.get_identifier(target_decl_node)

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1174,13 +1174,7 @@ impl<'a> CheckerState<'a> {
             // In JS files, `import x = require(...)` is TS-only syntax (TS8002).
             // tsc skips semantic analysis for such statements — skip circular check.
             if is_js_file {
-                let decl_idx = if sym.value_declaration.is_some() {
-                    sym.value_declaration
-                } else if let Some(&first) = sym.declarations.first() {
-                    first
-                } else {
-                    NodeIndex::NONE
-                };
+                let decl_idx = sym.primary_declaration().unwrap_or(NodeIndex::NONE);
                 if let Some(decl_node) = self.ctx.arena.get(decl_idx)
                     && decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
                 {
@@ -1437,11 +1431,7 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                let decl_idx = if sym.value_declaration.is_some() {
-                    sym.value_declaration
-                } else if let Some(first) = sym.declarations.first() {
-                    *first
-                } else {
+                let Some(decl_idx) = sym.primary_declaration() else {
                     continue;
                 };
 

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -905,11 +905,7 @@ impl<'a> CheckerState<'a> {
             return Some(format!("{}.{}", parent.escaped_name, symbol.escaped_name));
         }
         let mut parts = vec![symbol.escaped_name.clone()];
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol.declarations.first().copied()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let mut current = self.ctx.arena.get_extended(decl_idx)?.parent;
 
         while current.is_some() {

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -85,11 +85,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
         let Some(class_decl) = self.ctx.arena.get_class_at(decl_idx) else {

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -535,11 +535,7 @@ impl<'a> FlowAnalyzer<'a> {
 
         let sym_id = self.reference_symbol(reference)?;
         let symbol = self.binder.get_symbol(sym_id)?;
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol.declarations.first().copied()?
-        };
+        let decl = symbol.primary_declaration()?;
         self.fallback_declaration_type(decl)
     }
 

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1108,11 +1108,7 @@ impl<'a> FlowAnalyzer<'a> {
         if (symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0 {
             return None;
         }
-        let mut decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let mut decl_idx = symbol.primary_declaration()?;
         let mut decl_node = self.arena.get(decl_idx)?;
         if decl_node.kind == SyntaxKind::Identifier as u16 {
             decl_idx = self.arena.get_extended(decl_idx)?.parent;

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -2274,11 +2274,7 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(symbol) = self.binder.get_symbol(sym_id) else {
             return false;
         };
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first) = symbol.declarations.first() {
-            first
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
         self.declaration_has_never_return_type(decl_idx)

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1596,11 +1596,7 @@ impl<'a> FlowAnalyzer<'a> {
         if (symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0 {
             return None;
         }
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let decl_node = self.arena.get(decl_idx)?;
         // `value_declaration` for destructuring bindings may point to the identifier node
         // (the name/alias) rather than the BINDING_ELEMENT itself, because the binder calls

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -697,11 +697,7 @@ impl<'a> FlowAnalyzer<'a> {
         }
         visited.push(sym_id);
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let decl_node = self.arena.get(decl_idx)?;
         if decl_node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
             // For non-`import =` aliases (ImportSpecifier, ImportClause,

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -334,17 +334,13 @@ impl<'a> CheckerState<'a> {
             });
             if let Some(&class_d) = class_decl {
                 class_d
-            } else if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&first_decl) = symbol.declarations.first() {
-                first_decl
+            } else if let Some(d) = symbol.primary_declaration() {
+                d
             } else {
                 return false;
             }
-        } else if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
+        } else if let Some(d) = symbol.primary_declaration() {
+            d
         } else {
             return false;
         };

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -63,13 +63,8 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // 3. Get the declaration node
-        // Prefer value_declaration, fall back to first declaration
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        // 3. Get the declaration node (prefer value_declaration, fall back to first).
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -149,11 +144,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // 3. Get the declaration node
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -243,11 +234,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // 3. Get the declaration node
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -197,11 +197,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -1619,11 +1619,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Get the declaration position
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return;
         };
 

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -918,11 +918,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return false;
         };
-        let mut decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(mut decl_idx) = symbol.primary_declaration() else {
             return false;
         };
         let mut decl_node = match self.ctx.arena.get(decl_idx) {

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -358,11 +358,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                                 let exports = jsx_symbol.exports.as_ref()?;
                                 let lma_sym_id = exports.get("LibraryManagedAttributes")?;
                                 let lma_symbol = self.ctx.binder.symbols.get(lma_sym_id)?;
-                                if lma_symbol.value_declaration.is_some() {
-                                    Some(lma_symbol.value_declaration)
-                                } else {
-                                    lma_symbol.declarations.first().copied()
-                                }
+                                lma_symbol.primary_declaration()
                             })
                         {
                             let lma_error_node = self

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -307,13 +307,8 @@ impl<'a> CheckerState<'a> {
         }
 
         // Get the enum declaration to check if it's numeric
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            match symbol.declarations.first() {
-                Some(&idx) => idx,
-                None => return,
-            }
+        let Some(decl_idx) = symbol.primary_declaration() else {
+            return;
         };
 
         let Some(node) = self.ctx.arena.get(decl_idx) else {

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -813,12 +813,7 @@ impl<'a> CheckerState<'a> {
                                 // (e.g. `p.x` where `p: Point` inside class
                                 // Point) can find properties.
                                 let from_node_cache = if cached.is_none() {
-                                    let decl = if symbol.value_declaration.is_some() {
-                                        Some(symbol.value_declaration)
-                                    } else {
-                                        symbol.declarations.first().copied()
-                                    };
-                                    decl.and_then(|idx| {
+                                    symbol.primary_declaration().and_then(|idx| {
                                         self.ctx.class_instance_type_cache.get(&idx).copied()
                                     })
                                 } else {
@@ -1272,12 +1267,9 @@ impl<'a> CheckerState<'a> {
                     .get(&sym_id)
                     .copied()
                     .or_else(|| {
-                        let decl = if symbol.value_declaration.is_some() {
-                            Some(symbol.value_declaration)
-                        } else {
-                            symbol.declarations.first().copied()
-                        };
-                        decl.and_then(|idx| self.ctx.class_instance_type_cache.get(&idx).copied())
+                        symbol
+                            .primary_declaration()
+                            .and_then(|idx| self.ctx.class_instance_type_cache.get(&idx).copied())
                     })
                     .unwrap_or_else(|| self.get_type_of_symbol(sym_id))
             } else {
@@ -1495,12 +1487,9 @@ impl<'a> CheckerState<'a> {
                     .get(&sym_id)
                     .copied()
                     .or_else(|| {
-                        let decl = if symbol.value_declaration.is_some() {
-                            Some(symbol.value_declaration)
-                        } else {
-                            symbol.declarations.first().copied()
-                        };
-                        decl.and_then(|idx| self.ctx.class_instance_type_cache.get(&idx).copied())
+                        symbol
+                            .primary_declaration()
+                            .and_then(|idx| self.ctx.class_instance_type_cache.get(&idx).copied())
                     })
                     .unwrap_or_else(|| {
                         // Try building the instance type directly from the class symbol.

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1736,11 +1736,7 @@ impl<'a> CheckerState<'a> {
         request: &TypingRequest,
     ) -> Option<TypeId> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let decl_node = self.ctx.arena.get(decl_idx)?;
         let var_decl = self.ctx.arena.get_variable_declaration(decl_node)?;
         if var_decl.initializer.is_none() {

--- a/crates/tsz-checker/src/types/computation/access_super.rs
+++ b/crates/tsz-checker/src/types/computation/access_super.rs
@@ -215,13 +215,7 @@ impl<'a> CheckerState<'a> {
                             || n.kind == syntax_kind_ext::CLASS_EXPRESSION
                     })
                 })
-                .or_else(|| {
-                    if symbol.value_declaration.is_some() {
-                        Some(symbol.value_declaration)
-                    } else {
-                        symbol.declarations.first().copied()
-                    }
-                });
+                .or_else(|| symbol.primary_declaration());
             let Some(decl_idx) = decl_idx else {
                 continue;
             };

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -73,11 +73,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind != tsz_parser::parser::syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
             return None;

--- a/crates/tsz-checker/src/types/computation/complex_new_target.rs
+++ b/crates/tsz-checker/src/types/computation/complex_new_target.rs
@@ -268,11 +268,7 @@ impl<'a> CheckerState<'a> {
             );
             return Some(TypeId::ERROR);
         }
-        let symbol_decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first().unwrap_or(&NodeIndex::NONE)
-        };
+        let symbol_decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         if let Some(decl_node) = self.ctx.arena.get(symbol_decl_idx)
             && decl_node.kind == tsz_parser::parser::syntax_kind_ext::IMPORT_CLAUSE
             && let Some(ext) = self.ctx.arena.get_extended(symbol_decl_idx)

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -865,13 +865,7 @@ impl<'a> CheckerState<'a> {
                                     .ctx
                                     .binder
                                     .get_symbol(sym_id)
-                                    .and_then(|sym| {
-                                        if sym.value_declaration.is_some() {
-                                            Some(sym.value_declaration)
-                                        } else {
-                                            sym.declarations.first().copied()
-                                        }
-                                    })
+                                    .and_then(|sym| sym.primary_declaration())
                                     .and_then(|decl_idx| {
                                         self.jsdoc_type_annotation_for_node(decl_idx)
                                     });

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -199,11 +199,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(root_sym) else {
             return use_owner.is_none();
         };
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first().unwrap_or(&NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         self.declaration_scope_owner_node(decl_idx) == use_owner
     }
 

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -564,11 +564,7 @@ impl<'a> CheckerState<'a> {
 
         let sym_id = self.resolve_identifier_symbol(expr_idx)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol.declarations.first().copied()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
 
         let var_decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
         if var_decl.initializer.is_none() {

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -544,11 +544,7 @@ impl<'a> CheckerState<'a> {
             return Some(sym_id);
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
             let import = self.ctx.arena.get_import_decl(decl_node)?;

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -832,11 +832,7 @@ impl<'a> CheckerState<'a> {
         {
             let target_arena = self.ctx.get_arena_for_file(file_idx as u32);
             if let Some(target_file_name) = target_arena.source_files.first().map(|f| &f.file_name)
-                && let Some(decl_idx) = if target_sym.value_declaration.is_some() {
-                    Some(target_sym.value_declaration)
-                } else {
-                    target_sym.declarations.first().copied()
-                }
+                && let Some(decl_idx) = target_sym.primary_declaration()
                 && let Some(target_decl_node) = target_arena.get(decl_idx)
                 && let Some(target_ident) = target_arena.get_identifier(target_decl_node)
             {
@@ -1576,11 +1572,7 @@ impl<'a> CheckerState<'a> {
                 if export_name == "default"
                     && sym.flags & symbol_flags::ALIAS != 0
                     && sym.import_module.is_none()
-                    && let Some(target_decl_idx) = if sym.value_declaration.is_some() {
-                        Some(sym.value_declaration)
-                    } else {
-                        sym.declarations.first().copied()
-                    }
+                    && let Some(target_decl_idx) = sym.primary_declaration()
                     && let Some(target_decl_node) = target_arena.get(target_decl_idx)
                     && let Some(target_ident) = target_arena.get_identifier(target_decl_node)
                 {

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -204,11 +204,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -313,11 +309,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first_decl) = symbol.declarations.first() {
-            first_decl
-        } else {
+        let Some(decl_idx) = symbol.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-checker/src/types/type_checking/unused.rs
+++ b/crates/tsz-checker/src/types/type_checking/unused.rs
@@ -112,11 +112,7 @@ impl<'a> CheckerState<'a> {
             }
 
             // Get the declaration node
-            let decl_idx = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&first) = symbol.declarations.first() {
-                first
-            } else {
+            let Some(decl_idx) = symbol.primary_declaration() else {
                 continue;
             };
 
@@ -155,11 +151,7 @@ impl<'a> CheckerState<'a> {
             }
 
             // Get the declaration node
-            let decl_idx = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&first) = symbol.declarations.first() {
-                first
-            } else {
+            let Some(decl_idx) = symbol.primary_declaration() else {
                 continue;
             };
 
@@ -266,11 +258,7 @@ impl<'a> CheckerState<'a> {
             };
 
             let flags = symbol.flags;
-            let decl_idx = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&first) = symbol.declarations.first() {
-                first
-            } else {
+            let Some(decl_idx) = symbol.primary_declaration() else {
                 continue;
             };
 

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -771,11 +771,7 @@ impl<'a> CheckerState<'a> {
         if symbol.flags & symbol_flags::CLASS == 0 {
             return None;
         }
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl_idx = symbol.primary_declaration()?;
         let class = self.ctx.arena.get_class_at(decl_idx)?;
 
         // First, check if this class has an explicit constructor

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
@@ -876,19 +876,11 @@ impl Server {
                 item = item.with_detail(alias_detail);
                 if let Some(symbol_id) = binder.file_locals.get(&local_name)
                     && let Some(symbol) = binder.symbols.get(symbol_id)
+                    && let Some(decl) = symbol.primary_declaration()
                 {
-                    let decl = if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else if let Some(&first) = symbol.declarations.first() {
-                        first
-                    } else {
-                        tsz::parser::base::NodeIndex::NONE
-                    };
-                    if decl.is_some() {
-                        let doc = jsdoc_for_node(&arena, root, decl, &target_source_text);
-                        if !doc.is_empty() {
-                            item = item.with_documentation(doc);
-                        }
+                    let doc = jsdoc_for_node(&arena, root, decl, &target_source_text);
+                    if !doc.is_empty() {
+                        item = item.with_documentation(doc);
                     }
                 }
                 items.push(item);
@@ -1556,17 +1548,9 @@ impl Server {
         if raw_doc.is_empty()
             && let Some(symbol_id) = binder.file_locals.get(name)
             && let Some(symbol) = binder.symbols.get(symbol_id)
+            && let Some(decl) = symbol.primary_declaration()
         {
-            let decl = if symbol.value_declaration.is_some() {
-                symbol.value_declaration
-            } else if let Some(&first) = symbol.declarations.first() {
-                first
-            } else {
-                tsz::parser::base::NodeIndex::NONE
-            };
-            if decl.is_some() {
-                raw_doc = jsdoc_for_node(arena, root, decl, source_text);
-            }
+            raw_doc = jsdoc_for_node(arena, root, decl, source_text);
         }
         if raw_doc.trim().is_empty()
             && let Some(supplemental_jsdoc) = supplemental_jsdoc.as_deref()
@@ -1639,11 +1623,7 @@ impl Server {
 
         let symbol_id = binder.file_locals.get(name)?;
         let symbol = binder.symbols.get(symbol_id)?;
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl = symbol.primary_declaration()?;
         let node = arena.get(decl)?;
         let anchor = if node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
             if let Some(ext) = arena.get_extended(decl) {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_display.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_display.rs
@@ -435,11 +435,7 @@ impl Server {
 
         let symbol_id = binder.file_locals.get(name)?;
         let sym = binder.symbols.get(symbol_id)?;
-        let decl = if sym.value_declaration.is_some() {
-            sym.value_declaration
-        } else {
-            *sym.declarations.first()?
-        };
+        let decl = sym.primary_declaration()?;
         let node = arena.get(decl)?;
         if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
             return None;
@@ -485,11 +481,7 @@ impl Server {
     ) {
         let decl_text = binder.file_locals.get(name).and_then(|sid| {
             let sym = binder.symbols.get(sid)?;
-            let decl = if sym.value_declaration.is_some() {
-                sym.value_declaration
-            } else {
-                *sym.declarations.first()?
-            };
+            let decl = sym.primary_declaration()?;
             let node = arena.get(decl)?;
             let start = node.pos as usize;
             let end = node.end.min(source_text.len() as u32) as usize;
@@ -577,11 +569,7 @@ impl Server {
     ) -> bool {
         let decl_text = binder.file_locals.get(name).and_then(|sid| {
             let sym = binder.symbols.get(sid)?;
-            let decl = if sym.value_declaration.is_some() {
-                sym.value_declaration
-            } else {
-                *sym.declarations.first()?
-            };
+            let decl = sym.primary_declaration()?;
             let node = arena.get(decl)?;
             let start = node.pos as usize;
             let end = node.end.min(source_text.len() as u32) as usize;
@@ -657,11 +645,7 @@ impl Server {
 
         let symbol_id = binder.file_locals.get(name)?;
         let sym = binder.symbols.get(symbol_id)?;
-        let decl = if sym.value_declaration.is_some() {
-            sym.value_declaration
-        } else {
-            *sym.declarations.first()?
-        };
+        let decl = sym.primary_declaration()?;
         let node = arena.get(decl)?;
         if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
             return None;
@@ -836,11 +820,7 @@ impl Server {
         let Some(sym) = binder.symbols.get(symbol_id) else {
             return false;
         };
-        let decl = if sym.value_declaration.is_some() {
-            sym.value_declaration
-        } else if let Some(&first) = sym.declarations.first() {
-            first
-        } else {
+        let Some(decl) = sym.primary_declaration() else {
             return false;
         };
 

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo.rs
@@ -287,30 +287,23 @@ impl Server {
         if let Some(receiver_expr_idx) = receiver_expr_idx
             && let Some(receiver_sym) = binder.resolve_identifier(arena, receiver_expr_idx)
             && let Some(receiver_symbol) = binder.symbols.get(receiver_sym)
+            && let Some(receiver_decl_idx) = receiver_symbol.primary_declaration()
+            && let Some(receiver_decl_node) = arena.get(receiver_decl_idx)
+            && let Some(param) = arena.get_parameter(receiver_decl_node)
+            && param.type_annotation.is_some()
         {
-            let receiver_decl = if receiver_symbol.value_declaration.is_some() {
-                Some(receiver_symbol.value_declaration)
-            } else {
-                receiver_symbol.declarations.first().copied()
-            };
-            if let Some(receiver_decl_idx) = receiver_decl
-                && let Some(receiver_decl_node) = arena.get(receiver_decl_idx)
-                && let Some(param) = arena.get_parameter(receiver_decl_node)
-                && param.type_annotation.is_some()
-            {
-                container_type_name = arena
-                    .get_identifier_text(param.type_annotation)
-                    .map(std::string::ToString::to_string);
+            container_type_name = arena
+                .get_identifier_text(param.type_annotation)
+                .map(std::string::ToString::to_string);
 
-                if container_type_name.is_none()
-                    && let Some(type_node) = arena.get(param.type_annotation)
-                {
-                    let text = source_text
-                        .get(type_node.pos as usize..type_node.end as usize)
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty());
-                    container_type_name = text.map(std::string::ToString::to_string);
-                }
+            if container_type_name.is_none()
+                && let Some(type_node) = arena.get(param.type_annotation)
+            {
+                let text = source_text
+                    .get(type_node.pos as usize..type_node.end as usize)
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty());
+                container_type_name = text.map(std::string::ToString::to_string);
             }
         }
 

--- a/crates/tsz-lsp/src/completions/context.rs
+++ b/crates/tsz-lsp/src/completions/context.rs
@@ -697,12 +697,7 @@ impl<'a> Completions<'a> {
             mods.push("export");
         }
         // Check declaration node for ambient (declare) and deprecated
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol.declarations.first().copied().unwrap_or_default()
-        };
-        if decl_idx.is_some() {
+        if let Some(decl_idx) = symbol.primary_declaration() {
             if let Some(decl_node) = self.arena.get(decl_idx) {
                 let nf = decl_node.flags as u32;
                 // Check for deprecated (set by JSDoc @deprecated tag during parsing)

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -605,11 +605,7 @@ impl<'a> Completions<'a> {
     fn is_const_declaration(&self, symbol: &tsz_binder::Symbol) -> bool {
         use tsz_parser::parser::flags::node_flags;
 
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first) = symbol.declarations.first() {
-            first
-        } else {
+        let Some(decl) = symbol.primary_declaration() else {
             return false;
         };
 
@@ -673,11 +669,7 @@ impl<'a> Completions<'a> {
     }
 
     fn parameter_annotation_text(&self, symbol: &tsz_binder::Symbol) -> Option<String> {
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl = symbol.primary_declaration()?;
         let node = self.arena.get(decl)?;
         if node.kind != syntax_kind_ext::PARAMETER {
             return None;
@@ -857,11 +849,7 @@ impl<'a> Completions<'a> {
         symbol: &tsz_binder::Symbol,
         kind: CompletionItemKind,
     ) -> Option<String> {
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl = symbol.primary_declaration()?;
         let node = self.arena.get(decl)?;
         if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
             return None;

--- a/crates/tsz-lsp/src/completions/member.rs
+++ b/crates/tsz-lsp/src/completions/member.rs
@@ -454,11 +454,7 @@ impl<'a> Completions<'a> {
 
     fn symbol_type_annotation_node(&self, sym_id: tsz_binder::SymbolId) -> Option<NodeIndex> {
         let symbol = self.binder.symbols.get(sym_id)?;
-        let decl = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            *symbol.declarations.first()?
-        };
+        let decl = symbol.primary_declaration()?;
         let node = self.arena.get(decl)?;
         if node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
             let var_decl = self.arena.get_variable_declaration(node)?;

--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -1576,13 +1576,7 @@ impl<'a> HoverProvider<'a> {
                 }
             }
         }
-        if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else if let Some(&first) = symbol.declarations.first() {
-            first
-        } else {
-            NodeIndex::NONE
-        }
+        symbol.primary_declaration().unwrap_or(NodeIndex::NONE)
     }
 
     /// Check if `child` is a descendant of `ancestor` in the AST.


### PR DESCRIPTION
## Summary

Follow-up to #804. Applies the `Symbol::primary_declaration()` helper to ~50 call sites across `tsz-checker`, `tsz-cli`, and `tsz-lsp` that were still open-coding the value-declaration-else-first-declaration pattern.

Two collapsed shapes:

```rust
// Before (value-declaration prioritized, fallback to first):
if symbol.value_declaration.is_some() {
    symbol.value_declaration
} else {
    *symbol.declarations.first().unwrap_or(&NodeIndex::NONE)
}

// Before (match-based early-exit):
match symbol.declarations.first() {
    Some(&d) => d,
    None => return/continue,
}

// After:
symbol.primary_declaration()          // Option<NodeIndex>
symbol.primary_declaration().unwrap_or(NodeIndex::NONE)
let Some(d) = symbol.primary_declaration() else { return/continue; };
symbol.primary_declaration()?;
```

Exact-semantics preservation at every site (let-else, `?`, `unwrap_or`, `.and_then`, method chain, `match`, let-chain).

Also collapses a nested `if let` in `handlers_quickinfo.rs` into a single let-chain (clippy `collapsible_if`).

## Stats

- **38 files changed**, +89 / -337 (net **−248 LOC**)
- All 12986 precommit tests pass, clippy clean on the workspace

## Test plan

- [x] `cargo nextest run -p tsz-checker -p tsz-emitter -p tsz-lsp -p tsz-core` — 12986 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` via pre-commit
- [x] `cargo check --target wasm32-unknown-unknown -p tsz-checker -p tsz-emitter -p tsz-lsp`
- [x] Architecture guardrails (checker boundary) passed