### PR TITLE
chore(binder): use existing get_node_symbol helper for raw FxHashMap lookups

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -2739,7 +2739,7 @@ impl BinderState {
                 .and_then(|scope| {
                     if scope.kind == crate::ContainerKind::Module {
                         // Look up the namespace symbol from the scope's container node.
-                        self.node_symbols.get(&scope.container_node.0).copied()
+                        self.get_node_symbol(scope.container_node)
                     } else {
                         None
                     }

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -429,9 +429,7 @@ impl BinderState {
                                 (ctx.container_kind == ContainerKind::Module)
                                     .then_some(ctx.container_node)
                             })
-                            .and_then(|container_idx| {
-                                self.node_symbols.get(&container_idx.0).copied()
-                            });
+                            .and_then(|container_idx| self.get_node_symbol(container_idx));
 
                         for &spec_idx in &named.elements.nodes {
                             if let Some(spec_node) = arena.get(spec_idx)

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1348,7 +1348,7 @@ impl BinderState {
                 let container_sym = self
                     .scope_chain
                     .get(self.current_scope_idx)
-                    .and_then(|ctx| self.node_symbols.get(&ctx.container_node.0).copied());
+                    .and_then(|ctx| self.get_node_symbol(ctx.container_node));
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = Self::declaration_span(arena, declaration);
                     sym.add_declaration(declaration, span);
@@ -1424,7 +1424,7 @@ impl BinderState {
                 let container_sym = self
                     .scope_chain
                     .get(self.current_scope_idx)
-                    .and_then(|ctx| self.node_symbols.get(&ctx.container_node.0).copied());
+                    .and_then(|ctx| self.get_node_symbol(ctx.container_node));
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = Self::declaration_span(arena, declaration);
                     sym.add_declaration(declaration, span);
@@ -1463,7 +1463,7 @@ impl BinderState {
                 let container_sym = self
                     .scope_chain
                     .get(self.current_scope_idx)
-                    .and_then(|ctx| self.node_symbols.get(&ctx.container_node.0).copied());
+                    .and_then(|ctx| self.get_node_symbol(ctx.container_node));
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = Self::declaration_span(arena, declaration);
                     sym.add_declaration(declaration, span);
@@ -1570,7 +1570,7 @@ impl BinderState {
         let container_sym = self
             .scope_chain
             .get(self.current_scope_idx)
-            .and_then(|ctx| self.node_symbols.get(&ctx.container_node.0).copied());
+            .and_then(|ctx| self.get_node_symbol(ctx.container_node));
         if let Some(sym) = self.symbols.get_mut(sym_id) {
             let span = Self::declaration_span(arena, declaration);
             sym.add_declaration(declaration, span);

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -469,7 +469,7 @@ impl BinderState {
                         let param = arena.get_parameter_at(param_idx)?;
                         let ident = arena.get_identifier_at(param.name)?;
                         if ident.escaped_text == name {
-                            return self.node_symbols.get(&param.name.0).copied();
+                            return self.get_node_symbol(param.name);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- `BinderState::get_node_symbol(NodeIndex) -> Option<SymbolId>` has existed at `crates/tsz-binder/src/binding/declaration.rs:1475`, but ~13 external callers and 7 internal ones still reached into the raw `node_symbols` FxHashMap directly with `.get(&idx.0).copied()`.
- This PR migrates all 20 such call sites across 12 files in `tsz-binder`, `tsz-checker`, `tsz-emitter`, and `tsz-lsp` to use the existing helper. No new API; pure encapsulation tightening.
- Three remaining direct accesses are intentional and untouched: the helper's own definition, the cross-file `node_symbols` map in `class_type/core.rs`, and the per-file `file.node_symbols` accessor in the CLI driver (different struct, not `BinderState`).

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy` on affected crates — zero warnings
- [x] Full pre-commit pipeline: fmt, clippy, wasm32 rustc warnings gate, arch-guard, nextest
- [x] 18777 unit tests pass