### PR TITLE
ci/metrics: carry emit skip and timeout counts to docs

### DIFF
--- a/crates/tsz-website/src/_data/metrics.js
+++ b/crates/tsz-website/src/_data/metrics.js
@@ -47,32 +47,52 @@ function suiteSourceLabel(source) {
   }
 }
 
+function formatEmitExtra(skipped, timeouts = 0) {
+  const parts = [];
+  if (Number.isFinite(skipped) && skipped > 0) {
+    parts.push(`${fmt(skipped)} skipped`);
+  }
+  if (Number.isFinite(timeouts) && timeouts > 0) {
+    parts.push(`${fmt(timeouts)} timed out`);
+  }
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+function parseEmitExtraFromReadmeLine(line) {
+  const m = line.match(/\([^)]*tests;\s*([^)]*)\)/);
+  if (!m || !m[1]) return "";
+  const extra = m[1].trim();
+  return extra ? ` (${extra})` : "";
+}
+
 function setSuiteUnavailable(metrics, key) {
   metrics[`${key}_rate`] = "N/A";
   metrics[`${key}_rate_label`] = "N/A";
   metrics[`${key}_bar_rate`] = "0";
   metrics[`${key}_passed`] = "N/A";
   metrics[`${key}_total`] = "N/A";
+  metrics[`${key}_extra`] = "";
   metrics[`${key}_source`] = "missing";
   metrics[`${key}_source_label`] = suiteSourceLabel("missing");
 }
 
-function setSuiteMetrics(metrics, key, rate, passed, total, source) {
+function setSuiteMetrics(metrics, key, rate, passed, total, source, extra = "") {
   const normalizedRate = Number(rate).toFixed(1);
   metrics[`${key}_rate`] = normalizedRate;
   metrics[`${key}_rate_label`] = `${normalizedRate}%`;
   metrics[`${key}_bar_rate`] = normalizedRate;
   metrics[`${key}_passed`] = fmt(passed);
   metrics[`${key}_total`] = fmt(total);
+  metrics[`${key}_extra`] = extra;
   metrics[`${key}_source`] = source;
   metrics[`${key}_source_label`] = suiteSourceLabel(source);
 }
 
-function setSuiteIfValid(metrics, key, rate, passed, total, source) {
+function setSuiteIfValid(metrics, key, rate, passed, total, source, extra = "") {
   if (rate === null || passed === null || total === null || total <= 0) {
     return false;
   }
-  setSuiteMetrics(metrics, key, rate, passed, total, source);
+  setSuiteMetrics(metrics, key, rate, passed, total, source, extra);
   return true;
 }
 
@@ -118,6 +138,7 @@ function extractMetrics() {
         toInt(emit.js_passed),
         toInt(emit.js_total),
         "ci",
+        formatEmitExtra(toInt(emit.js_skipped), toInt(emit.js_timeouts)),
       )
     : false;
   const hasCiEmitDts = emit
@@ -128,6 +149,7 @@ function extractMetrics() {
         toInt(emit.dts_passed),
         toInt(emit.dts_total),
         "ci",
+        formatEmitExtra(toInt(emit.dts_skipped)),
       )
     : false;
   const hasCiFourslash = fourslash
@@ -176,6 +198,7 @@ function extractMetrics() {
               toInt(m[2]),
               toInt(m[3]),
               "readme",
+              parseEmitExtraFromReadmeLine(line),
             );
           } else if (!hasCiEmitDts && line.includes("Declaration")) {
             setSuiteIfValid(
@@ -185,6 +208,7 @@ function extractMetrics() {
               toInt(m[2]),
               toInt(m[3]),
               "readme",
+              parseEmitExtraFromReadmeLine(line),
             );
           }
         }

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -32,13 +32,13 @@ Currently targeting **TypeScript `{{ metrics.ts_version }}`**
 <div class="progress-row">
   <span class="progress-label">JS Emit</span>
   <div class="progress-bar"><div class="progress-fill emit-js" style="width: {{ metrics.emit_js_bar_rate }}%"></div></div>
-  <span class="progress-stat">{{ metrics.emit_js_rate_label }} - {{ metrics.emit_js_passed }}/{{ metrics.emit_js_total }}</span>
+  <span class="progress-stat">{{ metrics.emit_js_rate_label }} - {{ metrics.emit_js_passed }}/{{ metrics.emit_js_total }}{{ metrics.emit_js_extra }}</span>
 </div>
 
 <div class="progress-row">
   <span class="progress-label">Declaration Emit</span>
   <div class="progress-bar"><div class="progress-fill emit-dts" style="width: {{ metrics.emit_dts_bar_rate }}%"></div></div>
-  <span class="progress-stat">{{ metrics.emit_dts_rate_label }} - {{ metrics.emit_dts_passed }}/{{ metrics.emit_dts_total }}</span>
+  <span class="progress-stat">{{ metrics.emit_dts_rate_label }} - {{ metrics.emit_dts_passed }}/{{ metrics.emit_dts_total }}{{ metrics.emit_dts_extra }}</span>
 </div>
 
 <div class="progress-row">

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -414,21 +414,29 @@ run_emit_shards() {
     (
       set +e
       offset=$((shard * EMIT_CHUNK))
+      detail_json="$METRICS_DIR/emit-detail-${shard}.json"
       ./scripts/emit/run.sh --skip-build --max="$EMIT_CHUNK" --offset="$offset" --concurrency="$SHARD_WORKERS" \
+        --json-out="$detail_json" \
         >"$LOG_DIR/emit/shard-${shard}.log" 2>&1
       rc="$?"
-      js_line="$(grep -a 'Pass Rate:' "$LOG_DIR/emit/shard-${shard}.log" | sed -n '1p' || true)"
-      dts_line="$(grep -a 'Pass Rate:' "$LOG_DIR/emit/shard-${shard}.log" | sed -n '2p' || true)"
-      js_counts="$(echo "$js_line" | grep -oE '\([0-9]+/[0-9]+\)' | tr -d '()' || true)"
-      dts_counts="$(echo "$dts_line" | grep -oE '\([0-9]+/[0-9]+\)' | tr -d '()' || true)"
-      js_p="$(num_or_zero "$(echo "$js_counts" | cut -d/ -f1)")"
-      js_t="$(num_or_zero "$(echo "$js_counts" | cut -d/ -f2)")"
-      dts_p="$(num_or_zero "$(echo "$dts_counts" | cut -d/ -f1)")"
-      dts_t="$(num_or_zero "$(echo "$dts_counts" | cut -d/ -f2)")"
-      printf '{"shard":%s,"rc":%s,"js_passed":%s,"js_total":%s,"dts_passed":%s,"dts_total":%s}\n' \
-        "$shard" "$rc" "$js_p" "$js_t" "$dts_p" "$dts_t" \
+      js_p="$(jq -r '.summary.jsPass // 0' "$detail_json" 2>/dev/null || echo 0)"
+      js_t="$(jq -r '.summary.jsTotal // 0' "$detail_json" 2>/dev/null || echo 0)"
+      js_s="$(jq -r '.summary.jsSkip // 0' "$detail_json" 2>/dev/null || echo 0)"
+      js_to="$(jq -r '.summary.jsTimeout // 0' "$detail_json" 2>/dev/null || echo 0)"
+      dts_p="$(jq -r '.summary.dtsPass // 0' "$detail_json" 2>/dev/null || echo 0)"
+      dts_t="$(jq -r '.summary.dtsTotal // 0' "$detail_json" 2>/dev/null || echo 0)"
+      dts_s="$(jq -r '.summary.dtsSkip // 0' "$detail_json" 2>/dev/null || echo 0)"
+      js_p="$(num_or_zero "$js_p")"
+      js_t="$(num_or_zero "$js_t")"
+      js_s="$(num_or_zero "$js_s")"
+      js_to="$(num_or_zero "$js_to")"
+      dts_p="$(num_or_zero "$dts_p")"
+      dts_t="$(num_or_zero "$dts_t")"
+      dts_s="$(num_or_zero "$dts_s")"
+      printf '{"shard":%s,"rc":%s,"js_passed":%s,"js_total":%s,"js_skipped":%s,"js_timeouts":%s,"dts_passed":%s,"dts_total":%s,"dts_skipped":%s}\n' \
+        "$shard" "$rc" "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" \
         > "$METRICS_DIR/emit-shard-${shard}.json"
-      echo "EMIT_SHARD shard=${shard} rc=${rc} js=${js_p}/${js_t} dts=${dts_p}/${dts_t}"
+      echo "EMIT_SHARD shard=${shard} rc=${rc} js=${js_p}/${js_t} skip=${js_s} timeout=${js_to} dts=${dts_p}/${dts_t} skip=${dts_s}"
       exit 0
     ) &
   done
@@ -437,23 +445,42 @@ run_emit_shards() {
 
 aggregate_emit() {
   ci_section "Aggregate emit"
-  local js_passed=0 js_total=0 dts_passed=0 dts_total=0 shard_count=0
+  local js_passed=0 js_total=0 js_skipped=0 js_timeouts=0 dts_passed=0 dts_total=0 dts_skipped=0 shard_count=0
   for f in "$METRICS_DIR"/emit-shard-*.json; do
     [[ -f "$f" ]] || continue
     js_passed=$((js_passed + $(jq -r '.js_passed' "$f")))
     js_total=$((js_total + $(jq -r '.js_total' "$f")))
+    js_skipped=$((js_skipped + $(jq -r '.js_skipped // 0' "$f")))
+    js_timeouts=$((js_timeouts + $(jq -r '.js_timeouts // 0' "$f")))
     dts_passed=$((dts_passed + $(jq -r '.dts_passed' "$f")))
     dts_total=$((dts_total + $(jq -r '.dts_total' "$f")))
+    dts_skipped=$((dts_skipped + $(jq -r '.dts_skipped // 0' "$f")))
     shard_count=$((shard_count + 1))
   done
 
   echo "Emit shards: ${shard_count}/${SHARD_COUNT}"
-  echo "Emit aggregate: JS ${js_passed}/${js_total}, DTS ${dts_passed}/${dts_total}"
+  echo "Emit aggregate: JS ${js_passed}/${js_total} (skip=${js_skipped}, timeout=${js_timeouts}), DTS ${dts_passed}/${dts_total} (skip=${dts_skipped})"
 
   if [[ "$shard_count" -lt "$SHARD_COUNT" || "$js_total" -eq 0 ]]; then
     echo "error: emit shard coverage is not trustworthy" >&2
     return 1
   fi
+
+  js_rate="$(awk -v p="$js_passed" -v t="$js_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
+  dts_rate="$(awk -v p="$dts_passed" -v t="$dts_total" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
+  jq -n \
+    --arg suite "emit" \
+    --arg js_pass_rate "$js_rate" \
+    --argjson js_passed "$js_passed" \
+    --argjson js_total "$js_total" \
+    --argjson js_skipped "$js_skipped" \
+    --argjson js_timeouts "$js_timeouts" \
+    --arg dts_pass_rate "$dts_rate" \
+    --argjson dts_passed "$dts_passed" \
+    --argjson dts_total "$dts_total" \
+    --argjson dts_skipped "$dts_skipped" \
+    '{suite:$suite, js_pass_rate:$js_pass_rate, js_passed:$js_passed, js_total:$js_total, js_skipped:$js_skipped, js_timeouts:$js_timeouts, dts_pass_rate:$dts_pass_rate, dts_passed:$dts_passed, dts_total:$dts_total, dts_skipped:$dts_skipped}' \
+    > "$METRICS_DIR/emit.json"
 
   base_js="$(jq -r '.summary.jsPass // 0' scripts/emit/emit-snapshot.json)"
   base_dts="$(jq -r '.summary.dtsPass // 0' scripts/emit/emit-snapshot.json)"

--- a/scripts/update-readme-from-ci-metrics.mjs
+++ b/scripts/update-readme-from-ci-metrics.mjs
@@ -103,14 +103,24 @@ if (emit) {
   const jsRate = toNumber(emit.js_pass_rate);
   const jsPassed = toInt(emit.js_passed);
   const jsTotal = toInt(emit.js_total);
+  const jsSkipped = toInt(emit.js_skipped) ?? 0;
+  const jsTimeouts = toInt(emit.js_timeouts) ?? 0;
   const dtsRate = toNumber(emit.dts_pass_rate);
   const dtsPassed = toInt(emit.dts_passed);
   const dtsTotal = toInt(emit.dts_total);
+  const dtsSkipped = toInt(emit.dts_skipped) ?? 0;
   if (validSuiteMetrics(jsRate, jsPassed, jsTotal) && validSuiteMetrics(dtsRate, dtsPassed, dtsTotal)) {
+    const jsExtras = [];
+    if (jsSkipped > 0) jsExtras.push(`${formatInt(jsSkipped)} skipped`);
+    if (jsTimeouts > 0) jsExtras.push(`${formatInt(jsTimeouts)} timed out`);
+    const dtsExtras = [];
+    if (dtsSkipped > 0) dtsExtras.push(`${formatInt(dtsSkipped)} skipped`);
+    const jsSuffix = jsExtras.length > 0 ? `; ${jsExtras.join(", ")}` : "";
+    const dtsSuffix = dtsExtras.length > 0 ? `; ${dtsExtras.join(", ")}` : "";
     const block = [
       "```",
-      `JavaScript:  [${progressBar(jsRate)}] ${formatRate(jsRate)}% (${formatInt(jsPassed)} / ${formatInt(jsTotal)} tests)`,
-      `Declaration: [${progressBar(dtsRate)}] ${formatRate(dtsRate)}% (${formatInt(dtsPassed)} / ${formatInt(dtsTotal)} tests)`,
+      `JavaScript:  [${progressBar(jsRate)}] ${formatRate(jsRate)}% (${formatInt(jsPassed)} / ${formatInt(jsTotal)} tests${jsSuffix})`,
+      `Declaration: [${progressBar(dtsRate)}] ${formatRate(dtsRate)}% (${formatInt(dtsPassed)} / ${formatInt(dtsTotal)} tests${dtsSuffix})`,
       "```",
     ].join("\n");
     const updated = replaceSection(readme, "<!-- EMIT_START -->", "<!-- EMIT_END -->", block);


### PR DESCRIPTION
## Summary
- switch emit shard metrics extraction to `--json-out` summary data instead of fragile log scraping
- aggregate and publish emit `js_skipped`, `js_timeouts`, and `dts_skipped` in CI artifacts
- show skip/timeout context in emit step summaries and published emit metrics JSON
- render emit skip/timeout context in README update output and website progress rows

## Why
Emit pass-rate denominators currently exclude skipped tests, but that context is lost in published metrics. This adds transparent skip/timeout metadata end-to-end so dashboards and docs are easier to interpret.

## Validation
- `node --check scripts/update-readme-from-ci-metrics.mjs`
- `node --check crates/tsz-website/src/_data/metrics.js`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
