### PR TITLE
chore(parser): add NodeArena::identifier_text_owned and migrate callers

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -2267,15 +2267,14 @@ impl BinderState {
         }
 
         fn property_access_chain(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
+            if let Some(text) = arena.identifier_text_owned(idx) {
+                return Some(text);
             }
+            let node = arena.get(idx)?;
             if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                 let access = arena.get_access_expr(node)?;
                 let left = property_access_chain(arena, access.expression)?;
-                let right_node = arena.get(access.name_or_argument)?;
-                let right = arena.get_identifier(right_node)?.escaped_text.clone();
+                let right = arena.identifier_text_owned(access.name_or_argument)?;
                 return Some(format!("{left}.{right}"));
             }
             None
@@ -2346,7 +2345,7 @@ impl BinderState {
                     }
                 }
                 k if k == SyntaxKind::Identifier as u16 => {
-                    let name = arena.get_identifier(init_node)?.escaped_text.clone();
+                    let name = arena.identifier_text_owned(init_idx)?;
                     let next_sym = binder.file_locals.get(&name)?;
                     resolved_const_expando_key(binder, arena, next_sym, depth + 1)
                 }

--- a/crates/tsz-checker/src/symbols/name_text.rs
+++ b/crates/tsz-checker/src/symbols/name_text.rs
@@ -4,12 +4,10 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
 pub(crate) fn entity_name_text_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-    let node = arena.get(idx)?;
-    if node.kind == SyntaxKind::Identifier as u16 {
-        return arena
-            .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+    if let Some(text) = arena.identifier_text_owned(idx) {
+        return Some(text);
     }
+    let node = arena.get(idx)?;
 
     if node.kind == syntax_kind_ext::QUALIFIED_NAME {
         let qn = arena.get_qualified_name(node)?;
@@ -53,13 +51,10 @@ pub(crate) fn property_access_chain_text_in_arena(
     arena: &NodeArena,
     idx: NodeIndex,
 ) -> Option<String> {
-    let node = arena.get(idx)?;
-    if node.kind == SyntaxKind::Identifier as u16 {
-        return arena
-            .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone());
+    if let Some(text) = arena.identifier_text_owned(idx) {
+        return Some(text);
     }
-
+    let node = arena.get(idx)?;
     if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
         return None;
     }
@@ -76,9 +71,7 @@ pub(crate) fn simple_computed_name_expr_text_in_arena(
 ) -> Option<String> {
     let node = arena.get(idx)?;
     match node.kind {
-        k if k == SyntaxKind::Identifier as u16 => arena
-            .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone()),
+        k if k == SyntaxKind::Identifier as u16 => arena.identifier_text_owned(idx),
         k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
             let access = arena.get_access_expr(node)?;
             let left = simple_computed_name_expr_text_in_arena(arena, access.expression)?;

--- a/crates/tsz-checker/src/types/property_access_augmentation.rs
+++ b/crates/tsz-checker/src/types/property_access_augmentation.rs
@@ -397,23 +397,17 @@ impl<'a> CheckerState<'a> {
             arena: &tsz_parser::parser::node::NodeArena,
             idx: NodeIndex,
         ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
+            if let Some(text) = arena.identifier_text_owned(idx) {
+                return Some(text);
             }
+            let node = arena.get(idx)?;
             if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                 let access = arena.get_access_expr(node)?;
-                let name_node = arena.get(access.name_or_argument)?;
-                return arena
-                    .get_identifier(name_node)
-                    .map(|id| id.escaped_text.clone());
+                return arena.identifier_text_owned(access.name_or_argument);
             }
             if node.kind == syntax_kind_ext::QUALIFIED_NAME {
                 let name = arena.get_qualified_name(node)?;
-                let right = arena.get(name.right)?;
-                return arena
-                    .get_identifier(right)
-                    .map(|id| id.escaped_text.clone());
+                return arena.identifier_text_owned(name.right);
             }
             None
         }

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -16,10 +16,10 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     fn property_access_chain_in_arena(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-        let node = arena.get(idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return arena.get_identifier(node).map(|id| id.escaped_text.clone());
+        if let Some(text) = arena.identifier_text_owned(idx) {
+            return Some(text);
         }
+        let node = arena.get(idx)?;
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             let access = arena.get_access_expr(node)?;
             let left = Self::property_access_chain_in_arena(arena, access.expression)?;
@@ -792,10 +792,10 @@ impl<'a> CheckerState<'a> {
             arena: &tsz_parser::parser::node::NodeArena,
             idx: NodeIndex,
         ) -> Option<String> {
-            let node = arena.get(idx)?;
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return arena.get_identifier(node).map(|id| id.escaped_text.clone());
+            if let Some(text) = arena.identifier_text_owned(idx) {
+                return Some(text);
             }
+            let node = arena.get(idx)?;
             if node.kind == tsz_parser::parser::syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                 let access = arena.get_access_expr(node)?;
                 return root_identifier(arena, access.expression);

--- a/crates/tsz-emitter/src/emitter/expressions/access.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/access.rs
@@ -596,22 +596,15 @@ impl<'a> Printer<'a> {
         best.map(|e| &e.values)
     }
     fn build_access_chain_path(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.arena.get(idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return Some(self.arena.get_identifier(node)?.escaped_text.clone());
+        if let Some(text) = self.arena.identifier_text_owned(idx) {
+            return Some(text);
         }
+        let node = self.arena.get(idx)?;
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             let access = self.arena.get_access_expr(node)?;
             let left = self.build_access_chain_path(access.expression)?;
-            let nm = self.arena.get(access.name_or_argument)?;
-            if nm.kind != SyntaxKind::Identifier as u16 {
-                return None;
-            }
-            return Some(format!(
-                "{}.{}",
-                left,
-                &self.arena.get_identifier(nm)?.escaped_text
-            ));
+            let right = self.arena.identifier_text_owned(access.name_or_argument)?;
+            return Some(format!("{left}.{right}"));
         }
         None
     }

--- a/crates/tsz-emitter/src/enums/evaluator.rs
+++ b/crates/tsz-emitter/src/enums/evaluator.rs
@@ -673,18 +673,14 @@ impl<'a> EnumEvaluator<'a> {
 
     /// Build a dotted path string from a chain of property access expressions.
     fn build_property_chain(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.arena.get(idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
-            return Some(self.arena.get_identifier(node)?.escaped_text.clone());
+        if let Some(text) = self.arena.identifier_text_owned(idx) {
+            return Some(text);
         }
+        let node = self.arena.get(idx)?;
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             let access = self.arena.get_access_expr(node)?;
             let left = self.build_property_chain(access.expression)?;
-            let right_node = self.arena.get(access.name_or_argument)?;
-            if right_node.kind != SyntaxKind::Identifier as u16 {
-                return None;
-            }
-            let right = &self.arena.get_identifier(right_node)?.escaped_text;
+            let right = self.arena.identifier_text_owned(access.name_or_argument)?;
             return Some(format!("{left}.{right}"));
         }
         None

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -5,12 +5,7 @@ use tsz_scanner::SyntaxKind;
 
 /// Get identifier text from a node index, returning `None` if the node is not an identifier.
 pub(crate) fn identifier_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-    let node = arena.get(idx)?;
-    if node.kind == SyntaxKind::Identifier as u16 {
-        arena.get_identifier(node).map(|id| id.escaped_text.clone())
-    } else {
-        None
-    }
+    arena.identifier_text_owned(idx)
 }
 
 /// Get identifier text from a node index, returning an empty string on failure.

--- a/crates/tsz-lsp/src/utils/mod.rs
+++ b/crates/tsz-lsp/src/utils/mod.rs
@@ -114,15 +114,7 @@ pub fn node_range(
 
 /// Get the text of an identifier node, or `None` if the node is not an identifier.
 pub fn identifier_text(arena: &NodeArena, node_idx: NodeIndex) -> Option<String> {
-    if node_idx.is_none() {
-        return None;
-    }
-    let node = arena.get(node_idx)?;
-    if node.kind == SyntaxKind::Identifier as u16 {
-        arena.get_identifier(node).map(|id| id.escaped_text.clone())
-    } else {
-        None
-    }
+    arena.identifier_text_owned(node_idx)
 }
 
 /// Check whether a node is a valid symbol-query target for LSP symbol-resolution flows.

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -127,6 +127,22 @@ impl NodeArena {
         }
     }
 
+    /// Get the owned text of an `Identifier` node. Returns `None` for any
+    /// other kind, including `PrivateIdentifier` — mirrors the common
+    /// caller-side pattern that pre-filters on `SyntaxKind::Identifier`
+    /// before extracting `escaped_text`.
+    #[inline]
+    #[must_use]
+    pub fn identifier_text_owned(&self, index: NodeIndex) -> Option<String> {
+        use tsz_scanner::SyntaxKind;
+        let node = self.get(index)?;
+        if node.kind == SyntaxKind::Identifier as u16 {
+            self.get_identifier(node).map(|id| id.escaped_text.clone())
+        } else {
+            None
+        }
+    }
+
     /// Get literal data for a node.
     /// Returns None if node is not a literal or has no data.
     #[inline]

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -154,6 +154,11 @@ fn test_node_access_trait() {
     assert_eq!(arena.kind(ident_idx), Some(SyntaxKind::Identifier as u16));
     assert_eq!(arena.pos_end(ident_idx), Some((10, 20)));
     assert_eq!(arena.get_identifier_text(ident_idx), Some("testVar"));
+    assert_eq!(
+        arena.identifier_text_owned(ident_idx),
+        Some("testVar".to_string())
+    );
+    assert_eq!(arena.identifier_text_owned(NodeIndex::NONE), None);
 
     assert_eq!(arena.pos_at(ident_idx), Some(10));
     assert_eq!(arena.end_at(ident_idx), Some(20));


### PR DESCRIPTION
## Summary
- Adds `NodeArena::identifier_text_owned(NodeIndex) -> Option<String>` that returns the owned identifier text if (and only if) the node is a `SyntaxKind::Identifier`, matching the common caller-side pre-filter that excludes `PrivateIdentifier`.
- Collapses three duplicate `identifier_text` helpers (LSP utils, emitter transforms, checker name_text) onto the new arena method.
- Migrates six inline property-access-chain walkers (binder, emitter, checker) to the new helper, shedding hand-rolled `node.kind == Identifier` branches and repeated `get_identifier(node).map(|id| id.escaped_text.clone())` patterns.

## Test plan
- [x] `cargo nextest run -p tsz-parser` (unit test added at `node_tests.rs::test_node_access_trait` for both the `Identifier` path and `NodeIndex::NONE`)
- [x] Pre-commit gate: fmt + clippy + wasm32 rustc + arch-guard + nextest (19318 tests, 62 skipped)