### PR TITLE
chore(binder): add arena_for_declaration_or helper and migrate callers

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -346,6 +346,26 @@ impl BinderState {
         self.symbol_arenas.get(&sym_id)
     }
 
+    /// Resolve the arena that owns a declaration, falling back to a caller-provided
+    /// arena when no cross-file mapping exists.
+    ///
+    /// Callers frequently need the concrete `&NodeArena` that a declaration was
+    /// parsed into (e.g. to read its `kind`, children, or identifier text) and
+    /// want to default to the arena they are currently iterating over if the
+    /// declaration is purely local. This helper collapses the common
+    /// `get_arena_for_declaration(..).map_or(fallback, |arc| arc.as_ref())`
+    /// pattern into one call.
+    #[inline]
+    pub fn arena_for_declaration_or<'a>(
+        &'a self,
+        sym_id: SymbolId,
+        decl_idx: NodeIndex,
+        fallback: &'a NodeArena,
+    ) -> &'a NodeArena {
+        self.get_arena_for_declaration(sym_id, decl_idx)
+            .map_or(fallback, Arc::as_ref)
+    }
+
     /// Create a `BinderState` from pre-parsed lib data.
     ///
     /// This is used for loading pre-parsed lib files where we only have

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -6507,3 +6507,27 @@ enum MyEnum { A = 1, B = 2 }
         );
     }
 }
+
+#[test]
+fn arena_for_declaration_or_falls_back_when_unmapped() {
+    // Fresh binder has no cross-file declaration arenas registered, so the
+    // helper should return the fallback arena for any (sym, decl) pair.
+    let source = r"const x = 1;";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let sym_id = binder.file_locals.get("x").expect("symbol for x");
+    let sym = binder.symbols.get(sym_id).expect("symbol data");
+    let decl_idx = sym.primary_declaration().expect("primary declaration");
+
+    // No cross-file mapping exists — helper must hand back the fallback arena.
+    let got = binder.arena_for_declaration_or(sym_id, decl_idx, arena);
+    assert!(std::ptr::eq(got, arena));
+
+    // Helper matches the explicit Option-collapsing expression it replaces.
+    assert!(binder.get_arena_for_declaration(sym_id, decl_idx).is_none());
+}

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -180,17 +180,6 @@ impl<'a> CheckerState<'a> {
             CALL_SIGNATURE, INDEX_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
         };
 
-        fn decl_arena_for<'a>(
-            binder: &'a tsz_binder::BinderState,
-            current_arena: &'a tsz_parser::parser::node::NodeArena,
-            sym_id: tsz_binder::SymbolId,
-            decl_idx: NodeIndex,
-        ) -> &'a tsz_parser::parser::node::NodeArena {
-            binder
-                .get_arena_for_declaration(sym_id, decl_idx)
-                .map_or(current_arena, |arena| arena.as_ref())
-        }
-
         let iface_sym_id = self.ctx.binder.node_symbols.get(&_iface_idx.0).copied();
 
         // Get heritage clauses (extends) — must have at least one across all declarations
@@ -200,8 +189,11 @@ impl<'a> CheckerState<'a> {
                 .and_then(|sym_id| self.ctx.binder.symbols.get(sym_id).map(|sym| (sym_id, sym)))
                 .is_some_and(|(sym_id, sym)| {
                     sym.declarations.iter().any(|&decl_idx| {
-                        let decl_arena =
-                            decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+                        let decl_arena = self.ctx.binder.arena_for_declaration_or(
+                            sym_id,
+                            decl_idx,
+                            self.ctx.arena,
+                        );
                         decl_idx != _iface_idx
                             && decl_arena.get(decl_idx).is_some_and(|n| {
                                 decl_arena
@@ -254,8 +246,11 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .copied()
                     .filter(|&decl_idx| {
-                        let decl_arena =
-                            decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+                        let decl_arena = self.ctx.binder.arena_for_declaration_or(
+                            sym_id,
+                            decl_idx,
+                            self.ctx.arena,
+                        );
                         decl_arena
                             .get(decl_idx)
                             .is_some_and(|n| decl_arena.get_interface(n).is_some())
@@ -274,7 +269,10 @@ impl<'a> CheckerState<'a> {
             let Some(sym_id) = iface_sym_id else {
                 continue;
             };
-            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            let decl_arena =
+                self.ctx
+                    .binder
+                    .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
             if let Some(decl_node) = decl_arena.get(decl_idx)
                 && let Some(decl_iface) = decl_arena.get_interface(decl_node)
             {
@@ -393,7 +391,10 @@ impl<'a> CheckerState<'a> {
             let Some(sym_id) = iface_sym_id else {
                 continue;
             };
-            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            let decl_arena =
+                self.ctx
+                    .binder
+                    .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
             if let Some(decl_node) = decl_arena.get(decl_idx)
                 && let Some(decl_iface) = decl_arena.get_interface(decl_node)
             {
@@ -463,7 +464,10 @@ impl<'a> CheckerState<'a> {
             && let Some(sym) = self.ctx.binder.symbols.get(sym_id)
         {
             for &decl_idx in &sym.declarations {
-                let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+                let decl_arena =
+                    self.ctx
+                        .binder
+                        .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
                 if let Some(node) = decl_arena.get(decl_idx)
                     && decl_arena.get_class(node).is_some()
                 {
@@ -492,7 +496,10 @@ impl<'a> CheckerState<'a> {
             let Some(sym_id) = iface_sym_id else {
                 continue;
             };
-            let decl_arena = decl_arena_for(self.ctx.binder, self.ctx.arena, sym_id, decl_idx);
+            let decl_arena =
+                self.ctx
+                    .binder
+                    .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
             if let Some(decl_node) = decl_arena.get(decl_idx)
                 && let Some(decl_iface) = decl_arena.get_interface(decl_node)
                 && let Some(ref heritage_clauses) = decl_iface.heritage_clauses
@@ -560,7 +567,9 @@ impl<'a> CheckerState<'a> {
             let mut base_iface_indices = Vec::new();
             for &decl_idx in &base_symbol.declarations {
                 let decl_arena =
-                    decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    self.ctx
+                        .binder
+                        .arena_for_declaration_or(base_sym_id, decl_idx, self.ctx.arena);
                 if let Some(node) = decl_arena.get(decl_idx)
                     && decl_arena.get_interface(node).is_some()
                 {
@@ -570,7 +579,9 @@ impl<'a> CheckerState<'a> {
             if base_iface_indices.is_empty() && base_symbol.value_declaration.is_some() {
                 let decl_idx = base_symbol.value_declaration;
                 let decl_arena =
-                    decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    self.ctx
+                        .binder
+                        .arena_for_declaration_or(base_sym_id, decl_idx, self.ctx.arena);
                 if let Some(node) = decl_arena.get(decl_idx)
                     && decl_arena.get_interface(node).is_some()
                 {
@@ -602,11 +613,10 @@ impl<'a> CheckerState<'a> {
                 rustc_hash::FxHashSet::default();
 
             while let Some((iface_sym_id, iface_decl_idx, level_type_args)) = worklist.pop() {
-                let iface_arena = decl_arena_for(
-                    self.ctx.binder,
-                    self.ctx.arena,
+                let iface_arena = self.ctx.binder.arena_for_declaration_or(
                     iface_sym_id,
                     iface_decl_idx,
+                    self.ctx.arena,
                 );
                 let visit_key = (
                     iface_sym_id.0,
@@ -926,11 +936,10 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.binder.get_symbol(ancestor_sym_id)
                             {
                                 for &decl_idx in &ancestor_sym.declarations {
-                                    let decl_arena = decl_arena_for(
-                                        self.ctx.binder,
-                                        self.ctx.arena,
+                                    let decl_arena = self.ctx.binder.arena_for_declaration_or(
                                         ancestor_sym_id,
                                         decl_idx,
+                                        self.ctx.arena,
                                     );
                                     if let Some(dn) = decl_arena.get(decl_idx)
                                         && decl_arena.get_interface(dn).is_some()
@@ -954,8 +963,11 @@ impl<'a> CheckerState<'a> {
             if base_iface_indices.is_empty() {
                 let mut base_class_idx = None;
                 for &decl_idx in &base_symbol.declarations {
-                    let decl_arena =
-                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    let decl_arena = self.ctx.binder.arena_for_declaration_or(
+                        base_sym_id,
+                        decl_idx,
+                        self.ctx.arena,
+                    );
                     if let Some(node) = decl_arena.get(decl_idx)
                         && node.kind == syntax_kind_ext::CLASS_DECLARATION
                     {
@@ -966,8 +978,11 @@ impl<'a> CheckerState<'a> {
 
                 if base_class_idx.is_none() && base_symbol.value_declaration.is_some() {
                     let decl_idx = base_symbol.value_declaration;
-                    let decl_arena =
-                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, decl_idx);
+                    let decl_arena = self.ctx.binder.arena_for_declaration_or(
+                        base_sym_id,
+                        decl_idx,
+                        self.ctx.arena,
+                    );
                     if let Some(node) = decl_arena.get(decl_idx)
                         && node.kind == syntax_kind_ext::CLASS_DECLARATION
                     {
@@ -976,12 +991,16 @@ impl<'a> CheckerState<'a> {
                 }
 
                 if let Some(class_idx) = base_class_idx
-                    && let Some(class_node) =
-                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, class_idx)
-                            .get(class_idx)
-                    && let Some(class_data) =
-                        decl_arena_for(self.ctx.binder, self.ctx.arena, base_sym_id, class_idx)
-                            .get_class(class_node)
+                    && let Some(class_node) = self
+                        .ctx
+                        .binder
+                        .arena_for_declaration_or(base_sym_id, class_idx, self.ctx.arena)
+                        .get(class_idx)
+                    && let Some(class_data) = self
+                        .ctx
+                        .binder
+                        .arena_for_declaration_or(base_sym_id, class_idx, self.ctx.arena)
+                        .get_class(class_node)
                 {
                     // Build type parameter substitution for generic class bases
                     // e.g. `extends C<string>` where `class C<T> { a: T; }` → a: string

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -54,8 +54,7 @@ impl<'a> CheckerState<'a> {
             let arena = self
                 .ctx
                 .binder
-                .get_arena_for_declaration(sym_id, decl_idx)
-                .map_or(self.ctx.arena, |arena| arena.as_ref());
+                .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
             arena.get(decl_idx).is_some_and(|node| {
                 node.kind == syntax_kind_ext::INTERFACE_DECLARATION
                     || node.kind == syntax_kind_ext::CLASS_DECLARATION

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -98,11 +98,10 @@ impl<'a> CheckerState<'a> {
                 return lazy_type;
             }
             let has_interface_decl = declarations.iter().copied().any(|decl_idx| {
-                let arena = self
-                    .ctx
-                    .binder
-                    .get_arena_for_declaration(sym_id, decl_idx)
-                    .map_or(self.ctx.arena, |arena| arena.as_ref());
+                let arena =
+                    self.ctx
+                        .binder
+                        .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
                 arena
                     .get(decl_idx)
                     .is_some_and(|node| node.kind == syntax_kind_ext::INTERFACE_DECLARATION)
@@ -321,8 +320,7 @@ impl<'a> CheckerState<'a> {
                 let arena = self
                     .ctx
                     .binder
-                    .get_arena_for_declaration(sym_id, d)
-                    .map_or(self.ctx.arena, |arena| arena.as_ref());
+                    .arena_for_declaration_or(sym_id, d, self.ctx.arena);
                 arena
                     .get(d)
                     .and_then(|n| {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -928,18 +928,14 @@ impl<'a> CheckerState<'a> {
                         declarations[i];
                     let (other_idx, other_flags, other_is_local, other_is_exported, other_origin) =
                         declarations[j];
-                    let decl_arena = self
-                        .ctx
-                        .binder
-                        .get_arena_for_declaration(sym_id, decl_idx)
-                        .map(|arena| arena.as_ref())
-                        .unwrap_or(self.ctx.arena);
-                    let other_arena = self
-                        .ctx
-                        .binder
-                        .get_arena_for_declaration(sym_id, other_idx)
-                        .map(|arena| arena.as_ref())
-                        .unwrap_or(self.ctx.arena);
+                    let decl_arena =
+                        self.ctx
+                            .binder
+                            .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
+                    let other_arena =
+                        self.ctx
+                            .binder
+                            .arena_for_declaration_or(sym_id, other_idx, self.ctx.arena);
                     let decl_conflict_flags =
                         self.normalize_duplicate_conflict_flags(decl_arena, decl_idx, decl_flags);
                     let other_conflict_flags = self.normalize_duplicate_conflict_flags(


### PR DESCRIPTION
## Summary

- Add `BinderState::arena_for_declaration_or(sym_id, decl_idx, fallback) -> &NodeArena` as an inherent helper next to `get_arena_for_declaration`. It collapses the common `get_arena_for_declaration(..).map_or(fallback, |arc| arc.as_ref())` pattern into a single call.
- Migrate 6 checker callers (class_checker_compat: 14 occurrences + its local nested `decl_arena_for` fn, symbol_types x2, reference_helpers, duplicate_identifiers x2).
- Sites that intentionally return `Option<&NodeArena>` or fall across multiple binders (overload_compatibility, symbol_resolver) are left as-is — their semantics differ.

## Why

The `Option<&Arc<NodeArena>>` return type of `get_arena_for_declaration` was forcing every caller to write the same three-line resolve-or-fallback collapse. One file (class_checker_compat.rs) even introduced a local nested `decl_arena_for` helper so it could reuse the pattern 14 times within a single method. Promoting the collapse to `BinderState` makes intent obvious at the call site and removes the `Arc::as_ref` afterthought.

## Test plan
- [x] New `arena_for_declaration_or_falls_back_when_unmapped` unit test in `tsz-binder/src/state/tests.rs` verifies the fallback branch (no cross-file mapping) and asserts pointer-equality with the caller-provided arena.
- [x] `cargo nextest run -p tsz-binder -p tsz-checker` — 5321 tests pass.
- [x] Full pre-commit pipeline (fmt, clippy, wasm32 rustc, architecture guardrails, nextest) — 18778 tests pass.