### PR TITLE
[codex] infer fixed callback params from source rest annotations

### DIFF
--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -1747,6 +1747,46 @@ let check: number = result;
 }
 
 #[test]
+fn generic_callback_rest_annotation_does_not_emit_false_extra_ts2345() {
+    let source = r#"
+class C {
+  test: string
+}
+
+class D extends C {
+  test2: string
+}
+
+declare function test<T extends C>(a: (t: T, t1: T) => void): T
+declare function testRest<T extends C>(a: (t: T, t1: T, ...ts: T[]) => void): T
+
+test((...ts: D[]) => {})
+testRest((t2, ...t3: D[]) => {})
+"#;
+
+    let diagnostics = get_diagnostics(source);
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2345)
+        .collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "Expected only the trailing rest mismatch to emit TS2345, got diagnostics={diagnostics:?}"
+    );
+    assert!(
+        ts2345[0].1.contains("(t2: C, ...t3: D[]) => void"),
+        "Expected the surviving TS2345 to be the target-rest mismatch, got {:?}",
+        ts2345[0]
+    );
+    assert!(
+        !ts2345[0].1.contains("(...ts: D[]) => void"),
+        "Unexpected false-positive TS2345 for source rest callback: {:?}",
+        ts2345[0]
+    );
+}
+
+#[test]
 fn generic_return_context_inference() {
     // Return-context substitution: when a generic call is in a contextual
     // position, the return type context should help infer type params.

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -133,7 +133,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     ///
     /// Example: source `(a: string, b: number)` vs target `(...args: T)` where
     /// T is an inference variable → infers T = [string, number].
-    fn constrain_params_with_rest(
+    pub(super) fn constrain_params_with_rest(
         &mut self,
         ctx: &mut InferenceContext,
         var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
@@ -164,21 +164,27 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         // If target has a rest param typed as an inference variable, collect
         // remaining source params into a tuple and infer against the variable.
+        let target_has_rest = t_params.last().is_some_and(|t| t.rest);
         let target_rest_is_typevar = t_params
             .last()
             .is_some_and(|t| t.rest && var_map.contains_key(&t.type_id));
         if target_rest_is_typevar {
             self.infer_rest_param_tuple_candidate(ctx, var_map, &s_params, &t_params);
-        } else if let Some(s_last) = s_params.last()
+        } else if !target_has_rest
+            && let Some(s_last) = s_params.last()
             && s_last.rest
         {
             // Source has rest param, target doesn't — infer each remaining
             // target param against the source rest element type.
+            let source_rest_elem = self.rest_element_type(s_last.type_id);
             for t_p in t_params.iter().skip(matched) {
-                if t_p.rest {
-                    break;
-                }
-                self.constrain_parameter_types(ctx, var_map, s_last.type_id, t_p.type_id, priority);
+                self.constrain_parameter_types(
+                    ctx,
+                    var_map,
+                    source_rest_elem,
+                    t_p.type_id,
+                    priority,
+                );
             }
         }
     }

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1117,41 +1117,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
                 if s_fn.type_params.is_empty() {
                     // Non-generic source function - direct comparison
-                    // Unpack tuple rest parameters for proper matching
-                    use crate::type_queries::unpack_tuple_rest_parameter;
-                    let s_params_unpacked: Vec<ParamInfo> = s_fn
-                        .params
-                        .iter()
-                        .flat_map(|p| unpack_tuple_rest_parameter(self.interner, p))
-                        .collect();
-                    let t_params_unpacked: Vec<ParamInfo> = t_fn
-                        .params
-                        .iter()
-                        .flat_map(|p| unpack_tuple_rest_parameter(self.interner, p))
-                        .collect();
-
-                    // Contravariant parameters: target_param <: source_param
-                    for (s_p, t_p) in s_params_unpacked.iter().zip(t_params_unpacked.iter()) {
-                        if t_p.rest || s_p.rest {
-                            // If target has a rest parameter, we stop the 1-to-1 mapping
-                            // The special cases below will handle inferring the rest tuple
-                            // or array element type.
-                            break;
-                        }
-                        self.constrain_parameter_types(
-                            ctx,
-                            var_map,
-                            s_p.type_id,
-                            t_p.type_id,
-                            priority,
-                        );
-                    }
-
-                    self.infer_rest_param_tuple_candidate(
+                    self.constrain_params_with_rest(
                         ctx,
                         var_map,
-                        &s_params_unpacked,
-                        &t_params_unpacked,
+                        &s_fn.params,
+                        &t_fn.params,
+                        priority,
                     );
 
                     if let (Some(s_this), Some(t_this)) = (s_fn.this_type, t_fn.this_type) {

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -4866,6 +4866,125 @@ fn test_generic_rest_callback_instantiation_accepts_generic_binary_function() {
 }
 
 #[test]
+fn test_generic_callback_rest_annotation_infers_fixed_target_type_parameter() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let test_name = interner.intern_string("test");
+    let test2_name = interner.intern_string("test2");
+
+    let c_type = interner.object(vec![PropertyInfo {
+        name: test_name,
+        type_id: TypeId::STRING,
+        write_type: TypeId::STRING,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+    }]);
+    let d_type = interner.object(vec![
+        PropertyInfo {
+            name: test_name,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 0,
+            is_string_named: false,
+        },
+        PropertyInfo {
+            name: test2_name,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 1,
+            is_string_named: false,
+        },
+    ]);
+
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(c_type),
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+
+    let callback_param = interner.function(FunctionShape {
+        params: vec![
+            ParamInfo {
+                name: Some(interner.intern_string("t")),
+                type_id: t_type,
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("t1")),
+                type_id: t_type,
+                optional: false,
+                rest: false,
+            },
+        ],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let higher_order = interner.function(FunctionShape {
+        type_params: vec![t_param],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("cb")),
+            type_id: callback_param,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let source_callback = interner.function(FunctionShape {
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("ts")),
+            type_id: interner.array(d_type),
+            optional: false,
+            rest: true,
+        }],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    match evaluator.resolve_call(higher_order, &[source_callback]) {
+        CallResult::Success(ret) => assert_eq!(ret, d_type, "expected T to infer as D"),
+        other => panic!(
+            "Expected generic callback rest annotation to infer D for fixed target params, got {other:?}"
+        ),
+    }
+}
+
+#[test]
 fn test_array_union_is_not_strictly_assignable_to_tuple() {
     let interner = TypeInterner::new();
     let mut checker = CompatChecker::new(&interner);


### PR DESCRIPTION
## Summary
When a generic callback target has only fixed parameters, a non-generic source rest annotation like `(...ts: D[])` must contribute `T = D`; `tsz` was dropping that inference, defaulting `T` to its constraint `C`, and emitting a false `TS2345`.

The fix lives in solver constraint collection:
- reuse the shared rest-aware parameter constraint path for non-generic function-to-function inference
- only infer from a source rest parameter into remaining fixed target params when the target callback itself has no rest parameter
- use the source rest element type for that inference, not the array type

This keeps the real failing `testRest((t2, ...t3: D[]) => {})` case intact while removing the false-positive `test((...ts: D[]) => {})` error.

## Minimal Repro
```ts
class C { test: string }
class D extends C { test2: string }

declare function test<T extends C>(a: (t: T, t1: T) => void): T;
declare function testRest<T extends C>(a: (t: T, t1: T, ...ts: T[]) => void): T;

test((...ts: D[]) => {}); // ok
testRest((t2, ...t3: D[]) => {}); // TS2345
```

## Tests
- solver unit test for fixed-target inference from a source rest annotation
- checker regression test asserting only the trailing `testRest` mismatch emits `TS2345`

## Verification
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib` -> `2643 passed`
- `cargo nextest run --package tsz-solver --lib` -> `5265 passed`
- `./scripts/conformance/conformance.sh run --filter "partiallyAnnotatedFunctionInferenceWithTypeParameter" --verbose` -> `1/1 passed`
- `./scripts/conformance/conformance.sh run --max 200` -> `200/200 passed`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL` -> `FINAL RESULTS: 12100/12581 passed (96.2%)`
- `./scripts/conformance/conformance.sh diff` -> `11 improvements, 0 regressions`
