### PR TITLE
[codex] narrow union excess checks with partial discriminants

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -626,6 +626,30 @@ let value: {
 }
 
 #[test]
+fn mapped_enum_key_missing_property_uses_enum_member_display() {
+    let diagnostics = diagnostics_for(
+        r#"
+type Record<K extends string | number, T> = { [P in K]: T };
+enum E { A }
+let foo: Record<E, any> = {};
+"#,
+    );
+
+    let diag = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2741)
+        .expect("expected TS2741 for missing enum mapped key");
+    assert!(
+        diag.message_text.contains("Property '[E.A]' is missing"),
+        "TS2741 should render the enum member key, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("Property '0' is missing"),
+        "TS2741 should not render the erased numeric key, got: {diag:?}"
+    );
+}
+
+#[test]
 fn function_expression_assignment_reports_outer_signature_mismatch() {
     let source = r#"
 interface T {

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -376,6 +376,18 @@ impl<'a> CheckerState<'a> {
                                 args.len(),
                             )
                         };
+                        // Keep the first-pass instantiated retry consistent with the
+                        // signature-specific retry below. The retry may contextually
+                        // type an object literal with the inferred parameter type
+                        // (for example `Object.freeze<T>(o: T): Readonly<T>`). If
+                        // literal preservation is dropped here, the retry overwrites
+                        // the successful first pass with widened property values.
+                        let prev_preserve_literals_retry = self.ctx.preserve_literal_types;
+                        let prev_in_const_assertion_retry = self.ctx.in_const_assertion;
+                        self.ctx.preserve_literal_types = true;
+                        if sig.type_params.iter().any(|tp| tp.is_const) {
+                            self.ctx.in_const_assertion = true;
+                        }
                         let refreshed_arg_types = self.collect_call_argument_types_with_context(
                             args,
                             |i, _arg_count| refreshed_contextual_types.get(i).copied().flatten(),
@@ -383,6 +395,8 @@ impl<'a> CheckerState<'a> {
                             None,
                             sig_callable_ctx,
                         );
+                        self.ctx.preserve_literal_types = prev_preserve_literals_retry;
+                        self.ctx.in_const_assertion = prev_in_const_assertion_retry;
                         // When return-context substitution was used to provide better
                         // contextual types, re-resolve the call with the correctly-typed
                         // arguments to get the right return type. Without this, the return

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1562,6 +1562,31 @@ impl<'a> CheckerState<'a> {
                                 base_type,
                                 *derived_member_idx,
                             )
+                        } else if *derived_kind == METHOD_SIGNATURE
+                            && base_member_node.kind == METHOD_SIGNATURE
+                        {
+                            let derived_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    *member_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(*member_type);
+                            let base_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    base_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(base_type);
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_method_type,
+                                base_method_type,
+                                *derived_member_idx,
+                            )
                         } else {
                             should_report_member_type_mismatch(
                                 self,
@@ -1781,6 +1806,12 @@ impl<'a> CheckerState<'a> {
                             .iter()
                             .any(|&(signature, _)| !signature_has_literal_parameter(signature))
                     };
+                let signature_contains_error = |signature: TypeId| {
+                    crate::query_boundaries::common::contains_error_type_in_args(
+                        self.ctx.types,
+                        signature,
+                    )
+                };
 
                 // For overloaded method inheritance, tsc compatibility hinges on
                 // the trailing (implementation) signature.
@@ -1788,6 +1819,18 @@ impl<'a> CheckerState<'a> {
                     let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                         continue;
                     };
+                    // The overload coverage pass runs after ordinary member
+                    // compatibility, so it must apply the same cascading-error
+                    // suppression. Post-merge lib validation can leave event-map
+                    // overload parameters unresolved; those should not become
+                    // TS2430 diagnostics on unrelated default-lib interfaces.
+                    if base_sigs.iter().copied().any(signature_contains_error)
+                        || derived_sigs
+                            .iter()
+                            .any(|(signature, _)| signature_contains_error(*signature))
+                    {
+                        continue;
+                    }
                     if has_non_specialized_signature(base_sigs)
                         && !has_non_specialized_signature_with_node(derived_sigs)
                     {

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -738,13 +738,13 @@ impl<'a> CheckerState<'a> {
                         _derived_name,
                         derived_member_type,
                         derived_member_idx,
-                        _derived_kind,
+                        derived_kind,
                         _derived_optional,
                     )) = derived_members
                         .iter()
                         .find(|(derived_name, _, _, _, _)| derived_name == &member_key)
                     {
-                        let overloaded_method_compare = *_derived_kind == METHOD_SIGNATURE
+                        let overloaded_method_compare = *derived_kind == METHOD_SIGNATURE
                             && member_node.kind == METHOD_SIGNATURE
                             && (derived_method_counts.get(&member_key).copied().unwrap_or(0) > 1
                                 || base_method_counts.get(&member_key).copied().unwrap_or(0) > 1);
@@ -768,12 +768,45 @@ impl<'a> CheckerState<'a> {
                         .map(|p| p.type_id)
                         .unwrap_or(member_type);
 
-                        if should_report_member_type_mismatch(
-                            self,
-                            derived_prop_type,
-                            base_prop_type,
-                            *derived_member_idx,
-                        ) {
+                        let property_signature_pair = *derived_kind == PROPERTY_SIGNATURE
+                            && member_node.kind == PROPERTY_SIGNATURE;
+                        let callable_property_pair = property_signature_pair
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                derived_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    derived_prop_type,
+                                ))
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                base_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    base_prop_type,
+                                ));
+
+                        let type_mismatch = if callable_property_pair {
+                            should_report_property_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        } else {
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        };
+
+                        if type_mismatch {
                             let derived_type_str = self.format_type(derived_prop_type);
                             let base_type_str = self.format_type(base_prop_type);
                             self.error_at_node(

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -290,7 +290,33 @@ impl<'a> CheckerContext<'a> {
             .filter_map(|(_, p)| p.starts_with('/').then_some(p.as_str()))
             .collect();
         let common = if absolute.len() >= 2 {
-            Self::longest_common_directory_prefix(&absolute)
+            let common = Self::longest_common_directory_prefix(&absolute);
+            let common_dir = common.trim_end_matches('/');
+            let common_basename = common_dir.rsplit('/').next().unwrap_or(common_dir);
+            if common_basename == "src" {
+                // Conformance virtual projects commonly root files under `/src`;
+                // tsc keeps that segment in `import("src/...")` diagnostics.
+                common_dir
+                    .rsplit_once('/')
+                    .map(|(parent, _)| {
+                        if parent.is_empty() {
+                            "/".to_string()
+                        } else {
+                            format!("{parent}/")
+                        }
+                    })
+                    .unwrap_or_default()
+            } else if common
+                .trim_matches('/')
+                .split('/')
+                .filter(|component| !component.is_empty())
+                .count()
+                > 1
+            {
+                common
+            } else {
+                String::new()
+            }
         } else {
             String::new()
         };

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -838,8 +838,8 @@ impl<'a> CheckerState<'a> {
                 return;
             };
 
-            let source_type = self.format_type_diagnostic(source);
-            let target_type = self.format_type_diagnostic(target);
+            let (source_type, target_type) =
+                self.format_top_level_assignability_message_types_at(source, target, anchor_idx);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&source_type, &target_type],

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -129,6 +129,8 @@ impl<'a> CheckerState<'a> {
             {
                 arg_str = self.widen_weak_type_callable_source_display(arg_type, arg_str);
             }
+            let (arg_str, param_str) =
+                self.finalize_pair_display_for_diagnostic(arg_type, param_type, arg_str, param_str);
             let message = format_message(msg_template, &[&arg_str, &param_str]);
             let request =
                 DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message);

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -579,6 +579,7 @@ impl<'a> CheckerState<'a> {
             let mut formatter = self
                 .ctx
                 .create_diagnostic_type_formatter()
+                .with_long_property_receiver_display()
                 .with_display_properties()
                 .with_skip_application_alias_names();
             return formatter.format(display_ty).into_owned();

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -560,6 +560,38 @@ impl<'a> CheckerState<'a> {
         Some(symbol.escaped_name.clone())
     }
 
+    fn property_receiver_application_chain_depth(&self, ty: TypeId) -> u32 {
+        let mut current = ty;
+        let mut depth = 0;
+        let mut guard = 0;
+
+        loop {
+            let application =
+                crate::query_boundaries::common::type_application(self.ctx.types, current).or_else(
+                    || {
+                        self.ctx.types.get_display_alias(current).and_then(|alias| {
+                            crate::query_boundaries::common::type_application(self.ctx.types, alias)
+                        })
+                    },
+                );
+            let Some(app) = application else {
+                break;
+            };
+
+            depth += 1;
+            guard += 1;
+            if guard > 128 {
+                break;
+            }
+            let Some(&next) = app.args.first() else {
+                break;
+            };
+            current = next;
+        }
+
+        depth
+    }
+
     pub(crate) fn format_property_receiver_type_for_diagnostic(&mut self, ty: TypeId) -> String {
         if let Some(module_name) = self.ctx.namespace_module_names.get(&ty) {
             return format!("typeof import(\"{module_name}\")");
@@ -576,10 +608,14 @@ impl<'a> CheckerState<'a> {
         if let Some(application_display) = application_display {
             let display_ty =
                 self.normalize_property_receiver_application_display_type(application_display);
+            let elision_end_depth = self
+                .property_receiver_application_chain_depth(display_ty)
+                .saturating_sub(4);
             let mut formatter = self
                 .ctx
                 .create_diagnostic_type_formatter()
                 .with_long_property_receiver_display()
+                .with_long_property_receiver_object_elision_end_depth(elision_end_depth)
                 .with_display_properties()
                 .with_skip_application_alias_names();
             return Self::truncate_property_receiver_display(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -582,7 +582,9 @@ impl<'a> CheckerState<'a> {
                 .with_long_property_receiver_display()
                 .with_display_properties()
                 .with_skip_application_alias_names();
-            return formatter.format(display_ty).into_owned();
+            return Self::truncate_property_receiver_display(
+                formatter.format(display_ty).into_owned(),
+            );
         }
         let has_object_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty).is_some();

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -402,7 +402,17 @@ impl<'a> CheckerState<'a> {
         }
 
         if changed {
-            self.ctx.types.factory().object_with_index(normalized_shape)
+            let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
+            if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
+                if query::type_application(self.ctx.types, alias_origin).is_some() {
+                    self.ctx
+                        .types
+                        .store_display_alias_preferring_application(new_ty, alias_origin);
+                } else {
+                    self.ctx.types.store_display_alias(new_ty, alias_origin);
+                }
+            }
+            new_ty
         } else {
             ty
         }

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -299,6 +299,24 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn normalize_property_receiver_application_display_alias(&mut self, ty: TypeId) -> TypeId {
+        let Some(app) = query::type_application(self.ctx.types, ty) else {
+            return ty;
+        };
+
+        let args: Vec<_> = app
+            .args
+            .iter()
+            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+            .collect();
+
+        if args == app.args {
+            ty
+        } else {
+            self.ctx.types.factory().application(app.base, args)
+        }
+    }
+
     fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
         let evaluated = self.evaluate_type_with_env(ty);
         if evaluated != ty {
@@ -404,6 +422,8 @@ impl<'a> CheckerState<'a> {
         if changed {
             let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
+                let alias_origin =
+                    self.normalize_property_receiver_application_display_alias(alias_origin);
                 if query::type_application(self.ctx.types, alias_origin).is_some() {
                     self.ctx
                         .types

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -13,8 +13,17 @@ use tsz_solver::TypeId;
 impl<'a> CheckerState<'a> {
     pub(crate) fn truncate_property_receiver_display(display: String) -> String {
         const MAX_PROPERTY_RECEIVER_DISPLAY_CHARS: usize = 320;
-        if display.len() <= MAX_PROPERTY_RECEIVER_DISPLAY_CHARS || !display.starts_with("Omit<") {
+        let should_truncate = display.starts_with("Omit<") || display.starts_with("merge<");
+        if display.len() <= MAX_PROPERTY_RECEIVER_DISPLAY_CHARS || !should_truncate {
             return display;
+        }
+        if display.starts_with("merge<") {
+            let mut truncated: String = display
+                .chars()
+                .take(MAX_PROPERTY_RECEIVER_DISPLAY_CHARS - 2)
+                .collect();
+            truncated.push_str("..");
+            return truncated;
         }
         display
             .chars()

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -511,6 +511,12 @@ impl<'a> CheckerState<'a> {
                     *target_value_type,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
                 );
+                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_value_type,
+                    *target_value_type,
+                    source_str,
+                    target_str,
+                );
                 vec![
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Error,
@@ -546,6 +552,12 @@ impl<'a> CheckerState<'a> {
                 let target_str = self.format_type_for_diagnostic_role(
                     *target_element,
                     DiagnosticTypeDisplayRole::DefaultDiagnostic,
+                );
+                let (source_str, target_str) = self.finalize_pair_display_for_diagnostic(
+                    *source_element,
+                    *target_element,
+                    source_str,
+                    target_str,
                 );
                 vec![
                     DiagnosticRelatedInformation {

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -471,6 +471,12 @@ impl<'a> CheckerState<'a> {
 
         let type_str = self.format_type_diagnostic(type_arg);
         let constraint_str = self.format_type_diagnostic(constraint);
+        let (type_str, constraint_str) = self.finalize_pair_display_for_diagnostic(
+            type_arg,
+            constraint,
+            type_str,
+            constraint_str,
+        );
         self.error_at_node_msg(
             idx,
             diagnostic_codes::TYPE_HAS_NO_PROPERTIES_IN_COMMON_WITH_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -977,7 +977,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Private brand properties handling
-        let prop_name = self.ctx.types.resolve_atom_ref(property_name);
+        let prop_name = self.ctx.types.resolve_atom_ref(property_name).to_string();
         if prop_name.starts_with("__private_brand") {
             let src_str = if depth == 0 {
                 self.format_type_for_diagnostic_role(
@@ -1124,7 +1124,7 @@ impl<'a> CheckerState<'a> {
             let prop_list: Vec<String> = all_missing
                 .iter()
                 .take(4)
-                .map(|name| self.ctx.types.resolve_atom_ref(*name).to_string())
+                .map(|name| self.missing_property_name_for_display(*name, target))
                 .collect();
             let props_joined = prop_list.join(", ");
             let (message, code) = if all_missing.len() > 4 {
@@ -1204,9 +1204,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
+        let prop_name_display = self.missing_property_name_for_display(property_name, target);
         let message = format_message(
             diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-            &[&prop_name, &src_str, &tgt_str_qualified],
+            &[&prop_name_display, &src_str, &tgt_str_qualified],
         );
         Diagnostic::error(
             file_name,
@@ -1681,7 +1682,7 @@ impl<'a> CheckerState<'a> {
         let prop_list: Vec<String> = ordered_names
             .iter()
             .take(display_count)
-            .map(|name| self.ctx.types.resolve_atom_ref(*name).to_string())
+            .map(|name| self.missing_property_name_for_display(*name, target))
             .collect();
         let props_joined = prop_list.join(", ");
         if is_truncated {
@@ -1709,6 +1710,132 @@ impl<'a> CheckerState<'a> {
                 message,
                 diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
             )
+        }
+    }
+
+    fn missing_property_name_for_display(
+        &mut self,
+        property_name: tsz_common::interner::Atom,
+        target: TypeId,
+    ) -> String {
+        if let Some(display) = self.enum_mapped_property_name_for_display(property_name, target) {
+            return display;
+        }
+        self.ctx.types.resolve_atom_ref(property_name).to_string()
+    }
+
+    fn enum_mapped_property_name_for_display(
+        &mut self,
+        property_name: tsz_common::interner::Atom,
+        target: TypeId,
+    ) -> Option<String> {
+        let property_key = self.ctx.types.resolve_atom_ref(property_name).to_string();
+        let (_, args) = crate::query_boundaries::common::application_info(self.ctx.types, target)?;
+
+        args.into_iter()
+            .find_map(|arg| self.enum_key_property_name_for_display(&property_key, arg))
+    }
+
+    fn enum_key_property_name_for_display(
+        &mut self,
+        property_key: &str,
+        key_type: TypeId,
+    ) -> Option<String> {
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, key_type)
+        {
+            return members
+                .iter()
+                .find_map(|&member| self.enum_key_property_name_for_display(property_key, member));
+        }
+
+        let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, key_type)
+            .or_else(|| crate::query_boundaries::common::lazy_def_id(self.ctx.types, key_type))?;
+        let def = self.ctx.definition_store.get(def_id)?;
+        if def.kind == tsz_solver::def::DefKind::Enum && !def.enum_members.is_empty() {
+            return self.enum_property_name_from_parent_def(property_key, &def);
+        }
+
+        self.enum_property_name_from_member_type(property_key, key_type, &def)
+    }
+
+    fn enum_property_name_from_parent_def(
+        &mut self,
+        property_key: &str,
+        enum_def: &tsz_solver::def::DefinitionInfo,
+    ) -> Option<String> {
+        let enum_name = self.ctx.types.resolve_atom_ref(enum_def.name).to_string();
+        let enum_symbol_id = tsz_binder::SymbolId(enum_def.symbol_id?);
+        let enum_symbol = self.ctx.binder.get_symbol(enum_symbol_id)?;
+        let exports = enum_symbol.exports.as_ref()?;
+
+        for (member_atom, _) in &enum_def.enum_members {
+            let member_name = self.ctx.types.resolve_atom_ref(*member_atom).to_string();
+            let Some(member_symbol_id) = exports.get(&member_name) else {
+                continue;
+            };
+            let Some(member_type) = self.ctx.symbol_types.get(&member_symbol_id).copied() else {
+                continue;
+            };
+            if self.enum_member_type_matches_property_key(member_type, property_key) {
+                return Some(format!("[{enum_name}.{member_name}]"));
+            }
+        }
+
+        None
+    }
+
+    fn enum_property_name_from_member_type(
+        &mut self,
+        property_key: &str,
+        member_type: TypeId,
+        member_def: &tsz_solver::def::DefinitionInfo,
+    ) -> Option<String> {
+        if !self.enum_member_type_matches_property_key(member_type, property_key) {
+            return None;
+        }
+
+        let member_symbol_id = tsz_binder::SymbolId(member_def.symbol_id?);
+        let member_symbol = self.ctx.binder.get_symbol(member_symbol_id)?;
+        if member_symbol.parent.is_none() {
+            return None;
+        }
+        let enum_symbol = self.ctx.binder.get_symbol(member_symbol.parent)?;
+        Some(format!(
+            "[{}.{}]",
+            enum_symbol.escaped_name, member_symbol.escaped_name
+        ))
+    }
+
+    fn enum_member_type_matches_property_key(
+        &self,
+        member_type: TypeId,
+        property_key: &str,
+    ) -> bool {
+        let value_type =
+            crate::query_boundaries::common::enum_member_type(self.ctx.types, member_type)
+                .unwrap_or(member_type);
+        crate::query_boundaries::common::literal_value(self.ctx.types, value_type)
+            .and_then(|literal| self.literal_property_key_text(literal))
+            .is_some_and(|key| key == property_key)
+    }
+
+    fn literal_property_key_text(&self, literal: tsz_solver::LiteralValue) -> Option<String> {
+        match literal {
+            tsz_solver::LiteralValue::String(atom) | tsz_solver::LiteralValue::BigInt(atom) => {
+                Some(self.ctx.types.resolve_atom_ref(atom).to_string())
+            }
+            tsz_solver::LiteralValue::Number(value) => {
+                let value = value.0;
+                if value == 0.0 {
+                    Some("0".to_string())
+                } else if value.is_finite() && value.fract() == 0.0 {
+                    Some(format!("{value:.0}"))
+                } else {
+                    Some(value.to_string())
+                }
+            }
+            tsz_solver::LiteralValue::Boolean(value) => Some(value.to_string()),
         }
     }
 

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -490,6 +490,8 @@ impl<'a> CheckerState<'a> {
                 {
                     source_str = Self::widen_member_literals_in_display_text(&source_str);
                 }
+                let (source_str, target_str) = self
+                    .finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
                 let message = format_message(msg_template, &[&source_str, &target_str]);
                 Diagnostic::error(file_name, start, length, message, code)
             }

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -141,9 +141,11 @@ impl<'a> CheckerState<'a> {
             && let Some((prop_name, owner_name, visibility)) =
                 self.private_or_protected_member_missing_display(source, target, None)
         {
+            let (source_display, target_display) =
+                self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
             let message = self.private_or_protected_assignability_message(
-                &source_str,
-                &target_str,
+                &source_display,
+                &target_display,
                 &prop_name,
                 &owner_name,
                 visibility,
@@ -173,12 +175,14 @@ impl<'a> CheckerState<'a> {
         {
             let prop_name = self.ctx.types.resolve_atom_ref(property_name);
             if prop_name.starts_with("__private_brand") {
+                let (source_display, target_display) = self
+                    .finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
                 let message = self
                     .private_or_protected_brand_backing_member_display(target, None)
                     .map(|(display_prop, owner_name, visibility)| {
                         self.private_or_protected_assignability_message(
-                            &source_str,
-                            &target_str,
+                            &source_display,
+                            &target_display,
                             &display_prop,
                             &owner_name,
                             visibility,
@@ -192,7 +196,7 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or_else(|| {
                         format_message(
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                            &[&source_str, &target_str],
+                            &[&source_display, &target_display],
                         )
                     });
                 return Diagnostic::error(

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -58,6 +58,10 @@ pub(crate) struct RelationRequest {
     pub missing_property_mode: MissingPropertyMode,
     /// Whether the source is a fresh object literal.
     pub source_is_fresh: bool,
+    /// Whether failed contextual generic-signature inference may retry with
+    /// erased signatures. This is a targeted interface property compatibility
+    /// mode, not the default assignment relation.
+    pub allow_erased_generic_signature_retry: bool,
 }
 
 impl RelationRequest {
@@ -69,6 +73,7 @@ impl RelationRequest {
             excess_property_mode: ExcessPropertyMode::Skip,
             missing_property_mode: MissingPropertyMode::Report,
             source_is_fresh: false,
+            allow_erased_generic_signature_retry: false,
         }
     }
 
@@ -116,6 +121,12 @@ impl RelationRequest {
         self.missing_property_mode = mode;
         self
     }
+
+    /// Allow a failed generic-signature inference to retry with erased signatures.
+    pub(crate) fn with_erased_generic_signature_retry(mut self) -> Self {
+        self.allow_erased_generic_signature_retry = true;
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +148,8 @@ impl RelationFlags {
     pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
         tsz_solver::RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS;
     pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationCacheKey::FLAG_NO_ERASE_GENERICS;
+    pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        tsz_solver::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
     pub const DISABLE_METHOD_BIVARIANCE: u16 =
         tsz_solver::RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE;
 }
@@ -572,12 +585,17 @@ pub(crate) fn execute_relation<R: tsz_solver::TypeResolver>(
     )
     .entered();
 
+    let mut relation_flags = flags;
+    if request.allow_erased_generic_signature_retry {
+        relation_flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+    }
+
     let inputs = AssignabilityQueryInputs {
         db,
         resolver,
         source: request.source,
         target: request.target,
-        flags,
+        flags: relation_flags,
         inheritance_graph,
         sound_mode,
     };

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -459,6 +459,7 @@ pub(crate) fn should_report_property_type_mismatch(
         let (prepared_source, prepared_target) =
             checker.prepare_assignability_inputs(relation_source, relation_target);
         RelationRequest::assign(prepared_source, prepared_target)
+            .with_erased_generic_signature_retry()
     };
     let outcome = checker.execute_relation_request(&request);
 

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -343,7 +343,8 @@ impl<'a> CheckerState<'a> {
                 .into_iter()
                 .map(|i| target_shapes[i].clone())
                 .collect::<Vec<_>>();
-            let effective_shapes = if discriminant_shapes.is_empty() {
+            let had_discriminant_narrowing = !discriminant_shapes.is_empty();
+            let effective_shapes = if !had_discriminant_narrowing {
                 if has_unresolved_member {
                     let matching_shapes = target_shapes
                         .iter()
@@ -429,11 +430,27 @@ impl<'a> CheckerState<'a> {
                         self.ctx.types,
                         target_prop_types.clone(),
                     );
-                    let nested_target = self.nested_property_target_type(
-                        effective_target,
-                        source_prop.name,
-                        nested_target,
-                    );
+                    let nested_target = if had_discriminant_narrowing {
+                        nested_target
+                    } else {
+                        self.nested_property_target_type(
+                            effective_target,
+                            source_prop.name,
+                            nested_target,
+                        )
+                    };
+
+                    if had_discriminant_narrowing
+                        && self.try_emit_nested_discriminated_union_assignability_error(
+                            source,
+                            target,
+                            idx,
+                            source_prop.name,
+                            nested_target,
+                        )
+                    {
+                        return;
+                    }
 
                     self.check_nested_object_literal_excess_properties(
                         source_prop.name,
@@ -1087,6 +1104,191 @@ impl<'a> CheckerState<'a> {
     fn index_value_type_is_deferred(types: &dyn tsz_solver::TypeDatabase, type_id: TypeId) -> bool {
         crate::query_boundaries::common::is_index_access_type(types, type_id)
             || crate::query_boundaries::common::contains_type_parameters(types, type_id)
+    }
+
+    fn try_emit_nested_discriminated_union_assignability_error(
+        &mut self,
+        outer_source: TypeId,
+        outer_target: TypeId,
+        obj_literal_idx: NodeIndex,
+        prop_name: Atom,
+        nested_target: TypeId,
+    ) -> bool {
+        if !self.is_object_like_nested_target(nested_target) {
+            return false;
+        }
+
+        let literal_idx = if self
+            .ctx
+            .arena
+            .get(obj_literal_idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION)
+        {
+            obj_literal_idx
+        } else {
+            let Some(literal_idx) = self.find_rhs_object_literal(obj_literal_idx) else {
+                return false;
+            };
+            literal_idx
+        };
+
+        let Some((report_idx, value_idx)) =
+            self.object_literal_property_name_and_value(literal_idx, prop_name)
+        else {
+            return false;
+        };
+        let effective_value_idx = self.ctx.arena.skip_parenthesized(value_idx);
+        let Some(value_node) = self.ctx.arena.get(effective_value_idx) else {
+            return false;
+        };
+        if value_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return false;
+        }
+
+        let Some(rejected_property) =
+            self.nested_literal_rejected_fresh_property(effective_value_idx, nested_target)
+        else {
+            return false;
+        };
+
+        let source_str = self.format_type(outer_source);
+        let target_str = self.format_type(outer_target);
+        let message = crate::diagnostics::format_message(
+            crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        if let Some((start, length)) =
+            self.find_excess_property_anchor(effective_value_idx, rejected_property)
+        {
+            self.error(
+                start,
+                length,
+                message,
+                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+        } else {
+            self.error_at_anchor(
+                report_idx,
+                crate::error_reporter::DiagnosticAnchorKind::PropertyToken,
+                &message,
+                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+        }
+        true
+    }
+
+    fn is_object_like_nested_target(&mut self, nested_target: TypeId) -> bool {
+        let nested_target = self.evaluate_type_with_env(nested_target);
+        let nested_target = self.resolve_type_for_property_access(nested_target);
+
+        if query::object_shape(self.ctx.types, nested_target).is_some() {
+            return true;
+        }
+
+        let resolved_target = self.prune_impossible_object_union_members_with_env(nested_target);
+        query::union_members(self.ctx.types, resolved_target).is_some_and(|members| {
+            members.iter().any(|member| {
+                let resolved_member = self.resolve_type_for_property_access(*member);
+                query::object_shape(self.ctx.types, resolved_member).is_some()
+            })
+        })
+    }
+
+    fn nested_literal_rejected_fresh_property(
+        &mut self,
+        nested_literal_idx: NodeIndex,
+        nested_target: TypeId,
+    ) -> Option<Atom> {
+        let nested_target = self.evaluate_type_with_env(nested_target);
+        let nested_target = self.resolve_type_for_property_access(nested_target);
+        let resolved_target = self.prune_impossible_object_union_members_with_env(nested_target);
+        let Some(members) = query::union_members(self.ctx.types, resolved_target) else {
+            return None;
+        };
+
+        let mut target_shapes = Vec::new();
+        for &member in &members {
+            let resolved_member = self.resolve_type_for_property_access(member);
+            let Some(shape) = query::object_shape(self.ctx.types, resolved_member) else {
+                return None;
+            };
+            target_shapes.push(shape);
+        }
+        if target_shapes.is_empty() {
+            return None;
+        }
+
+        let nested_node = self.ctx.arena.get(nested_literal_idx)?;
+        let nested_literal = self.ctx.arena.get_literal_expr(nested_node)?;
+        for &elem_idx in &nested_literal.elements.nodes {
+            let elem_node = self.ctx.arena.get(elem_idx)?;
+            let prop_name = match elem_node.kind {
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                    self.get_property_name(prop.name)
+                }
+                syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_shorthand_property(elem_node)?;
+                    self.get_property_name(prop.name)
+                }
+                _ => None,
+            };
+            let Some(prop_name) = prop_name.map(|name| self.ctx.types.intern_string(&name)) else {
+                continue;
+            };
+            let accepted_by_target = target_shapes.iter().any(|shape| {
+                shape
+                    .properties
+                    .iter()
+                    .any(|target_prop| target_prop.name == prop_name)
+                    || shape.string_index.is_some()
+                    || (shape.number_index.is_some()
+                        && tsz_solver::utils::is_numeric_literal_name(
+                            &self.ctx.types.resolve_atom(prop_name),
+                        ))
+            });
+            if !accepted_by_target {
+                return Some(prop_name);
+            }
+        }
+
+        None
+    }
+
+    fn object_literal_property_name_and_value(
+        &self,
+        obj_literal_idx: NodeIndex,
+        prop_name: Atom,
+    ) -> Option<(NodeIndex, NodeIndex)> {
+        let obj_node = self.ctx.arena.get(obj_literal_idx)?;
+        let obj_lit = self.ctx.arena.get_literal_expr(obj_node)?;
+
+        for &elem_idx in obj_lit.elements.nodes.iter().rev() {
+            let elem_node = self.ctx.arena.get(elem_idx)?;
+            match elem_node.kind {
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                    let elem_prop_name = self
+                        .get_property_name(prop.name)
+                        .map(|name| self.ctx.types.intern_string(&name));
+                    if elem_prop_name == Some(prop_name) {
+                        return Some((prop.name, prop.initializer));
+                    }
+                }
+                syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_shorthand_property(elem_node)?;
+                    let elem_prop_name = self
+                        .get_property_name(prop.name)
+                        .map(|name| self.ctx.types.intern_string(&name));
+                    if elem_prop_name == Some(prop_name) {
+                        return Some((prop.name, prop.name));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
     }
 
     fn object_literal_direct_unit_discriminants(

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -231,6 +231,7 @@ impl<'a> CheckerState<'a> {
         // Handle union targets first using type_queries
         if let Some(members) = query::union_members(self.ctx.types, resolved_target) {
             let mut target_shapes = Vec::new();
+            let mut any_member_has_string_index = false;
             let mut any_member_has_number_index = false;
             let mut has_unresolved_member = false;
 
@@ -256,15 +257,24 @@ impl<'a> CheckerState<'a> {
                     continue;
                 };
 
-                // String index signatures accept ANY string-keyed property,
-                // so all excess property checking can be skipped.
-                if shape.string_index.is_some() {
-                    return;
+                if let Some(string_index) = &shape.string_index {
+                    any_member_has_string_index = true;
+                    if Self::index_value_type_is_deferred(self.ctx.types, string_index.value_type)
+                        || crate::query_boundaries::common::contains_type_parameters(
+                            self.ctx.types,
+                            resolved_target,
+                        )
+                    {
+                        return;
+                    }
                 }
 
                 // Empty types (like `{}`) accept any non-primitive,
                 // so skip excess property checking entirely.
-                if shape.properties.is_empty() && shape.number_index.is_none() {
+                if shape.properties.is_empty()
+                    && shape.string_index.is_none()
+                    && shape.number_index.is_none()
+                {
                     return;
                 }
 
@@ -287,6 +297,22 @@ impl<'a> CheckerState<'a> {
             }
 
             if target_shapes.is_empty() {
+                return;
+            }
+
+            if self.try_union_index_signature_value_check(
+                source_props,
+                idx,
+                &target_shapes,
+                explicit_property_names.as_ref(),
+            ) {
+                return;
+            }
+
+            // String index signatures accept arbitrary string-keyed property
+            // names, so fallback TS2353 excess-property checking can be skipped
+            // once index-signature value compatibility has had a chance to run.
+            if any_member_has_string_index {
                 return;
             }
 
@@ -624,6 +650,15 @@ impl<'a> CheckerState<'a> {
             // properties. E.g., for target `{ [k: string]: { a: 0 } & { b: 0 } }`,
             // a nested `{ a: 0, b: 0, c: 0 }` should flag `c` as excess.
             if let Some(ref idx_sig) = target_shape.string_index {
+                if self.try_union_index_signature_value_check(
+                    source_props,
+                    idx,
+                    std::slice::from_ref(&target_shape),
+                    explicit_property_names.as_ref(),
+                ) {
+                    return;
+                }
+
                 let idx_value_type = idx_sig.value_type;
                 for source_prop in source_props {
                     if explicit_property_names.is_some()
@@ -959,6 +994,99 @@ impl<'a> CheckerState<'a> {
         }
 
         None
+    }
+
+    fn try_union_index_signature_value_check(
+        &mut self,
+        source_props: &[tsz_solver::PropertyInfo],
+        obj_literal_idx: NodeIndex,
+        union_shapes: &[std::sync::Arc<tsz_solver::ObjectShape>],
+        explicit_property_names: Option<&HashSet<Atom>>,
+    ) -> bool {
+        let diag_count_before = self.ctx.diagnostics.len();
+
+        for source_prop in source_props {
+            if explicit_property_names.is_some()
+                && !explicit_property_names
+                    .as_ref()
+                    .is_some_and(|names| names.contains(&source_prop.name))
+            {
+                continue;
+            }
+
+            // Named properties have their own union-member compatibility paths.
+            // Keep this check scoped to properties whose only plausible union
+            // acceptance is through an index signature.
+            if union_shapes.iter().any(|shape| {
+                shape
+                    .properties
+                    .iter()
+                    .any(|target_prop| target_prop.name == source_prop.name)
+            }) {
+                continue;
+            }
+
+            let prop_name = self.ctx.types.resolve_atom(source_prop.name);
+            let is_numeric_name = tsz_solver::utils::is_numeric_literal_name(&prop_name);
+            let mut applicable_index_value_types = Vec::new();
+            let mut accepted_by_index = false;
+            let mut has_deferred_index_value_type = false;
+
+            for shape in union_shapes {
+                if let Some(string_index) = &shape.string_index {
+                    if Self::index_value_type_is_deferred(self.ctx.types, string_index.value_type) {
+                        has_deferred_index_value_type = true;
+                        continue;
+                    }
+                    applicable_index_value_types.push(string_index.value_type);
+                    if self.is_assignable_to(source_prop.type_id, string_index.value_type) {
+                        accepted_by_index = true;
+                        break;
+                    }
+                }
+
+                if is_numeric_name && let Some(number_index) = &shape.number_index {
+                    if Self::index_value_type_is_deferred(self.ctx.types, number_index.value_type) {
+                        has_deferred_index_value_type = true;
+                        continue;
+                    }
+                    applicable_index_value_types.push(number_index.value_type);
+                    if self.is_assignable_to(source_prop.type_id, number_index.value_type) {
+                        accepted_by_index = true;
+                        break;
+                    }
+                }
+            }
+
+            if accepted_by_index
+                || applicable_index_value_types.is_empty()
+                || has_deferred_index_value_type
+            {
+                continue;
+            }
+
+            let target_value_type =
+                tsz_solver::utils::union_or_single(self.ctx.types, applicable_index_value_types);
+            if self.is_assignable_to(source_prop.type_id, target_value_type) {
+                continue;
+            }
+
+            let report_idx = self
+                .find_object_literal_property_element(obj_literal_idx, source_prop.name)
+                .unwrap_or(obj_literal_idx);
+            self.error_type_not_assignable_at_with_anchor(
+                source_prop.type_id,
+                target_value_type,
+                report_idx,
+            );
+        }
+
+        self.ctx.diagnostics.len() > diag_count_before
+    }
+
+    fn index_value_type_is_deferred(types: &dyn tsz_solver::TypeDatabase, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::is_index_access_type(types, type_id)
+            || crate::query_boundaries::common::contains_type_parameters(types, type_id)
     }
 
     fn object_literal_direct_unit_discriminants(

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -331,18 +331,47 @@ impl<'a> CheckerState<'a> {
                 else {
                     continue;
                 };
-                // Check if the augmentation target re-exports from source
-                let reexports_from_source =
-                    aug_target_binder
-                        .wildcard_reexports
-                        .values()
-                        .any(|sources| {
-                            sources.iter().any(|src| {
-                                self.ctx
-                                    .resolve_import_target_from_file(aug_target_idx, src)
-                                    == Some(source_idx)
+                let Some(aug_target_file_name) = self
+                    .ctx
+                    .get_arena_for_file(aug_target_idx as u32)
+                    .source_files
+                    .first()
+                    .map(|source_file| source_file.file_name.as_str())
+                else {
+                    continue;
+                };
+                // Check if the augmentation target re-exports from source. Use
+                // context accessors because the real driver stores program-wide
+                // re-export maps on ProjectEnv instead of cloning them into each
+                // per-file binder.
+                let wildcard_reexports_from_source = self
+                    .ctx
+                    .wildcard_reexports_for_file(aug_target_binder, aug_target_file_name)
+                    .is_some_and(|sources| {
+                        sources.iter().any(|src| {
+                            self.ctx
+                                .resolve_import_target_from_file(aug_target_idx, src)
+                                == Some(source_idx)
+                        })
+                    });
+                let named_reexports_from_source = self
+                    .ctx
+                    .reexports_for_file(aug_target_binder, aug_target_file_name)
+                    .is_some_and(|reexports| {
+                        reexports
+                            .iter()
+                            .any(|(exported_name, (source_module, original_name))| {
+                                let reexported_name =
+                                    original_name.as_deref().unwrap_or(exported_name);
+                                reexported_name == interface_name
+                                    && self.ctx.resolve_import_target_from_file(
+                                        aug_target_idx,
+                                        source_module,
+                                    ) == Some(source_idx)
                             })
-                        });
+                    });
+                let reexports_from_source =
+                    wildcard_reexports_from_source || named_reexports_from_source;
                 if reexports_from_source {
                     for (file_idx, aug) in indexed_augs.iter() {
                         if aug.name != interface_name {

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -516,6 +516,68 @@ function f<T extends { [key: string]: number }>(c: T, k: keyof T) {
 }
 
 #[test]
+fn test_ts2339_preserves_merge_alias_receiver_for_instantiation_chain() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = Omit<base, keyof props & keyof base> & props;
+declare const merge: <l, r>(l: l, r: r) => merge<l, r>;
+
+const o1 = merge({ p1: 1 }, { p2: 2 });
+const o2 = merge(o1, { p3: 3 });
+o2.p4;
+"#,
+    );
+
+    let ts2339 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2339)
+        .expect("expected TS2339 for missing p4");
+    assert!(
+        ts2339.1.contains("merge<merge<"),
+        "Expected TS2339 receiver to preserve merge alias chain.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !ts2339.1.contains("Omit<"),
+        "Expected TS2339 receiver to avoid the expanded Omit surface.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_ts2339_keeps_conditional_merge_receiver_branch_display() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = keyof base & keyof props extends never
+    ? base & props
+    : Omit<base, keyof props & keyof base> & props;
+declare const merge: <l, r>(l: l, r: r) => merge<l, r>;
+
+const o1 = merge({ p1: 1 }, { p2: 2 });
+const o2 = merge(o1, { p2: 2, p3: 3 });
+o2.p4;
+"#,
+    );
+
+    let ts2339 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2339)
+        .expect("expected TS2339 for missing p4");
+    assert!(
+        ts2339.1.contains("Omit<"),
+        "Expected TS2339 receiver to preserve the conditional Omit branch.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !ts2339.1.contains("merge<"),
+        "Expected TS2339 receiver not to repaint a resolved conditional branch as merge.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_object_literal_source_display_preserves_quoted_numeric_property_names() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -647,6 +647,55 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
 }
 
 #[test]
+fn test_ts2339_elides_long_merge_receiver_method_chain_shape_access() {
+    let mut source = String::from(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = Omit<base, keyof props & keyof base> & props;
+type Type<t> = {
+    shape: t;
+    merge: <r>(r: r) => Type<merge<t, r>>;
+};
+
+declare const o1: Type<{ p1: 1 }>;
+"#,
+    );
+    for i in 2..=30 {
+        source.push_str(&format!(
+            "const o{i} = o{}.merge({{ p{}: {} }});\n",
+            i - 1,
+            i,
+            i
+        ));
+    }
+    source.push_str("o30.shape.p31;\no30.shape.p38;\no30.shape.p50;\n");
+
+    let diagnostics = compile_and_get_diagnostics(&source);
+    assert!(
+        diagnostics.iter().filter(|(code, _)| *code == 2339).count() == 3,
+        "Expected TS2339 for missing long-chain shape properties.\nActual diagnostics: {diagnostics:#?}"
+    );
+    for (_, message) in diagnostics.iter().filter(|(code, _)| *code == 2339) {
+        assert!(
+            message.contains("{ p1: 1; }")
+                && message.contains("{ p2: number; }")
+                && message.contains("{ p5: number; }"),
+            "Expected TS2339 receiver to preserve the stable method-chain prefix.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ...; }") && message.contains("{ ....."),
+            "Expected TS2339 receiver to elide and truncate the middle method-chain arguments.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("{ p30: number; }") && !message.contains("<...,"),
+            "Expected TS2339 receiver not to keep the shallow suffix or raw ellipsis.\nActual message: {message}"
+        );
+    }
+}
+
+#[test]
 fn test_object_literal_source_display_preserves_quoted_numeric_property_names() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -578,6 +578,49 @@ o2.p4;
 }
 
 #[test]
+fn test_ts2339_elides_long_merge_receiver_instantiation_chain() {
+    let mut source = String::from(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = Omit<base, keyof props & keyof base> & props;
+declare const merge: <l, r>(l: l, r: r) => merge<l, r>;
+
+const o1 = merge({ p1: 1 }, { p2: 2 });
+"#,
+    );
+    for i in 2..=30 {
+        source.push_str(&format!(
+            "const o{i} = merge(o{}, {{ p{}: {} }});\n",
+            i - 1,
+            i + 1,
+            i + 1
+        ));
+    }
+    source.push_str("o30.p38;\n");
+
+    let diagnostics = compile_and_get_diagnostics(&source);
+    let ts2339 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2339)
+        .expect("expected TS2339 for missing p38");
+    assert!(
+        ts2339.1.contains("merge<merge<merge<"),
+        "Expected TS2339 receiver to preserve the merge application chain.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        ts2339.1.contains("{ ...; }"),
+        "Expected TS2339 receiver to elide deep object branches.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        ts2339.1.len() < 420,
+        "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual diagnostics: {diagnostics:#?}",
+        ts2339.1.len()
+    );
+}
+
+#[test]
 fn test_object_literal_source_display_preserves_quoted_numeric_property_names() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -604,26 +604,32 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
             i + 1
         ));
     }
-    source.push_str("o30.p38;\n");
+    source.push_str("o30.p38;\no30.p51;\n");
 
     let diagnostics = compile_and_get_diagnostics(&source);
-    let ts2339 = diagnostics
-        .iter()
-        .find(|(code, _)| *code == 2339)
-        .expect("expected TS2339 for missing p38");
     assert!(
-        ts2339.1.contains("merge<merge<merge<"),
-        "Expected TS2339 receiver to preserve the merge application chain.\nActual diagnostics: {diagnostics:#?}"
+        diagnostics.iter().filter(|(code, _)| *code == 2339).count() == 2,
+        "Expected TS2339 for both missing long-chain properties.\nActual diagnostics: {diagnostics:#?}"
     );
-    assert!(
-        ts2339.1.contains("{ ...; }"),
-        "Expected TS2339 receiver to elide deep object branches.\nActual diagnostics: {diagnostics:#?}"
-    );
-    assert!(
-        ts2339.1.len() < 420,
-        "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual diagnostics: {diagnostics:#?}",
-        ts2339.1.len()
-    );
+    for (_, message) in diagnostics.iter().filter(|(code, _)| *code == 2339) {
+        assert!(
+            message.matches("merge<").count() >= 25,
+            "Expected TS2339 receiver to preserve the long merge application chain.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ...; }"),
+            "Expected TS2339 receiver to elide deep object branches.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("<...,"),
+            "Expected TS2339 receiver not to collapse the older chain to a raw ellipsis.\nActual message: {message}"
+        );
+        assert!(
+            message.len() < 1400,
+            "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual message: {message}",
+            message.len()
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -617,15 +617,29 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
             "Expected TS2339 receiver to preserve the long merge application chain.\nActual message: {message}"
         );
         assert!(
+            message.contains("{ p1: number; }")
+                && message.contains("{ p2: number; }")
+                && message.contains("{ p5: number; }"),
+            "Expected TS2339 receiver to preserve the stable merge chain prefix.\nActual message: {message}"
+        );
+        assert!(
             message.contains("{ ...; }"),
-            "Expected TS2339 receiver to elide deep object branches.\nActual message: {message}"
+            "Expected TS2339 receiver to elide the middle merge object arguments.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("{ p31: number; }"),
+            "Expected TS2339 receiver to truncate before the shallow suffix.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ....."),
+            "Expected TS2339 receiver truncation to match tsc's merge-chain suffix.\nActual message: {message}"
         );
         assert!(
             !message.contains("<...,"),
             "Expected TS2339 receiver not to collapse the older chain to a raw ellipsis.\nActual message: {message}"
         );
         assert!(
-            message.len() < 1400,
+            message.len() < 390,
             "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual message: {message}",
             message.len()
         );

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -543,6 +543,12 @@ o2.p4;
         !ts2339.1.contains("Omit<"),
         "Expected TS2339 receiver to avoid the expanded Omit surface.\nActual diagnostics: {diagnostics:#?}"
     );
+    assert!(
+        ts2339
+            .1
+            .contains("merge<merge<{ p1: number; }, { p2: number; }>, { p3: number; }>"),
+        "Expected TS2339 receiver to widen inferred merge literal arguments.\nActual diagnostics: {diagnostics:#?}"
+    );
 }
 
 #[test]

--- a/crates/tsz-checker/tests/conformance_issues/modules/context.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/context.rs
@@ -1,6 +1,69 @@
 use crate::core::*;
 
 #[test]
+fn module_augmentation_of_reexported_interface_applies_to_original_import() {
+    for index_source in [
+        r#"export * from "./eventList";"#,
+        r#"export { EventList } from "./eventList";"#,
+    ] {
+        let diagnostics = compile_named_files_get_diagnostics_with_options(
+            &[
+                ("index.ts", index_source),
+                (
+                    "test.ts",
+                    r#"
+import { EventList } from "./eventList";
+
+declare const p012: "p0" | "p1" | "p2";
+const t: keyof EventList = p012;
+"#,
+                ),
+                (
+                    "eventList.ts",
+                    r#"
+export interface EventList {
+    p0: [];
+}
+"#,
+                ),
+                (
+                    "foo.ts",
+                    r#"
+declare module "./index" {
+    interface EventList {
+        p1: [];
+    }
+}
+export {};
+"#,
+                ),
+                (
+                    "bar.ts",
+                    r#"
+declare module "./index" {
+    interface EventList {
+        p2: [];
+    }
+}
+export {};
+"#,
+                ),
+            ],
+            "test.ts",
+            CheckerOptions {
+                target: ScriptTarget::ES2015,
+                ..CheckerOptions::default()
+            },
+        );
+
+        assert!(
+            !diagnostics.iter().any(|(code, _)| *code == 2322),
+            "Expected keyof EventList to include module augmentations from re-exporting module {index_source:?}. Got: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn test_js_constructor_branch_property_visible_cross_file() {
     let diagnostics = compile_named_files_get_diagnostics_with_options(
         &[

--- a/crates/tsz-checker/tests/namespace_qualified_diagnostic_tests.rs
+++ b/crates/tsz-checker/tests/namespace_qualified_diagnostic_tests.rs
@@ -97,3 +97,85 @@ var w: M.A = new Other();
         "target should not be qualified when there is no collision; got: {msg:?}"
     );
 }
+
+#[test]
+fn ts2559_assignment_qualifies_weak_type_pair_when_names_collide() {
+    let source = r#"
+namespace M { export interface A { m?: string; } }
+namespace N { export interface A { n?: number; } }
+const sourceValue: N.A = {};
+const targetValue: M.A = sourceValue;
+"#;
+    let diags = get_diagnostics(source);
+
+    let ts2559: Vec<_> = diags.iter().filter(|(c, _)| *c == 2559).collect();
+    assert_eq!(
+        ts2559.len(),
+        1,
+        "expected exactly one TS2559 diagnostic; got: {diags:?}"
+    );
+    let msg = &ts2559[0].1;
+    assert!(
+        msg.contains("'N.A'") && msg.contains("'M.A'"),
+        "TS2559 assignment should qualify both weak types, got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Type 'A' has no properties in common with type 'A'."),
+        "TS2559 assignment should not collapse both sides to the same short name, got: {msg:?}"
+    );
+}
+
+#[test]
+fn ts2559_call_argument_qualifies_weak_type_pair_when_names_collide() {
+    let source = r#"
+namespace M { export interface A { m?: string; } }
+namespace N { export interface A { n?: number; } }
+declare function take(value: M.A): void;
+const sourceValue: N.A = {};
+take(sourceValue);
+"#;
+    let diags = get_diagnostics(source);
+
+    let ts2559: Vec<_> = diags.iter().filter(|(c, _)| *c == 2559).collect();
+    assert_eq!(
+        ts2559.len(),
+        1,
+        "expected exactly one TS2559 diagnostic; got: {diags:?}"
+    );
+    let msg = &ts2559[0].1;
+    assert!(
+        msg.contains("'N.A'") && msg.contains("'M.A'"),
+        "TS2559 call argument should qualify both weak types, got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Type 'A' has no properties in common with type 'A'."),
+        "TS2559 call argument should not collapse both sides to the same short name, got: {msg:?}"
+    );
+}
+
+#[test]
+fn ts2559_generic_constraint_qualifies_weak_type_pair_when_names_collide() {
+    let source = r#"
+namespace M { export interface A { m?: string; } }
+namespace N { export interface A { n?: number; } }
+type Box<T extends M.A> = T;
+type Bad = Box<N.A>;
+"#;
+    let diags = get_diagnostics(source);
+
+    let ts2559: Vec<_> = diags.iter().filter(|(c, _)| *c == 2559).collect();
+    assert_eq!(
+        ts2559.len(),
+        1,
+        "expected exactly one TS2559 diagnostic; got: {diags:?}"
+    );
+    let msg = &ts2559[0].1;
+    assert!(
+        msg.contains("'N.A'") && msg.contains("'M.A'"),
+        "TS2559 generic constraint should qualify both weak types, got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Type 'A' has no properties in common with type 'A'."),
+        "TS2559 generic constraint should not collapse both sides to the same short name, got: {msg:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3756,6 +3756,43 @@ const abac: AB = {
     );
 }
 
+#[test]
+fn object_freeze_preserves_literal_property_values_for_readonly_return() {
+    let source = r#"
+const PUPPETEER_REVISIONS = Object.freeze({
+    chromium: '1011831',
+    firefox: 'latest',
+});
+
+let preferredRevision = PUPPETEER_REVISIONS.chromium;
+preferredRevision = PUPPETEER_REVISIONS.firefox;
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected one TS2322 for Object.freeze literal property mismatch. Got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322[0]
+            .message_text
+            .contains("Type '\"latest\"' is not assignable to type '\"1011831\"'."),
+        "Expected literal property values to be preserved through Object.freeze. Got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2322[0].start,
+        source
+            .find("preferredRevision = PUPPETEER_REVISIONS.firefox")
+            .expect("assignment should exist") as u32,
+        "Expected TS2322 to anchor at the assignment expression. Got: {diagnostics:?}"
+    );
+}
+
 /// Regression: assignFromStringInterface2.ts
 /// When both source and target have number index signatures but the source is
 /// missing named properties from the target, TS2739/TS2740 should be emitted

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3692,6 +3692,70 @@ const obj2: { [x: string]: number } | { a: number } = { a: 5, c: 'abc' };
     );
 }
 
+#[test]
+fn test_nested_discriminated_union_property_mismatch_emits_ts2322() {
+    let source = r#"
+type AN = { a: string } | { c: string }
+type BN = { b: string }
+type AB = { kind: "A", n: AN } | { kind: "B", n: BN }
+
+const abab: AB = {
+    kind: "A",
+    n: {
+        a: "a",
+        b: "b",
+    }
+}
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected one nested union TS2322 mismatch. Got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322.iter().any(|diagnostic| {
+            diagnostic.message_text.contains(
+            "Type '{ kind: \"A\"; n: { a: string; b: string; }; }' is not assignable to type 'AB'."
+        )
+        }),
+        "Expected outer AB assignability message. Got: {diagnostics:?}"
+    );
+    let expected_start = source.find("b: \"b\"").expect("expected b property") as u32;
+    assert_eq!(
+        ts2322[0].start, expected_start,
+        "Expected TS2322 to anchor at the rejected nested property. Got: {diagnostics:?}"
+    );
+
+    let ok_source = r#"
+type AN = { a: string } | { c: string }
+type BN = { b: string }
+type AB = { kind: "A", n: AN } | { kind: "B", n: BN }
+
+const abac: AB = {
+    kind: "A",
+    n: {
+        a: "a",
+        c: "c",
+    }
+}
+"#;
+
+    let ok_diagnostics = get_all_diagnostics(ok_source);
+    assert!(
+        !ok_diagnostics.iter().any(|(code, _)| matches!(
+            *code,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE | 2353
+        )),
+        "Expected valid nested union object to stay accepted. Got: {ok_diagnostics:?}"
+    );
+}
+
 /// Regression: assignFromStringInterface2.ts
 /// When both source and target have number index signatures but the source is
 /// missing named properties from the target, TS2739/TS2740 should be emitted

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3639,6 +3639,59 @@ fn test_index_signature_target_missing_prop_emits_ts2322_not_ts2741() {
     );
 }
 
+#[test]
+fn test_union_index_signature_object_literal_value_mismatches_emit_ts2322() {
+    let source = r#"
+interface IValue {
+  value: string
+}
+
+interface StringKeys {
+    [propertyName: string]: IValue;
+};
+
+interface NumberKeys {
+    [propertyName: number]: IValue;
+}
+
+type ObjectDataSpecification = StringKeys | NumberKeys;
+
+const dataSpecification: ObjectDataSpecification = {
+    foo: "asdfsadffsd"
+};
+
+const obj1: { [x: string]: number } | { [x: number]: number } = { a: 'abc' };
+const obj2: { [x: string]: number } | { a: number } = { a: 5, c: 'abc' };
+"#;
+
+    let diagnostics = get_all_diagnostics(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        3,
+        "Expected three TS2322 index-signature value mismatches. Got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|(_, message)| message
+                .contains("Type 'string' is not assignable to type 'IValue'.")),
+        "Expected string-to-IValue mismatch. Got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2322
+            .iter()
+            .filter(|(_, message)| message
+                .contains("Type 'string' is not assignable to type 'number'."))
+            .count(),
+        2,
+        "Expected two string-to-number mismatches. Got: {diagnostics:?}"
+    );
+}
+
 /// Regression: assignFromStringInterface2.ts
 /// When both source and target have number index signatures but the source is
 /// missing named properties from the target, TS2739/TS2740 should be emitted
@@ -3803,11 +3856,10 @@ newTextChannel2.phoneNumber = '613-555-1234';
         "Expected one outer TS2322 for the return object. Got: {diagnostics:?}"
     );
     assert!(
-        ts2322.iter().any(|(_, message)| {
-            message.contains(
-                "Type '{ type: T; localChannelId: string; }' is not assignable to type 'NewChannel<ChannelOfType<T, TextChannel> | ChannelOfType<T, EmailChannel>>'"
-            )
-        }),
+        ts2322.iter().any(|(_, message)| message.contains(
+            "Type '{ type: T; localChannelId: string; }' is not assignable to type 'NewChannel<"
+        ) && message.contains("ChannelOfType<T, TextChannel>")
+            && message.contains("ChannelOfType<T, EmailChannel>")),
         "Expected TS2322 to stay on the outer object literal. Got: {diagnostics:?}"
     );
     assert!(

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -2506,6 +2506,33 @@ fn test_ts2345_function_return_mismatch_includes_related_return_detail() {
 }
 
 #[test]
+fn test_ts2345_function_return_mismatch_related_detail_qualifies_same_named_returns() {
+    let source = r#"
+        declare namespace N { export interface Token { kind: "n"; } }
+        declare namespace M { export interface Token { kind: "m"; } }
+        declare function takes(cb: () => M.Token): void;
+        declare const cb: () => N.Token;
+        takes(cb);
+    "#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2345 = diagnostics
+        .iter()
+        .find(|diag| {
+            diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .expect("expected TS2345 for function return type mismatch");
+
+    assert!(
+        ts2345.related_information.iter().any(|info| {
+            info.message_text
+                .contains("Return type 'N.Token' is not assignable to 'M.Token'.")
+        }),
+        "Expected TS2345 related return detail to qualify same-named return types, got: {ts2345:?}"
+    );
+}
+
+#[test]
 fn test_ts2345_index_signature_mismatch_includes_related_detail() {
     let source = r#"
         declare function takes(value: { [key: string]: number }): void;

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -2541,6 +2541,34 @@ fn test_ts2345_index_signature_mismatch_includes_related_detail() {
 }
 
 #[test]
+fn test_ts2345_index_signature_mismatch_related_detail_qualifies_same_named_values() {
+    let source = r#"
+        declare namespace N { export interface Token { kind: "n"; } }
+        declare namespace M { export interface Token { kind: "m"; } }
+        declare function takes(value: { [key: string]: M.Token }): void;
+        declare const arg: { [key: string]: N.Token };
+        takes(arg);
+    "#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2345 = diagnostics
+        .iter()
+        .find(|diag| {
+            diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .expect("expected TS2345 for index-signature mismatch");
+
+    assert!(
+        ts2345.related_information.iter().any(|info| {
+            info.message_text.contains(
+                "string index signature is incompatible: 'N.Token' is not assignable to 'M.Token'.",
+            )
+        }),
+        "Expected TS2345 related info to qualify same-named index value types, got: {ts2345:?}"
+    );
+}
+
+#[test]
 fn test_ts2345_missing_index_signature_includes_related_detail() {
     let source = r#"
         declare function takes(value: { [index: number]: number }): void;
@@ -2599,6 +2627,33 @@ fn test_ts2345_array_element_mismatch_includes_related_detail() {
                     .contains("Type 'string' is not assignable to type 'number'.")
         }),
         "Expected TS2345 to include nested type mismatch under array-element elaboration, got: {ts2345:?}"
+    );
+}
+
+#[test]
+fn test_ts2345_array_element_mismatch_related_detail_qualifies_same_named_elements() {
+    let source = r#"
+        declare namespace N { export interface Token { kind: "n"; } }
+        declare namespace M { export interface Token { kind: "m"; } }
+        declare function takes(value: M.Token[]): void;
+        declare const arg: N.Token[];
+        takes(arg);
+    "#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2345 = diagnostics
+        .iter()
+        .find(|diag| {
+            diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .expect("expected TS2345 for array-element mismatch");
+
+    assert!(
+        ts2345.related_information.iter().any(|info| {
+            info.message_text
+                .contains("Array element type 'N.Token' is not assignable to 'M.Token'.")
+        }),
+        "Expected TS2345 related info to qualify same-named element types, got: {ts2345:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -445,6 +445,53 @@ interface Child extends Parent {
 }
 
 #[test]
+fn test_generic_member_call_signature_with_extra_type_param_no_false_ts2430() {
+    // Contextual generic signature instantiation can relate a derived member with
+    // extra type params to a base member after erasing both signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member call signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_generic_member_construct_signature_with_extra_type_param_no_false_ts2430() {
+    // The same erased contextual comparison is needed for construct signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member construct signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_overloaded_generic_callable_property_incompatible_still_errors() {
     // The erasure path must NOT suppress genuine incompatibilities.
     // Here the return type is wrong (number[] vs string[]).

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2788,6 +2788,65 @@ mod tests {
         resolved
     }
 
+    fn collect_es2015_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(&file_path, source).expect("write source");
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics
+    }
+
     fn mapped_type_indexed_access_constraint_repro() -> &'static str {
         r#"type Identity<T> = { [K in keyof T]: T[K] };
 
@@ -4872,6 +4931,50 @@ function foo() {
         assert_eq!(
             ts2430_count, 1,
             "Expected one TS2430 diagnostic from lib.dom.d.ts after merging Node.kind, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_ignores_unresolved_overload_cascades_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    type: string;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics from unrelated unresolved overload parameters, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_normalizes_cross_arena_method_members_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    clientWidth: number;
+    isDisabled: boolean;
+}
+
+declare var document: Document;
+interface Document {
+    getElementById(elementId: string): HTMLElement;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics when a cross-arena method override is compatible, got: {diagnostics:?}"
         );
     }
 

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -156,6 +156,12 @@ pub trait TypeDatabase {
     /// its original Application TypeId for diagnostic display.
     fn store_display_alias(&self, _evaluated: TypeId, _application: TypeId) {}
 
+    /// Store an Application display alias even when structural provenance was
+    /// recorded earlier for the same evaluated type.
+    fn store_display_alias_preferring_application(&self, evaluated: TypeId, application: TypeId) {
+        self.store_display_alias(evaluated, application);
+    }
+
     /// Look up the original Application TypeId for a type produced by
     /// evaluating an Application. Returns `None` if no mapping exists.
     fn get_display_alias(&self, _type_id: TypeId) -> Option<TypeId> {
@@ -533,6 +539,10 @@ impl TypeDatabase for TypeInterner {
 
     fn store_display_alias(&self, evaluated: TypeId, application: TypeId) {
         Self::store_display_alias(self, evaluated, application);
+    }
+
+    fn store_display_alias_preferring_application(&self, evaluated: TypeId, application: TypeId) {
+        Self::store_display_alias_preferring_application(self, evaluated, application);
     }
 
     fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -978,6 +978,11 @@ impl TypeDatabase for QueryCache<'_> {
         self.interner.store_display_alias(evaluated, application);
     }
 
+    fn store_display_alias_preferring_application(&self, evaluated: TypeId, application: TypeId) {
+        self.interner
+            .store_display_alias_preferring_application(evaluated, application);
+    }
+
     fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {
         self.interner.get_display_alias(type_id)
     }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -407,7 +407,7 @@ impl<'a> TypeFormatter<'a> {
         }
         let type_key = self.interner.lookup(type_id);
         if self.long_property_receiver_display
-            && (8..=55).contains(&self.current_depth)
+            && (8..=26).contains(&self.current_depth)
             && matches!(
                 type_key,
                 Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -106,6 +106,7 @@ pub struct TypeFormatter<'a> {
     /// When true, preserve a longer generic alias prefix while eliding nested
     /// structural object branches. Used for long property receiver diagnostics.
     long_property_receiver_display: bool,
+    long_property_receiver_object_elision_end_depth: u32,
 }
 
 impl<'a> TypeFormatter<'a> {
@@ -131,6 +132,7 @@ impl<'a> TypeFormatter<'a> {
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -209,6 +211,7 @@ impl<'a> TypeFormatter<'a> {
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -267,6 +270,14 @@ impl<'a> TypeFormatter<'a> {
     pub const fn with_long_property_receiver_display(mut self) -> Self {
         self.max_depth = 64;
         self.long_property_receiver_display = true;
+        self
+    }
+
+    pub const fn with_long_property_receiver_object_elision_end_depth(
+        mut self,
+        end_depth: u32,
+    ) -> Self {
+        self.long_property_receiver_object_elision_end_depth = end_depth;
         self
     }
 
@@ -407,7 +418,8 @@ impl<'a> TypeFormatter<'a> {
         }
         let type_key = self.interner.lookup(type_id);
         if self.long_property_receiver_display
-            && (8..=26).contains(&self.current_depth)
+            && (8..=self.long_property_receiver_object_elision_end_depth)
+                .contains(&self.current_depth)
             && matches!(
                 type_key,
                 Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -608,6 +608,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Try to get the type parameters for this DefId
             let type_params = self.resolver.get_lazy_type_params(def_id);
             let resolved = self.resolver.resolve_lazy(def_id, self.interner);
+            let prefer_application_display_alias = matches!(
+                self.resolver.get_def_kind(def_id),
+                Some(crate::def::DefKind::TypeAlias)
+            ) && resolved.is_some_and(|body| {
+                !matches!(self.interner.lookup(body), Some(TypeData::Conditional(_)))
+            });
 
             tracing::trace!(
                 ?def_id,
@@ -922,7 +928,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         )
                     )
                 {
-                    self.interner.store_display_alias(result, original_type_id);
+                    if prefer_application_display_alias {
+                        self.interner
+                            .store_display_alias_preferring_application(result, original_type_id);
+                    } else {
+                        self.interner.store_display_alias(result, original_type_id);
+                    }
 
                     // If the conditional branch resolved to an intermediate Application
                     // (e.g., `DeepReadonly<Part>` -> conditional -> `DeepReadonlyObject<Part>`),

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1279,6 +1279,46 @@ impl TypeInterner {
         self.display_alias.insert(evaluated, application);
     }
 
+    /// Prefer a concrete Application display alias over structural provenance
+    /// recorded while evaluating the alias body.
+    pub fn store_display_alias_preferring_application(
+        &self,
+        evaluated: TypeId,
+        application: TypeId,
+    ) {
+        self.store_display_alias(evaluated, application);
+        if self.get_display_alias(evaluated) == Some(application) {
+            return;
+        }
+        if evaluated == application || evaluated.is_intrinsic() {
+            return;
+        }
+        let Some(TypeData::Application(app_id)) = self.lookup(application) else {
+            return;
+        };
+        let app = self.type_application(app_id);
+        if app.args.contains(&evaluated) {
+            return;
+        }
+        let application_has_generic_args = app
+            .args
+            .iter()
+            .any(|&arg| crate::type_queries::contains_generic_type_parameters_db(self, arg));
+        let evaluated_precedes_application = match (
+            self.lookup_alloc_order(evaluated),
+            self.lookup_alloc_order(application),
+        ) {
+            (Some(evaluated_order), Some(application_order)) => {
+                evaluated_order <= application_order
+            }
+            _ => evaluated.0 <= application.0,
+        };
+        if application_has_generic_args && evaluated_precedes_application {
+            return;
+        }
+        self.display_alias.insert(evaluated, application);
+    }
+
     /// Look up the original Application TypeId for a type that was produced
     /// by evaluating an Application.
     ///

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn unique_placeholder_name(buf: &mut String) {
     write!(buf, "__infer_{id}").expect("write to String is infallible");
 }
 
-/// Check if a type constraint is a primitive type (string, number, boolean, bigint)
+/// Check if a type constraint is a primitive type (string, number, boolean, bigint, symbol)
 /// or a union containing a primitive. Used to preserve literal types during inference
 /// when the constraint implies literals should be kept (e.g., `T extends string`).
 fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: TypeId) -> bool {
@@ -33,6 +33,7 @@ fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: Ty
         || type_id == TypeId::NUMBER
         || type_id == TypeId::BOOLEAN
         || type_id == TypeId::BIGINT
+        || type_id == TypeId::SYMBOL
     {
         return true;
     }
@@ -53,6 +54,57 @@ fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: Ty
             members
                 .iter()
                 .any(|&m| constraint_is_primitive_type(interner, m))
+        }
+        _ => false,
+    }
+}
+
+/// Check whether a type constraint contains a type parameter whose own declared
+/// constraint preserves primitive literals.
+///
+/// This covers dependent generic constraints like Object.freeze's
+/// `T extends { [idx: string]: U | null | undefined | object }, U extends string | ...`.
+/// `T`'s constraint is object-shaped, but its index value is governed by primitive-
+/// constrained `U`, so fresh literal property values must not be widened away.
+fn constraint_contains_primitive_constrained_type_param(
+    interner: &dyn crate::QueryDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 4 {
+        return false;
+    }
+
+    match interner.lookup(type_id) {
+        Some(TypeData::TypeParameter(info)) => info
+            .constraint
+            .is_some_and(|constraint| constraint_is_primitive_type(interner, constraint)),
+        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => {
+            interner.type_list(list_id).iter().any(|&member| {
+                constraint_contains_primitive_constrained_type_param(interner, member, depth + 1)
+            })
+        }
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = interner.object_shape(shape_id);
+            shape.properties.iter().any(|prop| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    prop.type_id,
+                    depth + 1,
+                )
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    index.value_type,
+                    depth + 1,
+                )
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    index.value_type,
+                    depth + 1,
+                )
+            })
         }
         _ => false,
     }

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -11,8 +11,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
 use super::{
-    constraint_is_primitive_type, instantiate_call_type, type_implies_literals_deep,
-    type_references_placeholder, unique_placeholder_name,
+    constraint_contains_primitive_constrained_type_param, constraint_is_primitive_type,
+    instantiate_call_type, type_implies_literals_deep, type_references_placeholder,
+    unique_placeholder_name,
 };
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
@@ -1593,30 +1594,40 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             .expect("inference substitution cache just initialized")
                     };
                     self.normalize_inferred_placeholder_type(ty, infer_subst)
-                } else if !tp.is_const
-                    && !contra_only
-                    && !tp
-                        .constraint
-                        .is_some_and(|c| constraint_is_primitive_type(self.interner, c))
-                {
-                    // Widen fresh inference results from expressions when the type
-                    // parameter does NOT have a primitive constraint (string, number,
-                    // bigint).
-                    // tsc preserves literal types when the constraint is a primitive:
-                    //   <T extends string>(a: T) => T  -- T="z" preserved
-                    //   <T>(a: T) => T                  -- T="z" widened to string
-                    if infer_ctx.all_candidates_are_fresh_literals(var) {
-                        crate::widen_literal_type(self.interner.as_type_database(), ty)
-                    } else if self.inference_type_contains_fresh_object_or_array(ty) {
-                        crate::operations::widening::widen_type_for_inference(
-                            self.interner.as_type_database(),
-                            ty,
-                        )
+                } else {
+                    let constraint_preserves_literals = tp.constraint.is_some_and(|constraint| {
+                        let instantiated_constraint = instantiate_call_type(
+                            self.interner,
+                            constraint,
+                            &substitution,
+                            actual_this_type,
+                        );
+                        constraint_is_primitive_type(self.interner, instantiated_constraint)
+                            || constraint_contains_primitive_constrained_type_param(
+                                self.interner,
+                                instantiated_constraint,
+                                0,
+                            )
+                    });
+                    if !tp.is_const && !contra_only && !constraint_preserves_literals {
+                        // Widen fresh inference results from expressions when the type
+                        // parameter does NOT have a primitive literal-preserving constraint.
+                        // tsc preserves literal types when the constraint is a primitive:
+                        //   <T extends string>(a: T) => T  -- T="z" preserved
+                        //   <T>(a: T) => T                  -- T="z" widened to string
+                        if infer_ctx.all_candidates_are_fresh_literals(var) {
+                            crate::widen_literal_type(self.interner.as_type_database(), ty)
+                        } else if self.inference_type_contains_fresh_object_or_array(ty) {
+                            crate::operations::widening::widen_type_for_inference(
+                                self.interner.as_type_database(),
+                                ty,
+                            )
+                        } else {
+                            ty
+                        }
                     } else {
                         ty
                     }
-                } else {
-                    ty
                 }
             } else if let Some(default) = tp.default {
                 let ty =

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -675,6 +675,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     /// - bit 5: `allow_void_return`
     /// - bit 6: `allow_bivariant_rest`
     /// - bit 7: `allow_bivariant_param_count`
+    /// - bit 13: `allow_erased_generic_signature_retry`
     ///
     /// This is used by `QueryCache::is_assignable_to_with_flags` to ensure
     /// cached results respect the compiler configuration.
@@ -702,6 +703,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.subtype.allow_void_return = (flags & (1 << 5)) != 0;
         self.subtype.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.subtype.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
+        self.subtype.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
     }
 
     ///

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -211,6 +211,13 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// fail for concrete types. Used for implements/extends member type checking
     /// where tsc's `compareSignaturesRelated` does NOT erase.
     pub erase_generics: bool,
+    /// When true, a failed contextual inference for two generic signatures with
+    /// different arity falls through to erased-signature comparison.
+    ///
+    /// This is intentionally opt-in: interface property compatibility needs the
+    /// retry, but ordinary assignments must keep the failed inference as a real
+    /// mismatch so invalid reverse generic assignments still report TS2322.
+    pub allow_erased_generic_signature_retry: bool,
     /// Type parameter equivalences established during generic function subtype checking.
     ///
     /// When alpha-renaming in `check_function_subtype` maps target type params to source
@@ -257,6 +264,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -297,6 +305,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -427,6 +436,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
         self.erase_generics = (flags & crate::RelationCacheKey::FLAG_NO_ERASE_GENERICS) == 0;
+        self.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
         self
     }
 

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -139,6 +139,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.erase_generics {
             flags |= RelationFlags::NO_ERASE_GENERICS;
         }
+        if self.allow_erased_generic_signature_retry {
+            flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+        }
         if self.assume_related_on_cycle {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -339,8 +339,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     &target_instantiated,
                     allow_constructor_bivariance,
                 );
-                self.type_param_equivalences.truncate(equiv_start);
-                return result;
+                if result.is_true() {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
+                if !self.allow_erased_generic_signature_retry {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
             }
 
             let source_canonical =

--- a/crates/tsz-solver/src/tests/visitor_tests.rs
+++ b/crates/tsz-solver/src/tests/visitor_tests.rs
@@ -381,6 +381,37 @@ fn test_contains_error_type() {
 
     let union_no_error = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
     assert!(!contains_error_type(&interner, union_no_error));
+
+    let name = interner.intern_string("x");
+    let function_with_error_param = interner.function(FunctionShape::new(
+        vec![ParamInfo::required(name, TypeId::ERROR)],
+        TypeId::VOID,
+    ));
+    assert!(contains_error_type(&interner, function_with_error_param));
+
+    let object_with_error_method = interner.object(vec![PropertyInfo {
+        name,
+        type_id: function_with_error_param,
+        write_type: function_with_error_param,
+        optional: false,
+        readonly: false,
+        is_method: true,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+    }]);
+    assert!(contains_error_type(&interner, object_with_error_method));
+
+    let callable_with_error_param = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::required(name, TypeId::ERROR)],
+            TypeId::VOID,
+        )],
+        ..CallableShape::default()
+    });
+    assert!(contains_error_type(&interner, callable_with_error_param));
 }
 
 #[test]

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -282,7 +282,7 @@ bitflags::bitflags! {
     /// Bits `0..=8` are preserved from the original packed `u16` layout so
     /// legacy callers (e.g. checker boundary helpers that import the
     /// `FLAG_*` constants) continue to interoperate byte-for-byte. Bits
-    /// `9..=12` are new and encode previously-missing Lawyer-layer options
+    /// `9..=13` are new and encode previously-missing Lawyer-layer options
     /// that were silently missing from the cache key.
     #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
     pub struct RelationFlags: u32 {
@@ -319,6 +319,11 @@ bitflags::bitflags! {
         /// Treat recursive relation cycles as assumed-related. When clear,
         /// cycles resolve to "not related".
         const ASSUME_RELATED_ON_CYCLE       = 1 << 12;
+        /// Retry a failed contextual generic-signature inference by comparing
+        /// erased signatures. This is a targeted relation mode for interface
+        /// property compatibility; ordinary assignment keeps inference failure
+        /// definitive so invalid generic assignments still report TS2322.
+        const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY = 1 << 13;
     }
 }
 
@@ -458,6 +463,11 @@ impl RelationCacheKey {
     /// When set, non-generic functions are NOT assignable to generic functions,
     /// matching tsc's `eraseGenerics=false` behavior for implements/extends checks.
     pub const FLAG_NO_ERASE_GENERICS: u16 = RelationFlags::NO_ERASE_GENERICS.bits() as u16;
+    /// Allow a failed contextual generic-signature inference to retry with
+    /// erased signatures. Used for interface property compatibility, not
+    /// ordinary assignment.
+    pub const FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
 
     /// Typed builder for subtype cache entries.
     pub const fn for_subtype(source: TypeId, target: TypeId, config: RelationCacheConfig) -> Self {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -493,6 +493,20 @@ fn contains_error_type_recursive(
                 .iter()
                 .any(|elem| contains_error_type_recursive(types, elem.type_id, memo))
         }
+        TypeData::Array(element_type) => contains_error_type_recursive(types, element_type, memo),
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = types.object_shape(shape_id);
+            shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
+        }
         TypeData::Function(shape_id) => {
             let shape = types.function_shape(shape_id);
             contains_error_type_recursive(types, shape.return_type, memo)
@@ -500,6 +514,35 @@ fn contains_error_type_recursive(
                     .params
                     .iter()
                     .any(|p| contains_error_type_recursive(types, p.type_id, memo))
+        }
+        TypeData::Callable(shape_id) => {
+            let shape = types.callable_shape(shape_id);
+            shape.call_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.construct_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
         }
         _ => false,
     };


### PR DESCRIPTION
## Summary

This is PR 1 in the Phase 5 diagnostic conformance stack.

- Allow discriminated union excess-property checking to narrow on unit discriminant properties that are present on only some union members.
- Keep partial-presence narrowing conservative by requiring the present target properties to be unit types, so payload fields like `abc: string` do not become accidental discriminants.
- Add a TS2353 regression for the `Overlapping` union shape from `excessPropertyCheckWithUnions.ts`.

## Root Cause

The existing discriminant matcher skipped a source property if any union member lacked that property. In the TypeScript conformance case, `a` and `b` each exclude one branch and both point to the first member, but tsz refused to narrow because neither property appears on every union member.

## Validation

- `cargo test -p tsz-checker --test ts2353_tests -- --nocapture`
- `cargo test -p tsz-checker --test ts2353_tests discriminated_union_excess_narrows_with_partial_discriminant_presence -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `./scripts/conformance/conformance.sh run --filter "excessPropertyCheckWithUnions.ts" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-excess-diffs`

Filtered conformance now reports 14 expected fingerprints, 10 actual, 4 missing, and 0 extra. Before this slice the same sample had 8 actual and 6 missing; the two `Overlapping` TS2353 misses are now produced.

