### PR TITLE
chore(parser): add Node::is_function_expression_or_arrow helper and migrate callers

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -2503,8 +2503,7 @@ impl BinderState {
                 return;
             };
             let has_type_annotation = var_decl.type_annotation.is_some();
-            let is_function_like = init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION;
+            let is_function_like = init_node.is_function_expression_or_arrow();
             let is_property_access_lhs =
                 lhs_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION;
             let is_expando_init = is_function_like

--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -207,8 +207,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Deferred function/class evaluation does not trigger TS2373.
-        if (node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION)
+        if (node.is_function_expression_or_arrow())
             && !self.ctx.arena.is_immediately_invoked(node_idx)
         {
             return;

--- a/crates/tsz-checker/src/classes/super_checker.rs
+++ b/crates/tsz-checker/src/classes/super_checker.rs
@@ -427,8 +427,7 @@ impl<'a> CheckerState<'a> {
             };
 
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || parent_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || parent_node.is_function_expression_or_arrow()
                 || parent_node.kind == syntax_kind_ext::METHOD_DECLARATION
                 || parent_node.kind == syntax_kind_ext::GET_ACCESSOR
                 || parent_node.kind == syntax_kind_ext::SET_ACCESSOR

--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -232,10 +232,7 @@ impl<'a> CheckerState<'a> {
             // through a symbol (e.g., named function expression `self` calling
             // itself), body analysis would recurse infinitely because the body
             // contains calls to the same function.
-            if check_body_for_throws
-                && (decl_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || decl_node.kind == syntax_kind_ext::ARROW_FUNCTION)
-            {
+            if check_body_for_throws && (decl_node.is_function_expression_or_arrow()) {
                 let body_idx = func.body;
                 if let Some(body_node) = self.ctx.arena.get(body_idx)
                     && let Some(block) = self.ctx.arena.get_block(body_node)

--- a/crates/tsz-checker/src/state/state_checking/isolated_declarations.rs
+++ b/crates/tsz-checker/src/state/state_checking/isolated_declarations.rs
@@ -387,8 +387,7 @@ impl<'a> CheckerState<'a> {
             // Also recurse into function expression defaults to check their inner params
             if param.initializer.is_some()
                 && let Some(init_node) = self.ctx.arena.get(param.initializer)
-                && (init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || init_node.kind == syntax_kind_ext::ARROW_FUNCTION)
+                && (init_node.is_function_expression_or_arrow())
                 && let Some(func) = self.ctx.arena.get_function(init_node)
             {
                 self.check_isolated_decl_function_params(&func.parameters);
@@ -690,8 +689,7 @@ impl<'a> CheckerState<'a> {
             // Even if the property value is inferrable, nested function-expression
             // defaults in parameters still require TS9007.
             if let Some(init_node) = self.ctx.arena.get(prop.initializer)
-                && (init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || init_node.kind == syntax_kind_ext::ARROW_FUNCTION)
+                && (init_node.is_function_expression_or_arrow())
                 && let Some(func) = self.ctx.arena.get_function(init_node)
             {
                 self.check_isolated_decl_function_params(&func.parameters);
@@ -864,8 +862,7 @@ impl<'a> CheckerState<'a> {
                 };
                 // Check if the initializer is a function expression or arrow function
                 if let Some(init_node) = self.ctx.arena.get(decl.initializer)
-                    && (init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                        || init_node.kind == syntax_kind_ext::ARROW_FUNCTION)
+                    && (init_node.is_function_expression_or_arrow())
                 {
                     // Get the variable name and scan for property assignments
                     if let Some(name_ident) = self.ctx.arena.get_identifier_at(decl.name) {

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -714,10 +714,9 @@ impl<'a> CheckerState<'a> {
                             if !self.is_assignment_operator(binary.operator_token) {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                             let Some(ext) = arena.get_extended(decl_idx) else {
@@ -738,10 +737,9 @@ impl<'a> CheckerState<'a> {
                             {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::VARIABLE_DECLARATION => {
                             let Some(var_decl) = arena.get_variable_declaration(node) else {
@@ -750,8 +748,7 @@ impl<'a> CheckerState<'a> {
                             let Some(init_node) = arena.get(var_decl.initializer) else {
                                 return false;
                             };
-                            init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                            init_node.is_function_expression_or_arrow()
                         }
                         _ => false,
                     }

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_detection.rs
@@ -725,8 +725,7 @@ impl<'a> CheckerState<'a> {
             };
             // Don't cross function/class boundaries
             if child_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || child_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || child_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || child_node.is_function_expression_or_arrow()
                 || child_node.kind == syntax_kind_ext::CLASS_DECLARATION
                 || child_node.kind == syntax_kind_ext::CLASS_EXPRESSION
             {

--- a/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
@@ -1016,8 +1016,7 @@ impl<'a> CheckerState<'a> {
                 }
                 // Stop at function boundaries (don't consider outer static blocks)
                 if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                    || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.is_function_expression_or_arrow()
                     || node.kind == syntax_kind_ext::METHOD_DECLARATION
                     || node.kind == syntax_kind_ext::CONSTRUCTOR
                     || node.kind == syntax_kind_ext::GET_ACCESSOR
@@ -1113,8 +1112,7 @@ impl<'a> CheckerState<'a> {
                 }
                 // Stop at function boundaries
                 if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                    || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.is_function_expression_or_arrow()
                     || node.kind == syntax_kind_ext::METHOD_DECLARATION
                     || node.kind == syntax_kind_ext::CONSTRUCTOR
                 {
@@ -1345,8 +1343,7 @@ impl<'a> CheckerState<'a> {
                 }
                 // Stop at function/class/interface boundaries
                 if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                    || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.is_function_expression_or_arrow()
                     || node.kind == syntax_kind_ext::METHOD_DECLARATION
                     || node.kind == syntax_kind_ext::CONSTRUCTOR
                     || node.kind == syntax_kind_ext::CLASS_DECLARATION
@@ -1416,8 +1413,7 @@ impl<'a> CheckerState<'a> {
 
             // Stop at function/class/interface boundaries
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || parent_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || parent_node.is_function_expression_or_arrow()
                 || parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
                 || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
                 || parent_node.kind == syntax_kind_ext::INTERFACE_DECLARATION
@@ -1506,8 +1502,7 @@ impl<'a> CheckerState<'a> {
 
             // Stop at function/class/interface boundaries
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || parent_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || parent_node.is_function_expression_or_arrow()
                 || parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
                 || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
                 || parent_node.kind == syntax_kind_ext::INTERFACE_DECLARATION

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -2197,8 +2197,7 @@ impl<'a> CheckerState<'a> {
             };
 
             if parent_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || parent_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || parent_node.is_function_expression_or_arrow()
                 || parent_node.kind == syntax_kind_ext::METHOD_DECLARATION
             {
                 if let Some(func) = self.ctx.arena.get_function(parent_node)

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -143,8 +143,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+        init_node.is_function_expression_or_arrow()
             || init_node.kind == syntax_kind_ext::CLASS_EXPRESSION
             || init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
     }
@@ -628,10 +627,9 @@ impl<'a> CheckerState<'a> {
                             {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::BINARY_EXPRESSION => {
                             let Some(binary_node) = arena.get(decl_idx) else {
@@ -643,10 +641,9 @@ impl<'a> CheckerState<'a> {
                             if !self.is_assignment_operator(binary.operator_token) {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::VARIABLE_DECLARATION => {
                             let Some(var_decl) = arena.get_variable_declaration(node) else {
@@ -655,8 +652,7 @@ impl<'a> CheckerState<'a> {
                             let Some(init_node) = arena.get(var_decl.initializer) else {
                                 return false;
                             };
-                            init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                            init_node.is_function_expression_or_arrow()
                         }
                         _ => false,
                     }
@@ -739,10 +735,7 @@ impl<'a> CheckerState<'a> {
                         .get(decl_idx)
                         .and_then(|decl_node| self.ctx.arena.get_variable_declaration(decl_node))
                         .and_then(|decl| self.ctx.arena.get(decl.initializer))
-                        .is_some_and(|init_node| {
-                            init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
-                        })
+                        .is_some_and(|init_node| init_node.is_function_expression_or_arrow())
                 };
             if !is_declared_function_or_class && !is_callable_variable {
                 return false;
@@ -964,10 +957,7 @@ impl<'a> CheckerState<'a> {
                         .get(decl_idx)
                         .and_then(|decl_node| self.ctx.arena.get_variable_declaration(decl_node))
                         .and_then(|decl| self.ctx.arena.get(decl.initializer))
-                        .is_some_and(|init_node| {
-                            init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
-                        })
+                        .is_some_and(|init_node| init_node.is_function_expression_or_arrow())
                 };
             let is_declared_function_or_class =
                 (symbol.flags & (symbol_flags::FUNCTION | symbol_flags::CLASS)) != 0;
@@ -1001,10 +991,9 @@ impl<'a> CheckerState<'a> {
                             {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::BINARY_EXPRESSION => {
                             let Some(binary_node) = arena.get(decl_idx) else {
@@ -1016,10 +1005,9 @@ impl<'a> CheckerState<'a> {
                             if !self.is_assignment_operator(binary.operator_token) {
                                 return false;
                             }
-                            arena.get(binary.right).is_some_and(|rhs| {
-                                rhs.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                    || rhs.kind == syntax_kind_ext::ARROW_FUNCTION
-                            })
+                            arena
+                                .get(binary.right)
+                                .is_some_and(|rhs| rhs.is_function_expression_or_arrow())
                         }
                         syntax_kind_ext::VARIABLE_DECLARATION => {
                             let Some(var_decl) = arena.get_variable_declaration(node) else {
@@ -1028,8 +1016,7 @@ impl<'a> CheckerState<'a> {
                             let Some(init_node) = arena.get(var_decl.initializer) else {
                                 return false;
                             };
-                            init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                                || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                            init_node.is_function_expression_or_arrow()
                         }
                         _ => false,
                     }

--- a/crates/tsz-checker/src/types/queries/callable_truthiness.rs
+++ b/crates/tsz-checker/src/types/queries/callable_truthiness.rs
@@ -849,8 +849,7 @@ impl<'a> CheckerState<'a> {
         let children = self.ctx.arena.get_children(subtree);
         for child in children {
             if let Some(child_node) = self.ctx.arena.get(child)
-                && (child_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || child_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                && (child_node.is_function_expression_or_arrow()
                     || child_node.kind == syntax_kind_ext::CLASS_EXPRESSION)
                 && self.func_shadows_symbol(child, sym_id)
             {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo.rs
@@ -840,8 +840,7 @@ impl Server {
                     let mut fn_cursor = arena.get_extended(current)?.parent;
                     while fn_cursor.is_some() {
                         let fn_node = arena.get(fn_cursor)?;
-                        if fn_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                            || fn_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                        if fn_node.is_function_expression_or_arrow()
                             || fn_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
                         {
                             let function = arena.get_function(fn_node)?;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -84,9 +84,7 @@ impl<'a> DeclarationEmitter<'a> {
                     return None;
                 }
                 let init_node = self.arena.get(decl.initializer)?;
-                if init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || init_node.kind == syntax_kind_ext::ARROW_FUNCTION
-                {
+                if init_node.is_function_expression_or_arrow() {
                     Some(decl.initializer)
                 } else {
                     None

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -183,8 +183,7 @@ impl<'a> AsyncES5Transformer<'a> {
             recover_await_default,
             type_annotation,
         ) = if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
         {
             if let Some(func) = self.arena.get_function(node) {
                 let name = if func.name.is_none() {
@@ -804,8 +803,7 @@ impl<'a> AsyncES5Transformer<'a> {
             return Some(idx);
         }
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
         {
             return None;
         }
@@ -1327,8 +1325,7 @@ impl<'a> AsyncES5Transformer<'a> {
         // Don't recurse into nested functions
         // This check must happen before recursing into any children
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
         {
             return false;
         }

--- a/crates/tsz-emitter/src/transforms/es5.rs
+++ b/crates/tsz-emitter/src/transforms/es5.rs
@@ -1310,8 +1310,7 @@ impl<'a> ES5AsyncTransformer<'a> {
 
         // Don't recurse into nested functions
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
         {
             return false;
         }

--- a/crates/tsz-lsp/src/code_actions/code_action_destructure_params.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_destructure_params.rs
@@ -92,8 +92,7 @@ impl<'a> CodeActionProvider<'a> {
         while current.is_some() {
             let node = self.arena.get(current)?;
             if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.is_function_expression_or_arrow()
                 || node.kind == syntax_kind_ext::METHOD_DECLARATION
             {
                 return Some(current);

--- a/crates/tsz-lsp/src/code_actions/code_action_extract_function.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_extract_function.rs
@@ -418,8 +418,7 @@ impl<'a> CodeActionProvider<'a> {
         // Skip into function/class bodies -- identifiers there are in a
         // separate scope and do not need to become parameters.
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
             || node.kind == syntax_kind_ext::CLASS_EXPRESSION
             || node.kind == syntax_kind_ext::CLASS_DECLARATION
         {
@@ -617,8 +616,7 @@ impl<'a> CodeActionProvider<'a> {
             };
 
             if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.is_function_expression_or_arrow()
             {
                 // Insert after this function's end
                 return node.end;

--- a/crates/tsz-lsp/src/code_actions/code_action_return_type.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_return_type.rs
@@ -159,8 +159,7 @@ impl<'a> CodeActionProvider<'a> {
 
         // Don't descend into nested functions
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.is_function_expression_or_arrow()
         {
             return;
         }

--- a/crates/tsz-lsp/src/completions/core.rs
+++ b/crates/tsz-lsp/src/completions/core.rs
@@ -704,8 +704,7 @@ impl<'a> Completions<'a> {
                 break;
             };
             if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.is_function_expression_or_arrow()
             {
                 if let Some(function) = self.arena.get_function(node)
                     && function.body.is_some()

--- a/crates/tsz-lsp/src/completions/filters.rs
+++ b/crates/tsz-lsp/src/completions/filters.rs
@@ -689,8 +689,7 @@ impl<'a> Completions<'a> {
                 }
                 // Stop at function boundary
                 if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                    || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.is_function_expression_or_arrow()
                     || node.kind == syntax_kind_ext::METHOD_DECLARATION
                     || node.kind == syntax_kind_ext::CONSTRUCTOR
                 {

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -1852,6 +1852,14 @@ impl Node {
         )
     }
 
+    /// Check if this is an anonymous function-valued expression
+    /// (`function () {}`, `function name() {}`, or `(a) => {}`).
+    #[inline]
+    #[must_use]
+    pub const fn is_function_expression_or_arrow(&self) -> bool {
+        matches!(self.kind, FUNCTION_EXPRESSION | ARROW_FUNCTION)
+    }
+
     /// Check if this is a binding pattern (array or object destructuring)
     #[inline]
     #[must_use]


### PR DESCRIPTION
## Summary
- Adds `Node::is_function_expression_or_arrow()` in `crates/tsz-parser/src/parser/node_access.rs` (sits next to `is_function_like` / `is_class_like`).
- Replaces 19 occurrences of the `kind == FUNCTION_EXPRESSION || kind == ARROW_FUNCTION` two-line OR across checker, emitter, binder, lsp, and cli.
- Skips 2 files currently touched by PR #933 to avoid rebase conflicts (`emitter/types/printer/symbol_resolution.rs`, `types/computation/helpers.rs`).
- Skips 1 file using a different pair (`code_actions/code_action_convert.rs` uses FUNCTION_EXPRESSION || FUNCTION_DECLARATION) — not the same helper.

Net: 21 files changed, 59 insertions, 97 deletions.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] wasm32 rustc check
- [x] arch-guard
- [x] `cargo nextest run` — 19318 tests passing