### PR TITLE
chore(checker): migrate member_access.rs to Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/member_access.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_access.rs
@@ -444,7 +444,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(symbol) = binder
                     .get_symbol(sym_id)
                     .or_else(|| self.ctx.binder.get_symbol(sym_id))
-                    && (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0
+                    && symbol.has_any_flags(tsz_binder::symbol_flags::VALUE)
                 {
                     return true;
                 }
@@ -465,7 +465,7 @@ impl<'a> CheckerState<'a> {
                             .get_symbol(sym_id)
                             .or_else(|| self.ctx.binder.get_symbol(sym_id))
                     })
-                    .is_some_and(|symbol| (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0)
+                    .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::VALUE))
             })
         })
     }
@@ -764,10 +764,10 @@ impl<'a> CheckerState<'a> {
                         self.ctx.binder.is_external_module()
                             && symbol.decl_file_idx != self.ctx.current_file_idx as u32
                             && (source_is_external_module || symbol.is_exported)
-                            && (symbol.flags
-                                & (tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE
-                                    | tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE))
-                                != 0
+                            && symbol.has_any_flags(
+                                tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE
+                                    | tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE,
+                            )
                     });
 
                 if treat_as_unresolved {


### PR DESCRIPTION
## Summary
- Replaces 3 raw `(symbol.flags & MASK) != 0` idioms in `state/state_checking_members/member_access.rs` with the canonical `Symbol::has_any_flags(MASK)` helper.
- Sites: cross-file `VALUE` lookup (two clauses) + `FUNCTION_SCOPED_VARIABLE | BLOCK_SCOPED_VARIABLE` gating for external-module deduplication.
- Part of the DRY sweep across `tsz-checker`; no behavior change.

## Test plan
- [x] Pre-commit: fmt + clippy + wasm32 + arch-guard + 12999 nextest