### PR TITLE
[codex] route render failure fallback display through roles

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -524,8 +524,13 @@ impl<'a> CheckerState<'a> {
                 source_param,
                 target_param,
             } => {
-                let source_str =
-                    self.format_assignment_source_type_for_diagnostic(source, target, idx);
+                let source_str = self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                );
                 let target_str = self.format_assignability_type_for_message(target, source);
                 let message = format_message(
                     diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -605,8 +610,13 @@ impl<'a> CheckerState<'a> {
             }
 
             _ => {
-                let source_str =
-                    self.format_assignment_source_type_for_diagnostic(source, target, idx);
+                let source_str = self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                );
                 let target_str = self.format_assignability_type_for_message(target, source);
                 let message = format_message(
                     diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,


### PR DESCRIPTION
## Summary
- Route `ParameterTypeMismatch` primary source display through `DiagnosticTypeDisplayRole::AssignmentSource`.
- Route the catch-all render-failure assignability fallback through the same role.
- Keep target formatting, TS2328 companion emission, and fallback diagnostic policy unchanged.

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests`
- `cargo test -p tsz-checker --test conformance_issues declaration_module_emit -- --nocapture`
- `cargo clippy -p tsz-checker -- -D warnings`
- `git diff --check`
- `git diff --cached --check`

Note: local git hooks were bypassed with `TSZ_SKIP_HOOKS=1` because the hook path resets the TypeScript submodule and has hung in fresh worktrees; the equivalent Rust checks above were run directly.
