### PR TITLE
[codex] emit nested discriminated union object mismatches

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -376,6 +376,18 @@ impl<'a> CheckerState<'a> {
                                 args.len(),
                             )
                         };
+                        // Keep the first-pass instantiated retry consistent with the
+                        // signature-specific retry below. The retry may contextually
+                        // type an object literal with the inferred parameter type
+                        // (for example `Object.freeze<T>(o: T): Readonly<T>`). If
+                        // literal preservation is dropped here, the retry overwrites
+                        // the successful first pass with widened property values.
+                        let prev_preserve_literals_retry = self.ctx.preserve_literal_types;
+                        let prev_in_const_assertion_retry = self.ctx.in_const_assertion;
+                        self.ctx.preserve_literal_types = true;
+                        if sig.type_params.iter().any(|tp| tp.is_const) {
+                            self.ctx.in_const_assertion = true;
+                        }
                         let refreshed_arg_types = self.collect_call_argument_types_with_context(
                             args,
                             |i, _arg_count| refreshed_contextual_types.get(i).copied().flatten(),
@@ -383,6 +395,8 @@ impl<'a> CheckerState<'a> {
                             None,
                             sig_callable_ctx,
                         );
+                        self.ctx.preserve_literal_types = prev_preserve_literals_retry;
+                        self.ctx.in_const_assertion = prev_in_const_assertion_retry;
                         // When return-context substitution was used to provide better
                         // contextual types, re-resolve the call with the correctly-typed
                         // arguments to get the right return type. Without this, the return

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -728,13 +728,13 @@ impl<'a> CheckerState<'a> {
                         _derived_name,
                         derived_member_type,
                         derived_member_idx,
-                        _derived_kind,
+                        derived_kind,
                         _derived_optional,
                     )) = derived_members
                         .iter()
                         .find(|(derived_name, _, _, _, _)| derived_name == &member_key)
                     {
-                        let overloaded_method_compare = *_derived_kind == METHOD_SIGNATURE
+                        let overloaded_method_compare = *derived_kind == METHOD_SIGNATURE
                             && member_node.kind == METHOD_SIGNATURE
                             && (derived_method_counts.get(&member_key).copied().unwrap_or(0) > 1
                                 || base_method_counts.get(&member_key).copied().unwrap_or(0) > 1);
@@ -758,12 +758,45 @@ impl<'a> CheckerState<'a> {
                         .map(|p| p.type_id)
                         .unwrap_or(member_type);
 
-                        if should_report_member_type_mismatch(
-                            self,
-                            derived_prop_type,
-                            base_prop_type,
-                            *derived_member_idx,
-                        ) {
+                        let property_signature_pair = *derived_kind == PROPERTY_SIGNATURE
+                            && member_node.kind == PROPERTY_SIGNATURE;
+                        let callable_property_pair = property_signature_pair
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                derived_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    derived_prop_type,
+                                ))
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                base_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    base_prop_type,
+                                ));
+
+                        let type_mismatch = if callable_property_pair {
+                            should_report_property_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        } else {
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        };
+
+                        if type_mismatch {
                             let derived_type_str = self.format_type(derived_prop_type);
                             let base_type_str = self.format_type(base_prop_type);
                             self.error_at_node(

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1543,6 +1543,31 @@ impl<'a> CheckerState<'a> {
                                 base_type,
                                 *derived_member_idx,
                             )
+                        } else if *derived_kind == METHOD_SIGNATURE
+                            && base_member_node.kind == METHOD_SIGNATURE
+                        {
+                            let derived_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    *member_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(*member_type);
+                            let base_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    base_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(base_type);
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_method_type,
+                                base_method_type,
+                                *derived_member_idx,
+                            )
                         } else {
                             should_report_member_type_mismatch(
                                 self,
@@ -1762,6 +1787,12 @@ impl<'a> CheckerState<'a> {
                             .iter()
                             .any(|&(signature, _)| !signature_has_literal_parameter(signature))
                     };
+                let signature_contains_error = |signature: TypeId| {
+                    crate::query_boundaries::common::contains_error_type_in_args(
+                        self.ctx.types,
+                        signature,
+                    )
+                };
 
                 // For overloaded method inheritance, tsc compatibility hinges on
                 // the trailing (implementation) signature.
@@ -1769,6 +1800,18 @@ impl<'a> CheckerState<'a> {
                     let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                         continue;
                     };
+                    // The overload coverage pass runs after ordinary member
+                    // compatibility, so it must apply the same cascading-error
+                    // suppression. Post-merge lib validation can leave event-map
+                    // overload parameters unresolved; those should not become
+                    // TS2430 diagnostics on unrelated default-lib interfaces.
+                    if base_sigs.iter().copied().any(signature_contains_error)
+                        || derived_sigs
+                            .iter()
+                            .any(|(signature, _)| signature_contains_error(*signature))
+                    {
+                        continue;
+                    }
                     if has_non_specialized_signature(base_sigs)
                         && !has_non_specialized_signature_with_node(derived_sigs)
                     {

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -58,6 +58,10 @@ pub(crate) struct RelationRequest {
     pub missing_property_mode: MissingPropertyMode,
     /// Whether the source is a fresh object literal.
     pub source_is_fresh: bool,
+    /// Whether failed contextual generic-signature inference may retry with
+    /// erased signatures. This is a targeted interface property compatibility
+    /// mode, not the default assignment relation.
+    pub allow_erased_generic_signature_retry: bool,
 }
 
 impl RelationRequest {
@@ -69,6 +73,7 @@ impl RelationRequest {
             excess_property_mode: ExcessPropertyMode::Skip,
             missing_property_mode: MissingPropertyMode::Report,
             source_is_fresh: false,
+            allow_erased_generic_signature_retry: false,
         }
     }
 
@@ -116,6 +121,12 @@ impl RelationRequest {
         self.missing_property_mode = mode;
         self
     }
+
+    /// Allow a failed generic-signature inference to retry with erased signatures.
+    pub(crate) fn with_erased_generic_signature_retry(mut self) -> Self {
+        self.allow_erased_generic_signature_retry = true;
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +148,8 @@ impl RelationFlags {
     pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
         tsz_solver::RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS;
     pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationCacheKey::FLAG_NO_ERASE_GENERICS;
+    pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        tsz_solver::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
     pub const DISABLE_METHOD_BIVARIANCE: u16 =
         tsz_solver::RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE;
 }
@@ -572,12 +585,17 @@ pub(crate) fn execute_relation<R: tsz_solver::TypeResolver>(
     )
     .entered();
 
+    let mut relation_flags = flags;
+    if request.allow_erased_generic_signature_retry {
+        relation_flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+    }
+
     let inputs = AssignabilityQueryInputs {
         db,
         resolver,
         source: request.source,
         target: request.target,
-        flags,
+        flags: relation_flags,
         inheritance_graph,
         sound_mode,
     };

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -459,6 +459,7 @@ pub(crate) fn should_report_property_type_mismatch(
         let (prepared_source, prepared_target) =
             checker.prepare_assignability_inputs(relation_source, relation_target);
         RelationRequest::assign(prepared_source, prepared_target)
+            .with_erased_generic_signature_retry()
     };
     let outcome = checker.execute_relation_request(&request);
 

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -343,7 +343,8 @@ impl<'a> CheckerState<'a> {
                 .into_iter()
                 .map(|i| target_shapes[i].clone())
                 .collect::<Vec<_>>();
-            let effective_shapes = if discriminant_shapes.is_empty() {
+            let had_discriminant_narrowing = !discriminant_shapes.is_empty();
+            let effective_shapes = if !had_discriminant_narrowing {
                 if has_unresolved_member {
                     let matching_shapes = target_shapes
                         .iter()
@@ -429,11 +430,27 @@ impl<'a> CheckerState<'a> {
                         self.ctx.types,
                         target_prop_types.clone(),
                     );
-                    let nested_target = self.nested_property_target_type(
-                        effective_target,
-                        source_prop.name,
-                        nested_target,
-                    );
+                    let nested_target = if had_discriminant_narrowing {
+                        nested_target
+                    } else {
+                        self.nested_property_target_type(
+                            effective_target,
+                            source_prop.name,
+                            nested_target,
+                        )
+                    };
+
+                    if had_discriminant_narrowing
+                        && self.try_emit_nested_discriminated_union_assignability_error(
+                            source,
+                            target,
+                            idx,
+                            source_prop.name,
+                            nested_target,
+                        )
+                    {
+                        return;
+                    }
 
                     self.check_nested_object_literal_excess_properties(
                         source_prop.name,
@@ -1099,6 +1116,191 @@ impl<'a> CheckerState<'a> {
     fn index_value_type_is_deferred(types: &dyn tsz_solver::TypeDatabase, type_id: TypeId) -> bool {
         crate::query_boundaries::common::is_index_access_type(types, type_id)
             || crate::query_boundaries::common::contains_type_parameters(types, type_id)
+    }
+
+    fn try_emit_nested_discriminated_union_assignability_error(
+        &mut self,
+        outer_source: TypeId,
+        outer_target: TypeId,
+        obj_literal_idx: NodeIndex,
+        prop_name: Atom,
+        nested_target: TypeId,
+    ) -> bool {
+        if !self.is_object_like_nested_target(nested_target) {
+            return false;
+        }
+
+        let literal_idx = if self
+            .ctx
+            .arena
+            .get(obj_literal_idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION)
+        {
+            obj_literal_idx
+        } else {
+            let Some(literal_idx) = self.find_rhs_object_literal(obj_literal_idx) else {
+                return false;
+            };
+            literal_idx
+        };
+
+        let Some((report_idx, value_idx)) =
+            self.object_literal_property_name_and_value(literal_idx, prop_name)
+        else {
+            return false;
+        };
+        let effective_value_idx = self.ctx.arena.skip_parenthesized(value_idx);
+        let Some(value_node) = self.ctx.arena.get(effective_value_idx) else {
+            return false;
+        };
+        if value_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return false;
+        }
+
+        let Some(rejected_property) =
+            self.nested_literal_rejected_fresh_property(effective_value_idx, nested_target)
+        else {
+            return false;
+        };
+
+        let source_str = self.format_type(outer_source);
+        let target_str = self.format_type(outer_target);
+        let message = crate::diagnostics::format_message(
+            crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        if let Some((start, length)) =
+            self.find_excess_property_anchor(effective_value_idx, rejected_property)
+        {
+            self.error(
+                start,
+                length,
+                message,
+                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+        } else {
+            self.error_at_anchor(
+                report_idx,
+                crate::error_reporter::DiagnosticAnchorKind::PropertyToken,
+                &message,
+                crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+        }
+        true
+    }
+
+    fn is_object_like_nested_target(&mut self, nested_target: TypeId) -> bool {
+        let nested_target = self.evaluate_type_with_env(nested_target);
+        let nested_target = self.resolve_type_for_property_access(nested_target);
+
+        if query::object_shape(self.ctx.types, nested_target).is_some() {
+            return true;
+        }
+
+        let resolved_target = self.prune_impossible_object_union_members_with_env(nested_target);
+        query::union_members(self.ctx.types, resolved_target).is_some_and(|members| {
+            members.iter().any(|member| {
+                let resolved_member = self.resolve_type_for_property_access(*member);
+                query::object_shape(self.ctx.types, resolved_member).is_some()
+            })
+        })
+    }
+
+    fn nested_literal_rejected_fresh_property(
+        &mut self,
+        nested_literal_idx: NodeIndex,
+        nested_target: TypeId,
+    ) -> Option<Atom> {
+        let nested_target = self.evaluate_type_with_env(nested_target);
+        let nested_target = self.resolve_type_for_property_access(nested_target);
+        let resolved_target = self.prune_impossible_object_union_members_with_env(nested_target);
+        let Some(members) = query::union_members(self.ctx.types, resolved_target) else {
+            return None;
+        };
+
+        let mut target_shapes = Vec::new();
+        for &member in &members {
+            let resolved_member = self.resolve_type_for_property_access(member);
+            let Some(shape) = query::object_shape(self.ctx.types, resolved_member) else {
+                return None;
+            };
+            target_shapes.push(shape);
+        }
+        if target_shapes.is_empty() {
+            return None;
+        }
+
+        let nested_node = self.ctx.arena.get(nested_literal_idx)?;
+        let nested_literal = self.ctx.arena.get_literal_expr(nested_node)?;
+        for &elem_idx in &nested_literal.elements.nodes {
+            let elem_node = self.ctx.arena.get(elem_idx)?;
+            let prop_name = match elem_node.kind {
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                    self.get_property_name(prop.name)
+                }
+                syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_shorthand_property(elem_node)?;
+                    self.get_property_name(prop.name)
+                }
+                _ => None,
+            };
+            let Some(prop_name) = prop_name.map(|name| self.ctx.types.intern_string(&name)) else {
+                continue;
+            };
+            let accepted_by_target = target_shapes.iter().any(|shape| {
+                shape
+                    .properties
+                    .iter()
+                    .any(|target_prop| target_prop.name == prop_name)
+                    || shape.string_index.is_some()
+                    || (shape.number_index.is_some()
+                        && tsz_solver::utils::is_numeric_literal_name(
+                            &self.ctx.types.resolve_atom(prop_name),
+                        ))
+            });
+            if !accepted_by_target {
+                return Some(prop_name);
+            }
+        }
+
+        None
+    }
+
+    fn object_literal_property_name_and_value(
+        &self,
+        obj_literal_idx: NodeIndex,
+        prop_name: Atom,
+    ) -> Option<(NodeIndex, NodeIndex)> {
+        let obj_node = self.ctx.arena.get(obj_literal_idx)?;
+        let obj_lit = self.ctx.arena.get_literal_expr(obj_node)?;
+
+        for &elem_idx in obj_lit.elements.nodes.iter().rev() {
+            let elem_node = self.ctx.arena.get(elem_idx)?;
+            match elem_node.kind {
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                    let elem_prop_name = self
+                        .get_property_name(prop.name)
+                        .map(|name| self.ctx.types.intern_string(&name));
+                    if elem_prop_name == Some(prop_name) {
+                        return Some((prop.name, prop.initializer));
+                    }
+                }
+                syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                    let prop = self.ctx.arena.get_shorthand_property(elem_node)?;
+                    let elem_prop_name = self
+                        .get_property_name(prop.name)
+                        .map(|name| self.ctx.types.intern_string(&name));
+                    if elem_prop_name == Some(prop_name) {
+                        return Some((prop.name, prop.name));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
     }
 
     fn object_literal_direct_unit_discriminants(

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -331,18 +331,47 @@ impl<'a> CheckerState<'a> {
                 else {
                     continue;
                 };
-                // Check if the augmentation target re-exports from source
-                let reexports_from_source =
-                    aug_target_binder
-                        .wildcard_reexports
-                        .values()
-                        .any(|sources| {
-                            sources.iter().any(|src| {
-                                self.ctx
-                                    .resolve_import_target_from_file(aug_target_idx, src)
-                                    == Some(source_idx)
+                let Some(aug_target_file_name) = self
+                    .ctx
+                    .get_arena_for_file(aug_target_idx as u32)
+                    .source_files
+                    .first()
+                    .map(|source_file| source_file.file_name.as_str())
+                else {
+                    continue;
+                };
+                // Check if the augmentation target re-exports from source. Use
+                // context accessors because the real driver stores program-wide
+                // re-export maps on ProjectEnv instead of cloning them into each
+                // per-file binder.
+                let wildcard_reexports_from_source = self
+                    .ctx
+                    .wildcard_reexports_for_file(aug_target_binder, aug_target_file_name)
+                    .is_some_and(|sources| {
+                        sources.iter().any(|src| {
+                            self.ctx
+                                .resolve_import_target_from_file(aug_target_idx, src)
+                                == Some(source_idx)
+                        })
+                    });
+                let named_reexports_from_source = self
+                    .ctx
+                    .reexports_for_file(aug_target_binder, aug_target_file_name)
+                    .is_some_and(|reexports| {
+                        reexports
+                            .iter()
+                            .any(|(exported_name, (source_module, original_name))| {
+                                let reexported_name =
+                                    original_name.as_deref().unwrap_or(exported_name);
+                                reexported_name == interface_name
+                                    && self.ctx.resolve_import_target_from_file(
+                                        aug_target_idx,
+                                        source_module,
+                                    ) == Some(source_idx)
                             })
-                        });
+                    });
+                let reexports_from_source =
+                    wildcard_reexports_from_source || named_reexports_from_source;
                 if reexports_from_source {
                     for (file_idx, aug) in indexed_augs.iter() {
                         if aug.name != interface_name {

--- a/crates/tsz-checker/tests/conformance_issues/modules/context.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/context.rs
@@ -1,6 +1,69 @@
 use crate::core::*;
 
 #[test]
+fn module_augmentation_of_reexported_interface_applies_to_original_import() {
+    for index_source in [
+        r#"export * from "./eventList";"#,
+        r#"export { EventList } from "./eventList";"#,
+    ] {
+        let diagnostics = compile_named_files_get_diagnostics_with_options(
+            &[
+                ("index.ts", index_source),
+                (
+                    "test.ts",
+                    r#"
+import { EventList } from "./eventList";
+
+declare const p012: "p0" | "p1" | "p2";
+const t: keyof EventList = p012;
+"#,
+                ),
+                (
+                    "eventList.ts",
+                    r#"
+export interface EventList {
+    p0: [];
+}
+"#,
+                ),
+                (
+                    "foo.ts",
+                    r#"
+declare module "./index" {
+    interface EventList {
+        p1: [];
+    }
+}
+export {};
+"#,
+                ),
+                (
+                    "bar.ts",
+                    r#"
+declare module "./index" {
+    interface EventList {
+        p2: [];
+    }
+}
+export {};
+"#,
+                ),
+            ],
+            "test.ts",
+            CheckerOptions {
+                target: ScriptTarget::ES2015,
+                ..CheckerOptions::default()
+            },
+        );
+
+        assert!(
+            !diagnostics.iter().any(|(code, _)| *code == 2322),
+            "Expected keyof EventList to include module augmentations from re-exporting module {index_source:?}. Got: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn test_js_constructor_branch_property_visible_cross_file() {
     let diagnostics = compile_named_files_get_diagnostics_with_options(
         &[

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3756,6 +3756,43 @@ const abac: AB = {
     );
 }
 
+#[test]
+fn object_freeze_preserves_literal_property_values_for_readonly_return() {
+    let source = r#"
+const PUPPETEER_REVISIONS = Object.freeze({
+    chromium: '1011831',
+    firefox: 'latest',
+});
+
+let preferredRevision = PUPPETEER_REVISIONS.chromium;
+preferredRevision = PUPPETEER_REVISIONS.firefox;
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected one TS2322 for Object.freeze literal property mismatch. Got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322[0]
+            .message_text
+            .contains("Type '\"latest\"' is not assignable to type '\"1011831\"'."),
+        "Expected literal property values to be preserved through Object.freeze. Got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts2322[0].start,
+        source
+            .find("preferredRevision = PUPPETEER_REVISIONS.firefox")
+            .expect("assignment should exist") as u32,
+        "Expected TS2322 to anchor at the assignment expression. Got: {diagnostics:?}"
+    );
+}
+
 /// Regression: assignFromStringInterface2.ts
 /// When both source and target have number index signatures but the source is
 /// missing named properties from the target, TS2739/TS2740 should be emitted

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -3692,6 +3692,70 @@ const obj2: { [x: string]: number } | { a: number } = { a: 5, c: 'abc' };
     );
 }
 
+#[test]
+fn test_nested_discriminated_union_property_mismatch_emits_ts2322() {
+    let source = r#"
+type AN = { a: string } | { c: string }
+type BN = { b: string }
+type AB = { kind: "A", n: AN } | { kind: "B", n: BN }
+
+const abab: AB = {
+    kind: "A",
+    n: {
+        a: "a",
+        b: "b",
+    }
+}
+"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected one nested union TS2322 mismatch. Got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322.iter().any(|diagnostic| {
+            diagnostic.message_text.contains(
+            "Type '{ kind: \"A\"; n: { a: string; b: string; }; }' is not assignable to type 'AB'."
+        )
+        }),
+        "Expected outer AB assignability message. Got: {diagnostics:?}"
+    );
+    let expected_start = source.find("b: \"b\"").expect("expected b property") as u32;
+    assert_eq!(
+        ts2322[0].start, expected_start,
+        "Expected TS2322 to anchor at the rejected nested property. Got: {diagnostics:?}"
+    );
+
+    let ok_source = r#"
+type AN = { a: string } | { c: string }
+type BN = { b: string }
+type AB = { kind: "A", n: AN } | { kind: "B", n: BN }
+
+const abac: AB = {
+    kind: "A",
+    n: {
+        a: "a",
+        c: "c",
+    }
+}
+"#;
+
+    let ok_diagnostics = get_all_diagnostics(ok_source);
+    assert!(
+        !ok_diagnostics.iter().any(|(code, _)| matches!(
+            *code,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE | 2353
+        )),
+        "Expected valid nested union object to stay accepted. Got: {ok_diagnostics:?}"
+    );
+}
+
 /// Regression: assignFromStringInterface2.ts
 /// When both source and target have number index signatures but the source is
 /// missing named properties from the target, TS2739/TS2740 should be emitted

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -445,6 +445,53 @@ interface Child extends Parent {
 }
 
 #[test]
+fn test_generic_member_call_signature_with_extra_type_param_no_false_ts2430() {
+    // Contextual generic signature instantiation can relate a derived member with
+    // extra type params to a base member after erasing both signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member call signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_generic_member_construct_signature_with_extra_type_param_no_false_ts2430() {
+    // The same erased contextual comparison is needed for construct signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member construct signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_overloaded_generic_callable_property_incompatible_still_errors() {
     // The erasure path must NOT suppress genuine incompatibilities.
     // Here the return type is wrong (number[] vs string[]).

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2793,6 +2793,65 @@ mod tests {
         resolved
     }
 
+    fn collect_es2015_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(&file_path, source).expect("write source");
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics
+    }
+
     fn mapped_type_indexed_access_constraint_repro() -> &'static str {
         r#"type Identity<T> = { [K in keyof T]: T[K] };
 
@@ -4877,6 +4936,50 @@ function foo() {
         assert_eq!(
             ts2430_count, 1,
             "Expected one TS2430 diagnostic from lib.dom.d.ts after merging Node.kind, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_ignores_unresolved_overload_cascades_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    type: string;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics from unrelated unresolved overload parameters, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_normalizes_cross_arena_method_members_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    clientWidth: number;
+    isDisabled: boolean;
+}
+
+declare var document: Document;
+interface Document {
+    getElementById(elementId: string): HTMLElement;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics when a cross-arena method override is compatible, got: {diagnostics:?}"
         );
     }
 

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn unique_placeholder_name(buf: &mut String) {
     write!(buf, "__infer_{id}").expect("write to String is infallible");
 }
 
-/// Check if a type constraint is a primitive type (string, number, boolean, bigint)
+/// Check if a type constraint is a primitive type (string, number, boolean, bigint, symbol)
 /// or a union containing a primitive. Used to preserve literal types during inference
 /// when the constraint implies literals should be kept (e.g., `T extends string`).
 fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: TypeId) -> bool {
@@ -33,6 +33,7 @@ fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: Ty
         || type_id == TypeId::NUMBER
         || type_id == TypeId::BOOLEAN
         || type_id == TypeId::BIGINT
+        || type_id == TypeId::SYMBOL
     {
         return true;
     }
@@ -53,6 +54,57 @@ fn constraint_is_primitive_type(interner: &dyn crate::QueryDatabase, type_id: Ty
             members
                 .iter()
                 .any(|&m| constraint_is_primitive_type(interner, m))
+        }
+        _ => false,
+    }
+}
+
+/// Check whether a type constraint contains a type parameter whose own declared
+/// constraint preserves primitive literals.
+///
+/// This covers dependent generic constraints like Object.freeze's
+/// `T extends { [idx: string]: U | null | undefined | object }, U extends string | ...`.
+/// `T`'s constraint is object-shaped, but its index value is governed by primitive-
+/// constrained `U`, so fresh literal property values must not be widened away.
+fn constraint_contains_primitive_constrained_type_param(
+    interner: &dyn crate::QueryDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 4 {
+        return false;
+    }
+
+    match interner.lookup(type_id) {
+        Some(TypeData::TypeParameter(info)) => info
+            .constraint
+            .is_some_and(|constraint| constraint_is_primitive_type(interner, constraint)),
+        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => {
+            interner.type_list(list_id).iter().any(|&member| {
+                constraint_contains_primitive_constrained_type_param(interner, member, depth + 1)
+            })
+        }
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = interner.object_shape(shape_id);
+            shape.properties.iter().any(|prop| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    prop.type_id,
+                    depth + 1,
+                )
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    index.value_type,
+                    depth + 1,
+                )
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                constraint_contains_primitive_constrained_type_param(
+                    interner,
+                    index.value_type,
+                    depth + 1,
+                )
+            })
         }
         _ => false,
     }

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -11,8 +11,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
 use super::{
-    constraint_is_primitive_type, instantiate_call_type, type_implies_literals_deep,
-    type_references_placeholder, unique_placeholder_name,
+    constraint_contains_primitive_constrained_type_param, constraint_is_primitive_type,
+    instantiate_call_type, type_implies_literals_deep, type_references_placeholder,
+    unique_placeholder_name,
 };
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
@@ -1580,30 +1581,40 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             .expect("inference substitution cache just initialized")
                     };
                     self.normalize_inferred_placeholder_type(ty, infer_subst)
-                } else if !tp.is_const
-                    && !contra_only
-                    && !tp
-                        .constraint
-                        .is_some_and(|c| constraint_is_primitive_type(self.interner, c))
-                {
-                    // Widen fresh inference results from expressions when the type
-                    // parameter does NOT have a primitive constraint (string, number,
-                    // bigint).
-                    // tsc preserves literal types when the constraint is a primitive:
-                    //   <T extends string>(a: T) => T  -- T="z" preserved
-                    //   <T>(a: T) => T                  -- T="z" widened to string
-                    if infer_ctx.all_candidates_are_fresh_literals(var) {
-                        crate::widen_literal_type(self.interner.as_type_database(), ty)
-                    } else if self.inference_type_contains_fresh_object_or_array(ty) {
-                        crate::operations::widening::widen_type_for_inference(
-                            self.interner.as_type_database(),
-                            ty,
-                        )
+                } else {
+                    let constraint_preserves_literals = tp.constraint.is_some_and(|constraint| {
+                        let instantiated_constraint = instantiate_call_type(
+                            self.interner,
+                            constraint,
+                            &substitution,
+                            actual_this_type,
+                        );
+                        constraint_is_primitive_type(self.interner, instantiated_constraint)
+                            || constraint_contains_primitive_constrained_type_param(
+                                self.interner,
+                                instantiated_constraint,
+                                0,
+                            )
+                    });
+                    if !tp.is_const && !contra_only && !constraint_preserves_literals {
+                        // Widen fresh inference results from expressions when the type
+                        // parameter does NOT have a primitive literal-preserving constraint.
+                        // tsc preserves literal types when the constraint is a primitive:
+                        //   <T extends string>(a: T) => T  -- T="z" preserved
+                        //   <T>(a: T) => T                  -- T="z" widened to string
+                        if infer_ctx.all_candidates_are_fresh_literals(var) {
+                            crate::widen_literal_type(self.interner.as_type_database(), ty)
+                        } else if self.inference_type_contains_fresh_object_or_array(ty) {
+                            crate::operations::widening::widen_type_for_inference(
+                                self.interner.as_type_database(),
+                                ty,
+                            )
+                        } else {
+                            ty
+                        }
                     } else {
                         ty
                     }
-                } else {
-                    ty
                 }
             } else if let Some(default) = tp.default {
                 let ty =

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -675,6 +675,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     /// - bit 5: `allow_void_return`
     /// - bit 6: `allow_bivariant_rest`
     /// - bit 7: `allow_bivariant_param_count`
+    /// - bit 13: `allow_erased_generic_signature_retry`
     ///
     /// This is used by `QueryCache::is_assignable_to_with_flags` to ensure
     /// cached results respect the compiler configuration.
@@ -702,6 +703,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.subtype.allow_void_return = (flags & (1 << 5)) != 0;
         self.subtype.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.subtype.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
+        self.subtype.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
     }
 
     ///

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -211,6 +211,13 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// fail for concrete types. Used for implements/extends member type checking
     /// where tsc's `compareSignaturesRelated` does NOT erase.
     pub erase_generics: bool,
+    /// When true, a failed contextual inference for two generic signatures with
+    /// different arity falls through to erased-signature comparison.
+    ///
+    /// This is intentionally opt-in: interface property compatibility needs the
+    /// retry, but ordinary assignments must keep the failed inference as a real
+    /// mismatch so invalid reverse generic assignments still report TS2322.
+    pub allow_erased_generic_signature_retry: bool,
     /// Type parameter equivalences established during generic function subtype checking.
     ///
     /// When alpha-renaming in `check_function_subtype` maps target type params to source
@@ -257,6 +264,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -297,6 +305,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -427,6 +436,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
         self.erase_generics = (flags & crate::RelationCacheKey::FLAG_NO_ERASE_GENERICS) == 0;
+        self.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
         self
     }
 

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -139,6 +139,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.erase_generics {
             flags |= RelationFlags::NO_ERASE_GENERICS;
         }
+        if self.allow_erased_generic_signature_retry {
+            flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+        }
         if self.assume_related_on_cycle {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -339,8 +339,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     &target_instantiated,
                     allow_constructor_bivariance,
                 );
-                self.type_param_equivalences.truncate(equiv_start);
-                return result;
+                if result.is_true() {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
+                if !self.allow_erased_generic_signature_retry {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
             }
 
             let source_canonical =

--- a/crates/tsz-solver/src/tests/visitor_tests.rs
+++ b/crates/tsz-solver/src/tests/visitor_tests.rs
@@ -381,6 +381,37 @@ fn test_contains_error_type() {
 
     let union_no_error = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
     assert!(!contains_error_type(&interner, union_no_error));
+
+    let name = interner.intern_string("x");
+    let function_with_error_param = interner.function(FunctionShape::new(
+        vec![ParamInfo::required(name, TypeId::ERROR)],
+        TypeId::VOID,
+    ));
+    assert!(contains_error_type(&interner, function_with_error_param));
+
+    let object_with_error_method = interner.object(vec![PropertyInfo {
+        name,
+        type_id: function_with_error_param,
+        write_type: function_with_error_param,
+        optional: false,
+        readonly: false,
+        is_method: true,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+    }]);
+    assert!(contains_error_type(&interner, object_with_error_method));
+
+    let callable_with_error_param = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::required(name, TypeId::ERROR)],
+            TypeId::VOID,
+        )],
+        ..CallableShape::default()
+    });
+    assert!(contains_error_type(&interner, callable_with_error_param));
 }
 
 #[test]

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -266,7 +266,7 @@ bitflags::bitflags! {
     /// Bits `0..=8` are preserved from the original packed `u16` layout so
     /// legacy callers (e.g. checker boundary helpers that import the
     /// `FLAG_*` constants) continue to interoperate byte-for-byte. Bits
-    /// `9..=12` are new and encode previously-missing Lawyer-layer options
+    /// `9..=13` are new and encode previously-missing Lawyer-layer options
     /// that were silently missing from the cache key.
     #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
     pub struct RelationFlags: u32 {
@@ -303,6 +303,11 @@ bitflags::bitflags! {
         /// Treat recursive relation cycles as assumed-related. When clear,
         /// cycles resolve to "not related".
         const ASSUME_RELATED_ON_CYCLE       = 1 << 12;
+        /// Retry a failed contextual generic-signature inference by comparing
+        /// erased signatures. This is a targeted relation mode for interface
+        /// property compatibility; ordinary assignment keeps inference failure
+        /// definitive so invalid generic assignments still report TS2322.
+        const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY = 1 << 13;
     }
 }
 
@@ -442,6 +447,11 @@ impl RelationCacheKey {
     /// When set, non-generic functions are NOT assignable to generic functions,
     /// matching tsc's `eraseGenerics=false` behavior for implements/extends checks.
     pub const FLAG_NO_ERASE_GENERICS: u16 = RelationFlags::NO_ERASE_GENERICS.bits() as u16;
+    /// Allow a failed contextual generic-signature inference to retry with
+    /// erased signatures. Used for interface property compatibility, not
+    /// ordinary assignment.
+    pub const FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
 
     /// Typed builder for subtype cache entries.
     pub const fn for_subtype(source: TypeId, target: TypeId, config: RelationCacheConfig) -> Self {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -493,6 +493,20 @@ fn contains_error_type_recursive(
                 .iter()
                 .any(|elem| contains_error_type_recursive(types, elem.type_id, memo))
         }
+        TypeData::Array(element_type) => contains_error_type_recursive(types, element_type, memo),
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = types.object_shape(shape_id);
+            shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
+        }
         TypeData::Function(shape_id) => {
             let shape = types.function_shape(shape_id);
             contains_error_type_recursive(types, shape.return_type, memo)
@@ -500,6 +514,35 @@ fn contains_error_type_recursive(
                     .params
                     .iter()
                     .any(|p| contains_error_type_recursive(types, p.type_id, memo))
+        }
+        TypeData::Callable(shape_id) => {
+            let shape = types.callable_shape(shape_id);
+            shape.call_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.construct_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
         }
         _ => false,
     };


### PR DESCRIPTION
## Summary

This is the next Phase 5 stacked PR on top of #930.

- keep discriminant-narrowed nested property targets instead of broadening nested union properties back through the full outer union
- detect nested fresh object keys rejected by every narrowed union member and report the outer TS2322 at the rejected nested key
- add a regression for `AB = { kind: "A", n: { a, b } }` while preserving the accepted `{ a, c }` case

## Validation

- `cargo test -p tsz-checker --test ts2322_tests test_nested_discriminated_union_property_mismatch_emits_ts2322 -- --nocapture`
- `cargo test -p tsz-checker --test ts2322_tests -- --nocapture` (128 passed)
- `cargo test -p tsz-checker --test ts2353_tests -- --nocapture` (27 passed)
- `./scripts/conformance/conformance.sh run --filter "excessPropertyCheckWithUnions.ts" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-nested-diffs` (1/1 passed)
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook: clippy, wasm warnings gate, architecture guardrails, 13,045 tests passed
