### PR TITLE
chore(tsz-checker): route complex_new_target.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/types/computation/complex_new_target.rs
+++ b/crates/tsz-checker/src/types/computation/complex_new_target.rs
@@ -29,7 +29,7 @@ impl<'a> CheckerState<'a> {
             return self
                 .class_symbol_from_expression(query.expr_name)
                 .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                .is_some_and(|symbol| (symbol.flags & symbol_flags::ABSTRACT) != 0);
+                .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::ABSTRACT));
         }
 
         if let Some(composite) = self.ctx.arena.get_composite_type(node) {
@@ -58,7 +58,7 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
 
-            if (symbol.flags & symbol_flags::TYPE_ALIAS) == 0 {
+            if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
                 return false;
             }
 
@@ -229,16 +229,16 @@ impl<'a> CheckerState<'a> {
             return Some(TypeId::ERROR);
         }
 
-        let has_type = (symbol.flags & symbol_flags::TYPE) != 0;
-        let has_value = (symbol.flags & symbol_flags::VALUE) != 0;
-        let is_type_alias = (symbol.flags & symbol_flags::TYPE_ALIAS) != 0;
+        let has_type = symbol.has_any_flags(symbol_flags::TYPE);
+        let has_value = symbol.has_any_flags(symbol_flags::VALUE);
+        let is_type_alias = symbol.has_any_flags(symbol_flags::TYPE_ALIAS);
 
         if !has_value && (is_type_alias || has_type) {
             // Type parameters only shadow in type contexts, not value contexts.
             // `new A()` where `A` is a type param shadowing an outer class should
             // resolve to the outer class, not emit TS2693.
             let is_type_param_only =
-                (symbol.flags & symbol_flags::TYPE_PARAMETER) != 0 && !has_value;
+                symbol.has_any_flags(symbol_flags::TYPE_PARAMETER) && !has_value;
             if is_type_param_only {
                 let lib_binders = self.get_lib_binders();
                 let has_outer_value = self
@@ -248,7 +248,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx
                             .binder
                             .get_symbol_with_libs(sid, &lib_binders)
-                            .is_some_and(|s| s.flags & symbol_flags::VALUE != 0)
+                            .is_some_and(|s| s.has_any_flags(symbol_flags::VALUE))
                     })
                     .is_some();
                 if has_outer_value {
@@ -293,7 +293,7 @@ impl<'a> CheckerState<'a> {
                 return Some(TypeId::ERROR);
             }
         }
-        let resolved_sym_id = if (symbol.flags & symbol_flags::ALIAS) != 0 {
+        let resolved_sym_id = if symbol.has_any_flags(symbol_flags::ALIAS) {
             self.resolve_alias_symbol(sym_id, &mut AliasCycleTracker::new())
                 .unwrap_or(sym_id)
         } else {
@@ -362,7 +362,7 @@ impl<'a> CheckerState<'a> {
             // construct signatures; this suppresses the false TS2351.
             if let Some(sym_id) = self.resolve_qualified_symbol(expr_idx)
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-                && (symbol.flags & symbol_flags::CLASS) != 0
+                && symbol.has_any_flags(symbol_flags::CLASS)
             {
                 return true;
             }
@@ -380,14 +380,14 @@ impl<'a> CheckerState<'a> {
             return false;
         };
         if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
-            if (symbol.flags & symbol_flags::CLASS) != 0 {
+            if symbol.has_any_flags(symbol_flags::CLASS) {
                 return true;
             }
             // Variables initialized with class expressions (e.g., `let C = class { ... }`)
             // should be treated as class symbols for circular self-reference suppression.
             // The variable has VARIABLE flags, not CLASS, but `new C()` inside the class
             // body is a valid self-referencing construct that tsc accepts.
-            if (symbol.flags & symbol_flags::VARIABLE) != 0
+            if symbol.has_any_flags(symbol_flags::VARIABLE)
                 && symbol.value_declaration.is_some()
                 && let Some(decl_node) = self.ctx.arena.get(symbol.value_declaration)
                 && let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node)
@@ -429,25 +429,24 @@ impl<'a> CheckerState<'a> {
                             let Some(parent_sym) = self.ctx.binder.get_symbol(parent_sym_id) else {
                                 continue;
                             };
-                            if parent_sym.flags
-                                & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
-                                == 0
-                            {
+                            if !parent_sym.has_any_flags(
+                                symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE,
+                            ) {
                                 continue;
                             }
                             if let Some(parent_exports) = parent_sym.exports.as_ref()
                                 && let Some(nested_ns_id) = parent_exports.get(ns_name)
                                 && let Some(nested_ns) = self.ctx.binder.get_symbol(nested_ns_id)
-                                && nested_ns.flags
-                                    & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
-                                    != 0
+                                && nested_ns.has_any_flags(
+                                    symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE,
+                                )
                                 && let Some(nested_exports) = nested_ns.exports.as_ref()
                                 && let Some(member_id) = nested_exports.get(name)
                                 && self
                                     .ctx
                                     .binder
                                     .get_symbol(member_id)
-                                    .is_some_and(|s| (s.flags & symbol_flags::CLASS) != 0)
+                                    .is_some_and(|s| s.has_any_flags(symbol_flags::CLASS))
                             {
                                 return true;
                             }
@@ -484,7 +483,7 @@ impl<'a> CheckerState<'a> {
             .resolve_identifier(self.ctx.arena, expr_idx)
             .or_else(|| self.ctx.binder.get_node_symbol(expr_idx))?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::CLASS == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return Some(false);
         }
 

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -61,6 +61,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - Flow worklist `defer_to_antecedent` helper (#800).
 - Checker enum numeric parser fallback routed through `tsz_common` (#798).
 - `Symbol::primary_declaration` helper on `tsz-binder`, routed through 7 checker call sites (current branch — see §tsz-checker below).
+- `Symbol::has_any_flags` sweep across `tsz-checker` — migrated raw `(sym.flags & mask) != 0` idioms in `types/queries/type_only.rs` (#850), `symbols/symbol_resolver_utils.rs` (#853), `state/state_checking/heritage.rs` (#856), `state/type_analysis/core.rs` (#858), `symbols/symbol_resolver.rs` (#863), `flow/flow_analysis/tdz.rs` (#867), `types/property_access_type/resolve.rs` (#873), and `types/computation/complex_new_target.rs` (current branch).
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary
- Migrates the 13 raw `(sym.flags & mask) != 0` / `== 0` call sites in `types/computation/complex_new_target.rs` onto the `Symbol::has_any_flags` helper, including two composite `NAMESPACE_MODULE | VALUE_MODULE` gates.
- Behavior-identical. Part of the ongoing DRY sweep tracked in `docs/DRY_AUDIT_2026-04-21.md` (follows #850, #853, #856, #858, #863, #867, #873).

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] Pre-commit hook (fmt + clippy + wasm32 + arch-guard + 12999 nextest tests)