### PR TITLE
fix(emitter): keep method syntax for computed names backed by enum members

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -1519,13 +1519,38 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::Identifier as u16
                 || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION =>
             {
-                let interner = self.type_interner?;
-                let type_id = self.get_node_type_or_names(&[expr_idx])?;
-                let literal = tsz_solver::visitor::literal_value(interner, type_id)?;
-                Some(Self::format_property_name_literal_value(&literal, interner))
+                if let Some(interner) = self.type_interner
+                    && let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
+                    && let Some(literal) = tsz_solver::visitor::literal_value(interner, type_id)
+                {
+                    return Some(Self::format_property_name_literal_value(&literal, interner));
+                }
+                // Fallback: an enum member access (e.g. `[E.A]`) is a valid
+                // property-name source even when the type cache hasn't
+                // produced a `Literal` form for it. Detecting it via the
+                // binder lets the caller keep method/getter syntax instead
+                // of degrading to `[E.A]: () => T`.
+                self.enum_member_access_name_text(expr_idx)
             }
             _ => None,
         }
+    }
+
+    /// If `expr_idx` is a value reference whose symbol is an enum member,
+    /// return the member's escaped name. This is used as a fallback to keep
+    /// method-like dts syntax for `[E.A]() {}` even when the type system
+    /// hasn't produced a literal type for the access expression.
+    pub(in crate::declaration_emitter) fn enum_member_access_name_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let binder = self.binder?;
+        let sym_id = self.value_reference_symbol(expr_idx)?;
+        let symbol = binder.symbols.get(sym_id)?;
+        if symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0 {
+            return None;
+        }
+        Some(symbol.escaped_name.clone())
     }
 
     pub(in crate::declaration_emitter) fn format_property_name_literal_value(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
@@ -1020,3 +1020,32 @@ fn test_accessor_keyword_preserved_on_class_field() {
         "static accessor keyword should be preserved: {output}"
     );
 }
+
+#[test]
+fn test_const_enum_computed_method_name_keeps_method_syntax() {
+    // Regression: a class method with a const-enum-member computed name
+    // (e.g. `[G.A]() {}`) must emit method syntax (`[G.A](): void;`),
+    // not property syntax (`[G.A]: () => void;`). The dts predicate that
+    // chooses syntax was reading the type cache for a `Literal` form;
+    // the binder's `ENUM_MEMBER` symbol flag is now consulted as a
+    // fallback so we keep method syntax even when the type system
+    // shapes the access as the enum-member type rather than the literal.
+    let output = emit_dts_with_binding(
+        r#"
+const enum G { A = 1, B = 2 }
+class C {
+    [G.A]() { }
+    get [G.B]() { return true; }
+    set [G.B](x: number) { }
+}
+"#,
+    );
+    assert!(
+        output.contains("[G.A](): "),
+        "const enum computed method must keep method syntax: {output}"
+    );
+    assert!(
+        !output.contains("[G.A]: () =>"),
+        "must not degrade to property syntax for const enum computed method: {output}"
+    );
+}


### PR DESCRIPTION
## Summary
The dts predicate that decides between method and property syntax for computed-name members like `class C { [G.A]() {} }` walks `resolved_computed_property_name_text` to confirm the name is a usable property identifier. That helper only consulted the type cache for a `Literal` form, so when the type system shaped the access as the enum-member type instead of the raw literal value (the common case for const-enum member access), the helper returned `None` and the predicate fell back to `[G.A]: () => void` instead of `[G.A](): void`.

This change adds a binder-symbol fallback: if the access expression resolves to a symbol whose flags contain `ENUM_MEMBER`, return the member's escaped name from `resolved_computed_property_name_text`. That signal is enough to convince the predicate that the name is property-name-shaped, which keeps method/getter/setter syntax for the member.

Matches tsc's `constEnumPropertyAccess1` baseline.

## Test plan
- [x] New unit test `test_const_enum_computed_method_name_keeps_method_syntax`
- [x] Pre-commit suite (4358 tests) passes
- [x] `constEnumPropertyAccess1` dts emit verified passing