### PR TITLE
chore(node): add typed NodeFlags predicates and migrate raw bitmask checks

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -1664,7 +1664,7 @@ impl BinderState {
                 }
             }
             k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                if (u32::from(node.flags) & node_flags::OPTIONAL_CHAIN) != 0 {
+                if node.is_optional_chain() {
                     return true;
                 }
                 if let Some(call) = arena.get_call_expr(node) {
@@ -2084,8 +2084,7 @@ impl BinderState {
                 if let Some(call) = arena.get_call_expr(node) {
                     self.bind_expression(arena, call.expression);
 
-                    let is_optional_call =
-                        (u32::from(node.flags) & node_flags::OPTIONAL_CHAIN) != 0;
+                    let is_optional_call = node.is_optional_chain();
                     if is_optional_call {
                         let after_callee = if self.continues_optional_chain(arena, idx)
                             || Self::is_optional_chain_access(arena, call.expression)

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -7,7 +7,6 @@ use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
 use std::sync::Arc;
 use tsz_parser::parser::node::{Node, NodeArena};
-use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
@@ -93,8 +92,7 @@ impl BinderState {
                     .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
             }
 
-            let is_global_augmentation = u32::from(node.flags) & node_flags::GLOBAL_AUGMENTATION
-                != 0
+            let is_global_augmentation = node.is_global_augmentation()
                 || arena
                     .get(module.name)
                     .and_then(|name_node| {

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -774,7 +774,7 @@ impl BinderState {
             if stmt.kind != syntax_kind_ext::MODULE_DECLARATION {
                 continue;
             }
-            if (stmt.flags as u32) & tsz_parser::parser::node_flags::GLOBAL_AUGMENTATION != 0 {
+            if stmt.is_global_augmentation() {
                 return true;
             }
             let Some(module) = arena.get_module(stmt) else {

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -16,7 +16,6 @@ use tracing::trace;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
-use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::NarrowingContext;
@@ -1239,10 +1238,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if let Some(current_node) = self.ctx.arena.get(current) {
-                let flags = current_node.flags as u32;
-                if (flags & node_flags::THIS_NODE_HAS_ERROR) != 0
-                    || (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
-                {
+                if current_node.this_node_has_error() || current_node.this_or_subtree_has_error() {
                     return true;
                 }
             } else {

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -6,7 +6,6 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::flags::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -140,7 +139,7 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::CALL_EXPRESSION => {
                 // Call expressions get the OPTIONAL_CHAIN flag from the parser
-                if (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0 {
+                if node.is_optional_chain() {
                     return true;
                 }
                 // Check if the callee is part of an optional chain

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -10,7 +10,6 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
     pub fn check_module_declaration(&mut self, module_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
         use tsz_binder::symbol_flags;
-        use tsz_parser::parser::node_flags;
         use tsz_parser::parser::syntax_kind_ext;
         use tsz_scanner::SyntaxKind;
 
@@ -123,7 +122,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
         // Only check the GLOBAL_AUGMENTATION flag set by the parser — a plain
         // `namespace global {}` in a non-module file is a regular namespace, not
         // a global augmentation.
-        let is_global_augmentation = (node.flags as u32) & node_flags::GLOBAL_AUGMENTATION != 0;
+        let is_global_augmentation = node.is_global_augmentation();
         // TS1280: Namespaces are not allowed in global script files when
         // isolatedModules is enabled. tsc emits a single diagnostic per file,
         // anchored on the first top-level namespace declaration.

--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -153,8 +153,6 @@ impl<'a> CheckerState<'a> {
 
     /// Check if a node is inside a `declare global { ... }` augmentation block.
     pub(crate) fn is_inside_global_augmentation(&self, node_idx: NodeIndex) -> bool {
-        use tsz_parser::parser::flags::node_flags;
-
         let mut current = node_idx;
         while current.is_some() {
             let Some(ext) = self.ctx.arena.get_extended(current) else {
@@ -167,9 +165,7 @@ impl<'a> CheckerState<'a> {
             let Some(node) = self.ctx.arena.get(current) else {
                 break;
             };
-            if node.kind == syntax_kind_ext::MODULE_DECLARATION
-                && (node.flags as u32) & node_flags::GLOBAL_AUGMENTATION != 0
-            {
+            if node.kind == syntax_kind_ext::MODULE_DECLARATION && node.is_global_augmentation() {
                 return true;
             }
         }

--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -378,8 +378,6 @@ impl<'a> CheckerState<'a> {
         statements: &[NodeIndex],
         ident_name: &str,
     ) -> Option<NodeIndex> {
-        use tsz_parser::parser::node_flags;
-
         let mut matching_namespace_export = None;
         let mut matching_global_augmentation = None;
 
@@ -406,14 +404,13 @@ impl<'a> CheckerState<'a> {
             let Some(module_decl) = self.ctx.arena.get_module(stmt_node) else {
                 continue;
             };
-            let is_global_augmentation =
-                (u32::from(stmt_node.flags) & node_flags::GLOBAL_AUGMENTATION) != 0
-                    || self
-                        .ctx
-                        .arena
-                        .get(module_decl.name)
-                        .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                        .is_some_and(|ident| ident.escaped_text == "global");
+            let is_global_augmentation = stmt_node.is_global_augmentation()
+                || self
+                    .ctx
+                    .arena
+                    .get(module_decl.name)
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .is_some_and(|ident| ident.escaped_text == "global");
             if !is_global_augmentation || !module_decl.body.is_some() {
                 continue;
             }

--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -11,7 +11,6 @@ use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
-use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -165,7 +164,7 @@ impl<'a> CheckerState<'a> {
             if stmt.kind != syntax_kind_ext::MODULE_DECLARATION {
                 continue;
             }
-            if (stmt.flags as u32) & node_flags::GLOBAL_AUGMENTATION == 0 {
+            if !stmt.is_global_augmentation() {
                 continue;
             }
             let Some(module) = arena.get_module(stmt) else {
@@ -204,7 +203,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             // Must NOT be a global augmentation
-            if (stmt.flags as u32) & node_flags::GLOBAL_AUGMENTATION != 0 {
+            if stmt.is_global_augmentation() {
                 continue;
             }
             let Some(module) = arena.get_module(stmt) else {
@@ -245,7 +244,7 @@ impl<'a> CheckerState<'a> {
             if stmt.kind != syntax_kind_ext::MODULE_DECLARATION {
                 continue;
             }
-            if (stmt.flags as u32) & node_flags::GLOBAL_AUGMENTATION == 0 {
+            if !stmt.is_global_augmentation() {
                 continue;
             }
             let Some(module) = arena.get_module(stmt) else {
@@ -721,10 +720,7 @@ impl<'a> CheckerState<'a> {
 
         // Suppress semantic diagnostics (TS2307, TS2823, TS2322) when the import
         // statement has parse errors. Matches TSC: syntax errors take priority.
-        use tsz_parser::parser::node_flags;
-        let has_parse_errors =
-            (node.flags as u32 & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
-                || self.ctx.has_real_syntax_errors;
+        let has_parse_errors = node.this_or_subtree_has_error() || self.ctx.has_real_syntax_errors;
 
         // TS18058/TS18059: Validate deferred import binding restrictions.
         // Deferred imports only allow namespace imports: `import defer * as ns from "..."`

--- a/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
@@ -1,8 +1,8 @@
 use super::FlowAnalyzer;
 use crate::query_boundaries::common::union_members;
 use crate::query_boundaries::flow as flow_boundary;
+use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{AccessExprData, Node};
-use tsz_parser::parser::{NodeIndex, node_flags};
 use tsz_solver::{GuardSense, NarrowingContext, TypeGuard, TypeId};
 
 impl<'a> FlowAnalyzer<'a> {
@@ -57,7 +57,7 @@ impl<'a> FlowAnalyzer<'a> {
             return Some(narrowed);
         }
         if is_true_branch {
-            let optional_call = (cond_node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0;
+            let optional_call = cond_node.is_optional_chain();
             if optional_call && self.is_matching_reference(call.expression, target) {
                 return Some(flow_boundary::narrow_optional_chain(
                     self.interner.as_type_database(),
@@ -142,6 +142,6 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     const fn call_access_is_optional_chain(&self, node: &Node, access: &AccessExprData) -> bool {
-        access.question_dot_token || (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0
+        access.question_dot_token || node.is_optional_chain()
     }
 }

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -10,7 +10,7 @@ use crate::query_boundaries::flow_analysis::is_unit_type;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{FlowNodeId, SymbolId, symbol_flags};
 use tsz_parser::parser::node::BinaryExprData;
-use tsz_parser::parser::{NodeIndex, node_flags, syntax_kind_ext};
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{GuardSense, NarrowingContext, TypeGuard, TypeId, TypeofKind};
 
@@ -962,7 +962,7 @@ impl<'a> FlowAnalyzer<'a> {
         if node.kind == syntax_kind_ext::CALL_EXPRESSION
             && let Some(call) = self.arena.get_call_expr(node)
         {
-            if (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0 {
+            if node.is_optional_chain() {
                 return true;
             }
             return self.contains_optional_chain(call.expression);
@@ -984,7 +984,7 @@ impl<'a> FlowAnalyzer<'a> {
         node: &tsz_parser::parser::node::Node,
         access: &tsz_parser::parser::node::AccessExprData,
     ) -> bool {
-        access.question_dot_token || (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0
+        access.question_dot_token || node.is_optional_chain()
     }
 
     /// Check if `expr` is an optional chain (or typeof of one) that contains `target`

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -3,7 +3,7 @@
 
 use crate::query_boundaries::common::TypeResolver;
 use tsz_parser::parser::node::CallExprData;
-use tsz_parser::parser::{NodeIndex, node_flags, syntax_kind_ext};
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{SymbolRef, TypeGuard, TypeId, TypeofKind};
 
@@ -824,7 +824,7 @@ impl<'a> FlowAnalyzer<'a> {
     fn is_optional_call(&self, call_node_idx: NodeIndex, call: &CallExprData) -> bool {
         // 1. Check if the call node itself has OptionalChain flag (e.g., func?.())
         if let Some(node) = self.arena.get(call_node_idx)
-            && (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0
+            && node.is_optional_chain()
         {
             return true;
         }

--- a/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
+++ b/crates/tsz-checker/src/flow/flow_graph_builder/expressions.rs
@@ -12,7 +12,6 @@
 //!   computed property names
 
 use tsz_binder::flow_flags;
-use tsz_parser::parser::flags::node_flags;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
@@ -36,7 +35,7 @@ impl<'a> FlowGraphBuilder<'a> {
                 }
             }
             k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                if (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0 {
+                if node.is_optional_chain() {
                     return true;
                 }
                 if let Some(call) = self.arena.get_call_expr(node) {
@@ -349,7 +348,7 @@ impl<'a> FlowGraphBuilder<'a> {
                 if let Some(call) = self.arena.get_call_expr(node) {
                     self.handle_expression_for_assignments(call.expression);
                     let after_callee_flow = self.current_flow;
-                    let is_optional_call = (node.flags as u32 & node_flags::OPTIONAL_CHAIN) != 0;
+                    let is_optional_call = node.is_optional_chain();
 
                     if is_optional_call {
                         let after_callee_flow = if self.continues_optional_chain(expr_idx)

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -2017,7 +2017,6 @@ impl<'a> CheckerState<'a> {
     /// has no parse diagnostics.
     pub(crate) fn check_grammar_decorator(&mut self, expression_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use tsz_parser::parser::flags::node_flags;
 
         // Skip if the source file has parse diagnostics (matches tsc's hasParseDiagnostics gate)
         if self.ctx.has_parse_errors {
@@ -2060,8 +2059,7 @@ impl<'a> CheckerState<'a> {
                     error_node = Some(current);
                 }
                 // Check for optional chaining on call: x?.()
-                let flags_u32 = u32::from(node.flags);
-                if (flags_u32 & node_flags::OPTIONAL_CHAIN) != 0 {
+                if node.is_optional_chain() {
                     // Optional chaining — always an error, even if we already have one
                     error_node = Some(current);
                 }

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -225,7 +225,6 @@ impl<'a> CheckerState<'a> {
                     let mut is_valid = true;
 
                     let mut current_idx = expr_idx;
-                    use tsz_parser::parser::flags::node_flags;
                     use tsz_parser::parser::syntax_kind_ext::*;
 
                     loop {
@@ -234,7 +233,7 @@ impl<'a> CheckerState<'a> {
                             break;
                         };
 
-                        if node.flags & (node_flags::OPTIONAL_CHAIN as u16) != 0 {
+                        if node.is_optional_chain() {
                             is_valid = false;
                             break;
                         }
@@ -267,7 +266,6 @@ impl<'a> CheckerState<'a> {
                     let mut is_valid = true;
 
                     let mut current_idx = expr_idx;
-                    use tsz_parser::parser::flags::node_flags;
                     use tsz_parser::parser::syntax_kind_ext::*;
 
                     loop {
@@ -276,7 +274,7 @@ impl<'a> CheckerState<'a> {
                             break;
                         };
 
-                        if node.flags & (node_flags::OPTIONAL_CHAIN as u16) != 0 {
+                        if node.is_optional_chain() {
                             is_valid = false;
                             break;
                         }

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -122,12 +122,9 @@ impl<'a> CheckerState<'a> {
         // tsc always emits TS7019 for rest parameters even when related parse errors exist
         // (e.g., TS1047 "rest can't be optional" for `...arg?`, TS1014 "rest not last"
         // for `...x, y`). The empty-name check below still catches truly malformed rest params.
-        use tsz_parser::parser::node_flags;
         if !param.dot_dot_dot_token {
             if let Some(name_node) = self.ctx.arena.get(param.name) {
-                let flags = name_node.flags as u32;
-                if ((flags & node_flags::THIS_NODE_HAS_ERROR) != 0
-                    || (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0)
+                if (name_node.this_node_has_error() || name_node.this_or_subtree_has_error())
                     && !preserve_on_strict_mode_parse_error
                 {
                     return;
@@ -138,8 +135,7 @@ impl<'a> CheckerState<'a> {
                 // param.name's parent is ParameterDeclaration; its parent is the function/arrow
                 let param_decl = ext.parent;
                 if let Some(param_node) = self.ctx.arena.get(param_decl) {
-                    let flags = param_node.flags as u32;
-                    if (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
+                    if param_node.this_or_subtree_has_error()
                         && !preserve_on_strict_mode_parse_error
                     {
                         return;
@@ -148,9 +144,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(param_ext) = self.ctx.arena.get_extended(param_decl)
                     && let Some(func_node) = self.ctx.arena.get(param_ext.parent)
                 {
-                    let flags = func_node.flags as u32;
-                    if (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
-                        && !preserve_on_strict_mode_parse_error
+                    if func_node.this_or_subtree_has_error() && !preserve_on_strict_mode_parse_error
                     {
                         return;
                     }

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -3,7 +3,6 @@
 use crate::context::TypingRequest;
 use crate::state::{CheckerState, MemberAccessInfo, MemberAccessLevel, MemberLookup};
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -1067,10 +1066,7 @@ impl<'a> CheckerState<'a> {
                 }
                 syntax_kind_ext::METHOD_DECLARATION => {
                     if let Some(method) = self.ctx.arena.get_method_decl(node) {
-                        let flags = u32::from(node.flags);
-                        if (flags & node_flags::THIS_NODE_HAS_ERROR) != 0
-                            || (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
-                        {
+                        if node.this_node_has_error() || node.this_or_subtree_has_error() {
                             continue;
                         }
                         // Abstract methods don't need implementations (they're meant for derived classes).

--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -525,8 +525,6 @@ impl<'a> CheckerState<'a> {
     /// Emits on every module declaration that uses the `module` keyword (i.e., lacks the
     /// NAMESPACE node flag) and has an identifier name (not a string literal).
     pub(crate) fn check_module_keyword_deprecated(&mut self, module_idx: NodeIndex) {
-        use tsz_parser::parser::node_flags;
-
         // Suppress when file has parse errors (tsc's grammarErrorOnNode pattern).
         if self.has_syntax_parse_errors() {
             return;
@@ -536,9 +534,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        let has_namespace_flag = (node.flags as u32) & node_flags::NAMESPACE != 0;
-        let is_global_augmentation = (node.flags as u32) & node_flags::GLOBAL_AUGMENTATION != 0;
-        if has_namespace_flag || is_global_augmentation {
+        if node.has_namespace_flag() || node.is_global_augmentation() {
             return;
         }
 

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -39,7 +39,7 @@ pub(crate) fn is_optional_chain(arena: &NodeArena, idx: NodeIndex) -> bool {
             // A call can be optional in two ways:
             // 1. The callee itself is optional: `o?.b()` -> callee `o?.b` has question_dot_token
             // 2. The call has an optional token: `o.b?.()` -> call node has OPTIONAL_CHAIN flag
-            if (node.flags as u32) & tsz_parser::parser::node_flags::OPTIONAL_CHAIN != 0 {
+            if node.is_optional_chain() {
                 return true;
             }
             if let Some(call) = arena.get_call_expr(node) {

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -881,12 +881,11 @@ impl<'a> CheckerState<'a> {
                 // our parser but by tsc's checker, so they set has_parse_errors in our
                 // pipeline but shouldn't suppress TS2695. Only suppress when the binary
                 // expression itself has structural parse errors (e.g., `(a, new)`).
-                let node_has_parse_error = self.ctx.arena.get(node_idx).is_some_and(|n| {
-                    use tsz_parser::parser::node_flags;
-                    let flags = n.flags as u32;
-                    (flags & node_flags::THIS_NODE_HAS_ERROR) != 0
-                        || (flags & node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR) != 0
-                });
+                let node_has_parse_error = self
+                    .ctx
+                    .arena
+                    .get(node_idx)
+                    .is_some_and(|n| n.this_node_has_error() || n.this_or_subtree_has_error());
                 // Also suppress TS2695 when the comma expression is inside a bare
                 // block statement (not a function/method body).  This matches tsc's
                 // behavior: `{ a, b } = fn()` is parsed as a block followed by `=`,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -27,7 +27,6 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         request: &TypingRequest,
     ) -> TypeId {
-        use tsz_parser::parser::node_flags;
         use tsz_parser::parser::syntax_kind_ext;
         let contextual_type = request.contextual_type;
         let Some(node) = self.ctx.arena.get(idx) else {
@@ -227,7 +226,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let mut nullish_cause = None;
-        if (node.flags as u32) & node_flags::OPTIONAL_CHAIN != 0 {
+        if node.is_optional_chain() {
             // Evaluate the callee type to resolve Application/Lazy types before
             // splitting nullish members. Without this, `Transform1<T>` stays as an
             // unevaluated Application and split_nullish_type can't see its union members.

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -1969,9 +1969,7 @@ impl<'a> CheckerState<'a> {
                         {
                             saw_namespace_declaration = true;
                             if let Some(module) = self.ctx.arena.get_module(parent_node) {
-                                let is_global_augmentation = (u32::from(parent_node.flags)
-                                    & tsz_parser::parser::node_flags::GLOBAL_AUGMENTATION)
-                                    != 0
+                                let is_global_augmentation = parent_node.is_global_augmentation()
                                     || self
                                         .ctx
                                         .arena

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -8,7 +8,6 @@ use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::flags::node_flags;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -532,7 +531,7 @@ impl<'a> CheckerState<'a> {
                     return false;
                 };
                 if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION {
-                    if u32::from(parent_node.flags) & node_flags::GLOBAL_AUGMENTATION != 0 {
+                    if parent_node.is_global_augmentation() {
                         return true;
                     }
                     if let Some(module_decl) = arena.get_module(parent_node)

--- a/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
+++ b/crates/tsz-checker/src/types/type_checking/cross_file_conflicts.rs
@@ -647,8 +647,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn check_cross_file_global_augmentation_namespace_member_conflicts(&mut self) {
-        use tsz_parser::parser::node_flags;
-
         let Some(all_arenas) = self.ctx.all_arenas.clone() else {
             return;
         };
@@ -676,12 +674,11 @@ impl<'a> CheckerState<'a> {
                 let Some(module_decl) = arena.get_module(stmt_node) else {
                     continue;
                 };
-                let is_global_augmentation =
-                    (u32::from(stmt_node.flags) & node_flags::GLOBAL_AUGMENTATION) != 0
-                        || arena
-                            .get(module_decl.name)
-                            .and_then(|name_node| arena.get_identifier(name_node))
-                            .is_some_and(|ident| ident.escaped_text == "global");
+                let is_global_augmentation = stmt_node.is_global_augmentation()
+                    || arena
+                        .get(module_decl.name)
+                        .and_then(|name_node| arena.get_identifier(name_node))
+                        .is_some_and(|ident| ident.escaped_text == "global");
                 if is_global_augmentation {
                     let Some(body_node) = arena.get(module_decl.body) else {
                         continue;

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -1110,8 +1110,6 @@ impl<'a> CheckerState<'a> {
         decl_idx: NodeIndex,
         flags: u32,
     ) -> bool {
-        use tsz_parser::parser::node_flags;
-
         if (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) == 0 || (flags & symbol_flags::VALUE) == 0
         {
             return false;
@@ -1130,15 +1128,14 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
             if parent.kind == syntax_kind_ext::MODULE_DECLARATION {
-                let is_global_augmentation =
-                    (u32::from(parent.flags) & node_flags::GLOBAL_AUGMENTATION) != 0
-                        || self
-                            .ctx
-                            .arena
-                            .get_module(parent)
-                            .and_then(|module| self.ctx.arena.get(module.name))
-                            .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                            .is_some_and(|ident| ident.escaped_text == "global");
+                let is_global_augmentation = parent.is_global_augmentation()
+                    || self
+                        .ctx
+                        .arena
+                        .get_module(parent)
+                        .and_then(|module| self.ctx.arena.get(module.name))
+                        .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                        .is_some_and(|ident| ident.escaped_text == "global");
                 if is_global_augmentation {
                     return true;
                 }
@@ -1274,7 +1271,6 @@ impl<'a> CheckerState<'a> {
         &self,
         name: &str,
     ) -> Vec<(NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin)> {
-        use tsz_parser::parser::node_flags;
         use tsz_parser::parser::syntax_kind_ext;
 
         let Some(all_arenas) = self.ctx.all_arenas.as_ref() else {
@@ -1320,8 +1316,7 @@ impl<'a> CheckerState<'a> {
 
                 // Check for `declare global { ... }` containing variable declarations
                 if stmt_node.kind == syntax_kind_ext::MODULE_DECLARATION {
-                    let is_global = (u32::from(stmt_node.flags) & node_flags::GLOBAL_AUGMENTATION)
-                        != 0
+                    let is_global = stmt_node.is_global_augmentation()
                         || arena
                             .get_module(stmt_node)
                             .and_then(|m| arena.get(m.name))
@@ -1675,7 +1670,6 @@ impl<'a> CheckerState<'a> {
     }
 
     fn first_current_file_global_import_equals_named(&self, name: &str) -> Option<NodeIndex> {
-        use tsz_parser::parser::node_flags;
         use tsz_parser::parser::syntax_kind_ext;
 
         let source_file = self.ctx.arena.source_files.first()?;
@@ -1690,14 +1684,13 @@ impl<'a> CheckerState<'a> {
             let Some(module_decl) = self.ctx.arena.get_module(stmt_node) else {
                 continue;
             };
-            let is_global_augmentation =
-                (u32::from(stmt_node.flags) & node_flags::GLOBAL_AUGMENTATION) != 0
-                    || self
-                        .ctx
-                        .arena
-                        .get(module_decl.name)
-                        .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                        .is_some_and(|ident| ident.escaped_text == "global");
+            let is_global_augmentation = stmt_node.is_global_augmentation()
+                || self
+                    .ctx
+                    .arena
+                    .get(module_decl.name)
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .is_some_and(|ident| ident.escaped_text == "global");
             if !is_global_augmentation {
                 continue;
             }

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -1,6 +1,6 @@
 use super::super::Printer;
 use crate::transforms::private_fields_es5::get_private_field_name;
-use tsz_parser::parser::{NodeIndex, node::Node, node_flags, syntax_kind_ext};
+use tsz_parser::parser::{NodeIndex, node::Node, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
@@ -688,7 +688,7 @@ impl<'a> Printer<'a> {
     }
 
     const fn is_optional_chain(&self, node: &Node) -> bool {
-        (node.flags as u32) & node_flags::OPTIONAL_CHAIN != 0
+        node.is_optional_chain()
     }
 
     fn has_optional_call_token(

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -2,7 +2,7 @@ use super::{JsxEmit, ModuleKind, Printer};
 use crate::output::source_writer::SourcePosition;
 use crate::safe_slice;
 use tsz_parser::parser::node::{Node, NodeAccess};
-use tsz_parser::parser::{NodeIndex, node_flags, syntax_kind_ext};
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
@@ -130,7 +130,7 @@ impl<'a> Printer<'a> {
                 if let Some(access) = self.arena.get_access_expr(inner) {
                     access.question_dot_token
                 } else {
-                    (inner.flags as u32) & node_flags::OPTIONAL_CHAIN != 0
+                    inner.is_optional_chain()
                 }
             } else {
                 false
@@ -819,7 +819,7 @@ impl<'a> Printer<'a> {
             return access.question_dot_token;
         }
         // Check for CallExpression with OPTIONAL_CHAIN flag
-        (node.flags as u32) & node_flags::OPTIONAL_CHAIN != 0
+        node.is_optional_chain()
     }
 
     // =========================================================================

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -107,6 +107,52 @@ impl Node {
     pub const fn has_data(&self) -> bool {
         self.data_index != Self::NO_DATA
     }
+
+    /// Return `true` if any of the given `NodeFlags` bits are set.
+    ///
+    /// Only flags whose bit fits in the u16 `flags` field are observable via
+    /// this method; higher-bit `NodeFlags` values are stored elsewhere and
+    /// will always return `false` here.
+    #[inline]
+    #[must_use]
+    pub const fn has_any_node_flags(&self, mask: u32) -> bool {
+        (self.flags as u32 & mask) != 0
+    }
+
+    /// `true` if this node carries the `OPTIONAL_CHAIN` flag.
+    #[inline]
+    #[must_use]
+    pub const fn is_optional_chain(&self) -> bool {
+        self.has_any_node_flags(super::flags::node_flags::OPTIONAL_CHAIN)
+    }
+
+    /// `true` if this node carries the `GLOBAL_AUGMENTATION` flag.
+    #[inline]
+    #[must_use]
+    pub const fn is_global_augmentation(&self) -> bool {
+        self.has_any_node_flags(super::flags::node_flags::GLOBAL_AUGMENTATION)
+    }
+
+    /// `true` if this node carries the `NAMESPACE` flag.
+    #[inline]
+    #[must_use]
+    pub const fn has_namespace_flag(&self) -> bool {
+        self.has_any_node_flags(super::flags::node_flags::NAMESPACE)
+    }
+
+    /// `true` if this node carries the `THIS_NODE_HAS_ERROR` flag.
+    #[inline]
+    #[must_use]
+    pub const fn this_node_has_error(&self) -> bool {
+        self.has_any_node_flags(super::flags::node_flags::THIS_NODE_HAS_ERROR)
+    }
+
+    /// `true` if this node or any of its sub-nodes has an error.
+    #[inline]
+    #[must_use]
+    pub const fn this_or_subtree_has_error(&self) -> bool {
+        self.has_any_node_flags(super::flags::node_flags::THIS_NODE_OR_ANY_SUB_NODES_HAS_ERROR)
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds single-flag typed predicates on `Node` in `crates/tsz-parser/src/parser/node.rs` for the high-traffic `NodeFlags` bits that checker/binder/emitter were reading via raw `(node.flags as u32) & node_flags::FOO != 0` idioms.
- Migrates ~50 raw bitmask sites across 27 files (binder + emitter + checker) onto:
  - `Node::is_optional_chain()` — 21 sites, 13 files
  - `Node::is_global_augmentation()` — 17 sites, 12 files
  - `Node::has_namespace_flag()` — 1 site
  - `Node::this_node_has_error()` — 4 sites
  - `Node::this_or_subtree_has_error()` — 7 sites
- Plus a generic `Node::has_any_node_flags(mask: u32)` that handles the `u16 -> u32` widening in one place. Only flags whose bit fits in the u16 `flags` field are observable via the helper — higher `NodeFlags` bits (`AMBIENT`, `JSDOC`, `JAVASCRIPT_FILE`, etc.) live elsewhere and were never read via `node.flags` anyway.
- Follows the same pattern as the recent `Symbol::has_any_flags` sweeps (#850 / #853 / #856 / #858 / #863 / #867 / #873 / #877 / #881 / #883 / #884 / #885 / #886 / #919–#923). Pure readability / consistency cleanup — no behavior change.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo nextest run -p tsz-parser -p tsz-binder -p tsz-checker -p tsz-emitter --lib` — 4828 / 19318 tests pass (pre-commit)
- [x] `cargo clippy --workspace --all-targets` clean on touched crates (pre-existing `tsz-conformance` warning on main is unrelated)
- [x] Pre-commit gate (fmt + clippy + wasm32 + arch-guard + nextest 19318 tests) passes