### PR TITLE
[codex] route assignability helper display through roles

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -6,6 +6,7 @@ use crate::error_reporter::assignability::is_object_prototype_method;
 use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
 };
+use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::NodeIndex;
@@ -157,15 +158,19 @@ impl<'a> CheckerState<'a> {
             )
         } else {
             (
-                self.format_assignment_source_type_for_diagnostic(
+                self.format_type_for_diagnostic_role(
                     source_for_display,
-                    target_for_display,
-                    anchor_idx,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target: target_for_display,
+                        anchor_idx,
+                    },
                 ),
-                self.format_assignment_target_type_for_diagnostic(
+                self.format_type_for_diagnostic_role(
                     target_for_display,
-                    source_for_display,
-                    anchor_idx,
+                    DiagnosticTypeDisplayRole::AssignmentTarget {
+                        source: source_for_display,
+                        anchor_idx,
+                    },
                 ),
             )
         };


### PR DESCRIPTION
## Summary
- Route assignment source/target display in `assignability_helpers.rs` through `DiagnosticTypeDisplayRole`.
- Preserve the existing function-like fallback to default diagnostic display.
- Keep message text and anchor selection unchanged.

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests`
- `cargo test -p tsz-checker --test conformance_issues declaration_module_emit -- --nocapture`
- `cargo clippy -p tsz-checker -- -D warnings`
- `git diff --check`
- `git diff --cached --check`

Note: local git hooks were bypassed with `TSZ_SKIP_HOOKS=1` because the hook path resets the TypeScript submodule and has hung in fresh worktrees; the equivalent Rust checks above were run directly.
