### PR TITLE
[codex] add anchor and count render buckets

### DIFF
--- a/scripts/conformance/build-snapshot-detail.py
+++ b/scripts/conformance/build-snapshot-detail.py
@@ -99,6 +99,7 @@ def build_aggregates(tests):
     n_all_missing = 0
     n_wrong_code = 0
     n_fingerprint_only = 0
+    n_same_code_count_drift = 0
     n_close = 0  # diff <= 2
 
     fail_tests = {}
@@ -109,6 +110,8 @@ def build_aggregates(tests):
 
         expected = result.get("expected", [])
         actual = result.get("actual", [])
+        exp_counter = Counter(expected)
+        act_counter = Counter(actual)
         missing, extra = compute_diff(expected, actual)
 
         all_emitted.update(actual)
@@ -133,6 +136,8 @@ def build_aggregates(tests):
             if diff_size == 0:
                 n_fingerprint_only += 1
             else:
+                if set(exp_counter) == set(act_counter):
+                    n_same_code_count_drift += 1
                 n_wrong_code += 1
                 if diff_size <= 2:
                     n_close += 1
@@ -172,6 +177,7 @@ def build_aggregates(tests):
             "all_missing": n_all_missing,
             "wrong_code": n_wrong_code,
             "fingerprint_only": n_fingerprint_only,
+            "same_code_count_drift": n_same_code_count_drift,
             "close_to_passing": n_close,
         },
         "one_missing_zero_extra": [

--- a/scripts/conformance/classify-render-corpus.py
+++ b/scripts/conformance/classify-render-corpus.py
@@ -19,6 +19,14 @@ Examples:
     --fingerprint-log /tmp/tsz-fingerprint-deltas.txt \
     --json-output /tmp/render-corpus.json \
     --csv-output /tmp/render-corpus.csv
+
+  # Isolate Phase 5 anchor/count work.
+  python3 scripts/conformance/classify-render-corpus.py \
+    --fingerprint-log /tmp/tsz-fingerprint-deltas.txt \
+    --category location-only
+  python3 scripts/conformance/classify-render-corpus.py \
+    --fingerprint-log /tmp/tsz-fingerprint-deltas.txt \
+    --category under-count --category over-count --paths-only
 """
 
 from __future__ import annotations
@@ -38,6 +46,42 @@ DEFAULT_DETAIL = SCRIPT_DIR / "conformance-detail.json"
 FINGERPRINT_RE = re.compile(
     r"^\s*-\s+(TS\d+)\s+(.+?):(\d+):(\d+)\s+(.*)$"
 )
+
+ANCHOR_SURFACE_BY_CODE = {
+    # Assignment-like relation diagnostics usually flow through
+    # DiagnosticAnchorKind::RewriteAssignment or Exact fallback.
+    "TS2322": "DiagnosticAnchorKind::RewriteAssignment",
+    "TS2416": "DiagnosticAnchorKind::RewriteAssignment",
+    "TS2739": "DiagnosticAnchorKind::RewriteAssignment",
+    "TS2740": "DiagnosticAnchorKind::RewriteAssignment",
+    "TS2741": "DiagnosticAnchorKind::RewriteAssignment",
+    # Call and overload diagnostics choose between argument anchors and
+    # call/overload-primary anchors in call_errors/error_emission.rs.
+    "TS2345": "DiagnosticAnchorKind::CallPrimary/Exact",
+    "TS2554": "DiagnosticAnchorKind::CallPrimary",
+    "TS2555": "DiagnosticAnchorKind::CallPrimary",
+    "TS2769": "DiagnosticAnchorKind::OverloadPrimary",
+    # Property/member diagnostics are centralized in properties.rs.
+    "TS2339": "DiagnosticAnchorKind::PropertyToken",
+    "TS2551": "DiagnosticAnchorKind::PropertyToken",
+    "TS4111": "DiagnosticAnchorKind::PropertyToken",
+    "TS7053": "DiagnosticAnchorKind::ElementAccessExpr/ElementIndexArg",
+    # Special semantic anchor policies.
+    "TS2352": "DiagnosticAnchorKind::TypeAssertionOverlap",
+    "TS2353": "manual excess-property anchor",
+}
+
+COUNT_CATEGORIES = {"under-count", "over-count", "same-code count drift"}
+ANCHOR_CATEGORIES = {"location-only"}
+FINGERPRINT_DETAIL_CATEGORIES = {
+    "message-only",
+    "location-only",
+    "under-count",
+    "over-count",
+    "per-instance wrong code",
+    "mixed",
+    "fingerprint-unclassified",
+}
 
 
 def normalize_code(code: str) -> str:
@@ -193,34 +237,66 @@ def classify_fingerprint_delta(missing: list[dict], extra: list[dict]) -> str:
     return "mixed"
 
 
+def code_counter(codes: list[str]) -> Counter:
+    return Counter(normalize_code(code) for code in codes)
+
+
 def failure_category(failure: dict) -> str:
     expected = failure.get("e", [])
     actual = failure.get("a", [])
     missing = failure.get("m", [])
     extra = failure.get("x", [])
 
-    if expected and actual and expected == actual:
-        return "fingerprint-only"
-    if not expected and actual:
+    if expected and actual:
+        expected_counts = code_counter(expected)
+        actual_counts = code_counter(actual)
+        if expected_counts == actual_counts:
+            return "fingerprint-only"
+        if set(expected_counts) == set(actual_counts):
+            return "same-code count drift"
+    elif not expected and actual:
         return "false-positive"
-    if expected and not actual:
+    elif expected and not actual:
         return "all-missing"
     if missing or extra:
         return "wrong-code"
     return "unknown"
 
 
+def fingerprint_codes(record: dict) -> set[str]:
+    codes = set(record.get("codes", []))
+    codes.update(record.get("actual_codes", []))
+    codes.update(record.get("missing_codes", []))
+    codes.update(record.get("extra_codes", []))
+    for fp in record.get("missing_fingerprints", []):
+        codes.add(fp["code"])
+    for fp in record.get("extra_fingerprints", []):
+        codes.add(fp["code"])
+    return codes
+
+
+def anchor_surface_for_codes(codes: set[str]) -> str:
+    surfaces = []
+    for code in sorted(codes):
+        if code in ANCHOR_SURFACE_BY_CODE:
+            surfaces.append(ANCHOR_SURFACE_BY_CODE[code])
+        elif re.match(r"TS1\d\d\d$", code):
+            surfaces.append("parser/scanner")
+    if not surfaces:
+        return "DiagnosticAnchorKind::Exact/unknown"
+    return " + ".join(sorted(set(surfaces)))
+
+
 def code_filter_matches(record: dict, codes: set[str]) -> bool:
     if not codes:
         return True
-    record_codes = set(record.get("codes", []))
-    record_codes.update(record.get("missing_codes", []))
-    record_codes.update(record.get("extra_codes", []))
-    for fp in record.get("missing_fingerprints", []):
-        record_codes.add(fp["code"])
-    for fp in record.get("extra_fingerprints", []):
-        record_codes.add(fp["code"])
-    return bool(record_codes & codes)
+    return bool(fingerprint_codes(record) & codes)
+
+
+def category_filter_matches(record: dict, categories: set[str]) -> bool:
+    if not categories:
+        return True
+    return record["category"] in categories or record["base_category"] in categories
 
 
 def build_records(detail: dict, fingerprint_log: dict[str, dict[str, list[dict]]] | None) -> list[dict]:
@@ -245,6 +321,13 @@ def build_records(detail: dict, fingerprint_log: dict[str, dict[str, list[dict]]
         for fp in extra_fps:
             delta_codes[(fp["code"], "extra")] += 1
 
+        record_codes = set(failure.get("e", []))
+        record_codes.update(failure.get("a", []))
+        for fp in missing_fps:
+            record_codes.add(fp["code"])
+        for fp in extra_fps:
+            record_codes.add(fp["code"])
+
         records.append(
             {
                 "path": path,
@@ -252,6 +335,7 @@ def build_records(detail: dict, fingerprint_log: dict[str, dict[str, list[dict]]
                 "area": area_of(path),
                 "category": render_class,
                 "base_category": category,
+                "anchor_surface": anchor_surface_for_codes(record_codes),
                 "codes": failure.get("e", []),
                 "actual_codes": failure.get("a", []),
                 "missing_codes": failure.get("m", []),
@@ -275,15 +359,22 @@ def summarize(records: list[dict]) -> dict:
     code_deltas = Counter()
     class_code_counts: dict[str, Counter] = {}
     area_counts = Counter()
+    anchor_surface_counts = Counter()
 
     for record in records:
         category = record["category"]
         class_code_counts.setdefault(category, Counter())
         if record["area"]:
             area_counts[record["area"]] += 1
+        if category in ANCHOR_CATEGORIES:
+            anchor_surface_counts[record["anchor_surface"]] += 1
 
-        for code in record.get("codes", []):
-            if record["base_category"] == "fingerprint-only":
+        for code in fingerprint_codes(record):
+            if (
+                record["base_category"] == "fingerprint-only"
+                or category in FINGERPRINT_DETAIL_CATEGORIES
+                or category in COUNT_CATEGORIES
+            ):
                 class_code_counts[category][code] += 1
 
         for fp in record.get("missing_fingerprints", []):
@@ -299,16 +390,10 @@ def summarize(records: list[dict]) -> dict:
 
     total_fingerprint_only = base_category_counts.get("fingerprint-only", 0)
     classified_fingerprint_only = sum(
-        count
-        for category, count in category_counts.items()
-        if category
-        not in {
-            "fingerprint-unclassified",
-            "wrong-code",
-            "all-missing",
-            "false-positive",
-            "unknown",
-        }
+        1
+        for record in records
+        if record["base_category"] == "fingerprint-only"
+        and record["category"] != "fingerprint-unclassified"
     )
 
     return {
@@ -317,6 +402,7 @@ def summarize(records: list[dict]) -> dict:
             "fingerprint_only": total_fingerprint_only,
             "classified_fingerprint_only": classified_fingerprint_only,
             "unclassified_fingerprint_only": category_counts.get("fingerprint-unclassified", 0),
+            "same_code_count_drift": base_category_counts.get("same-code count drift", 0),
             "wrong_code": base_category_counts.get("wrong-code", 0),
             "all_missing": base_category_counts.get("all-missing", 0),
             "false_positive": base_category_counts.get("false-positive", 0),
@@ -338,6 +424,10 @@ def summarize(records: list[dict]) -> dict:
         "areas": [
             {"area": area, "tests": count} for area, count in area_counts.most_common(20)
         ],
+        "location_anchor_surfaces": [
+            {"anchor_surface": surface, "tests": count}
+            for surface, count in anchor_surface_counts.most_common()
+        ],
     }
 
 
@@ -354,6 +444,7 @@ def print_summary(summary: dict, records: list[dict], top: int, paths_only: bool
     print(f"Fingerprint-only:          {s['fingerprint_only']}")
     print(f"Classified fingerprint-only: {s['classified_fingerprint_only']}")
     print(f"Unclassified fingerprint-only: {s['unclassified_fingerprint_only']}")
+    print(f"Same-code count drift:     {s['same_code_count_drift']}")
     print(f"Wrong-code:                {s['wrong_code']}")
     print(f"All-missing:               {s['all_missing']}")
     print(f"False-positive:            {s['false_positive']}")
@@ -373,14 +464,48 @@ def print_summary(summary: dict, records: list[dict], top: int, paths_only: bool
             )
         print()
 
+    if summary["location_anchor_surfaces"]:
+        print("Location-only anchor surfaces:")
+        for item in summary["location_anchor_surfaces"][:10]:
+            print(f"  {item['anchor_surface']:<48} {item['tests']:>4}")
+        print()
+
+    class_rows = [
+        (
+            category,
+            summary["class_top_codes"].get(category, []),
+        )
+        for category in [
+            "location-only",
+            "under-count",
+            "over-count",
+            "message-only",
+            "mixed",
+            "same-code count drift",
+        ]
+    ]
+    class_rows = [(category, codes) for category, codes in class_rows if codes]
+    if class_rows:
+        print("Top codes by render/count class:")
+        for category, codes in class_rows:
+            top_codes = ", ".join(
+                f"{item['code']}={item['tests']}" for item in codes[:5]
+            )
+            print(f"  {category:<24} {top_codes}")
+        print()
+
     interesting = [
         record
         for record in records
-        if record["base_category"] == "fingerprint-only"
+        if (
+            record["base_category"] == "fingerprint-only"
+            or record["category"] in COUNT_CATEGORIES
+        )
         and (
             record["missing_fingerprint_count"]
             or record["extra_fingerprint_count"]
             or record["category"] == "fingerprint-unclassified"
+            or record["category"] in COUNT_CATEGORIES
         )
     ]
     interesting.sort(
@@ -401,6 +526,8 @@ def print_summary(summary: dict, records: list[dict], top: int, paths_only: bool
             f"extra={record['extra_fingerprint_count']:>2} "
             f"codes=[{codes}] {record['name']}"
         )
+        if record["category"] == "location-only":
+            print(f"    anchor-surface: {record['anchor_surface']}")
     if len(interesting) > top:
         print(f"  ... and {len(interesting) - top} more")
 
@@ -419,6 +546,7 @@ def write_csv(path: Path, records: list[dict]) -> None:
         "area",
         "category",
         "base_category",
+        "anchor_surface",
         "codes",
         "actual_codes",
         "missing_codes",
@@ -464,6 +592,15 @@ def main() -> int:
         default=[],
         help="Restrict printed/exported records to a diagnostic code, e.g. TS2322",
     )
+    parser.add_argument(
+        "--category",
+        action="append",
+        default=[],
+        help=(
+            "Restrict printed/exported records to a category, e.g. "
+            "location-only, under-count, over-count, message-only"
+        ),
+    )
     parser.add_argument("--top", type=int, default=25, help="Rows to show in text output")
     parser.add_argument("--paths-only", action="store_true", help="Print only matching paths")
     args = parser.parse_args()
@@ -479,7 +616,9 @@ def main() -> int:
 
     records = build_records(detail, fingerprint_log)
     codes = {normalize_code(code) for code in args.code}
+    categories = set(args.category)
     records = [record for record in records if code_filter_matches(record, codes)]
+    records = [record for record in records if category_filter_matches(record, categories)]
     summary = summarize(records)
 
     print_summary(summary, records, args.top, args.paths_only)

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -73,6 +73,14 @@ Analyze options:
   --paths-only      Output only test paths for code queries
   --top N           Show top N rows in detailed views (default: 20)
 
+Render-corpus options:
+  --fingerprint-log PATH
+                    Verbose run output from --print-fingerprints
+  --category CAT    Filter render buckets, e.g. location-only, under-count,
+                    over-count, message-only
+  --code TSXXXX     Filter render records by diagnostic code
+  --paths-only      Output only matching test paths
+
 Areas options:
   --depth N         Grouping depth: 1=top-level, 2=sub-areas (default: 1)
   --min-tests N     Minimum tests in area to display (default: 5)
@@ -86,6 +94,7 @@ Examples:
   ./scripts/conformance/conformance.sh analyze --campaigns        # Ranked root-cause campaigns
   ./scripts/conformance/conformance.sh analyze --campaign big3    # Deep dive one campaign
   ./scripts/conformance/conformance.sh render-corpus              # Render failure buckets
+  ./scripts/conformance/conformance.sh render-corpus --category location-only --paths-only
   ./scripts/conformance/conformance.sh areas --depth 2            # Sub-area breakdown
 
 Note: Fingerprint comparison (code + location + message) is always enabled.

--- a/scripts/conformance/query-conformance.py
+++ b/scripts/conformance/query-conformance.py
@@ -38,6 +38,9 @@ Usage:
   # List fingerprint-only tests touching a specific code
   python3 scripts/conformance/query-conformance.py --fingerprint-only --code TS2322
 
+  # Show same-code count drift visible in compact expected/actual code lists
+  python3 scripts/conformance/query-conformance.py --count-drift
+
   # Export test paths for a code to feed into conformance runner
   python3 scripts/conformance/query-conformance.py --code TS2454 --paths-only
 """
@@ -269,6 +272,26 @@ def count_codes(failure):
     return counts
 
 
+def code_counts(codes):
+    return Counter(codes)
+
+
+def is_fingerprint_only(failure):
+    expected = failure.get("e", [])
+    actual = failure.get("a", [])
+    return bool(expected) and bool(actual) and code_counts(expected) == code_counts(actual)
+
+
+def is_same_code_count_drift(failure):
+    expected = failure.get("e", [])
+    actual = failure.get("a", [])
+    if not expected or not actual:
+        return False
+    expected_counts = code_counts(expected)
+    actual_counts = code_counts(actual)
+    return expected_counts != actual_counts and set(expected_counts) == set(actual_counts)
+
+
 def match_campaign(path, failure, config):
     # Fingerprint-only campaigns match only FP-only tests containing their codes
     if config.get("match_mode") == "fingerprint_only":
@@ -280,6 +303,21 @@ def match_campaign(path, failure, config):
             return False, 0, [], area_of(path)
         score = len(matched_codes) * 3
         return True, score, matched_codes, area_of(path)
+
+    if config.get("match_mode") == "same_code_count_drift":
+        if not is_same_code_count_drift(failure):
+            return False, 0, [], area_of(path)
+        expected_counts = code_counts(failure.get("e", []))
+        actual_counts = code_counts(failure.get("a", []))
+        drift_codes = [
+            code
+            for code in config.get("codes", [])
+            if expected_counts.get(code, 0) != actual_counts.get(code, 0)
+        ]
+        if not drift_codes:
+            return False, 0, [], area_of(path)
+        score = len(drift_codes) * 3
+        return True, score, drift_codes, area_of(path)
 
     low = path.lower()
     area = area_of(path)
@@ -414,8 +452,10 @@ def show_dashboard(data):
     close_1 = sum(1 for f in failures.values() if len(f.get("m", [])) + len(f.get("x", [])) == 1)
     close_2 = sum(1 for f in failures.values() if len(f.get("m", [])) + len(f.get("x", [])) == 2)
     fp_only = sum(1 for f in failures.values() if is_fingerprint_only(f))
+    count_drift = sum(1 for f in failures.values() if is_same_code_count_drift(f))
     print(f"  KPI 4: Close-to-passing:")
     print(f"    Fingerprint-only (same codes, wrong tuple): {fp_only}")
+    print(f"    Same-code count drift (compact codes): {count_drift}")
     print(f"    Diff = 1: {close_1}")
     print(f"    Diff = 2: {close_2}")
     print(f"    Total diff <= 2: {close_1 + close_2}")
@@ -429,6 +469,7 @@ def show_dashboard(data):
         print(f"    All missing (expected errors, we emit 0): {cats.get('all_missing', '?')}")
         print(f"    Fingerprint-only (same codes, wrong tuple): {cats.get('fingerprint_only', '?')}")
         print(f"    Wrong codes (both have, codes differ):  {cats.get('wrong_code', '?')}")
+        print(f"    Same-code count drift (computed):       {count_drift}")
         print(f"    Close to passing (diff <= 2):           {cats.get('close_to_passing', '?')}")
     print()
 
@@ -474,11 +515,13 @@ def show_overview(data):
     print()
 
     cats = a["categories"]
+    count_drift = sum(1 for f in data["failures"].values() if is_same_code_count_drift(f))
     print("Failure categories:")
     print(f"  False positives (expected 0, we emit):  {cats['false_positive']}")
     print(f"  All missing (expected errors, we emit 0): {cats['all_missing']}")
     print(f"  Fingerprint-only (same codes, wrong tuple): {cats.get('fingerprint_only', 0)}")
     print(f"  Wrong codes (both have, codes differ):  {cats['wrong_code']}")
+    print(f"  Same-code count drift (compact codes):  {count_drift}")
     print(f"  Close to passing (diff <= 2):           {cats['close_to_passing']}")
     print()
 
@@ -608,10 +651,6 @@ def show_code(data, code, paths_only=False):
             print(f"      {basename}")
 
 
-def is_fingerprint_only(failure):
-    return bool(failure.get("e")) and failure.get("e") == failure.get("a", [])
-
-
 def show_fingerprint_only(data, code=None, paths_only=False, top=40):
     failures = data["failures"]
     matches = []
@@ -654,6 +693,61 @@ def show_fingerprint_only(data, code=None, paths_only=False, top=40):
         name = basename(path)
         codes = ",".join(failure.get("e", []))
         print(f"  {name}  codes=[{codes}]")
+    if len(matches) > top:
+        print(f"  ... and {len(matches) - top} more")
+
+
+def show_count_drift(data, code=None, paths_only=False, top=40):
+    failures = data["failures"]
+    matches = []
+    under_counts = Counter()
+    over_counts = Counter()
+
+    for path, failure in sorted(failures.items()):
+        if not is_same_code_count_drift(failure):
+            continue
+        expected_counts = code_counts(failure.get("e", []))
+        actual_counts = code_counts(failure.get("a", []))
+        drift_codes = []
+        for item_code in sorted(set(expected_counts) | set(actual_counts)):
+            diff = actual_counts.get(item_code, 0) - expected_counts.get(item_code, 0)
+            if diff < 0:
+                under_counts[item_code] += -diff
+                drift_codes.append(item_code)
+            elif diff > 0:
+                over_counts[item_code] += diff
+                drift_codes.append(item_code)
+        if code and code not in drift_codes:
+            continue
+        matches.append((path, failure, expected_counts, actual_counts, drift_codes))
+
+    if paths_only:
+        for path, *_ in matches:
+            print(path)
+        return
+
+    scope = f" for {code}" if code else ""
+    print(f"Same-code count drift failures{scope}: {len(matches)}")
+    print()
+    if under_counts or over_counts:
+        print("Top compact count deltas:")
+        for item_code in sorted(set(under_counts) | set(over_counts)):
+            print(
+                f"  {item_code:>8s}: "
+                f"under={under_counts.get(item_code, 0):>3d} "
+                f"over={over_counts.get(item_code, 0):>3d}"
+            )
+        print()
+
+    print("Representative tests:")
+    for path, failure, expected_counts, actual_counts, drift_codes in matches[:top]:
+        name = basename(path)
+        deltas = []
+        for item_code in drift_codes:
+            deltas.append(
+                f"{item_code} {expected_counts.get(item_code, 0)}->{actual_counts.get(item_code, 0)}"
+            )
+        print(f"  {name}  {', '.join(deltas)}")
     if len(matches) > top:
         print(f"  ... and {len(matches) - top} more")
 
@@ -774,6 +868,11 @@ def main():
         action="store_true",
         help="Show failures where expected and actual code lists already match",
     )
+    parser.add_argument(
+        "--count-drift",
+        action="store_true",
+        help="Show failures whose compact expected/actual lists contain the same codes with different counts",
+    )
     parser.add_argument("--paths-only", action="store_true", help="Output only test paths (for piping)")
     parser.add_argument("--top", type=int, default=20, help="Limit rows shown in detailed views")
     parser.add_argument(
@@ -809,6 +908,8 @@ def main():
         show_false_positives(data)
     elif args.fingerprint_only:
         show_fingerprint_only(data, code=args.code, paths_only=args.paths_only, top=args.top)
+    elif args.count_drift:
+        show_count_drift(data, code=args.code, paths_only=args.paths_only, top=args.top)
     elif args.code:
         show_code(data, args.code, args.paths_only)
     elif args.extra_code:


### PR DESCRIPTION
## What changed

- Adds `--category` filtering to `classify-render-corpus.py` for `location-only`, `under-count`, `over-count`, `message-only`, and related buckets.
- Adds anchor-surface hints for location-only render failures so Phase 5 can target `DiagnosticAnchorKind` policy areas instead of reading raw fingerprint diffs by hand.
- Adds compact same-code count-drift reporting to query/dashboard tooling and future snapshot aggregates.
- Documents render-corpus filters in `conformance.sh help`.

## Why

Phase 5 needs count and anchor work to stay separate from type-display fixes. The existing tooling could classify message/location/count only after manual inspection, and compact count drift was lumped into the wrong-code bucket.

## Validation

- `python3 -m py_compile scripts/conformance/classify-render-corpus.py scripts/conformance/query-conformance.py scripts/conformance/build-snapshot-detail.py`
- `python3 scripts/conformance/classify-render-corpus.py --top 3`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- Synthetic fingerprint logs for `location-only` and `under-count` classifier filters
- Synthetic raw runner output for `same_code_count_drift` snapshot aggregate
- `git diff --check`
