### PR TITLE
perf(binder): Arc-wrap reexports to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -5,6 +5,7 @@
 
 use crate::state::BinderState;
 use crate::{ContainerKind, SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
@@ -617,7 +618,9 @@ impl BinderState {
                             }
 
                             // Now apply the mutable borrow to insert the mappings
-                            let file_reexports = self.reexports.entry(current_file).or_default();
+                            let file_reexports = Arc::make_mut(&mut self.reexports)
+                                .entry(current_file)
+                                .or_default();
                             for (exported, original, _) in export_mappings {
                                 file_reexports.insert(exported, (source_module.clone(), original));
                             }

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -206,7 +206,7 @@ impl BinderState {
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
-            reexports: FxHashMap::default(),
+            reexports: Arc::new(FxHashMap::default()),
             wildcard_reexports: FxHashMap::default(),
             wildcard_reexports_type_only: FxHashMap::default(),
             resolved_export_cache: Default::default(),
@@ -270,7 +270,7 @@ impl BinderState {
         self.lib_binders.clear();
         Arc::make_mut(&mut self.lib_symbol_ids).clear();
         self.module_exports.clear();
-        self.reexports.clear();
+        Arc::make_mut(&mut self.reexports).clear();
         self.wildcard_reexports.clear();
         self.wildcard_reexports_type_only.clear();
         self.resolved_export_cache
@@ -423,7 +423,7 @@ impl BinderState {
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
-            reexports: FxHashMap::default(),
+            reexports: Arc::new(FxHashMap::default()),
             wildcard_reexports: FxHashMap::default(),
             wildcard_reexports_type_only: FxHashMap::default(),
             resolved_export_cache: Default::default(),

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -333,7 +333,7 @@ pub struct BinderState {
     /// Re-exports: tracks `export { x } from 'module'` declarations
     /// Maps (`current_file`, `exported_name`) -> (`source_module`, `original_name`)
     /// Example: ("./a.ts", "foo", "./b.ts") means a.ts re-exports "foo" from b.ts
-    pub reexports: FileReexportsMap,
+    pub reexports: Arc<FileReexportsMap>,
 
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
     /// Maps `current_file` -> Vec of `source_modules`
@@ -804,7 +804,7 @@ pub struct BinderStateScopeInputs {
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
     pub module_exports: FxHashMap<String, SymbolTable>,
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
-    pub reexports: FileReexportsMap,
+    pub reexports: Arc<FileReexportsMap>,
     pub wildcard_reexports: FxHashMap<String, Vec<String>>,
     pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
     pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -741,7 +741,8 @@ pub(super) fn collect_diagnostics(
     // cross-file lookup binders can share the single allocation instead of
     // each deep-cloning a copy. Cross-file consumers read these via
     // `ctx.reexports_for_file` / `wildcard_reexports_for_file`.
-    let program_reexports = Arc::new(program.reexports.clone());
+    // `program.reexports` is already `Arc`-wrapped on `MergedProgram`; cheap atomic clone.
+    let program_reexports = Arc::clone(&program.reexports);
     let program_wildcard_reexports = Arc::new(program.wildcard_reexports.clone());
     let program_wildcard_reexports_type_only =
         Arc::new(program.wildcard_reexports_type_only.clone());
@@ -1559,9 +1560,7 @@ fn propagate_module_export_maps(
                 .insert(current_specifier.clone(), type_only_flags);
         }
         if let Some(reexports) = program.reexports.get(target_file_name).cloned() {
-            binder
-                .reexports
-                .insert(current_specifier.clone(), reexports);
+            Arc::make_mut(&mut binder.reexports).insert(current_specifier.clone(), reexports);
         }
 
         if let Some(source_modules) = program.wildcard_reexports.get(target_file_name).cloned() {

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -502,7 +502,7 @@ pub struct BindResult {
     /// Maps symbols declared inside module augmentation blocks to their target module specifier
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
     /// Re-exports: tracks `export { x } from 'module'` declarations
-    pub reexports: Reexports,
+    pub reexports: Arc<Reexports>,
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
     pub wildcard_reexports: FxHashMap<String, Vec<String>>,
     /// Wildcard re-export type-only provenance aligned with `wildcard_reexports`.
@@ -650,7 +650,7 @@ impl BindResult {
         }
 
         // reexports (FxHashMap<String, FxHashMap<String, (String, Option<String>)>>)
-        for (k, inner) in &self.reexports {
+        for (k, inner) in self.reexports.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             for (ik, (s1, s2)) in inner {
                 size += ik.capacity() + s1.capacity() + 8;
@@ -1574,7 +1574,7 @@ pub struct MergedProgram {
     pub module_exports: FxHashMap<String, SymbolTable>,
     /// Re-exports: tracks `export { x } from 'module'` declarations
     /// Maps (`current_file`, `exported_name`) -> (`source_module`, `original_name`)
-    pub reexports: Reexports,
+    pub reexports: Arc<Reexports>,
     /// Wildcard re-exports: tracks `export * from 'module'` declarations
     /// Maps `current_file` -> Vec of `source_modules`
     pub wildcard_reexports: FxHashMap<String, Vec<String>>,
@@ -2394,7 +2394,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         shorthand_ambient_modules.extend(result.shorthand_ambient_modules.iter().cloned());
 
         // Merge reexports from this file
-        for (file_name, file_reexports) in &result.reexports {
+        for (file_name, file_reexports) in result.reexports.iter() {
             let entry = reexports.entry(file_name.clone()).or_default();
             for (export_name, mapping) in file_reexports {
                 entry.insert(export_name.clone(), mapping.clone());
@@ -3270,7 +3270,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         declared_modules,
         shorthand_ambient_modules,
         module_exports,
-        reexports,
+        reexports: Arc::new(reexports),
         wildcard_reexports,
         wildcard_reexports_type_only,
         lib_binders,

--- a/crates/tsz-core/src/parallel/skeleton.rs
+++ b/crates/tsz-core/src/parallel/skeleton.rs
@@ -241,7 +241,7 @@ pub fn extract_skeleton(result: &BindResult) -> FileSkeleton {
 
     // Named re-exports
     let mut reexports = Vec::new();
-    for (file_name, file_reexports) in &result.reexports {
+    for (file_name, file_reexports) in result.reexports.iter() {
         // Only include re-exports from this file (the reexport map key is the file name)
         if file_name == &result.file_name {
             for (exported_name, (source_module, original_name)) in file_reexports {


### PR DESCRIPTION
## Summary
Mirrors the lib_symbol_ids treatment in #932, the shorthand_ambient_modules treatment in #935, and the wildcard_reexports treatment in #944. The merged `MergedProgram.reexports` (named `export { x } from "..."` mappings) is identical for every file in a project build; per-file `BinderState` reconstruction was deep-cloning the nested `FxHashMap<String, FxHashMap<String, (String, Option<String>)>>` into every one of N binders.

## Changes
- Field is now `Arc<FileReexportsMap>` on `BinderState`, `BinderStateScopeInputs`, `BindResult`, and `MergedProgram`.
- The two binder mutation sites (clear in `state/core.rs`, per-file `entry().or_default()` in `modules/import_export.rs`) route through `Arc::make_mut` (zero-cost when refcount is 1, which is always during binding).
- Merge accumulator is wrapped in `Arc::new` once at `MergedProgram` construction.
- Eliminates the now-redundant `Arc::new(program.reexports.clone())` wrap in the CLI driver — `Arc::clone(&program.reexports)` is the cheap path now.
- Iter sites adapted to `result.reexports.iter()` (`Arc` doesn't auto-implement `IntoIterator` for `&Self`).

Pure plumbing. Consumer surface for `binder.reexports.get(...)` and `.iter()` is unchanged thanks to `Deref`. No behavior change.

## Test plan
- [x] `cargo nextest run` (full pre-commit suite, 18777 tests passed)
- [x] Workspace clippy clean
- [ ] Conformance suite no-regression check post-merge