### PR TITLE
refactor: sweep primary_declaration pattern through checker + lsp (wave 3)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -649,15 +649,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(sym_id) = self.resolve_identifier_symbol(right_idx)
                     && let Some(symbol) = self.get_symbol_from_any_binder(sym_id)
                 {
-                    let decl_idx = if symbol.value_declaration.is_some() {
-                        symbol.value_declaration
-                    } else {
-                        symbol
-                            .declarations
-                            .first()
-                            .copied()
-                            .unwrap_or(NodeIndex::NONE)
-                    };
+                    let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
                     if decl_idx.is_some()
                         && let Some(decl_node) = self.ctx.arena.get(decl_idx)
                         && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -491,15 +491,7 @@ impl<'a> CheckerState<'a> {
         visited_aliases.push(sym_id);
 
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         if decl_idx.is_none() {
             return None;
         }
@@ -598,15 +590,7 @@ impl<'a> CheckerState<'a> {
                 .map(|symbol| (symbol, decl_file_idx))
         })?;
         let arena = self.ctx.get_arena_for_file(decl_file_idx);
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         if decl_idx.is_none() {
             return None;
         }

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -546,15 +546,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         if decl_idx.is_none() {
             return false;
         }
@@ -639,15 +631,7 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let mut decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let mut decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         // When the primary declaration doesn't resolve to a class in the current
         // arena (e.g., class+interface merged symbol where value_declaration was
         // not propagated through program-level symbol merging), search all

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -1304,17 +1304,7 @@ impl<'a> CheckerState<'a> {
                             })
                             .unwrap_or(false)
                     })
-                    .unwrap_or_else(|| {
-                        if symbol.value_declaration.is_some() {
-                            symbol.value_declaration
-                        } else {
-                            symbol
-                                .declarations
-                                .first()
-                                .copied()
-                                .unwrap_or(NodeIndex::NONE)
-                        }
-                    });
+                    .unwrap_or_else(|| symbol.primary_declaration().unwrap_or(NodeIndex::NONE));
 
                 if decl_idx.is_some() {
                     // Try user arena first (fast path for user-defined type aliases)

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -874,15 +874,7 @@ impl<'a> CheckerState<'a> {
         if let Some(&instance_type) = self.ctx.symbol_instance_types.get(&sym_id) {
             return Some(instance_type);
         }
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
         self.ctx.class_instance_type_cache.get(&decl_idx).copied()
     }
 

--- a/crates/tsz-checker/src/types/computation/complex_new_target.rs
+++ b/crates/tsz-checker/src/types/computation/complex_new_target.rs
@@ -158,14 +158,9 @@ impl<'a> CheckerState<'a> {
         let Some(export_symbol) = target_binder.get_symbol(export_sym_id) else {
             return false;
         };
-        let decl_idx = if export_symbol.value_declaration.is_some() {
-            export_symbol.value_declaration
-        } else {
-            *export_symbol
-                .declarations
-                .first()
-                .unwrap_or(&NodeIndex::NONE)
-        };
+        let decl_idx = export_symbol
+            .primary_declaration()
+            .unwrap_or(NodeIndex::NONE);
         target_arena
             .get(decl_idx)
             .filter(|decl| decl.kind == tsz_parser::parser::syntax_kind_ext::CLASS_DECLARATION)
@@ -323,14 +318,9 @@ impl<'a> CheckerState<'a> {
                 let target_arena = target_file_idx
                     .map(|file_idx| self.ctx.get_arena_for_file(file_idx as u32))
                     .unwrap_or(self.ctx.arena);
-                let resolved_decl_idx = if resolved_symbol.value_declaration.is_some() {
-                    resolved_symbol.value_declaration
-                } else {
-                    *resolved_symbol
-                        .declarations
-                        .first()
-                        .unwrap_or(&NodeIndex::NONE)
-                };
+                let resolved_decl_idx = resolved_symbol
+                    .primary_declaration()
+                    .unwrap_or(NodeIndex::NONE);
                 target_arena
                     .get(resolved_decl_idx)
                     .filter(|decl| {

--- a/crates/tsz-checker/src/types/type_checking/unused.rs
+++ b/crates/tsz-checker/src/types/type_checking/unused.rs
@@ -57,13 +57,7 @@ impl<'a> CheckerState<'a> {
                     .ctx
                     .binder
                     .get_symbol(sym_id)
-                    .map(|s| {
-                        if s.value_declaration.is_some() {
-                            s.value_declaration
-                        } else {
-                            s.declarations.first().copied().unwrap_or(NodeIndex::NONE)
-                        }
-                    })
+                    .and_then(|s| s.primary_declaration())
                     .unwrap_or(NodeIndex::NONE);
                 let key = (name.clone(), decl_idx);
                 if !seen_decls.insert(key) {

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -412,15 +412,7 @@ impl<'a> Completions<'a> {
                             item.is_snippet = true;
                         }
 
-                        let decl_node = if symbol.value_declaration.is_some() {
-                            symbol.value_declaration
-                        } else {
-                            symbol
-                                .declarations
-                                .first()
-                                .copied()
-                                .unwrap_or(NodeIndex::NONE)
-                        };
+                        let decl_node = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
                         if decl_node.is_some() {
                             let doc = jsdoc_for_node(self.arena, root, decl_node, self.source_text);
                             if !doc.is_empty() {

--- a/crates/tsz-lsp/src/editor_decorations/inlay_hints.rs
+++ b/crates/tsz-lsp/src/editor_decorations/inlay_hints.rs
@@ -220,15 +220,7 @@ impl<'a> InlayHintsProvider<'a> {
         };
 
         // Get the function declaration to extract parameter names
-        let decl_idx = if symbol.value_declaration.is_some() {
-            symbol.value_declaration
-        } else {
-            symbol
-                .declarations
-                .first()
-                .copied()
-                .unwrap_or(NodeIndex::NONE)
-        };
+        let decl_idx = symbol.primary_declaration().unwrap_or(NodeIndex::NONE);
 
         if decl_idx.is_none() {
             return;

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -35,7 +35,8 @@ The sections below have had completed bullets removed. This log keeps a running 
 - Keyword→TypeId sites route through `lib_resolution` helper (#775, #778).
 - `is_assignment_operator` centralized in `tsz-solver` (#777).
 - `is_compound_assignment_operator` call sites centralized via `query_boundaries::common`; 3 ad-hoc duplicate classifiers replaced (#818).
-- `is_logical_compound_assignment_operator` extracted in `tsz-solver`; 5 checker sites (3 flow, 1 assignability, 1 error-reporter) migrated through `query_boundaries::common`.
+- `is_logical_compound_assignment_operator` extracted in `tsz-solver`; 5 checker sites (3 flow, 1 assignability, 1 error-reporter) migrated through `query_boundaries::common` (#819).
+- `Symbol::primary_declaration()` sweep wave 3: 10 checker + 2 LSP sites migrated (reference_helpers×2, complex_constructors, complex_new_target×2, symbol_types, assignment_ops, promise_checker×2, unused, inlay_hints, completions/core).
 - `tsz_common::numeric::parse_numeric_literal_value` reused for checker enum and truthiness paths (#760, #788; plus in-flight follow-ups).
 - Indexed-access helper methods split into submodule (#555).
 


### PR DESCRIPTION
## Summary
- Migrates 12 call sites of the `value_declaration.is_some() ? value_declaration : declarations.first()` pattern onto the `Symbol::primary_declaration()` helper introduced in #804 and swept further in #814.
- Net **-89 LOC** across 10 checker + 2 LSP files with no behavior change.

## Sites migrated

**checker (10):**
- `state/type_resolution/reference_helpers.rs` (x2)
- `types/computation/complex_constructors.rs`
- `types/computation/complex_new_target.rs` (x2 — also normalizes `*x.first().unwrap_or(&NodeIndex::NONE)` shape)
- `state/type_resolution/symbol_types.rs`
- `assignability/assignment_checker/assignment_ops.rs`
- `checkers/promise_checker.rs` (x2)
- `types/type_checking/unused.rs`

**lsp (2):**
- `editor_decorations/inlay_hints.rs`
- `completions/core.rs`

## Skipped on purpose
- Sites that iterate `declarations` filtering `is_some()` — distinct semantics from `primary_declaration()`'s `first()` fallback (callable_truthiness, property_access_helpers/access_semantics, symbols/symbol_resolver, symbols/symbol_resolver_qualified).
- `context/resolver.rs` enum site uses a `NodeIndex(0)` sentinel that predates the `NodeIndex::NONE` convention — separate audit needed to avoid behavior drift.
- `types/computation/call/inner.rs` guards on `declarations.len() == 1`, so it's not the clean shape.
- `binder/src/binding/declaration.rs` — binder must not depend on checker; could call the helper directly but left for a binder-local pass.

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib` — 2642 pass
- [x] `cargo nextest run -p tsz-lsp --lib` — 3712 pass
- [x] Full pre-commit (fmt + clippy zero warnings + wasm32 + arch-guard + 12995 nextest tests) green