### PR TITLE
perf(binder): Arc-wrap wildcard_reexports to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -728,11 +728,11 @@ impl BinderState {
                 if let Some(source_module) = module_name {
                     let current_file = self.debugger.current_file.clone();
                     // Add to wildcard_reexports list - a file can have multiple export * from
-                    self.wildcard_reexports
+                    Arc::make_mut(&mut self.wildcard_reexports)
                         .entry(current_file.clone())
                         .or_default()
                         .push(source_module.clone());
-                    self.wildcard_reexports_type_only
+                    Arc::make_mut(&mut self.wildcard_reexports_type_only)
                         .entry(current_file)
                         .or_default()
                         .push((source_module, export_type_only));

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -207,8 +207,8 @@ impl BinderState {
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: Arc::new(FxHashMap::default()),
             reexports: Arc::new(FxHashMap::default()),
-            wildcard_reexports: FxHashMap::default(),
-            wildcard_reexports_type_only: FxHashMap::default(),
+            wildcard_reexports: Arc::new(FxHashMap::default()),
+            wildcard_reexports_type_only: Arc::new(FxHashMap::default()),
             resolved_export_cache: Default::default(),
             resolved_identifier_cache: Default::default(),
             shorthand_ambient_modules: Arc::new(FxHashSet::default()),
@@ -271,8 +271,8 @@ impl BinderState {
         Arc::make_mut(&mut self.lib_symbol_ids).clear();
         Arc::make_mut(&mut self.module_exports).clear();
         Arc::make_mut(&mut self.reexports).clear();
-        self.wildcard_reexports.clear();
-        self.wildcard_reexports_type_only.clear();
+        Arc::make_mut(&mut self.wildcard_reexports).clear();
+        Arc::make_mut(&mut self.wildcard_reexports_type_only).clear();
         self.resolved_export_cache
             .write()
             .expect("RwLock not poisoned")
@@ -444,8 +444,8 @@ impl BinderState {
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: Arc::new(FxHashMap::default()),
             reexports: Arc::new(FxHashMap::default()),
-            wildcard_reexports: FxHashMap::default(),
-            wildcard_reexports_type_only: FxHashMap::default(),
+            wildcard_reexports: Arc::new(FxHashMap::default()),
+            wildcard_reexports_type_only: Arc::new(FxHashMap::default()),
             resolved_export_cache: Default::default(),
             resolved_identifier_cache: Default::default(),
             shorthand_ambient_modules: Arc::new(FxHashSet::default()),

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -35,6 +35,12 @@ pub(crate) const MAX_SCOPE_WALK_ITERATIONS: usize = 10_000;
 pub type ReexportTarget = (String, Option<String>);
 pub type FileReexports = FxHashMap<String, ReexportTarget>;
 pub type FileReexportsMap = FxHashMap<String, FileReexports>;
+/// Per-file map of `export * from "X"` source modules.
+/// Maps `current_file` -> `Vec<source_module>`.
+pub type WildcardReexportsMap = FxHashMap<String, Vec<String>>;
+/// Type-only provenance aligned with [`WildcardReexportsMap`].
+/// Maps `current_file` -> `Vec<(source_module, is_type_only)>`.
+pub type WildcardReexportsTypeOnlyMap = FxHashMap<String, Vec<(String, bool)>>;
 type ExportCache = FxHashMap<(String, String), Option<SymbolId>>;
 type IdentifierCache = FxHashMap<(usize, u32), Option<SymbolId>>;
 /// Wrapper around `RwLock` that implements `Clone` by cloning the inner data.
@@ -347,11 +353,20 @@ pub struct BinderState {
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
     /// Maps `current_file` -> Vec of `source_modules`
     /// A file can have multiple wildcard re-exports (e.g., `export * from 'a'; export * from 'b'`)
-    pub wildcard_reexports: FxHashMap<String, Vec<String>>,
+    ///
+    /// `Arc`-wrapped so the cross-file merge can hand a single shared
+    /// allocation to every per-file `BinderState` via `Arc::clone`
+    /// instead of deep-cloning the underlying `FxHashMap` for each of
+    /// N per-file binders. Mutations during binding go through
+    /// `Arc::make_mut` (zero-cost when refcount=1, which is always
+    /// during binding).
+    pub wildcard_reexports: Arc<WildcardReexportsMap>,
     /// Tracks whether wildcard re-export entries are type-only.
     /// Maps `current_file` -> Vec of (`source_module`, `is_type_only`).
     /// This captures `export type * from './module'` chains during import resolution.
-    pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
+    ///
+    /// Same `Arc` rationale as `wildcard_reexports`.
+    pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,
 
     /// Cache for resolved exports to avoid repeated lookups through re-export chains.
     /// Key: (`module_specifier`, `export_name`) -> resolved `SymbolId` (or None if not found)
@@ -814,8 +829,8 @@ pub struct BinderStateScopeInputs {
     pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     pub reexports: Arc<FileReexportsMap>,
-    pub wildcard_reexports: FxHashMap<String, Vec<String>>,
-    pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
+    pub wildcard_reexports: Arc<WildcardReexportsMap>,
+    pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,
     pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
     pub declaration_arenas: DeclarationArenaMap,
     pub cross_file_node_symbols: CrossFileNodeSymbols,

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -316,35 +316,29 @@ fn resolves_wildcard_type_only_reexports_with_provenance() {
     a_exports.set("B".to_string(), b_sym);
     Arc::make_mut(&mut binder.module_exports).insert("./a".to_string(), a_exports);
 
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./b".to_string())
         .or_default()
         .push("./a".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./b".to_string())
         .or_default()
         .push(("./a".to_string(), true));
 
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./c".to_string())
         .or_default()
         .push("./b".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./c".to_string())
         .or_default()
         .push(("./b".to_string(), false));
 
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./d".to_string())
         .or_default()
         .push("./a".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./d".to_string())
         .or_default()
         .push(("./a".to_string(), false));
@@ -2805,13 +2799,11 @@ fn wildcard_reexport_resolution() {
     Arc::make_mut(&mut binder.module_exports).insert("./a".to_string(), a_exports);
 
     // ./b re-exports everything from ./a
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./b".to_string())
         .or_default()
         .push("./a".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./b".to_string())
         .or_default()
         .push(("./a".to_string(), false));
@@ -2830,25 +2822,21 @@ fn reexport_cycle_does_not_hang() {
     let mut binder = BinderState::new();
 
     // ./a re-exports from ./b
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./a".to_string())
         .or_default()
         .push("./b".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./a".to_string())
         .or_default()
         .push(("./b".to_string(), false));
 
     // ./b re-exports from ./a (cycle!)
-    binder
-        .wildcard_reexports
+    Arc::make_mut(&mut binder.wildcard_reexports)
         .entry("./b".to_string())
         .or_default()
         .push("./a".to_string());
-    binder
-        .wildcard_reexports_type_only
+    Arc::make_mut(&mut binder.wildcard_reexports_type_only)
         .entry("./b".to_string())
         .or_default()
         .push(("./a".to_string(), false));

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -743,9 +743,10 @@ pub(super) fn collect_diagnostics(
     // `ctx.reexports_for_file` / `wildcard_reexports_for_file`.
     // `program.reexports` is already `Arc`-wrapped on `MergedProgram`; cheap atomic clone.
     let program_reexports = Arc::clone(&program.reexports);
-    let program_wildcard_reexports = Arc::new(program.wildcard_reexports.clone());
-    let program_wildcard_reexports_type_only =
-        Arc::new(program.wildcard_reexports_type_only.clone());
+    // `program.wildcard_reexports` and `program.wildcard_reexports_type_only`
+    // are already `Arc`-wrapped on `MergedProgram`; cheap atomic clone.
+    let program_wildcard_reexports = Arc::clone(&program.wildcard_reexports);
+    let program_wildcard_reexports_type_only = Arc::clone(&program.wildcard_reexports_type_only);
     // `program.module_exports` is already `Arc`-wrapped on `MergedProgram`;
     // cheap atomic clone for ProjectEnv install.
     let program_module_exports = Arc::clone(&program.module_exports);
@@ -1543,8 +1544,7 @@ fn propagate_module_export_maps(
             Arc::make_mut(&mut binder.module_exports).insert(current_specifier.clone(), exports);
         }
         if let Some(wildcards) = program.wildcard_reexports.get(target_file_name).cloned() {
-            binder
-                .wildcard_reexports
+            Arc::make_mut(&mut binder.wildcard_reexports)
                 .insert(current_specifier.clone(), wildcards.clone());
         }
         if let Some(type_only_flags) = program
@@ -1552,8 +1552,7 @@ fn propagate_module_export_maps(
             .get(target_file_name)
             .cloned()
         {
-            binder
-                .wildcard_reexports_type_only
+            Arc::make_mut(&mut binder.wildcard_reexports_type_only)
                 .insert(current_specifier.clone(), type_only_flags);
         }
         if let Some(reexports) = program.reexports.get(target_file_name).cloned() {

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -28,7 +28,10 @@
 
 use crate::binder::BinderOptions;
 use crate::binder::BinderState;
-use crate::binder::state::{BinderStateScopeInputs, CrossFileNodeSymbols, DeclarationArenaMap};
+use crate::binder::state::{
+    BinderStateScopeInputs, CrossFileNodeSymbols, DeclarationArenaMap, WildcardReexportsMap,
+    WildcardReexportsTypeOnlyMap,
+};
 use crate::binder::{
     FlowNodeArena, FlowNodeId, Scope, ScopeId, SymbolArena, SymbolId, SymbolTable,
 };
@@ -504,9 +507,12 @@ pub struct BindResult {
     /// Re-exports: tracks `export { x } from 'module'` declarations
     pub reexports: Arc<Reexports>,
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
-    pub wildcard_reexports: FxHashMap<String, Vec<String>>,
+    /// `Arc`-wrapped to mirror `BinderState.wildcard_reexports`; the
+    /// final `MergedProgram` builds its own `Arc` once and shares it
+    /// with every per-file `BinderState` via `Arc::clone`.
+    pub wildcard_reexports: Arc<WildcardReexportsMap>,
     /// Wildcard re-export type-only provenance aligned with `wildcard_reexports`.
-    pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
+    pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,
     /// Lib binders for global type resolution (Array, String, etc.)
     /// These are merged from lib.d.ts files and enable cross-file symbol lookup
     pub lib_binders: Arc<Vec<Arc<BinderState>>>,
@@ -661,7 +667,7 @@ impl BindResult {
         }
 
         // wildcard_reexports
-        for (k, v) in &self.wildcard_reexports {
+        for (k, v) in self.wildcard_reexports.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             for s in v {
                 size += s.capacity();
@@ -669,7 +675,7 @@ impl BindResult {
         }
 
         // wildcard_reexports_type_only
-        for (k, v) in &self.wildcard_reexports_type_only {
+        for (k, v) in self.wildcard_reexports_type_only.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             for (s, _) in v {
                 size += s.capacity() + 1;
@@ -1579,9 +1585,12 @@ pub struct MergedProgram {
     pub reexports: Arc<Reexports>,
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
     /// Maps `current_file` -> Vec of `source_modules`
-    pub wildcard_reexports: FxHashMap<String, Vec<String>>,
+    /// `Arc`-wrapped so per-file `BinderState` reconstruction is a
+    /// cheap atomic increment instead of a deep clone of the merged
+    /// `FxHashMap`. Mutations during binding go through `Arc::make_mut`.
+    pub wildcard_reexports: Arc<WildcardReexportsMap>,
     /// Wildcard re-export type-only provenance per entry.
-    pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
+    pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,
     /// Lib binders for global type resolution (Array, String, Promise, etc.)
     /// These contain symbols from lib.d.ts files and enable resolution of built-in types
     pub lib_binders: Arc<Vec<Arc<BinderState>>>,
@@ -2404,7 +2413,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         }
 
         // Merge wildcard reexports from this file
-        for (file_name, source_modules) in &result.wildcard_reexports {
+        for (file_name, source_modules) in result.wildcard_reexports.iter() {
             let entry = wildcard_reexports.entry(file_name.clone()).or_default();
             let type_only_entry = wildcard_reexports_type_only
                 .entry(file_name.clone())
@@ -3273,8 +3282,8 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         shorthand_ambient_modules: Arc::new(shorthand_ambient_modules),
         module_exports: Arc::new(module_exports),
         reexports: Arc::new(reexports),
-        wildcard_reexports,
-        wildcard_reexports_type_only,
+        wildcard_reexports: Arc::new(wildcard_reexports),
+        wildcard_reexports_type_only: Arc::new(wildcard_reexports_type_only),
         lib_binders: Arc::new(lib_binders),
         lib_symbol_ids: Arc::new(global_lib_symbol_ids),
         type_interner,

--- a/crates/tsz-core/tests/binder_state_tests.rs
+++ b/crates/tsz-core/tests/binder_state_tests.rs
@@ -2891,6 +2891,7 @@ export * from './wildcard2';
 fn test_export_resolution_multiple_wildcards() {
     use crate::binder::{BinderState, SymbolTable, symbol_flags};
     use crate::parser::ParserState;
+    use std::sync::Arc;
 
     // Setup: We'll create module_exports and wildcard_reexports manually
     // to test the resolution logic without parsing multiple files
@@ -2921,7 +2922,7 @@ fn test_export_resolution_multiple_wildcards() {
         .insert("./moduleB".to_string(), module_b_exports);
 
     // Setup index.ts to re-export from both
-    binder.wildcard_reexports.insert(
+    Arc::make_mut(&mut binder.wildcard_reexports).insert(
         "./index".to_string(),
         vec!["./moduleA".to_string(), "./moduleB".to_string()],
     );


### PR DESCRIPTION
## Summary
Mirrors #932 (lib_symbol_ids) and #935 (shorthand_ambient_modules). The merged `MergedProgram.wildcard_reexports` and its `_type_only` companion are identical for every file in a project build; per-file `BinderState` reconstruction was deep-cloning each map into every one of N binders, scaling outer-map allocation and hashing with N.

## Changes
- Both fields are now `Arc<...>` on `BinderState`, `BinderStateScopeInputs`, `BindResult`, and `MergedProgram`. Type aliases `WildcardReexportsMap` / `WildcardReexportsTypeOnlyMap` keep field types under `clippy::type_complexity`.
- The two binder mutation sites route through `Arc::make_mut` (zero-cost when refcount is 1, which is always during binding).
- Merge accumulator is wrapped in `Arc::new` once at `MergedProgram` construction.
- Eliminates the now-redundant `Arc::new(program.wildcard_reexports.clone())` wraps in the CLI driver — `Arc::clone(&program.wildcard_reexports)` is the cheap path now.
- Iter sites that used `&result.wildcard_reexports` now go through `.iter()` (Arc doesn't auto-implement `IntoIterator` for `&Self`).

Pure plumbing: consumer surface for `binder.wildcard_reexports.get(...)` and `.iter()` is unchanged thanks to `Deref`. No behavior change.

## Test plan
- [x] `cargo nextest run` (full pre-commit suite, 18777 tests passed)
- [x] Workspace clippy clean
- [ ] Conformance suite no-regression check post-merge