### PR TITLE
[codex] apply pair finalization to related info

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -652,6 +652,8 @@ impl<'a> CheckerState<'a> {
         if needs_downgrade {
             let src_str = self.format_type_for_assignability_message(source);
             let tgt_str = self.format_type_for_assignability_message(target);
+            let (src_str, tgt_str) =
+                self.finalize_pair_display_for_diagnostic(source, target, src_str, tgt_str);
             let new_message = crate::diagnostics::format_message(
                 crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
@@ -1140,7 +1142,7 @@ impl<'a> CheckerState<'a> {
         ) {
             source_str = widened;
         }
-        (source_str, target_str)
+        self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str)
     }
 
     pub(in crate::error_reporter) fn rewrite_standalone_literal_source_for_keyof_display(
@@ -1200,7 +1202,7 @@ impl<'a> CheckerState<'a> {
         let (source_str, _) = self.format_top_level_assignability_message_types(source, target);
         let target_str =
             self.format_assignment_target_type_for_diagnostic(target, source, anchor_idx);
-        (source_str, target_str)
+        self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str)
     }
 
     pub(super) fn rewrite_source_display_for_non_literal_target_assignability(
@@ -1666,6 +1668,8 @@ impl<'a> CheckerState<'a> {
                 self.format_assignment_source_type_for_diagnostic(source, target, anchor_idx);
             let tgt_str =
                 self.format_assignment_target_type_for_diagnostic(target, source, anchor_idx);
+            let (src_str, tgt_str) =
+                self.finalize_pair_display_for_diagnostic(source, target, src_str, tgt_str);
             // TS2719: when both types display identically but are different,
             // emit "Two different types with this name exist" instead of TS2322.
             let authoritative_src = self.authoritative_assignability_def_name(source);
@@ -1691,13 +1695,17 @@ impl<'a> CheckerState<'a> {
                     && authoritative_src == authoritative_tgt
                     && source_generic_base == target_generic_base
                     && authoritative_src.as_deref() == source_generic_base;
-                let source_name = if src_str.starts_with("typeof ") || preserve_generic_nominal_pair
+                let source_name = if src_str.starts_with("typeof ")
+                    || src_str.starts_with("import(")
+                    || preserve_generic_nominal_pair
                 {
                     src_str.as_str()
                 } else {
                     authoritative_src.as_deref().unwrap_or(&src_str)
                 };
-                let target_name = if tgt_str.starts_with("typeof ") || preserve_generic_nominal_pair
+                let target_name = if tgt_str.starts_with("typeof ")
+                    || tgt_str.starts_with("import(")
+                    || preserve_generic_nominal_pair
                 {
                     tgt_str.as_str()
                 } else {

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -128,6 +128,8 @@ impl<'a> CheckerState<'a> {
 
         let arg_str = self.format_call_argument_type_for_diagnostic(arg_type, param_type, idx);
         let param_str = self.format_call_parameter_type_for_diagnostic(param_type, arg_type, idx);
+        let (arg_str, param_str) =
+            self.finalize_pair_display_for_diagnostic(arg_type, param_type, arg_str, param_str);
         let message = format_message(
             diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
             &[&arg_str, &param_str],

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -689,6 +689,80 @@ impl<'a> CheckerState<'a> {
         self.format_assignability_type_for_message_internal(ty, other, false)
     }
 
+    pub(in crate::error_reporter) fn finalize_pair_display_for_diagnostic(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        source_display: String,
+        target_display: String,
+    ) -> (String, String) {
+        if source == target || source_display != target_display {
+            return (source_display, target_display);
+        }
+
+        let Some(source_name) = Self::bare_nominal_display_name(&source_display) else {
+            return (source_display, target_display);
+        };
+        let Some(target_name) = Self::bare_nominal_display_name(&target_display) else {
+            return (source_display, target_display);
+        };
+        if source_name != target_name {
+            return (source_display, target_display);
+        }
+
+        let (pair_source, pair_target) = self.format_type_pair_diagnostic(source, target);
+        if pair_source == pair_target
+            || (pair_source == source_display && pair_target == target_display)
+        {
+            let source_candidate = self.format_assignability_type_for_message(source, target);
+            let target_candidate = self.format_assignability_type_for_message(target, source);
+            if source_candidate == target_candidate
+                || (source_candidate == source_display && target_candidate == target_display)
+            {
+                return (source_display, target_display);
+            }
+            return (source_candidate, target_candidate);
+        }
+
+        (pair_source, pair_target)
+    }
+
+    fn bare_nominal_display_name(display: &str) -> Option<&str> {
+        let mut text = display.trim();
+        if let Some(rest) = text.strip_prefix("typeof ") {
+            text = rest.trim();
+        }
+
+        if text.is_empty()
+            || text.starts_with('{')
+            || text.starts_with('[')
+            || text.starts_with('"')
+            || text.starts_with('\'')
+            || text.contains("=>")
+            || text.contains(" | ")
+            || text.contains(" & ")
+        {
+            return None;
+        }
+
+        let head = text.split_once('<').map(|(head, _)| head).unwrap_or(text);
+        let name = head.rsplit_once('.').map(|(_, name)| name).unwrap_or(head);
+        let mut chars = name.chars();
+        let first = chars.next()?;
+        if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+            return None;
+        }
+        if !chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()) {
+            return None;
+        }
+
+        match name {
+            "any" | "unknown" | "never" | "string" | "number" | "boolean" | "symbol" | "bigint"
+            | "void" | "undefined" | "null" | "object" => None,
+            _ => Some(name),
+        }
+    }
+
     fn format_assignability_type_for_message_internal(
         &mut self,
         ty: TypeId,

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -696,7 +696,7 @@ impl<'a> CheckerState<'a> {
         source_display: String,
         target_display: String,
     ) -> (String, String) {
-        if source == target || source_display != target_display {
+        if source == target {
             return (source_display, target_display);
         }
 

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -265,6 +265,12 @@ impl<'a> CheckerState<'a> {
                 }
                 let widened = self.widen_type_for_display(*source_type);
                 let src_str = self.format_type_diagnostic(widened);
+                let (src_str, tgt_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_type,
+                    *target_type,
+                    src_str,
+                    tgt_str,
+                );
                 vec![DiagnosticRelatedInformation {
                     category: DiagnosticCategory::Error,
                     code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
@@ -297,6 +303,12 @@ impl<'a> CheckerState<'a> {
                     return None;
                 }
                 let src_str = self.format_type_diagnostic(*source_type);
+                let (src_str, tgt_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_type,
+                    *target_type,
+                    src_str,
+                    tgt_str,
+                );
                 let names: Vec<String> = property_names
                     .iter()
                     .filter(|a| !is_object_prototype_method(self.ctx.types.resolve_atom_ref(**a)))
@@ -349,6 +361,15 @@ impl<'a> CheckerState<'a> {
                 } else {
                     *target_property_type
                 };
+                let source_str = self.format_type_diagnostic(*source_property_type);
+                let target_str = self.format_type_diagnostic(target_property_type);
+                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_property_type,
+                    target_property_type,
+                    source_str,
+                    target_str,
+                );
+
                 vec![
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Error,
@@ -369,15 +390,16 @@ impl<'a> CheckerState<'a> {
                         length,
                         message_text: format_message(
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                            &[
-                                &self.format_type_diagnostic(*source_property_type),
-                                &self.format_type_diagnostic(target_property_type),
-                            ],
+                            &[&source_str, &target_str],
                         ),
                     },
                 ]
             }
             SubtypeFailureReason::OptionalPropertyRequired { property_name } => {
+                let src_str = self.format_type_diagnostic(source);
+                let tgt_str = self.format_type_diagnostic(target);
+                let (src_str, tgt_str) =
+                    self.finalize_pair_display_for_diagnostic(source, target, src_str, tgt_str);
                 vec![DiagnosticRelatedInformation {
                     category: DiagnosticCategory::Error,
                     code: diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
@@ -388,8 +410,8 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
                         &[
                             &self.ctx.types.resolve_atom_ref(*property_name),
-                            &self.format_type_diagnostic(source),
-                            &self.format_type_diagnostic(target),
+                            &src_str,
+                            &tgt_str,
                         ],
                     ),
                 }]
@@ -401,6 +423,12 @@ impl<'a> CheckerState<'a> {
             } => {
                 let source_str = self.format_type_diagnostic(*source_return);
                 let target_str = self.format_type_diagnostic(*target_return);
+                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_return,
+                    *target_return,
+                    source_str,
+                    target_str,
+                );
                 let mut items = vec![
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Error,

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -242,6 +242,10 @@ impl<'a> CheckerState<'a> {
         }
 
         source_str = self.canonicalize_assignment_numeric_literal_union_display(source_str);
+        if depth == 0 {
+            (source_str, target_str) =
+                self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
+        }
 
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
@@ -551,6 +551,64 @@ acceptsM(n);
     );
 }
 
+#[test]
+fn test_ts2345_related_property_mismatch_uses_qualified_pair() {
+    let code = r#"
+declare namespace N {
+    export class Token {
+        kind: "n";
+    }
+}
+declare namespace M {
+    export class Token {
+        kind: "m";
+    }
+}
+
+interface Source {
+    value: N.Token;
+}
+interface Target {
+    value: M.Token;
+}
+
+declare const source: Source;
+function acceptsTarget(value: Target): void {}
+acceptsTarget(source);
+"#;
+
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "test.ts",
+        code,
+        CheckerOptions {
+            no_lib: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == 2345)
+        .unwrap_or_else(|| panic!("Expected TS2345, got: {diagnostics:?}"));
+    let related_messages: Vec<&str> = diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.as_str())
+        .collect();
+
+    assert!(
+        related_messages
+            .iter()
+            .any(|message| message.contains("Types of property 'value' are incompatible.")),
+        "Expected property mismatch related info. Related: {related_messages:#?}"
+    );
+    assert!(
+        related_messages
+            .iter()
+            .any(|message| message.contains("Type 'N.Token' is not assignable to type 'M.Token'.")),
+        "Expected qualified Token pair in related info. Related: {related_messages:#?}"
+    );
+}
+
 /// Union of tuple types with `.filter()` should contextually type callback parameters
 /// as the union of element types, matching tsc behavior.
 ///

--- a/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/declaration_module_emit.rs
@@ -513,6 +513,44 @@ class Foo<T> {
     );
 }
 
+#[test]
+fn test_ts2345_same_named_namespace_classes_use_qualified_pair() {
+    let code = r#"
+declare namespace N {
+    export class Token {
+        kind: "n";
+    }
+}
+declare namespace M {
+    export class Token {
+        kind: "m";
+    }
+}
+
+declare const n: N.Token;
+function acceptsM(value: M.Token): void {}
+acceptsM(n);
+"#;
+
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            no_lib: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 2345),
+        "Expected TS2345 for same-named namespace class argument, got: {diagnostics:?}"
+    );
+    let message = diagnostic_message(&diagnostics, 2345).unwrap_or("");
+    assert!(
+        message.contains("N.Token") && message.contains("M.Token"),
+        "Expected namespace-qualified Token names in TS2345 message. Message: {message}"
+    );
+}
+
 /// Union of tuple types with `.filter()` should contextually type callback parameters
 /// as the union of element types, matching tsc behavior.
 ///


### PR DESCRIPTION
## Summary
- Broaden conservative pair finalization so same bare nominal-name collisions can still qualify both sides when the initial display strings differ.
- Apply pair finalization to related-info rendering for missing-property, missing-properties, property-type-mismatch, optional-property-required, and return-type-mismatch failure reasons.
- Add a TS2345 related-info regression asserting nested property mismatch renders `N.Token` / `M.Token`.

## Validation
- `cargo fmt`
- `cargo test -p tsz-checker --test conformance_issues test_ts2345_related_property_mismatch_uses_qualified_pair -- --nocapture`
- `cargo test -p tsz-checker --test conformance_issues declaration_module_emit -- --nocapture`
- `cargo test -p tsz-checker --test conformance_issues test_enum_assignment_compat_uses_qualified_names_not_ts2719 -- --nocapture`
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests`
- `cargo check -p tsz-checker`
- `cargo clippy -p tsz-checker -- -D warnings`
- `git diff --check`
- `git diff --cached --check`

Note: local git hooks were bypassed with `TSZ_SKIP_HOOKS=1` because the hook path resets the TypeScript submodule and has hung in fresh worktrees; the equivalent Rust checks above were run directly.
