### PR TITLE
[codex] align string mapping TS2322 displays with tsc

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -971,6 +971,13 @@ impl<'a> CheckerState<'a> {
                 if display.contains('<') || display.contains('{') || display.contains('|') {
                     return None; // Already expanded
                 }
+                if display.starts_with('"')
+                    || display.starts_with('`')
+                    || display == "true"
+                    || display == "false"
+                {
+                    return None; // Keep concrete literal displays instead of repainting alias provenance.
+                }
                 // Only for types that have a display_alias (were produced by Application eval)
                 state.ctx.types.get_display_alias(ty)?;
                 let mut formatter = state

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1429,6 +1429,21 @@ impl<'a> CheckerState<'a> {
                     self.widen_fresh_object_literal_properties_for_display(target),
                 )
             };
+            let assignability_display =
+                self.format_assignability_type_for_message(display_target, source);
+            if assignability_display.starts_with('"')
+                || assignability_display.starts_with('`')
+                || assignability_display == "true"
+                || assignability_display == "false"
+                || (crate::query_boundaries::common::string_intrinsic_components(
+                    self.ctx.types,
+                    display_target,
+                )
+                .is_some()
+                    && assignability_display != fallback)
+            {
+                return assignability_display;
+            }
             // Generic callable targets preserve type alias names from annotations
             let target_is_generic_callable =
                 crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, target)
@@ -1482,12 +1497,46 @@ impl<'a> CheckerState<'a> {
         }
 
         if self.target_preserves_literal_surface(source) {
-            self.format_type_diagnostic(display_target)
+            let assignability_display =
+                self.format_assignability_type_for_message(display_target, source);
+            let fallback = self.format_type_diagnostic(display_target);
+            if assignability_display.starts_with('"')
+                || assignability_display.starts_with('`')
+                || assignability_display == "true"
+                || assignability_display == "false"
+                || (crate::query_boundaries::common::string_intrinsic_components(
+                    self.ctx.types,
+                    display_target,
+                )
+                .is_some()
+                    && assignability_display != fallback)
+            {
+                assignability_display
+            } else {
+                fallback
+            }
         } else {
             // Use diagnostic mode to avoid synthetic `?: undefined` in unions
-            self.format_type_diagnostic_widened(
+            let assignability_display =
+                self.format_assignability_type_for_message(display_target, source);
+            let fallback = self.format_type_diagnostic_widened(
                 self.widen_fresh_object_literal_properties_for_display(display_target),
-            )
+            );
+            if assignability_display.starts_with('"')
+                || assignability_display.starts_with('`')
+                || assignability_display == "true"
+                || assignability_display == "false"
+                || (crate::query_boundaries::common::string_intrinsic_components(
+                    self.ctx.types,
+                    display_target,
+                )
+                .is_some()
+                    && assignability_display != fallback)
+            {
+                assignability_display
+            } else {
+                fallback
+            }
         }
     }
 

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -164,6 +164,11 @@ impl<'a> CheckerState<'a> {
                 .is_some_and(|shape| !shape.type_params.is_empty())
         };
 
+        // Diagnostics for alias-wrapped string mappings and similar evaluated
+        // surfaces need nested lazy refs ready before we decide whether to show
+        // the original alias text or the evaluated result.
+        self.ensure_relation_input_ready(ty);
+
         // If the type is a TypeParameter or Infer, format it directly as
         // its name.  This must happen before any evaluation/resolution that
         // could replace the type parameter with its constraint type.
@@ -235,6 +240,42 @@ impl<'a> CheckerState<'a> {
         }
         if ty == TypeId::BOOLEAN_FALSE {
             return "false".to_string();
+        }
+
+        // Alias bodies like `Uppercase<A>` often arrive here before the nested
+        // lazy arg has been reduced, even though the fully evaluated surface is
+        // a concrete literal or template pattern that tsc prints in TS2322.
+        if let Some((kind, type_arg)) =
+            crate::query_boundaries::common::string_intrinsic_components(self.ctx.types, ty)
+        {
+            let resolved_arg =
+                crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_arg)
+                    .and_then(|def_id| self.ctx.definition_store.get(def_id))
+                    .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
+                    .and_then(|def| def.body)
+                    .map(|body| self.evaluate_type_for_assignability(body))
+                    .unwrap_or_else(|| self.evaluate_type_for_assignability(type_arg));
+            if resolved_arg != type_arg {
+                let remapped = self.ctx.types.string_intrinsic(kind, resolved_arg);
+                let evaluated_remapped = self.evaluate_type_for_assignability(remapped);
+                if crate::query_boundaries::common::literal_value(
+                    self.ctx.types,
+                    evaluated_remapped,
+                )
+                .is_some()
+                    || crate::query_boundaries::common::is_template_literal_type(
+                        self.ctx.types,
+                        evaluated_remapped,
+                    )
+                    || crate::query_boundaries::common::string_intrinsic_components(
+                        self.ctx.types,
+                        evaluated_remapped,
+                    )
+                    .is_some()
+                {
+                    return self.format_type_for_assignability_message(evaluated_remapped);
+                }
+            }
         }
 
         // For deferred conditional types, check if the conditional is ambiguous

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1,6 +1,8 @@
 //! Lazy type resolution and type environment population.
 
-use crate::query_boundaries::common::{collect_lazy_def_ids, collect_type_queries, lazy_def_id};
+use crate::query_boundaries::common::{
+    collect_lazy_def_ids, collect_type_queries, contains_lazy_or_recursive, lazy_def_id,
+};
 use crate::query_boundaries::state::type_environment as query;
 use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -232,7 +234,17 @@ impl<'a> CheckerState<'a> {
         // CheckerContext resolver which can resolve Lazy(DefId) on the fly via
         // get_type_of_symbol.
         let needs_resolver_pass = query::index_access_types(self.ctx.types, result).is_some()
-            || query::mapped_type_id(self.ctx.types, result).is_some();
+            || query::mapped_type_id(self.ctx.types, result).is_some()
+            || (contains_lazy_or_recursive(self.ctx.types, result)
+                && (crate::query_boundaries::common::string_intrinsic_components(
+                    self.ctx.types,
+                    result,
+                )
+                .is_some()
+                    || crate::query_boundaries::common::is_template_literal_type(
+                        self.ctx.types,
+                        result,
+                    )));
         let final_result = if needs_resolver_pass {
             let seed_iter = if use_cache {
                 let cache = self.ctx.env_eval_cache.borrow();

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -1318,6 +1318,165 @@ y = "AbC";
     );
 }
 
+#[test]
+fn test_ts2322_string_mapping_alias_displays_resolved_literal_target() {
+    let source = r#"
+type A = "aA";
+type B = Uppercase<A>;
+type ATemplate = `aA${string}`;
+type BTemplate = Uppercase<ATemplate>;
+
+declare let lit: B;
+declare let tpl: BTemplate;
+
+lit = tpl;
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let message = diagnostics
+        .iter()
+        .find_map(|d| {
+            (d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && d.message_text.contains("Type '`AA${Uppercase<string>}`'"))
+            .then_some(d.message_text.as_str())
+        })
+        .expect("expected TS2322 for assigning uppercase template to uppercase literal");
+
+    assert!(
+        message.contains(r#"is not assignable to type '"AA"'."#),
+        "expected evaluated uppercase literal target display, got: {message}"
+    );
+    assert!(
+        !message.contains("Uppercase<A>"),
+        "did not expect intrinsic alias repaint for literal target, got: {message}"
+    );
+}
+
+#[test]
+fn test_ts2322_string_mapping_alias_displays_resolved_template_target() {
+    let source = r#"
+type Source = `aA${string}`;
+type Target = Uppercase<Source>;
+
+declare let sourceValue: Source;
+declare let targetValue: Target;
+
+targetValue = sourceValue;
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let message = diagnostics
+        .iter()
+        .find_map(|d| {
+            (d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && d.message_text.contains("Type '`aA${string}`'"))
+            .then_some(d.message_text.as_str())
+        })
+        .expect("expected TS2322 for assigning unmapped template to mapped template target");
+
+    assert!(
+        message.contains("is not assignable to type '`AA${Uppercase<string>}`'."),
+        "expected evaluated uppercase template target display, got: {message}"
+    );
+    assert!(
+        !message.contains("Uppercase<Source>"),
+        "did not expect intrinsic alias repaint for template target, got: {message}"
+    );
+}
+
+#[test]
+fn test_ts2322_string_intrinsic_target_does_not_gain_nested_alias_display() {
+    let source = r#"
+declare let upper: Uppercase<string>;
+declare let lowerUpper: Lowercase<Uppercase<string>>;
+
+upper = lowerUpper;
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let message = diagnostics
+        .iter()
+        .find_map(|d| {
+            (d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && d.message_text.contains("Lowercase<Uppercase<string>>"))
+            .then_some(d.message_text.as_str())
+        })
+        .expect("expected TS2322 for lowerUpper assigned to upper");
+
+    assert!(
+        message.contains("is not assignable to type 'Uppercase<string>'."),
+        "expected resolved intrinsic target display, got: {message}"
+    );
+    assert!(
+        !message.contains("Uppercase<Uppercase<string>>"),
+        "did not expect nested intrinsic repaint in target display, got: {message}"
+    );
+}
+
+#[test]
+fn test_ts2322_parameter_string_intrinsic_target_does_not_gain_nested_alias_display() {
+    let source = r#"
+function f(
+    upper: Uppercase<string>,
+    upperUpper: Uppercase<Uppercase<string>>,
+    lowerUpper: Lowercase<Uppercase<string>>,
+) {
+    upper = lowerUpper;
+}
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let message = diagnostics
+        .iter()
+        .find_map(|d| {
+            (d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && d.message_text.contains("Lowercase<Uppercase<string>>"))
+            .then_some(d.message_text.as_str())
+        })
+        .expect("expected TS2322 for lowerUpper assigned to upper parameter");
+
+    assert!(
+        message.contains("is not assignable to type 'Uppercase<string>'."),
+        "expected resolved intrinsic parameter target display, got: {message}"
+    );
+    assert!(
+        !message.contains("Uppercase<Uppercase<string>>"),
+        "did not expect nested intrinsic repaint for parameter target, got: {message}"
+    );
+}
+
+#[test]
+fn test_ts2322_parameter_nested_same_kind_string_intrinsic_simplifies_target_display() {
+    let source = r#"
+function f(
+    upper: Uppercase<string>,
+    upperUpper: Uppercase<Uppercase<string>>,
+    lowerUpper: Lowercase<Uppercase<string>>,
+) {
+    upperUpper = lowerUpper;
+}
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let message = diagnostics
+        .iter()
+        .find_map(|d| {
+            (d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && d.message_text.contains("Lowercase<Uppercase<string>>"))
+            .then_some(d.message_text.as_str())
+        })
+        .expect("expected TS2322 for lowerUpper assigned to upperUpper parameter");
+
+    assert!(
+        message.contains("is not assignable to type 'Uppercase<string>'."),
+        "expected simplified same-kind intrinsic target display, got: {message}"
+    );
+    assert!(
+        !message.contains("Uppercase<Uppercase<string>>"),
+        "did not expect nested same-kind intrinsic target display, got: {message}"
+    );
+}
+
 // =============================================================================
 // User-Defined Generic Type Application Tests (TS2322 False Positives)
 // These test the root cause of 11,000+ extra TS2322 errors

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -586,6 +586,8 @@ impl<'a> TypeFormatter<'a> {
                 | TypeData::Tuple(_)
                 | TypeData::Union(_)
                 | TypeData::Function(_)
+                | TypeData::TemplateLiteral(_)
+                | TypeData::StringIntrinsic { .. }
                 | TypeData::Enum(_, _)
         );
         if let Some(alias_origin) = self.interner.get_display_alias(type_id) {

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -1842,6 +1842,65 @@ fn structural_display_alias_can_replace_generic_helper_alias() {
     );
 }
 
+#[test]
+fn string_intrinsic_display_alias_keeps_resolved_intrinsic_surface() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+    let alias_name = db.intern_string("Wrapper");
+    let def_id = def_store.register(crate::def::DefinitionInfo::interface(
+        alias_name,
+        vec![TypeParamInfo {
+            name: db.intern_string("T"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        }],
+        vec![],
+    ));
+    let app = db.application(db.lazy(def_id), vec![TypeId::STRING]);
+    let evaluated = db.string_intrinsic(StringIntrinsicKind::Uppercase, TypeId::STRING);
+
+    db.store_display_alias(evaluated, app);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(evaluated),
+        "Uppercase<string>",
+        "Resolved string intrinsics should not be repainted through alias provenance"
+    );
+}
+
+#[test]
+fn template_literal_display_alias_keeps_resolved_pattern_surface() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+    let alias_name = db.intern_string("Wrapper");
+    let def_id = def_store.register(crate::def::DefinitionInfo::interface(
+        alias_name,
+        vec![TypeParamInfo {
+            name: db.intern_string("T"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        }],
+        vec![],
+    ));
+    let app = db.application(db.lazy(def_id), vec![TypeId::STRING]);
+    let evaluated = db.template_literal(vec![
+        TemplateSpan::Text(db.intern_string("AA")),
+        TemplateSpan::Type(db.string_intrinsic(StringIntrinsicKind::Uppercase, TypeId::STRING)),
+    ]);
+
+    db.store_display_alias(evaluated, app);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(evaluated),
+        "`AA${Uppercase<string>}`",
+        "Resolved template literal patterns should not be repainted through alias provenance"
+    );
+}
+
 // =================================================================
 // Callable type formatting
 // =================================================================


### PR DESCRIPTION
## Summary
- preserve evaluated string-intrinsic and template-literal diagnostic surfaces instead of repainting alias provenance
- let TS2322 target formatting prefer the assignability display when string mappings reduce to concrete literal, template, or simplified intrinsic surfaces
- add checker and solver regression tests for the picked conformance case and the same-kind intrinsic display path

## Root cause
When a string-mapping target in TS2322 reduced to a concrete literal, template pattern, or idempotent same-kind intrinsic, tsz repainted the original alias or nested intrinsic form instead of the evaluated surface that tsc reports.

## Repro
```ts
type A = "aA";
type B = Uppercase<A>;
type T = `aA${string}`;
type U = Uppercase<T>;

declare let b: B;
declare let u: U;
b = u; // target should display "AA"

function f(
  upperUpper: Uppercase<Uppercase<string>>,
  lowerUpper: Lowercase<Uppercase<string>>,
) {
  upperUpper = lowerUpper; // target should display Uppercase<string>
}
```

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib` (`2647 passed`)
- `cargo nextest run --package tsz-solver --lib` (`5265 passed`)
- `./scripts/conformance/conformance.sh run --filter "stringMappingOverPatternLiterals" --verbose` (`1/1 passed`)
- `./scripts/conformance/conformance.sh run --max 200` (`200/200 passed`)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL` (`FINAL RESULTS: 12097/12581 passed (96.2%)`)
