### PR TITLE
refactor(checker): collapse compound-assignment classification duplicates

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -4,12 +4,14 @@
 //! has been extracted to `condition_narrowing.rs`.
 
 use super::{FlowAnalyzer, PropertyKey};
+use crate::query_boundaries::common::{
+    is_assignment_operator as boundary_is_assignment_operator, is_compound_assignment_operator,
+    map_compound_assignment_to_binary,
+};
 use crate::query_boundaries::flow_analysis::{
     array_type, enum_member_domain, evaluate_application_type, fallback_compound_assignment_result,
     get_array_element_type, get_lazy_def_id, is_assignable, is_assignable_with_env,
-    is_assignment_operator as boundary_is_assignment_operator, is_compound_assignment_operator,
-    map_compound_assignment_to_binary, tuple_elements_for_type, union_members_for_type,
-    widen_literal_to_primitive,
+    tuple_elements_for_type, union_members_for_type, widen_literal_to_primitive,
 };
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -708,23 +708,9 @@ impl<'a> FlowAnalyzer<'a> {
         if node_data.kind == syntax_kind_ext::BINARY_EXPRESSION
             && let Some(bin) = self.arena.get_binary_expr(node_data)
         {
-            use tsz_scanner::SyntaxKind;
-            let op = bin.operator_token;
-            return op == SyntaxKind::PlusEqualsToken as u16
-                || op == SyntaxKind::MinusEqualsToken as u16
-                || op == SyntaxKind::AsteriskEqualsToken as u16
-                || op == SyntaxKind::SlashEqualsToken as u16
-                || op == SyntaxKind::PercentEqualsToken as u16
-                || op == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                || op == SyntaxKind::LessThanLessThanEqualsToken as u16
-                || op == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                || op == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                || op == SyntaxKind::AmpersandEqualsToken as u16
-                || op == SyntaxKind::BarEqualsToken as u16
-                || op == SyntaxKind::CaretEqualsToken as u16
-                || op == SyntaxKind::BarBarEqualsToken as u16
-                || op == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || op == SyntaxKind::QuestionQuestionEqualsToken as u16;
+            return crate::query_boundaries::common::is_compound_assignment_operator(
+                bin.operator_token,
+            );
         }
 
         false

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -1395,25 +1395,9 @@ impl<'a> CheckerState<'a> {
         if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
             && let Some(bin) = self.ctx.arena.get_binary_expr(parent_node)
         {
-            let is_compound_assign = matches!(
+            return crate::query_boundaries::common::is_compound_assignment_operator(
                 bin.operator_token,
-                op if op == SyntaxKind::PlusEqualsToken as u16
-                    || op == SyntaxKind::MinusEqualsToken as u16
-                    || op == SyntaxKind::AsteriskEqualsToken as u16
-                    || op == SyntaxKind::SlashEqualsToken as u16
-                    || op == SyntaxKind::PercentEqualsToken as u16
-                    || op == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                    || op == SyntaxKind::LessThanLessThanEqualsToken as u16
-                    || op == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                    || op == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                    || op == SyntaxKind::AmpersandEqualsToken as u16
-                    || op == SyntaxKind::BarEqualsToken as u16
-                    || op == SyntaxKind::CaretEqualsToken as u16
-                    || op == SyntaxKind::BarBarEqualsToken as u16
-                    || op == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                    || op == SyntaxKind::QuestionQuestionEqualsToken as u16
-            );
-            return is_compound_assign && bin.left == ident_idx;
+            ) && bin.left == ident_idx;
         }
 
         false

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -74,18 +74,6 @@ pub(crate) fn is_assignable_strict_null(
     .is_related()
 }
 
-pub(crate) const fn is_compound_assignment_operator(operator_token: u16) -> bool {
-    tsz_solver::is_compound_assignment_operator(operator_token)
-}
-
-pub(crate) const fn is_assignment_operator(operator_token: u16) -> bool {
-    tsz_solver::is_assignment_operator(operator_token)
-}
-
-pub(crate) const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
-    tsz_solver::map_compound_assignment_to_binary(operator_token)
-}
-
 pub(crate) fn fallback_compound_assignment_result(
     db: &dyn TypeDatabase,
     operator_token: u16,


### PR DESCRIPTION
## Summary

Two hand-rolled 15-operator `||` chains in flow analysis were duplicating `tsz_solver::is_compound_assignment_operator`. Both sites collapse to a single call through the `query_boundaries::common` wrapper:

- `crates/tsz-checker/src/flow/control_flow/var_utils.rs:706-727` (24 lines → 5)
- `crates/tsz-checker/src/flow/flow_analysis/usage.rs:1398-1416` (18 lines → 4)

Also removes three unused boundary wrappers from `crates/tsz-checker/src/query_boundaries/flow_analysis.rs` (`is_compound_assignment_operator`, `is_assignment_operator`, `map_compound_assignment_to_binary`) — live callers all import from `query_boundaries::common`.

## Stats

- **4 files changed**, +10 / -50 (net **−40 LOC**)
- All 12986 precommit tests pass, clippy clean, architecture guardrails pass

## Test plan

- [x] `cargo nextest run -p tsz-checker -p tsz-emitter -p tsz-lsp -p tsz-core` — 12986 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` via pre-commit
- [x] `cargo check --target wasm32-unknown-unknown -p tsz-checker -p tsz-emitter -p tsz-lsp`
- [x] Architecture contract tests (including `test_no_inline_solver_function_calls_in_checker_modules`)