### PR TITLE
fix(checker): preserve declaration order for type-parameter union TS2322

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1615,6 +1615,13 @@ impl<'a> CheckerState<'a> {
             }
 
             let type_id = factory.type_param(info);
+            if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&data.name.0)
+                && let Some(def_id) = self.ctx.definition_store.find_def_by_symbol(sym_id.0)
+            {
+                self.ctx
+                    .definition_store
+                    .register_type_to_def(type_id, def_id);
+            }
             let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
             updates.push((name, previous, shadowed_class_param));
             param_indices.push(param_idx);
@@ -1695,6 +1702,13 @@ impl<'a> CheckerState<'a> {
                 };
 
                 let constrained_type_id = factory.type_param(info);
+                if let Some(&sym_id) = self.ctx.binder.node_symbols.get(&data.name.0)
+                    && let Some(def_id) = self.ctx.definition_store.find_def_by_symbol(sym_id.0)
+                {
+                    self.ctx
+                        .definition_store
+                        .register_type_to_def(constrained_type_id, def_id);
+                }
                 if self.ctx.type_parameter_scope.get(&name).copied() != Some(constrained_type_id) {
                     self.ctx
                         .type_parameter_scope

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -187,6 +187,35 @@ var iu: typeof undefined = i;
     );
 }
 
+#[test]
+fn test_ts2322_type_parameter_union_display_preserves_declaration_order() {
+    let diagnostics = get_all_diagnostics(
+        r#"
+function diamondTop<Top>() {
+    function diamondMiddle<T, U>() {
+        let top!: Top;
+        let middle!: Top | T | U;
+        top = middle;
+    }
+}
+"#,
+    );
+
+    let message = diagnostics
+        .iter()
+        .find_map(|(code, message)| {
+            (*code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && message.contains("is not assignable to type 'Top'."))
+            .then_some(message.as_str())
+        })
+        .expect("expected TS2322 diagnostic for top = middle assignment");
+
+    assert!(
+        message.contains("Type 'Top | T | U' is not assignable to type 'Top'."),
+        "expected declaration-order union display, got: {message}"
+    );
+}
+
 fn compile_with_options(
     source: &str,
     file_name: &str,

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -1918,6 +1918,18 @@ impl<'a> TypeFormatter<'a> {
 
         let data = self.interner.lookup(type_id);
 
+        // Type parameters are modeled as `TypeData::TypeParameter` and lose direct
+        // declaration span information unless the checker registers their DefId.
+        // When available, use that DefId span so diagnostics can display unions in
+        // declaration/source order (e.g. `Top | T | U` instead of alloc-order drift).
+        if matches!(data, Some(TypeData::TypeParameter(_) | TypeData::Infer(_)))
+            && let Some(def_id) = def_store.find_def_for_type(type_id)
+            && let Some(def) = def_store.get(def_id)
+            && let (Some(file_id), Some((span_start, _))) = (def.file_id, def.span)
+        {
+            return (1, file_id, span_start);
+        }
+
         // Try Lazy(DefId) - type aliases, interfaces, classes
         if let Some(TypeData::Lazy(def_id)) = &data
             && let Some(def) = def_store.get(*def_id)


### PR DESCRIPTION
## Summary
Root cause: TS2322 union display ordering for type parameters drifted to allocation/interner order because checker-created `TypeData::TypeParameter` values were not mapped to their declaration `DefId`, so solver formatting could not source-sort them.

Fixed conformance target: `TypeScript/tests/cases/compiler/typeParameterDiamond4.ts`.

## What Changed
- Registered type-parameter `TypeId -> DefId` mappings when entering checker type-parameter scopes (both unconstrained and constrained passes).
- Updated solver diagnostic type-position ranking to use `DefStore` spans for `TypeData::TypeParameter` / `TypeData::Infer` when available.
- Added a TS2322 unit test that locks declaration-order display for type-parameter unions.

## Unit Test
- `crates/tsz-checker/tests/ts2322_tests.rs`
- `test_ts2322_type_parameter_union_display_preserves_declaration_order`

## Minimal TS Repro
```ts
function diamondTop<Top>() {
  function diamondMiddle<T, U>() {
    let top!: Top;
    let middle!: Top | T | U;
    top = middle;
    // TS2322 should render as: Type 'Top | T | U' is not assignable to type 'Top'.
  }
}
```

## Verification
- `./scripts/conformance/conformance.sh run --filter "typeParameterDiamond4" --verbose` (PASS)
- `./scripts/conformance/conformance.sh run --max 200` (PASS)
- `scripts/session/verify-all.sh` (PASS)
  - formatting: pass
  - clippy: pass
  - unit tests: pass
  - conformance: `12090` (baseline `12089`, `+1`)
  - emit tests: no change (`JS=12324`, `DTS=1247`)
  - fourslash/LSP: no change (`50`)

## Branch Hygiene
- Pre-PR sync done: `git fetch origin --prune && git rebase origin/main` (already up to date, no replay changes).
