### PR TITLE
chore(tsz-checker): route context/resolver.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -190,11 +190,11 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
                     // be in the DefinitionStore).
                     let symbol = self.binder.symbols.get(sym_id);
                     if let Some(symbol) = symbol
-                        && (symbol.flags
-                            & (symbol_flags::CLASS
+                        && symbol.has_any_flags(
+                            symbol_flags::CLASS
                                 | symbol_flags::INTERFACE
-                                | symbol_flags::TYPE_ALIAS))
-                            != 0
+                                | symbol_flags::TYPE_ALIAS,
+                        )
                     {
                         return Some(*instance_type);
                     }
@@ -213,7 +213,7 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
             // Type parameters are always local symbols (never from lib binders), so
             // only check the primary binder.
             if let Some(symbol) = self.binder.symbols.get(sym_id)
-                && (symbol.flags & symbol_flags::TYPE_PARAMETER) != 0
+                && symbol.has_any_flags(symbol_flags::TYPE_PARAMETER)
                 && let Some(&tp_type) = self.type_parameter_scope.get(symbol.escaped_name.as_str())
             {
                 return Some(tp_type);
@@ -539,13 +539,13 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
         };
 
         // Enum members resolve via their parent ENUM symbol.
-        let enum_symbol = if (symbol.flags & symbol_flags::ENUM_MEMBER) != 0 {
+        let enum_symbol = if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             // It's a member, get the parent enum symbol
             let Some(parent) = self.binder.get_symbol(symbol.parent) else {
                 return false;
             };
             parent
-        } else if (symbol.flags & symbol_flags::ENUM) != 0 {
+        } else if symbol.has_any_flags(symbol_flags::ENUM) {
             // It's the enum itself
             symbol
         } else {
@@ -668,8 +668,8 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
             };
 
             // It's an enum type if it has ENUM flag but not ENUM_MEMBER flag
-            return (symbol.flags & symbol_flags::ENUM) != 0
-                && (symbol.flags & symbol_flags::ENUM_MEMBER) == 0;
+            return symbol.has_any_flags(symbol_flags::ENUM)
+                && !symbol.has_any_flags(symbol_flags::ENUM_MEMBER);
         }
 
         // Case 2: Union of Enum members (e.g., the full enum type E = E.A | E.B | ...)
@@ -696,7 +696,7 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
                     };
 
                     // If this is an enum member, track the PARENT enum symbol
-                    if (symbol.flags & symbol_flags::ENUM_MEMBER) != 0 {
+                    if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
                         // Get the parent symbol (the enum itself)
                         let parent_sym_id = symbol.parent;
 
@@ -764,7 +764,7 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
         })?;
 
         // Check if this is an enum member
-        if (symbol.flags & symbol_flags::ENUM_MEMBER) == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return None;
         }
 
@@ -823,18 +823,18 @@ impl<'a> tsz_solver::TypeResolver for CheckerContext<'a> {
         };
 
         // Check if this is a user-defined enum or enum member
-        if (symbol.flags & symbol_flags::ENUM) != 0 {
+        if symbol.has_any_flags(symbol_flags::ENUM) {
             // This is an enum type - check it's not an intrinsic
-            return (symbol.flags & symbol_flags::ENUM_MEMBER) == 0;
+            return !symbol.has_any_flags(symbol_flags::ENUM_MEMBER);
         }
 
-        if (symbol.flags & symbol_flags::ENUM_MEMBER) != 0 {
+        if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             // This is an enum member - check if the parent is a user-defined enum
             let parent_sym_id = symbol.parent;
             if let Some(parent_symbol) = self.binder.get_symbol(parent_sym_id) {
                 // Parent is a user enum if it has ENUM flag but not ENUM_MEMBER
-                return (parent_symbol.flags & symbol_flags::ENUM) != 0
-                    && (parent_symbol.flags & symbol_flags::ENUM_MEMBER) == 0;
+                return parent_symbol.has_any_flags(symbol_flags::ENUM)
+                    && !parent_symbol.has_any_flags(symbol_flags::ENUM_MEMBER);
             }
         }
 

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -61,6 +61,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - Flow worklist `defer_to_antecedent` helper (#800).
 - Checker enum numeric parser fallback routed through `tsz_common` (#798).
 - `Symbol::primary_declaration` helper on `tsz-binder`, routed through 7 checker call sites (current branch — see §tsz-checker below).
+- `Symbol::has_any_flags(mask)` sweep across `tsz-checker` — migrated file-by-file: `state/type_analysis/core.rs` (#858), `symbols/symbol_resolver.rs` (#863), `flow/flow_analysis/tdz.rs` (#867), `types/property_access_type/resolve.rs` (#873), `types/computation/complex_new_target.rs` (#877), `symbols/symbol_resolver_qualified.rs` (#881), `assignability/assignment_checker/commonjs_assignment.rs` (#883), `context/resolver.rs` (current branch).
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary
- Continues the `Symbol::has_any_flags(mask)` sweep across `tsz-checker`.
- Migrates 13 raw `(sym.flags & MASK) != 0` / `== 0` sites in `crates/tsz-checker/src/context/resolver.rs` (user-enum detection, enum member/parent checks, type-parameter scope lookup, class/interface/type-alias filtering) onto the canonical helper.
- Behavior preserved — `has_any_flags` is `const fn has_any_flags(self, flags) -> bool { (self.flags & flags) != 0 }`.

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] Pre-commit: fmt + clippy + wasm32 rustc gate + arch-guard + `cargo nextest run` (all green)