### PR TITLE
[codex] preserve raw indexed-access diagnostic surfaces

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/errors/runtime.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/runtime.rs
@@ -456,6 +456,159 @@ type TypeHardcodedAsParameterWithoutReturnType<
 }
 
 #[test]
+fn test_constraint_with_indexed_access_formats_instantiated_alias_bodies() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+interface Array<T> {}
+interface Boolean {}
+interface Function {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+interface CallableFunction extends Function {}
+interface NewableFunction extends Function {}
+
+type ReturnType<T extends (...args: any) => any> =
+    T extends (...args: any) => infer R ? R : any;
+
+type DataFetchFns = {
+    Boat: {
+        requiresLicense: (id: string) => boolean;
+        maxGroundSpeed: (id: string) => number;
+        description: (id: string) => string;
+        displacement: (id: string) => number;
+        name: (id: string) => string;
+    };
+    Plane: {
+        requiresLicense: (id: string) => boolean;
+        maxGroundSpeed: (id: string) => number;
+        maxTakeoffWeight: (id: string) => number;
+        maxCruisingAltitude: (id: string) => number;
+        name: (id: string) => string;
+    };
+};
+
+type TypeHardcodedAsParameterWithoutReturnType<
+    T extends 'Boat',
+    F extends keyof DataFetchFns[T]
+> = DataFetchFns[T][F];
+type NoTypeParamBoatRequired<F extends keyof DataFetchFns['Boat']> =
+    ReturnType<DataFetchFns['Boat'][F]>;
+type allAreFunctionsAsExpected =
+    TypeHardcodedAsParameterWithoutReturnType<'Boat', keyof DataFetchFns['Boat']>;
+type returnTypeOfFunctions = ReturnType<allAreFunctionsAsExpected>;
+type SucceedingCombo =
+    ReturnType<TypeHardcodedAsParameterWithoutReturnType<'Boat', keyof DataFetchFns['Boat']>>;
+type VehicleSelector<T extends keyof DataFetchFns> = DataFetchFns[T];
+
+type FailingCombo<
+    T extends 'Boat',
+    F extends keyof DataFetchFns[T]
+> = ReturnType<TypeHardcodedAsParameterWithoutReturnType<T, F>>;
+type TypeHardcodedAsParameter<
+    T extends 'Boat',
+    F extends keyof DataFetchFns[T]
+> = ReturnType<DataFetchFns[T][F]>;
+type TypeHardcodedAsParameter2<
+    T extends 'Boat',
+    F extends keyof DataFetchFns[T]
+> = ReturnType<VehicleSelector<T>[F]>;
+type TypeGeneric1<
+    T extends keyof DataFetchFns,
+    F extends keyof DataFetchFns[T]
+> = ReturnType<DataFetchFns[T][F]>;
+type TypeGeneric2<
+    T extends keyof DataFetchFns,
+    F extends keyof DataFetchFns[T]
+> = ReturnType<DataFetchFns[T][T]>;
+type TypeGeneric3<
+    T extends keyof DataFetchFns,
+    F extends keyof DataFetchFns[T]
+> = ReturnType<DataFetchFns[F][F]>;
+        ",
+    );
+
+    let ts2344 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .map(|(_, message)| message.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ts2344.len(),
+        6,
+        "Expected the full conformance TS2344 surface. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|message| message.contains("TypeHardcodedAsParameterWithoutReturnType<T, F>")),
+        "Expected TS2344 to preserve the written helper alias surface for direct alias applications. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|message| message.contains("VehicleSelector<T>[F]")),
+        "Expected TS2344 to preserve the written helper alias surface for nested alias access. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|message| message.contains("DataFetchFns[T][F]")),
+        "Expected TS2344 to keep raw indexed-access expressions structural. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|message| message.contains("DataFetchFns[T][T]")),
+        "Expected TS2344 to keep raw indexed-access expressions structural for mismatched keys. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|message| message.contains("DataFetchFns[F][F]")),
+        "Expected TS2344 to keep raw indexed-access expressions structural for mismatched object aliases. Actual diagnostics: {diagnostics:?}"
+    );
+
+    let ts2536 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2536)
+        .map(|(_, message)| message.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ts2536.len(),
+        3,
+        "Expected the full conformance TS2536 surface. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2536
+            .iter()
+            .any(|message| message
+                .contains("Type 'T' cannot be used to index type 'DataFetchFns[T]'")),
+        "Expected TS2536 to display the expanded indexed-access object. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2536
+            .iter()
+            .any(|message| message.contains("Type 'F' cannot be used to index type 'DataFetchFns'")),
+        "Expected TS2536 to preserve raw object surfaces for direct indexed access. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2536
+            .iter()
+            .any(|message| message
+                .contains("Type 'F' cannot be used to index type 'DataFetchFns[F]'")),
+        "Expected TS2536 to preserve nested raw object surfaces for direct indexed access. Actual diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        ts2536.iter().all(|message| !message
+            .contains("Type 'T' cannot be used to index type 'VehicleSelector<T>'")),
+        "TS2536 should not repaint raw indexed-access objects with helper alias names. Actual diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_no_ts2344_for_concrete_indexed_access_callable_union() {
     let diagnostics = compile_and_get_diagnostics(
         r"

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -459,6 +459,13 @@ impl<'a> TypeFormatter<'a> {
                 use crate::def::DefKind;
                 let skip_alias = if def.kind == DefKind::TypeAlias {
                     def.body.is_some_and(|b| def_store.is_computed_body(b))
+                        || (!def.type_params.is_empty()
+                            && def.body.is_some_and(|b| {
+                                matches!(
+                                    self.interner.lookup(b),
+                                    Some(TypeData::IndexAccess(_, _) | TypeData::Conditional(_))
+                                )
+                            }))
                         || (self.skip_application_alias_names
                             && def.type_params.is_empty()
                             && self.interner.get_display_alias(type_id).is_some())

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -2340,6 +2340,81 @@ fn application_lazy_shows_type_args() {
         "Application should show formatted type args"
     );
 }
+
+#[test]
+fn resolved_indexed_access_alias_bodies_stay_structural_without_repainting_written_aliases() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let data_fetch_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("DataFetchFns"),
+        vec![],
+        db.object(vec![]),
+    ));
+
+    let t_param = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let f_param = TypeParamInfo {
+        name: db.intern_string("F"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t = db.type_param(t_param);
+    let f = db.type_param(f_param);
+
+    let direct_body = db.index_access(db.index_access(db.lazy(data_fetch_def), t), f);
+    let direct_alias_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("TypeHardcodedAsParameterWithoutReturnType"),
+        vec![t_param, f_param],
+        direct_body,
+    ));
+    def_store.register_type_to_def(direct_body, direct_alias_def);
+    let direct_app = db.application(db.lazy(direct_alias_def), vec![t, f]);
+
+    let vehicle_t_param = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let vehicle_t = db.type_param(vehicle_t_param);
+    let vehicle_body = db.index_access(db.lazy(data_fetch_def), vehicle_t);
+    let vehicle_alias_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("VehicleSelector"),
+        vec![vehicle_t_param],
+        vehicle_body,
+    ));
+    def_store.register_type_to_def(vehicle_body, vehicle_alias_def);
+    let vehicle_app = db.application(db.lazy(vehicle_alias_def), vec![t]);
+    let nested_access = db.index_access(vehicle_app, f);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    assert_eq!(
+        fmt.format(direct_body),
+        "DataFetchFns[T][F]",
+        "Resolved indexed-access alias bodies should stay expanded"
+    );
+    assert_eq!(
+        fmt.format(vehicle_body),
+        "DataFetchFns[T]",
+        "Resolved indexed-access helper aliases should stay expanded"
+    );
+    assert_eq!(
+        fmt.format(direct_app),
+        "TypeHardcodedAsParameterWithoutReturnType<T, F>",
+        "Direct generic alias applications should preserve the alias name"
+    );
+    assert_eq!(
+        fmt.format(nested_access),
+        "VehicleSelector<T>[F]",
+        "Nested indexed access should preserve the helper alias surface when it is written directly"
+    );
+}
 // NOTE: lazy_raw_def_id_falls_back_to_symbol_name was removed.
 // DefId and SymbolId are independent ID spaces. The raw-value fallback
 // was removed in bfd1e1ad05 because it caused incorrect type names


### PR DESCRIPTION
## Summary
- preserve raw indexed-access diagnostic surfaces when resolved generic helper aliases map back through the definition store
- keep written generic alias applications named in diagnostics when that alias surface is what the source wrote
- add solver and checker regression coverage for `constraintWithIndexedAccess`

## Invariant
Generic indexed-access helper aliases must not repaint raw indexed-access diagnostics through definition-store alias mappings; alias names should be preserved only when the alias surface is written directly.

## Repro
```ts
type DataFetchFns = {
  Boat: { name: (id: string) => string };
};

type VehicleSelector<T extends keyof DataFetchFns> = DataFetchFns[T];
type Helper<T extends "Boat", F extends keyof DataFetchFns[T]> = DataFetchFns[T][F];

type A<T extends keyof DataFetchFns, F extends keyof DataFetchFns[T]> =
  ReturnType<DataFetchFns[T][F]>;
// TS2344 should keep `DataFetchFns[T][F]` structural

type B<T extends "Boat", F extends keyof DataFetchFns[T]> =
  ReturnType<Helper<T, F>>;
// TS2344 should preserve `Helper<T, F>` because that alias surface was written directly

type C<T extends "Boat", F extends keyof DataFetchFns[T]> =
  ReturnType<VehicleSelector<T>[F]>;
// TS2344 should preserve `VehicleSelector<T>[F]` because that nested alias surface was written directly
```

## Verification
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "constraintWithIndexedAccess" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
