### PR TITLE
[codex] include full fingerprints in diff artifacts

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -227,6 +227,10 @@ fn compare_diagnostics(
             f.message_key.clone(),
         )
     };
+    let mut expected_fingerprints = tsc_fps.to_vec();
+    let mut actual_fingerprints = compile_result.diagnostic_fingerprints.clone();
+    expected_fingerprints.sort_by_key(fp_sort_key);
+    actual_fingerprints.sort_by_key(fp_sort_key);
     missing_fingerprints.sort_by_key(fp_sort_key);
     extra_fingerprints.sort_by_key(fp_sort_key);
 
@@ -246,6 +250,8 @@ fn compare_diagnostics(
             extra,
             missing_fingerprints,
             extra_fingerprints,
+            expected_fingerprints,
+            actual_fingerprints,
             options,
             known_failure: None,
         }
@@ -512,6 +518,8 @@ impl Runner {
                                     extra,
                                     missing_fingerprints,
                                     extra_fingerprints,
+                                    expected_fingerprints,
+                                    actual_fingerprints,
                                     options,
                                     known_failure,
                                 } => {
@@ -621,6 +629,14 @@ impl Runner {
                                                 .map(super::tsc_results::DiagnosticFingerprint::display_key)
                                                 .collect::<Vec<_>>(),
                                             "extra_fingerprints": extra_fingerprints
+                                                .iter()
+                                                .map(super::tsc_results::DiagnosticFingerprint::display_key)
+                                                .collect::<Vec<_>>(),
+                                            "expected_fingerprints": expected_fingerprints
+                                                .iter()
+                                                .map(super::tsc_results::DiagnosticFingerprint::display_key)
+                                                .collect::<Vec<_>>(),
+                                            "actual_fingerprints": actual_fingerprints
                                                 .iter()
                                                 .map(super::tsc_results::DiagnosticFingerprint::display_key)
                                                 .collect::<Vec<_>>(),
@@ -2010,6 +2026,47 @@ mod tests {
                         .map(|f| (f.code, f.file.clone()))
                         .collect::<Vec<_>>(),
                     vec![(2304, "a.ts".into()), (2322, "b.ts".into())],
+                );
+            }
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compare_diagnostics_carries_full_fingerprint_sets_on_fail() {
+        let tsc_codes = vec![2304, 2322];
+        let tsc_fps = vec![
+            fp(2322, "b.ts", "Type mismatch."),
+            fp(2304, "a.ts", "Cannot find."),
+        ];
+        let compile = compilation(
+            &[2304, 2322],
+            vec![
+                fp(2322, "actual.ts", "Type mismatch."),
+                fp(2304, "a.ts", "Cannot find."),
+            ],
+        );
+
+        let result = compare_diagnostics(&compile, &tsc_codes, &tsc_fps, HashMap::new());
+        match result {
+            TestResult::Fail {
+                expected_fingerprints,
+                actual_fingerprints,
+                ..
+            } => {
+                assert_eq!(
+                    expected_fingerprints
+                        .iter()
+                        .map(|f| (f.code, f.file.as_str()))
+                        .collect::<Vec<_>>(),
+                    vec![(2304, "a.ts"), (2322, "b.ts")],
+                );
+                assert_eq!(
+                    actual_fingerprints
+                        .iter()
+                        .map(|f| (f.code, f.file.as_str()))
+                        .collect::<Vec<_>>(),
+                    vec![(2304, "a.ts"), (2322, "actual.ts")],
                 );
             }
             other => panic!("expected Fail, got {other:?}"),

--- a/crates/conformance/src/tsc_results.rs
+++ b/crates/conformance/src/tsc_results.rs
@@ -133,6 +133,10 @@ pub enum TestResult {
         missing_fingerprints: Vec<DiagnosticFingerprint>,
         /// Extra diagnostic fingerprints (present in tsz but not TSC)
         extra_fingerprints: Vec<DiagnosticFingerprint>,
+        /// Full expected diagnostic fingerprints after conformance filtering.
+        expected_fingerprints: Vec<DiagnosticFingerprint>,
+        /// Full actual diagnostic fingerprints after conformance filtering.
+        actual_fingerprints: Vec<DiagnosticFingerprint>,
         /// Resolved compiler options used
         options: std::collections::HashMap<String, String>,
         /// Known conformance debt reason. These are reported separately and are


### PR DESCRIPTION
## What changed

- Carries full expected and actual diagnostic fingerprint sets through `TestResult::Fail`.
- Writes `expected_fingerprints` and `actual_fingerprints` into `--write-diff-artifacts` JSON.
- Adds a focused conformance-runner test proving failed comparisons retain sorted full fingerprint sets.

## Why

Phase 5 count work needs to distinguish true under-emission from location/message drift. Missing/extra-only artifacts show the delta, but not the actual tsz subset that matched TSC. Full sets make under-count producer paths auditable from one artifact.

## Validation

- `cargo fmt --check`
- `cargo test -p tsz-conformance compare_diagnostics_carries_full_fingerprint_sets_on_fail -- --nocapture`
- `./scripts/conformance/conformance.sh run --filter "excessPropertyCheckWithUnions.ts" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-diffs`
- `jq` check confirmed the sample artifact reports 14 expected fingerprints, 8 actual fingerprints, 6 missing fingerprints, and 0 extra fingerprints.
- `git diff --check`
