### PR TITLE
fix(parser): reject compound greater in expression type args

### DIFF
--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -2192,7 +2192,7 @@ impl ParserState {
 
         // Check for empty type argument list: <>
         // TypeScript reports TS1099: "Type argument list cannot be empty"
-        if self.is_greater_than_or_compound() {
+        if self.is_plain_greater_than_for_expression_type_arguments() {
             use tsz_common::diagnostics::diagnostic_codes;
             self.parse_error_at(
                 less_than_start,
@@ -2233,7 +2233,7 @@ impl ParserState {
                 args.push(type_node);
             }
 
-            if self.is_greater_than_or_compound() {
+            if self.is_plain_greater_than_for_expression_type_arguments() {
                 depth -= 1;
             } else if self.is_token(SyntaxKind::CommaToken) {
                 // Comma indicates another type argument follows.
@@ -2308,6 +2308,13 @@ impl ParserState {
                     || !self.is_expression_start()
             }
         }
+    }
+
+    fn is_plain_greater_than_for_expression_type_arguments(&mut self) -> bool {
+        // tsc's expression disambiguation calls reScanGreaterToken() and accepts
+        // only a plain `>`. Compound tokens like `>=` and `>>` keep the parse in
+        // relational-expression space instead of becoming speculative type args.
+        self.try_rescan_greater_token() == SyntaxKind::GreaterThanToken
     }
 
     /// Parse array type suffix (T[]) or indexed access type (T[K])

--- a/crates/tsz-parser/tests/state_expression_tests.rs
+++ b/crates/tsz-parser/tests/state_expression_tests.rs
@@ -21,6 +21,51 @@ fn expression_parsing_handles_shift_and_greater_token_ambiguity() {
 }
 
 #[test]
+fn expression_type_argument_probe_rejects_greater_equals_as_closing_angle() {
+    let source = r#"
+const enum MyVer { v1 = 1, v2 = 2 }
+let ver = 21
+const a = ver < (MyVer.v1 >= MyVer.v2 ? MyVer.v1 : MyVer.v2)
+"#;
+    let (parser, _root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+    assert_eq!(
+        diags.len(),
+        0,
+        "`>=` inside a relational expression should not close speculative expression type arguments: {diags:?}"
+    );
+}
+
+#[test]
+fn jsx_empty_type_arguments_accept_compound_closer_without_text_child() {
+    let source = "const a = <div<>></div>;";
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    parser.parse_source_file();
+
+    let diags = parser.get_diagnostics();
+    assert!(
+        diags
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::TYPE_ARGUMENT_LIST_CANNOT_BE_EMPTY),
+        "empty JSX type arguments should still report TS1099: {diags:?}"
+    );
+    assert!(
+        parser
+            .get_arena()
+            .jsx_text
+            .iter()
+            .all(|text| text.text.trim() != ">"),
+        "the JSX opening tag closer should not be parsed as a text child: {:?}",
+        parser
+            .get_arena()
+            .jsx_text
+            .iter()
+            .map(|text| text.text.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn expression_parsing_handles_regex_division_boundary_after_tokens() {
     let diag_count =
         parse_diagnostics("const n = 10 / 2; const re = /foo/g; const tail = (a / b) / c;");


### PR DESCRIPTION
Root cause: Speculative expression type-argument parsing accepted compound greater-than tokens such as `>=` as closing angles; tsc only accepts a plain `>` in expression disambiguation, so `>=` must remain relational.

Fixed conformance target:
- `TypeScript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts`

Unit tests:
- `expression_type_argument_probe_rejects_greater_equals_as_closing_angle`
- `jsx_empty_type_arguments_accept_compound_closer_without_text_child`

Verification:
- `cargo nextest run --package tsz-parser --lib expression_type_argument_probe_rejects_greater_equals_as_closing_angle jsx_empty_type_arguments_accept_compound_closer_without_text_child`
- `./scripts/conformance/conformance.sh run --filter "instantiationExpressionErrors" --verbose`
- `./scripts/emit/run.sh --skip-build --filter=jsxIntrinsicElementsTypeArgumentErrors --verbose --json-out=/tmp/emit-jsxIntrinsicElementsTypeArgumentErrors.json`
- `scripts/session/verify-all.sh` passed after final fetch/rebase: formatting, clippy, unit tests, conformance +9 (12098 vs baseline 12089), emit tests JS +0/DTS +8 (12324/1255 vs 12324/1247 baseline), fourslash/LSP =50.