### PR TITLE
perf(binder): Arc-wrap shorthand_ambient_modules to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -5,6 +5,7 @@
 
 use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
@@ -159,7 +160,8 @@ impl BinderState {
                             // Shorthand ambient module: `declare module "*.json";` (no body)
                             // Even when classified as augmentation, a bodyless declaration
                             // is a shorthand that makes matching imports resolve to `any`.
-                            self.shorthand_ambient_modules.insert(module_specifier);
+                            Arc::make_mut(&mut self.shorthand_ambient_modules)
+                                .insert(module_specifier);
                         } else {
                             self.node_scope_ids
                                 .insert(module.body.0, self.current_scope_id);
@@ -283,7 +285,7 @@ impl BinderState {
                     && let Some(lit) = arena.get_literal(name_node)
                     && !lit.text.is_empty()
                 {
-                    self.shorthand_ambient_modules.insert(lit.text.clone());
+                    Arc::make_mut(&mut self.shorthand_ambient_modules).insert(lit.text.clone());
                 }
             } else {
                 self.node_scope_ids

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -211,7 +211,7 @@ impl BinderState {
             wildcard_reexports_type_only: FxHashMap::default(),
             resolved_export_cache: Default::default(),
             resolved_identifier_cache: Default::default(),
-            shorthand_ambient_modules: FxHashSet::default(),
+            shorthand_ambient_modules: Arc::new(FxHashSet::default()),
             modules_with_export_equals: FxHashSet::default(),
             module_export_equals_non_module: FxHashMap::default(),
             lib_symbols_merged: false,
@@ -281,7 +281,7 @@ impl BinderState {
             .write()
             .expect("RwLock not poisoned")
             .clear();
-        self.shorthand_ambient_modules.clear();
+        Arc::make_mut(&mut self.shorthand_ambient_modules).clear();
         self.modules_with_export_equals.clear();
         self.module_export_equals_non_module.clear();
         self.lib_symbols_merged = false;
@@ -428,7 +428,7 @@ impl BinderState {
             wildcard_reexports_type_only: FxHashMap::default(),
             resolved_export_cache: Default::default(),
             resolved_identifier_cache: Default::default(),
-            shorthand_ambient_modules: FxHashSet::default(),
+            shorthand_ambient_modules: Arc::new(FxHashSet::default()),
             modules_with_export_equals: FxHashSet::default(),
             module_export_equals_non_module: FxHashMap::default(),
             lib_symbols_merged: false,

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -358,7 +358,7 @@ pub struct BinderState {
 
     /// Shorthand ambient modules: modules declared with just `declare module "xxx"` (no body)
     /// Imports from these modules should resolve to `any` type
-    pub shorthand_ambient_modules: FxHashSet<String>,
+    pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
 
     /// Modules that use `export =` syntax (CommonJS-style exports)
     /// Used by the import checker to validate require-style imports
@@ -810,7 +810,7 @@ pub struct BinderStateScopeInputs {
     pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
     pub declaration_arenas: DeclarationArenaMap,
     pub cross_file_node_symbols: CrossFileNodeSymbols,
-    pub shorthand_ambient_modules: FxHashSet<String>,
+    pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     pub modules_with_export_equals: FxHashSet<String>,
     pub flow_nodes: FlowNodeArena,
     pub node_flow: FxHashMap<u32, FlowNodeId>,

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -493,7 +493,7 @@ pub struct BindResult {
     /// Parse diagnostics
     pub parse_diagnostics: Vec<ParseDiagnostic>,
     /// Shorthand ambient modules (`declare module "foo"` without body)
-    pub shorthand_ambient_modules: FxHashSet<String>,
+    pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     /// Global augmentations (interface declarations inside `declare global` blocks)
     pub global_augmentations: FxHashMap<String, Vec<crate::binder::GlobalAugmentation>>,
     /// Module augmentations (interface/type declarations inside `declare module 'x'` blocks)
@@ -625,7 +625,7 @@ impl BindResult {
         }
 
         // shorthand_ambient_modules
-        for s in &self.shorthand_ambient_modules {
+        for s in self.shorthand_ambient_modules.iter() {
             size += s.capacity() + std::mem::size_of::<u64>();
         }
 
@@ -1568,7 +1568,7 @@ pub struct MergedProgram {
     /// Ambient module declarations across all files
     pub declared_modules: FxHashSet<String>,
     /// Shorthand ambient modules (`declare module "foo"` without body) - imports from these are `any`
-    pub shorthand_ambient_modules: FxHashSet<String>,
+    pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     /// Module exports: maps file name (or module specifier) to its exported symbols
     /// This enables cross-file module resolution: import { X } from './file' can find X's symbol
     pub module_exports: FxHashMap<String, SymbolTable>,
@@ -3268,7 +3268,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         globals,
         file_locals: file_locals_list,
         declared_modules,
-        shorthand_ambient_modules,
+        shorthand_ambient_modules: Arc::new(shorthand_ambient_modules),
         module_exports,
         reexports,
         wildcard_reexports,

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -3673,7 +3673,7 @@ fn skeleton_validate_against_merged_shorthand_ambient() {
 
     let idx = program.skeleton_index.as_ref().unwrap();
     assert_eq!(
-        idx.shorthand_ambient_modules, program.shorthand_ambient_modules,
+        idx.shorthand_ambient_modules, *program.shorthand_ambient_modules,
         "skeleton and legacy shorthand_ambient_modules must match"
     );
     // Verify actual content


### PR DESCRIPTION
## Summary
- Mirrors the lib_symbol_ids Arc treatment from #932
- Each per-file `BinderState` now holds an `Arc<FxHashSet<String>>` for shorthand ambient modules instead of cloning the underlying set N times during the parallel build
- Mutation sites (`reset()`, `insert()`) use `Arc::make_mut`, so they remain cheap when the refcount is 1 and copy-on-write otherwise

## Why this helps
For large repos the global shorthand-ambient-modules set is identical across every file. Cloning the underlying `FxHashSet<String>` for each per-file binder was a real fixed cost in the parallel pipeline; `Arc::clone` collapses that to one atomic increment per file.

## Test plan
- [x] `cargo nextest run` (full pre-commit suite, 18777 tests passed)
- [x] `cargo nextest run --package tsz-core --lib`
- [ ] Conformance suite pass-rate sanity check after merge