### PR TITLE
config: support compilerOptions.sound in tsconfig

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -182,6 +182,9 @@ pub struct CompilerOptions {
     pub incremental: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub strict: Option<bool>,
+    /// Enable experimental Sound Mode checks.
+    #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+    pub sound: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
     pub no_emit: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_bool_or_string")]
@@ -893,6 +896,10 @@ pub fn resolve_compiler_options(
             resolved.checker.strict_builtin_iterator_return = false;
             resolved.printer.always_strict = false;
         }
+    }
+
+    if let Some(sound) = options.sound {
+        resolved.checker.sound_mode = sound;
     }
 
     // tsc 6.0 defaults: strict-family options are true when not explicitly set.
@@ -2627,6 +2634,7 @@ fn compiler_option_expected_type(key: &str) -> &'static str {
         | "skipLibCheck"
         | "sourceMap"
         | "strict"
+        | "sound"
         | "strictBindCallApply"
         | "strictBuiltinIteratorReturn"
         | "strictFunctionTypes"
@@ -2780,6 +2788,7 @@ fn known_compiler_option(key_lower: &str) -> Option<&'static str> {
         "sourcemap" => Some("sourceMap"),
         "sourceroot" => Some("sourceRoot"),
         "strict" => Some("strict"),
+        "sound" => Some("sound"),
         "strictbindcallapply" => Some("strictBindCallApply"),
         "strictbuiltiniteratorreturn" => Some("strictBuiltinIteratorReturn"),
         "strictfunctiontypes" => Some("strictFunctionTypes"),
@@ -3257,6 +3266,7 @@ fn merge_compiler_options(base: CompilerOptions, child: CompilerOptions) -> Comp
             ts_build_info_file,
             incremental,
             strict,
+            sound,
             no_emit,
             no_emit_on_error,
             isolated_modules,
@@ -5772,6 +5782,44 @@ mod tests {
         let resolved = resolve_compiler_options(parsed.config.compiler_options.as_ref()).unwrap();
 
         assert!(resolved.checker.no_property_access_from_index_signature);
+    }
+
+    #[test]
+    fn test_sound_resolves_from_tsconfig() {
+        let source = r#"{
+            "compilerOptions": {
+                "sound": true
+            }
+        }"#;
+        let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+        assert!(
+            parsed
+                .diagnostics
+                .iter()
+                .all(|diag| diag.code != diagnostic_codes::UNKNOWN_COMPILER_OPTION),
+            "sound should be recognized as a compiler option, got diagnostics: {:?}",
+            parsed.diagnostics
+        );
+        let resolved = resolve_compiler_options(parsed.config.compiler_options.as_ref()).unwrap();
+        assert!(resolved.checker.sound_mode);
+    }
+
+    #[test]
+    fn test_sound_mis_cased_option_reports_did_you_mean() {
+        let source = r#"{
+            "compilerOptions": {
+                "Sound": true
+            }
+        }"#;
+        let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+        assert!(
+            parsed
+                .diagnostics
+                .iter()
+                .any(|diag| diag.code == diagnostic_codes::UNKNOWN_COMPILER_OPTION_DID_YOU_MEAN),
+            "Expected TS5025-style diagnostic for miscased sound option, got: {:?}",
+            parsed.diagnostics
+        );
     }
 
     #[test]

--- a/docs/plan/SOUND_MODE.md
+++ b/docs/plan/SOUND_MODE.md
@@ -23,15 +23,23 @@ Once the contract stabilizes, this doc should split into separate status, contra
 ## Quick Start
 
 ```bash
-# Enable sound mode via CLI (current implementation and only supported entrypoint today)
+# Enable sound mode via CLI
 tsz check --sound src/
 ```
 
-Planned configuration surfaces such as tsconfig support or per-file pragmas are not wired yet, and the public config shape is intentionally still open.
+```json
+{
+  "compilerOptions": {
+    "sound": true
+  }
+}
+```
+
+Per-file pragmas and broader `sound*` option families are still not wired, and the full public config shape remains intentionally open.
 
 ## Implementation Status
 
-Today, sound mode is effectively a **CLI-only boolean** (`--sound`). The planned `sound` tsconfig option, per-file pragma, and server/LSP exposure are not wired yet. The live implementation works by tightening the existing Lawyer (`CompatChecker`) with `strict_subtype_checking` and `strict_any_propagation` flags on `RelationPolicy`. Errors are still emitted as standard TS diagnostic codes (TS2322, TS2345, etc.), not dedicated TSZ-family sound diagnostics yet.
+Today, sound mode is a project-wide boolean exposed through both CLI (`--sound`) and tsconfig (`compilerOptions.sound`). Per-file pragmas and server/LSP exposure are not wired yet. The live implementation works by tightening the existing Lawyer (`CompatChecker`) with `strict_subtype_checking` and `strict_any_propagation` flags on `RelationPolicy`. Errors are still emitted as standard TS diagnostic codes (TS2322, TS2345, etc.), not dedicated TSZ-family sound diagnostics yet.
 
 **Note on diagnostic codes:** The codebase defines `SoundDiagnosticCode` with codes TS9001–TS9005 in `crates/tsz-solver/src/sound.rs`. Those should be treated as temporary implementation placeholders, not the public contract. This doc uses the target **family-based TSZNNNN taxonomy** (`TSZ1000`, `TSZ2000`, etc.), which has not yet been applied to the implementation. A `DiagnosticDomain::Sound` infrastructure exists but is not yet used by the checker.
 
@@ -50,7 +58,7 @@ Today, sound mode is effectively a **CLI-only boolean** (`--sound`). The planned
 - `SoundLawyer` struct in `sound.rs` is fully defined but never called from the checker pipeline (dead code)
 - `SoundModeConfig` struct with granular flags is defined but never consumed
 - cache correctness still needs a precise sound-policy audit: method-bivariance disablement is now represented in relation flags, but `strict_any_propagation` still piggybacks on `FLAG_STRICT_FUNCTION_TYPES`, and some query-cache helper paths still construct keys with `any_mode = 0`
-- The tsconfig `sound` option described in this doc is not currently parsed into `CheckerOptions`
+- Only `compilerOptions.sound` is currently wired; broader flat `sound*` family options remain planned
 - `tsz-server` / LSP currently hardcodes `sound_mode: false`
 - CLI help / dead prototype code still reference older `TS900x` semantics and should not be treated as the product contract
 
@@ -79,7 +87,7 @@ Important limits:
 
 Today, even that narrow target is not fully implemented:
 
-1. Sound mode is effectively a CLI-only project-wide boolean.
+1. Sound mode is currently a project-wide boolean from CLI (`--sound`) or tsconfig (`compilerOptions.sound`).
 2. Method bivariance tightening is live.
 3. `any` handling is only partial: nested restrictions exist, but top-level `any` still behaves too permissively.
 4. Declaration-boundary quarantine is **not** implemented.


### PR DESCRIPTION
## Summary
- add `compilerOptions.sound` to tsconfig parsing and resolution
- recognize `sound` in compiler-option diagnostics/type validation/extends merging
- update sound-mode plan doc status to reflect current wiring (`--sound` + `compilerOptions.sound`)
- add config tests for recognized/miscased `sound` behavior

## Why
Phase-1 dogfooding needs a flat tsconfig entrypoint so teams can enable sound mode without only relying on CLI flags.

## Validation
- `cargo test -p tsz-core sound_ -- --nocapture`
- `cargo fmt --all --check`
