### PR TITLE
fix(emitter): preserve `typeof X` in arrow function parameter annotations

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -125,7 +125,8 @@ impl<'a> DeclarationEmitter<'a> {
             } else if has_initializer
                 && (self.function_initializer_has_inline_parameter_comments(initializer)
                     || self.function_initializer_is_self_returning(initializer)
-                    || self.function_initializer_returns_unique_identifier(initializer))
+                    || self.function_initializer_returns_unique_identifier(initializer)
+                    || self.function_initializer_has_typeof_in_param_annotation(initializer))
                 && {
                     self.maybe_emit_non_portable_function_return_diagnostic(decl_name, initializer);
                     self.emit_function_initializer_type_annotation(decl_idx, decl_name, initializer)
@@ -1081,6 +1082,88 @@ impl<'a> DeclarationEmitter<'a> {
             && self
                 .function_body_unique_return_identifier(func.body)
                 .is_some()
+    }
+
+    /// True when the function/arrow initializer has a parameter whose
+    /// explicit type annotation contains a `typeof` (`TypeQuery`) somewhere.
+    /// Used to keep source-written `typeof X` annotations in dts emit —
+    /// the type-printer path collapses `TypeQuery` into the resolved value
+    /// type and loses the syntactic form.
+    pub(in crate::declaration_emitter) fn function_initializer_has_typeof_in_param_annotation(
+        &self,
+        initializer: NodeIndex,
+    ) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return false;
+        }
+        let Some(func) = self.arena.get_function(init_node) else {
+            return false;
+        };
+        func.parameters.nodes.iter().any(|&param_idx| {
+            self.arena
+                .get(param_idx)
+                .and_then(|n| self.arena.get_parameter(n))
+                .is_some_and(|p| {
+                    p.type_annotation.is_some()
+                        && self.type_node_contains_type_query(p.type_annotation)
+                })
+        })
+    }
+
+    /// Recursively check whether a type AST subtree contains a `TYPE_QUERY`
+    /// (i.e. a `typeof X` form). Walks the common composing forms — unions,
+    /// intersections, parens, arrays, tuples, optional/rest — so callers can
+    /// detect typeof anywhere in a parameter annotation.
+    pub(in crate::declaration_emitter) fn type_node_contains_type_query(
+        &self,
+        type_idx: NodeIndex,
+    ) -> bool {
+        if type_idx.is_none() {
+            return false;
+        }
+        let Some(type_node) = self.arena.get(type_idx) else {
+            return false;
+        };
+        if type_node.kind == syntax_kind_ext::TYPE_QUERY {
+            return true;
+        }
+        if (type_node.kind == syntax_kind_ext::UNION_TYPE
+            || type_node.kind == syntax_kind_ext::INTERSECTION_TYPE)
+            && let Some(comp) = self.arena.get_composite_type(type_node)
+        {
+            return comp
+                .types
+                .nodes
+                .iter()
+                .any(|&t| self.type_node_contains_type_query(t));
+        }
+        if (type_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            || type_node.kind == syntax_kind_ext::OPTIONAL_TYPE
+            || type_node.kind == syntax_kind_ext::REST_TYPE)
+            && let Some(wrapped) = self.arena.get_wrapped_type(type_node)
+        {
+            return self.type_node_contains_type_query(wrapped.type_node);
+        }
+        if type_node.kind == syntax_kind_ext::ARRAY_TYPE
+            && let Some(arr) = self.arena.get_array_type(type_node)
+        {
+            return self.type_node_contains_type_query(arr.element_type);
+        }
+        if type_node.kind == syntax_kind_ext::TUPLE_TYPE
+            && let Some(tup) = self.arena.get_tuple_type(type_node)
+        {
+            return tup
+                .elements
+                .nodes
+                .iter()
+                .any(|&t| self.type_node_contains_type_query(t));
+        }
+        false
     }
 
     pub(in crate::declaration_emitter) fn refine_invokable_return_type_from_identifier(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
@@ -1020,3 +1020,23 @@ fn test_accessor_keyword_preserved_on_class_field() {
         "static accessor keyword should be preserved: {output}"
     );
 }
+
+#[test]
+fn test_arrow_initializer_preserves_typeof_in_param_annotation() {
+    // Regression: a `const f = (x: typeof something) => ...` must preserve
+    // the `typeof something` in the inferred dts parameter type. The
+    // type-printer path collapses TypeQuery into the resolved value type,
+    // so we route through the AST-based function-initializer path when any
+    // parameter annotation contains a `typeof`.
+    let output = emit_dts_with_binding(
+        r#"
+declare function foo(n: number): number;
+
+const printFn = (action: typeof foo) => { action(1); };
+"#,
+    );
+    assert!(
+        output.contains("typeof foo"),
+        "arrow parameter `typeof X` must be preserved in dts: {output}"
+    );
+}


### PR DESCRIPTION
## Summary
For an inferred-type variable like

```ts
const printFn = (action: typeof actionA | typeof actionB) => { ... };
```

the parameter annotation contains explicit `typeof` AST nodes. The existing dts emit, however, routes inferred function-typed initializers through the type-printer path, which collapses `TypeQuery` into the resolved value type and loses the syntactic form — producing `(action: Action<...> | Action<...>) => void` instead of `(action: typeof actionA | typeof actionB) => void`.

There is already an AST-based emit path (`emit_function_initializer_type_annotation`) that emits parameter annotations directly via `emit_type`, which correctly handles `TYPE_QUERY` nodes. It was previously gated by a narrow set of conditions (inline param comments, self-returning, unique return identifier). This change adds a fourth gate (`function_initializer_has_typeof_in_param_annotation`) that recursively walks each parameter's type annotation looking for `TYPE_QUERY` — including unions, intersections, parens, arrays, tuples, optional/rest wrappers — and routes through the AST path when one is found.

## Impact
- `coAndContraVariantInferences` now passes
- Full dts emit suite: **+1 passing test**

## Test plan
- [x] New unit test `test_arrow_initializer_preserves_typeof_in_param_annotation`
- [x] Pre-commit suite (~4358 tests) passes
- [x] No dts regressions in full suite