### PR TITLE
chore(solver): add TypeId::is_unknown_or_error predicates and migrate callers

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -1035,10 +1035,7 @@ impl<'a> CheckerState<'a> {
                     } = result
                     {
                         if mismatch_recovery_return.is_none()
-                            && !matches!(
-                                fallback_return,
-                                TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-                            )
+                            && !fallback_return.is_any_unknown_or_error()
                             && !crate::query_boundaries::common::is_type_deeply_any(
                                 self.ctx.types,
                                 fallback_return,

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1395,11 +1395,11 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or(TypeId::ANY);
             let return_type = self
                 .get_generator_return_type_argument(shape.return_type)
-                .filter(|ty| !matches!(*ty, TypeId::UNKNOWN | TypeId::ERROR))
+                .filter(|ty| !ty.is_unknown_or_error())
                 .unwrap_or(TypeId::VOID);
             let next_type = self
                 .get_generator_next_type_argument(shape.return_type)
-                .filter(|ty| !matches!(*ty, TypeId::UNKNOWN | TypeId::ERROR))
+                .filter(|ty| !ty.is_unknown_or_error())
                 .unwrap_or(TypeId::ANY);
             format!(
                 "{generator_name}<{}, {}, {}>",

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -35,9 +35,7 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common::SubtypeFailureReason;
         use tsz_parser::parser::syntax_kind_ext;
 
-        if matches!(source_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
-            || matches!(target_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
-        {
+        if source_type.is_any_unknown_or_error() || target_type.is_any_unknown_or_error() {
             return false;
         }
 
@@ -123,11 +121,8 @@ impl<'a> CheckerState<'a> {
                         };
 
                     let elem_type = self.elaboration_source_expression_type(elem_idx);
-                    if matches!(elem_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
-                        || matches!(
-                            target_element_type,
-                            TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-                        )
+                    if elem_type.is_any_unknown_or_error()
+                        || target_element_type.is_any_unknown_or_error()
                     {
                         continue;
                     }
@@ -157,7 +152,7 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                     let elem_type = self.elaboration_source_expression_type(elem_idx);
-                    if matches!(elem_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+                    if elem_type.is_any_unknown_or_error() {
                         continue;
                     }
                     if !self.is_assignable_to(elem_type, target_element) {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -683,7 +683,7 @@ impl<'a> CheckerState<'a> {
 
         let constructor_name = format!("{base_name}Constructor");
         let constructor_type = self.resolve_lib_type_by_name(&constructor_name)?;
-        if matches!(constructor_type, TypeId::UNKNOWN | TypeId::ERROR) {
+        if constructor_type.is_unknown_or_error() {
             return None;
         }
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -146,10 +146,7 @@ impl<'a> CheckerState<'a> {
         let contextual_target = raw_call_param_property_target
             .or(object_property_target)
             .or(property_diag_target)?;
-        if matches!(
-            contextual_target,
-            TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-        ) {
+        if contextual_target.is_any_unknown_or_error() {
             return None;
         }
 

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -54,10 +54,7 @@ impl<'a> FlowAnalyzer<'a> {
         else {
             return Some(assigned_type);
         };
-        if matches!(
-            read_target_type,
-            TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-        ) {
+        if read_target_type.is_any_unknown_or_error() {
             return Some(assigned_type);
         }
 

--- a/crates/tsz-checker/src/state/state_checking_members/member_access.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_access.rs
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
                         .is_some_and(|name| name == property_name)
                 {
                     let mut rhs_type = self.get_type_of_node(bin.right);
-                    if matches!(rhs_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                    if rhs_type.is_any_unknown_or_error()
                         && let Some(name_idx) = self.this_access_name_node(bin.right)
                         && let Some(ref_name) = self.get_property_name(name_idx)
                         && ref_name != property_name

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -950,10 +950,7 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::widen_literal_type(self.ctx.types, prop_type);
             let prop_atom = self.ctx.types.intern_string(&prop_name);
             if let Some(existing) = properties.get_mut(&prop_atom) {
-                let existing_is_placeholder = matches!(
-                    existing.type_id,
-                    TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-                );
+                let existing_is_placeholder = existing.type_id.is_any_unknown_or_error();
                 if existing_is_placeholder && !matches!(prop_type, TypeId::ANY | TypeId::UNKNOWN) {
                     existing.type_id = prop_type;
                     existing.write_type = prop_type;

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -583,7 +583,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let define_property_type = self.ctx.types.factory().object(props);
-        if matches!(base_type, TypeId::UNKNOWN | TypeId::ERROR) {
+        if base_type.is_unknown_or_error() {
             define_property_type
         } else {
             self.ctx

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -25,7 +25,7 @@ impl<'a> CheckerState<'a> {
 
         let value_type =
             self.type_of_value_declaration_for_symbol(sym_id, symbol.value_declaration);
-        (!matches!(value_type, TypeId::UNKNOWN | TypeId::ERROR)).then_some(value_type)
+        (!value_type.is_unknown_or_error()).then_some(value_type)
     }
 
     pub(crate) fn imported_namespace_display_module_name(&self, module_name: &str) -> String {

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -215,9 +215,7 @@ impl<'a> CheckerState<'a> {
         pattern_idx: NodeIndex,
         parent_type: TypeId,
     ) -> TypeId {
-        if !self.ctx.strict_null_checks()
-            || matches!(parent_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
-        {
+        if !self.ctx.strict_null_checks() || parent_type.is_any_unknown_or_error() {
             return parent_type;
         }
 

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -213,7 +213,7 @@ impl<'a> CheckerState<'a> {
         let has_mappable_param = source_fn.params.iter().zip(target_fn.params.iter()).any(
             |(source_param, target_param)| {
                 let target_type = target_param.type_id;
-                if matches!(target_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+                if target_type.is_any_unknown_or_error() {
                     return false;
                 }
                 common::collect_all_types(self.ctx.types, source_param.type_id)

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -1153,7 +1153,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let value_type = self.type_of_value_symbol_by_name(name);
-        if !matches!(value_type, TypeId::UNKNOWN | TypeId::ERROR) {
+        if !value_type.is_unknown_or_error() {
             return None;
         }
 

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -397,7 +397,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(&existing) = self.ctx.symbol_types.get(&sym_id)
                         && existing != TypeId::ERROR
                         && type_id != existing
-                        && matches!(type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                        && type_id.is_any_unknown_or_error()
                     {
                         continue;
                     }

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -257,7 +257,7 @@ impl<'a> InferenceContext<'a> {
         upper_bounds
             .iter()
             .copied()
-            .filter(|&upper| !matches!(upper, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
+            .filter(|&upper| !upper.is_any_unknown_or_error())
             .collect()
     }
 
@@ -366,14 +366,14 @@ impl<'a> InferenceContext<'a> {
             // (e.g. Promise/iterable inference with implicit `extends unknown`).
             let has_informative_upper_bound = upper_bounds
                 .iter()
-                .any(|&upper| !matches!(upper, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR));
+                .any(|&upper| !upper.is_any_unknown_or_error());
             // Check if there are concrete (non-top) candidates before filtering.
             // When `any` is the only meaningful candidate, keep it even with
             // informative upper bounds. This matches tsc where passing `any` to
             // `f<T extends X>(v: T)` infers T=any, not T=X.
             let has_concrete_candidate = candidates
                 .iter()
-                .any(|c| !matches!(c.type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR));
+                .any(|c| !c.type_id.is_any_unknown_or_error());
             candidates.retain(|candidate| match candidate.type_id {
                 TypeId::UNKNOWN | TypeId::ERROR => false,
                 TypeId::ANY => !has_informative_upper_bound || !has_concrete_candidate,
@@ -1652,10 +1652,10 @@ impl<'a> InferenceContext<'a> {
                 let has_informative_upper_bound = info
                     .upper_bounds
                     .iter()
-                    .any(|&upper| !matches!(upper, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR));
+                    .any(|&upper| !upper.is_any_unknown_or_error());
                 let has_concrete_candidate = candidates
                     .iter()
-                    .any(|c| !matches!(c.type_id, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR));
+                    .any(|c| !c.type_id.is_any_unknown_or_error());
                 candidates.retain(|candidate| match candidate.type_id {
                     TypeId::UNKNOWN | TypeId::ERROR => false,
                     TypeId::ANY => !has_informative_upper_bound || !has_concrete_candidate,

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -59,7 +59,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     let concrete_bounds: Vec<TypeId> = lower_bounds
                         .iter()
                         .copied()
-                        .filter(|ty| !matches!(*ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
+                        .filter(|ty| !ty.is_any_unknown_or_error())
                         .collect();
                     if !concrete_bounds.is_empty() {
                         return crate::utils::union_or_single(self.interner, concrete_bounds);
@@ -85,7 +85,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         lower_bounds
             .iter()
             .copied()
-            .find(|ty| !matches!(*ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR))
+            .find(|ty| !ty.is_any_unknown_or_error())
             .unwrap_or(lower_bounds[0])
     }
 
@@ -199,7 +199,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .iter()
             .copied()
             .filter(|ty| {
-                !matches!(*ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                !ty.is_any_unknown_or_error()
                     && !crate::visitor::contains_type_parameters(
                         self.interner.as_type_database(),
                         *ty,
@@ -1221,7 +1221,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .iter()
             .copied()
             .filter(|upper| {
-                !matches!(*upper, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                !upper.is_any_unknown_or_error()
                     && !crate::visitor::contains_type_parameters(
                         self.interner.as_type_database(),
                         *upper,

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1472,10 +1472,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                             };
                                             for lb in other_constraints.lower_bounds.iter().copied()
                                             {
-                                                if matches!(
-                                                    lb,
-                                                    TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-                                                ) {
+                                                if lb.is_any_unknown_or_error() {
                                                     continue;
                                                 }
                                                 if !self.checker.is_assignable_to(lb, ty)

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -125,7 +125,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         contextual: TypeId,
         var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
     ) -> bool {
-        if matches!(inferred, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+        if inferred.is_any_unknown_or_error() {
             return true;
         }
 
@@ -195,7 +195,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return true;
         }
 
-        if matches!(inferred, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+        if inferred.is_any_unknown_or_error() {
             return true;
         }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -753,7 +753,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     }
 
     const fn is_uninformative_contextual_inference_input(&self, ty: TypeId) -> bool {
-        matches!(ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+        ty.is_any_unknown_or_error()
     }
 
     pub(crate) fn infer_source_type_param_substitution(

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -1008,8 +1008,8 @@ fn resolve_concrete_conditional_result(
     }
 
     if contains_type_parameters_db(db, check_type)
-        || matches!(check_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
-        || matches!(extends_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+        || check_type.is_any_unknown_or_error()
+        || extends_type.is_any_unknown_or_error()
     {
         return None;
     }

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -206,6 +206,22 @@ impl TypeId {
         self.is_top_type()
     }
 
+    /// Returns true if this type is `UNKNOWN` or `ERROR` — the "unresolved"
+    /// intrinsics that typically indicate a failed resolution or a propagated
+    /// error, regardless of display.
+    #[inline]
+    pub const fn is_unknown_or_error(self) -> bool {
+        matches!(self, Self::UNKNOWN | Self::ERROR)
+    }
+
+    /// Returns true if this type is `ANY`, `UNKNOWN`, or `ERROR` — the
+    /// "information-less" intrinsics callers typically treat as wildcards
+    /// when deciding whether a type carries useful structural information.
+    #[inline]
+    pub const fn is_any_unknown_or_error(self) -> bool {
+        matches!(self, Self::ANY | Self::UNKNOWN | Self::ERROR)
+    }
+
     // =========================================================================
     // Local/Global Partitioning (for ScopedTypeInterner GC)
     // =========================================================================


### PR DESCRIPTION
## Summary
- Adds two const predicates on `TypeId` that sit next to the existing `is_top_type` and `is_any_or_unknown` helpers:
  - `is_unknown_or_error()` — matches `UNKNOWN | ERROR`.
  - `is_any_unknown_or_error()` — matches `ANY | UNKNOWN | ERROR`.
- Migrates ~22 call sites across `tsz-solver` and `tsz-checker` that open-coded the `matches!(ty, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)` pattern (and its narrower two-way variant). No behavior change; both predicates are `const` and auto-deref through `&TypeId`.

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy` on affected crates — zero warnings
- [x] Full pre-commit pipeline: fmt, clippy, wasm32 rustc warnings gate, arch-guard, nextest
- [x] 18427 unit tests pass