### PR TITLE
chore(tsz-checker): route checkers/enum_checker.rs through Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/checkers/enum_checker.rs
+++ b/crates/tsz-checker/src/checkers/enum_checker.rs
@@ -15,7 +15,7 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
         {
-            return (symbol.flags & symbol_flags::ENUM) != 0;
+            return symbol.has_any_flags(symbol_flags::ENUM);
         }
         false
     }
@@ -74,7 +74,7 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
         {
-            return (symbol.flags & (symbol_flags::ENUM | symbol_flags::ENUM_MEMBER)) != 0;
+            return symbol.has_any_flags(symbol_flags::ENUM | symbol_flags::ENUM_MEMBER);
         }
         false
     }
@@ -97,7 +97,7 @@ impl<'a> CheckerState<'a> {
             None => return false,
         };
 
-        if (symbol.flags & symbol_flags::INTERFACE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::INTERFACE) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Migrates 3 raw `(sym.flags & mask) != 0`/`== 0` sites in `crates/tsz-checker/src/checkers/enum_checker.rs` to the canonical `Symbol::has_any_flags` helper.
- Covers: `is_enum_type` (line 18), `is_enum_or_enum_member_type` (77), and the INTERFACE gate of `is_enum_like_interface` (100).
- Continues the file-by-file DRY sweep.

## Test plan
- [x] `cargo clippy -p tsz-checker --lib -- -D warnings`
- [x] pre-commit (fmt / clippy / wasm / arch-guard / nextest 12999 / microbench)