### PR TITLE
[codex] Fix non-generic explicit type arg call diagnostics

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -7,6 +7,11 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_solver::TypeId;
 
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct CallTypeArgumentValidation {
+    pub count_mismatch: bool,
+}
+
 // =============================================================================
 // Generic Type Argument Checking Methods
 // =============================================================================
@@ -425,15 +430,13 @@ impl<'a> CheckerState<'a> {
     /// Validate explicit type arguments against their constraints for call expressions.
     /// Reports TS2344 when a type argument doesn't satisfy its constraint.
     /// Reports TS2558 when a non-generic function is called with type arguments.
-    /// Returns `true` when a type argument count mismatch was detected (TS2558 emitted),
-    /// signaling that the caller should skip argument type checking against the
-    /// incorrectly-instantiated signature.
+    /// Returns validation state for downstream call diagnostics.
     pub(crate) fn validate_call_type_arguments(
         &mut self,
         callee_type: TypeId,
         type_args_list: &tsz_parser::parser::NodeList,
         call_idx: NodeIndex,
-    ) -> bool {
+    ) -> CallTypeArgumentValidation {
         use tsz_scanner::SyntaxKind;
 
         if let Some(call_expr) = self.ctx.arena.get_call_expr_at(call_idx)
@@ -443,7 +446,7 @@ impl<'a> CheckerState<'a> {
         {
             // The parser already reports TS2754 for `super<T>(...)`.
             // Skip re-emitting it here to avoid duplicate diagnostics.
-            return false;
+            return CallTypeArgumentValidation::default();
         }
 
         let callee_type_orig = callee_type;
@@ -476,7 +479,7 @@ impl<'a> CheckerState<'a> {
             for &arg_idx in &type_args_list.nodes {
                 self.get_type_of_node(arg_idx);
             }
-            return false;
+            return CallTypeArgumentValidation::default();
         }
 
         // Get the type parameters from the callee type. For callables with overloads,
@@ -488,7 +491,7 @@ impl<'a> CheckerState<'a> {
             got,
         ) else {
             // None = multiple overloads match or not a callable type; skip validation.
-            return false;
+            return CallTypeArgumentValidation::default();
         };
 
         let max_expected = type_params.len();
@@ -514,7 +517,9 @@ impl<'a> CheckerState<'a> {
                                 &counts[1].to_string(),
                             ],
                         );
-                        return false;
+                        return CallTypeArgumentValidation {
+                            count_mismatch: true,
+                        };
                     }
                 }
                 // TS2558: Expected 0 type arguments, but got N.
@@ -523,12 +528,11 @@ impl<'a> CheckerState<'a> {
                     crate::diagnostics::diagnostic_codes::EXPECTED_TYPE_ARGUMENTS_BUT_GOT,
                     &["0", &got.to_string()],
                 );
-                // For non-generic functions (0 type params), tsc still proceeds with argument
-                // type checking against the original signature. Return false (not a count mismatch)
-                // so the caller continues to check argument types.
-                return false;
+                return CallTypeArgumentValidation {
+                    count_mismatch: true,
+                };
             }
-            return false;
+            return CallTypeArgumentValidation::default();
         }
 
         if got < min_required || got > max_expected {
@@ -547,7 +551,9 @@ impl<'a> CheckerState<'a> {
                         &counts[1].to_string(),
                     ],
                 );
-                return true;
+                return CallTypeArgumentValidation {
+                    count_mismatch: true,
+                };
             }
             // TS2558: Expected N type arguments, but got M.
             // When there are type params with defaults, show the range
@@ -561,11 +567,13 @@ impl<'a> CheckerState<'a> {
                 crate::diagnostics::diagnostic_codes::EXPECTED_TYPE_ARGUMENTS_BUT_GOT,
                 &[&expected_str, &got.to_string()],
             );
-            return true;
+            return CallTypeArgumentValidation {
+                count_mismatch: true,
+            };
         }
 
         self.validate_type_args_against_params(&type_params, type_args_list);
-        false
+        CallTypeArgumentValidation::default()
     }
 
     /// Validate type arguments against their constraints for type references (e.g., `A<X, Y>`).

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -248,11 +248,11 @@ impl<'a> CheckerState<'a> {
         // args is already defined above before the ANY/ERROR check
 
         // Validate explicit type arguments against constraints (TS2344)
-        let mut type_arg_count_mismatch = false;
+        let mut type_arg_validation = crate::generic_checker::CallTypeArgumentValidation::default();
         if let Some(ref type_args_list) = call.type_arguments
             && !type_args_list.nodes.is_empty()
         {
-            type_arg_count_mismatch =
+            type_arg_validation =
                 self.validate_call_type_arguments(callee_type, type_args_list, idx);
 
             // `super<T>(...)` is always invalid (TS2754). Don't proceed with
@@ -280,7 +280,7 @@ impl<'a> CheckerState<'a> {
         // tsc skips argument checking in this case. Without this guard, the checker
         // would run generic inference on an uninstantiated signature and emit spurious
         // TS2345 errors for arguments that are actually valid.
-        if type_arg_count_mismatch {
+        if type_arg_validation.count_mismatch {
             // Still evaluate argument expressions for side-effect errors
             // (definite assignment, etc.) but don't type-check them against
             // the function signature.

--- a/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
+++ b/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
@@ -161,6 +161,55 @@ var r = add<number>(1, 2);
     );
 }
 
+#[test]
+fn non_generic_explicit_type_args_suppress_argument_mismatch_but_plain_calls_report() {
+    let source = r#"
+function foo<T, U>(f: (v: T) => U) {
+   var r1 = f<number>(1);
+   var r2 = f(1);
+   var r3 = f<any>(null);
+   var r4 = f(null);
+}
+"#;
+    let diagnostics = check_diagnostics(source);
+    let mut ts2558: Vec<_> = diagnostics.iter().filter(|d| d.code == 2558).collect();
+    let mut ts2345: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
+    ts2558.sort_by_key(|d| d.start);
+    ts2345.sort_by_key(|d| d.start);
+
+    let explicit_number = source.find("number").expect("number type argument") as u32;
+    let explicit_any = source.find("any").expect("any type argument") as u32;
+    let plain_number_arg = (source.find("f(1)").expect("plain number call") + 2) as u32;
+    let plain_null_arg = (source.find("f(null)").expect("plain null call") + 2) as u32;
+
+    assert_eq!(
+        ts2558.len(),
+        2,
+        "Expected two TS2558 diagnostics, got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2558[0].start, explicit_number,
+        "TS2558 from f<number>(1) should anchor at the explicit type argument"
+    );
+    assert_eq!(
+        ts2558[1].start, explicit_any,
+        "TS2558 from f<any>(null) should anchor at the explicit type argument"
+    );
+    assert_eq!(
+        ts2345.len(),
+        2,
+        "Expected two TS2345 diagnostics, got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2345[0].start, plain_number_arg,
+        "TS2345 should come from the plain f(1) call, not f<number>(1)"
+    );
+    assert_eq!(
+        ts2345[1].start, plain_null_arg,
+        "TS2345 should come from the plain f(null) call, not f<any>(null)"
+    );
+}
+
 /// When type arg count is wrong but argument count is also wrong,
 /// both TS2558 and TS2554 should be suppressed (only TS2558 for the
 /// type arg count). TSC does not emit argument count errors in this case.


### PR DESCRIPTION
## Summary
- Treat explicit type arguments on non-generic callables as a type-argument count validation failure, so call argument compatibility is skipped after TS2558.
- Add a regression test covering `f<number>(1)`/`f<any>(null)` suppression while preserving TS2345 on plain `f(1)`/`f(null)` calls.

## Root Cause
Tsz emitted TS2558 for explicit type arguments on a non-generic callable but still checked the invalid call arguments, producing extra TS2345 diagnostics that TSC suppresses.

## Conformance Target
`TypeScript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts`

## Unit Test
`non_generic_explicit_type_args_suppress_argument_mismatch_but_plain_calls_report` in `crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs`

## Verification
- `cargo fmt --check` -> passed
- `cargo nextest run --package tsz-checker --test type_arg_count_mismatch_tests` -> passed
- `./scripts/conformance/conformance.sh run --filter "typeArgumentsOnFunctionsWithNoTypeParameters" --verbose` -> 1/1 passed
- `scripts/session/verify-all.sh` -> passed: formatting, clippy, unit tests, conformance +13 (`12102` vs baseline `12089`), emit tests JS +0/DTS +8, fourslash/LSP 50/50

Final pre-PR rebase check: `git fetch origin --prune` followed by `git rebase origin/main` reported the branch was up to date after verification.