### PR TITLE
tsz-server: gate fourslash virtual rewrites by harness path

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -701,18 +701,22 @@ impl Server {
         None
     }
 
+    fn is_fourslash_virtual_harness_path(file_path: &str) -> bool {
+        let normalized = file_path.replace('\\', "/");
+        normalized == "/fourslash.ts"
+            || normalized == "fourslash.ts"
+            || normalized.starts_with("/tests/cases/fourslash/")
+            || normalized.starts_with("tests/cases/fourslash/")
+    }
+
     fn normalize_fourslash_virtual_content(file_path: &str, content: &str) -> String {
-        let has_virtual_lines = content
-            .lines()
-            .any(|line| line.trim_start().starts_with("////"));
-        if !has_virtual_lines {
+        if !Self::is_fourslash_virtual_harness_path(file_path) {
             return content.to_string();
         }
-        let looks_like_fourslash = file_path.contains("fourslash")
-            || content.contains("fourslash.ts")
-            || content.contains("verify.codeFix")
-            || content.contains("verify.codeFixAll");
-        if !looks_like_fourslash {
+        if !content
+            .lines()
+            .any(|line| line.trim_start().starts_with("////"))
+        {
             return content.to_string();
         }
 

--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -121,6 +121,27 @@ fn test_line_offset_to_byte_end_of_line() {
 }
 
 #[test]
+fn test_normalize_fourslash_virtual_content_rewrites_harness_lines() {
+    let content = "//// const x = 1;\n//// x;\n";
+    let normalized = Server::normalize_fourslash_virtual_content("/fourslash.ts", content);
+    assert_eq!(normalized, " const x = 1;\n x;");
+}
+
+#[test]
+fn test_normalize_fourslash_virtual_content_keeps_non_harness_files_unchanged() {
+    let content = "//// const x = 1;\n//// x;\n";
+    let normalized = Server::normalize_fourslash_virtual_content("/workspace/src/app.ts", content);
+    assert_eq!(normalized, content);
+}
+
+#[test]
+fn test_normalize_fourslash_virtual_content_keeps_plain_harness_content_unchanged() {
+    let content = "// @module: none\nconst x = 1;\n";
+    let normalized = Server::normalize_fourslash_virtual_content("/fourslash.ts", content);
+    assert_eq!(normalized, content);
+}
+
+#[test]
 fn test_line_offset_to_byte_mid_line() {
     // Offset 3 (1-based) on line 1 means col 2 (0-based) -> byte 2
     assert_eq!(Server::line_offset_to_byte("hello\nworld\n", 1, 3), 2);


### PR DESCRIPTION
## Summary
- stop rewriting file content based on heuristic marker text alone
- only apply `////` fourslash normalization for explicit virtual harness paths
- add focused unit tests proving harness paths rewrite while normal source files remain untouched

## Why
This trims test-fixture coupling from runtime tsserver behavior so real user files are not transformed just because they contain marker-like text.

## Validation
- `cargo test -p tsz-cli --bin tsz-server test_normalize_fourslash_virtual_content -- --nocapture`
- `cargo fmt --all --check`
