### PR TITLE
chore(node-flags): add typed helpers for variable declaration kinds

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -27,14 +27,14 @@ impl BinderState {
     ) {
         if let Some(decl) = arena.get_variable_declaration(node) {
             let mut decl_flags = u32::from(node.flags);
-            if (decl_flags & (node_flags::LET | node_flags::CONST)) == 0
+            if !node_flags::is_let_or_const(decl_flags)
                 && let Some(ext) = arena.get_extended(idx)
                 && let Some(parent_node) = arena.get(ext.parent)
                 && parent_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST
             {
                 decl_flags |= u32::from(parent_node.flags);
             }
-            let is_block_scoped = (decl_flags & (node_flags::LET | node_flags::CONST)) != 0;
+            let is_block_scoped = node_flags::is_let_or_const(decl_flags);
             if let Some(name) = Self::get_identifier_name(arena, decl.name) {
                 // Determine if block-scoped (let/const) or function-scoped (var)
                 let flags = if is_block_scoped {

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -239,7 +239,7 @@ impl BinderState {
             && let Some(list) = arena.get_variable(node)
         {
             // Check if this is a var declaration (not let/const)
-            let is_var = (u32::from(node.flags) & (node_flags::LET | node_flags::CONST)) == 0;
+            let is_var = !node_flags::is_let_or_const(u32::from(node.flags));
             if is_var {
                 for &decl_idx in &list.declarations.nodes {
                     if let Some(decl) = arena.get_variable_declaration_at(decl_idx) {
@@ -364,7 +364,7 @@ impl BinderState {
                     if let Some(&decl_list_idx) = var_stmt.declarations.nodes.first() {
                         if let Some(list_node) = arena.get(decl_list_idx) {
                             let flags = u32::from(list_node.flags);
-                            if (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING {
+                            if node_flags::is_await_using(flags) {
                                 self.file_features.set(FileFeatures::AWAIT_USING);
                             } else if (flags & node_flags::USING) != 0 {
                                 self.file_features.set(FileFeatures::USING);

--- a/crates/tsz-binder/src/nodes/names.rs
+++ b/crates/tsz-binder/src/nodes/names.rs
@@ -406,7 +406,7 @@ impl BinderState {
         let Some(list) = arena.get_variable(node) else {
             return;
         };
-        let is_var = (u32::from(node.flags) & (node_flags::LET | node_flags::CONST)) == 0;
+        let is_var = !node_flags::is_let_or_const(u32::from(node.flags));
         if !include_block_scoped && !is_var {
             return;
         }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -1012,7 +1012,7 @@ impl<'a> CheckerState<'a> {
         {
             let flags = self.ctx.arena.get_variable_declaration_flags(list_idx);
             use tsz_parser::parser::flags::node_flags;
-            (flags & (node_flags::LET | node_flags::CONST)) != 0
+            node_flags::is_let_or_const(flags)
         } else {
             false
         };

--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -869,7 +869,7 @@ impl<'a> CheckerState<'a> {
         for &list_idx in &var_data.declarations.nodes {
             // Check let/const flag at the list level.
             let list_flags = self.ctx.arena.get_variable_declaration_flags(list_idx);
-            if (list_flags & (node_flags::LET | node_flags::CONST)) != 0 {
+            if node_flags::is_let_or_const(list_flags) {
                 return false;
             }
             let Some(list_node) = self.ctx.arena.get(list_idx) else {

--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -23,7 +23,7 @@ impl<'a> CheckerState<'a> {
         match node.kind {
             syntax_kind_ext::VARIABLE_DECLARATION => {
                 let decl_flags = arena.get_variable_declaration_flags(decl_idx);
-                if (decl_flags & (node_flags::LET | node_flags::CONST)) != 0 {
+                if node_flags::is_let_or_const(decl_flags) {
                     Some(symbol_flags::BLOCK_SCOPED_VARIABLE)
                 } else {
                     Some(symbol_flags::FUNCTION_SCOPED_VARIABLE)

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -1124,7 +1124,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                     if let Some(list_node) = self.ctx.arena.get(list_idx) {
                         let flags = list_node.flags as u32;
                         // Check USING first — AWAIT_USING (6) includes CONST bit
-                        if (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING {
+                        if node_flags::is_await_using(flags) {
                             Some("await using")
                         } else if flags & node_flags::USING != 0 {
                             Some("using")

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -118,7 +118,7 @@ impl<'a> CheckerState<'a> {
             {
                 let flags = other_parent.flags as u32;
                 use tsz_parser::parser::node_flags;
-                if (flags & (node_flags::LET | node_flags::CONST | node_flags::USING)) != 0 {
+                if node_flags::is_block_scoped(flags) {
                     return false;
                 }
             }
@@ -1727,7 +1727,7 @@ impl<'a> CheckerState<'a> {
             {
                 let flags = parent.flags as u32;
                 use tsz_parser::parser::node_flags;
-                (flags & (node_flags::LET | node_flags::CONST | node_flags::USING)) != 0
+                node_flags::is_block_scoped(flags)
             } else {
                 false
             };
@@ -1963,10 +1963,7 @@ impl<'a> CheckerState<'a> {
                             {
                                 let flags = other_parent.flags as u32;
                                 use tsz_parser::parser::node_flags;
-                                if (flags
-                                    & (node_flags::LET | node_flags::CONST | node_flags::USING))
-                                    != 0
-                                {
+                                if node_flags::is_block_scoped(flags) {
                                     continue;
                                 }
                             }
@@ -2199,12 +2196,7 @@ impl<'a> CheckerState<'a> {
                                     {
                                         let other_flags = other_parent.flags as u32;
                                         use tsz_parser::parser::node_flags;
-                                        if (other_flags
-                                            & (node_flags::LET
-                                                | node_flags::CONST
-                                                | node_flags::USING))
-                                            != 0
-                                        {
+                                        if node_flags::is_block_scoped(other_flags) {
                                             continue; // block-scoped, skip
                                         }
                                     }

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -55,7 +55,7 @@ impl<'a> CheckerState<'a> {
             && let Some(parent_node) = self.ctx.arena.get(ext.parent)
         {
             let parent_flags = parent_node.flags as u32;
-            if parent_flags & (node_flags::LET | node_flags::CONST) != 0 {
+            if node_flags::is_let_or_const(parent_flags) {
                 return;
             }
         } else {
@@ -329,7 +329,7 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|parent| {
                 let flags = parent.flags as u32;
                 parent.kind == tsz_parser::parser::syntax_kind_ext::VARIABLE_DECLARATION_LIST
-                    && (flags & (node_flags::LET | node_flags::CONST)) == 0
+                    && !node_flags::is_let_or_const(flags)
             });
         if !is_var {
             return false;

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1460,8 +1460,7 @@ impl<'a> CheckerState<'a> {
             // TS2492: Check if let/const declarations inside a catch block shadow
             // the catch clause variable. `var` is allowed (different scoping), but
             // `let`/`const` are not.
-            let is_let_or_const =
-                (flags_u32 & (node_flags::LET | node_flags::CONST)) != 0 && !is_using;
+            let is_let_or_const = node_flags::is_let_or_const(flags_u32) && !is_using;
             if is_let_or_const {
                 self.check_catch_clause_variable_redeclaration(
                     list_idx,

--- a/crates/tsz-emitter/src/emitter/es5/bindings.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings.rs
@@ -95,7 +95,7 @@ impl<'a> Printer<'a> {
         decl_list: &tsz_parser::parser::node::VariableData,
         flags: u32,
     ) {
-        let using_async = (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING;
+        let using_async = node_flags::is_await_using(flags);
 
         // When a block-level using wrapper is already active (block_using_env is set),
         // just emit the __addDisposableResource calls inline as `var d1 = ..., d2 = ...;`.

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit.rs
@@ -580,8 +580,7 @@ impl<'a> Printer<'a> {
                 };
                 var_stmt.declarations.nodes.iter().any(|&decl_list_idx| {
                     self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
-                        (decl_list_node.flags as u32 & tsz_parser::parser::node_flags::AWAIT_USING)
-                            == tsz_parser::parser::node_flags::AWAIT_USING
+                        tsz_parser::parser::node_flags::is_await_using(decl_list_node.flags as u32)
                     })
                 })
             });
@@ -819,8 +818,7 @@ impl<'a> Printer<'a> {
             };
             let flags = decl_list_node.flags as u32;
             let is_using = (flags & tsz_parser::parser::node_flags::USING) != 0;
-            let using_async = (flags & tsz_parser::parser::node_flags::AWAIT_USING)
-                == tsz_parser::parser::node_flags::AWAIT_USING;
+            let using_async = tsz_parser::parser::node_flags::is_await_using(flags);
 
             for &decl_idx in &decl_list.declarations.nodes {
                 let Some(decl_node) = self.arena.get(decl_idx) else {
@@ -913,8 +911,7 @@ impl<'a> Printer<'a> {
             };
             let flags = decl_list_node.flags as u32;
             let is_using = (flags & tsz_parser::parser::node_flags::USING) != 0;
-            let is_await_using = (flags & tsz_parser::parser::node_flags::AWAIT_USING)
-                == tsz_parser::parser::node_flags::AWAIT_USING;
+            let is_await_using = tsz_parser::parser::node_flags::is_await_using(flags);
 
             if is_using || is_await_using {
                 if emitted {

--- a/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/wrapper_entry.rs
@@ -452,8 +452,7 @@ impl<'a> Printer<'a> {
             };
             var_stmt.declarations.nodes.iter().any(|&decl_list_idx| {
                 self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
-                    (decl_list_node.flags as u32 & tsz_parser::parser::node_flags::AWAIT_USING)
-                        == tsz_parser::parser::node_flags::AWAIT_USING
+                    tsz_parser::parser::node_flags::is_await_using(decl_list_node.flags as u32)
                 })
             })
         });

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
@@ -19,8 +19,7 @@ impl<'a> Printer<'a> {
                 self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
                     let flags = decl_list_node.flags as u32;
                     (flags & tsz_parser::parser::node_flags::USING) != 0
-                        || (flags & tsz_parser::parser::node_flags::AWAIT_USING)
-                            == tsz_parser::parser::node_flags::AWAIT_USING
+                        || tsz_parser::parser::node_flags::is_await_using(flags)
                 })
             })
         })
@@ -45,8 +44,7 @@ impl<'a> Printer<'a> {
             };
             var_stmt.declarations.nodes.iter().any(|&decl_list_idx| {
                 self.arena.get(decl_list_idx).is_some_and(|decl_list_node| {
-                    (decl_list_node.flags as u32 & tsz_parser::parser::node_flags::AWAIT_USING)
-                        == tsz_parser::parser::node_flags::AWAIT_USING
+                    tsz_parser::parser::node_flags::is_await_using(decl_list_node.flags as u32)
                 })
             })
         });
@@ -872,8 +870,7 @@ impl<'a> Printer<'a> {
             };
             let flags = decl_list_node.flags as u32;
             let is_using = (flags & tsz_parser::parser::node_flags::USING) != 0;
-            let using_async = (flags & tsz_parser::parser::node_flags::AWAIT_USING)
-                == tsz_parser::parser::node_flags::AWAIT_USING;
+            let using_async = tsz_parser::parser::node_flags::is_await_using(flags);
 
             for &decl_idx in &decl_list.declarations.nodes {
                 let Some(decl_node) = self.arena.get(decl_idx) else {

--- a/crates/tsz-emitter/src/emitter/statements/control_flow.rs
+++ b/crates/tsz-emitter/src/emitter/statements/control_flow.rs
@@ -414,7 +414,7 @@ impl<'a> Printer<'a> {
             return;
         }
         // Only strip `var`, not `let`/`const`
-        let is_var = (init_node.flags as u32 & (node_flags::LET | node_flags::CONST)) == 0;
+        let is_var = !node_flags::is_let_or_const(init_node.flags as u32);
         if !is_var {
             self.emit(initializer);
             return;
@@ -1011,7 +1011,7 @@ impl<'a> Printer<'a> {
         if (flags & node_flags::USING) == 0 {
             return None;
         }
-        let using_async = (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING;
+        let using_async = node_flags::is_await_using(flags);
         let decl_list = self.arena.get_variable(init_node)?;
         if decl_list.declarations.nodes.len() != 1 {
             return None;
@@ -1197,7 +1197,7 @@ impl<'a> Printer<'a> {
     ) {
         let init_node = self.arena.get(loop_stmt.initializer).unwrap();
         let flags = init_node.flags as u32;
-        let using_async = (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING;
+        let using_async = node_flags::is_await_using(flags);
         let decl_list = self.arena.get_variable(init_node).unwrap();
         let (env_name, error_name, result_name) = self.next_disposable_env_names();
 

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -850,7 +850,7 @@ impl<'a> Printer<'a> {
         decl_list: &tsz_parser::parser::node::VariableData,
         flags: u32,
     ) {
-        let using_async = (flags & node_flags::AWAIT_USING) == node_flags::AWAIT_USING;
+        let using_async = node_flags::is_await_using(flags);
         let (env_name, error_name, result_name) = self.next_disposable_env_names();
 
         let initialized_decls: Vec<_> = decl_list

--- a/crates/tsz-lsp/src/resolver/core.rs
+++ b/crates/tsz-lsp/src/resolver/core.rs
@@ -329,7 +329,7 @@ impl<'a> ScopeWalker<'a> {
     }
 
     const fn is_var_declaration_list(&self, node: &Node) -> bool {
-        (node.flags as u32 & (node_flags::LET | node_flags::CONST)) == 0
+        !node_flags::is_let_or_const(node.flags as u32)
     }
 
     fn is_var_declaration(&self, decl_idx: NodeIndex) -> bool {

--- a/crates/tsz-parser/src/parser/flags.rs
+++ b/crates/tsz-parser/src/parser/flags.rs
@@ -40,6 +40,30 @@ pub mod node_flags {
 
     // Type-only imports/exports
     pub const TYPE_ONLY: u32 = 1_073_741_824; // 1 << 30
+
+    /// Returns `true` if the flags represent an `await using` declaration.
+    /// Since `AWAIT_USING == CONST | USING`, both bits must be set.
+    #[inline]
+    #[must_use]
+    pub const fn is_await_using(flags: u32) -> bool {
+        (flags & AWAIT_USING) == AWAIT_USING
+    }
+
+    /// Returns `true` if the declaration is block-scoped via `let` or `const`
+    /// (does not include `using` / `await using`).
+    #[inline]
+    #[must_use]
+    pub const fn is_let_or_const(flags: u32) -> bool {
+        (flags & (LET | CONST)) != 0
+    }
+
+    /// Returns `true` if the declaration is any lexical (block-scoped) binding:
+    /// `let`, `const`, or `using` (including `await using`).
+    #[inline]
+    #[must_use]
+    pub const fn is_block_scoped(flags: u32) -> bool {
+        (flags & (LET | CONST | USING)) != 0
+    }
 }
 
 /// Modifier flags for declarations.

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -541,7 +541,7 @@ impl NodeArena {
         };
         let mut flags = node.flags as u32;
         use super::flags::node_flags;
-        if (flags & (node_flags::LET | node_flags::CONST | node_flags::USING)) == 0
+        if !node_flags::is_block_scoped(flags)
             && let Some(ext) = self.get_extended(node_idx)
             && let Some(parent) = self.get(ext.parent)
             && parent.kind == VARIABLE_DECLARATION_LIST


### PR DESCRIPTION
## Summary

- Add three `const fn` helpers to `tsz_parser::parser::node_flags`:
  - `is_await_using(flags)` — replaces the non-obvious `(flags & AWAIT_USING) == AWAIT_USING` pattern. Needed because `AWAIT_USING == CONST | USING` so a single-bit mask check would false-match plain `const` or plain `using`.
  - `is_let_or_const(flags)` — replaces `(flags & (LET | CONST)) != 0`
  - `is_block_scoped(flags)` — replaces `(flags & (LET | CONST | USING)) != 0`
- Migrate ~25 call sites across 19 files in binder / checker / emitter / lsp / parser.
- No behavior change; `const fn` keeps every site callable from `const` contexts.

## Why

Raw bitmask patterns obscure intent and are error-prone — the `AWAIT_USING` check in particular is easy to write incorrectly because `AWAIT_USING` is a compound `CONST | USING` value. Named predicates make the semantics self-documenting.

Continues the DRY-sweep started with `Symbol::has_any_flags()` and `Node::is_optional_chain()` in recent PRs (#915-#924).

## Test plan
- [x] `cargo check -p tsz-parser -p tsz-binder -p tsz-checker -p tsz-emitter -p tsz-lsp` clean
- [x] `cargo nextest run` — 19318 tests pass (62 skipped)
- [x] `cargo clippy` zero warnings on affected crates
- [x] wasm32 rustc warnings gate clean
- [x] Architecture guardrails pass