### PR TITLE
Fix JSX any-props callback diagnostics

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -595,6 +595,11 @@ impl<'a> CheckerState<'a> {
 
                 // Skip prop-type checking when props type is any/error/contains-error
                 if skip_prop_checks {
+                    let attr_value_type =
+                        self.compute_jsx_attr_value_type_without_context(attr_data.initializer);
+                    if let Some(entry) = provided_attrs.last_mut() {
+                        entry.1 = attr_value_type;
+                    }
                     continue;
                 }
 
@@ -821,7 +826,7 @@ impl<'a> CheckerState<'a> {
                     let expected_context_type =
                         self.evaluate_application_type(expected_context_type);
                     let expected_context_type = self.evaluate_type_with_env(expected_context_type);
-                    let mut function_value_span = None;
+                    let mut function_param_diagnostic_span = None;
                     if let Some(value_node) = self.ctx.arena.get(value_node_idx)
                         && matches!(
                             value_node.kind,
@@ -852,7 +857,13 @@ impl<'a> CheckerState<'a> {
                             .implicit_any_checked_closures
                             .insert(value_node_idx);
                         self.invalidate_function_like_for_contextual_retry(value_node_idx);
-                        function_value_span = Some((value_node.pos, value_node.end));
+                        let param_span_end = self
+                            .ctx
+                            .arena
+                            .get_function(value_node)
+                            .and_then(|func| self.ctx.arena.get(func.body))
+                            .map_or(value_node.end, |body_node| body_node.pos);
+                        function_param_diagnostic_span = Some((value_node.pos, param_span_end));
                     }
                     let contextual_expected_type =
                         if self.ctx.arena.get(value_node_idx).is_some_and(|node| {
@@ -864,7 +875,8 @@ impl<'a> CheckerState<'a> {
                             expected_context_type
                         };
                     // Set contextual type to preserve narrow literal types.
-                    let diag_snap = function_value_span.map(|_| self.ctx.snapshot_diagnostics());
+                    let diag_snap =
+                        function_param_diagnostic_span.map(|_| self.ctx.snapshot_diagnostics());
                     let actual_type = self.compute_type_of_node_with_request(
                         value_node_idx,
                         &request
@@ -872,7 +884,8 @@ impl<'a> CheckerState<'a> {
                             .normal_origin()
                             .contextual(contextual_expected_type),
                     );
-                    if let (Some((start, end)), Some(diag_snap)) = (function_value_span, diag_snap)
+                    if let (Some((start, end)), Some(diag_snap)) =
+                        (function_param_diagnostic_span, diag_snap)
                     {
                         self.ctx.rollback_diagnostics_filtered(&diag_snap, |diag| {
                             !(matches!(diag.code, 7006 | 7019 | 7031 | 7051)

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -171,14 +171,15 @@ impl<'a> CheckerState<'a> {
                     self.get_type_of_node(type_arg_idx);
                 }
             }
-            // Still need to check arguments for definite assignment (TS2454) and other errors.
-            // Return Some(ANY) for every index so spread arguments are accepted (avoids
-            // false TS2556 — `any` is callable with any arguments).
-            let check_excess_properties = false;
+            // Untyped calls accept ordinary args; callbacks still get their own context for TS7006.
+            let cb_args: Vec<_> = args
+                .iter()
+                .map(|&idx| self.is_callback_like_argument(idx))
+                .collect();
             self.collect_call_argument_types_with_context(
                 args,
-                |_i, _arg_count| Some(TypeId::ANY),
-                check_excess_properties,
+                |i, _arg_count| (!matches!(cb_args.get(i), Some(true))).then_some(TypeId::ANY),
+                false,
                 None, // No skipping needed
                 CallableContext::none(),
             );

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests.rs
@@ -980,6 +980,23 @@ fn cross_file_jsx_diagnostics_with_mode_and_default_libs(
     jsx_mode: JsxMode,
     include_default_libs: bool,
 ) -> Vec<(u32, String)> {
+    cross_file_jsx_diagnostics_with_options_and_default_libs(
+        lib_source,
+        main_source,
+        CheckerOptions {
+            jsx_mode,
+            ..CheckerOptions::default()
+        },
+        include_default_libs,
+    )
+}
+
+fn cross_file_jsx_diagnostics_with_options_and_default_libs(
+    lib_source: &str,
+    main_source: &str,
+    options: CheckerOptions,
+    include_default_libs: bool,
+) -> Vec<(u32, String)> {
     let default_lib_files = if include_default_libs {
         load_cross_file_jsx_lib_files()
     } else {
@@ -1023,11 +1040,6 @@ fn cross_file_jsx_diagnostics_with_mode_and_default_libs(
     }
     let all_arenas = Arc::new(all_arenas_vec);
     let all_binders = Arc::new(all_binders_vec);
-
-    let options = CheckerOptions {
-        jsx_mode,
-        ..CheckerOptions::default()
-    };
 
     let types = TypeInterner::new();
     let mut checker = CheckerState::new(
@@ -1847,6 +1859,94 @@ fn test_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006() {
     assert!(
         !has_code(&diags, diagnostic_codes::PARAMETER_IMPLICITLY_HAS_AN_TYPE),
         "real react16 fixture should not emit TS7006, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_jsx_fragment_factory_no_unused_locals_react16_fixture_checks_nested_callback_body() {
+    let Some(react_types) = load_typescript_fixture("TypeScript/tests/lib/react16.d.ts") else {
+        return;
+    };
+    let Some(source) = load_typescript_fixture(
+        "TypeScript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx",
+    ) else {
+        return;
+    };
+    let source = source.replace("/// <reference path=\"/.lib/react16.d.ts\" />", "");
+
+    let diags = cross_file_jsx_diagnostics_with_options_and_default_libs(
+        &react_types,
+        &source,
+        CheckerOptions {
+            jsx_mode: JsxMode::React,
+            jsx_factory: "createElement".to_string(),
+            jsx_factory_from_config: true,
+            jsx_fragment_factory: "Fragment".to_string(),
+            jsx_fragment_factory_from_config: true,
+            no_unused_locals: true,
+            ..CheckerOptions::default()
+        },
+        true,
+    );
+    assert!(
+        has_code(&diags, diagnostic_codes::PARAMETER_IMPLICITLY_HAS_AN_TYPE),
+        "expected nested setCnt callback to emit TS7006 for prev, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, message)| {
+            *code == diagnostic_codes::IS_DECLARED_BUT_ITS_VALUE_IS_NEVER_READ
+                && message.contains("'setCnt'")
+        }),
+        "setCnt is read inside the JSX onClick callback body and should not emit TS6133, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsx_any_intrinsic_props_still_evaluate_attribute_callback_body() {
+    let source = r#"
+declare namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {
+        p: any;
+        button: any;
+    }
+}
+declare function createElement(...args: any[]): any;
+declare const Fragment: any;
+
+export function Counter() {
+    const [cnt, setCnt] = null as any;
+    return <>
+        <p>{cnt}</p>
+        <button onClick={() => setCnt((prev) => prev + 1)} type="button">Update</button>
+    </>;
+}
+"#;
+
+    let diags = cross_file_jsx_diagnostics_with_options_and_default_libs(
+        "",
+        source,
+        CheckerOptions {
+            jsx_mode: JsxMode::React,
+            jsx_factory: "createElement".to_string(),
+            jsx_factory_from_config: true,
+            jsx_fragment_factory: "Fragment".to_string(),
+            jsx_fragment_factory_from_config: true,
+            no_unused_locals: true,
+            ..CheckerOptions::default()
+        },
+        false,
+    );
+    assert!(
+        has_code(&diags, diagnostic_codes::PARAMETER_IMPLICITLY_HAS_AN_TYPE),
+        "any intrinsic props should still evaluate nested callback bodies, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, message)| {
+            *code == diagnostic_codes::IS_DECLARED_BUT_ITS_VALUE_IS_NEVER_READ
+                && message.contains("'setCnt'")
+        }),
+        "setCnt is read inside an any-props JSX attribute callback, got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Root cause: tsz skipped JSX attribute initializer evaluation when the resolved props type was `any`/error, and untyped calls also supplied `any` as a contextual type to callback arguments; together this hid the nested `prev` TS7006 and left `setCnt` marked unread.

Fixed conformance target: `TypeScript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx`.

Unit test coverage:
- `test_jsx_fragment_factory_no_unused_locals_react16_fixture_checks_nested_callback_body`
- `jsx_any_intrinsic_props_still_evaluate_attribute_callback_body`
- Existing JSX contextual callback regression tests stayed green.

Verification:
- `cargo nextest run --package tsz-checker --test jsx_component_attribute_tests test_jsx_fragment_factory_no_unused_locals_react16_fixture_checks_nested_callback_body jsx_any_intrinsic_props_still_evaluate_attribute_callback_body test_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006 test_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts2322` passed.
- `./scripts/conformance/conformance.sh run --filter "jsxFragmentFactoryNoUnusedLocals" --verbose` passed 1/1.
- `scripts/session/verify-all.sh` passed: formatting, clippy, unit tests, conformance +12 (12101 vs 12089 baseline), emit tests JS +0 / DTS +9, fourslash/LSP =50.
- After the final rebase onto the latest `origin/main` CI/doc-only commits, reran the focused unit command above and the targeted conformance command above; both passed.