### PR TITLE
fix(checker): report implicit any for chained JS exports

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -615,6 +615,8 @@ impl<'a> CheckerState<'a> {
             .and_then(|node| self.ctx.arena.get_binary_expr(node))
             .is_some_and(|binary| binary.operator_token == SyntaxKind::EqualsToken as u16);
 
+        self.maybe_report_commonjs_export_implicit_any_assignment(left_idx, right_idx);
+
         if is_function_assignment {
             // TS2629/TS2628/TS2630 are terminal for simple assignment targets in tsc.
             // Do not contextually type the RHS against the class/function/enum object

--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -15,6 +15,105 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
 impl<'a> CheckerState<'a> {
+    pub(crate) fn maybe_report_commonjs_export_implicit_any_assignment(
+        &mut self,
+        target_idx: NodeIndex,
+        right_idx: NodeIndex,
+    ) {
+        if !self.is_js_file()
+            || !self.ctx.compiler_options.check_js
+            || !self.ctx.no_implicit_any()
+            || self.ctx.has_real_syntax_errors
+        {
+            return;
+        }
+
+        let Some(name_idx) = self.commonjs_export_property_name_node(target_idx) else {
+            return;
+        };
+
+        let direct_null = self.is_null_literal(right_idx);
+        let chained_nullish = self.is_assignment_expression(right_idx)
+            && self.assignment_chain_terminal_is_null_or_undefined(right_idx);
+        if !direct_null && !chained_nullish {
+            return;
+        }
+
+        let Some(name) = self
+            .ctx
+            .arena
+            .get_identifier_at(name_idx)
+            .map(|ident| ident.escaped_text.clone())
+        else {
+            return;
+        };
+
+        self.error_at_node_msg(
+            self.ctx.arena.skip_parenthesized(target_idx),
+            crate::diagnostics::diagnostic_codes::VARIABLE_IMPLICITLY_HAS_AN_TYPE,
+            &[&name, "any"],
+        );
+    }
+
+    fn commonjs_export_property_name_node(&self, target_idx: NodeIndex) -> Option<NodeIndex> {
+        let target_idx = self.ctx.arena.skip_parenthesized(target_idx);
+        let target_node = self.ctx.arena.get(target_idx)?;
+        if target_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+
+        let access = self.ctx.arena.get_access_expr(target_node)?;
+        self.is_commonjs_module_exports_assignment(access.expression)
+            .then_some(access.name_or_argument)
+    }
+
+    fn is_assignment_expression(&self, idx: NodeIndex) -> bool {
+        self.ctx
+            .arena
+            .get(idx)
+            .filter(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
+            .and_then(|node| self.ctx.arena.get_binary_expr(node))
+            .is_some_and(|binary| binary.operator_token == SyntaxKind::EqualsToken as u16)
+    }
+
+    fn assignment_chain_terminal_is_null_or_undefined(&self, idx: NodeIndex) -> bool {
+        let mut current = idx;
+        for _ in 0..512 {
+            current = self.ctx.arena.skip_parenthesized_and_assertions(current);
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::BINARY_EXPRESSION
+                && let Some(binary) = self.ctx.arena.get_binary_expr(node)
+                && binary.operator_token == SyntaxKind::EqualsToken as u16
+            {
+                current = binary.right;
+                continue;
+            }
+
+            return self.is_null_literal(current) || self.is_undefined_identifier(current);
+        }
+
+        false
+    }
+
+    fn is_null_literal(&self, idx: NodeIndex) -> bool {
+        let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
+        self.ctx
+            .arena
+            .get(idx)
+            .is_some_and(|node| node.kind == SyntaxKind::NullKeyword as u16)
+    }
+
+    fn is_undefined_identifier(&self, idx: NodeIndex) -> bool {
+        let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
+        self.ctx
+            .arena
+            .get(idx)
+            .and_then(|node| self.ctx.arena.get_identifier(node))
+            .is_some_and(|ident| ident.escaped_text == "undefined")
+    }
+
     /// In JS files, `module.exports = X` and `exports = X` are declarations, not assignments.
     /// tsc does not check assignability for these — the type flows from the RHS.
     /// Without this suppression, tsz would emit false TS2322/TS2741 errors when the

--- a/crates/tsz-checker/tests/js_export_surface_tests.rs
+++ b/crates/tsz-checker/tests/js_export_surface_tests.rs
@@ -1838,6 +1838,47 @@ var x = exports.alpha;
 }
 
 #[test]
+fn test_chained_undefined_export_assignment_reports_outer_implicit_any() {
+    let diagnostics = check_commonjs_single_file(
+        "self.js",
+        r#"
+exports.first = exports.second = exports.third = undefined;
+exports.direct = undefined;
+"#,
+    );
+
+    let ts7005: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 7005)
+        .collect();
+    assert_eq!(
+        ts7005.len(),
+        2,
+        "Expected TS7005 only for non-terminal chained export assignments, got: {diagnostics:#?}"
+    );
+
+    let messages: Vec<_> = ts7005.iter().map(|(_, message)| message.as_str()).collect();
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("Variable 'first' implicitly has an 'any' type.")),
+        "Expected TS7005 for `exports.first`, got: {messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("Variable 'second' implicitly has an 'any' type.")),
+        "Expected TS7005 for `exports.second`, got: {messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| !message.contains("'third'") && !message.contains("'direct'")),
+        "Terminal/direct undefined export assignments should not report TS7005, got: {messages:#?}"
+    );
+}
+
+#[test]
 #[ignore = "regressed after remote changes: expected 2 TS2322 for same-file CommonJS reassignments, now emits 0"]
 fn test_current_file_exports_reads_use_prior_assignment_types() {
     let diagnostics = check_commonjs_single_file(


### PR DESCRIPTION
## Root cause
Checked-JS CommonJS export assignments were treated as declaration-like assignment declarations, so chained `exports.foo = ... = undefined` assignments skipped the TS7005 implicit-any diagnostic for every non-terminal export.

## Fixed conformance target
- `TypeScript/tests/cases/conformance/jsdoc/jsdocTypeFromChainedAssignment3.ts`

## Unit test
- `test_chained_undefined_export_assignment_reports_outer_implicit_any` in `crates/tsz-checker/tests/js_export_surface_tests.rs`

## Verification
- `scripts/session/verify-all.sh`: PASSED (formatting, clippy, unit tests, conformance +10, emit JS +2/DTS +9, fourslash =50). Run with `NEXTEST_TEST_THREADS=8` and emit runner constrained to `--concurrency=4 --timeout=20000` to avoid local load-sensitive timeouts from another concurrent conformance loop.
- After final `git rebase origin/main`: `cargo nextest run --package tsz-checker --test js_export_surface_tests test_chained_undefined_export_assignment_reports_outer_implicit_any` passed.
- After final `git rebase origin/main`: `./scripts/conformance/conformance.sh run --filter "jsdocTypeFromChainedAssignment3" --verbose` passed (1/1).
