### PR TITLE
chore(tsz-checker): route assignment_ops.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -401,7 +401,7 @@ impl<'a> CheckerState<'a> {
         // Import bindings are readonly in ESM — you cannot reassign them.
         if let Some(local_sym_id) = self.ctx.binder.file_locals.get(name)
             && let Some(local_sym) = self.ctx.binder.get_symbol(local_sym_id)
-            && local_sym.flags & symbol_flags::ALIAS != 0
+            && local_sym.has_any_flags(symbol_flags::ALIAS)
         {
             self.error_at_node_msg(
                 inner,
@@ -424,9 +424,9 @@ impl<'a> CheckerState<'a> {
         };
 
         // Check for uninstantiated namespaces first (TS2708)
-        let is_namespace = (symbol.flags & symbol_flags::NAMESPACE_MODULE) != 0;
+        let is_namespace = symbol.has_any_flags(symbol_flags::NAMESPACE_MODULE);
         let value_flags_except_module = symbol_flags::VALUE & !symbol_flags::VALUE_MODULE;
-        let has_other_value = (symbol.flags & value_flags_except_module) != 0;
+        let has_other_value = symbol.has_any_flags(value_flags_except_module);
 
         if is_namespace && !has_other_value {
             let mut is_instantiated = false;
@@ -447,7 +447,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check for type-only symbols used as values in assignment position (TS2693)
-        if symbol.flags & symbol_flags::TYPE != 0 && symbol.flags & symbol_flags::VALUE == 0 {
+        if symbol.has_any_flags(symbol_flags::TYPE) && !symbol.has_any_flags(symbol_flags::VALUE) {
             self.report_wrong_meaning_diagnostic(
                 name,
                 inner,
@@ -457,13 +457,13 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if this symbol is a class, enum, function, or namespace (TS2629, TS2628, TS2630, TS2631)
-        let code = if symbol.flags & symbol_flags::MODULE != 0 {
+        let code = if symbol.has_any_flags(symbol_flags::MODULE) {
             diagnostic_codes::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_A_NAMESPACE
-        } else if symbol.flags & symbol_flags::CLASS != 0 {
+        } else if symbol.has_any_flags(symbol_flags::CLASS) {
             diagnostic_codes::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_A_CLASS
-        } else if symbol.flags & symbol_flags::ENUM != 0 {
+        } else if symbol.has_any_flags(symbol_flags::ENUM) {
             diagnostic_codes::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_AN_ENUM
-        } else if symbol.flags & symbol_flags::FUNCTION != 0 {
+        } else if symbol.has_any_flags(symbol_flags::FUNCTION) {
             diagnostic_codes::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_A_FUNCTION
         } else {
             return false;

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -61,6 +61,7 @@ The sections below have had completed bullets removed. This log keeps a running 
 - Flow worklist `defer_to_antecedent` helper (#800).
 - Checker enum numeric parser fallback routed through `tsz_common` (#798).
 - `Symbol::primary_declaration` helper on `tsz-binder`, routed through 7 checker call sites (current branch — see §tsz-checker below).
+- `Symbol::has_any_flags(mask)` sweep across `tsz-checker` — migrated file-by-file: `state/type_analysis/core.rs` (#858), `symbols/symbol_resolver.rs` (#863), `flow/flow_analysis/tdz.rs` (#867), `types/property_access_type/resolve.rs` (#873), `types/computation/complex_new_target.rs` (#877), `symbols/symbol_resolver_qualified.rs` (#881), `assignability/assignment_checker/commonjs_assignment.rs` (#883), `context/resolver.rs` (#884), `flow/control_flow/narrowing.rs` (#885), `assignability/assignment_checker/assignment_ops.rs` (current branch).
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary
- Continues the `Symbol::has_any_flags(mask)` sweep across `tsz-checker`.
- Migrates 8 raw `(sym.flags & MASK) != 0` / `== 0` sites in `crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs` — covers the TS2632 import-binding guard, TS2708 uninstantiated-namespace detection (including the `value_flags_except_module` computed-mask check), TS2693 type-only usage, and the TS2628/2629/2630/2631 class/enum/function/namespace reassignment diagnostics.
- Behavior preserved — helper is `const fn has_any_flags(self, flags) -> bool { (self.flags & flags) != 0 }`.

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] Pre-commit: fmt + clippy + wasm32 rustc gate + arch-guard + `cargo nextest run` (all green)