### PR TITLE
fix(checker): report implicit any for JS prototype params

### DIFF
--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -562,6 +562,8 @@ impl<'a> CheckerState<'a> {
                 };
                 let is_this_param = name == Some(this_atom);
                 let is_js_file = self.is_js_file();
+                let is_bare_js_prototype_assignment_function =
+                    is_js_file && prototype_owner_expr.is_some() && !has_jsdoc_type_function;
                 let contextual_type = if let Some(ref helper) = ctx_helper {
                     let expected_contextual_type = helper.expected().and_then(|expected| {
                         if param.dot_dot_dot_token {
@@ -732,10 +734,18 @@ impl<'a> CheckerState<'a> {
                 // Rest parameters (`...x`) are always contextually typed when a contextual
                 // type helper exists — even if the contextual function has fewer parameters,
                 // the rest param captures the "remaining" args (type `[]` for 0-param context).
-                let has_contextual_type = contextual_type
+                // A JS prototype assignment can synthesize its own method type while
+                // resolving the LHS. That `any` parameter context is not real user
+                // context, so it must not suppress TS7006 for the RHS function.
+                let weak_self_contextual_prototype_any = is_bare_js_prototype_assignment_function
+                    && contextual_type == Some(TypeId::ANY);
+                let has_contextual_type = (contextual_type
                     .is_some_and(|t| t != TypeId::UNKNOWN || !is_js_file)
+                    && !weak_self_contextual_prototype_any)
                     || (has_unknown_expected_context && !is_js_file)
-                    || (param.dot_dot_dot_token && ctx_helper.is_some())
+                    || (param.dot_dot_dot_token
+                        && ctx_helper.is_some()
+                        && !weak_self_contextual_prototype_any)
                     || jsdoc_initializer_callable_context;
                 let suppresses_implicit_any_context =
                     has_contextual_type && !has_never_expected_context;
@@ -913,20 +923,22 @@ impl<'a> CheckerState<'a> {
                         element_type_from_pattern = Some(pattern_type);
                     }
                 }
-                let cached_param_type = (!has_contextual_type && param.type_annotation.is_none())
-                    .then(|| {
-                        self.ctx
-                            .node_types
-                            .get(&param.name.0)
-                            .copied()
-                            .or_else(|| self.ctx.node_types.get(&param_idx.0).copied())
-                    })
-                    .flatten()
-                    .filter(|cached_param_type| {
-                        *cached_param_type != TypeId::ANY
-                            && *cached_param_type != TypeId::UNKNOWN
-                            && *cached_param_type != TypeId::ERROR
-                    });
+                let cached_param_type = (!has_contextual_type
+                    && param.type_annotation.is_none()
+                    && !(is_bare_js_prototype_assignment_function && ctx_helper.is_none()))
+                .then(|| {
+                    self.ctx
+                        .node_types
+                        .get(&param.name.0)
+                        .copied()
+                        .or_else(|| self.ctx.node_types.get(&param_idx.0).copied())
+                })
+                .flatten()
+                .filter(|cached_param_type| {
+                    *cached_param_type != TypeId::ANY
+                        && *cached_param_type != TypeId::UNKNOWN
+                        && *cached_param_type != TypeId::ERROR
+                });
                 let mut type_id = if let Some(pattern_type) = element_type_from_pattern {
                     if param.type_annotation.is_some()
                         || ((has_contextual_type || has_external_binding_context)

--- a/crates/tsz-checker/tests/js_constructor_property_tests.rs
+++ b/crates/tsz-checker/tests/js_constructor_property_tests.rs
@@ -1844,6 +1844,32 @@ Installer.prototype.loadArgMetadata = function(next) {
 }
 
 #[test]
+fn test_js_prototype_method_reports_implicit_any_for_own_params() {
+    let source = r#"
+function Installer() {
+    this.args = 0;
+}
+Installer.prototype.loadArgMetadata = function(next) {
+    (args) => {
+        this.args = "hi";
+    };
+}
+"#;
+    let diagnostics = check_js(source);
+    let ts7006_next: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, msg)| {
+            *code == 7006 && msg.contains("Parameter 'next' implicitly has an 'any' type.")
+        })
+        .collect();
+    assert_eq!(
+        ts7006_next.len(),
+        1,
+        "Expected bare JS prototype method parameter to report TS7006, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_js_prototype_method_arrow_adds_instance_properties() {
     let source = r#"
 function Installer() {


### PR DESCRIPTION
## Root cause
JS prototype assignments could synthesize the RHS function's own prototype method type while resolving the assignment target, and the resulting `any` parameter context incorrectly suppressed TS7006 on unannotated prototype method parameters.

## Fixed conformance target
- `TypeScript/tests/cases/conformance/salsa/typeFromPropertyAssignment22.ts`

## Unit test
- `test_js_prototype_method_reports_implicit_any_for_own_params` in `crates/tsz-checker/tests/js_constructor_property_tests.rs`

## Verification
- `cargo nextest run --package tsz-checker --test js_constructor_property_tests test_js_prototype_method_reports_implicit_any_for_own_params`
- `./scripts/conformance/conformance.sh run --filter "typeFromPropertyAssignment22" --verbose`
- `cargo nextest run --package tsz-checker --test js_constructor_property_tests`
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/session/verify-all.sh` after final rebase: all suites passed; conformance 12098 vs 12089 baseline (+9), emit tests JS +0 / DTS +8, fourslash/LSP 50/50.
