### PR TITLE
refactor: centralize is_assignment_operator in emitter + lsp

### DIFF
--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -379,26 +379,6 @@ impl<'a> LoweringPass<'a> {
         }
     }
 
-    /// Return true if a binary operator token is any assignment operator.
-    const fn is_assignment_operator(op: u16) -> bool {
-        op == SyntaxKind::EqualsToken as u16
-            || op == SyntaxKind::PlusEqualsToken as u16
-            || op == SyntaxKind::MinusEqualsToken as u16
-            || op == SyntaxKind::AsteriskEqualsToken as u16
-            || op == SyntaxKind::SlashEqualsToken as u16
-            || op == SyntaxKind::PercentEqualsToken as u16
-            || op == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-            || op == SyntaxKind::LessThanLessThanEqualsToken as u16
-            || op == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-            || op == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-            || op == SyntaxKind::AmpersandEqualsToken as u16
-            || op == SyntaxKind::BarEqualsToken as u16
-            || op == SyntaxKind::CaretEqualsToken as u16
-            || op == SyntaxKind::BarBarEqualsToken as u16
-            || op == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-            || op == SyntaxKind::QuestionQuestionEqualsToken as u16
-    }
-
     /// Check if a class has any reads of private fields in its method bodies.
     pub(super) fn class_has_private_field_reads(
         &self,
@@ -524,7 +504,7 @@ impl<'a> LoweringPass<'a> {
                     let Some(bin) = self.arena.get_binary_expr(n) else {
                         continue;
                     };
-                    if !Self::is_assignment_operator(bin.operator_token) {
+                    if !tsz_solver::is_assignment_operator(bin.operator_token) {
                         continue;
                     }
                     let left = self.unwrap_parens_and_types(bin.left);
@@ -644,7 +624,7 @@ impl<'a> LoweringPass<'a> {
                 // Check for binary expressions with private field on LHS
                 if n.kind == syntax_kind_ext::BINARY_EXPRESSION
                     && let Some(bin) = self.arena.get_binary_expr(n)
-                    && Self::is_assignment_operator(bin.operator_token)
+                    && tsz_solver::is_assignment_operator(bin.operator_token)
                 {
                     let left = self.unwrap_parens(bin.left);
                     if self.is_private_field_access(left) {
@@ -677,7 +657,7 @@ impl<'a> LoweringPass<'a> {
                 // skip those — they're already handled.
                 if n.kind == syntax_kind_ext::BINARY_EXPRESSION
                     && let Some(bin) = self.arena.get_binary_expr(n)
-                    && !Self::is_assignment_operator(bin.operator_token)
+                    && !tsz_solver::is_assignment_operator(bin.operator_token)
                 {
                     // Check if either side has a private field access
                     let left = self.unwrap_parens(bin.left);

--- a/crates/tsz-emitter/tests/lowering_helpers.rs
+++ b/crates/tsz-emitter/tests/lowering_helpers.rs
@@ -859,10 +859,6 @@ fn test_collect_module_dependencies_no_duplicates() {
     );
 }
 
-// =============================================================================
-// is_assignment_operator (const fn - test via static assertions)
-// =============================================================================
-
 #[test]
 fn test_is_commonjs_default_false() {
     let arena = NodeArena::new();

--- a/crates/tsz-lsp/src/code_actions/code_action_extract.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_extract.rs
@@ -780,25 +780,7 @@ impl<'a> CodeActionProvider<'a> {
             return false;
         };
 
-        matches!(
-            binary.operator_token,
-            k if k == SyntaxKind::EqualsToken as u16
-                || k == SyntaxKind::PlusEqualsToken as u16
-                || k == SyntaxKind::MinusEqualsToken as u16
-                || k == SyntaxKind::AsteriskEqualsToken as u16
-                || k == SyntaxKind::AsteriskAsteriskEqualsToken as u16
-                || k == SyntaxKind::SlashEqualsToken as u16
-                || k == SyntaxKind::PercentEqualsToken as u16
-                || k == SyntaxKind::AmpersandEqualsToken as u16
-                || k == SyntaxKind::BarEqualsToken as u16
-                || k == SyntaxKind::CaretEqualsToken as u16
-                || k == SyntaxKind::LessThanLessThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::GreaterThanGreaterThanGreaterThanEqualsToken as u16
-                || k == SyntaxKind::AmpersandAmpersandEqualsToken as u16
-                || k == SyntaxKind::BarBarEqualsToken as u16
-                || k == SyntaxKind::QuestionQuestionEqualsToken as u16
-        )
+        tsz_solver::is_assignment_operator(binary.operator_token)
     }
 
     fn is_super_call_expression(&self, expr_node: &Node) -> bool {


### PR DESCRIPTION
## Summary

Both `tsz-emitter/src/lowering/helpers.rs` and `tsz-lsp/src/code_actions/code_action_extract.rs` inlined the full 16-operator `||` chain that `tsz-solver` already owns (via `tsz_solver::is_assignment_operator`, #777).

Changes:
- **tsz-emitter**: Removed the local `const fn is_assignment_operator` wrapper entirely; 3 `Self::` call sites now call `tsz_solver::is_assignment_operator` directly.
- **tsz-lsp**: Replaced the body of `is_assignment_expression` with a direct call to `tsz_solver::is_assignment_operator`.
- **tsz-emitter/tests/lowering_helpers.rs**: Dropped a dead section-header comment that labeled a non-existent test.

Both crates already declared `tsz-solver` as a dependency, so no `Cargo.toml` changes.

Net: **-42 LOC**, one canonical definition.

## Test plan
- [x] `cargo nextest run -p tsz-emitter -p tsz-lsp --lib` — 5112 + 2949 passed
- [x] Pre-commit: fmt, clippy zero-warnings, wasm32 rustc, arch-guard, microbench
- [x] Full affected nextest run during hook: 8061 passed, 22 skipped