### PR TITLE
chore(checker): migrate declarations/import/ to Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -336,7 +336,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_symbol_with_libs(export_equals_sym, &lib_binders)
-            && (sym.flags & symbol_flags::ALIAS) != 0
+            && sym.has_any_flags(symbol_flags::ALIAS)
         {
             let mut visited = AliasCycleTracker::new();
             let Some(resolved_sym) = self.resolve_alias_symbol(export_equals_sym, &mut visited)
@@ -353,17 +353,17 @@ impl<'a> CheckerState<'a> {
         };
 
         // tsc checks: !(symbol.flags & (SymbolFlags.Module | SymbolFlags.Variable))
-        let is_module_or_variable = (target.flags
-            & (symbol_flags::MODULE
+        let is_module_or_variable = target.has_any_flags(
+            symbol_flags::MODULE
                 | symbol_flags::FUNCTION_SCOPED_VARIABLE
-                | symbol_flags::BLOCK_SCOPED_VARIABLE))
-            != 0;
+                | symbol_flags::BLOCK_SCOPED_VARIABLE,
+        );
 
         // Namespace imports (`import * as X from "mod"`) resolve back to their
         // alias symbol rather than the module symbol.  They represent the entire
         // module namespace, so treat them as module-like for TS2497 purposes.
         if !is_module_or_variable
-            && (target.flags & symbol_flags::ALIAS) != 0
+            && target.has_any_flags(symbol_flags::ALIAS)
             && target.import_module.is_some()
             && target.import_name.as_deref() == Some("*")
         {
@@ -496,7 +496,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_symbol_with_libs(export_equals_sym, &lib_binders)
-            && (export_sym.flags & symbol_flags::ALIAS) != 0
+            && export_sym.has_any_flags(symbol_flags::ALIAS)
         {
             let mut visited_aliases = AliasCycleTracker::new();
             self.resolve_alias_symbol(export_equals_sym, &mut visited_aliases)
@@ -517,7 +517,7 @@ impl<'a> CheckerState<'a> {
 
         // For `export = alias` where `alias` comes from `import alias = Namespace`,
         // resolve the namespace target explicitly so named imports can see members.
-        if (target_symbol.flags & symbol_flags::ALIAS) != 0 {
+        if target_symbol.has_any_flags(symbol_flags::ALIAS) {
             let mut decl_candidates = target_symbol.declarations.clone();
             if target_symbol.value_declaration.is_some()
                 && !decl_candidates.contains(&target_symbol.value_declaration)

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -836,15 +836,15 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        if (symbol.flags & symbol_flags::ALIAS) != 0 {
+        if symbol.has_any_flags(symbol_flags::ALIAS) {
             let mut visited = AliasCycleTracker::new();
             if let Some(resolved) = self.resolve_alias_symbol(sym_id, &mut visited) {
                 return self.symbol_member_is_type_only(resolved, None);
             }
         }
 
-        let has_type = (symbol.flags & symbol_flags::TYPE) != 0;
-        let has_value = (symbol.flags & symbol_flags::VALUE) != 0;
+        let has_type = symbol.has_any_flags(symbol_flags::TYPE);
+        let has_value = symbol.has_any_flags(symbol_flags::VALUE);
         has_type && !has_value
     }
 
@@ -996,8 +996,8 @@ impl<'a> CheckerState<'a> {
                                 && let Some(sym_id) = binder.file_locals.get(&ident.escaped_text)
                                 && let Some(sym) = binder.get_symbol(sym_id)
                             {
-                                let has_type = (sym.flags & symbol_flags::TYPE) != 0;
-                                let has_value = (sym.flags & symbol_flags::VALUE) != 0;
+                                let has_type = sym.has_any_flags(symbol_flags::TYPE);
+                                let has_value = sym.has_any_flags(symbol_flags::VALUE);
                                 has_default_type |= has_type && !has_value;
                                 has_default_value |= has_value;
                             }
@@ -1172,7 +1172,7 @@ impl<'a> CheckerState<'a> {
         if (sym.flags & PURE_TYPE) != 0 && (sym.flags & VALUE) == 0 {
             return true;
         }
-        if sym.flags & symbol_flags::ALIAS != 0 && sym.import_module.is_none() {
+        if sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module.is_none() {
             let arena = self.ctx.get_arena_for_file(owner_file_idx as u32);
             let mut declarations = sym.declarations.clone();
             if sym.value_declaration.is_some() && !declarations.contains(&sym.value_declaration) {
@@ -1187,7 +1187,7 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
         }
-        if (sym.flags & symbol_flags::ALIAS) != 0 {
+        if sym.has_any_flags(symbol_flags::ALIAS) {
             let mut visited_aliases = AliasCycleTracker::new();
             if let Some(resolved_sym_id) = self.resolve_alias_symbol(sym_id, &mut visited_aliases) {
                 for alias_id in &visited_aliases {
@@ -1238,13 +1238,13 @@ impl<'a> CheckerState<'a> {
         if (sym.flags & PURE_TYPE) != 0 && (sym.flags & VALUE) == 0 {
             return true;
         }
-        if (sym.flags & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)) != 0
+        if sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
             && !self.symbol_has_runtime_value_in_binder(self.ctx.binder, sym_id)
         {
             return true;
         }
 
-        (sym.flags & symbol_flags::ALIAS) != 0 && self.alias_resolves_to_type_only(sym_id)
+        sym.has_any_flags(symbol_flags::ALIAS) && self.alias_resolves_to_type_only(sym_id)
     }
 
     fn should_report_js_type_only_import_diagnostic(

--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -547,8 +547,8 @@ impl<'a> CheckerState<'a> {
                                         | symbol_flags::CLASS
                                         | symbol_flags::ENUM
                                         | symbol_flags::ENUM_MEMBER;
-                                    (sym.flags & value_flags) == 0
-                                        && (sym.flags & symbol_flags::TYPE) != 0
+                                    !sym.has_any_flags(value_flags)
+                                        && sym.has_any_flags(symbol_flags::TYPE)
                                 });
 
                         if is_type_only_ident {

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -131,7 +131,7 @@ impl<'a> CheckerState<'a> {
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
         {
             // TYPE includes: Interface, TypeLiteral, TypeParameter, TypeAlias, Class, Enum, EnumMember
-            return (symbol.flags & symbol_flags::TYPE) != 0;
+            return symbol.has_any_flags(symbol_flags::TYPE);
         }
         false
     }
@@ -576,8 +576,8 @@ impl<'a> CheckerState<'a> {
 
                 if let Some(sym) = self.ctx.binder.symbols.get(sym_id) {
                     // Check if this symbol has value semantics
-                    let is_value = (sym.flags & symbol_flags::VALUE) != 0;
-                    let is_namespace = (sym.flags & symbol_flags::NAMESPACE_MODULE) != 0;
+                    let is_value = sym.has_any_flags(symbol_flags::VALUE);
+                    let is_namespace = sym.has_any_flags(symbol_flags::NAMESPACE_MODULE);
 
                     // TS2300: duplicate `import =` aliases with the same name in the same scope.
                     // TypeScript reports this as duplicate identifier (not TS2440).
@@ -626,7 +626,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx.binder.node_symbols.get(&decl_idx.0) == Some(&sym_id)
                     });
 
-                    let is_type_alias = (sym.flags & symbol_flags::TYPE_ALIAS) != 0;
+                    let is_type_alias = sym.has_any_flags(symbol_flags::TYPE_ALIAS);
                     if import_has_value && (is_value || is_type_alias) && has_local_declaration {
                         let message = format_message(
                             diagnostic_messages::IMPORT_DECLARATION_CONFLICTS_WITH_LOCAL_DECLARATION_OF,
@@ -1090,14 +1090,14 @@ impl<'a> CheckerState<'a> {
                     if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
                     {
                         let is_namespace =
-                            (symbol.flags & tsz_binder::symbol_flags::NAMESPACE) != 0;
-                        let mut has_value = (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0;
+                            symbol.has_any_flags(tsz_binder::symbol_flags::NAMESPACE);
+                        let mut has_value = symbol.has_any_flags(tsz_binder::symbol_flags::VALUE);
                         if has_value
-                            && (symbol.flags & tsz_binder::symbol_flags::VALUE_MODULE) != 0
-                            && (symbol.flags
-                                & (tsz_binder::symbol_flags::VALUE
-                                    & !tsz_binder::symbol_flags::VALUE_MODULE))
-                                == 0
+                            && symbol.has_any_flags(tsz_binder::symbol_flags::VALUE_MODULE)
+                            && !symbol.has_any_flags(
+                                tsz_binder::symbol_flags::VALUE
+                                    & !tsz_binder::symbol_flags::VALUE_MODULE,
+                            )
                         {
                             has_value = symbol.declarations.iter().any(|&decl_idx| {
                                 self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
@@ -1297,7 +1297,7 @@ impl<'a> CheckerState<'a> {
         // import_module, so the per-symbol `is_type_only` check alone can't trace
         // through. Check the declaration's RHS for type-only references.
         // Also follow through export alias → local symbol chains.
-        if symbol.flags & tsz_binder::symbol_flags::ALIAS != 0 {
+        if symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
             // Collect all symbols to check: the current symbol plus anything it aliases to
             let mut syms_to_check = vec![sym_id];
             let mut visited_resolve = AliasCycleTracker::new();
@@ -1770,12 +1770,12 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let mut has_value = (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0;
+        let mut has_value = symbol.has_any_flags(tsz_binder::symbol_flags::VALUE);
         if has_value
-            && (symbol.flags & tsz_binder::symbol_flags::VALUE_MODULE) != 0
-            && (symbol.flags
-                & (tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::VALUE_MODULE))
-                == 0
+            && symbol.has_any_flags(tsz_binder::symbol_flags::VALUE_MODULE)
+            && !symbol.has_any_flags(
+                tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::VALUE_MODULE,
+            )
         {
             has_value = symbol.declarations.iter().any(|&decl_idx| {
                 self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {

--- a/crates/tsz-checker/src/declarations/import/exports.rs
+++ b/crates/tsz-checker/src/declarations/import/exports.rs
@@ -135,7 +135,7 @@ impl<'a> CheckerState<'a> {
         {
             // If this is an alias, follow it to the source module
             if let Some(sym) = target_binder.symbols.get(sym_id)
-                && (sym.flags & tsz_binder::symbol_flags::ALIAS) != 0
+                && sym.has_any_flags(tsz_binder::symbol_flags::ALIAS)
                 && let Some(ref import_module) = sym.import_module
             {
                 let import_name = sym.import_name.as_deref().unwrap_or(export_name);

--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -51,10 +51,10 @@ impl<'a> CheckerState<'a> {
         // symbol (no NAMESPACE_MODULE flag) whose own exports/members are
         // empty. Follow `import_module` to check the target module's
         // top-level exports for any runtime value before short-circuiting.
-        let is_namespace_style_alias = (sym.flags & symbol_flags::ALIAS) != 0
+        let is_namespace_style_alias = sym.has_any_flags(symbol_flags::ALIAS)
             && sym.import_module.is_some()
             && sym.import_name.as_deref() == Some("*");
-        if (sym.flags & (symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)) == 0
+        if !sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
             && !is_namespace_style_alias
         {
             return false;
@@ -62,7 +62,7 @@ impl<'a> CheckerState<'a> {
 
         let member_has_runtime_value = |member_id: tsz_binder::SymbolId| {
             binder.get_symbol(member_id).is_some_and(|member_sym| {
-                (member_sym.flags & symbol_flags::VALUE) != 0
+                member_sym.has_any_flags(symbol_flags::VALUE)
                     && !self.symbol_member_is_type_only(member_id, None)
             })
         };
@@ -102,7 +102,7 @@ impl<'a> CheckerState<'a> {
                 return exports.iter().any(|(_, &member_id)| {
                     target_binder
                         .get_symbol(member_id)
-                        .is_some_and(|member_sym| (member_sym.flags & symbol_flags::VALUE) != 0)
+                        .is_some_and(|member_sym| member_sym.has_any_flags(symbol_flags::VALUE))
                 });
             }
         }
@@ -320,7 +320,7 @@ impl<'a> CheckerState<'a> {
         let Some(sym) = target_binder.get_symbol(sym_id) else {
             return false;
         };
-        (sym.flags & symbol_flags::ALIAS) != 0
+        sym.has_any_flags(symbol_flags::ALIAS)
     }
 
     /// Check if a named import refers to a purely type-only entity.
@@ -401,7 +401,7 @@ impl<'a> CheckerState<'a> {
                         if candidate_name == "default"
                             && let Some(default_sym_id) = exports.get(candidate_name)
                             && let Some(default_sym) = target_binder.get_symbol(default_sym_id)
-                            && (default_sym.flags & symbol_flags::ALIAS) != 0
+                            && default_sym.has_any_flags(symbol_flags::ALIAS)
                             && default_sym.import_module.is_none()
                             && let Some(target_decl_idx) = default_sym.primary_declaration()
                             && let Some(target_decl_node) = target_arena.get(target_decl_idx)
@@ -480,7 +480,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(sym_id) = target_binder.file_locals.get(import_name)
                 && let Some(sym) = target_binder.get_symbol(sym_id)
             {
-                return (sym.flags & tsz_binder::symbol_flags::CONST_ENUM) != 0;
+                return sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM);
             }
         }
 
@@ -495,7 +495,7 @@ impl<'a> CheckerState<'a> {
                 // In module_exports mode, check if any declaration is in a .d.ts
                 // We check symbol flags: if it's CONST_ENUM and declared in the current
                 // binder's d.ts file context
-                if (sym.flags & tsz_binder::symbol_flags::CONST_ENUM) != 0 {
+                if sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM) {
                     // Check declarations to see if they come from ambient context
                     let all_ambient = sym.declarations.iter().all(|&decl_idx| {
                         self.ctx.arena.is_in_ambient_context(decl_idx)
@@ -517,7 +517,7 @@ impl<'a> CheckerState<'a> {
         let lib_binders = self.get_lib_binders();
         let sym = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders);
         let Some(sym) = sym else { return false };
-        if (sym.flags & tsz_binder::symbol_flags::CONST_ENUM) == 0 {
+        if !sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
Sweeps the entire `crates/tsz-checker/src/declarations/import/` directory (excluding `declaration.rs`, which is already in PR #910) onto the canonical `Symbol::has_any_flags(MASK)` helper, replacing raw `(symbol.flags & MASK) != 0 / == 0` idioms.

Files touched (32 sites total):
- `declarations/import/verbatim.rs` (8)
- `declarations/import/equals.rs` (10)
- `declarations/import/exports.rs` (1)
- `declarations/import/core/module_exports.rs` (1)
- `declarations/import/core/import_members.rs` (8)
- `declarations/import/core/helpers.rs` (4)

Pure DRY cleanup — no behavior change.

## Test plan
- [x] `cargo check -p tsz-checker`
- [x] Pre-commit (fmt + clippy + wasm32 + arch-guard + nextest)