### PR TITLE
[codex] route render failure index displays through roles

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -5,6 +5,7 @@ use crate::diagnostics::{
     diagnostic_messages, format_message,
 };
 use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
+use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::query_boundaries::type_checking_utilities as query_utils;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -305,8 +306,13 @@ impl<'a> CheckerState<'a> {
                 target_value_type,
             } => {
                 if depth == 0 {
-                    let source_str =
-                        self.format_assignment_source_type_for_diagnostic(source, target, idx);
+                    let source_str = self.format_type_for_diagnostic_role(
+                        source,
+                        DiagnosticTypeDisplayRole::AssignmentSource {
+                            target,
+                            anchor_idx: idx,
+                        },
+                    );
                     let target_str = self.format_assignability_type_for_message(target, source);
                     let message = format_message(
                         diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -330,8 +336,13 @@ impl<'a> CheckerState<'a> {
 
             SubtypeFailureReason::MissingIndexSignature { index_kind } => {
                 if depth == 0 {
-                    let source_str =
-                        self.format_assignment_source_type_for_diagnostic(source, target, idx);
+                    let source_str = self.format_type_for_diagnostic_role(
+                        source,
+                        DiagnosticTypeDisplayRole::AssignmentSource {
+                            target,
+                            anchor_idx: idx,
+                        },
+                    );
                     let target_str = self.format_assignability_type_for_message(target, source);
                     let message = format_message(
                         diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -363,12 +374,24 @@ impl<'a> CheckerState<'a> {
                             .is_none();
                     (
                         if use_structural_source_display {
-                            self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                            self.format_type_for_diagnostic_role(
+                                source,
+                                DiagnosticTypeDisplayRole::AssignmentSource {
+                                    target,
+                                    anchor_idx: idx,
+                                },
+                            )
                         } else {
                             self.format_type_diagnostic(*source_type)
                         },
                         if use_structural_source_display {
-                            self.format_assignment_target_type_for_diagnostic(target, source, idx)
+                            self.format_type_for_diagnostic_role(
+                                target,
+                                DiagnosticTypeDisplayRole::AssignmentTarget {
+                                    source,
+                                    anchor_idx: idx,
+                                },
+                            )
                         } else {
                             self.format_type_diagnostic(target)
                         },


### PR DESCRIPTION
## Summary
- Route index-signature and missing-index-signature top-level source displays through `DiagnosticTypeDisplayRole::AssignmentSource`.
- Route the structural branch of `NoUnionMemberMatches` through assignment source/target display roles.
- Keep recursive render-failure message policy and non-structural enum display behavior unchanged.

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests`
- `cargo test -p tsz-checker --test conformance_issues declaration_module_emit -- --nocapture`
- `cargo clippy -p tsz-checker -- -D warnings`
- `git diff --check`
- `git diff --cached --check`
- local git hook path completed during commit
