### PR TITLE
fix(checker): validate generic defaults against bare type params

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -2,6 +2,7 @@
 //! type queries, and contextual literal type analysis.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::checkers::generic as generic_query;
 use crate::query_boundaries::common::lazy_def_id;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
@@ -1737,22 +1738,22 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             let constraint_has_type_params =
-                crate::query_boundaries::checkers::generic::contains_type_parameters(
-                    self.ctx.types,
-                    constraint_type,
-                );
+                generic_query::contains_type_parameters(self.ctx.types, constraint_type);
             let default_has_type_params =
-                crate::query_boundaries::checkers::generic::contains_type_parameters(
-                    self.ctx.types,
-                    default_type,
-                );
-            if constraint_has_type_params
-                || default_has_type_params
-                || !self.is_assignable_to(default_type, constraint_type)
-            {
-                if constraint_has_type_params || default_has_type_params {
+                generic_query::contains_type_parameters(self.ctx.types, default_type);
+            if constraint_has_type_params || default_has_type_params {
+                let is_other_bare_type_parameter = |type_id| {
+                    generic_query::is_bare_type_parameter(self.ctx.types, type_id)
+                        && generic_query::type_parameter_name(self.ctx.types, type_id)
+                            .is_some_and(|name| name != param.name)
+                };
+                if !is_other_bare_type_parameter(default_type)
+                    && !is_other_bare_type_parameter(constraint_type)
+                {
                     continue;
                 }
+            }
+            if !self.is_assignable_to(default_type, constraint_type) {
                 let Some(node) = self.ctx.arena.get(param_idx) else {
                     continue;
                 };

--- a/crates/tsz-checker/tests/generic_tests.rs
+++ b/crates/tsz-checker/tests/generic_tests.rs
@@ -752,6 +752,78 @@ interface ExplicitArgDefault<T = SelfRef<number>> {}
     );
 }
 
+#[test]
+fn test_type_parameter_default_constraints_validate_type_parameter_references() {
+    let source = r#"
+declare function f04<T extends string, U extends number = T>(): void;
+declare function f05<T, U extends number = T>(): void;
+declare function f06<T, U extends T = number>(): void;
+interface i06<T extends string, U extends number = T> { }
+interface i07<T, U extends number = T> { }
+interface i08<T, U extends T = number> { }
+"#;
+
+    let diagnostics = crate::test_utils::check_source_diagnostics(source);
+    let ts2344_messages = diagnostics
+        .iter()
+        .filter(|d| d.code == 2344)
+        .map(|d| d.message_text.as_str())
+        .collect::<Vec<_>>();
+
+    let default_type_param_vs_number = ts2344_messages
+        .iter()
+        .filter(|message| message.contains("Type 'T' does not satisfy the constraint 'number'."))
+        .count();
+    let number_vs_default_type_param = ts2344_messages
+        .iter()
+        .filter(|message| message.contains("Type 'number' does not satisfy the constraint 'T'."))
+        .count();
+
+    assert_eq!(
+        ts2344_messages.len(),
+        6,
+        "Expected six TS2344 default-constraint diagnostics, got {ts2344_messages:?}"
+    );
+    assert_eq!(
+        default_type_param_vs_number, 4,
+        "Expected four TS2344 diagnostics for T defaulting into number constraints, got {ts2344_messages:?}"
+    );
+    assert_eq!(
+        number_vs_default_type_param, 2,
+        "Expected two TS2344 diagnostics for number defaulting into T constraints, got {ts2344_messages:?}"
+    );
+}
+
+#[test]
+fn test_type_parameter_default_constraints_skip_self_and_derived_type_parameter_references() {
+    let source = r#"
+type SelfDefault<T extends string = T> = { value: T };
+
+interface Settable<T, V> {
+    set(value: V): T;
+}
+interface Identity<V> extends Settable<Identity<V>, V> { }
+interface Test1<V, T extends Settable<T, V> = Identity<V>> { }
+
+type Prefixes = "foo" | "bar";
+type AllPrefixData = "foo:baz" | "bar:baz";
+type PrefixData<P extends Prefixes> = `${P}:baz`;
+interface ITest<P extends Prefixes, E extends AllPrefixData = PrefixData<P>> { }
+"#;
+
+    let diagnostics = crate::test_utils::check_source_diagnostics(source);
+    let ts2344_messages = diagnostics
+        .iter()
+        .filter(|d| d.code == 2344)
+        .map(|d| d.message_text.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        ts2344_messages.is_empty(),
+        "Expected no TS2344 diagnostics for self or derived generic defaults, got {ts2344_messages:?}"
+    );
+}
+
 /// Generic function references passed as callback arguments should be properly
 /// instantiated, not cause the earlier arguments to be deferred from inference.
 /// Regression test for: `map("", identity)` incorrectly inferred T as `unknown`


### PR DESCRIPTION
## Summary
- Root cause: Default-constraint validation skipped every pair containing type parameters, so defaults or constraints that were bare references to another type parameter never reached assignability and missed TS2344 diagnostics.
- Fixed conformance target: `TypeScript/tests/cases/compiler/genericDefaultsErrors.ts`
- Fix: validate default/constraint assignability when either side is a bare reference to another type parameter, while preserving skips for self-references and derived generic defaults.

## Unit Tests
- `test_type_parameter_default_constraints_validate_type_parameter_references`
- `test_type_parameter_default_constraints_skip_self_and_derived_type_parameter_references`

## Verification
- `scripts/session/verify-all.sh` passed after final fetch/rebase on `origin/main` `75db6d888a`.
- Summary: formatting, clippy, unit tests, conformance `12099` vs baseline `12089` (`+10`), emit tests `JS +0, DTS +8`, fourslash/LSP `50/50`.

## Diagnostic Proof
The checker now emits TS2344 at the default for bare type-parameter references like:

```ts
declare function f<T, U extends number = T>(): void;
declare function g<T, U extends T = number>(): void;
```

Assignability still goes through the solver relation; the change only allows these simple bare-reference cases to reach that relation instead of being skipped upfront.