### PR TITLE
fix(conformance): align exact optional writes in strictOptionalProperties1

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -31,6 +31,7 @@ impl<'a> CheckerContext<'a> {
         if configure_no_unchecked_indexed_access {
             types.set_no_unchecked_indexed_access(compiler_options.no_unchecked_indexed_access);
         }
+        types.set_exact_optional_property_types(compiler_options.exact_optional_property_types);
         compiler_options
     }
 

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -176,6 +176,123 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Detect assignment-to-optional-slot mismatches that should produce TS2412.
+    ///
+    /// TS2412 applies for exact-optional write targets (e.g. `obj.a = value`)
+    /// where the write type excludes `undefined` but the source includes it.
+    pub(super) fn has_exact_optional_write_target_mismatch(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        anchor_idx: NodeIndex,
+    ) -> bool {
+        if !self.ctx.compiler_options.exact_optional_property_types {
+            return false;
+        }
+        if !crate::query_boundaries::class_type::type_includes_undefined(self.ctx.types, source) {
+            return false;
+        }
+        if crate::query_boundaries::class_type::type_includes_undefined(self.ctx.types, target) {
+            return false;
+        }
+
+        let anchor_idx = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
+        let Some(anchor_node) = self.ctx.arena.get(anchor_idx) else {
+            return false;
+        };
+
+        let mut write_target_idx = if anchor_node.kind
+            == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || anchor_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            Some(anchor_idx)
+        } else if anchor_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT {
+            self.ctx
+                .arena
+                .get_expression_statement(anchor_node)
+                .and_then(|stmt| self.ctx.arena.get(stmt.expression))
+                .and_then(|expr_node| {
+                    if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                        return None;
+                    }
+                    let binary = self.ctx.arena.get_binary_expr(expr_node)?;
+                    if !self.is_assignment_operator(binary.operator_token) {
+                        return None;
+                    }
+                    let lhs = self
+                        .ctx
+                        .arena
+                        .skip_parenthesized_and_assertions(binary.left);
+                    let lhs_node = self.ctx.arena.get(lhs)?;
+                    (lhs_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                        || lhs_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+                        .then_some(lhs)
+                })
+        } else if anchor_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+            self.ctx
+                .arena
+                .get_binary_expr(anchor_node)
+                .and_then(|binary| {
+                    if !self.is_assignment_operator(binary.operator_token) {
+                        return None;
+                    }
+                    let lhs = self
+                        .ctx
+                        .arena
+                        .skip_parenthesized_and_assertions(binary.left);
+                    let lhs_node = self.ctx.arena.get(lhs)?;
+                    (lhs_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                        || lhs_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+                        .then_some(lhs)
+                })
+        } else {
+            None
+        };
+
+        if write_target_idx.is_none()
+            && let Some(ext) = self.ctx.arena.get_extended(anchor_idx)
+            && let Some(parent_node) = self.ctx.arena.get(ext.parent)
+            && (parent_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || parent_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+            && let Some(access) = self.ctx.arena.get_access_expr(parent_node)
+            && access.name_or_argument == anchor_idx
+        {
+            write_target_idx = Some(ext.parent);
+        }
+
+        let Some(write_target_idx) = write_target_idx else {
+            return false;
+        };
+        let Some(write_target_node) = self.ctx.arena.get(write_target_idx) else {
+            return false;
+        };
+
+        let is_property_like_write =
+            if write_target_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                true
+            } else if write_target_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+                self.ctx
+                    .arena
+                    .get_access_expr(write_target_node)
+                    .is_some_and(|access| {
+                        self.get_literal_index_from_node(access.name_or_argument)
+                            .is_some()
+                            || self
+                                .get_literal_string_from_node(access.name_or_argument)
+                                .is_some()
+                    })
+            } else {
+                false
+            };
+        if !is_property_like_write {
+            return false;
+        }
+
+        let read_target = self
+            .get_type_of_node_with_request(write_target_idx, &crate::context::TypingRequest::NONE);
+        crate::query_boundaries::class_type::type_includes_undefined(self.ctx.types, read_target)
+    }
+
     /// Get the declaring type name for a property in a target type.
     /// For inherited properties (e.g., from a base class), returns the base class name.
     /// Falls back to formatting the target type if no parent info is available.
@@ -761,6 +878,28 @@ impl<'a> CheckerState<'a> {
                 DiagnosticRenderRequest::simple(
                     DiagnosticAnchorKind::Exact,
                     diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD,
+                    message,
+                ),
+            ) {
+                return;
+            }
+            return;
+        }
+
+        // TS2412: exactOptionalPropertyTypes write target mismatch (property/element write).
+        if self.has_exact_optional_write_target_mismatch(source, target, anchor_idx) {
+            let src_str =
+                self.format_assignment_source_type_for_diagnostic(source, target, anchor_idx);
+            let tgt_str = self.format_assignability_type_for_message(target, source);
+            let message = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD_2,
+                &[&src_str, &tgt_str],
+            );
+            if !self.emit_render_request(
+                anchor_idx,
+                DiagnosticRenderRequest::simple(
+                    DiagnosticAnchorKind::Exact,
+                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD_2,
                     message,
                 ),
             ) {

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -254,6 +254,22 @@ foo2([match(y => y > 0)]);
 }
 
 #[test]
+fn optional_tuple_generic_param_accepts_required_undefined_union_tuple() {
+    let source = r#"
+declare let tx2: [string | undefined];
+declare function f12<T>(x: [T?]): T;
+declare function f13<T>(x: Partial<T>): T;
+f12(tx2);
+f13(tx2);
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2345),
+        "Expected no TS2345 for [string | undefined] against [T?]-based generics. Diagnostics: {diags:#?}"
+    );
+}
+
+#[test]
 fn speculative_callback_recheck_drops_stale_property_errors_after_instantiation() {
     let source = r#"
 type Mapper<T, U> = (x: T) => U;

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3647,3 +3647,28 @@ function foo<T, U>(x: T) {
         "mapped conditional assignment should not fail, got: {ts2322_messages:?}"
     );
 }
+
+#[test]
+fn exact_optional_property_write_uses_ts2412() {
+    let source = r#"
+interface U2 {
+    email?: string | number;
+}
+declare const e: string | boolean | undefined;
+declare let u2: U2;
+u2.email = e;
+"#;
+    let options = CheckerOptions {
+        exact_optional_property_types: true,
+        ..CheckerOptions::default()
+    };
+    let diagnostics = with_lib_contexts(source, "test.ts", options);
+
+    assert!(
+        diagnostics.iter().any(|(code, _)| {
+            *code
+                == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE_WITH_EXACTOPTIONALPROPERTYTYPES_TRUE_CONSIDER_ADD_2
+        }),
+        "Expected TS2412 for exact-optional property write mismatch, got: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -738,6 +738,12 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver {
 
     fn set_no_unchecked_indexed_access(&self, _enabled: bool) {}
 
+    fn exact_optional_property_types(&self) -> bool {
+        false
+    }
+
+    fn set_exact_optional_property_types(&self, _enabled: bool) {}
+
     fn contextual_property_type(&self, expected: TypeId, prop_name: &str) -> Option<TypeId> {
         let ctx = crate::ContextualTypeContext::with_expected(self.as_type_database(), expected);
         ctx.get_property_type(prop_name)
@@ -1091,7 +1097,9 @@ impl QueryDatabase for TypeInterner {
     ) -> crate::operations::property::PropertyAccessResult {
         // TypeInterner doesn't have TypeResolver capability, so it can't resolve Lazy types
         // Use PropertyAccessEvaluator with QueryDatabase (self implements both TypeDatabase and TypeResolver)
-        let evaluator = crate::operations::property::PropertyAccessEvaluator::new(self);
+        let mut evaluator = crate::operations::property::PropertyAccessEvaluator::new(self);
+        evaluator
+            .set_exact_optional_property_types(TypeInterner::exact_optional_property_types(self));
         evaluator.resolve_property_access(object_type, prop_name)
     }
 
@@ -1103,6 +1111,8 @@ impl QueryDatabase for TypeInterner {
     ) -> crate::operations::property::PropertyAccessResult {
         let mut evaluator = crate::operations::property::PropertyAccessEvaluator::new(self);
         evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
+        evaluator
+            .set_exact_optional_property_types(TypeInterner::exact_optional_property_types(self));
         evaluator.resolve_property_access(object_type, prop_name)
     }
 
@@ -1135,6 +1145,14 @@ impl QueryDatabase for TypeInterner {
 
     fn set_no_unchecked_indexed_access(&self, enabled: bool) {
         TypeInterner::set_no_unchecked_indexed_access(self, enabled);
+    }
+
+    fn exact_optional_property_types(&self) -> bool {
+        TypeInterner::exact_optional_property_types(self)
+    }
+
+    fn set_exact_optional_property_types(&self, enabled: bool) {
+        TypeInterner::set_exact_optional_property_types(self, enabled);
     }
 
     fn get_type_param_variance(&self, _def_id: DefId) -> Option<Arc<[Variance]>> {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -31,7 +31,7 @@ use tsz_common::interner::Atom;
 type EvalCacheKey = (TypeId, bool);
 type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]>, bool);
 type ElementAccessTypeCacheKey = (TypeId, TypeId, Option<u32>, bool);
-type PropertyAccessCacheKey = (TypeId, Atom, bool);
+type PropertyAccessCacheKey = (TypeId, Atom, bool, bool);
 
 /// Build a `RelationCacheConfig` from the legacy packed `u16` flags in a way
 /// that matches the defaults a fresh `SubtypeChecker::new().apply_flags(flags)`
@@ -300,6 +300,7 @@ pub struct QueryCache<'a> {
     assignability_cache_hits: Cell<u64>,
     assignability_cache_misses: Cell<u64>,
     no_unchecked_indexed_access: Cell<bool>,
+    exact_optional_property_types: Cell<bool>,
     /// Optional shared cross-file cache for multi-file project checking.
     /// When present, local cache misses fall through to the shared `DashMap` cache,
     /// and local cache inserts are also written to the shared cache.
@@ -341,6 +342,7 @@ impl<'a> QueryCache<'a> {
             assignability_cache_hits: Cell::new(0),
             assignability_cache_misses: Cell::new(0),
             no_unchecked_indexed_access: Cell::new(interner.no_unchecked_indexed_access()),
+            exact_optional_property_types: Cell::new(interner.exact_optional_property_types()),
             shared,
         }
     }
@@ -1472,13 +1474,20 @@ impl QueryDatabase for QueryCache<'_> {
         // QueryCache doesn't have full TypeResolver capability, so use PropertyAccessEvaluator
         // with the current QueryDatabase.
         let prop_atom = self.interner.intern_string(prop_name);
-        let key = (object_type, prop_atom, no_unchecked_indexed_access);
+        let exact_optional_property_types = self.exact_optional_property_types();
+        let key = (
+            object_type,
+            prop_atom,
+            no_unchecked_indexed_access,
+            exact_optional_property_types,
+        );
         if let Some(result) = self.check_property_cache(key) {
             return result;
         }
 
         let mut evaluator = crate::operations::property::PropertyAccessEvaluator::new(self);
         evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
+        evaluator.set_exact_optional_property_types(exact_optional_property_types);
         let result = evaluator.resolve_property_access(object_type, prop_name);
         self.insert_property_cache(key, result);
         result
@@ -1526,6 +1535,14 @@ impl QueryDatabase for QueryCache<'_> {
 
     fn set_no_unchecked_indexed_access(&self, enabled: bool) {
         self.no_unchecked_indexed_access.set(enabled);
+    }
+
+    fn exact_optional_property_types(&self) -> bool {
+        self.exact_optional_property_types.get()
+    }
+
+    fn set_exact_optional_property_types(&self, enabled: bool) {
+        self.exact_optional_property_types.set(enabled);
     }
 
     fn get_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>> {

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -552,6 +552,8 @@ pub struct TypeInterner {
     pub(super) poisoned: std::sync::atomic::AtomicBool,
     /// Effective value for `noUncheckedIndexedAccess` used by query-boundary helpers.
     pub(super) no_unchecked_indexed_access: AtomicBool,
+    /// Effective value for `exactOptionalPropertyTypes` used by query-boundary helpers.
+    pub(super) exact_optional_property_types: AtomicBool,
     /// Display properties for fresh object literal types.
     ///
     /// When object literal properties are widened (e.g., `"hello"` → `string`),
@@ -633,6 +635,7 @@ impl TypeInterner {
             alloc_counter: AtomicU32::new(0),
             poisoned: std::sync::atomic::AtomicBool::new(false),
             no_unchecked_indexed_access: AtomicBool::new(false),
+            exact_optional_property_types: AtomicBool::new(false),
             display_properties: DashMap::with_hasher(FxBuildHasher),
             display_alias: DashMap::with_hasher(FxBuildHasher),
             union_too_complex: AtomicBool::new(false),
@@ -649,6 +652,17 @@ impl TypeInterner {
     #[inline]
     pub fn set_no_unchecked_indexed_access(&self, enabled: bool) {
         self.no_unchecked_indexed_access
+            .store(enabled, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn exact_optional_property_types(&self) -> bool {
+        self.exact_optional_property_types.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set_exact_optional_property_types(&self, enabled: bool) {
+        self.exact_optional_property_types
             .store(enabled, Ordering::Relaxed);
     }
 

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -153,6 +153,7 @@ pub struct PropertyAccessEvaluator<'a> {
     pub(crate) db: &'a dyn QueryDatabase,
     resolver: Option<&'a dyn TypeResolver>,
     pub(crate) no_unchecked_indexed_access: bool,
+    pub(crate) exact_optional_property_types: bool,
     /// Unified recursion guard for cycle detection and depth limiting.
     pub(crate) guard: RefCell<crate::recursion::RecursionGuard<TypeId>>,
     // Context for visitor pattern (set during property access resolution)
@@ -182,6 +183,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             db,
             resolver: None,
             no_unchecked_indexed_access: false,
+            exact_optional_property_types: db.exact_optional_property_types(),
             guard: RefCell::new(crate::recursion::RecursionGuard::with_profile(
                 crate::recursion::RecursionProfile::PropertyAccess,
             )),
@@ -199,6 +201,10 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
     pub const fn set_no_unchecked_indexed_access(&mut self, enabled: bool) {
         self.no_unchecked_indexed_access = enabled;
+    }
+
+    pub const fn set_exact_optional_property_types(&mut self, enabled: bool) {
+        self.exact_optional_property_types = enabled;
     }
 
     /// Skip `this` binding during property resolution. When set, raw `ThisType`

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -864,7 +864,16 @@ impl<'a> PropertyAccessEvaluator<'a> {
     }
 
     pub(crate) fn optional_property_write_type(&self, prop: &PropertyInfo) -> TypeId {
-        crate::utils::optional_property_write_type(self.interner(), prop)
+        let write = if prop.write_type == TypeId::NONE {
+            prop.type_id
+        } else {
+            prop.write_type
+        };
+        if prop.optional && !self.exact_optional_property_types {
+            self.interner().union2(write, TypeId::UNDEFINED)
+        } else {
+            write
+        }
     }
 
     fn resolve_apparent_property(

--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -193,7 +193,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     return SubtypeResult::False;
                 }
 
-                if !self.check_subtype(s_elem.type_id, t_elem.type_id).is_true() {
+                // A required source element can satisfy an optional target slot
+                // when its type already includes `undefined` (e.g. `[string | undefined]`
+                // assignable to `[string?]`).
+                let target_elem_type = if t_elem.optional && !s_elem.optional {
+                    self.interner.union2(t_elem.type_id, TypeId::UNDEFINED)
+                } else {
+                    t_elem.type_id
+                };
+
+                if !self
+                    .check_subtype(s_elem.type_id, target_elem_type)
+                    .is_true()
+                {
                     return SubtypeResult::False;
                 }
             } else if !t_elem.optional {

--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -12137,6 +12137,30 @@ fn test_tuple_optional_required_to_optional() {
 }
 
 #[test]
+fn test_tuple_required_undefined_union_to_optional() {
+    // A required element typed as `T | undefined` should satisfy an optional `T` slot.
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let str_or_undef = interner.union2(TypeId::STRING, TypeId::UNDEFINED);
+    let tuple_required_union = interner.tuple(vec![TupleElement {
+        type_id: str_or_undef,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+
+    let tuple_optional = interner.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: true,
+        rest: false,
+    }]);
+
+    assert!(checker.is_subtype_of(tuple_required_union, tuple_optional));
+}
+
+#[test]
 fn test_tuple_optional_to_required_not_subtype() {
     // [string?] is NOT subtype of [string]
     let interner = TypeInterner::new();


### PR DESCRIPTION
## Summary
Fix conformance behavior for `strictOptionalProperties1` by aligning exact-optional write diagnostics and tuple optional-slot assignability.

## Root Cause
Tuple subtype checking compared required source elements directly against optional target element types (instead of `target | undefined`) and exact-optional write reporting missed rewritten assignment anchors, so valid tuple cases failed and property writes fell back to TS2322 instead of TS2412.

## Fixed Conformance Target
- `TypeScript/tests/cases/compiler/strictOptionalProperties1.ts`

## Unit Tests Added
- `crates/tsz-solver/tests/subtype_tests.rs`
  - `test_tuple_required_undefined_union_to_optional`
- `crates/tsz-checker/tests/generic_call_inference_tests.rs`
  - `optional_tuple_generic_param_accepts_required_undefined_union_tuple`
- `crates/tsz-checker/tests/ts2322_tests.rs`
  - `exact_optional_property_write_uses_ts2412`

## Verification Result
Post-rebase run:
- `scripts/session/verify-all.sh`
  - formatting: passed
  - clippy: passed
  - unit tests: passed
  - conformance: `12094` (baseline `12089`, `+5`)
  - emit tests: `JS 12324` / `DTS 1255` (baseline `JS 12324` / `DTS 1247`, `JS +0`, `DTS +8`)
  - fourslash/LSP: `50` passing (`no change`)

`Verification Summary: Passed 6, Failed 0`
