### PR TITLE
fix(parser): align malformed arrow object recovery

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -3157,6 +3157,21 @@ impl ParserState {
         // - Contextually reserved words (await in async/static contexts)
         // - String literals ("key")
         // - Numeric literals (0, 1, etc.)
+        let property_name_start = self.token_pos();
+        let property_name_kind = self.token();
+        let property_name_had_prior_missing_colon =
+            self.parse_diagnostics.last().is_some_and(|diag| {
+                diag.start == property_name_start && diag.message == "':' expected."
+            });
+        let literal_property_name = matches!(
+            property_name_kind,
+            SyntaxKind::StringLiteral
+                | SyntaxKind::NumericLiteral
+                | SyntaxKind::BigIntLiteral
+                | SyntaxKind::TrueKeyword
+                | SyntaxKind::FalseKeyword
+                | SyntaxKind::NullKeyword
+        );
         let requires_colon = self.is_reserved_word()
             || (self.is_token(SyntaxKind::AwaitKeyword)
                 && (self.in_async_context() || self.in_static_block_context()))
@@ -3254,7 +3269,12 @@ impl ParserState {
             // Shorthand property - but certain property names require `:` syntax
             if requires_colon {
                 use tsz_common::diagnostics::diagnostic_codes;
-                self.parse_error_at_current_token("':' expected.", diagnostic_codes::EXPECTED);
+                let defer_to_comma_recovery = literal_property_name
+                    && property_name_had_prior_missing_colon
+                    && self.is_token(SyntaxKind::SemicolonToken);
+                if !defer_to_comma_recovery {
+                    self.parse_error_at_current_token("':' expected.", diagnostic_codes::EXPECTED);
+                }
             }
 
             // CoverInitializedName: `{ x = expr }` in destructuring patterns

--- a/crates/tsz-parser/tests/state_expression_tests.rs
+++ b/crates/tsz-parser/tests/state_expression_tests.rs
@@ -227,6 +227,31 @@ fn object_literal_dotted_property_recovery() {
 }
 
 #[test]
+fn malformed_numeric_arrow_body_reports_comma_at_return_semicolon() {
+    let source = "foo((1)=>{return 0;});";
+    let (parser, _root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+    let return_semicolon = source.find("0;").expect("return expression") as u32 + 1;
+
+    assert!(
+        diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::EXPECTED
+                && diag.start == return_semicolon
+                && diag.message == "',' expected."),
+        "expected tsc-compatible comma recovery at the malformed arrow body's semicolon, got {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .all(|diag| !(diag.code == diagnostic_codes::EXPECTED
+                && diag.start == return_semicolon
+                && diag.message == "':' expected.")),
+        "should not emit a second missing-colon diagnostic at the semicolon, got {diags:?}"
+    );
+}
+
+#[test]
 fn object_method_arrow_return_token_prefers_brace_expected_then_ts1434() {
     let source = r#"let o = {
     m(n: number) => string {


### PR DESCRIPTION
## Summary

Fix parser recovery for malformed numeric-parameter arrow syntax so `fatarrowfunctionsErrors.ts` matches TypeScript's diagnostic fingerprint at the semicolon after `return 0`.

```ts
foo((1)=>{return 0;});
// tsc: TS1005 "," expected at the semicolon after return 0
```

## Root Cause

The invalid arrow head `(1)=>` is recovered as an object-literal-like body. After a literal-like property name had already participated in missing-colon recovery, tsz emitted a second `':' expected.` at the semicolon. TypeScript instead defers to object-literal separator recovery there, producing `',' expected.`.

## Changes

- Track whether a literal property name already had a missing-colon diagnostic at its start.
- Suppress the duplicate missing-colon diagnostic at a following semicolon so comma recovery can report the TypeScript-compatible diagnostic.
- Add a parser regression test for `foo((1)=>{return 0;});`.

## Validation

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=.target cargo nextest run --package tsz-parser`
- `CARGO_TARGET_DIR=.target cargo nextest run --package tsz-parser malformed_numeric_arrow_body_reports_comma_at_return_semicolon`
- `./scripts/conformance/conformance.sh run --filter "fatarrowfunctionsErrors" --verbose`
- `NEXTEST_TEST_THREADS=8 scripts/session/verify-all.sh`
  - formatting: passed
  - clippy: passed
  - unit tests: passed
  - conformance: improved `12089 -> 12099` (+10), includes `fatarrowfunctionsErrors.ts`
  - emit tests: improved DTS `1247 -> 1255`, JS unchanged
  - fourslash/LSP: passed, 50/50 sampled
