### PR TITLE
perf(cli): parallelize collect_module_specifiers AST scan

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -672,8 +672,23 @@ pub(super) fn collect_diagnostics(
         tsz::module_resolver::ImportKind,
         Option<tsz::module_resolver::ImportingModuleKind>,
     );
-    let mut cached_module_specifiers: Vec<Vec<CachedModuleSpecifier>> =
-        Vec::with_capacity(program.files.len());
+
+    // AST traversal is pure read-only and embarrassingly parallel: each file
+    // independently scans its own arena. Doing this up-front in parallel lets
+    // the subsequent (sequential) module-resolution loop iterate over a
+    // pre-built `Vec<Vec<...>>` instead of interleaving the AST scan with
+    // the resolution-cache mutation. On large repos this turns N sequential
+    // AST passes into one N-way parallel pass.
+    let cached_module_specifiers: Vec<Vec<CachedModuleSpecifier>> = {
+        use rayon::prelude::*;
+        let _span =
+            tracing::info_span!("collect_module_specifiers", files = program.files.len()).entered();
+        program
+            .files
+            .par_iter()
+            .map(|file| collect_module_specifiers(&file.arena, file.source_file))
+            .collect()
+    };
 
     // Duplicate package redirect map
     let package_redirects: FxHashMap<PathBuf, PathBuf> = {
@@ -683,7 +698,6 @@ pub(super) fn collect_diagnostics(
     {
         let _span = tracing::info_span!("build_resolved_module_maps").entered();
         for (file_idx, file) in program.files.iter().enumerate() {
-            cached_module_specifiers.push(collect_module_specifiers(&file.arena, file.source_file));
             let file_path = Path::new(&file.file_name);
 
             for (specifier, specifier_node, import_kind, resolution_mode_override) in


### PR DESCRIPTION
## Summary

The driver's `build_resolved_module_maps` block previously interleaved per-file AST scans for module specifiers with the (sequential, mutable-cache-bound) module-resolution loop. AST traversal is pure read-only — each file independently scans its own arena — so it is embarrassingly parallel.

This PR lifts the scan into a separate `par_iter()` pass that pre-builds the full `Vec<Vec<CachedModuleSpecifier>>` before the resolution loop runs. Rayon spreads N file scans across cores; the resolution loop is untouched (the `resolution_cache` mutation still requires a single thread).

## Why this helps large repos

On a 6086-file fixture each AST pass runs once per file. Previously: N sequential traversals before any resolution work could start. Now: one N-way parallel traversal, then resolution proceeds on pre-built data. Pure CPU win, no behavior change.

## Test plan
- [x] `cargo check -p tsz-cli` clean
- [x] `cargo nextest run -p tsz-cli --lib` — only pre-existing `tsc_compat_tests::tsc_parity_*` failures (same as main); no new failures
- [ ] CI: full test matrix + bench-vs-base

## Stack note

Independent of #803 (currently the migration-fix), #815 (build_cross_file_binders parallelization), and #817 (bench tooling). All four can land in any order.