### PR TITLE
refactor(solver): SubtypeChecker::with_identity_check_mode helper

### DIFF
--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -655,13 +655,6 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // assuming related. Without this, `IPromise2<W, U>` vs `Promise2<any, W>` at
         // a cycle point would be assumed related (because same DefId pair), even though
         // the type arguments [W, U] vs [any, W] are NOT identical.
-        let saved_any_mode = self.subtype.any_propagation;
-        let saved_identity_cycle = self.subtype.identity_cycle_check;
-        let saved_method_bivariance = self.subtype.disable_method_bivariance;
-        let saved_strict_fn = self.subtype.strict_function_types;
-        self.subtype.any_propagation =
-            crate::relations::subtype::core::AnyPropagationMode::TopLevelOnly;
-        self.subtype.identity_cycle_check = true;
         // TS2403 identity checking mirrors tsc's `isTypeIdenticalTo` which uses
         // the `identity` relation — strictly bidirectional structural equality.
         // Unlike the subtype relation, identity does NOT have bivariance at all:
@@ -670,14 +663,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // Without this, recursive method types can appear identical through a
         // bivariant path that hits a cycle (CycleDetected = True) even when the
         // forward structural check correctly rejects the types.
-        self.subtype.disable_method_bivariance = true;
-        self.subtype.strict_function_types = true;
-        let fwd = self.subtype.is_subtype_of(a, b);
-        let bwd = self.subtype.is_subtype_of(b, a);
-        self.subtype.any_propagation = saved_any_mode;
-        self.subtype.identity_cycle_check = saved_identity_cycle;
-        self.subtype.disable_method_bivariance = saved_method_bivariance;
-        self.subtype.strict_function_types = saved_strict_fn;
+        let (fwd, bwd) = self
+            .subtype
+            .with_identity_check_mode(|sub| (sub.is_subtype_of(a, b), sub.is_subtype_of(b, a)));
         tracing::trace!(
             a = a.0,
             b = b.0,
@@ -767,21 +755,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return true;
         }
 
-        let saved_any_mode = self.subtype.any_propagation;
-        let saved_identity_cycle = self.subtype.identity_cycle_check;
-        let saved_method_bivariance = self.subtype.disable_method_bivariance;
-        let saved_strict_fn = self.subtype.strict_function_types;
-        self.subtype.any_propagation =
-            crate::relations::subtype::core::AnyPropagationMode::TopLevelOnly;
-        self.subtype.identity_cycle_check = true;
-        self.subtype.disable_method_bivariance = true;
-        self.subtype.strict_function_types = true;
-        let fwd = self.subtype.is_subtype_of(a, b);
-        let bwd = self.subtype.is_subtype_of(b, a);
-        self.subtype.any_propagation = saved_any_mode;
-        self.subtype.identity_cycle_check = saved_identity_cycle;
-        self.subtype.disable_method_bivariance = saved_method_bivariance;
-        self.subtype.strict_function_types = saved_strict_fn;
+        let (fwd, bwd) = self
+            .subtype
+            .with_identity_check_mode(|sub| (sub.is_subtype_of(a, b), sub.is_subtype_of(b, a)));
         fwd && bwd
     }
 

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -380,6 +380,31 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.guard.is_exceeded()
     }
 
+    /// Run `f` with subtype flags configured for tsc's `isTypeIdenticalTo`
+    /// identity checking (TS2403 and related redeclaration/identity paths).
+    ///
+    /// Temporarily sets `any_propagation = TopLevelOnly`, enables
+    /// `identity_cycle_check`, disables method bivariance, and forces
+    /// `strict_function_types = true` — matching tsc's strict bidirectional
+    /// structural equality. All four flags are restored on return, even if
+    /// `f` returns early.
+    pub fn with_identity_check_mode<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let saved_any_mode = self.any_propagation;
+        let saved_identity_cycle = self.identity_cycle_check;
+        let saved_method_bivariance = self.disable_method_bivariance;
+        let saved_strict_fn = self.strict_function_types;
+        self.any_propagation = AnyPropagationMode::TopLevelOnly;
+        self.identity_cycle_check = true;
+        self.disable_method_bivariance = true;
+        self.strict_function_types = true;
+        let result = f(self);
+        self.any_propagation = saved_any_mode;
+        self.identity_cycle_check = saved_identity_cycle;
+        self.disable_method_bivariance = saved_method_bivariance;
+        self.strict_function_types = saved_strict_fn;
+        result
+    }
+
     /// Apply compiler flags from a packed u16 bitmask.
     ///
     /// This unpacks the flags used by `RelationCacheKey` and applies them to the checker.
@@ -2306,3 +2331,38 @@ mod overlap_tests;
 #[cfg(test)]
 #[path = "../../../tests/intersection_optional_subtype_tests.rs"]
 mod intersection_optional_subtype_tests;
+
+#[cfg(test)]
+mod with_identity_check_mode_tests {
+    use super::*;
+    use crate::TypeInterner;
+
+    #[test]
+    fn restores_flags_after_closure() {
+        let interner = TypeInterner::new();
+        let mut checker = SubtypeChecker::new(&interner);
+        checker.any_propagation = AnyPropagationMode::All;
+        checker.identity_cycle_check = false;
+        checker.disable_method_bivariance = false;
+        checker.strict_function_types = false;
+
+        let inside = checker.with_identity_check_mode(|sub| {
+            (
+                sub.any_propagation,
+                sub.identity_cycle_check,
+                sub.disable_method_bivariance,
+                sub.strict_function_types,
+            )
+        });
+
+        assert_eq!(inside.0, AnyPropagationMode::TopLevelOnly);
+        assert!(inside.1);
+        assert!(inside.2);
+        assert!(inside.3);
+
+        assert_eq!(checker.any_propagation, AnyPropagationMode::All);
+        assert!(!checker.identity_cycle_check);
+        assert!(!checker.disable_method_bivariance);
+        assert!(!checker.strict_function_types);
+    }
+}

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -46,6 +46,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - `DiagnosticCollector` report methods collapsed onto `collect_with` (#781).
 - Helpers extracted: `constrain_object_properties` (#790), `constrain_type_predicates` (#784), `constrain_template_against_properties` (#793), `infer_rest_param_tuple_candidate` (#786).
 - Walker type-predicate sites routed through shared helper (#791).
+- `SubtypeChecker::with_identity_check_mode` scopes the 4-flag save/restore (`any_propagation`, `identity_cycle_check`, `disable_method_bivariance`, `strict_function_types`) used by `are_types_identical_for_redeclaration` and `type_ids_are_identity_related`; two ~15-line hand-rolled prologue/epilogue blocks collapsed onto the helper.
 
 **tsz-emitter**
 - Numeric parse/radix callers moved to shared `tsz_common::numeric` primitive (#759, #768, #769).


### PR DESCRIPTION
## Summary
- Add `SubtypeChecker::with_identity_check_mode(f)` to scope the 4-flag save/restore used for tsc's `isTypeIdenticalTo` semantics.
- Collapse the two hand-rolled prologue/epilogue blocks in `compat_overrides.rs` (`are_types_identical_for_redeclaration` and `type_ids_are_identity_related`) onto the helper.
- Add a unit test verifying state is restored after the closure runs.

The helper sets `any_propagation = TopLevelOnly`, enables `identity_cycle_check`, disables method bivariance, and forces `strict_function_types = true` — the exact configuration both callsites had to duplicate before.

## Test plan
- [x] `cargo nextest run -p tsz-solver --lib` (5265 passed, +1 new)
- [x] Pre-commit pipeline full 18k tests across 5 affected crates (all green)
- [x] Clippy zero warnings, wasm32 rustc gate, architecture guardrail