### PR TITLE
fix(conformance): align call tuple mismatch elaboration for destructuringParameterDeclaration4

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1214,6 +1214,11 @@ impl<'a> CheckerState<'a> {
         if self.call_target_preserves_literal_argument_surface(param_type, arg_idx)
             && let Some(display) = self.literal_call_argument_display(arg_idx)
         {
+            if (display == "true" || display == "false")
+                && self.call_target_should_widen_boolean_literal_display(param_type)
+            {
+                return "boolean".to_string();
+            }
             return display;
         }
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_boolean.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_boolean.rs
@@ -1,0 +1,30 @@
+//! Boolean literal display helpers for call error diagnostics.
+
+use crate::query_boundaries::common as query_common;
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(in crate::error_reporter::call_errors) fn call_target_should_widen_boolean_literal_display(
+        &mut self,
+        param_type: TypeId,
+    ) -> bool {
+        let members = query_common::union_members(self.ctx.types, param_type).or_else(|| {
+            query_common::union_members(
+                self.ctx.types,
+                self.evaluate_type_for_assignability(param_type),
+            )
+        });
+        let Some(members) = members else {
+            return false;
+        };
+
+        !members.iter().copied().any(|member| {
+            let member = self.evaluate_type_for_assignability(member);
+            matches!(
+                member,
+                TypeId::BOOLEAN | TypeId::BOOLEAN_TRUE | TypeId::BOOLEAN_FALSE
+            )
+        })
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -459,7 +459,17 @@ impl<'a> CheckerState<'a> {
                     source_type_override,
                 ),
             k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
-                self.try_elaborate_array_literal_elements(arg_idx, param_type)
+                if self.try_elaborate_array_literal_elements(arg_idx, param_type) {
+                    true
+                } else {
+                    let source_type = source_type_override
+                        .unwrap_or_else(|| self.elaboration_source_expression_type(arg_idx));
+                    self.try_elaborate_array_literal_mismatch_from_failure_reason(
+                        arg_idx,
+                        source_type,
+                        param_type,
+                    )
+                }
             }
             k if k == syntax_kind_ext::ARROW_FUNCTION
                 || k == syntax_kind_ext::FUNCTION_EXPRESSION =>
@@ -661,19 +671,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn try_elaborate_function_block_returns(
-        &mut self,
-        block_idx: NodeIndex,
-        expected_return_type: TypeId,
-    ) -> bool {
-        self.try_elaborate_function_block_returns_with_param_type(
-            block_idx,
-            expected_return_type,
-            expected_return_type,
-            NodeIndex(0), // dummy
-        )
-    }
-
     fn try_elaborate_function_block_returns_with_param_type(
         &mut self,
         block_idx: NodeIndex,
@@ -698,19 +695,6 @@ impl<'a> CheckerState<'a> {
             );
         }
         elaborated
-    }
-
-    fn try_elaborate_return_statements_in_stmt(
-        &mut self,
-        stmt_idx: NodeIndex,
-        expected_return_type: TypeId,
-    ) -> bool {
-        self.try_elaborate_return_statements_in_stmt_with_param_type(
-            stmt_idx,
-            expected_return_type,
-            expected_return_type,
-            NodeIndex(0), // dummy
-        )
     }
 
     fn try_elaborate_return_statements_in_stmt_with_param_type(
@@ -1695,13 +1679,10 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if self
-            .generic_mapped_receiver_explicit_property_names(param_type)
-            .is_empty()
-            && self.generic_mapped_receiver_lacks_explicit_property(param_type, "0")
-        {
-            return false;
-        }
+        let effective_param_type = self.evaluate_type_with_env(param_type);
+        let effective_param_type = self.resolve_type_for_property_access(effective_param_type);
+        let effective_param_type = self.resolve_lazy_type(effective_param_type);
+        let effective_param_type = self.evaluate_application_type(effective_param_type);
 
         let arg_node = match self.ctx.arena.get(arg_idx) {
             Some(node) if node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => node,
@@ -1712,19 +1693,17 @@ impl<'a> CheckerState<'a> {
             Some(arr) => arr.clone(),
             None => return false,
         };
-
-        if let Some(target_count) =
-            crate::query_boundaries::common::get_fixed_tuple_length(self.ctx.types, param_type)
-            && arr.elements.nodes.len() > target_count
-        {
+        if self.call_argument_targets_generic_parameter(arg_idx) {
             return false;
         }
 
         let ctx_helper = tsz_solver::ContextualTypeContext::with_expected_and_options(
             self.ctx.types,
-            param_type,
+            effective_param_type,
             self.ctx.compiler_options.no_implicit_any,
         );
+        let tuple_target_elements =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, effective_param_type);
 
         let mut elaborated = false;
 
@@ -1739,9 +1718,19 @@ impl<'a> CheckerState<'a> {
             }
 
             // Get the expected element type from the parameter array/tuple type
-            let target_element_type = if let Some(t) = ctx_helper.get_tuple_element_type(index) {
+            let target_element_type = if let Some(elements) = tuple_target_elements.as_deref() {
+                let Some(t) = self.elaboration_tuple_element_type_at(elements, index) else {
+                    continue;
+                };
+                t
+            } else if let Some(t) = ctx_helper.get_tuple_element_type(index) {
                 t
             } else if let Some(t) = ctx_helper.get_array_element_type() {
+                t
+            } else if let Some(t) = crate::query_boundaries::common::array_element_type(
+                self.ctx.types,
+                effective_param_type,
+            ) {
                 t
             } else {
                 continue;

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -1,0 +1,265 @@
+//! Array-literal mismatch elaboration helpers for call errors.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(in crate::error_reporter::call_errors) fn elaboration_tuple_element_type_at(
+        &self,
+        elements: &[tsz_solver::TupleElement],
+        index: usize,
+    ) -> Option<TypeId> {
+        if let Some(element) = elements.get(index) {
+            if element.rest {
+                return crate::query_boundaries::common::array_element_type(
+                    self.ctx.types,
+                    element.type_id,
+                )
+                .or(Some(element.type_id));
+            }
+            return Some(element.type_id);
+        }
+
+        let rest = elements.last().filter(|element| element.rest)?;
+        crate::query_boundaries::common::array_element_type(self.ctx.types, rest.type_id)
+            .or(Some(rest.type_id))
+    }
+
+    pub(in crate::error_reporter::call_errors) fn try_elaborate_array_literal_mismatch_from_failure_reason(
+        &mut self,
+        arg_idx: NodeIndex,
+        source_type: TypeId,
+        target_type: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common::SubtypeFailureReason;
+        use tsz_parser::parser::syntax_kind_ext;
+
+        if matches!(source_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+            || matches!(target_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+        {
+            return false;
+        }
+
+        let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
+            return false;
+        };
+        if arg_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            return false;
+        }
+        let Some(arr) = self.ctx.arena.get_literal_expr(arg_node).cloned() else {
+            return false;
+        };
+        if self.call_argument_targets_generic_parameter(arg_idx) {
+            return false;
+        }
+
+        let effective_target_type = self.evaluate_type_with_env(target_type);
+        let effective_target_type = self.resolve_type_for_property_access(effective_target_type);
+        let effective_target_type = self.resolve_lazy_type(effective_target_type);
+        let effective_target_type = self.evaluate_application_type(effective_target_type);
+        let ctx_helper = tsz_solver::ContextualTypeContext::with_expected_and_options(
+            self.ctx.types,
+            effective_target_type,
+            self.ctx.compiler_options.no_implicit_any,
+        );
+        let tuple_target_elements =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, effective_target_type);
+
+        let analysis = self.analyze_assignability_failure(source_type, target_type);
+        match analysis.failure_reason {
+            Some(SubtypeFailureReason::TupleElementTypeMismatch {
+                index,
+                source_element,
+                target_element,
+            }) => {
+                let Some(&elem_idx) = arr.elements.nodes.get(index) else {
+                    return false;
+                };
+                let is_spread = self
+                    .ctx
+                    .arena
+                    .get(elem_idx)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::SPREAD_ELEMENT);
+                if is_spread {
+                    return false;
+                }
+                self.error_type_not_assignable_at_with_anchor(
+                    source_element,
+                    target_element,
+                    elem_idx,
+                );
+                true
+            }
+            Some(SubtypeFailureReason::TupleElementMismatch { .. }) => {
+                for (index, &elem_idx) in arr.elements.nodes.iter().enumerate() {
+                    let is_spread = self
+                        .ctx
+                        .arena
+                        .get(elem_idx)
+                        .is_some_and(|node| node.kind == syntax_kind_ext::SPREAD_ELEMENT);
+                    if is_spread {
+                        continue;
+                    }
+
+                    let target_element_type =
+                        if let Some(elements) = tuple_target_elements.as_deref() {
+                            let Some(t) = self.elaboration_tuple_element_type_at(elements, index)
+                            else {
+                                continue;
+                            };
+                            t
+                        } else if let Some(t) = ctx_helper.get_tuple_element_type(index) {
+                            t
+                        } else if let Some(t) = ctx_helper.get_array_element_type() {
+                            t
+                        } else if let Some(t) = crate::query_boundaries::common::array_element_type(
+                            self.ctx.types,
+                            effective_target_type,
+                        ) {
+                            t
+                        } else {
+                            continue;
+                        };
+
+                    let elem_type = self.elaboration_source_expression_type(elem_idx);
+                    if matches!(elem_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                        || matches!(
+                            target_element_type,
+                            TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
+                        )
+                    {
+                        continue;
+                    }
+
+                    if !self.is_assignable_to(elem_type, target_element_type) {
+                        self.error_type_not_assignable_at_with_anchor(
+                            elem_type,
+                            target_element_type,
+                            elem_idx,
+                        );
+                        return true;
+                    }
+                }
+                false
+            }
+            Some(SubtypeFailureReason::ArrayElementMismatch {
+                source_element: _,
+                target_element,
+            }) => {
+                for &elem_idx in &arr.elements.nodes {
+                    let is_spread = self
+                        .ctx
+                        .arena
+                        .get(elem_idx)
+                        .is_some_and(|node| node.kind == syntax_kind_ext::SPREAD_ELEMENT);
+                    if is_spread {
+                        continue;
+                    }
+                    let elem_type = self.elaboration_source_expression_type(elem_idx);
+                    if matches!(elem_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+                        continue;
+                    }
+                    if !self.is_assignable_to(elem_type, target_element) {
+                        self.error_type_not_assignable_at_with_anchor(
+                            elem_type,
+                            target_element,
+                            elem_idx,
+                        );
+                        return true;
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    pub(in crate::error_reporter::call_errors) fn call_argument_targets_generic_parameter(
+        &mut self,
+        arg_idx: NodeIndex,
+    ) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let mut current = arg_idx;
+        while current.is_some() {
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::CALL_EXPRESSION
+                && let Some(call) = self.ctx.arena.get_call_expr(node)
+                && let Some(args) = &call.arguments
+                && let Some(arg_pos) = args
+                    .nodes
+                    .iter()
+                    .position(|&candidate| candidate == arg_idx)
+            {
+                if call
+                    .type_arguments
+                    .as_ref()
+                    .is_some_and(|type_args| !type_args.nodes.is_empty())
+                {
+                    return false;
+                }
+                let callee_type = self.get_type_of_node(call.expression);
+                let arg_count = args.nodes.len();
+
+                let raw_param_contains_type_params = |sig: &tsz_solver::CallSignature| {
+                    if !self.call_signature_accepts_arg_count(sig, arg_count) {
+                        return false;
+                    }
+                    self.raw_param_for_argument_index(sig, arg_pos)
+                        .is_some_and(|raw_param| {
+                            crate::query_boundaries::common::contains_type_parameters(
+                                self.ctx.types,
+                                raw_param.type_id,
+                            ) || crate::query_boundaries::common::contains_infer_types(
+                                self.ctx.types,
+                                raw_param.type_id,
+                            )
+                        })
+                };
+
+                if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
+                    self.ctx.types,
+                    callee_type,
+                ) {
+                    let sig = tsz_solver::CallSignature {
+                        type_params: shape.type_params.clone(),
+                        params: shape.params.clone(),
+                        this_type: shape.this_type,
+                        return_type: shape.return_type,
+                        type_predicate: shape.type_predicate,
+                        is_method: shape.is_method,
+                    };
+                    if raw_param_contains_type_params(&sig) {
+                        return true;
+                    }
+                }
+
+                if let Some(signatures) = crate::query_boundaries::common::call_signatures_for_type(
+                    self.ctx.types,
+                    callee_type,
+                ) {
+                    for sig in signatures {
+                        if raw_param_contains_type_params(&sig) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                return false;
+            };
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+        }
+
+        false
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -73,6 +73,10 @@ impl<'a> CheckerState<'a> {
         {
             return;
         }
+        if self.try_elaborate_array_literal_mismatch_from_failure_reason(idx, arg_type, param_type)
+        {
+            return;
+        }
         // Run failure analysis to produce elaboration as related information,
         // matching tsc's behavior of emitting TS2741/TS2739/TS2740 etc. as
         // related diagnostics under the primary TS2345.

--- a/crates/tsz-checker/src/error_reporter/call_errors/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/mod.rs
@@ -6,7 +6,9 @@
 //! - `error_emission`: Call error emission functions
 
 mod display_formatting;
+mod display_formatting_boolean;
 mod elaboration;
+mod elaboration_array_mismatch;
 mod error_emission;
 
 #[path = "../call_errors_binding_patterns.rs"]

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -420,6 +420,106 @@ takes("abc");
 }
 
 #[test]
+fn ts2345_call_argument_display_widens_boolean_literal_for_non_boolean_union_target() {
+    let source = r#"
+declare function takes(...value: (number | string)[]): void;
+takes(1, 2, "hello", true);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+
+    assert!(
+        diag.message_text.contains("Argument of type 'boolean'"),
+        "TS2345 should widen boolean literals for non-boolean union targets, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("Argument of type 'true'"),
+        "TS2345 should not preserve boolean literal text for non-boolean union targets, got: {diag:?}"
+    );
+}
+
+#[test]
+fn ts2345_array_literal_tuple_overflow_elaborates_element_mismatch_to_ts2322() {
+    let source = r#"
+function a5([a, b, [[c]]]) { }
+a5([1, 2, "string", false, true]);
+a5([1, 2]);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|d| {
+            d.code == 2322
+                && d.message_text
+                    .contains("Type 'string' is not assignable to type '[[any]]'.")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected element-level TS2322 for overflowing tuple literal call, got: {diagnostics:?}"
+            )
+        });
+    assert!(
+        ts2322.start > 0,
+        "expected TS2322 to anchor to the mismatched element"
+    );
+
+    let has_outer_overflow_ts2345 = diagnostics.iter().any(|d| {
+        d.code == 2345
+            && d.message_text
+                .contains("Argument of type '[number, number, string, false, true]'")
+    });
+    assert!(
+        !has_outer_overflow_ts2345,
+        "should suppress outer TS2345 when tuple overflow literal has a concrete element mismatch, got: {diagnostics:?}"
+    );
+
+    let has_short_tuple_ts2345 = diagnostics.iter().any(|d| {
+        d.code == 2345
+            && d.message_text
+                .contains("Argument of type '[number, number]'")
+    });
+    assert!(
+        has_short_tuple_ts2345,
+        "should still report TS2345 for the short tuple argument, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn inferred_generic_call_suppresses_ts2345_when_other_argument_is_error() {
+    let source = r#"
+declare let anythingAny: any;
+function foo1<T extends number>(...a: T[]) { }
+foo1(1, 2, "string", anythingAny);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != 2345),
+        "inferred generic call should suppress cascading TS2345 when another argument is error-like (`any`), got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn explicit_generic_call_keeps_ts2345_with_other_error_arguments() {
+    let source = r#"
+declare let anythingAny: any;
+function foo1<T extends number>(...a: T[]) { }
+foo1<number>(1, "string", anythingAny);
+"#;
+
+    let diagnostics = check_source_with_strict_null(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2345),
+        "explicit generic instantiation should still report TS2345 for mismatched typed arguments even with `any` arguments, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn ts2322_optional_function_property_target_display_omits_synthetic_undefined() {
     let source = r#"
 interface Stuff {

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -73,6 +73,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return inferred;
         }
 
+        if lower_bounds
+            .iter()
+            .any(|ty| matches!(*ty, TypeId::ANY | TypeId::ERROR))
+        {
+            return TypeId::ANY;
+        }
+
         // Fall back to the first lower-bound candidate so later argument checks
         // drive assignability failures on the mismatch site.
         lower_bounds

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -456,6 +456,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
 
+        // Primitive wrapper fallback must not make primitives assignable to tuple
+        // targets. Structural checks against boxed interfaces can otherwise
+        // incorrectly accept cases like `string <: [any]`.
+        let evaluated_target = self.evaluate_type(target);
+        if tuple_list_id(self.interner, target).is_some()
+            || tuple_list_id(self.interner, evaluated_target).is_some()
+        {
+            return false;
+        }
+        if readonly_inner_type(self.interner, target)
+            .is_some_and(|inner| tuple_list_id(self.interner, inner).is_some())
+            || readonly_inner_type(self.interner, evaluated_target)
+                .is_some_and(|inner| tuple_list_id(self.interner, inner).is_some())
+        {
+            return false;
+        }
+
         // String-iterable shortcut: when the target is iterable with a yield type
         // compatible with `string`, check if the target is PURELY iterable (no extra
         // named properties beyond what String provides). This is needed because the


### PR DESCRIPTION
## Summary
This PR fixes one randomly selected conformance failure:
- `TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts`

### Root cause
`tsz` was relying on overly broad call-argument mismatch surfaces (and a primitive-wrapper subtype fallback) for tuple/array rest-call errors, which caused missed element-level diagnostics and incorrect acceptance paths in generic/tuple scenarios where `tsc` reports precise assignability failures.

### What changed
- Added tuple/array-literal mismatch elaboration fallback for call errors so tuple overflow/mismatch paths can emit element-level TS2322 where appropriate.
- Widened boolean literal display in TS2345 call diagnostics to `boolean` for non-boolean-union targets (matching `tsc` surface rendering).
- Guarded elaboration for unresolved generic-parameter targets to avoid false-positive deep elaboration during inference.
- Tightened solver behavior:
  - inference fallback to `any` when lower-bound inference includes `any/error` in direct param inference path.
  - prevented primitive-wrapper fallback from making primitives assignable to tuple targets.
- Split call-error helpers into focused submodules to satisfy architecture file-size guardrails.

## TypeScript snippet (behavioral intent)
```ts
function a1(...x: (number | string)[]) {}
a1(1, 2, "hello", true); // error (TS2345) with boolean/non-assignable surface matching tsc

function a5([a, b, [[c]]]) {}
a5([1, 2]); // element-level tuple mismatch elaboration path
```

## Unit tests added
- `ts2345_call_argument_display_widens_boolean_literal_for_non_boolean_union_target`
- `ts2345_array_literal_tuple_overflow_elaborates_element_mismatch_to_ts2322`
- `inferred_generic_call_suppresses_ts2345_when_other_argument_is_error`
- `explicit_generic_call_keeps_ts2345_with_other_error_arguments`

(all in `crates/tsz-checker/src/error_reporter/call_errors_tests.rs`)

## Verification
- `NEXTEST_RETRIES=2 scripts/session/verify-all.sh` on rebased head: **ALL SUITES PASSED**
  - formatting ✅
  - clippy ✅
  - unit tests ✅
  - conformance ✅ (`12096` vs baseline `12089`, `+7`)
  - emit ✅ (`JS +0`, `DTS +8`)
  - fourslash/LSP ✅ (`=50`)
- Post-final-rebase sanity:
  - `NEXTEST_RETRIES=2 cargo nextest run --status-level fail` (`21108` passed)
  - `./scripts/conformance/conformance.sh run --filter "destructuringParameterDeclaration4" --verbose` (`1/1` passed)
