### PR TITLE
fix(checker): retry property lookup on evaluated narrowed receivers

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -556,6 +556,57 @@ fn no_ts1345_void_in_logical_and_without_strict() {
     );
 }
 
+#[test]
+fn type_predicate_logical_and_property_access_keeps_narrowed_property_types() {
+    let diags = check_source_diagnostics(
+        r#"
+interface C1 {
+    (): C1;
+    prototype: C1;
+    p1: string;
+}
+interface C2 {
+    (): C2;
+    prototype: C2;
+    p2: number;
+}
+interface D1 extends C1 {
+    prototype: D1;
+    p3: number;
+}
+var str: string;
+var num: number;
+function isC2(x: any): x is C2 { return true; }
+function isD1(x: any): x is D1 { return true; }
+var c1Orc2: C1 | C2 = undefined as any;
+var c2Ord1: C2 | D1 = undefined as any;
+num = isC2(c1Orc2) && c1Orc2.p2;
+str = isD1(c1Orc2) && c1Orc2.p1;
+num = isD1(c1Orc2) && c1Orc2.p3;
+num = isD1(c2Ord1) && c2Ord1.p3;
+str = isD1(c2Ord1) && c2Ord1.p1;
+"#,
+    );
+
+    let ts2322_count = diags.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        5,
+        "Expected 5 TS2322 errors for `&&` false-union assignment shape, got codes: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2339),
+        "Should not emit TS2339 for narrowed predicate property access, got codes: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2454),
+        "Should not emit TS2454 when test initializes union vars, got codes: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
 // Tests for optional property overlap (TS2365/TS2367)
 
 #[test]

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1628,8 +1628,44 @@ impl<'a> CheckerState<'a> {
 
             // Use the environment-aware resolver so that array methods, boxed
             // primitive types, and other lib-registered types are available.
-            let result =
+            let mut result =
                 self.resolve_property_access_with_env(object_type_for_access, property_name);
+            // Flow predicate narrowing can produce unions/intersections like
+            // `C2 | (C2 & C1)` or `(D1 & C2) | (D1 & C1)`. Looking up properties
+            // directly on those unevaluated shells may fall back to a bare `any`.
+            // Retry on the evaluated receiver to recover the concrete property type.
+            if matches!(
+                result,
+                PropertyAccessResult::Success {
+                    type_id: TypeId::ANY,
+                    from_index_signature: false,
+                    ..
+                }
+            ) && !crate::query_boundaries::state::checking::is_type_parameter_like(
+                self.ctx.types,
+                object_type_for_access,
+            ) {
+                let evaluated_receiver = self.evaluate_type_with_env(object_type_for_access);
+                if evaluated_receiver != object_type_for_access
+                    && evaluated_receiver != TypeId::ANY
+                    && evaluated_receiver != TypeId::ERROR
+                {
+                    let retry =
+                        self.resolve_property_access_with_env(evaluated_receiver, property_name);
+                    let retry_improved = match retry {
+                        PropertyAccessResult::Success {
+                            type_id,
+                            from_index_signature,
+                            ..
+                        } => type_id != TypeId::ANY || from_index_signature,
+                        _ => true,
+                    };
+                    if retry_improved {
+                        object_type_for_access = evaluated_receiver;
+                        result = retry;
+                    }
+                }
+            }
             match result {
                 PropertyAccessResult::Success {
                     type_id: mut prop_type,


### PR DESCRIPTION
## Root cause
When checking `isType(x) && x.prop`, flow-narrowed receivers like `C2 | (C2 & C1)` were queried as unevaluated union/intersection shells, so property resolution could fall back to bare `any` and miss TS2322 fingerprints.

## Fixed conformance target
- `TypeScript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts`

## What changed
- Updated `crates/tsz-checker/src/types/property_access_type/resolve.rs`.
- After an environment-aware property lookup returns bare `any` (and not from an index signature), the checker now evaluates the receiver type with `evaluate_type_with_env` and retries property lookup on the evaluated receiver.
- The retry is used only when it improves the result.

## Unit test
- Added `type_predicate_logical_and_property_access_keeps_narrowed_property_types` in `crates/tsz-checker/src/types/computation/binary_tests.rs`.
- The test asserts 5x `TS2322` and no `TS2339`/`TS2454` for predicate + `&&` property-access narrowing.

## Verification
- `cargo nextest run --package tsz-checker --lib --failure-output immediate-final` ✅
- `scripts/session/verify-all.sh` (post-rebase) ✅
  - formatting ✅
  - clippy ✅
  - unit tests ✅
  - conformance ✅ (`12093` vs baseline `12089`, `+4`)
  - emit tests ✅ (`12324/1249` vs baseline `12324/1247`)
  - fourslash/LSP ✅ (`50`, no change)

## Minimal TS snippet
```ts
interface C1 { p1: string }
interface C2 { p2: number }
declare function isC2(x: unknown): x is C2;
declare const c1Orc2: C1 | C2;

const n: number = isC2(c1Orc2) && c1Orc2.p2;
// expected: TS2322 (because expression type is false | number)
```