### PR TITLE
perf(binder): Arc-wrap module_exports to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -5,6 +5,7 @@
 
 use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
@@ -355,7 +356,7 @@ impl BinderState {
                 && let Some(exports) = symbol.exports.as_ref()
                 && !exports.is_empty()
             {
-                self.module_exports
+                Arc::make_mut(&mut self.module_exports)
                     .insert(module_specifier.clone(), exports.as_ref().clone());
             }
 

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -5,6 +5,7 @@
 
 use crate::state::BinderState;
 use crate::{ContainerKind, SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
@@ -703,7 +704,7 @@ impl BinderState {
                     } else {
                         // Regular namespace re-export — add to module exports
                         let current_file = self.debugger.current_file.clone();
-                        self.module_exports
+                        Arc::make_mut(&mut self.module_exports)
                             .entry(current_file)
                             .or_default()
                             .set(name.to_string(), sym_id);

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -205,7 +205,7 @@ impl BinderState {
             lib_binders: Vec::new(),
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
-            module_exports: FxHashMap::default(),
+            module_exports: Arc::new(FxHashMap::default()),
             reexports: FxHashMap::default(),
             wildcard_reexports: FxHashMap::default(),
             wildcard_reexports_type_only: FxHashMap::default(),
@@ -269,7 +269,7 @@ impl BinderState {
         self.current_augmented_module = None;
         self.lib_binders.clear();
         Arc::make_mut(&mut self.lib_symbol_ids).clear();
-        self.module_exports.clear();
+        Arc::make_mut(&mut self.module_exports).clear();
         self.reexports.clear();
         self.wildcard_reexports.clear();
         self.wildcard_reexports_type_only.clear();
@@ -422,7 +422,7 @@ impl BinderState {
             lib_binders: Vec::new(),
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
-            module_exports: FxHashMap::default(),
+            module_exports: Arc::new(FxHashMap::default()),
             reexports: FxHashMap::default(),
             wildcard_reexports: FxHashMap::default(),
             wildcard_reexports_type_only: FxHashMap::default(),
@@ -1151,7 +1151,9 @@ impl BinderState {
         // Collect all exports from all module-level symbols in this file
         // Start from any exports recorded during binding that intentionally do not create
         // file-local bindings (for example `export * as ns from "./mod"`).
-        let mut file_exports = self.module_exports.remove(file_name).unwrap_or_default();
+        let mut file_exports = Arc::make_mut(&mut self.module_exports)
+            .remove(file_name)
+            .unwrap_or_default();
         let mut export_equals_target: Option<SymbolId> = None;
 
         // Iterate through file_locals to find modules and their exports
@@ -1219,8 +1221,7 @@ impl BinderState {
         }
 
         if !file_exports.is_empty() {
-            self.module_exports
-                .insert(file_name.to_string(), file_exports);
+            Arc::make_mut(&mut self.module_exports).insert(file_name.to_string(), file_exports);
         }
     }
 
@@ -1492,10 +1493,13 @@ impl BinderState {
     /// Recompute `export =` non-module classification for all known module exports.
     pub fn recompute_module_export_equals_non_module(&mut self) {
         self.module_export_equals_non_module.clear();
-        for (module_name, exports) in self.module_exports.clone() {
-            if let Some(non_module) = self.compute_module_export_equals_non_module(&exports) {
+        // `Arc::clone` is cheap; the inner iteration borrows the shared map
+        // while we mutate `self.module_export_equals_non_module`.
+        let module_exports = Arc::clone(&self.module_exports);
+        for (module_name, exports) in module_exports.iter() {
+            if let Some(non_module) = self.compute_module_export_equals_non_module(exports) {
                 self.module_export_equals_non_module
-                    .insert(module_name, non_module);
+                    .insert(module_name.clone(), non_module);
             }
         }
     }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -328,7 +328,7 @@ pub struct BinderState {
 
     /// Module exports: maps file names to their exported symbols for cross-file module resolution
     /// This enables resolving imports like `import { X } from './file'` where './file' is another file
-    pub module_exports: FxHashMap<String, SymbolTable>,
+    pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
 
     /// Re-exports: tracks `export { x } from 'module'` declarations
     /// Maps (`current_file`, `exported_name`) -> (`source_module`, `original_name`)
@@ -802,7 +802,7 @@ pub struct BinderStateScopeInputs {
     pub global_augmentations: FxHashMap<String, Vec<GlobalAugmentation>>,
     pub module_augmentations: FxHashMap<String, Vec<ModuleAugmentation>>,
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
-    pub module_exports: FxHashMap<String, SymbolTable>,
+    pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     pub reexports: FileReexportsMap,
     pub wildcard_reexports: FxHashMap<String, Vec<String>>,

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -2,6 +2,7 @@ use super::{BinderOptions, BinderState};
 use crate::flow::{FlowNodeId, flow_flags};
 use crate::scopes::ContainerKind;
 use crate::{SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_common::common::ScriptTarget;
 use tsz_parser::parser::ParserState;
 
@@ -313,7 +314,7 @@ fn resolves_wildcard_type_only_reexports_with_provenance() {
     let mut a_exports = SymbolTable::new();
     a_exports.set("A".to_string(), a_sym);
     a_exports.set("B".to_string(), b_sym);
-    binder.module_exports.insert("./a".to_string(), a_exports);
+    Arc::make_mut(&mut binder.module_exports).insert("./a".to_string(), a_exports);
 
     binder
         .wildcard_reexports
@@ -2782,7 +2783,7 @@ fn direct_module_export_resolution() {
         .alloc(symbol_flags::FUNCTION, "myFunc".to_string());
     let mut exports = SymbolTable::new();
     exports.set("myFunc".to_string(), sym);
-    binder.module_exports.insert("./mod".to_string(), exports);
+    Arc::make_mut(&mut binder.module_exports).insert("./mod".to_string(), exports);
 
     let resolved = binder.resolve_import_if_needed_public("./mod", "myFunc");
     assert_eq!(resolved, Some(sym), "should resolve direct export");
@@ -2801,7 +2802,7 @@ fn wildcard_reexport_resolution() {
         .alloc(symbol_flags::CLASS, "Widget".to_string());
     let mut a_exports = SymbolTable::new();
     a_exports.set("Widget".to_string(), sym);
-    binder.module_exports.insert("./a".to_string(), a_exports);
+    Arc::make_mut(&mut binder.module_exports).insert("./a".to_string(), a_exports);
 
     // ./b re-exports everything from ./a
     binder

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -983,7 +983,7 @@ impl<'a> CheckerContext<'a> {
         if let Some(ref idx) = self.program_module_exports {
             return Self::lookup_any_file_key(module_key, idx);
         }
-        Self::lookup_any_file_key(module_key, &binder.module_exports)
+        Self::lookup_any_file_key(module_key, binder.module_exports.as_ref())
     }
 
     /// Like `module_exports_for_module` but tests existence only.

--- a/crates/tsz-checker/tests/commonjs_constructor_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/commonjs_constructor_diagnostics_tests.rs
@@ -37,8 +37,7 @@ inst[x.S];
 
     let file_a_exports = binder_a.module_exports.get("a.js").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert("./a.js".to_string(), exports.clone());
     }
 
@@ -132,8 +131,7 @@ x[x.S];
 
     let file_a_exports = binder_a.module_exports.get("a.js").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert("./a.js".to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/commonjs_module_export_alias_tests.rs
+++ b/crates/tsz-checker/tests/commonjs_module_export_alias_tests.rs
@@ -63,8 +63,7 @@ fn check_commonjs_two_files(
 
     let file_a_exports = binder_a.module_exports.get(producer_name).cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_specifier.to_string(), exports.clone());
     }
 
@@ -159,8 +158,7 @@ fn check_commonjs_three_files_with_types(
 
     let file_exports = binder_producer.module_exports.get(producer_name).cloned();
     if let Some(exports) = &file_exports {
-        binder_consumer
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_consumer.module_exports)
             .insert(module_specifier.to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/commonjs_require_value_tests.rs
+++ b/crates/tsz-checker/tests/commonjs_require_value_tests.rs
@@ -37,8 +37,7 @@ fn check_js_require_value_diagnostics(
 
     let file_js_exports = binder_js.module_exports.get("js.js").cloned();
     if let Some(exports) = &file_js_exports {
-        binder_user
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_user.module_exports)
             .insert("./js.js".to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
@@ -69,8 +69,7 @@ pub(crate) fn compile_two_files_get_diagnostics_with_options(
     // Merge module exports: copy a.ts exports into b.ts's binder for cross-file resolution
     let file_a_exports = binder_a.module_exports.get("a.ts").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_spec.to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/conformance_issues/errors/accessors.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/accessors.rs
@@ -40,10 +40,9 @@ a();
 
     // Copy module exports from ambient to consumer binder
     for module_name in &["a", "b"] {
-        if let Some(exports) = binder_a.module_exports.get(*module_name) {
-            binder_b
-                .module_exports
-                .insert(module_name.to_string(), exports.clone());
+        if let Some(exports) = binder_a.module_exports.get(*module_name).cloned() {
+            std::sync::Arc::make_mut(&mut binder_b.module_exports)
+                .insert(module_name.to_string(), exports);
         }
     }
 

--- a/crates/tsz-checker/tests/conformance_issues/modules/context.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/context.rs
@@ -379,8 +379,7 @@ fn compile_two_files_get_diagnostics_with_options(
     // Merge module exports: copy a.ts exports into b.ts's binder for cross-file resolution
     let file_a_exports = binder_a.module_exports.get("a.ts").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_spec.to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
@@ -653,8 +653,7 @@ fn compile_ambient_module_and_consumer_get_diagnostics(
 
     let ambient_exports = binder_a.module_exports.get(module_spec).cloned();
     if let Some(exports) = &ambient_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_spec.to_string(), exports.clone());
     }
 
@@ -729,8 +728,7 @@ new x.F();
 
     let file_a_exports = binder_a.module_exports.get("a.js").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert("./a.js".to_string(), exports.clone());
     }
 
@@ -825,8 +823,7 @@ inst[x.S];
 
     let file_a_exports = binder_a.module_exports.get("a.js").cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert("./a.js".to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/js_export_surface_tests.rs
+++ b/crates/tsz-checker/tests/js_export_surface_tests.rs
@@ -41,8 +41,7 @@ fn check_commonjs_two_files(
 
     let file_a_exports = binder_a.module_exports.get(producer_name).cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_specifier.to_string(), exports.clone());
     }
 
@@ -356,8 +355,7 @@ fn inspect_commonjs_two_file_consumer_symbol(
 
     let file_a_exports = binder_a.module_exports.get(producer_name).cloned();
     if let Some(exports) = &file_a_exports {
-        binder_b
-            .module_exports
+        std::sync::Arc::make_mut(&mut binder_b.module_exports)
             .insert(module_specifier.to_string(), exports.clone());
     }
 

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -232,15 +232,13 @@ fn build_global_indices_if_changed_rebuilds_on_first_call() {
 #[test]
 fn build_global_indices_populates_module_binder_index() {
     let mut binder_a = BinderState::new();
-    binder_a
-        .module_exports
+    std::sync::Arc::make_mut(&mut binder_a.module_exports)
         .entry("\"my-lib\"".to_string())
         .or_default()
         .set("foo".to_string(), SymbolId(1));
 
     let mut binder_b = BinderState::new();
-    binder_b
-        .module_exports
+    std::sync::Arc::make_mut(&mut binder_b.module_exports)
         .entry("\"other-lib\"".to_string())
         .or_default()
         .set("bar".to_string(), SymbolId(2));

--- a/crates/tsz-checker/tests/ts2498_tests.rs
+++ b/crates/tsz-checker/tests/ts2498_tests.rs
@@ -31,7 +31,7 @@ fn check_reexport_of_export_equals(b_source: &str) -> Vec<(u32, String)> {
 
     // Wire up module resolution: make a.ts exports available to b.ts
     if let Some(a_exports) = binder_a.module_exports.get("a.ts").cloned() {
-        binder_b.module_exports.insert("./a".to_string(), a_exports);
+        std::sync::Arc::make_mut(&mut binder_b.module_exports).insert("./a".to_string(), a_exports);
     }
 
     let arena_a = Arc::new(parser_a.get_arena().clone());
@@ -130,7 +130,7 @@ fn check_reexport_of_normal_module(b_source: &str) -> Vec<(u32, String)> {
 
     // Wire up module resolution
     if let Some(a_exports) = binder_a.module_exports.get("a.ts").cloned() {
-        binder_b.module_exports.insert("./a".to_string(), a_exports);
+        std::sync::Arc::make_mut(&mut binder_b.module_exports).insert("./a".to_string(), a_exports);
     }
 
     let arena_a = Arc::new(parser_a.get_arena().clone());

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -745,10 +745,9 @@ pub(super) fn collect_diagnostics(
     let program_wildcard_reexports = Arc::new(program.wildcard_reexports.clone());
     let program_wildcard_reexports_type_only =
         Arc::new(program.wildcard_reexports_type_only.clone());
-    // Same rationale for `program.module_exports`: the merged map is the
-    // authoritative cross-file exports table; wrap once, share via `Arc`
-    // to avoid N deep-clones into per-file cross-file lookup binders.
-    let program_module_exports = Arc::new(program.module_exports.clone());
+    // `program.module_exports` is already `Arc`-wrapped on `MergedProgram`;
+    // cheap atomic clone for ProjectEnv install.
+    let program_module_exports = Arc::clone(&program.module_exports);
     // Same rationale for `program.cross_file_node_symbols`: the outer
     // map is `FxHashMap<usize, Arc<…>>` (~24 bytes * N_files for the
     // entries plus hash overhead). Cloning into every one of N per-file
@@ -1540,9 +1539,7 @@ fn propagate_module_export_maps(
         let target_file_name = &program.files[current_target_idx].file_name;
 
         if let Some(exports) = program.module_exports.get(target_file_name).cloned() {
-            binder
-                .module_exports
-                .insert(current_specifier.clone(), exports);
+            Arc::make_mut(&mut binder.module_exports).insert(current_specifier.clone(), exports);
         }
         if let Some(wildcards) = program.wildcard_reexports.get(target_file_name).cloned() {
             binder

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -477,7 +477,7 @@ pub struct BindResult {
     /// Ambient module declarations by specifier
     pub declared_modules: FxHashSet<String>,
     /// Module exports keyed by specifier or file name
-    pub module_exports: FxHashMap<String, SymbolTable>,
+    pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
     /// Node-to-symbol mapping
     pub node_symbols: FxHashMap<u32, SymbolId>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
@@ -586,7 +586,7 @@ impl BindResult {
         }
 
         // module_exports
-        for (k, v) in &self.module_exports {
+        for (k, v) in self.module_exports.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             size += std::mem::size_of::<SymbolTable>();
             size += v.len() * (32 + std::mem::size_of::<SymbolId>());
@@ -1571,7 +1571,9 @@ pub struct MergedProgram {
     pub shorthand_ambient_modules: FxHashSet<String>,
     /// Module exports: maps file name (or module specifier) to its exported symbols
     /// This enables cross-file module resolution: import { X } from './file' can find X's symbol
-    pub module_exports: FxHashMap<String, SymbolTable>,
+    /// `Arc`-wrapped so per-file `BinderState` reconstruction is a cheap atomic
+    /// increment instead of a deep clone of the merged map.
+    pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
     /// Re-exports: tracks `export { x } from 'module'` declarations
     /// Maps (`current_file`, `exported_name`) -> (`source_module`, `original_name`)
     pub reexports: Reexports,
@@ -2745,7 +2747,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
             module_exports.insert(result.file_name.clone(), exports);
         }
 
-        for (module_key, exports_table) in &result.module_exports {
+        for (module_key, exports_table) in result.module_exports.iter() {
             let remapped = remap_symbol_table(exports_table, &id_remap);
             if !remapped.is_empty() {
                 merge_symbol_table(
@@ -3269,7 +3271,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         file_locals: file_locals_list,
         declared_modules,
         shorthand_ambient_modules,
-        module_exports,
+        module_exports: Arc::new(module_exports),
         reexports,
         wildcard_reexports,
         wildcard_reexports_type_only,

--- a/crates/tsz-core/tests/binder_state_tests.rs
+++ b/crates/tsz-core/tests/binder_state_tests.rs
@@ -2580,14 +2580,12 @@ const y = bar;
     let mut importer_binder = BinderState::new();
 
     // Populate module_exports with the exported symbols from file1
-    importer_binder
-        .module_exports
-        .insert("./file1".to_string(), {
-            let mut table = crate::binder::SymbolTable::new();
-            table.set("foo".to_string(), foo_export_sym_id);
-            table.set("bar".to_string(), bar_export_sym_id);
-            table
-        });
+    std::sync::Arc::make_mut(&mut importer_binder.module_exports).insert("./file1".to_string(), {
+        let mut table = crate::binder::SymbolTable::new();
+        table.set("foo".to_string(), foo_export_sym_id);
+        table.set("bar".to_string(), bar_export_sym_id);
+        table
+    });
 
     importer_binder.bind_source_file(importer_arena, importer_root);
 
@@ -2678,13 +2676,11 @@ const x = aliasedValue;
     let mut importer_binder = BinderState::new();
 
     // Populate module_exports with the exported symbol from file1
-    importer_binder
-        .module_exports
-        .insert("./file1".to_string(), {
-            let mut table = crate::binder::SymbolTable::new();
-            table.set("originalValue".to_string(), export_sym_id);
-            table
-        });
+    std::sync::Arc::make_mut(&mut importer_binder.module_exports).insert("./file1".to_string(), {
+        let mut table = crate::binder::SymbolTable::new();
+        table.set("originalValue".to_string(), export_sym_id);
+        table
+    });
 
     importer_binder.bind_source_file(importer_arena, importer_root);
 
@@ -2913,8 +2909,7 @@ fn test_export_resolution_multiple_wildcards() {
         .symbols
         .alloc(symbol_flags::FUNCTION, "funcA".to_string());
     module_a_exports.set("funcA".to_string(), sym_a);
-    binder
-        .module_exports
+    std::sync::Arc::make_mut(&mut binder.module_exports)
         .insert("./moduleA".to_string(), module_a_exports);
 
     let mut module_b_exports = SymbolTable::new();
@@ -2922,8 +2917,7 @@ fn test_export_resolution_multiple_wildcards() {
         .symbols
         .alloc(symbol_flags::FUNCTION, "funcB".to_string());
     module_b_exports.set("funcB".to_string(), sym_b);
-    binder
-        .module_exports
+    std::sync::Arc::make_mut(&mut binder.module_exports)
         .insert("./moduleB".to_string(), module_b_exports);
 
     // Setup index.ts to re-export from both

--- a/crates/tsz-core/tests/module_resolution_tests.rs
+++ b/crates/tsz-core/tests/module_resolution_tests.rs
@@ -67,7 +67,7 @@ fn check_with_module_exports(
                 table.set(name.to_string(), sym_id);
             }
         }
-        binder.module_exports.insert(module_name.to_string(), table);
+        std::sync::Arc::make_mut(&mut binder.module_exports).insert(module_name.to_string(), table);
     }
 
     binder.bind_source_file(parser.get_arena(), root);
@@ -138,7 +138,7 @@ pub fn check_with_module_sources(
         for (name, &sym_id) in export_binder.file_locals.iter() {
             table.set(name.clone(), sym_id);
         }
-        binder.module_exports.insert(module_name.to_string(), table);
+        std::sync::Arc::make_mut(&mut binder.module_exports).insert(module_name.to_string(), table);
     }
 
     binder.bind_source_file(parser.get_arena(), root);
@@ -1216,13 +1216,11 @@ const x = value;
     let importer_arena = importer_parser.get_arena();
 
     let mut importer_binder = BinderState::new();
-    importer_binder
-        .module_exports
-        .insert("./file1".to_string(), {
-            let mut table = crate::binder::SymbolTable::new();
-            table.set("value".to_string(), export_sym_id);
-            table
-        });
+    std::sync::Arc::make_mut(&mut importer_binder.module_exports).insert("./file1".to_string(), {
+        let mut table = crate::binder::SymbolTable::new();
+        table.set("value".to_string(), export_sym_id);
+        table
+    });
     importer_binder.bind_source_file(importer_arena, importer_root);
 
     assert!(
@@ -1268,13 +1266,11 @@ import hello from './file1';
     let importer_root = importer_parser.parse_source_file();
 
     let mut importer_binder = BinderState::new();
-    importer_binder
-        .module_exports
-        .insert("./file1".to_string(), {
-            let mut table = crate::binder::SymbolTable::new();
-            table.set("default".to_string(), default_sym_id);
-            table
-        });
+    std::sync::Arc::make_mut(&mut importer_binder.module_exports).insert("./file1".to_string(), {
+        let mut table = crate::binder::SymbolTable::new();
+        table.set("default".to_string(), default_sym_id);
+        table
+    });
     importer_binder.bind_source_file(importer_parser.get_arena(), importer_root);
 
     assert!(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -217,7 +217,7 @@ impl<'a> DeclarationEmitter<'a> {
                 // same-named exports in unrelated modules.
                 let import_module = symbol.import_module.as_deref().unwrap_or("");
                 let mut found = None;
-                for (path, table) in &binder.module_exports {
+                for (path, table) in binder.module_exports.iter() {
                     // Only search in modules whose path ends with the import specifier.
                     // e.g. import_module="foo" matches ".../node_modules/foo/index.d.ts"
                     if !import_module.is_empty() {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -1696,7 +1696,7 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> bool {
         let package_root_str = package_root.to_string_lossy();
 
-        for (module_path, exports) in &binder.module_exports {
+        for (module_path, exports) in binder.module_exports.iter() {
             // Only consider modules inside the same package.
             if !module_path.starts_with(package_root_str.as_ref()) {
                 continue;
@@ -1756,7 +1756,7 @@ impl<'a> DeclarationEmitter<'a> {
         };
         let source_relative_stripped = self.strip_ts_extensions(source_relative);
 
-        for (module_path, exports) in &binder.module_exports {
+        for (module_path, exports) in binder.module_exports.iter() {
             if module_path == source_path || !module_path.starts_with(package_root_str.as_ref()) {
                 continue;
             }


### PR DESCRIPTION
## Summary
Mirrors the lib_symbol_ids treatment in #932, the shorthand_ambient_modules treatment in #935, the wildcard_reexports treatment in #944, and the reexports treatment in #948. The merged `MergedProgram.module_exports` (the cross-file authoritative exports table mapping module specifier/file name → `SymbolTable`) is identical for every file in a project build; per-file `BinderState` reconstruction was deep-cloning the entire `FxHashMap<String, SymbolTable>` into every one of N binders.

On large repos this is the **biggest single field** in the per-file binder clone tax — the perf followup doc identified it as potentially hundreds of MB across 6000+ binders on `large-ts-repo`.

## Changes
- Field is now `Arc<FxHashMap<String, SymbolTable>>` on `BinderState`, `BinderStateScopeInputs`, `BindResult`, and `MergedProgram`.
- Routes the binder mutation sites through `Arc::make_mut` (zero-cost when the refcount is 1, which is always during binding):
  - `state/core.rs::reset` (clear)
  - `state/core.rs::populate_module_exports` (remove + insert)
  - `state/core.rs::recompute_module_export_equals_non_module` — iterates the shared `Arc` instead of cloning the inner map
  - `modules/binding.rs` (anonymous-module export promotion)
  - `modules/import_export.rs` (regular namespace re-export)
- Wraps the merge accumulator in `Arc::new` once at `MergedProgram` construction.
- Eliminates the now-redundant `Arc::new(program.module_exports.clone())` wrap in the CLI driver — `Arc::clone(&program.module_exports)` is the cheap path now.
- Adapts a few `&binder.module_exports` ref/iter sites in `tsz-emitter::declaration_emitter::helpers::portability_*` and the `lookup_any_file_key` accessor in `tsz-checker::context::core` to `binder.module_exports.iter()` / `.as_ref()`.
- Updates the handful of test files that mutate `binder.module_exports` directly to go through `Arc::make_mut`.

Pure plumbing. The consumer surface for `binder.module_exports.get(...)`, `.iter()`, `.contains_key(...)` is unchanged thanks to `Deref`. No behavior change.

## Test plan
- [x] `cargo nextest run` (full pre-commit suite, 18777 tests passed)
- [x] Workspace clippy clean
- [ ] Conformance suite no-regression check post-merge
- [ ] `large-ts-repo` memory profile post-merge to validate the expected several-hundred-MB reduction