### PR TITLE
refactor(solver): TypeSubstitution::single constructor + sweep 19 callsites

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -885,8 +885,7 @@ impl<'a> CheckerState<'a> {
         for key_name in string_keys {
             let remapped_names: Vec<Atom> = if let Some(name_type) = mapped.name_type {
                 let key_literal = self.ctx.types.literal_string_atom(key_name);
-                let mut subst = TypeSubstitution::new();
-                subst.insert(mapped.type_param.name, key_literal);
+                let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
                 let instantiated_name = instantiate_type(self.ctx.types, name_type, &subst);
                 let remapped = self.evaluate_type_with_env(instantiated_name);
                 if remapped == TypeId::NEVER {

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -1365,8 +1365,7 @@ impl<'a> CheckerState<'a> {
 
                 // Create a substitution mapping the mapped type's key param to this literal key
                 let key_literal = self.ctx.types.literal_string(&name);
-                let mut subst = common::TypeSubstitution::new();
-                subst.insert(type_param_name, key_literal);
+                let subst = common::TypeSubstitution::single(type_param_name, key_literal);
 
                 // Instantiate the template with this key
                 let instantiated_template =

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -199,8 +199,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
 
                 if check_type == TypeId::ANY {
-                    let mut subst = TypeSubstitution::new();
-                    subst.insert(info.name, check_type);
+                    let subst = TypeSubstitution::single(info.name, check_type);
                     let true_eval = self.evaluate(instantiate_type_with_infer(
                         self.interner(),
                         cond.true_type,
@@ -214,8 +213,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     return self.interner().union2(true_eval, false_eval);
                 }
 
-                let mut subst = TypeSubstitution::new();
-                subst.insert(info.name, check_type);
+                let mut subst = TypeSubstitution::single(info.name, check_type);
                 let mut inferred = check_type;
                 if let Some(constraint) = info.constraint {
                     let mut checker =
@@ -1002,8 +1000,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.evaluate(cond.false_type);
         };
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(info.name, inferred);
+        let mut subst = TypeSubstitution::single(info.name, inferred);
 
         if let Some(constraint) = info.constraint {
             let mut checker = SubtypeChecker::with_resolver(self.interner(), self.resolver());
@@ -1109,8 +1106,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.evaluate(cond.false_type);
         };
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(info.name, inferred);
+        let mut subst = TypeSubstitution::single(info.name, inferred);
 
         if let Some(constraint) = info.constraint {
             let mut checker = SubtypeChecker::with_resolver(self.interner(), self.resolver());
@@ -1291,8 +1287,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.evaluate(cond.false_type);
         };
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(info.name, inferred);
+        let mut subst = TypeSubstitution::single(info.name, inferred);
 
         if let Some(constraint) = info.constraint {
             let mut checker = SubtypeChecker::with_resolver(self.interner(), self.resolver());
@@ -1535,8 +1530,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return self.evaluate(cond.false_type);
         };
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(info.name, inferred);
+        let mut subst = TypeSubstitution::single(info.name, inferred);
 
         if let Some(constraint) = info.constraint {
             let mut checker = SubtypeChecker::with_resolver(self.interner(), self.resolver());

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -103,8 +103,7 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
             is_const: mapped.type_param.is_const,
         });
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, constrained_key);
+        let subst = TypeSubstitution::single(mapped.type_param.name, constrained_key);
 
         let mut value_type = self.evaluator.evaluate(instantiate_type(
             self.evaluator.interner(),
@@ -861,8 +860,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
                 return Some(self.instantiate_mapped_template_with_constraint_param(&mapped));
             }
 
-            let mut subst = TypeSubstitution::new();
-            subst.insert(mapped.type_param.name, self.index_type);
+            let subst = TypeSubstitution::single(mapped.type_param.name, self.index_type);
 
             let value_type = self.evaluator.evaluate(instantiate_type(
                 self.evaluator.interner(),
@@ -1450,8 +1448,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
 
         // Substitute K into the mapped template
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, index_type);
+        let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
 
         let value_type = self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -47,8 +47,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             "remap_key_type_for_mapped: before substitution"
         );
 
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, key_type);
+        let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
         let remapped = instantiate_type(self.interner(), name_type, &subst);
 
         tracing::trace!(
@@ -1260,9 +1259,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ///
     /// We instantiate the template with `K = number` to get the mapped element type.
     fn evaluate_mapped_array(&mut self, mapped: &MappedType, _element_type: TypeId) -> TypeId {
-        // Create substitution: type_param.name -> number
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, TypeId::NUMBER);
+        let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
 
         // Substitute into the template to get the mapped element type
         let mut mapped_element =
@@ -1296,9 +1293,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         _element_type: TypeId,
         is_readonly: bool,
     ) -> TypeId {
-        // Create substitution: type_param.name -> number
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, TypeId::NUMBER);
+        let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
 
         // Substitute into the template to get the mapped element type
         let mut mapped_element =
@@ -1359,8 +1354,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     _ => {
                         // Fallback: try index substitution (may not work correctly)
                         let index_type = self.interner().literal_number(i as f64);
-                        let mut subst = TypeSubstitution::new();
-                        subst.insert(mapped.type_param.name, index_type);
+                        let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
                         self.evaluate(instantiate_type(self.interner(), mapped.template, &subst))
                     }
                 };
@@ -1386,9 +1380,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Create a literal number type for this tuple position
             let index_type = self.interner().literal_number(i as f64);
 
-            // Create substitution: type_param.name -> literal number
-            let mut subst = TypeSubstitution::new();
-            subst.insert(mapped.type_param.name, index_type);
+            let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
 
             // Substitute into the template to get the mapped element type
             let mapped_type =

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -573,8 +573,7 @@ impl<'a> InferenceContext<'a> {
             let template_priority = InferencePriority::MappedType;
             for prop in &source.properties {
                 let key_literal = self.interner.literal_string_atom(prop.name);
-                let mut subst = TypeSubstitution::new();
-                subst.insert(mapped.type_param.name, key_literal);
+                let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
                 let instantiated_template =
                     instantiate_type(self.interner, mapped.template, &subst);
                 // Use the partially inferable version of the source property type.
@@ -693,8 +692,7 @@ impl<'a> InferenceContext<'a> {
         let template_priority = InferencePriority::MappedType;
         for (i, elem) in source_elems.iter().enumerate() {
             let key_literal = name_literals[i];
-            let mut subst = TypeSubstitution::new();
-            subst.insert(iter_param_name, key_literal);
+            let subst = TypeSubstitution::single(iter_param_name, key_literal);
             let instantiated_template = instantiate_type(self.interner, mapped.template, &subst);
             let inferable_elem_type = self.get_partially_inferable_type(elem.type_id);
             self.infer_from_types(

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -150,8 +150,7 @@ impl<'a> InferenceContext<'a> {
         if !self_referential_bounds.is_empty() && result != TypeId::ANY {
             let names = self.type_param_names_for_root(root);
             if let Some(&param_name) = names.first() {
-                let mut sub = TypeSubstitution::new();
-                sub.insert(param_name, result);
+                let sub = TypeSubstitution::single(param_name, result);
                 for &bound in &self_referential_bounds {
                     let instantiated_bound = instantiate_type(self.interner, bound, &sub);
                     if !self.is_subtype(result, instantiated_bound) {
@@ -222,8 +221,7 @@ impl<'a> InferenceContext<'a> {
         if !self_referential_bounds.is_empty() && result != TypeId::ANY {
             let names = self.type_param_names_for_root(root);
             if let Some(&param_name) = names.first() {
-                let mut sub = TypeSubstitution::new();
-                sub.insert(param_name, result);
+                let sub = TypeSubstitution::single(param_name, result);
                 for &bound in &self_referential_bounds {
                     let instantiated_bound = instantiate_type(self.interner, bound, &sub);
                     if !is_subtype(result, instantiated_bound) {

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -39,6 +39,14 @@ impl TypeSubstitution {
         }
     }
 
+    /// Create a substitution containing a single `name -> type_id` binding.
+    /// Equivalent to `let mut s = TypeSubstitution::new(); s.insert(name, type_id);`.
+    pub fn single(name: Atom, type_id: TypeId) -> Self {
+        let mut map = FxHashMap::default();
+        map.insert(name, type_id);
+        Self { map }
+    }
+
     /// Clear the substitution for reuse, preserving allocated capacity.
     #[inline]
     pub fn clear(&mut self) {
@@ -941,8 +949,7 @@ impl<'a> TypeInstantiator<'a> {
                             let new_template = self.instantiate(mapped.template);
                             self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
-                            let mut subst = TypeSubstitution::new();
-                            subst.insert(mapped.type_param.name, TypeId::NUMBER);
+                            let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
                             let mapped_element = crate::evaluation::evaluate::evaluate_type(
                                 self.interner,
                                 instantiate_type(self.interner, new_template, &subst),
@@ -1013,8 +1020,7 @@ impl<'a> TypeInstantiator<'a> {
                         let mut new_elements = Vec::with_capacity(elements.len());
                         for (i, elem) in elements.iter().enumerate() {
                             let key_type = self.interner.literal_string(&i.to_string());
-                            let mut subst = TypeSubstitution::new();
-                            subst.insert(mapped.type_param.name, key_type);
+                            let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
                             let mapped_type = crate::evaluation::evaluate::evaluate_type(
                                 self.interner,
                                 instantiate_type(self.interner, new_template, &subst),
@@ -1055,8 +1061,7 @@ impl<'a> TypeInstantiator<'a> {
                         let new_template = self.instantiate(mapped.template);
                         self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
-                        let mut subst = TypeSubstitution::new();
-                        subst.insert(mapped.type_param.name, TypeId::NUMBER);
+                        let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
                         let mapped_element = crate::evaluation::evaluate::evaluate_type(
                             self.interner,
                             crate::instantiation::instantiate::instantiate_type(

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -184,8 +184,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         for prop in &source_obj.properties {
             // Substitute the iteration parameter K with the property name literal
             let key_literal = self.interner.literal_string_atom(prop.name);
-            let mut subst = TypeSubstitution::new();
-            subst.insert(iter_param_name, key_literal);
+            let subst = TypeSubstitution::single(iter_param_name, key_literal);
             let instantiated_template = instantiate_type(self.interner, template, &subst);
 
             // Reverse-infer through the template: find what T[K] should be.
@@ -341,8 +340,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             let key_str = i.to_string();
             let key_atom = self.interner.intern_string(&key_str);
             let key_literal = self.interner.literal_string_atom(key_atom);
-            let mut subst = TypeSubstitution::new();
-            subst.insert(iter_param_name, key_literal);
+            let subst = TypeSubstitution::single(iter_param_name, key_literal);
             let instantiated_template = instantiate_type(self.interner, template, &subst);
 
             // Reverse-infer through the template: find what T[K] should be.
@@ -735,8 +733,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 for prop in &source_props {
                     // Instantiate the mapped template with the concrete key
                     let key_literal = self.interner.literal_string_atom(prop.name);
-                    let mut subst = TypeSubstitution::new();
-                    subst.insert(mapped.type_param.name, key_literal);
+                    let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
                     let instantiated_template =
                         instantiate_type(self.interner, mapped.template, &subst);
 

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -2101,8 +2101,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let iter_param_name = mapped.type_param.name;
         for prop in properties {
             let key_literal = self.interner.literal_string_atom(prop.name);
-            let mut subst = TypeSubstitution::new();
-            subst.insert(iter_param_name, key_literal);
+            let subst = TypeSubstitution::single(iter_param_name, key_literal);
             let instantiated_template = instantiate_type(self.interner, mapped.template, &subst);
             self.constrain_types(ctx, var_map, prop.type_id, instantiated_template, priority);
         }

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -81,8 +81,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
         // Handle name remapping if present (e.g., `as` clause in mapped types)
         if let Some(name_type) = mapped.name_type {
-            let mut subst = TypeSubstitution::new();
-            subst.insert(mapped.type_param.name, key_literal);
+            let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
             let remapped = instantiate_type(self.interner(), name_type, &subst);
             let remapped = self
                 .db
@@ -116,8 +115,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             self.db
                 .evaluate_type_with_options(index_access, self.no_unchecked_indexed_access)
         } else {
-            let mut subst = TypeSubstitution::new();
-            subst.insert(mapped.type_param.name, key_literal);
+            let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
             let instantiated = instantiate_type(self.interner(), mapped.template, &subst);
             self.db
                 .evaluate_type_with_options(instantiated, self.no_unchecked_indexed_access)
@@ -181,8 +179,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
         // Get the element type mapping: instantiate template with `number` as the key
         let number_type = TypeId::NUMBER;
-        let mut subst = TypeSubstitution::new();
-        subst.insert(mapped.type_param.name, number_type);
+        let subst = TypeSubstitution::single(mapped.type_param.name, number_type);
         let mapped_element = instantiate_type(self.interner(), mapped.template, &subst);
         let mapped_element = self
             .db

--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -184,8 +184,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
             if !is_non_deterministic {
                 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
-                let mut sub = TypeSubstitution::new();
-                sub.insert(param_info.name, constraint);
+                let sub = TypeSubstitution::single(param_info.name, constraint);
                 let cond_type_id = self.interner.conditional(*cond);
                 let instantiated = instantiate_type(self.interner, cond_type_id, &sub);
                 if instantiated != cond_type_id {
@@ -411,8 +410,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // with a type that satisfies the extends clause.
                     // Substitute source for check_type in the true branch.
                     use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
-                    let mut sub = TypeSubstitution::new();
-                    sub.insert(param_info.name, source);
+                    let sub = TypeSubstitution::single(param_info.name, source);
                     let instantiated_true = instantiate_type(self.interner, target.true_type, &sub);
                     let evaluated = self.evaluate_type(instantiated_true);
                     if self.check_subtype(source, evaluated).is_true() {

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -1434,8 +1434,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 return None;
             }
 
-            let mut subst = TypeSubstitution::new();
-            subst.insert(param.name, constraint);
+            let subst = TypeSubstitution::single(param.name, constraint);
             // Use keyof(constraint) directly to prevent eager evaluation
             // which would break array/tuple preservation in evaluate_mapped.
             let inst_constraint = self.interner.keyof(constraint);
@@ -1615,8 +1614,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.interner.literal_string_atom(key_name)
             };
 
-            let mut subst = TypeSubstitution::new();
-            subst.insert(mapped.type_param.name, key_literal);
+            let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
 
             let remapped_names: Vec<tsz_common::interner::Atom> = if let Some(name_type) =
                 mapped.name_type

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -597,8 +597,7 @@ pub fn instantiate_mapped_template_for_property(
     }
 
     // Normal path: substitute the key parameter name with the key literal
-    let mut subst = TypeSubstitution::new();
-    subst.insert(key_param_name, key_literal);
+    let subst = TypeSubstitution::single(key_param_name, key_literal);
     instantiate_type(db, template, &subst)
 }
 

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -27,8 +27,7 @@ fn remap_mapped_property_key(
 
     use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 
-    let mut subst = TypeSubstitution::new();
-    subst.insert(mapped.type_param.name, source_key);
+    let subst = TypeSubstitution::single(mapped.type_param.name, source_key);
     crate::evaluation::evaluate::evaluate_type(db, instantiate_type(db, name_type, &subst))
 }
 

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -46,6 +46,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - `DiagnosticCollector` report methods collapsed onto `collect_with` (#781).
 - Helpers extracted: `constrain_object_properties` (#790), `constrain_type_predicates` (#784), `constrain_template_against_properties` (#793), `infer_rest_param_tuple_candidate` (#786).
 - Walker type-predicate sites routed through shared helper (#791).
+- `TypeSubstitution::single(name, type_id)` constructor added; 19 single-binding callsites across conditional/mapped/index-access evaluation rules, inference resolve/matching, reverse-mapped and walker constraints, subtype generics/conditionals, property helpers, mapped/signature type queries, call_helpers and type_environment/core migrated off the `new() + insert()` pair.
 
 **tsz-emitter**
 - Numeric parse/radix callers moved to shared `tsz_common::numeric` primitive (#759, #768, #769).


### PR DESCRIPTION
## Summary
- Add `TypeSubstitution::single(name, type_id)` constructor for the common one-shot single-binding case.
- Migrate 19 `let mut s = TypeSubstitution::new(); s.insert(n, t);` pairs across solver and checker onto the new constructor.
- Leave loop-populated and multi-insert sites alone.

Sites migrated:
- solver: conditional/mapped/index-access evaluation rules, inference resolve + matching, reverse-mapped and walker constraints, subtype generics/conditionals, property_helpers, type_queries (mapped, signatures_and_advanced), instantiation/instantiate (internal).
- checker: `types/computation/call_helpers.rs`, `state/type_environment/core.rs`.

## Test plan
- [x] `cargo nextest run -p tsz-solver --lib` (5263 passed)
- [x] `cargo nextest run -p tsz-checker --lib` (2642 passed)
- [x] Pre-commit pipeline full 18,372 tests across 5 affected crates (all green)
- [x] Clippy zero warnings, wasm32 rustc gate, architecture guardrail