### PR TITLE
chore(parser): add Node::is_class_like helper and migrate callers

### DIFF
--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -449,9 +449,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
             let Some(parent) = self.ctx.arena.get(parent_idx) else {
                 return false;
             };
-            if parent.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent.is_class_like() {
                 return true;
             }
             current = parent_idx;

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -547,9 +547,7 @@ impl<'a> CheckerState<'a> {
                         break;
                     }
                     if let Some(n) = self.ctx.arena.get(cur) {
-                        if n.kind == syntax_kind_ext::CLASS_DECLARATION
-                            || n.kind == syntax_kind_ext::CLASS_EXPRESSION
-                        {
+                        if n.is_class_like() {
                             found = true;
                             break;
                         }
@@ -869,9 +867,7 @@ impl<'a> CheckerState<'a> {
                     let Some(inner_node) = self.ctx.arena.get(current) else {
                         break;
                     };
-                    if inner_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                        || inner_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-                    {
+                    if inner_node.is_class_like() {
                         in_class = true;
                     }
                     if inner_node.kind == syntax_kind_ext::CONSTRUCTOR

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -2348,9 +2348,7 @@ impl<'a> FlowAnalyzer<'a> {
             }
             current = ext.parent;
             let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if node.is_class_like() {
                 return self.binder.get_node_symbol(current);
             }
         }

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -427,9 +427,7 @@ impl<'a> CheckerState<'a> {
             let is_class = symbol.has_any_flags(symbol_flags::CLASS);
             let is_enum = symbol.has_any_flags(symbol_flags::ENUM);
             let is_var = symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE);
-            let kind_ok = (is_class
-                && (decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION))
+            let kind_ok = (is_class && (decl_node.is_class_like()))
                 || (is_enum && decl_node.kind == syntax_kind_ext::ENUM_DECLARATION)
                 || (is_var
                     && (decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -1407,8 +1407,7 @@ impl<'a> CheckerState<'a> {
             let Some(parent_node) = self.ctx.arena.get(parent) else {
                 return false;
             };
-            if (parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION)
+            if (parent_node.is_class_like())
                 && self
                     .ctx
                     .binder
@@ -1630,9 +1629,7 @@ impl<'a> CheckerState<'a> {
         // Validate that the node at decl_idx actually matches the expected kind.
         // A mismatch means the declaration is in another file — no TDZ applies.
         if self.ctx.all_arenas.is_some() {
-            let kind_ok = (is_class
-                && (decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION))
+            let kind_ok = (is_class && (decl_node.is_class_like()))
                 || (is_enum && decl_node.kind == syntax_kind_ext::ENUM_DECLARATION);
             if !kind_ok {
                 return;

--- a/crates/tsz-checker/src/state/state_checking/strict_names.rs
+++ b/crates/tsz-checker/src/state/state_checking/strict_names.rs
@@ -183,9 +183,7 @@ impl<'a> CheckerState<'a> {
                     break;
                 }
                 if let Some(n) = self.ctx.arena.get(cur) {
-                    if n.kind == syntax_kind_ext::CLASS_DECLARATION
-                        || n.kind == syntax_kind_ext::CLASS_EXPRESSION
-                    {
+                    if n.is_class_like() {
                         found = true;
                         break;
                     }

--- a/crates/tsz-checker/src/state/state_checking_members/property_init.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/property_init.rs
@@ -571,8 +571,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // Don't recurse into nested class definitions
-        if node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        if node.is_class_like()
         {
             return;
         }

--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -313,8 +313,7 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
 
-            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+            if parent_node.is_class_like()
                 || parent_node.kind == syntax_kind_ext::METHOD_DECLARATION
                 || parent_node.kind == syntax_kind_ext::GET_ACCESSOR
                 || parent_node.kind == syntax_kind_ext::SET_ACCESSOR

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -726,8 +726,7 @@ impl<'a> CheckerState<'a> {
             // Don't cross function/class boundaries
             if child_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
                 || child_node.is_function_expression_or_arrow()
-                || child_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || child_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                || child_node.is_class_like()
             {
                 continue;
             }

--- a/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
@@ -1343,8 +1343,7 @@ impl<'a> CheckerState<'a> {
                     || node.is_function_expression_or_arrow()
                     || node.kind == syntax_kind_ext::METHOD_DECLARATION
                     || node.kind == syntax_kind_ext::CONSTRUCTOR
-                    || node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                    || node.is_class_like()
                     || node.kind == syntax_kind_ext::INTERFACE_DECLARATION
                 {
                     return None;
@@ -1411,8 +1410,7 @@ impl<'a> CheckerState<'a> {
             // Stop at function/class/interface boundaries
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
                 || parent_node.is_function_expression_or_arrow()
-                || parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                || parent_node.is_class_like()
                 || parent_node.kind == syntax_kind_ext::INTERFACE_DECLARATION
                 || parent_node.kind == syntax_kind_ext::SOURCE_FILE
             {
@@ -1467,9 +1465,7 @@ impl<'a> CheckerState<'a> {
                 }
 
                 // Class: check extends vs implements, and declare modifier
-                if hc_parent.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || hc_parent.kind == syntax_kind_ext::CLASS_EXPRESSION
-                {
+                if hc_parent.is_class_like() {
                     // `implements` is always a type-only context
                     if let Some(heritage) = self.ctx.arena.get_heritage_clause(parent_node)
                         && heritage.token == SyntaxKind::ImplementsKeyword as u16
@@ -1500,8 +1496,7 @@ impl<'a> CheckerState<'a> {
             // Stop at function/class/interface boundaries
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
                 || parent_node.is_function_expression_or_arrow()
-                || parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                || parent_node.is_class_like()
                 || parent_node.kind == syntax_kind_ext::INTERFACE_DECLARATION
                 || parent_node.kind == syntax_kind_ext::SOURCE_FILE
             {

--- a/crates/tsz-lsp/src/code_actions/code_action_extract_interface.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_extract_interface.rs
@@ -145,9 +145,7 @@ impl<'a> CodeActionProvider<'a> {
         let mut current = find_node_at_offset(self.arena, offset);
         while current.is_some() {
             let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if node.is_class_like() {
                 return Some(current);
             }
             current = self.arena.get_extended(current)?.parent;

--- a/crates/tsz-lsp/src/code_actions/code_action_imports.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_imports.rs
@@ -504,9 +504,7 @@ impl<'a> CodeActionProvider<'a> {
         let container_node = self.arena.get(container_idx)?;
 
         if heritage.token == SyntaxKind::ExtendsKeyword as u16 {
-            if container_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || container_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if container_node.is_class_like() {
                 return Some(ImportUsage::Value);
             }
             return Some(ImportUsage::Type);

--- a/crates/tsz-lsp/src/code_actions/code_action_provider.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_provider.rs
@@ -1006,9 +1006,7 @@ impl<'a> CodeActionProvider<'a> {
         let mut current = node_idx;
         while current.is_some() {
             let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if node.is_class_like() {
                 return Some(current);
             }
             current = self.arena.get_extended(current)?.parent;

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -756,9 +756,7 @@ impl<'a> Completions<'a> {
         let mut current = node_idx;
         for _ in 0..15 {
             if let Some(node) = self.arena.get(current)
-                && (node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-                    || node.kind == syntax_kind_ext::INTERFACE_DECLARATION)
+                && (node.is_class_like() || node.kind == syntax_kind_ext::INTERFACE_DECLARATION)
             {
                 let start = node.pos as usize;
                 let end = node.end as usize;
@@ -787,8 +785,7 @@ impl<'a> Completions<'a> {
                 if node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
                     return true;
                 }
-                if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+                if node.is_class_like()
                     || node.kind == syntax_kind_ext::FUNCTION_DECLARATION
                     || node.kind == syntax_kind_ext::SOURCE_FILE
                 {

--- a/crates/tsz-lsp/src/completions/member.rs
+++ b/crates/tsz-lsp/src/completions/member.rs
@@ -548,9 +548,7 @@ impl<'a> Completions<'a> {
                 return None;
             }
             let parent = self.arena.get(ext.parent)?;
-            if parent.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent.is_class_like() {
                 let class = self.arena.get_class(parent)?;
                 let heritage = class.heritage_clauses.as_ref()?;
                 for &clause_idx in &heritage.nodes {
@@ -1527,9 +1525,7 @@ impl<'a> Completions<'a> {
         let mut current = node_idx;
         while current.is_some() {
             let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if node.is_class_like() {
                 return Some(current);
             }
             // Stop at regular function boundaries — `function() {}` resets

--- a/crates/tsz-lsp/src/editor_decorations/inlay_hints.rs
+++ b/crates/tsz-lsp/src/editor_decorations/inlay_hints.rs
@@ -265,9 +265,7 @@ impl<'a> InlayHintsProvider<'a> {
             Some(&method.parameters)
         } else if let Some(ctor) = self.arena.get_constructor(node) {
             Some(&ctor.parameters)
-        } else if node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
+        } else if node.is_class_like() {
             // For class declarations (from new expressions), find the constructor
             return self.get_constructor_param_names(node);
         } else {

--- a/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
+++ b/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
@@ -647,8 +647,7 @@ impl<'a> CallHierarchyProvider<'a> {
             let parent = ext.parent;
             if parent.is_some()
                 && let Some(parent_node) = self.arena.get(parent)
-                && (parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                    || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION)
+                && (parent_node.is_class_like())
                 && let Some(class_decl) = self.arena.get_class(parent_node)
                 && class_decl.name == node_idx
                 && let Some(ctor_idx) = self.class_constructor_node(parent)
@@ -843,9 +842,7 @@ impl<'a> CallHierarchyProvider<'a> {
                 return None;
             }
             let parent_node = self.arena.get(parent)?;
-            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent_node.is_class_like() {
                 let class_decl = self.arena.get_class(parent_node)?;
                 if class_decl.name.is_some() {
                     return self.get_identifier_text(class_decl.name);
@@ -874,9 +871,7 @@ impl<'a> CallHierarchyProvider<'a> {
             if parent_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
                 return Some(parent);
             }
-            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent_node.is_class_like() {
                 return None;
             }
             current = parent;
@@ -908,9 +903,7 @@ impl<'a> CallHierarchyProvider<'a> {
                 return None;
             }
             let parent_node = self.arena.get(parent)?;
-            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent_node.is_class_like() {
                 return Some(parent);
             }
             current = parent;
@@ -1077,9 +1070,7 @@ impl<'a> CallHierarchyProvider<'a> {
                 return None;
             }
             let parent_node = self.arena.get(parent)?;
-            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent_node.is_class_like() {
                 return Some(parent);
             }
             if parent_node.is_function_like()
@@ -1541,9 +1532,7 @@ impl<'a> CallHierarchyProvider<'a> {
     ) -> Option<CallHierarchyItem> {
         let node = self.arena.get(decl_idx)?;
 
-        if node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
+        if node.is_class_like() {
             let mut selection_range =
                 node_range(self.arena, self.line_map, self.source_text, decl_idx);
             if let Some(class_decl) = self.arena.get_class(node)
@@ -1630,9 +1619,7 @@ impl<'a> CallHierarchyProvider<'a> {
             return Some(item);
         }
         let caller_node = self.arena.get(caller_idx)?;
-        if caller_node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || caller_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
+        if caller_node.is_class_like() {
             let class_decl = self.arena.get_class(caller_node)?;
             let class_name = self.get_identifier_text(class_decl.name)?;
             return self.make_call_hierarchy_item_for_declaration(caller_idx, &class_name);
@@ -1678,8 +1665,7 @@ impl<'a> CallHierarchyProvider<'a> {
             }
         }
 
-        if (node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || node.kind == syntax_kind_ext::CLASS_EXPRESSION)
+        if (node.is_class_like())
             && let Some(ctor_idx) = self.class_constructor_node(decl_idx)
         {
             return Some(ctor_idx);

--- a/crates/tsz-lsp/src/navigation/definition.rs
+++ b/crates/tsz-lsp/src/navigation/definition.rs
@@ -656,9 +656,7 @@ impl<'a> GoToDefinition<'a> {
         }
 
         // Class declaration: walk class members (backup for non-binder-tracked members)
-        if decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
+        if decl_node.is_class_like() {
             let class = self.arena.get_class(decl_node)?;
             for &member_idx in &class.members.nodes {
                 let member_node = self.arena.get(member_idx)?;
@@ -736,9 +734,7 @@ impl<'a> GoToDefinition<'a> {
         for &decl_idx in &class_symbol.declarations {
             let decl_node = self.arena.get(decl_idx)?;
             // Get heritage clauses from class or interface declarations
-            let heritage_clauses = if decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            let heritage_clauses = if decl_node.is_class_like() {
                 self.arena
                     .get_class(decl_node)
                     .and_then(|c| c.heritage_clauses.as_ref())
@@ -921,9 +917,7 @@ impl<'a> GoToDefinition<'a> {
                 self.arena
                     .get_interface(decl_node)
                     .and_then(|i| i.heritage_clauses.as_ref())
-            } else if decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            } else if decl_node.is_class_like() {
                 self.arena
                     .get_class(decl_node)
                     .and_then(|c| c.heritage_clauses.as_ref())
@@ -988,9 +982,7 @@ impl<'a> GoToDefinition<'a> {
 
         let members_list = if decl_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
             Some(self.arena.get_interface(decl_node)?.members.nodes.clone())
-        } else if decl_node.kind == syntax_kind_ext::CLASS_DECLARATION
-            || decl_node.kind == syntax_kind_ext::CLASS_EXPRESSION
-        {
+        } else if decl_node.is_class_like() {
             Some(self.arena.get_class(decl_node)?.members.nodes.clone())
         } else {
             None
@@ -1081,9 +1073,7 @@ impl<'a> GoToDefinition<'a> {
                 return None;
             }
             let parent = self.arena.get(ext.parent)?;
-            if parent.kind == syntax_kind_ext::CLASS_DECLARATION
-                || parent.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if parent.is_class_like() {
                 let class = self.arena.get_class(parent)?;
                 let heritage = class.heritage_clauses.as_ref()?;
                 for &clause_idx in &heritage.nodes {

--- a/crates/tsz-lsp/src/signature_help.rs
+++ b/crates/tsz-lsp/src/signature_help.rs
@@ -1561,9 +1561,7 @@ impl<'a> SignatureHelpProvider<'a> {
         let mut depth = 0;
         while current.is_some() && depth < 100 {
             let node = self.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CLASS_DECLARATION
-                || node.kind == syntax_kind_ext::CLASS_EXPRESSION
-            {
+            if node.is_class_like() {
                 let class_data = self.arena.get_class(node)?;
                 let heritage_clauses = class_data.heritage_clauses.as_ref()?;
                 for &clause_idx in &heritage_clauses.nodes {

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -1903,6 +1903,14 @@ impl Node {
         self.kind == CLASS_DECLARATION
     }
 
+    /// Check if this is any class-like node (class declaration or class expression).
+    #[inline]
+    #[must_use]
+    pub const fn is_class_like(&self) -> bool {
+        use super::syntax_kind_ext::{CLASS_DECLARATION, CLASS_EXPRESSION};
+        matches!(self.kind, CLASS_DECLARATION | CLASS_EXPRESSION)
+    }
+
     /// Check if this is any kind of function-like node
     #[inline]
     #[must_use]


### PR DESCRIPTION
## Summary
- Adds `Node::is_class_like()` on `node_access.rs` next to the existing `is_class_declaration` / `is_function_like` predicates.
- Migrates 20 files in `tsz-lsp` and `tsz-checker` that open-coded the two-line `X.kind == CLASS_DECLARATION || X.kind == CLASS_EXPRESSION` check to the new helper.
- Conservative scope: u16-only patterns (no Node value) and patterns that add extra alternatives like `INTERFACE_DECLARATION` are intentionally left untouched.

## Test plan
- [x] `cargo check --workspace` clean
- [x] Full pre-commit pipeline: fmt, clippy, wasm32 rustc warnings gate, arch-guard, nextest
- [x] 19318 unit tests pass