### PR TITLE
chore(parser): add NodeArena::parent_of helper and migrate parent lookups

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -119,7 +119,7 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        let mut current = self.ctx.arena.get_extended(node_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(node_idx);
         while let Some(parent_idx) = current {
             if parent_idx == ancestor_idx {
                 return true;
@@ -144,7 +144,7 @@ impl<'a> CheckerState<'a> {
         // In nested conditionals like `T extends A ? T extends B ? X<T> : ...`,
         // the effective constraint on T is the intersection A & B.
         let mut accumulated_extends: Vec<TypeId> = Vec::new();
-        let mut current = self.ctx.arena.get_extended(arg_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(arg_idx);
         while let Some(parent_idx) = current {
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
                 break;
@@ -230,7 +230,7 @@ impl<'a> CheckerState<'a> {
     /// Check if a type argument is inside the FALSE branch of a conditional type
     /// where the check type is (or contains) the same type parameter.
     fn type_arg_is_in_conditional_false_branch_of_check_type(&self, arg_idx: NodeIndex) -> bool {
-        let mut current = self.ctx.arena.get_extended(arg_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(arg_idx);
         while let Some(parent_idx) = current {
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
                 break;

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -943,7 +943,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn spread_iterability_error_anchor(&self, expr_idx: NodeIndex) -> NodeIndex {
-        let mut current = self.ctx.arena.get_extended(expr_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(expr_idx);
         while let Some(parent_idx) = current {
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
                 break;

--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -262,7 +262,7 @@ impl<'a> CheckerState<'a> {
         let mut decl_idx = decl_idx;
         let mut decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-            && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+            && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
             && parent.is_some()
         {
             decl_idx = parent;

--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -234,7 +234,7 @@ impl<'a> CheckerState<'a> {
         let mut decl_idx = decl_idx;
         let mut decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-            && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+            && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
             && parent.is_some()
         {
             decl_idx = parent;
@@ -293,7 +293,7 @@ impl<'a> CheckerState<'a> {
         let mut decl_idx = decl_idx;
         let mut decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-            && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+            && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
             && parent.is_some()
         {
             decl_idx = parent;
@@ -366,7 +366,7 @@ impl<'a> CheckerState<'a> {
         let mut decl_idx = decl_idx;
         let mut decl_node = self.ctx.arena.get(decl_idx)?;
         if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-            && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+            && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
             && parent.is_some()
         {
             decl_idx = parent;

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -274,7 +274,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-                && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+                && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
                 && parent.is_some()
             {
                 decl_idx = parent;
@@ -505,7 +505,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-                && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+                && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
                 && parent.is_some()
             {
                 decl_idx = parent;

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -436,7 +436,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             if decl_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
-                && let Some(parent) = self.ctx.arena.get_extended(decl_idx).map(|ext| ext.parent)
+                && let Some(parent) = self.ctx.arena.parent_of(decl_idx)
                 && parent.is_some()
             {
                 decl_idx = parent;

--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -63,7 +63,7 @@ impl<'a> CheckerState<'a> {
     /// Check if a node is NOT in a valid module-element context (`SourceFile` or `ModuleBlock`).
     /// Returns true when the node is inside a block, function body, or other non-module context.
     pub(crate) fn is_in_non_module_element_context(&self, node_idx: NodeIndex) -> bool {
-        let parent_idx = self.ctx.arena.get_extended(node_idx).map(|ext| ext.parent);
+        let parent_idx = self.ctx.arena.parent_of(node_idx);
         let parent_kind = parent_idx
             .and_then(|p| self.ctx.arena.get(p))
             .map(|p| p.kind);

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1877,7 +1877,7 @@ impl<'a> CheckerState<'a> {
         raw_param_type: TypeId,
     ) -> bool {
         let mut child = arg_idx;
-        let Some(mut current) = self.ctx.arena.get_extended(arg_idx).map(|ext| ext.parent) else {
+        let Some(mut current) = self.ctx.arena.parent_of(arg_idx) else {
             return false;
         };
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -28,8 +28,7 @@ impl<'a> CheckerState<'a> {
                             parent.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                         });
                     if is_object_literal_property {
-                        object_literal_idx =
-                            self.ctx.arena.get_extended(current).map(|ext| ext.parent);
+                        object_literal_idx = self.ctx.arena.parent_of(current);
                         property_elem = Some(current);
                         break;
                     }

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -118,7 +118,7 @@ impl<'a> CheckerState<'a> {
             // Some nodes in type positions (e.g. `typeof x` inside a type alias)
             // don't carry direct flow links. Fall back to the nearest parent that
             // has flow information so narrowing can still apply at that site.
-            let mut current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+            let mut current = self.ctx.arena.parent_of(idx);
             let mut found = None;
             while let Some(parent) = current {
                 if parent.is_none() {
@@ -128,7 +128,7 @@ impl<'a> CheckerState<'a> {
                     found = Some(flow);
                     break;
                 }
-                current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+                current = self.ctx.arena.parent_of(parent);
             }
             match found {
                 Some(flow) => flow,

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -1281,7 +1281,7 @@ impl<'a> CheckerState<'a> {
         let flow_node = if let Some(flow) = self.ctx.binder.get_node_flow(idx) {
             flow
         } else {
-            let mut current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+            let mut current = self.ctx.arena.parent_of(idx);
             let mut found = None;
             while let Some(parent) = current {
                 if parent.is_none() {
@@ -1294,13 +1294,13 @@ impl<'a> CheckerState<'a> {
                     // BEFORE the assignment, so we need the prior flow state.
                     if self.is_compound_read_write_target(parent, idx) {
                         // Skip this flow node and keep walking up
-                        current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+                        current = self.ctx.arena.parent_of(parent);
                         continue;
                     }
                     found = Some(flow);
                     break;
                 }
-                current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+                current = self.ctx.arena.parent_of(parent);
             }
             match found {
                 Some(flow) => flow,

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -337,7 +337,7 @@ impl<'a> CheckerState<'a> {
                 function_idx = Some(idx);
                 break;
             }
-            current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+            current = self.ctx.arena.parent_of(idx);
         }
 
         let Some(function_idx) = function_idx else {

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -1216,7 +1216,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         // Check if the parent is a valid module-element context (SourceFile or ModuleBlock).
         // For import-equals inside `export import X = N;`, the direct parent is
         // EXPORT_DECLARATION — look through it to the grandparent.
-        let parent_idx = self.ctx.arena.get_extended(stmt_idx).map(|ext| ext.parent);
+        let parent_idx = self.ctx.arena.parent_of(stmt_idx);
         let parent_kind = parent_idx
             .and_then(|p| self.ctx.arena.get(p))
             .map(|p| p.kind);
@@ -1370,7 +1370,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
 
         // Check if the parent is a valid context for `declare`
         let is_valid_context = {
-            let parent_idx = self.ctx.arena.get_extended(stmt_idx).map(|ext| ext.parent);
+            let parent_idx = self.ctx.arena.parent_of(stmt_idx);
             let parent_kind = parent_idx
                 .and_then(|p| self.ctx.arena.get(p))
                 .map(|p| p.kind);

--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -295,8 +295,7 @@ impl<'a> CheckerState<'a> {
         if fn_node.kind == FUNCTION_EXPRESSION {
             let mut current = enclosing_fn;
             for _ in 0..3 {
-                let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-                else {
+                let Some(parent) = self.ctx.arena.parent_of(current) else {
                     break;
                 };
                 let Some(parent_node) = self.ctx.arena.get(parent) else {

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -39,7 +39,7 @@ impl<'a> CheckerState<'a> {
     ) -> Option<SymbolId> {
         use tsz_parser::parser::syntax_kind_ext;
 
-        let mut current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(idx);
         // Track whether we've passed through a ComputedPropertyName. If so,
         // the enclosing class member's type parameters must be skipped because
         // computed property names are evaluated in the class scope, not the

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -23,8 +23,7 @@ impl CheckerState<'_> {
 
         let mut current = node_idx;
         for _ in 0..12 {
-            let Some(parent_idx) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-            else {
+            let Some(parent_idx) = self.ctx.arena.parent_of(current) else {
                 break;
             };
             if parent_idx.is_none() {
@@ -82,7 +81,7 @@ impl CheckerState<'_> {
         body_idx: NodeIndex,
     ) -> FxHashMap<String, TypeId> {
         let mut param_type_map = FxHashMap::default();
-        let Some(parent_idx) = self.ctx.arena.get_extended(body_idx).map(|ext| ext.parent) else {
+        let Some(parent_idx) = self.ctx.arena.parent_of(body_idx) else {
             return param_type_map;
         };
         let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
@@ -390,8 +389,7 @@ impl CheckerState<'_> {
 
         let mut current = idx;
         for _ in 0..12 {
-            let Some(parent_idx) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-            else {
+            let Some(parent_idx) = self.ctx.arena.parent_of(current) else {
                 break;
             };
             if parent_idx.is_none() {
@@ -595,8 +593,7 @@ impl CheckerState<'_> {
                                     .map(|id| id.escaped_text.as_str());
                                 if let Some(pname) = param_name {
                                     // Walk to enclosing function via extended node parent
-                                    let func_idx =
-                                        self.ctx.arena.get_extended(decl).map(|ext| ext.parent);
+                                    let func_idx = self.ctx.arena.parent_of(decl);
                                     func_idx
                                         .and_then(|fidx| self.get_jsdoc_for_function(fidx))
                                         .is_some_and(|jsdoc| {

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -27,7 +27,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn empty_array_literal_prefers_never(&self, idx: NodeIndex) -> bool {
-        let Some(parent_idx) = self.ctx.arena.get_extended(idx).map(|ext| ext.parent) else {
+        let Some(parent_idx) = self.ctx.arena.parent_of(idx) else {
             return false;
         };
         let Some(parent_node) = self.ctx.arena.get(parent_idx) else {

--- a/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
+++ b/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
@@ -148,7 +148,7 @@ impl<'a> CheckerState<'a> {
         if body_idx.is_none() {
             return None;
         }
-        let func_node_idx = self.ctx.arena.get_extended(body_idx).map(|ext| ext.parent);
+        let func_node_idx = self.ctx.arena.parent_of(body_idx);
 
         // Build effective template/parameter data for JS generic constructors.
         let func_shape = crate::query_boundaries::common::function_shape_for_type(

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1185,7 +1185,7 @@ impl<'a> CheckerState<'a> {
 
             if self.ctx.in_destructuring_target
                 && self.resolve_identifier_symbol_for_write(idx).is_none()
-                && let Some(parent_idx) = self.ctx.arena.get_extended(idx).map(|ext| ext.parent)
+                && let Some(parent_idx) = self.ctx.arena.parent_of(idx)
                 && let Some(parent_node) = self.ctx.arena.get(parent_idx)
                 && parent_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT
                 && self

--- a/crates/tsz-checker/src/types/computation/identifier_flow.rs
+++ b/crates/tsz-checker/src/types/computation/identifier_flow.rs
@@ -540,7 +540,7 @@ impl<'a> CheckerState<'a> {
             return Some(flow);
         }
 
-        let mut current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(idx);
         while let Some(parent) = current {
             if parent.is_none() {
                 break;
@@ -548,7 +548,7 @@ impl<'a> CheckerState<'a> {
             if let Some(flow) = self.ctx.binder.get_node_flow(parent) {
                 return Some(flow);
             }
-            current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+            current = self.ctx.arena.parent_of(parent);
         }
 
         None

--- a/crates/tsz-checker/src/types/computation/object_literal/mod.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/mod.rs
@@ -19,7 +19,7 @@ impl<'a> CheckerState<'a> {
     fn is_object_define_property_descriptor_literal(&self, idx: NodeIndex) -> bool {
         use tsz_scanner::SyntaxKind;
 
-        let Some(parent_idx) = self.ctx.arena.get_extended(idx).map(|ext| ext.parent) else {
+        let Some(parent_idx) = self.ctx.arena.parent_of(idx) else {
             return false;
         };
         let Some(parent_node) = self.ctx.arena.get(parent_idx) else {

--- a/crates/tsz-checker/src/types/function_type/jsx_body_context.rs
+++ b/crates/tsz-checker/src/types/function_type/jsx_body_context.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::syntax_kind_ext;
 impl<'a> CheckerState<'a> {
     pub(super) fn is_jsx_body_child_closure(&self, func_idx: NodeIndex) -> bool {
         let mut current = func_idx;
-        while let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent) {
+        while let Some(parent) = self.ctx.arena.parent_of(current) {
             let Some(parent_node) = self.ctx.arena.get(parent) else {
                 break;
             };

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -147,7 +147,7 @@ impl<'a> CheckerState<'a> {
             return Some(flow);
         }
 
-        let mut current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(idx);
         while let Some(parent) = current {
             if parent.is_none() {
                 break;
@@ -155,7 +155,7 @@ impl<'a> CheckerState<'a> {
             if let Some(flow) = self.ctx.binder.get_node_flow(parent) {
                 return Some(flow);
             }
-            current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+            current = self.ctx.arena.parent_of(parent);
         }
 
         None
@@ -227,7 +227,7 @@ impl<'a> CheckerState<'a> {
             if self.is_scope_owner_kind(node.kind) {
                 return node_idx;
             }
-            current = self.ctx.arena.get_extended(node_idx).map(|ext| ext.parent);
+            current = self.ctx.arena.parent_of(node_idx);
         }
         NodeIndex::NONE
     }
@@ -261,8 +261,7 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         let mut current = property_access_idx;
         loop {
-            let Some(parent_idx) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-            else {
+            let Some(parent_idx) = self.ctx.arena.parent_of(current) else {
                 return false;
             };
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -2426,7 +2426,7 @@ impl<'a> CheckerState<'a> {
                 export_idx = Some(current);
                 break;
             }
-            let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent) else {
+            let Some(parent) = self.ctx.arena.parent_of(current) else {
                 break;
             };
             if parent.is_none() {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -74,7 +74,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let mut current = self.ctx.arena.get_extended(node_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(node_idx);
         while current.is_some() {
             let parent_idx = current.expect("loop guard ensures current.is_some()");
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
@@ -451,7 +451,7 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or(NodeIndex::NONE),
         );
 
-        let mut current = self.ctx.arena.get_extended(node_idx).map(|ext| ext.parent);
+        let mut current = self.ctx.arena.parent_of(node_idx);
         while let Some(parent_idx) = current {
             let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
                 break;
@@ -657,7 +657,7 @@ impl<'a> CheckerState<'a> {
             if idx == node_b {
                 return true;
             }
-            current = self.ctx.arena.get_extended(idx).map(|ext| ext.parent);
+            current = self.ctx.arena.parent_of(idx);
         }
         false
     }

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -721,7 +721,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             if let Some(flow) = self.ctx.binder.get_node_flow(parent) {
                                 return Some(flow);
                             }
-                            current = self.ctx.arena.get_extended(parent).map(|ext| ext.parent);
+                            current = self.ctx.arena.parent_of(parent);
                         }
                         None
                     });

--- a/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
+++ b/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
@@ -436,7 +436,7 @@ fn enum_namespace_path(
     mut enum_decl_idx: NodeIndex,
 ) -> Vec<String> {
     let mut path = Vec::new();
-    while let Some(parent_idx) = arena.get_extended(enum_decl_idx).map(|ext| ext.parent) {
+    while let Some(parent_idx) = arena.parent_of(enum_decl_idx) {
         enum_decl_idx = parent_idx;
         let Some(module_decl) = arena.get_module_at(enum_decl_idx) else {
             continue;

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -102,7 +102,7 @@ impl<'a> TypePrinter<'a> {
             return is_nameable_statement;
         }
 
-        let mut current = node_arena.get_extended(decl_idx).map(|ext| ext.parent);
+        let mut current = node_arena.parent_of(decl_idx);
         while let Some(parent_idx) = current {
             let Some(parent_node) = node_arena.get(parent_idx) else {
                 break;
@@ -121,7 +121,7 @@ impl<'a> TypePrinter<'a> {
                 k if k == syntax_kind_ext::SOURCE_FILE => return true,
                 k if k == syntax_kind_ext::MODULE_BLOCK => return true,
                 _ => {
-                    current = node_arena.get_extended(parent_idx).map(|ext| ext.parent);
+                    current = node_arena.parent_of(parent_idx);
                 }
             }
         }

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -111,6 +111,20 @@ impl NodeArena {
         }
     }
 
+    /// Get the parent index of a node via its extended info. Returns `None`
+    /// if the index is `NodeIndex::NONE` or out of bounds. Inherent helper
+    /// for the very common `arena.get_extended(idx).map(|ext| ext.parent)`
+    /// pattern used by ~140 parent-walk call sites across checker/emitter.
+    ///
+    /// A root node returns `Some(NodeIndex::NONE)`; callers that want to
+    /// distinguish "root" from "unknown" should check `is_none()` on the
+    /// inner index.
+    #[inline]
+    #[must_use]
+    pub fn parent_of(&self, index: NodeIndex) -> Option<NodeIndex> {
+        self.get_extended(index).map(|ext| ext.parent)
+    }
+
     /// Get identifier data for a node.
     /// Returns None if node is not an identifier or has no data.
     #[inline]

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -238,6 +238,12 @@ fn test_parent_mapping() {
         binary_extended.parent.is_none(),
         "Binary expression should have no parent (it's the root)"
     );
+
+    // `parent_of` inherent helper mirrors `get_extended(..).map(|ext| ext.parent)`
+    assert_eq!(arena.parent_of(left_ident), Some(binary_expr));
+    assert_eq!(arena.parent_of(right_ident), Some(binary_expr));
+    assert_eq!(arena.parent_of(binary_expr), Some(NodeIndex::NONE));
+    assert_eq!(arena.parent_of(NodeIndex::NONE), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add inherent `NodeArena::parent_of(idx) -> Option<NodeIndex>` beside `get_extended`/`get_extended_mut`.
- Migrate 47 single-line occurrences of `arena.get_extended(idx).map(|ext| ext.parent)` across tsz-checker (checkers, flow analysis, symbol resolver, scope finder, type-checking, property access, JSX, generic checker, iterable checker, JS class properties, indexed access, const enum eval, duplicate identifiers, error reporter, declarations, state checking) and tsz-emitter (type printer symbol resolution).
- Extend `test_parent_mapping` to cover the new helper including the `NodeIndex::NONE` sentinel path and the root-node `Some(NodeIndex::NONE)` case.

The raw pattern appears in roughly 140 spots. This PR focuses on the single-line invocations for a uniform, reviewable diff — the multi-line chain variants (where rustfmt wrapped the call across two lines) stay for a follow-up.

Shrinks parent-walk expressions from ~40 chars to ~18 and gives a single grep target for future changes to the parent layout in `ExtendedNodeInfo`.

## Test plan
- [x] `cargo nextest run -p tsz-parser -E 'test(test_node_access_trait) | test(test_parent_mapping)'` — passes
- [x] Full pre-commit pipeline (fmt, clippy zero-warnings, wasm32 rustc, arch-guard, nextest 19318 tests) — passes