### PR TITLE
chore(checker): migrate state/ to Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -295,7 +295,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return;
         };
-        if symbol.flags & symbol_flags::VARIABLE == 0 || !symbol.value_declaration.is_some() {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE) || !symbol.value_declaration.is_some() {
             return;
         }
         let Some(decl_node) = self.ctx.arena.get(symbol.value_declaration) else {

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -754,7 +754,7 @@ impl<'a> CheckerState<'a> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
 
         // Must be a namespace/module symbol
-        if symbol.flags & symbol_flags::MODULE == 0 {
+        if !symbol.has_any_flags(symbol_flags::MODULE) {
             return Some(false);
         }
 
@@ -763,7 +763,7 @@ impl<'a> CheckerState<'a> {
         let member_symbol = self.ctx.binder.get_symbol(member_sym_id)?;
 
         // Check if the member is a block-scoped variable (const/let)
-        if member_symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE == 0 {
+        if !member_symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
             return Some(false);
         }
 
@@ -812,7 +812,7 @@ impl<'a> CheckerState<'a> {
                     return false;
                 };
 
-                if (resolved_symbol.flags & symbol_flags::NAMESPACE) == 0 {
+                if !resolved_symbol.has_any_flags(symbol_flags::NAMESPACE) {
                     return false;
                 }
 
@@ -821,7 +821,7 @@ impl<'a> CheckerState<'a> {
                     && let Some(member_sym_id) = exports.get(name)
                     && let Some(member_symbol) = self.ctx.binder.get_symbol(member_sym_id)
                 {
-                    return member_symbol.flags & symbol_flags::ENUM != 0;
+                    return member_symbol.has_any_flags(symbol_flags::ENUM);
                 }
             }
             return false;
@@ -837,7 +837,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(resolved_sym_id) else {
             return false;
         };
-        symbol.flags & symbol_flags::ENUM != 0
+        symbol.has_any_flags(symbol_flags::ENUM)
     }
 
     /// Check whether an expression resolves to an immutable module import binding.
@@ -862,7 +862,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        if (symbol.flags & symbol_flags::ALIAS) == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return false;
         }
 

--- a/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
@@ -639,7 +639,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return;
         };
-        if symbol.flags & symbol_flags::TYPE_PARAMETER == 0 {
+        if !symbol.has_any_flags(symbol_flags::TYPE_PARAMETER) {
             return;
         }
 

--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -344,7 +344,7 @@ impl<'a> CheckerState<'a> {
         // returns the stored value (which may be undefined), but tsc treats enum
         // member references as "evaluated" — the TS18033 check was already done on
         // the member itself.
-        if symbol.flags & symbol_flags::ENUM_MEMBER != 0 {
+        if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return Some(true);
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -391,7 +391,7 @@ impl<'a> CheckerState<'a> {
                     && target_sym_id != sym_id
                     && let Some(target_symbol) = self.get_symbol_globally(target_sym_id)
                 {
-                    if (target_symbol.flags & symbol_flags::CLASS) != 0 {
+                    if target_symbol.has_any_flags(symbol_flags::CLASS) {
                         let target_type = self.get_type_of_symbol(target_sym_id);
                         // Also cache the instance type so type-position references
                         // (`let x: Observable<number>`) continue to work.

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -294,7 +294,7 @@ impl<'a> CheckerState<'a> {
                         .ctx
                         .alias_partner_for(self.ctx.binder, sym_id)
                         .and_then(|partner_id| self.ctx.binder.get_symbol(partner_id))
-                        .is_some_and(|partner| partner.flags & symbol_flags::ALIAS != 0);
+                        .is_some_and(|partner| partner.has_any_flags(symbol_flags::ALIAS));
                     // tsc's hasParseDiagnostics() checks ALL parse diagnostics
                     // (including grammar checks like TS1359) to suppress TS2456.
                     // Our has_parse_errors only tracks "real" syntax errors, so
@@ -1612,8 +1612,8 @@ impl<'a> CheckerState<'a> {
                         }
                         let should_cache_on_export_symbol =
                             self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
-                                (sym.flags & symbol_flags::TYPE) == 0
-                                    || (sym.flags & symbol_flags::VALUE) == 0
+                                !sym.has_any_flags(symbol_flags::TYPE)
+                                    || !sym.has_any_flags(symbol_flags::VALUE)
                             });
                         if should_cache_on_export_symbol {
                             self.ctx.symbol_types.insert(export_sym_id, result);
@@ -1629,7 +1629,7 @@ impl<'a> CheckerState<'a> {
                     // aliases (value position), we need the variable/function
                     // type so the imported binding is callable/constructable.
                     let mut result = if let Some(sym) = self.get_symbol_globally(export_sym_id) {
-                        let has_interface = sym.flags & symbol_flags::INTERFACE != 0;
+                        let has_interface = sym.has_any_flags(symbol_flags::INTERFACE);
                         let has_value = sym.flags
                             & (symbol_flags::FUNCTION_SCOPED_VARIABLE
                                 | symbol_flags::BLOCK_SCOPED_VARIABLE
@@ -1660,8 +1660,8 @@ impl<'a> CheckerState<'a> {
                     }
                     let should_cache_on_export_symbol =
                         self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
-                            (sym.flags & symbol_flags::TYPE) == 0
-                                || (sym.flags & symbol_flags::VALUE) == 0
+                            !sym.has_any_flags(symbol_flags::TYPE)
+                                || !sym.has_any_flags(symbol_flags::VALUE)
                         });
                     if should_cache_on_export_symbol {
                         self.ctx.symbol_types.insert(export_sym_id, result);

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -135,7 +135,7 @@ impl<'a> CheckerState<'a> {
             }
             let referenced_sym_id = resolve_type_name(ident_name)?;
             let symbol = binder.get_symbol_with_libs(referenced_sym_id, &lib_binders)?;
-            ((symbol.flags & symbol_flags::TYPE) != 0).then_some(referenced_sym_id.0)
+            (symbol.has_any_flags(symbol_flags::TYPE)).then_some(referenced_sym_id.0)
         };
         let value_resolver = |node_idx: NodeIndex| -> Option<u32> {
             let ident_name = decl_arena.get_identifier_text(node_idx)?;
@@ -159,7 +159,7 @@ impl<'a> CheckerState<'a> {
             }
             let referenced_sym_id = resolve_type_name(ident_name)?;
             let symbol = binder.get_symbol_with_libs(referenced_sym_id, &lib_binders)?;
-            ((symbol.flags & symbol_flags::TYPE) != 0)
+            (symbol.has_any_flags(symbol_flags::TYPE))
                 .then(|| self.ctx.get_or_create_def_id(referenced_sym_id))
         };
         let name_resolver = |type_name: &str| -> Option<tsz_solver::def::DefId> {

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -40,7 +40,7 @@ impl<'a> CheckerState<'a> {
 
         let sym_id = self.resolve_identifier_symbol_without_tracking(rhs_expr)?;
         let symbol = self.get_symbol_globally(sym_id)?;
-        if (symbol.flags & symbol_flags::CLASS) == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return None;
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -1024,7 +1024,7 @@ impl<'a> CheckerState<'a> {
                     .and_then(|idx| self.ctx.get_binder_for_file(idx))
                     .and_then(|binder| {
                         let sym = binder.get_symbol(export_equals_sym)?;
-                        if (sym.flags & symbol_flags::VALUE) != 0 {
+                        if sym.has_any_flags(symbol_flags::VALUE) {
                             return None;
                         }
                         let sym_name = sym.escaped_name.clone();
@@ -1039,7 +1039,7 @@ impl<'a> CheckerState<'a> {
                             .filter(|&mid| {
                                 binder
                                     .get_symbol(mid)
-                                    .is_some_and(|m| (m.flags & symbol_flags::VALUE) != 0)
+                                    .is_some_and(|m| m.has_any_flags(symbol_flags::VALUE))
                             })
                     })
                     .unwrap_or(export_equals_sym);

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -924,7 +924,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .binder
                     .get_symbol(sym_id)
-                    .is_some_and(|s| s.flags & symbol_flags::TYPE_ALIAS != 0)
+                    .is_some_and(|s| s.has_any_flags(symbol_flags::TYPE_ALIAS))
             })
             .collect::<FxHashSet<_>>()
             .into_iter()

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -37,7 +37,7 @@ impl<'a> CheckerState<'a> {
         let symbol = self
             .get_cross_file_symbol(sym_id)
             .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
-        if symbol.flags & symbol_flags::ENUM == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM) {
             return None;
         }
 
@@ -130,7 +130,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let properties: Vec<PropertyInfo> = props.into_values().collect();
-        let is_const_enum = symbol.flags & symbol_flags::CONST_ENUM != 0;
+        let is_const_enum = symbol.has_any_flags(symbol_flags::CONST_ENUM);
         let flags = if is_const_enum {
             tsz_solver::ObjectFlags::CONST_ENUM
         } else {
@@ -1403,7 +1403,7 @@ impl<'a> CheckerState<'a> {
 
         let mut sym_id = sym_id;
         if let Some(symbol) = self.get_symbol_globally(sym_id)
-            && symbol.flags & symbol_flags::ALIAS != 0
+            && symbol.has_any_flags(symbol_flags::ALIAS)
         {
             let mut visited_aliases = AliasCycleTracker::new();
             if let Some(target) = self.resolve_alias_symbol(sym_id, &mut visited_aliases) {

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -793,7 +793,7 @@ impl<'a> CheckerState<'a> {
                 return TypeId::ERROR;
             }
             if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
-                if (symbol.flags & symbol_flags::VALUE) == 0 {
+                if !symbol.has_any_flags(symbol_flags::VALUE) {
                     // Route through wrong-meaning boundary: symbol has no value meaning
                     use crate::query_boundaries::name_resolution::NameLookupKind;
                     self.report_wrong_meaning_diagnostic(name, error_node, NameLookupKind::Type);
@@ -802,8 +802,8 @@ impl<'a> CheckerState<'a> {
                 // In TypeScript, `typeof globalThis` only exposes `var`-declared
                 // globals (FUNCTION_SCOPED_VARIABLE) and function/class declarations.
                 // Block-scoped variables (let/const) are NOT properties of globalThis.
-                if symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0
-                    && symbol.flags & symbol_flags::FUNCTION_SCOPED_VARIABLE == 0
+                if symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
+                    && !symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE)
                 {
                     // Before erroring, check if a lib `var` declaration exists.
                     // E.g. `const Symbol = globalThis.Symbol` — the local const shadows
@@ -835,8 +835,8 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let base_type = if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
-                let has_type_side = (symbol.flags & symbol_flags::TYPE) != 0;
-                let has_value_side = (symbol.flags & symbol_flags::VALUE) != 0;
+                let has_type_side = symbol.has_any_flags(symbol_flags::TYPE);
+                let has_value_side = symbol.has_any_flags(symbol_flags::VALUE);
                 if has_type_side && has_value_side {
                     let value_type = self.type_of_value_symbol_by_name(name);
                     if value_type != TypeId::UNKNOWN && value_type != TypeId::ERROR {

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -193,11 +193,11 @@ impl<'a> CheckerState<'a> {
                 let lib_binders = self.get_lib_binders();
                 let symbol_info = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders);
                 let is_type_alias =
-                    symbol_info.is_some_and(|s| s.flags & symbol_flags::TYPE_ALIAS != 0);
+                    symbol_info.is_some_and(|s| s.has_any_flags(symbol_flags::TYPE_ALIAS));
                 // TS2589 detection for class types with generic type arguments that may
                 // recursively expand (e.g., `Foo<[...Elements, "abc"]>` where mapped types
                 // in the class cause infinite type instantiation)
-                let is_class = symbol_info.is_some_and(|s| s.flags & symbol_flags::CLASS != 0);
+                let is_class = symbol_info.is_some_and(|s| s.has_any_flags(symbol_flags::CLASS));
 
                 if is_type_alias || is_class {
                     let args_have_type_params = query::get_application_info(
@@ -235,7 +235,7 @@ impl<'a> CheckerState<'a> {
                                     // The base is a type alias whose body is a mapped
                                     // type that references itself in its template
                                     self.ctx.binder.get_symbol(ref_sym).is_some_and(|symbol| {
-                                        symbol.flags & symbol_flags::TYPE_ALIAS != 0
+                                        symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
                                             && symbol.declarations.iter().any(|&decl_idx| {
                                                 self.alias_has_self_referencing_mapped_body(
                                                     ref_sym, decl_idx,
@@ -742,7 +742,7 @@ impl<'a> CheckerState<'a> {
                         .ctx
                         .binder
                         .get_symbol_with_libs(sym_id, &lib_binders)
-                        .is_some_and(|s| s.flags & symbol_flags::TYPE_ALIAS != 0);
+                        .is_some_and(|s| s.has_any_flags(symbol_flags::TYPE_ALIAS));
                     if is_type_alias {
                         let args_have_type_params = query::get_application_info(
                             self.ctx.types,
@@ -777,7 +777,7 @@ impl<'a> CheckerState<'a> {
                                         // The base is a type alias whose body is a mapped
                                         // type that references itself in its template
                                         self.ctx.binder.get_symbol(ref_sym).is_some_and(|symbol| {
-                                            symbol.flags & symbol_flags::TYPE_ALIAS != 0
+                                            symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
                                                 && symbol.declarations.iter().any(|&decl_idx| {
                                                     self.alias_has_self_referencing_mapped_body(
                                                         ref_sym, decl_idx,
@@ -848,7 +848,7 @@ impl<'a> CheckerState<'a> {
                                         .binder
                                         .get_symbol_with_libs(candidate_sym_id, &lib_binders)
                                         .is_some_and(|base_symbol| {
-                                            base_symbol.flags & symbol_flags::CLASS != 0
+                                            base_symbol.has_any_flags(symbol_flags::CLASS)
                                         })
                                 })
                                 .or_else(|| {
@@ -868,7 +868,7 @@ impl<'a> CheckerState<'a> {
                                                     &lib_binders,
                                                 )
                                                 .is_some_and(|base_symbol| {
-                                                    base_symbol.flags & symbol_flags::CLASS != 0
+                                                    base_symbol.has_any_flags(symbol_flags::CLASS)
                                                 })
                                         })
                                 });

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -298,7 +298,7 @@ impl<'a> CheckerState<'a> {
             .binder
             .get_symbol_with_libs(alias_sym_id, &lib_binders)?;
 
-        if symbol.flags & symbol_flags::ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return None;
         }
         let module_name = symbol.import_module.as_ref()?;
@@ -2134,7 +2134,7 @@ impl<'a> CheckerState<'a> {
             //   namespace a.b { class C {} } export = a.b;
             // where named imports should resolve via members on `a.b`.
             if let Some(export_equals_symbol) = lookup_symbol(export_equals_sym)
-                && (export_equals_symbol.flags & symbol_flags::ALIAS) != 0
+                && export_equals_symbol.has_any_flags(symbol_flags::ALIAS)
             {
                 if let Some(resolved_export_equals) =
                     self.resolve_alias_symbol(export_equals_sym, visited_aliases)

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -1880,7 +1880,7 @@ impl<'a> CheckerState<'a> {
                                 // (interfaces, type aliases) occupy a different declaration
                                 // space and never conflict with var declarations.
                                 use tsz_binder::symbols::symbol_flags;
-                                if lib_sym.flags & symbol_flags::VALUE == 0 {
+                                if !lib_sym.has_any_flags(symbol_flags::VALUE) {
                                     continue;
                                 }
                                 for &lib_decl in &lib_sym.declarations {

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -107,7 +107,7 @@ impl<'a> CheckerState<'a> {
                 };
                 if let Some(sym_id) = scope.table.get(var_name)
                     && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
-                    && sym.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0
+                    && sym.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
                 {
                     found_block_scoped_symbol = Some(sym_id);
                     found_scope_kind = Some(scope.kind);
@@ -368,7 +368,7 @@ impl<'a> CheckerState<'a> {
         // Check if this scope has a symbol with BLOCK_SCOPED_VARIABLE flag for this name
         if let Some(sym_id) = scope.table.get(var_name)
             && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
-            && (sym.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+            && sym.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
         {
             // The scope has a block-scoped binding for this name.
             // Check that this scope is NOT at function/module/source-file level

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -546,7 +546,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let is_from_current_file = local_symbol.decl_file_idx == u32::MAX
                     || local_symbol.decl_file_idx == self.ctx.current_file_idx as u32;
-                let is_import = (local_symbol.flags & symbol_flags::ALIAS) != 0;
+                let is_import = local_symbol.has_any_flags(symbol_flags::ALIAS);
                 if !is_from_current_file && !is_import {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- Continue the DRY sweep migrating raw `(symbol.flags & MASK) != 0` / `== 0` bitmask idioms onto the canonical `Symbol::has_any_flags(MASK)` helper.
- Covers 17 files under `state/{state_checking, state_checking_members, type_analysis, type_environment, type_resolution, variable_checking}` — 43 sites total.
- No semantic change — `has_any_flags` is a const fn returning `(flags & mask) != 0`. Pure readability / consistency cleanup.

## Test plan
- [x] `cargo check -p tsz-checker`
- [x] Pre-commit gate: fmt + clippy (zero warnings) + wasm32 rustc + arch-guard + full nextest (13039 tests pass, 54 skipped) in ~20s.