### PR TITLE
chore(tsz-checker): route state/type_resolution/module_tests.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/module_tests.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module_tests.rs
@@ -203,12 +203,12 @@ declare module "renameModule" {
 
     assert_eq!(n3_symbol.escaped_name, "n3");
     assert!(
-        (n3_symbol.flags
-            & (symbol_flags::MODULE | symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE))
-            != 0,
+        n3_symbol.has_any_flags(
+            symbol_flags::MODULE | symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE,
+        ),
         "n3 should resolve to a namespace/module-like symbol"
     );
-    assert_ne!(d_symbol.flags & symbol_flags::CLASS, 0);
-    assert_ne!(c_symbol.flags & symbol_flags::CLASS, 0);
-    assert_ne!(ee_symbol.flags & symbol_flags::CLASS, 0);
+    assert!(d_symbol.has_any_flags(symbol_flags::CLASS));
+    assert!(c_symbol.has_any_flags(symbol_flags::CLASS));
+    assert!(ee_symbol.has_any_flags(symbol_flags::CLASS));
 }


### PR DESCRIPTION
## Summary
- Migrates 4 raw `(sym.flags & mask)` assertions in `crates/tsz-checker/src/state/type_resolution/module_tests.rs` to the canonical `Symbol::has_any_flags` helper.
- Covers: the n3 namespace-or-module assertion (MODULE | NAMESPACE_MODULE | VALUE_MODULE) at 206-208, and three CLASS-flag assertions for `d`, `c`, and `ee` at 211-213.
- Continues the file-by-file DRY sweep into test code.

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] pre-commit (fmt / clippy / wasm / arch-guard / nextest 12999 / microbench)