### PR TITLE
chore(checker): migrate types/{computation,queries,utilities} to has_any_flags

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -729,12 +729,12 @@ impl<'a> CheckerState<'a> {
                     if let Some(sym_id) = self.ctx.binder.file_locals.get(expr_name)
                         && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                     {
-                        let is_merged = (symbol.flags & symbol_flags::MODULE) != 0
-                            && (symbol.flags
-                                & (symbol_flags::CLASS
+                        let is_merged = symbol.has_any_flags(symbol_flags::MODULE)
+                            && symbol.has_any_flags(
+                                symbol_flags::CLASS
                                     | symbol_flags::FUNCTION
-                                    | symbol_flags::REGULAR_ENUM))
-                                != 0;
+                                    | symbol_flags::REGULAR_ENUM,
+                            );
 
                         if is_merged
                             && let Some(exports) = symbol.exports.as_ref()

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -36,9 +36,9 @@ impl<'a> CheckerState<'a> {
 
             symbol.escaped_name == identifier_text
                 && (is_unannotated_impl || is_local_ambient_signature)
-                && (symbol.flags & tsz_binder::symbol_flags::FUNCTION) != 0
-                && (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0
-                && (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0
+                && symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION)
+                && symbol.has_any_flags(tsz_binder::symbol_flags::VALUE)
+                && !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
                 && (symbol.decl_file_idx == u32::MAX
                     || symbol.decl_file_idx == self.ctx.current_file_idx as u32)
         })
@@ -93,12 +93,12 @@ impl<'a> CheckerState<'a> {
             // Emit the correct diagnostic based on symbol kind:
             // TS2449 for classes, TS2450 for enums, TS2448 for variables
             let (msg_template, code) = if let Some(sym) = self.ctx.binder.symbols.get(sym_id) {
-                if sym.flags & tsz_binder::symbol_flags::CLASS != 0 {
+                if sym.has_any_flags(tsz_binder::symbol_flags::CLASS) {
                     (
                         diagnostic_messages::CLASS_USED_BEFORE_ITS_DECLARATION,
                         diagnostic_codes::CLASS_USED_BEFORE_ITS_DECLARATION,
                     )
-                } else if sym.flags & tsz_binder::symbol_flags::ENUM != 0 {
+                } else if sym.has_any_flags(tsz_binder::symbol_flags::ENUM) {
                     (
                         diagnostic_messages::ENUM_USED_BEFORE_ITS_DECLARATION,
                         diagnostic_codes::ENUM_USED_BEFORE_ITS_DECLARATION,
@@ -139,10 +139,10 @@ impl<'a> CheckerState<'a> {
                         && sym.decl_file_idx != self.ctx.current_file_idx as u32
                 }))
                 && self.ctx.binder.symbols.get(sym_id).is_some_and(|sym| {
-                    sym.flags & tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE != 0
-                        && sym.flags
-                            & (tsz_binder::symbol_flags::CLASS | tsz_binder::symbol_flags::ENUM)
-                            == 0
+                    sym.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
+                        && !sym.has_any_flags(
+                            tsz_binder::symbol_flags::CLASS | tsz_binder::symbol_flags::ENUM,
+                        )
                 })
                 && let Some(usage_node) = self.ctx.arena.get(idx)
             {
@@ -202,7 +202,7 @@ impl<'a> CheckerState<'a> {
                                 base_sym.members.as_ref().and_then(|m| m.get(member_name))
                             })?;
                         let member_sym = self.ctx.binder.get_symbol(member_sym_id)?;
-                        Some(member_sym.flags & tsz_binder::symbol_flags::METHOD != 0)
+                        Some(member_sym.has_any_flags(tsz_binder::symbol_flags::METHOD))
                     })
                     .unwrap_or(false);
                 if !member_is_method {
@@ -941,8 +941,8 @@ impl<'a> CheckerState<'a> {
                 .binder
                 .get_symbol_with_libs(value_sym_id, &lib_binders)
             {
-                let has_type_side = (symbol.flags & tsz_binder::symbol_flags::TYPE) != 0;
-                let has_value_side = (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0;
+                let has_type_side = symbol.has_any_flags(tsz_binder::symbol_flags::TYPE);
+                let has_value_side = symbol.has_any_flags(tsz_binder::symbol_flags::VALUE);
                 if has_type_side && has_value_side {
                     // Merged symbol: scan declarations for a variable declaration
                     for &decl_idx in &symbol.declarations {

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1121,7 +1121,7 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .def_to_symbol_id(def_id)
                 .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                .is_some_and(|symbol| (symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS) != 0)
+                .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS))
         })
     }
 }

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -69,7 +69,7 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let sym_id = self.resolve_identifier_symbol(expr_idx)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
             return None;
         }
 
@@ -87,7 +87,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .binder
             .get_symbol(export_equals_sym)
-            .is_some_and(|symbol| (symbol.flags & tsz_binder::symbol_flags::ALIAS) != 0)
+            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS))
             .then(|| {
                 let mut visited_aliases = AliasCycleTracker::new();
                 self.resolve_alias_symbol(export_equals_sym, &mut visited_aliases)
@@ -240,9 +240,9 @@ impl<'a> CheckerState<'a> {
                             });
                             symbol.escaped_name == identifier_text
                                 && has_class_decl
-                                && (symbol.flags & tsz_binder::symbol_flags::CLASS) != 0
-                                && (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0
-                                && (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0
+                                && symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
+                                && symbol.has_any_flags(tsz_binder::symbol_flags::VALUE)
+                                && !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
                                 && (symbol.decl_file_idx == u32::MAX
                                     || symbol.decl_file_idx == self.ctx.current_file_idx as u32)
                         })
@@ -259,9 +259,9 @@ impl<'a> CheckerState<'a> {
                     if self.ctx.is_js_file()
                         && self.ctx.should_resolve_jsdoc()
                         && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-                        && (symbol.flags & tsz_binder::symbol_flags::CLASS) != 0
-                        && (symbol.flags & tsz_binder::symbol_flags::VARIABLE) != 0
-                        && (symbol.flags & tsz_binder::symbol_flags::FUNCTION) == 0
+                        && symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
+                        && symbol.has_any_flags(tsz_binder::symbol_flags::VARIABLE)
+                        && !symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION)
                         && let Some(preferred_decl) = self.checked_js_constructor_value_declaration(
                             sym_id,
                             symbol.value_declaration,

--- a/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
+++ b/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
@@ -86,7 +86,7 @@ impl<'a> CheckerState<'a> {
             let node = self.ctx.arena.get(value_decl)?;
 
             // Only handle plain JS function constructors (not classes).
-            if symbol.flags & symbol_flags::CLASS != 0
+            if symbol.has_any_flags(symbol_flags::CLASS)
                 && !self.declaration_is_checked_js_constructor_value_declaration(sym_id, value_decl)
             {
                 return None;

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1422,8 +1422,8 @@ impl<'a> CheckerState<'a> {
             && let Some(symbol) = self
                 .get_cross_file_symbol(obj_sym)
                 .or_else(|| self.ctx.binder.get_symbol(obj_sym))
-            && (symbol.flags & tsz_binder::symbol_flags::FUNCTION) != 0
-            && (symbol.flags & tsz_binder::symbol_flags::CLASS) == 0
+            && symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION)
+            && !symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
         {
             let symbol_declarations = symbol.declarations.clone();
             let declaration_is_function_value = |decl_idx: NodeIndex| -> bool {

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -189,7 +189,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx
                         .binder
                         .get_symbol(sym_id)
-                        .map(|s| s.flags & tsz_binder::symbol_flags::VALUE != 0)
+                        .map(|s| s.has_any_flags(tsz_binder::symbol_flags::VALUE))
                 })
                 .unwrap_or(false);
             if !has_value_shadow {
@@ -211,8 +211,8 @@ impl<'a> CheckerState<'a> {
                                 // Accept VALUE symbols and non-type-only ALIAS symbols
                                 // (e.g., `import * as E from "mod"` provides a runtime
                                 // namespace object).
-                                (s.flags & tsz_binder::symbol_flags::VALUE != 0)
-                                    || ((s.flags & tsz_binder::symbol_flags::ALIAS != 0)
+                                s.has_any_flags(tsz_binder::symbol_flags::VALUE)
+                                    || (s.has_any_flags(tsz_binder::symbol_flags::ALIAS)
                                         && !s.is_type_only)
                             })
                     })
@@ -720,8 +720,8 @@ impl<'a> CheckerState<'a> {
                             .get_symbol_with_libs(sid, &lib_binders)
                             .is_some_and(|s| {
                                 sid != sym_id
-                                    && ((s.flags & tsz_binder::symbol_flags::VALUE) != 0
-                                        || ((s.flags & tsz_binder::symbol_flags::ALIAS) != 0
+                                    && (s.has_any_flags(tsz_binder::symbol_flags::VALUE)
+                                        || (s.has_any_flags(tsz_binder::symbol_flags::ALIAS)
                                             && !s.is_type_only))
                             })
                     })

--- a/crates/tsz-checker/src/types/computation/identifier_flow.rs
+++ b/crates/tsz-checker/src/types/computation/identifier_flow.rs
@@ -25,7 +25,7 @@ impl<'a> CheckerState<'a> {
             return true;
         };
 
-        if (symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
             return true;
         }
 

--- a/crates/tsz-checker/src/types/queries/callable_truthiness.rs
+++ b/crates/tsz-checker/src/types/queries/callable_truthiness.rs
@@ -199,7 +199,7 @@ impl<'a> CheckerState<'a> {
             .resolve_qualified_symbol(node_idx)
             .or_else(|| self.ctx.resolve_type_to_symbol_id(ty))?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if (symbol.flags & symbol_flags::ENUM_MEMBER) == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return None;
         }
 
@@ -307,7 +307,7 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
     ) -> Option<&'static str> {
         let symbol = self.get_cross_file_symbol(sym_id)?;
-        if (symbol.flags & symbol_flags::ENUM_MEMBER) == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return None;
         }
         let member_decl = if symbol.value_declaration.is_some() {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -297,7 +297,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             {
                 // Check if name matches and symbol has STATIC flag
-                if symbol.escaped_name == name && (symbol.has_any_flags(symbol_flags::STATIC)) {
+                if symbol.escaped_name == name && symbol.has_any_flags(symbol_flags::STATIC) {
                     return true;
                 }
             }
@@ -312,7 +312,7 @@ impl<'a> CheckerState<'a> {
             if let Some(sym_id) = self.ctx.binder.get_node_symbol(member_idx)
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                 && symbol.escaped_name == name
-                && (!symbol.has_any_flags(symbol_flags::STATIC))
+                && !symbol.has_any_flags(symbol_flags::STATIC)
             {
                 return true;
             }
@@ -1253,7 +1253,7 @@ impl<'a> CheckerState<'a> {
         for (sym_id, sym_type) in self.ctx.symbol_types.iter() {
             if sym_type == type_id
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-                && symbol.flags & tsz_binder::symbol_flags::CLASS != 0
+                && symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
                 && let Some(class_idx) = self.get_class_declaration_from_symbol(sym_id)
             {
                 return Some((class_idx, true));

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -249,7 +249,7 @@ impl<'a> CheckerState<'a> {
         let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
         // Defensive: Verify symbol is valid before accessing fields
         // This prevents crashes when symbol IDs reference non-existent symbols
-        if symbol.flags & symbol_flags::ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return Some(sym_id);
         }
         if visited_aliases.contains(&sym_id) {
@@ -683,7 +683,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let resolved_member_id = if let Some(member_symbol) = self.get_cross_file_symbol(member_id)
-            && member_symbol.flags & symbol_flags::ALIAS != 0
+            && member_symbol.has_any_flags(symbol_flags::ALIAS)
         {
             let mut visited_aliases = AliasCycleTracker::new();
             let resolved = self
@@ -721,7 +721,7 @@ impl<'a> CheckerState<'a> {
             && let Some(member_symbol) = self
                 .get_cross_file_symbol(resolved_member_id)
                 .or_else(|| self.ctx.binder.get_symbol(resolved_member_id))
-            && (member_symbol.flags & symbol_flags::CLASS) != 0
+            && member_symbol.has_any_flags(symbol_flags::CLASS)
             && member_symbol.value_declaration.is_some()
         {
             return Some(self.type_of_value_declaration_for_symbol(
@@ -789,9 +789,9 @@ impl<'a> CheckerState<'a> {
         // Namespace export tables may point at EXPORT_VALUE wrapper symbols
         // (e.g. `export { x }`). Treat them as runtime-value members.
         if let Some(member_symbol) = self.get_cross_file_symbol(resolved_member_id)
-            && member_symbol.flags & symbol_flags::VALUE == 0
-            && member_symbol.flags & symbol_flags::ALIAS == 0
-            && member_symbol.flags & symbol_flags::EXPORT_VALUE == 0
+            && !member_symbol.has_any_flags(
+                symbol_flags::VALUE | symbol_flags::ALIAS | symbol_flags::EXPORT_VALUE,
+            )
         {
             return None;
         }
@@ -1225,7 +1225,7 @@ impl<'a> CheckerState<'a> {
                 // map to wrong symbols in the local binder (SymbolId collision).
                 let symbol = self.get_cross_file_symbol(sym_id)?;
 
-                if symbol.flags & symbol_flags::ENUM == 0 {
+                if !symbol.has_any_flags(symbol_flags::ENUM) {
                     return None;
                 }
 

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -795,7 +795,7 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_id) = sym_id {
             // Get the symbol's declaration(s) from the main file's binder
             if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) {
-                symbol_has_interface = (symbol.flags & tsz_binder::symbol_flags::INTERFACE) != 0;
+                symbol_has_interface = symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE);
                 let fallback_arena = resolve_lib_fallback_arena(
                     self.ctx.binder,
                     sym_id,
@@ -898,7 +898,7 @@ impl<'a> CheckerState<'a> {
                     // lowering. Type aliases like Record<K,T>, Partial<T>, Pick<T,K>
                     // would incorrectly succeed interface lowering with 0 type params,
                     // preventing the proper type alias path from running.
-                    let is_type_alias = (symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS) != 0;
+                    let is_type_alias = symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS);
 
                     if !is_type_alias {
                         let deduped = dedup_decl_arenas(&decls_with_arenas);

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -1288,7 +1288,7 @@ impl<'a> CheckerState<'a> {
         // Fallback: check via symbol flags (legacy path)
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) != 0
+            && symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
         {
             return self.get_type_of_symbol(symbol.parent);
         }
@@ -1321,7 +1321,7 @@ impl<'a> CheckerState<'a> {
         // Fallback: check via symbol flags (legacy path)
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) != 0
+            && symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
         {
             return self.get_type_of_symbol(symbol.parent);
         }
@@ -1599,7 +1599,7 @@ impl<'a> CheckerState<'a> {
         // Fast path using symbol flags: if symbol has TYPE flag, it's not value-only
         // This handles classes, interfaces, enums, type aliases, etc.
         // TYPE flag includes: CLASS | INTERFACE | ENUM | ENUM_MEMBER | TYPE_LITERAL | TYPE_PARAMETER | TYPE_ALIAS
-        let has_type_flag = (symbol.flags & symbol_flags::TYPE) != 0;
+        let has_type_flag = symbol.has_any_flags(symbol_flags::TYPE);
         if has_type_flag {
             return false;
         }
@@ -1607,14 +1607,13 @@ impl<'a> CheckerState<'a> {
         // Modules/namespaces can be used as types in some contexts, but not if they're
         // merged with functions or other values (e.g., function+namespace declaration merging)
         // In such cases, the function/value takes precedence and TS2749 should be emitted
-        let has_module = (symbol.flags & symbol_flags::MODULE) != 0;
-        let has_function = (symbol.flags & symbol_flags::FUNCTION) != 0;
+        let has_module = symbol.has_any_flags(symbol_flags::MODULE);
+        let has_function = symbol.has_any_flags(symbol_flags::FUNCTION);
         // Exclude both FUNCTION and MODULE flags when checking for "other" value flags.
         // VALUE_MODULE is part of VALUE, but a symbol that only has module flags
         // (VALUE_MODULE | NAMESPACE_MODULE) should be treated as a pure namespace.
-        let has_other_value = (symbol.flags
-            & (symbol_flags::VALUE & !symbol_flags::FUNCTION & !symbol_flags::MODULE))
-            != 0;
+        let has_other_value = symbol
+            .has_any_flags(symbol_flags::VALUE & !symbol_flags::FUNCTION & !symbol_flags::MODULE);
 
         // Pure namespace (MODULE only, no function/value flags) is not value-only
         if has_module && !has_function && !has_other_value {
@@ -1633,8 +1632,8 @@ impl<'a> CheckerState<'a> {
         }
 
         // Finally, check if this is purely a value symbol (has VALUE but not TYPE)
-        let has_value = (symbol.flags & symbol_flags::VALUE) != 0;
-        let has_type = (symbol.flags & symbol_flags::TYPE) != 0;
+        let has_value = symbol.has_any_flags(symbol_flags::VALUE);
+        let has_type = symbol.has_any_flags(symbol_flags::TYPE);
         has_value && !has_type
     }
 
@@ -1664,7 +1663,7 @@ impl<'a> CheckerState<'a> {
             None => return false,
         };
 
-        if symbol.flags & symbol_flags::ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return false;
         }
 

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -147,7 +147,7 @@ impl<'a> CheckerState<'a> {
         if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return Some(symbol.parent);
         }
-        (symbol.has_any_flags(symbol_flags::ENUM)).then_some(sym_id)
+        symbol.has_any_flags(symbol_flags::ENUM).then_some(sym_id)
     }
 
     pub(crate) fn apparent_enum_instance_type(&self, type_id: TypeId) -> Option<TypeId> {
@@ -529,7 +529,7 @@ impl<'a> CheckerState<'a> {
             })?;
 
         let member_symbol = self.ctx.binder.get_symbol(member_sym_id)?;
-        if member_symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0 {
+        if !member_symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER) {
             return None;
         }
 
@@ -714,10 +714,9 @@ impl<'a> CheckerState<'a> {
         if symbol.has_any_flags(symbol_flags::CLASS) {
             return Some(sym_id);
         }
-        if symbol.flags
-            & (symbol_flags::FUNCTION_SCOPED_VARIABLE | symbol_flags::BLOCK_SCOPED_VARIABLE)
-            == 0
-        {
+        if !symbol.has_any_flags(
+            symbol_flags::FUNCTION_SCOPED_VARIABLE | symbol_flags::BLOCK_SCOPED_VARIABLE,
+        ) {
             return None;
         }
         if symbol.value_declaration.is_none() {

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -647,7 +647,7 @@ impl<'a> CheckerState<'a> {
             return type_id;
         };
 
-        if symbol.flags & tsz_binder::symbol_flags::CLASS == 0 {
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::CLASS) {
             return type_id;
         }
 


### PR DESCRIPTION
## Summary
- Replaces ~66 raw `(sym.flags & MASK) != 0` / `== 0` idioms with the canonical `Symbol::has_any_flags(MASK)` helper
- 18 files across `types/computation/`, `types/queries/`, `types/utilities/`
- Pure DRY refactor — no behavioral change

## Test plan
- [x] `cargo check -p tsz-checker` clean
- [x] Pre-commit: fmt, clippy (zero warnings), wasm32 rustc, arch-guard
- [x] `cargo nextest run` (13039 tests passed)