### PR TITLE
perf(cli): O(N×M)→O(N+M) — symbol_file_targets via arena pointer hashmap

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -623,18 +623,37 @@ pub(super) fn collect_diagnostics(
             .map(|file| Arc::clone(&file.arena))
             .collect()
     });
-    let symbol_file_targets: Arc<Vec<(tsz::binder::SymbolId, usize)>> = Arc::new(
+    // Build symbol → file_idx mapping in O(symbols + files) instead of
+    // O(symbols × files). Previously each symbol scanned `all_arenas` linearly
+    // looking for the matching `Arc<NodeArena>` via `ptr_eq` — on a large
+    // project (~100K-500K symbols × 6000+ files) that exploded into
+    // billion-scale pointer comparisons just to populate the map.
+    //
+    // `Arc::ptr_eq` compares the inner allocation address, so the raw pointer
+    // value uniquely identifies an arena. A small one-shot pointer→idx
+    // hashmap drops the per-symbol cost from O(N_files) to O(1).
+    let symbol_file_targets: Arc<Vec<(tsz::binder::SymbolId, usize)>> = Arc::new({
+        let _span = tracing::info_span!(
+            "build_symbol_file_targets",
+            symbols = program.symbol_arenas.len(),
+            files = all_arenas.len()
+        )
+        .entered();
+        let arena_ptr_to_idx: FxHashMap<*const tsz::parser::NodeArena, usize> = all_arenas
+            .iter()
+            .enumerate()
+            .map(|(idx, arena)| (Arc::as_ptr(arena), idx))
+            .collect();
         program
             .symbol_arenas
             .iter()
             .filter_map(|(sym_id, arena)| {
-                all_arenas
-                    .iter()
-                    .position(|file_arena| Arc::ptr_eq(file_arena, arena))
-                    .map(|file_idx| (*sym_id, file_idx))
+                arena_ptr_to_idx
+                    .get(&Arc::as_ptr(arena))
+                    .map(|&file_idx| (*sym_id, file_idx))
             })
-            .collect(),
-    );
+            .collect()
+    });
 
     // Create ModuleResolver instance for proper error reporting (TS2834, TS2835, TS2792, etc.)
     let mut module_resolver = ModuleResolver::new(options);


### PR DESCRIPTION
## Summary

`symbol_file_targets` was building a global `(SymbolId, file_idx)` table by **linearly scanning** `all_arenas` for each symbol:

\`\`\`rust
program.symbol_arenas
    .iter()
    .filter_map(|(sym_id, arena)| {
        all_arenas
            .iter()
            .position(|file_arena| Arc::ptr_eq(file_arena, arena))  // ← linear scan per symbol
            .map(|file_idx| (*sym_id, file_idx))
    })
\`\`\`

That's **O(N_symbols × N_files)**. On a 6086-file project with ~100K-500K symbols this is **~0.6-3 billion pointer comparisons** at startup, before checking even begins.

## Fix

`Arc::ptr_eq` ultimately compares the inner allocation address, so the raw `*const NodeArena` value uniquely identifies each arena. Build an `arena_ptr → file_idx` hashmap once (O(N_files)), then per-symbol lookup becomes O(1) — total O(N_symbols + N_files).

## Test plan
- [x] `cargo check -p tsz-cli` clean
- [x] `cargo nextest run -p tsz-cli --lib` — only pre-existing `tsc_compat_tests::tsc_parity_*` failures (same as main); no new failures
- [ ] CI: full test matrix + bench-vs-base

## Stack note
Independent of #803/#815/#817/#821/#824/#825. Pure algorithmic complexity reduction in startup phase.