### PR TITLE
chore(parser): add NodeArena pos/end/pos_end helpers and migrate callers

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1674,7 +1674,7 @@ impl BinderState {
                     sym.value_declaration =
                         sym.declarations.first().copied().unwrap_or(NodeIndex::NONE);
                     sym.value_declaration_span = if sym.value_declaration.is_some() {
-                        arena.get(sym.value_declaration).map(|n| (n.pos, n.end))
+                        arena.pos_end_at(sym.value_declaration)
                     } else {
                         None
                     };

--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -838,7 +838,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
             if let Some(sym_id) = self.ctx.binder.get_node_symbol(enum_idx)
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             {
-                let current_pos = self.ctx.arena.get(enum_idx).map(|n| n.pos).unwrap_or(0);
+                let current_pos = self.ctx.arena.pos_at(enum_idx).unwrap_or(0);
                 for &decl_idx in &symbol.declarations {
                     let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
                         continue;

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -307,7 +307,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                 // TS1234: An ambient module declaration is only allowed at the top level in a file.
                 // This fires when `declare module "string"` is inside a block or function body.
                 if !self.ctx.has_syntax_parse_errors {
-                    let decl_start = self.ctx.arena.get(module_idx).map(|n| n.pos).unwrap_or(0);
+                    let decl_start = self.ctx.arena.pos_at(module_idx).unwrap_or(0);
                     let start = if let Some(sf) = self.ctx.arena.source_files.first() {
                         let bytes = sf.text.as_bytes();
                         let mut pos = decl_start as usize;
@@ -403,7 +403,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                     .and_then(|ext| self.ctx.arena.get(ext.parent))
                     .filter(|p| p.kind == syntax_kind_ext::EXPORT_DECLARATION)
                     .map(|p| p.pos)
-                    .or_else(|| self.ctx.arena.get(module_idx).map(|n| n.pos))
+                    .or_else(|| self.ctx.arena.pos_at(module_idx))
                     .unwrap_or(name_node.pos);
                 // Skip leading whitespace/newlines to find actual keyword start
                 let start = if let Some(sf) = self.ctx.arena.source_files.first() {

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -89,7 +89,7 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         // Get the reference position in source
-        let ref_pos = self.arena.get(reference).map(|n| n.pos).unwrap_or(0);
+        let ref_pos = self.arena.pos_at(reference).unwrap_or(0);
 
         // Get the last assignment position for this symbol
         let last_assign_pos = self.get_last_assignment_pos(symbol_id, reference);

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1761,7 +1761,7 @@ impl<'a> CheckerState<'a> {
                         .iter()
                         .zip(member_info.is_property.iter())
                         .filter(|(_, is_prop)| **is_prop)
-                        .filter_map(|(&idx, _)| self.ctx.arena.get(idx).map(|n| n.pos))
+                        .filter_map(|(&idx, _)| self.ctx.arena.pos_at(idx))
                         .min();
                     let field_strictly_after_accessor = matches!(
                         (first_field_pos, first_accessor_pos),
@@ -1795,7 +1795,7 @@ impl<'a> CheckerState<'a> {
                         .unwrap_or(u32::MAX);
                     let last_accessor_pos = accessor_indices
                         .iter()
-                        .filter_map(|&idx| self.ctx.arena.get(idx).map(|n| n.pos))
+                        .filter_map(|&idx| self.ctx.arena.pos_at(idx))
                         .max()
                         .unwrap_or(0);
 

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -319,7 +319,7 @@ impl<'a> CheckerState<'a> {
 
             // tsc points TS1255/TS1263/TS1264 at the `!` token itself, which is
             // immediately after the variable name node (name_node.end, length 1).
-            let excl_pos = self.ctx.arena.get(var_decl.name).map(|n| n.end);
+            let excl_pos = self.ctx.arena.end_at(var_decl.name);
 
             // TS1255: ! is not permitted in ambient context (declare let/var/const)
             if self.is_ambient_declaration(decl_idx) {

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -587,7 +587,7 @@ impl<'a> CheckerState<'a> {
 
             if let Some(prop_name) = prop_name.as_deref()
                 && let Some(prototype_root_expr) = prototype_root_expr
-                && let Some(read_pos) = self.ctx.arena.get(property_access_idx).map(|n| n.pos)
+                && let Some(read_pos) = self.ctx.arena.pos_at(property_access_idx)
                 && self
                     .prior_js_prototype_object_literal_declares_property(
                         prototype_root_expr,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -902,7 +902,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_identifier_at(prototype_access.name_or_argument)
                     .is_some_and(|prototype_ident| prototype_ident.escaped_text == "prototype")
-                && let Some(read_pos) = self.ctx.arena.get(idx).map(|n| n.pos)
+                && let Some(read_pos) = self.ctx.arena.pos_at(idx)
                 && self
                     .prior_js_prototype_object_literal_declares_property(
                         prototype_access.expression,

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -219,7 +219,7 @@ impl<'a> Printer<'a> {
                             self.write(",");
                         } else {
                             // Find the separator comma in the source that follows this element.
-                            let elem_end = self.arena.get(elem).map(|n| n.end).unwrap_or(0);
+                            let elem_end = self.arena.end_at(elem).unwrap_or(0);
 
                             // Some element nodes (e.g. function expressions) include the
                             // trailing comma and whitespace in their `end` span.  In that

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1311,7 +1311,7 @@ impl<'a> AstToIr<'a> {
         } else {
             Vec::new()
         };
-        let body_source_range = self.arena.get(method.body).map(|n| (n.pos, n.end));
+        let body_source_range = self.arena.pos_end_at(method.body);
         Some(IRNode::FunctionExpr {
             name: None,
             parameters: params,
@@ -1343,7 +1343,7 @@ impl<'a> AstToIr<'a> {
         } else {
             Vec::new()
         };
-        let body_source_range = self.arena.get(accessor.body).map(|n| (n.pos, n.end));
+        let body_source_range = self.arena.pos_end_at(accessor.body);
         Some(IRNode::FunctionExpr {
             name: None,
             parameters: params,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -310,7 +310,7 @@ impl<'a> ES5ClassTransformer<'a> {
 
         let params = self.extract_parameters(&accessor_data.parameters);
 
-        let body_source_range = self.arena.get(accessor_data.body).map(|n| (n.pos, n.end));
+        let body_source_range = self.arena.pos_end_at(accessor_data.body);
 
         let body = if accessor_data.body.is_none() {
             vec![]
@@ -364,7 +364,7 @@ impl<'a> ES5ClassTransformer<'a> {
             self.generate_destructuring_prologue(&accessor_data.parameters, &params);
 
         let body_source_range = if accessor_destructuring.is_empty() {
-            self.arena.get(accessor_data.body).map(|n| (n.pos, n.end))
+            self.arena.pos_end_at(accessor_data.body)
         } else {
             None // Force multi-line when destructuring prologue exists
         };

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -973,7 +973,7 @@ impl<'a> NamespaceES5Transformer<'a> {
                 .arena
                 .has_modifier(&func_data.modifiers, SyntaxKind::ExportKeyword);
 
-        let body_source_range = self.arena.get(func_data.body).map(|n| (n.pos, n.end));
+        let body_source_range = self.arena.pos_end_at(func_data.body);
 
         // Convert function to IR (stripping type annotations)
         let func_decl = IRNode::FunctionDecl {

--- a/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
+++ b/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
@@ -1598,7 +1598,7 @@ impl<'a> CallHierarchyProvider<'a> {
             .modifiers
             .as_ref()
             .and_then(|mods| mods.nodes.first().copied())
-            .and_then(|mod_idx| self.arena.get(mod_idx).map(|n| n.pos))
+            .and_then(|mod_idx| self.arena.pos_at(mod_idx))
             .unwrap_or(class_node.pos);
         if class_node.pos > 0 {
             let bytes = self.source_text.as_bytes();

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -61,6 +61,34 @@ impl NodeArena {
         }
     }
 
+    /// Get the source start position of a node by index. Returns `None` if
+    /// the index is `NodeIndex::NONE` or out of bounds. Inherent helper for
+    /// the common `arena.get(idx).map(|n| n.pos)` pattern.
+    #[inline]
+    #[must_use]
+    pub fn pos_at(&self, index: NodeIndex) -> Option<u32> {
+        self.get(index).map(|n| n.pos)
+    }
+
+    /// Get the source end position of a node by index. Returns `None` if
+    /// the index is `NodeIndex::NONE` or out of bounds. Inherent helper for
+    /// the common `arena.get(idx).map(|n| n.end)` pattern.
+    #[inline]
+    #[must_use]
+    pub fn end_at(&self, index: NodeIndex) -> Option<u32> {
+        self.get(index).map(|n| n.end)
+    }
+
+    /// Get the `(pos, end)` source range of a node by index. Returns `None`
+    /// if the index is `NodeIndex::NONE` or out of bounds. Inherent helper
+    /// for the common `arena.get(idx).map(|n| (n.pos, n.end))` pattern used
+    /// by emitter source-range plumbing and diagnostics.
+    #[inline]
+    #[must_use]
+    pub fn pos_end_at(&self, index: NodeIndex) -> Option<(u32, u32)> {
+        self.get(index).map(|n| (n.pos, n.end))
+    }
+
     /// Get extended info for a node
     #[inline]
     #[must_use]

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -155,6 +155,13 @@ fn test_node_access_trait() {
     assert_eq!(arena.pos_end(ident_idx), Some((10, 20)));
     assert_eq!(arena.get_identifier_text(ident_idx), Some("testVar"));
 
+    assert_eq!(arena.pos_at(ident_idx), Some(10));
+    assert_eq!(arena.end_at(ident_idx), Some(20));
+    assert_eq!(arena.pos_end_at(ident_idx), Some((10, 20)));
+    assert_eq!(arena.pos_at(NodeIndex::NONE), None);
+    assert_eq!(arena.end_at(NodeIndex::NONE), None);
+    assert_eq!(arena.pos_end_at(NodeIndex::NONE), None);
+
     // Test NodeInfo
     let info = arena.node_info(ident_idx).expect("node info should exist");
     assert_eq!(info.kind, SyntaxKind::Identifier as u16);


### PR DESCRIPTION
## Summary
- Add inherent `NodeArena::pos_at`, `end_at`, and `pos_end_at` methods beside the existing `get`/`get_mut`.
- Migrate 17 call sites across `tsz-binder`, `tsz-checker`, `tsz-emitter`, `tsz-lsp`, and the in-crate parser tests that were reconstructing position metadata via `arena.get(idx).map(|n| n.pos | n.end | (n.pos, n.end))`.
- Extend `test_node_access_trait` to cover the new helpers plus the `NodeIndex::NONE` sentinel path.

The pattern was duplicated across binder value-declaration spans, enum/module/accessor/expando diagnostics, flow reference anchors, emitter class/namespace body source ranges, array-literal element-end scanning, and the LSP call-hierarchy symbol start. Consolidating the accessors trims the option-hop chain into a single call and gives a single grep target if the node position layout ever changes (e.g. migrating to a `Span` handle).

## Test plan
- [x] `cargo nextest run -p tsz-parser -E 'test(test_node_access_trait)'` — passes
- [x] Full pre-commit pipeline (fmt, clippy zero-warnings, wasm32 rustc, arch-guard, nextest 19318 tests) — passes