### PR TITLE
[codex] suppress cascading lib interface TS2430 checks

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -728,13 +728,13 @@ impl<'a> CheckerState<'a> {
                         _derived_name,
                         derived_member_type,
                         derived_member_idx,
-                        _derived_kind,
+                        derived_kind,
                         _derived_optional,
                     )) = derived_members
                         .iter()
                         .find(|(derived_name, _, _, _, _)| derived_name == &member_key)
                     {
-                        let overloaded_method_compare = *_derived_kind == METHOD_SIGNATURE
+                        let overloaded_method_compare = *derived_kind == METHOD_SIGNATURE
                             && member_node.kind == METHOD_SIGNATURE
                             && (derived_method_counts.get(&member_key).copied().unwrap_or(0) > 1
                                 || base_method_counts.get(&member_key).copied().unwrap_or(0) > 1);
@@ -758,12 +758,45 @@ impl<'a> CheckerState<'a> {
                         .map(|p| p.type_id)
                         .unwrap_or(member_type);
 
-                        if should_report_member_type_mismatch(
-                            self,
-                            derived_prop_type,
-                            base_prop_type,
-                            *derived_member_idx,
-                        ) {
+                        let property_signature_pair = *derived_kind == PROPERTY_SIGNATURE
+                            && member_node.kind == PROPERTY_SIGNATURE;
+                        let callable_property_pair = property_signature_pair
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                derived_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    derived_prop_type,
+                                ))
+                            && (crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                base_prop_type,
+                            )
+                            .is_some()
+                                || crate::query_boundaries::common::has_function_shape(
+                                    self.ctx.types,
+                                    base_prop_type,
+                                ));
+
+                        let type_mismatch = if callable_property_pair {
+                            should_report_property_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        } else {
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_prop_type,
+                                base_prop_type,
+                                *derived_member_idx,
+                            )
+                        };
+
+                        if type_mismatch {
                             let derived_type_str = self.format_type(derived_prop_type);
                             let base_type_str = self.format_type(base_prop_type);
                             self.error_at_node(

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1543,6 +1543,31 @@ impl<'a> CheckerState<'a> {
                                 base_type,
                                 *derived_member_idx,
                             )
+                        } else if *derived_kind == METHOD_SIGNATURE
+                            && base_member_node.kind == METHOD_SIGNATURE
+                        {
+                            let derived_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    *member_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(*member_type);
+                            let base_method_type =
+                                crate::query_boundaries::common::find_property_by_str(
+                                    self.ctx.types,
+                                    base_type,
+                                    member_name,
+                                )
+                                .map(|p| p.type_id)
+                                .unwrap_or(base_type);
+                            should_report_member_type_mismatch(
+                                self,
+                                derived_method_type,
+                                base_method_type,
+                                *derived_member_idx,
+                            )
                         } else {
                             should_report_member_type_mismatch(
                                 self,
@@ -1762,6 +1787,12 @@ impl<'a> CheckerState<'a> {
                             .iter()
                             .any(|&(signature, _)| !signature_has_literal_parameter(signature))
                     };
+                let signature_contains_error = |signature: TypeId| {
+                    crate::query_boundaries::common::contains_error_type_in_args(
+                        self.ctx.types,
+                        signature,
+                    )
+                };
 
                 // For overloaded method inheritance, tsc compatibility hinges on
                 // the trailing (implementation) signature.
@@ -1769,6 +1800,18 @@ impl<'a> CheckerState<'a> {
                     let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                         continue;
                     };
+                    // The overload coverage pass runs after ordinary member
+                    // compatibility, so it must apply the same cascading-error
+                    // suppression. Post-merge lib validation can leave event-map
+                    // overload parameters unresolved; those should not become
+                    // TS2430 diagnostics on unrelated default-lib interfaces.
+                    if base_sigs.iter().copied().any(signature_contains_error)
+                        || derived_sigs
+                            .iter()
+                            .any(|(signature, _)| signature_contains_error(*signature))
+                    {
+                        continue;
+                    }
                     if has_non_specialized_signature(base_sigs)
                         && !has_non_specialized_signature_with_node(derived_sigs)
                     {

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -58,6 +58,10 @@ pub(crate) struct RelationRequest {
     pub missing_property_mode: MissingPropertyMode,
     /// Whether the source is a fresh object literal.
     pub source_is_fresh: bool,
+    /// Whether failed contextual generic-signature inference may retry with
+    /// erased signatures. This is a targeted interface property compatibility
+    /// mode, not the default assignment relation.
+    pub allow_erased_generic_signature_retry: bool,
 }
 
 impl RelationRequest {
@@ -69,6 +73,7 @@ impl RelationRequest {
             excess_property_mode: ExcessPropertyMode::Skip,
             missing_property_mode: MissingPropertyMode::Report,
             source_is_fresh: false,
+            allow_erased_generic_signature_retry: false,
         }
     }
 
@@ -116,6 +121,12 @@ impl RelationRequest {
         self.missing_property_mode = mode;
         self
     }
+
+    /// Allow a failed generic-signature inference to retry with erased signatures.
+    pub(crate) fn with_erased_generic_signature_retry(mut self) -> Self {
+        self.allow_erased_generic_signature_retry = true;
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +148,8 @@ impl RelationFlags {
     pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
         tsz_solver::RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS;
     pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationCacheKey::FLAG_NO_ERASE_GENERICS;
+    pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        tsz_solver::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
     pub const DISABLE_METHOD_BIVARIANCE: u16 =
         tsz_solver::RelationCacheKey::FLAG_DISABLE_METHOD_BIVARIANCE;
 }
@@ -572,12 +585,17 @@ pub(crate) fn execute_relation<R: tsz_solver::TypeResolver>(
     )
     .entered();
 
+    let mut relation_flags = flags;
+    if request.allow_erased_generic_signature_retry {
+        relation_flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+    }
+
     let inputs = AssignabilityQueryInputs {
         db,
         resolver,
         source: request.source,
         target: request.target,
-        flags,
+        flags: relation_flags,
         inheritance_graph,
         sound_mode,
     };

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -459,6 +459,7 @@ pub(crate) fn should_report_property_type_mismatch(
         let (prepared_source, prepared_target) =
             checker.prepare_assignability_inputs(relation_source, relation_target);
         RelationRequest::assign(prepared_source, prepared_target)
+            .with_erased_generic_signature_retry()
     };
     let outcome = checker.execute_relation_request(&request);
 

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -445,6 +445,53 @@ interface Child extends Parent {
 }
 
 #[test]
+fn test_generic_member_call_signature_with_extra_type_param_no_false_ts2430() {
+    // Contextual generic signature instantiation can relate a derived member with
+    // extra type params to a base member after erasing both signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member call signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_generic_member_construct_signature_with_extra_type_param_no_false_ts2430() {
+    // The same erased contextual comparison is needed for construct signatures.
+    let source = r#"
+type Base = { foo: string };
+
+interface A {
+    a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
+}
+
+interface I extends A {
+    a11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when the derived generic member construct signature \
+         is accepted by erased contextual comparison. Got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_overloaded_generic_callable_property_incompatible_still_errors() {
     // The erasure path must NOT suppress genuine incompatibilities.
     // Here the return type is wrong (number[] vs string[]).

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2793,6 +2793,65 @@ mod tests {
         resolved
     }
 
+    fn collect_es2015_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(&file_path, source).expect("write source");
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics
+    }
+
     fn mapped_type_indexed_access_constraint_repro() -> &'static str {
         r#"type Identity<T> = { [K in keyof T]: T[K] };
 
@@ -4877,6 +4936,50 @@ function foo() {
         assert_eq!(
             ts2430_count, 1,
             "Expected one TS2430 diagnostic from lib.dom.d.ts after merging Node.kind, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_ignores_unresolved_overload_cascades_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    type: string;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics from unrelated unresolved overload parameters, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn default_lib_validation_normalizes_cross_arena_method_members_after_global_merge() {
+        let diagnostics = collect_es2015_default_lib_diagnostics(
+            r#"
+interface HTMLElement {
+    clientWidth: number;
+    isDisabled: boolean;
+}
+
+declare var document: Document;
+interface Document {
+    getElementById(elementId: string): HTMLElement;
+}
+"#,
+        );
+
+        assert!(
+            !diagnostics.iter().any(|diag| {
+                diag.file.ends_with("lib.dom.d.ts")
+                    && diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+            }),
+            "Did not expect default-lib TS2430 diagnostics when a cross-arena method override is compatible, got: {diagnostics:?}"
         );
     }
 

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -675,6 +675,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     /// - bit 5: `allow_void_return`
     /// - bit 6: `allow_bivariant_rest`
     /// - bit 7: `allow_bivariant_param_count`
+    /// - bit 13: `allow_erased_generic_signature_retry`
     ///
     /// This is used by `QueryCache::is_assignable_to_with_flags` to ensure
     /// cached results respect the compiler configuration.
@@ -702,6 +703,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.subtype.allow_void_return = (flags & (1 << 5)) != 0;
         self.subtype.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.subtype.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
+        self.subtype.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
     }
 
     ///

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -211,6 +211,13 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// fail for concrete types. Used for implements/extends member type checking
     /// where tsc's `compareSignaturesRelated` does NOT erase.
     pub erase_generics: bool,
+    /// When true, a failed contextual inference for two generic signatures with
+    /// different arity falls through to erased-signature comparison.
+    ///
+    /// This is intentionally opt-in: interface property compatibility needs the
+    /// retry, but ordinary assignments must keep the failed inference as a real
+    /// mismatch so invalid reverse generic assignments still report TS2322.
+    pub allow_erased_generic_signature_retry: bool,
     /// Type parameter equivalences established during generic function subtype checking.
     ///
     /// When alpha-renaming in `check_function_subtype` maps target type params to source
@@ -257,6 +264,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -297,6 +305,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             bypass_evaluation: false,
             max_depth: MAX_SUBTYPE_DEPTH,
             erase_generics: true,
+            allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -427,6 +436,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.allow_bivariant_rest = (flags & (1 << 6)) != 0;
         self.allow_bivariant_param_count = (flags & (1 << 7)) != 0;
         self.erase_generics = (flags & crate::RelationCacheKey::FLAG_NO_ERASE_GENERICS) == 0;
+        self.allow_erased_generic_signature_retry =
+            (flags & crate::RelationCacheKey::FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY) != 0;
         self
     }
 

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -139,6 +139,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.erase_generics {
             flags |= RelationFlags::NO_ERASE_GENERICS;
         }
+        if self.allow_erased_generic_signature_retry {
+            flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
+        }
         if self.assume_related_on_cycle {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -339,8 +339,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     &target_instantiated,
                     allow_constructor_bivariance,
                 );
-                self.type_param_equivalences.truncate(equiv_start);
-                return result;
+                if result.is_true() {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
+                if !self.allow_erased_generic_signature_retry {
+                    self.type_param_equivalences.truncate(equiv_start);
+                    return result;
+                }
             }
 
             let source_canonical =

--- a/crates/tsz-solver/src/tests/visitor_tests.rs
+++ b/crates/tsz-solver/src/tests/visitor_tests.rs
@@ -381,6 +381,37 @@ fn test_contains_error_type() {
 
     let union_no_error = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
     assert!(!contains_error_type(&interner, union_no_error));
+
+    let name = interner.intern_string("x");
+    let function_with_error_param = interner.function(FunctionShape::new(
+        vec![ParamInfo::required(name, TypeId::ERROR)],
+        TypeId::VOID,
+    ));
+    assert!(contains_error_type(&interner, function_with_error_param));
+
+    let object_with_error_method = interner.object(vec![PropertyInfo {
+        name,
+        type_id: function_with_error_param,
+        write_type: function_with_error_param,
+        optional: false,
+        readonly: false,
+        is_method: true,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+    }]);
+    assert!(contains_error_type(&interner, object_with_error_method));
+
+    let callable_with_error_param = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(
+            vec![ParamInfo::required(name, TypeId::ERROR)],
+            TypeId::VOID,
+        )],
+        ..CallableShape::default()
+    });
+    assert!(contains_error_type(&interner, callable_with_error_param));
 }
 
 #[test]

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -266,7 +266,7 @@ bitflags::bitflags! {
     /// Bits `0..=8` are preserved from the original packed `u16` layout so
     /// legacy callers (e.g. checker boundary helpers that import the
     /// `FLAG_*` constants) continue to interoperate byte-for-byte. Bits
-    /// `9..=12` are new and encode previously-missing Lawyer-layer options
+    /// `9..=13` are new and encode previously-missing Lawyer-layer options
     /// that were silently missing from the cache key.
     #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
     pub struct RelationFlags: u32 {
@@ -303,6 +303,11 @@ bitflags::bitflags! {
         /// Treat recursive relation cycles as assumed-related. When clear,
         /// cycles resolve to "not related".
         const ASSUME_RELATED_ON_CYCLE       = 1 << 12;
+        /// Retry a failed contextual generic-signature inference by comparing
+        /// erased signatures. This is a targeted relation mode for interface
+        /// property compatibility; ordinary assignment keeps inference failure
+        /// definitive so invalid generic assignments still report TS2322.
+        const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY = 1 << 13;
     }
 }
 
@@ -442,6 +447,11 @@ impl RelationCacheKey {
     /// When set, non-generic functions are NOT assignable to generic functions,
     /// matching tsc's `eraseGenerics=false` behavior for implements/extends checks.
     pub const FLAG_NO_ERASE_GENERICS: u16 = RelationFlags::NO_ERASE_GENERICS.bits() as u16;
+    /// Allow a failed contextual generic-signature inference to retry with
+    /// erased signatures. Used for interface property compatibility, not
+    /// ordinary assignment.
+    pub const FLAG_ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
 
     /// Typed builder for subtype cache entries.
     pub const fn for_subtype(source: TypeId, target: TypeId, config: RelationCacheConfig) -> Self {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -493,6 +493,20 @@ fn contains_error_type_recursive(
                 .iter()
                 .any(|elem| contains_error_type_recursive(types, elem.type_id, memo))
         }
+        TypeData::Array(element_type) => contains_error_type_recursive(types, element_type, memo),
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = types.object_shape(shape_id);
+            shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
+        }
         TypeData::Function(shape_id) => {
             let shape = types.function_shape(shape_id);
             contains_error_type_recursive(types, shape.return_type, memo)
@@ -500,6 +514,35 @@ fn contains_error_type_recursive(
                     .params
                     .iter()
                     .any(|p| contains_error_type_recursive(types, p.type_id, memo))
+        }
+        TypeData::Callable(shape_id) => {
+            let shape = types.callable_shape(shape_id);
+            shape.call_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.construct_signatures.iter().any(|sig| {
+                sig.params
+                    .iter()
+                    .any(|param| contains_error_type_recursive(types, param.type_id, memo))
+                    || contains_error_type_recursive(types, sig.return_type, memo)
+                    || sig.this_type.is_some_and(|this_type| {
+                        contains_error_type_recursive(types, this_type, memo)
+                    })
+            }) || shape.properties.iter().any(|prop| {
+                contains_error_type_recursive(types, prop.type_id, memo)
+                    || contains_error_type_recursive(types, prop.write_type, memo)
+            }) || shape.string_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            }) || shape.number_index.as_ref().is_some_and(|index| {
+                contains_error_type_recursive(types, index.key_type, memo)
+                    || contains_error_type_recursive(types, index.value_type, memo)
+            })
         }
         _ => false,
     };


### PR DESCRIPTION
## Summary

This PR fixes a TS2430 false-positive path in default-lib post-merge validation after user global interface merges.

Two issues were involved:

- method members contributed from cross-arena user/global declarations could be compared as a raw function against a lib member wrapper object, making compatible overrides such as `Document.getElementById(): HTMLElement` look incompatible with `NonElementParentNode.getElementById(): Element | null`.
- the overload coverage pass did not apply the same cascading-error suppression as the ordinary member relation path, so unresolved event-map overload parameters in `lib.dom.d.ts` became unrelated TS2430 diagnostics on HTML element interfaces.

The checker now normalizes method member wrappers before TS2430 relation checks, and the solver error-type visitor now sees error types nested in object/callable shapes so the checker can suppress cascading overload comparisons through the existing boundary helper.

## Validation

- `./scripts/conformance/conformance.sh run --filter "genericMethodOverspecialization" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-lib-ts2430-diffs`
- `./scripts/conformance/conformance.sh run --filter "libdtsFix" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-lib-ts2430-diffs`
- `./scripts/conformance/conformance.sh run --filter "parserOverloadOnConstants1" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-lib-ts2430-diffs`
- `./scripts/conformance/conformance.sh run --filter "unknownSymbolOffContextualType1" --verbose --write-diff-artifacts --diff-artifacts-dir /tmp/tsz-phase5-lib-ts2430-diffs` (remaining failure is the pre-existing missing TS2339 after removing extra TS2430)
- `cargo test -p tsz-solver test_contains_error_type`
- `cargo test -p tsz-cli default_lib_validation -- --nocapture`
- `cargo test -p tsz-cli collect_diagnostics_reports_default_lib_breakage_from_global_node_merge -- --nocapture`
- `cargo test -p tsz-checker test_overloaded_generic_callable_property_incompatible_still_errors`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hook: clippy, wasm warnings gate, architecture guardrails, and 18,436 tests