### PR TITLE
chore(checker): migrate types/{class_type,type_node,type_checking,property_access_*} to has_any_flags

### DIFF
--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -2283,7 +2283,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             // Only check class arguments
-            if arg_symbol.flags & tsz_binder::symbol_flags::CLASS == 0 {
+            if !arg_symbol.has_any_flags(tsz_binder::symbol_flags::CLASS) {
                 continue;
             }
 

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -1819,7 +1819,7 @@ impl<'a> CheckerState<'a> {
                 let Some(candidate_symbol) = self.get_cross_file_symbol(candidate_id) else {
                     continue;
                 };
-                if (candidate_symbol.flags & tsz_binder::symbol_flags::INTERFACE) == 0 {
+                if !candidate_symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE) {
                     continue;
                 }
 
@@ -2038,7 +2038,7 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_id) = current_sym {
             let is_class_symbol = self
                 .get_symbol_globally(sym_id)
-                .is_some_and(|s| s.flags & tsz_binder::symbol_flags::CLASS != 0);
+                .is_some_and(|s| s.has_any_flags(tsz_binder::symbol_flags::CLASS));
             if is_class_symbol {
                 let def_id = self.ctx.get_or_create_def_id(sym_id);
                 self.ctx

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -743,7 +743,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // Only handle type aliases (not classes/interfaces)
-        if symbol.flags & symbol_flags::TYPE_ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
             return false;
         }
 

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -320,7 +320,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // Only check class declarations
-        if (symbol.flags & symbol_flags::CLASS) == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return false;
         }
 
@@ -407,7 +407,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return false;
         };
-        if (symbol.flags & symbol_flags::VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE) {
             return false;
         }
 

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -113,17 +113,16 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        if (symbol.flags
-            & (symbol_flags::FUNCTION
+        if symbol.has_any_flags(
+            symbol_flags::FUNCTION
                 | symbol_flags::CLASS
                 | symbol_flags::VALUE_MODULE
-                | symbol_flags::NAMESPACE_MODULE))
-            != 0
-        {
+                | symbol_flags::NAMESPACE_MODULE,
+        ) {
             return true;
         }
 
-        if (symbol.flags & symbol_flags::VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE) {
             return false;
         }
 
@@ -807,8 +806,8 @@ impl<'a> CheckerState<'a> {
             && let Some(root_name) = root_identifier(self.ctx.arena, object_expr_idx)
             && let Some(root_sym) = self.ctx.binder.file_locals.get(&root_name)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym)
-            && (root_symbol.flags & (symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE))
-                != 0
+            && root_symbol
+                .has_any_flags(symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE)
         {
             return true;
         }
@@ -863,7 +862,7 @@ impl<'a> CheckerState<'a> {
             && root_node.kind == SyntaxKind::Identifier as u16
             && let Some(root_sym_id) = self.resolve_identifier_symbol(root_idx)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym_id)
-            && (root_symbol.flags & symbol_flags::ALIAS) != 0
+            && root_symbol.has_any_flags(symbol_flags::ALIAS)
             && root_symbol.import_module.is_some()
         {
             return false;
@@ -912,7 +911,7 @@ impl<'a> CheckerState<'a> {
                 .is_some_and(|ident| ident.escaped_text == "prototype")
             && let Some(root_sym_id) = self.resolve_identifier_symbol(object_access.expression)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym_id)
-            && (root_symbol.flags & symbol_flags::ALIAS) != 0
+            && root_symbol.has_any_flags(symbol_flags::ALIAS)
             && root_symbol.import_module.is_some()
         {
             return false;

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -407,9 +407,9 @@ impl<'a> CheckerState<'a> {
                 .get_symbol(sym_id)
                 .or_else(|| self.get_cross_file_symbol(sym_id))?;
 
-            let is_namespace = (symbol.flags & symbol_flags::NAMESPACE_MODULE) != 0;
+            let is_namespace = symbol.has_any_flags(symbol_flags::NAMESPACE_MODULE);
             let value_flags_except_module = symbol_flags::VALUE & !symbol_flags::VALUE_MODULE;
-            let has_other_value = (symbol.flags & value_flags_except_module) != 0;
+            let has_other_value = symbol.has_any_flags(value_flags_except_module);
             if !is_namespace || has_other_value {
                 return None;
             }
@@ -439,8 +439,8 @@ impl<'a> CheckerState<'a> {
                 .binder
                 .get_symbol(ns_member_sym_id)
                 .or_else(|| self.get_cross_file_symbol(ns_member_sym_id))?;
-            if (ns_member_symbol.flags & symbol_flags::ENUM) == 0
-                || (ns_member_symbol.flags & symbol_flags::ENUM_MEMBER) != 0
+            if !ns_member_symbol.has_any_flags(symbol_flags::ENUM)
+                || ns_member_symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
             {
                 return None;
             }
@@ -450,7 +450,7 @@ impl<'a> CheckerState<'a> {
                 .binder
                 .get_symbol(ns_member_symbol.parent)
                 .or_else(|| self.get_cross_file_symbol(ns_member_symbol.parent))?;
-            if (parent_symbol.flags & symbol_flags::NAMESPACE_MODULE) == 0 {
+            if !parent_symbol.has_any_flags(symbol_flags::NAMESPACE_MODULE) {
                 return None;
             }
 
@@ -628,7 +628,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // If the symbol only has VALUE flags (no TYPE flags), we can trust is_exported
-        let has_type_flags = symbol.flags & symbol_flags::TYPE != 0;
+        let has_type_flags = symbol.has_any_flags(symbol_flags::TYPE);
         if !has_type_flags {
             return symbol.is_exported;
         }
@@ -638,11 +638,11 @@ impl<'a> CheckerState<'a> {
         // Enum members are considered exported if they're in the enum's exports table.
         // We only need special handling for namespace + interface/type-alias merges.
         let is_merged_with_type_only =
-            (symbol.flags & (symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)) != 0;
+            symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS);
         if !is_merged_with_type_only {
             // Enum members may not have is_exported set, but they're accessible
             // if they're in the enum's exports table (which they must be to get here)
-            if (symbol.flags & symbol_flags::ENUM_MEMBER) != 0 {
+            if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
                 return true;
             }
             return symbol.is_exported;

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -1138,7 +1138,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn is_class_symbol(&self, symbol_id: tsz_binder::SymbolId) -> bool {
         use tsz_binder::symbol_flags;
         if let Some(symbol) = self.ctx.binder.get_symbol(symbol_id) {
-            (symbol.flags & symbol_flags::CLASS) != 0
+            symbol.has_any_flags(symbol_flags::CLASS)
         } else {
             false
         }
@@ -1298,7 +1298,7 @@ impl<'a> CheckerState<'a> {
                 let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                     return false;
                 };
-                if symbol.flags & symbol_flags::ENUM == 0 {
+                if !symbol.has_any_flags(symbol_flags::ENUM) {
                     return false;
                 }
                 if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -188,30 +188,30 @@ impl<'a> CheckerState<'a> {
 
             if has_local && has_remote {
                 // Interfaces always merge with other interfaces across files in TypeScript.
-                let is_interface_merge = (symbol.flags & symbol_flags::INTERFACE) != 0
-                    && (symbol.flags
-                        & (symbol_flags::FUNCTION_SCOPED_VARIABLE
+                let is_interface_merge = symbol.has_any_flags(symbol_flags::INTERFACE)
+                    && !symbol.has_any_flags(
+                        symbol_flags::FUNCTION_SCOPED_VARIABLE
                             | symbol_flags::BLOCK_SCOPED_VARIABLE
                             | symbol_flags::TYPE_ALIAS
                             | symbol_flags::REGULAR_ENUM
-                            | symbol_flags::CONST_ENUM))
-                        == 0;
+                            | symbol_flags::CONST_ENUM,
+                    );
                 // var declarations merge across script files (non-modules).
                 let is_var_merge = !is_external_module
-                    && (symbol.flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) != 0
-                    && (symbol.flags
-                        & (symbol_flags::BLOCK_SCOPED_VARIABLE
+                    && symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE)
+                    && !symbol.has_any_flags(
+                        symbol_flags::BLOCK_SCOPED_VARIABLE
                             | symbol_flags::CLASS
                             | symbol_flags::FUNCTION
                             | symbol_flags::REGULAR_ENUM
                             | symbol_flags::CONST_ENUM
-                            | symbol_flags::TYPE_ALIAS))
-                        == 0;
+                            | symbol_flags::TYPE_ALIAS,
+                    );
                 // Function declarations merge across files via module augmentation.
-                let is_function_merge = (symbol.flags & symbol_flags::FUNCTION) != 0
+                let is_function_merge = symbol.has_any_flags(symbol_flags::FUNCTION)
                     && !module_augmentation_declarations.is_empty();
                 // Import aliases referencing remote declarations are valid merges.
-                let is_alias_import_merge = (symbol.flags & symbol_flags::ALIAS) != 0
+                let is_alias_import_merge = symbol.has_any_flags(symbol_flags::ALIAS)
                     && symbol
                         .declarations
                         .iter()
@@ -1863,7 +1863,7 @@ impl<'a> CheckerState<'a> {
             .binder
             .symbols
             .iter()
-            .filter(|symbol| (symbol.flags & symbol_flags::FUNCTION) != 0)
+            .filter(|symbol| symbol.has_any_flags(symbol_flags::FUNCTION))
             .flat_map(|symbol| {
                 symbol.declarations.iter().filter_map(|&decl_idx| {
                     let node = self.ctx.arena.get(decl_idx)?;

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -151,7 +151,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .binder
                     .get_symbol(sym_id)
-                    .is_some_and(|symbol| (symbol.flags & symbol_flags::TYPE_PARAMETER) != 0)
+                    .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::TYPE_PARAMETER))
             })
     }
 }

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -949,10 +949,12 @@ impl<'a> CheckerState<'a> {
                 {
                     let name = &ident.escaped_text;
                     // Check if this identifier resolves to a type symbol
-                    let has_type = (symbol.flags & tsz_binder::symbol_flags::TYPE) != 0
-                        || (symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS) != 0
-                        || (symbol.flags & tsz_binder::symbol_flags::INTERFACE) != 0;
-                    let has_value = (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0;
+                    let has_type = symbol.has_any_flags(
+                        tsz_binder::symbol_flags::TYPE
+                            | tsz_binder::symbol_flags::TYPE_ALIAS
+                            | tsz_binder::symbol_flags::INTERFACE,
+                    );
+                    let has_value = symbol.has_any_flags(tsz_binder::symbol_flags::VALUE);
                     if has_type && !has_value {
                         // The identifier refers to a type-only symbol
                         // Emit TS2693: Type only used as value

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -515,11 +515,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
             if let Some(sym_id) = sym_id
                 && self.ctx.symbol_resolution_set.contains(&sym_id)
-                && self
-                    .ctx
-                    .binder
-                    .get_symbol(sym_id)
-                    .is_some_and(|symbol| symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0)
+                && self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
+                    symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS)
+                })
             {
                 // A TypeReference with type arguments (e.g. `C1<T>`) creates a new
                 // instantiation boundary -- not circular even inside computation.
@@ -1149,10 +1147,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         .resolve_identifier(self.ctx.arena, param_data.name)
                         && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                     {
-                        let has_type = (symbol.flags & tsz_binder::symbol_flags::TYPE) != 0
-                            || (symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS) != 0
-                            || (symbol.flags & tsz_binder::symbol_flags::INTERFACE) != 0;
-                        let has_value = (symbol.flags & tsz_binder::symbol_flags::VALUE) != 0;
+                        let has_type = symbol.has_any_flags(
+                            tsz_binder::symbol_flags::TYPE
+                                | tsz_binder::symbol_flags::TYPE_ALIAS
+                                | tsz_binder::symbol_flags::INTERFACE,
+                        );
+                        let has_value = symbol.has_any_flags(tsz_binder::symbol_flags::VALUE);
                         if has_type && !has_value {
                             // The identifier refers to a type-only symbol
                             // Emit TS2693: Type only used as value
@@ -1369,18 +1369,17 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             if let Some(scoped_sym_id) = scoped_sym_id
                 && scoped_sym_id != sym_id
                 && let Some(scoped_symbol) = self.get_symbol_from_any_context(scoped_sym_id)
-                && (scoped_symbol.flags
-                    & (symbol_flags::TYPE | symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM))
-                    != 0
-                && (scoped_symbol.flags & symbol_flags::TYPE_ALIAS) != 0
-                && (symbol.flags & symbol_flags::TYPE_ALIAS) == 0
+                && scoped_symbol.has_any_flags(
+                    symbol_flags::TYPE | symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM,
+                )
+                && scoped_symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
+                && !symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
             {
                 return Some(scoped_sym_id.0);
             }
-            if (symbol.flags
-                & (symbol_flags::TYPE | symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM))
-                != 0
-            {
+            if symbol.has_any_flags(
+                symbol_flags::TYPE | symbol_flags::REGULAR_ENUM | symbol_flags::CONST_ENUM,
+            ) {
                 return Some(sym_id.0);
             }
         }

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -255,9 +255,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         .get(key.as_str())
                         .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
                         .is_some_and(|symbol| {
-                            symbol.flags & tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE != 0
-                                && symbol.flags & tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE
-                                    == 0
+                            symbol.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
+                                && !symbol.has_any_flags(
+                                    tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE,
+                                )
                         });
                     if not_in_locals || is_block_scoped {
                         if let Some(idx_node) = self.ctx.arena.get(indexed_access.index_type) {

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -647,7 +647,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         let Some(symbol) = symbol else {
             return;
         };
-        if symbol.flags & symbol_flags::TYPE_ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- Continue the DRY sweep migrating raw `(symbol.flags & MASK) != 0` / `== 0` bitmask idioms onto the canonical `Symbol::has_any_flags(MASK)` helper.
- Covers `types/class_type/`, `types/type_node*.rs`, `types/type_literal_checker.rs`, `types/type_checking/{declarations,duplicate_identifiers,indexed_access}`, `types/property_access_helpers/{access_semantics,expando}`, `types/property_access_type/helpers.rs`, and `types/function_type_helpers.rs`.
- No semantic change — `has_any_flags` is a const fn returning `(flags & mask) != 0`. Pure readability / consistency cleanup.

## Test plan
- [x] `cargo check -p tsz-checker`
- [x] Pre-commit gate: fmt + clippy (zero warnings) + wasm32 rustc + arch-guard + full nextest (13039 tests pass, 54 skipped) in ~17s.