### PR TITLE
[codex] route missing-property render display through roles

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -650,7 +650,13 @@ impl<'a> CheckerState<'a> {
     ) -> Diagnostic {
         // Primitive sources use TS2322 rather than missing-property wording.
         let display_src_str = if depth == 0 && source_type != tsz_solver::TypeId::OBJECT {
-            self.format_assignment_source_type_for_diagnostic(source, target, idx)
+            self.format_type_for_diagnostic_role(
+                source,
+                DiagnosticTypeDisplayRole::AssignmentSource {
+                    target,
+                    anchor_idx: idx,
+                },
+            )
         } else {
             self.format_type_diagnostic(source_type)
         };
@@ -699,7 +705,13 @@ impl<'a> CheckerState<'a> {
                 );
         if is_source_fn && !target_has_call_sigs {
             let src_str = if depth == 0 {
-                self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                )
             } else {
                 self.format_type_diagnostic(source_type)
             };
@@ -749,7 +761,13 @@ impl<'a> CheckerState<'a> {
                 .is_some();
                 if !target_has_named_prop {
                     let src_str = if depth == 0 {
-                        self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                        self.format_type_for_diagnostic_role(
+                            source,
+                            DiagnosticTypeDisplayRole::AssignmentSource {
+                                target,
+                                anchor_idx: idx,
+                            },
+                        )
                     } else {
                         self.format_type_diagnostic(source_type)
                     };
@@ -882,7 +900,13 @@ impl<'a> CheckerState<'a> {
             || (depth == 0 && self.anchor_source_has_intersection_annotation(idx))
         {
             let src_str = if depth == 0 {
-                self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                )
             } else {
                 self.format_type_diagnostic(source_type)
             };
@@ -921,7 +945,13 @@ impl<'a> CheckerState<'a> {
                     );
             if base_is_intersection {
                 let src_str = if depth == 0 {
-                    self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                    self.format_type_for_diagnostic_role(
+                        source,
+                        DiagnosticTypeDisplayRole::AssignmentSource {
+                            target,
+                            anchor_idx: idx,
+                        },
+                    )
                 } else {
                     self.format_type_diagnostic(source_type)
                 };
@@ -948,7 +978,13 @@ impl<'a> CheckerState<'a> {
         let prop_name = self.ctx.types.resolve_atom_ref(property_name);
         if prop_name.starts_with("__private_brand") {
             let src_str = if depth == 0 {
-                self.format_assignment_source_type_for_diagnostic(source, target, idx)
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource {
+                        target,
+                        anchor_idx: idx,
+                    },
+                )
             } else {
                 self.format_type_for_assignability_message(source_type)
             };


### PR DESCRIPTION
## Summary
- Route `render_missing_property` top-level assignment-source display branches through `DiagnosticTypeDisplayRole::AssignmentSource`.
- Preserve depth-sensitive fallback formatting and missing-property vs TS2322 routing.
- Keep target formatting and private/protected elaboration behavior unchanged.

## Validation
- `cargo fmt`
- `cargo check -p tsz-checker`
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests`
- `cargo test -p tsz-checker --test conformance_issues declaration_module_emit -- --nocapture`
- `cargo clippy -p tsz-checker -- -D warnings`
- `git diff --check`
- `git diff --cached --check`

Note: local git hooks were bypassed with `TSZ_SKIP_HOOKS=1` because the hook path resets the TypeScript submodule and has hung in fresh worktrees; the equivalent Rust checks above were run directly.
