### PR TITLE
chore(checker): migrate declarations/checkers/classes/flow to has_any_flags

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -121,7 +121,7 @@ impl<'a> CheckerState<'a> {
             || self.is_well_known_lib_type_name(&name)
             || self
                 .get_cross_file_symbol(heritage_sym)
-                .is_some_and(|symbol| (symbol.flags & symbol_flags::VARIABLE) != 0)
+                .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::VARIABLE))
         {
             return;
         }

--- a/crates/tsz-checker/src/classes/class_inheritance.rs
+++ b/crates/tsz-checker/src/classes/class_inheritance.rs
@@ -358,7 +358,7 @@ impl<'a, 'ctx> ClassInheritanceChecker<'a, 'ctx> {
                 {
                     let is_enum_member = binder
                         .get_symbol(member_id)
-                        .is_some_and(|s| s.flags & symbol_flags::ENUM_MEMBER != 0);
+                        .is_some_and(|s| s.has_any_flags(symbol_flags::ENUM_MEMBER));
                     if !is_enum_member {
                         return Some(member_id);
                     }
@@ -372,7 +372,7 @@ impl<'a, 'ctx> ClassInheritanceChecker<'a, 'ctx> {
                 {
                     let is_enum_member = binder
                         .get_symbol(member_id)
-                        .is_some_and(|s| s.flags & symbol_flags::ENUM_MEMBER != 0);
+                        .is_some_and(|s| s.has_any_flags(symbol_flags::ENUM_MEMBER));
                     if !is_enum_member {
                         return Some(member_id);
                     }

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -615,7 +615,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(symbol) =
                         self.ctx.binder.get_symbol(tsz_binder::SymbolId(sym_ref.0))
                     {
-                        symbol.flags & symbol_flags::ABSTRACT != 0
+                        symbol.has_any_flags(symbol_flags::ABSTRACT)
                     } else {
                         false
                     }
@@ -918,7 +918,7 @@ impl<'a> CheckerState<'a> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
 
         // Verify it's a class
-        (symbol.flags & symbol_flags::CLASS != 0).then_some(sym_id)
+        (symbol.has_any_flags(symbol_flags::CLASS)).then_some(sym_id)
     }
 
     /// Find ALL enclosing class symbols by walking up the AST parent chain.

--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -1311,7 +1311,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
 
     fn resolve_imported_const_target(&self, sym_id: SymbolId) -> Option<SymbolId> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if (symbol.flags & symbol_flags::ALIAS) == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return Some(sym_id);
         }
         let module_specifier = symbol.import_module.as_ref()?;

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1151,7 +1151,7 @@ impl<'a> CheckerState<'a> {
         for scope in &self.ctx.binder.scopes {
             for (_, &sym_id) in scope.table.iter() {
                 if let Some(s) = self.ctx.binder.symbols.get(sym_id)
-                    && s.flags & symbol_flags::ALIAS != 0
+                    && s.has_any_flags(symbol_flags::ALIAS)
                     && !s.is_umd_export
                 {
                     local_alias_ids.push(sym_id);
@@ -1249,7 +1249,7 @@ impl<'a> CheckerState<'a> {
                     None => break,
                 };
 
-                if curr_sym.flags & symbol_flags::ALIAS == 0 {
+                if !curr_sym.has_any_flags(symbol_flags::ALIAS) {
                     break;
                 }
 

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -223,7 +223,7 @@ impl<'a> CheckerState<'a> {
             if sym.is_type_only {
                 return false;
             }
-            if (sym.flags & symbol_flags::ALIAS) != 0
+            if sym.has_any_flags(symbol_flags::ALIAS)
                 && let Some(ref module_spec) = sym.import_module
             {
                 let import_name = sym.import_name.as_deref().unwrap_or(name);
@@ -247,7 +247,7 @@ impl<'a> CheckerState<'a> {
             if sym.is_type_only {
                 return false;
             }
-            if (sym.flags & symbol_flags::ALIAS) != 0
+            if sym.has_any_flags(symbol_flags::ALIAS)
                 && let Some(ref module_spec) = sym.import_module
             {
                 let import_name = sym.import_name.as_deref().unwrap_or(name);
@@ -310,7 +310,7 @@ impl<'a> CheckerState<'a> {
             {
                 return true;
             }
-            if (sym.flags & symbol_flags::ALIAS) != 0
+            if sym.has_any_flags(symbol_flags::ALIAS)
                 && let Some(ref module_spec) = sym.import_module
             {
                 let import_name = sym.import_name.as_deref().unwrap_or(name);

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1105,7 +1105,7 @@ impl<'a> FlowAnalyzer<'a> {
     ) -> Option<(SymbolId, NodeIndex)> {
         let sym_id = self.binder.resolve_identifier(self.arena, ident_idx)?;
         let symbol = self.binder.get_symbol(sym_id)?;
-        if (symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
             return None;
         }
         let mut decl_idx = symbol.primary_declaration()?;

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -689,7 +689,7 @@ impl<'a> FlowAnalyzer<'a> {
         visited: &mut Vec<SymbolId>,
     ) -> Option<SymbolId> {
         let symbol = self.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::ALIAS == 0 {
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return Some(sym_id);
         }
         if visited.contains(&sym_id) {

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -814,7 +814,7 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(symbol) = self.binder.get_symbol(sym_id) else {
             return false;
         };
-        if (symbol.flags & symbol_flags::VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE) {
             return false;
         }
 
@@ -869,7 +869,7 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(symbol) = self.binder.get_symbol(sym_id) else {
             return false;
         };
-        if (symbol.flags & symbol_flags::VARIABLE) == 0 {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Continue the DRY sweep migrating raw `(symbol.flags & MASK) != 0` / `== 0` bitmask idioms onto the canonical `Symbol::has_any_flags(MASK)` helper.
- Covers 17 files under `declarations/{import,module_checker}`, `checkers/{jsx,promise_checker,generic_checker}`, `classes/`, and `flow/control_flow/` — 45 sites total.
- No semantic change — `has_any_flags` is a const fn returning `(flags & mask) != 0`. Pure readability / consistency cleanup.

## Test plan
- [x] `cargo check -p tsz-checker`
- [x] Pre-commit gate: fmt + clippy (zero warnings) + wasm32 rustc + arch-guard + full nextest (13039 tests pass, 54 skipped) in ~21s.