### PR TITLE
refactor(solver): extract is_logical_compound_assignment_operator helper

### DIFF
--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -386,12 +386,8 @@ impl<'a> CheckerState<'a> {
 
         let result_type =
             self.compound_assignment_result_type(left_read_type, right_type, operator);
-        let is_logical_assignment = matches!(
-            operator,
-            k if k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || k == SyntaxKind::BarBarEqualsToken as u16
-                || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-        );
+        let is_logical_assignment =
+            crate::query_boundaries::common::is_logical_compound_assignment_operator(operator);
         let assigned_type = if is_logical_assignment {
             right_type
         } else {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/compound_assignment_context.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/compound_assignment_context.rs
@@ -1,7 +1,6 @@
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
 
 impl<'a> CheckerState<'a> {
     /// Returns true when `anchor_idx` sits inside an arithmetic/bitwise
@@ -17,12 +16,7 @@ impl<'a> CheckerState<'a> {
     pub(super) fn in_arithmetic_compound_assignment_context(&self, anchor_idx: NodeIndex) -> bool {
         let is_arith_compound_op = |op: u16| -> bool {
             crate::query_boundaries::common::is_compound_assignment_operator(op)
-                && !matches!(
-                    op,
-                    k if k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                        || k == SyntaxKind::BarBarEqualsToken as u16
-                        || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-                )
+                && !crate::query_boundaries::common::is_logical_compound_assignment_operator(op)
         };
 
         let node_is_arith_compound_bin = |idx: NodeIndex| -> bool {

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -226,10 +226,9 @@ impl<'a> FlowAnalyzer<'a> {
                         );
                     }
 
-                    if bin.operator_token == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                        || bin.operator_token == SyntaxKind::BarBarEqualsToken as u16
-                        || bin.operator_token == SyntaxKind::QuestionQuestionEqualsToken as u16
-                    {
+                    if crate::query_boundaries::common::is_logical_compound_assignment_operator(
+                        bin.operator_token,
+                    ) {
                         // For logical assignments (&&=, ||=, ??=), the post-assignment
                         // type of the LHS must reflect the full expression semantics:
                         //   x ??= y  →  NonNullable<x> | typeof y

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1770,10 +1770,7 @@ impl<'a> FlowAnalyzer<'a> {
         // - RHS (y): For &&= only, the TRUE branch also guarantees y is truthy,
         //   because &&= evaluates y only when x is truthy, and the result IS y.
         //   For ||= and ??=, the TRUE branch doesn't guarantee y was evaluated.
-        if operator == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-            || operator == SyntaxKind::BarBarEqualsToken as u16
-            || operator == SyntaxKind::QuestionQuestionEqualsToken as u16
-        {
+        if crate::query_boundaries::common::is_logical_compound_assignment_operator(operator) {
             let matches_lhs = self.is_matching_reference(bin.left, target);
             let matches_rhs = operator == SyntaxKind::AmpersandAmpersandEqualsToken as u16
                 && self.is_matching_reference(bin.right, target);

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -1074,9 +1074,7 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(bin) = self.arena.get_binary_expr(node_data) else {
             return false;
         };
-        bin.operator_token == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-            || bin.operator_token == SyntaxKind::BarBarEqualsToken as u16
-            || bin.operator_token == SyntaxKind::QuestionQuestionEqualsToken as u16
+        crate::query_boundaries::common::is_logical_compound_assignment_operator(bin.operator_token)
     }
 
     /// Check if a node is a binding pattern (array or object destructuring pattern)

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1808,6 +1808,10 @@ pub(crate) const fn is_compound_assignment_operator(operator_token: u16) -> bool
     tsz_solver::is_compound_assignment_operator(operator_token)
 }
 
+pub(crate) const fn is_logical_compound_assignment_operator(operator_token: u16) -> bool {
+    tsz_solver::is_logical_compound_assignment_operator(operator_token)
+}
+
 pub(crate) const fn is_assignment_operator(operator_token: u16) -> bool {
     tsz_solver::is_assignment_operator(operator_token)
 }

--- a/crates/tsz-solver/src/operations/compound_assignment.rs
+++ b/crates/tsz-solver/src/operations/compound_assignment.rs
@@ -29,6 +29,17 @@ pub const fn is_assignment_operator(operator_token: u16) -> bool {
         || is_compound_assignment_operator(operator_token)
 }
 
+/// Check if a token is a logical compound assignment: `&&=`, `||=`, or `??=`.
+///
+/// These three operators share a short-circuit semantics (the RHS is only
+/// evaluated when the LHS fails the guard), which is why so many flow and
+/// narrowing paths treat them as a distinct subset of compound assignment.
+pub const fn is_logical_compound_assignment_operator(operator_token: u16) -> bool {
+    operator_token == SyntaxKind::AmpersandAmpersandEqualsToken as u16
+        || operator_token == SyntaxKind::BarBarEqualsToken as u16
+        || operator_token == SyntaxKind::QuestionQuestionEqualsToken as u16
+}
+
 pub const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
     match operator_token {
         k if k == SyntaxKind::PlusEqualsToken as u16 => Some("+"),

--- a/crates/tsz-solver/tests/compound_assignment_tests.rs
+++ b/crates/tsz-solver/tests/compound_assignment_tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     BinaryOpEvaluator, BinaryOpResult, QueryDatabase, TypeDatabase, TypeId, TypeInterner,
     fallback_compound_assignment_result, is_compound_assignment_operator,
-    map_compound_assignment_to_binary,
+    is_logical_compound_assignment_operator, map_compound_assignment_to_binary,
 };
 use tsz_scanner::SyntaxKind;
 
@@ -14,6 +14,30 @@ fn recognizes_compound_assignment_tokens() {
         SyntaxKind::QuestionQuestionEqualsToken as u16
     ));
     assert!(!is_compound_assignment_operator(
+        SyntaxKind::EqualsToken as u16
+    ));
+}
+
+#[test]
+fn recognizes_logical_compound_assignment_tokens() {
+    assert!(is_logical_compound_assignment_operator(
+        SyntaxKind::AmpersandAmpersandEqualsToken as u16
+    ));
+    assert!(is_logical_compound_assignment_operator(
+        SyntaxKind::BarBarEqualsToken as u16
+    ));
+    assert!(is_logical_compound_assignment_operator(
+        SyntaxKind::QuestionQuestionEqualsToken as u16
+    ));
+    // Non-logical compound forms are rejected.
+    assert!(!is_logical_compound_assignment_operator(
+        SyntaxKind::PlusEqualsToken as u16
+    ));
+    assert!(!is_logical_compound_assignment_operator(
+        SyntaxKind::AmpersandEqualsToken as u16
+    ));
+    // Simple assignment is rejected.
+    assert!(!is_logical_compound_assignment_operator(
         SyntaxKind::EqualsToken as u16
     ));
 }

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -34,6 +34,8 @@ The sections below have had completed bullets removed. This log keeps a running 
 **tsz-checker**
 - Keyword→TypeId sites route through `lib_resolution` helper (#775, #778).
 - `is_assignment_operator` centralized in `tsz-solver` (#777).
+- `is_compound_assignment_operator` call sites centralized via `query_boundaries::common`; 3 ad-hoc duplicate classifiers replaced (#818).
+- `is_logical_compound_assignment_operator` extracted in `tsz-solver`; 5 checker sites (3 flow, 1 assignability, 1 error-reporter) migrated through `query_boundaries::common`.
 - `tsz_common::numeric::parse_numeric_literal_value` reused for checker enum and truthiness paths (#760, #788; plus in-flight follow-ups).
 - Indexed-access helper methods split into submodule (#555).
 


### PR DESCRIPTION
## Summary

Adds a `const fn is_logical_compound_assignment_operator` in `tsz-solver` that classifies the three logical compound assignments (`&&=`, `||=`, `??=`) — a set with shared short-circuit semantics that the codebase already treated as a distinct subset.

Replaces **5 ad-hoc three-operator `||` chains** across the checker:
- `flow/control_flow/assignment.rs` — post-assignment type picker for logical assigns
- `flow/control_flow/var_utils.rs::is_logical_assignment`
- `flow/control_flow/condition_narrowing.rs` — truthiness guards for `if (x &&= y)` / etc.
- `assignability/compound_assignment.rs::is_logical_assignment` (uses cleaner composition: `is_compound && !is_logical`)
- `error_reporter/.../compound_assignment_context.rs` — negated (arith/bitwise filter)

All checker call sites route through the `query_boundaries::common` wrapper so the architecture guard (§4 — no inline `tsz_solver::` calls in checker modules) stays green.

## Test plan
- [x] New unit test `recognizes_logical_compound_assignment_tokens` in `tsz-solver` covers all 3 positive and 3 negative cases
- [x] `cargo nextest run -p tsz-solver -p tsz-checker --lib` — 18366 passed, 55 skipped
- [x] Pre-commit: fmt, clippy zero-warnings, wasm32 rustc, arch-guard (`test_no_inline_solver_function_calls_in_checker_modules`)
- [x] Full scoped tests including `logical_assignment_narrowing_tests` (5/5 pass)

## Follow-ups (not in this PR)
- 3 sibling sites in `tsz-binder/src/binding/declaration.rs` use the same 3-op chain, but the binder crate has no `tsz-solver` dependency (architecture §3: binder is purely syntactic). A follow-up could either (a) accept them as local duplicates or (b) move the helper to `tsz-scanner` where both can share it.
- `tsz-emitter/src/lowering/helpers.rs:383-400` and `tsz-lsp/src/code_actions/code_action_extract.rs:775-802` are sibling full-`is_assignment_operator` duplicates (16-18 lines each). Separate scope — queued for next PR.