### PR TITLE
chore(checker): final has_any_flags sweep across remaining stragglers

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/arithmetic_ops.rs
@@ -23,7 +23,7 @@ impl<'a> CheckerState<'a> {
         {
             // Check if the symbol is an enum (ENUM flags)
             use tsz_binder::symbol_flags;
-            if (symbol.flags & symbol_flags::ENUM) != 0 {
+            if symbol.has_any_flags(symbol_flags::ENUM) {
                 return true;
             }
         }

--- a/crates/tsz-checker/src/context/lib_queries.rs
+++ b/crates/tsz-checker/src/context/lib_queries.rs
@@ -25,7 +25,7 @@ impl<'a> CheckerContext<'a> {
         let check_symbol_has_value =
             |sym_id: tsz_binder::SymbolId, binder: &tsz_binder::BinderState| -> bool {
                 if let Some(sym) = binder.symbols.get(sym_id) {
-                    (sym.flags & symbol_flags::VALUE) != 0
+                    sym.has_any_flags(symbol_flags::VALUE)
                 } else {
                     false
                 }

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -332,7 +332,7 @@ impl<'a> CheckerState<'a> {
                     let Some(symbol) = binder.get_symbol(sym_id) else {
                         continue;
                     };
-                    if (symbol.flags & symbol_flags::ENUM) == 0 {
+                    if !symbol.has_any_flags(symbol_flags::ENUM) {
                         continue;
                     }
                     let arena = self.ctx.get_arena_for_file(file_idx as u32);

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -377,7 +377,7 @@ impl<'a> CheckerState<'a> {
             // Only applies to alias symbols explicitly marked type-only
             // Check this FIRST — if the local symbol is marked type-only from
             // `import type`, that takes precedence over export-side type-only.
-            if (symbol.flags & symbol_flags::ALIAS) != 0 && symbol.is_type_only {
+            if symbol.has_any_flags(symbol_flags::ALIAS) && symbol.is_type_only {
                 // Walk up from the symbol's declaration to determine if it came from
                 // an import or export statement.
                 for &decl in &symbol.declarations {
@@ -479,7 +479,7 @@ impl<'a> CheckerState<'a> {
                         }
                         // Also check if the export= symbol is an alias that
                         // resolves to a type-only import
-                        if eq_sym.flags & symbol_flags::ALIAS != 0
+                        if eq_sym.has_any_flags(symbol_flags::ALIAS)
                             && let Some(ref eq_import_module) = eq_sym.import_module
                         {
                             let eq_name = eq_sym

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -474,7 +474,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
         // Must actually be a value (variable, function, etc.).
-        if symbol.flags & symbol_flags::VALUE == 0 {
+        if !symbol.has_any_flags(symbol_flags::VALUE) {
             return;
         }
         // CommonJS `var mod = require("./x")` binds `mod` to the module's

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -568,7 +568,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn is_string_literal_module_symbol_for_display(&self, symbol: &tsz_binder::Symbol) -> bool {
-        if (symbol.flags & symbol_flags::MODULE) == 0 || symbol.declarations.is_empty() {
+        if !symbol.has_any_flags(symbol_flags::MODULE) || symbol.declarations.is_empty() {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Migrate the last 7 raw `(symbol.flags & symbol_flags::MASK) != 0` / `== 0` sites across `crates/tsz-checker/src/` onto `Symbol::has_any_flags(MASK)`.
- Covers scattered single-site files that the prior directory-scoped sweeps (#919–#922) didn't touch: `jsdoc/lookup.rs`, `context/lib_queries.rs`, `error_reporter/{name_resolution,type_value}.rs`, `assignability/assignment_checker/arithmetic_ops.rs`, `query_boundaries/name_resolution.rs`.
- After this PR lands, all raw symbol-flags bitmask sites in the checker are gone.

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib` — 13039 tests pass, 54 skipped
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Pre-commit hook ran end-to-end (fmt + clippy + wasm32 + arch-guard + nextest)