### PR TITLE
chore(checker): migrate symbol_type_helpers.rs to Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -200,7 +200,8 @@ impl<'a> CheckerState<'a> {
         use tsz_solver::{CallableShape, FunctionShape};
 
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::FUNCTION == 0 || symbol.flags & symbol_flags::INTERFACE != 0
+        if !symbol.has_any_flags(symbol_flags::FUNCTION)
+            || symbol.has_any_flags(symbol_flags::INTERFACE)
         {
             return None;
         }
@@ -302,7 +303,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return;
         };
-        if symbol.flags & symbol_flags::ENUM == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- Replaces 2 raw `symbol.flags & MASK == 0 / != 0` idioms in `state/type_analysis/symbol_type_helpers.rs` with the canonical `Symbol::has_any_flags` helper.
- Sites: FUNCTION overload-set guard with INTERFACE exclusion (line 203) and enum numeric-value gate (line 305).
- Part of the DRY sweep across `tsz-checker`; no behavior change.

## Test plan
- [x] Pre-commit: fmt + clippy + wasm32 + arch-guard + 12999 nextest