### PR TITLE
perf(cli): parallelize build_cross_file_binders

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -586,10 +586,12 @@ pub(super) fn collect_diagnostics(
 
     // Pre-create all binders for cross-file resolution
     let all_binders: Arc<Vec<Arc<BinderState>>> = Arc::new({
-        let _span = tracing::info_span!("build_cross_file_binders").entered();
+        use rayon::prelude::*;
+        let _span =
+            tracing::info_span!("build_cross_file_binders", files = program.files.len()).entered();
         program
             .files
-            .iter()
+            .par_iter()
             .enumerate()
             .map(|(file_idx, file)| {
                 Arc::new(create_cross_file_lookup_binder_with_augmentations(


### PR DESCRIPTION
## Summary

- Switch the per-file `build_cross_file_binders` loop from `.iter()` to `.par_iter()` so Rayon can construct N cross-file lookup binders in parallel.
- Each call to `create_cross_file_lookup_binder_with_augmentations` only takes `&` references and returns an owned `BinderState` — no shared mutable state, so this is embarrassingly parallel.
- On a 6086-file fixture the sequential pass was a measurable startup tax that scaled linearly with file count.

## Stack

This stacks on top of #803 and #810. CI bench will compare against base.

## Test plan
- [x] `cargo check -p tsz-cli` clean
- [x] `cargo nextest run -p tsz-cli --lib` — same 6 pre-existing `tsc_compat_tests::tsc_parity_*` failures as main; no new failures
- [ ] CI: full test matrix + bench-vs-base on large-ts-repo