### PR TITLE
chore(tsz-checker): route commonjs_assignment.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -291,10 +291,10 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        if (root_symbol.flags & symbol_flags::ALIAS) != 0 && root_symbol.import_module.is_some() {
+        if root_symbol.has_any_flags(symbol_flags::ALIAS) && root_symbol.import_module.is_some() {
             return false;
         }
-        if (root_symbol.flags & symbol_flags::CLASS) != 0 {
+        if root_symbol.has_any_flags(symbol_flags::CLASS) {
             return false;
         }
 
@@ -402,18 +402,16 @@ impl<'a> CheckerState<'a> {
             && let Some(member_symbol) = self
                 .get_cross_file_symbol(member_sym_id)
                 .or_else(|| self.ctx.binder.get_symbol(member_sym_id))
-            && (member_symbol.flags & symbol_flags::ENUM) != 0
+            && member_symbol.has_any_flags(symbol_flags::ENUM)
         {
             let parent_sym_id = member_symbol.parent;
             if let Some(parent_symbol) = self
                 .get_cross_file_symbol(parent_sym_id)
                 .or_else(|| self.ctx.binder.get_symbol(parent_sym_id))
-                && (parent_symbol.flags
-                    & (symbol_flags::MODULE
-                        | symbol_flags::NAMESPACE
-                        | symbol_flags::NAMESPACE_MODULE))
-                    != 0
-                && (parent_symbol.flags & symbol_flags::ENUM) == 0
+                && parent_symbol.has_any_flags(
+                    symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE,
+                )
+                && !parent_symbol.has_any_flags(symbol_flags::ENUM)
             {
                 return true;
             }
@@ -427,8 +425,8 @@ impl<'a> CheckerState<'a> {
             && let Some(enum_symbol) = self
                 .get_cross_file_symbol(enum_sym_id)
                 .or_else(|| self.ctx.binder.get_symbol(enum_sym_id))
-            && (enum_symbol.flags & symbol_flags::ENUM) != 0
-            && (enum_symbol.flags & symbol_flags::ENUM_MEMBER) == 0
+            && enum_symbol.has_any_flags(symbol_flags::ENUM)
+            && !enum_symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
         {
             // If the property being assigned is a declared member of this enum,
             // this is an enum member assignment (should get TS2540), not a rebind.
@@ -447,12 +445,10 @@ impl<'a> CheckerState<'a> {
             if let Some(parent_symbol) = self
                 .get_cross_file_symbol(parent_sym_id)
                 .or_else(|| self.ctx.binder.get_symbol(parent_sym_id))
-                && (parent_symbol.flags
-                    & (symbol_flags::MODULE
-                        | symbol_flags::NAMESPACE
-                        | symbol_flags::NAMESPACE_MODULE))
-                    != 0
-                && (parent_symbol.flags & symbol_flags::ENUM) == 0
+                && parent_symbol.has_any_flags(
+                    symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE,
+                )
+                && !parent_symbol.has_any_flags(symbol_flags::ENUM)
             {
                 return true;
             }
@@ -474,10 +470,9 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if (base_symbol.flags
-            & (symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE))
-            == 0
-        {
+        if !base_symbol.has_any_flags(
+            symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE,
+        ) {
             return false;
         }
 
@@ -494,7 +489,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        (member_symbol.flags & symbol_flags::ENUM) != 0
+        member_symbol.has_any_flags(symbol_flags::ENUM)
     }
 
     pub(crate) fn is_js_namespace_enum_expando_member_assignment(
@@ -559,8 +554,8 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if (enum_symbol.flags & symbol_flags::ENUM) == 0
-            || (enum_symbol.flags & symbol_flags::ENUM_MEMBER) != 0
+        if !enum_symbol.has_any_flags(symbol_flags::ENUM)
+            || enum_symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
         {
             return false;
         }
@@ -571,10 +566,9 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if (parent_symbol.flags
-            & (symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE))
-            == 0
-            || (parent_symbol.flags & symbol_flags::ENUM) != 0
+        if !parent_symbol.has_any_flags(
+            symbol_flags::MODULE | symbol_flags::NAMESPACE | symbol_flags::NAMESPACE_MODULE,
+        ) || parent_symbol.has_any_flags(symbol_flags::ENUM)
         {
             return false;
         }
@@ -637,7 +631,7 @@ impl<'a> CheckerState<'a> {
         let member_symbol = self
             .get_cross_file_symbol(member_sym_id)
             .or_else(|| self.ctx.binder.get_symbol(member_sym_id));
-        member_symbol.is_some_and(|sym| (sym.flags & symbol_flags::ENUM_MEMBER) != 0)
+        member_symbol.is_some_and(|sym| sym.has_any_flags(symbol_flags::ENUM_MEMBER))
     }
 
     pub(crate) fn error_top_level_js_this_computed_element_assignment(

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -61,6 +61,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - Flow worklist `defer_to_antecedent` helper (#800).
 - Checker enum numeric parser fallback routed through `tsz_common` (#798).
 - `Symbol::primary_declaration` helper on `tsz-binder`, routed through 7 checker call sites (current branch — see §tsz-checker below).
+- `Symbol::has_any_flags(mask)` sweep across `tsz-checker` — migrated file-by-file: `state/type_analysis/core.rs` (#858), `symbols/symbol_resolver.rs` (#863), `flow/flow_analysis/tdz.rs` (#867), `types/property_access_type/resolve.rs` (#873), `types/computation/complex_new_target.rs` (#877), `symbols/symbol_resolver_qualified.rs` (#881), `assignability/assignment_checker/commonjs_assignment.rs` (current branch).
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary
- Continues the `Symbol::has_any_flags(mask)` sweep across `tsz-checker`.
- Migrates 12 raw `(sym.flags & MASK) != 0` / `== 0` sites in `crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs` onto the canonical helper.
- Composite masks (`MODULE | NAMESPACE | NAMESPACE_MODULE`, etc.) now read as `sym.has_any_flags(a | b | c)` — semantics preserved because the helper is `const fn has_any_flags(self, flags) -> bool { (self.flags & flags) != 0 }`.

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] Pre-commit: fmt + clippy + wasm32 rustc gate + arch-guard + `cargo nextest run` (all tests passing)