### PR TITLE
perf(binder): wrap lib_symbol_ids in Arc to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -203,7 +203,7 @@ impl BinderState {
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),
             lib_binders: Vec::new(),
-            lib_symbol_ids: FxHashSet::default(),
+            lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
             reexports: FxHashMap::default(),
@@ -268,7 +268,7 @@ impl BinderState {
         self.in_module_augmentation = false;
         self.current_augmented_module = None;
         self.lib_binders.clear();
-        self.lib_symbol_ids.clear();
+        Arc::make_mut(&mut self.lib_symbol_ids).clear();
         self.module_exports.clear();
         self.reexports.clear();
         self.wildcard_reexports.clear();
@@ -420,7 +420,7 @@ impl BinderState {
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),
             lib_binders: Vec::new(),
-            lib_symbol_ids: FxHashSet::default(),
+            lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
             reexports: FxHashMap::default(),
@@ -543,7 +543,7 @@ impl BinderState {
             current_augmented_module: None,
             augmentation_target_modules,
             lib_binders: Vec::new(),
-            lib_symbol_ids: FxHashSet::default(),
+            lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports,
             reexports,

--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -373,7 +373,7 @@ impl BinderState {
                         self.file_locals.set(name.clone(), new_id);
                     }
                     // Track all lib-originating symbols for unused checking exclusion
-                    self.lib_symbol_ids.insert(new_id);
+                    Arc::make_mut(&mut self.lib_symbol_ids).insert(new_id);
                 }
             }
         }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -310,7 +310,16 @@ pub struct BinderState {
     /// Symbol IDs that originated from lib files.
     /// Used by `get_symbol()` to check `lib_binders` first for these IDs,
     /// avoiding collision with local symbols at the same index.
-    pub lib_symbol_ids: FxHashSet<SymbolId>,
+    ///
+    /// Stored as `Arc` so per-file binders constructed by the CLI driver
+    /// can share the merged lib symbol set without deep-cloning the
+    /// underlying `FxHashSet` for every file. On large projects this set
+    /// holds thousands of symbol IDs, and the driver builds 12K+ per-file
+    /// binders (cross-file lookup + per-file checking) — N deep clones
+    /// add up. Mutations during binding go through `Arc::make_mut`,
+    /// which is essentially free while refcount=1 (always the case
+    /// during a single binder's construction).
+    pub lib_symbol_ids: Arc<FxHashSet<SymbolId>>,
 
     /// Reverse mapping from user-local lib symbol IDs to (`lib_binder_ptr`, `original_local_id`).
     /// This allows Phase 2 of `merge_bind_results` to find the Phase 1 global ID for each

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -169,7 +169,7 @@ impl<'a> CheckerState<'a> {
     /// Handles block-scoped local shadowing a lib global var (e.g. `const Symbol = globalThis.Symbol`).
     pub(crate) fn resolve_lib_global_var_symbol(&self, name: &str) -> Option<SymbolId> {
         if self.ctx.binder.lib_symbols_are_merged() {
-            for &lib_id in &self.ctx.binder.lib_symbol_ids {
+            for &lib_id in self.ctx.binder.lib_symbol_ids.iter() {
                 if let Some(lib_sym) = self.ctx.binder.get_symbol(lib_id)
                     && lib_sym.escaped_name == name
                     && lib_sym.has_any_flags(symbol_flags::VALUE)

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -513,8 +513,10 @@ pub struct BindResult {
     /// Arenas corresponding to each `lib_binder` (same order/length as `lib_binders`).
     /// Used by `merge_bind_results_ref` to populate `declaration_arenas` for lib symbols.
     pub lib_arenas: Vec<Arc<NodeArena>>,
-    /// Symbol IDs that originated from lib files (pre-merge local IDs)
-    pub lib_symbol_ids: FxHashSet<SymbolId>,
+    /// Symbol IDs that originated from lib files (pre-merge local IDs).
+    /// `Arc`-wrapped so the merge can move it into the per-file
+    /// `BinderState.lib_symbol_ids` (also `Arc`) without deep-cloning.
+    pub lib_symbol_ids: Arc<FxHashSet<SymbolId>>,
     /// Reverse mapping from user-local lib symbol IDs to (`lib_binder_ptr`, `original_local_id`)
     pub lib_symbol_reverse_remap: FxHashMap<SymbolId, (usize, SymbolId)>,
     /// Flow nodes for control flow analysis
@@ -1581,8 +1583,12 @@ pub struct MergedProgram {
     /// Lib binders for global type resolution (Array, String, Promise, etc.)
     /// These contain symbols from lib.d.ts files and enable resolution of built-in types
     pub lib_binders: Vec<Arc<BinderState>>,
-    /// Global symbol IDs that originated from lib files (remapped to global arena IDs)
-    pub lib_symbol_ids: FxHashSet<SymbolId>,
+    /// Global symbol IDs that originated from lib files (remapped to global arena IDs).
+    /// `Arc`-wrapped so the CLI driver can install the same set into
+    /// every per-file `BinderState.lib_symbol_ids` via `Arc::clone`
+    /// (cheap atomic increment) instead of deep-cloning the
+    /// `FxHashSet` for each of N per-file binders.
+    pub lib_symbol_ids: Arc<FxHashSet<SymbolId>>,
     /// Global type interner - shared across all threads for type deduplication
     pub type_interner: TypeInterner,
     /// Alias partners: maps `TYPE_ALIAS` `SymbolId` → `ALIAS` `SymbolId` for merged type+namespace exports.
@@ -2565,7 +2571,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         }
 
         // Track remapped lib symbol IDs for unused-checking exclusion
-        for &old_lib_id in &result.lib_symbol_ids {
+        for &old_lib_id in result.lib_symbol_ids.iter() {
             if let Some(&new_id) = id_remap.get(&old_lib_id) {
                 global_lib_symbol_ids.insert(new_id);
             }
@@ -3268,7 +3274,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         wildcard_reexports,
         wildcard_reexports_type_only,
         lib_binders,
-        lib_symbol_ids: global_lib_symbol_ids,
+        lib_symbol_ids: Arc::new(global_lib_symbol_ids),
         type_interner,
         alias_partners,
         semantic_defs,


### PR DESCRIPTION
## Summary

`BinderState.lib_symbol_ids: FxHashSet<SymbolId>` was deep-cloned for every per-file binder constructed by the CLI driver:

\`\`\`rust
binder.lib_symbol_ids = program.lib_symbol_ids.clone();
\`\`\`

On a large project this set holds **thousands of lib-originating symbol IDs** (one per built-in like `Array`, `Promise`, `Math.*`, every DOM type, etc.), and the driver builds **N per-file binders for cross-file lookup + N per-file checking binders** — so on a 6086-file project that's ~12K deep clones of a 10K-entry HashSet.

## Fix

Wrap the field in `Arc<FxHashSet<SymbolId>>` end-to-end:
- `BinderState.lib_symbol_ids: Arc<FxHashSet<SymbolId>>` (per-file binder)
- `BindResult.lib_symbol_ids: Arc<FxHashSet<SymbolId>>` (per-file bind result)
- `MergedProgram.lib_symbol_ids: Arc<FxHashSet<SymbolId>>` (program-wide merged)

Mutations during binding (only two: `clear()` in `BinderState::reset` and `insert(new_id)` in lib-merge Phase 3) go through `Arc::make_mut`, which is essentially free while the refcount is 1 (always the case during a single binder's construction).

After this:
- `binder.lib_symbol_ids = program.lib_symbol_ids.clone()` in `check_utils` is now an Arc clone (atomic increment) — **no deep copy**.
- All `.contains(&sym_id)` reads still work via `Arc`'s `Deref`.
- Two `for &x in &binder.lib_symbol_ids` loops switched to `.iter()` (since `&Arc<HashSet>` doesn't implement `IntoIterator` directly).

## Test plan
- [x] `cargo check --workspace` clean
- [x] Pre-commit hook: 18777/18777 tests pass (clippy, wasm32 warnings gate, arch guard, full nextest)
- [ ] CI: full test matrix + bench-vs-base

## Followup context

This is one of the items called out in `docs/plan/perf-large-repo-followup.md` (added in #898) as a "moderate scope" memory win. It's a stepping stone — the bigger remaining levers (`binder.module_exports` consumer migration, `binder.declaration_arenas` per-file materialization) require the same Arc-wrap pattern but more consumer-side work.