### PR TITLE
chore(parser): add Node::is_accessor helper and migrate callers

### DIFF
--- a/crates/tsz-checker/src/classes/super_checker.rs
+++ b/crates/tsz-checker/src/classes/super_checker.rs
@@ -242,8 +242,7 @@ impl<'a> CheckerState<'a> {
     fn is_in_object_literal_member(&self, idx: NodeIndex) -> bool {
         use tsz_parser::parser::syntax_kind_ext::{
             ARROW_FUNCTION, CLASS_DECLARATION, CLASS_EXPRESSION, FUNCTION_DECLARATION,
-            FUNCTION_EXPRESSION, GET_ACCESSOR, METHOD_DECLARATION, OBJECT_LITERAL_EXPRESSION,
-            SET_ACCESSOR,
+            FUNCTION_EXPRESSION, METHOD_DECLARATION, OBJECT_LITERAL_EXPRESSION,
         };
         let mut current = idx;
         let mut saw_object_member = false;
@@ -257,10 +256,7 @@ impl<'a> CheckerState<'a> {
                 break;
             };
 
-            if parent_node.kind == METHOD_DECLARATION
-                || parent_node.kind == GET_ACCESSOR
-                || parent_node.kind == SET_ACCESSOR
-            {
+            if parent_node.kind == METHOD_DECLARATION || parent_node.is_accessor() {
                 saw_object_member = true;
             }
 

--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -174,8 +174,7 @@ impl<'a> CheckerState<'a> {
     /// defines the `this` context.
     pub(crate) fn find_enclosing_non_arrow_function(&self, idx: NodeIndex) -> Option<NodeIndex> {
         use tsz_parser::parser::syntax_kind_ext::{
-            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, GET_ACCESSOR,
-            METHOD_DECLARATION, SET_ACCESSOR,
+            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, METHOD_DECLARATION,
         };
         let mut current = idx;
         let mut iterations = 0;
@@ -189,8 +188,7 @@ impl<'a> CheckerState<'a> {
                     || node.kind == FUNCTION_EXPRESSION
                     || node.kind == METHOD_DECLARATION
                     || node.kind == CONSTRUCTOR
-                    || node.kind == GET_ACCESSOR
-                    || node.kind == SET_ACCESSOR)
+                    || node.is_accessor())
             {
                 return Some(current);
             }
@@ -420,9 +418,7 @@ impl<'a> CheckerState<'a> {
                         .get_extended(current)
                         .and_then(|ext| self.ctx.arena.get(ext.parent))
                         .is_some_and(|parent| {
-                            parent.kind == METHOD_DECLARATION
-                                || parent.kind == GET_ACCESSOR
-                                || parent.kind == SET_ACCESSOR
+                            parent.kind == METHOD_DECLARATION || parent.is_accessor()
                         });
                     if !parent_is_class_member {
                         return false;
@@ -512,8 +508,7 @@ impl<'a> CheckerState<'a> {
     /// typed and TS2683 ("'this' implicitly has type 'any'") must be suppressed.
     pub(crate) fn enclosing_function_has_explicit_this_parameter(&self, idx: NodeIndex) -> bool {
         use tsz_parser::parser::syntax_kind_ext::{
-            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, GET_ACCESSOR,
-            METHOD_DECLARATION, SET_ACCESSOR,
+            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, METHOD_DECLARATION,
         };
 
         let enclosing_fn = match self.find_enclosing_non_arrow_function(idx) {
@@ -542,7 +537,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_constructor(fn_node)
                     .and_then(|c| c.parameters.nodes.first().copied())
-            } else if fn_node.kind == GET_ACCESSOR || fn_node.kind == SET_ACCESSOR {
+            } else if fn_node.is_accessor() {
                 self.ctx
                     .arena
                     .get_accessor(fn_node)

--- a/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
@@ -1143,8 +1143,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn is_this_in_class_member_computed_property_name(&self, idx: NodeIndex) -> bool {
         use tsz_parser::parser::syntax_kind_ext::{
             ARROW_FUNCTION, CLASS_DECLARATION, CLASS_EXPRESSION, COMPUTED_PROPERTY_NAME,
-            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, GET_ACCESSOR,
-            METHOD_DECLARATION, SET_ACCESSOR,
+            CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION, METHOD_DECLARATION,
         };
         let mut current = idx;
         loop {
@@ -1164,8 +1163,7 @@ impl<'a> CheckerState<'a> {
                 || parent_node.kind == ARROW_FUNCTION
                 || parent_node.kind == METHOD_DECLARATION
                 || parent_node.kind == CONSTRUCTOR
-                || parent_node.kind == GET_ACCESSOR
-                || parent_node.kind == SET_ACCESSOR
+                || parent_node.is_accessor()
             {
                 return false;
             }
@@ -1220,7 +1218,7 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext::{
             ARROW_FUNCTION, CALL_EXPRESSION, CLASS_STATIC_BLOCK_DECLARATION,
             COMPUTED_PROPERTY_NAME, CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION,
-            GET_ACCESSOR, METHOD_DECLARATION, PROPERTY_DECLARATION, SET_ACCESSOR,
+            METHOD_DECLARATION, PROPERTY_DECLARATION,
         };
 
         // Determine whether this `super` is used as a call (`super()`).
@@ -1312,8 +1310,7 @@ impl<'a> CheckerState<'a> {
             // super is inside a valid class member body and TS2466 does not apply.
             if parent_node.kind == METHOD_DECLARATION
                 || parent_node.kind == CONSTRUCTOR
-                || parent_node.kind == GET_ACCESSOR
-                || parent_node.kind == SET_ACCESSOR
+                || parent_node.is_accessor()
                 || parent_node.kind == CLASS_STATIC_BLOCK_DECLARATION
                 || parent_node.kind == PROPERTY_DECLARATION
             {

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -238,9 +238,7 @@ pub fn collect_private_accessors(
         };
 
         // Check for both GET_ACCESSOR and SET_ACCESSOR
-        if member_node.kind == syntax_kind_ext::GET_ACCESSOR
-            || member_node.kind == syntax_kind_ext::SET_ACCESSOR
-        {
+        if member_node.is_accessor() {
             let Some(accessor_data) = arena.get_accessor(member_node) else {
                 continue;
             };

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -1097,8 +1097,7 @@ impl NodeArena {
     #[inline]
     #[must_use]
     pub fn get_accessor(&self, node: &Node) -> Option<&AccessorData> {
-        use super::syntax_kind_ext::{GET_ACCESSOR, SET_ACCESSOR};
-        if node.has_data() && (node.kind == GET_ACCESSOR || node.kind == SET_ACCESSOR) {
+        if node.has_data() && node.is_accessor() {
             self.accessors.get(node.data_index as usize)
         } else {
             None
@@ -1850,6 +1849,13 @@ impl Node {
                 | GET_ACCESSOR
                 | SET_ACCESSOR
         )
+    }
+
+    /// Check if this is a get or set accessor declaration.
+    #[inline]
+    #[must_use]
+    pub const fn is_accessor(&self) -> bool {
+        matches!(self.kind, GET_ACCESSOR | SET_ACCESSOR)
     }
 
     /// Check if this is a binding pattern (array or object destructuring)


### PR DESCRIPTION
## Summary
- Adds `Node::is_accessor()` in `crates/tsz-parser/src/parser/node_access.rs`, right next to `is_function_like` and `is_class_like`.
- Migrates 7 two-line `kind == GET_ACCESSOR || kind == SET_ACCESSOR` chains to a single method call across parser, checker, and emitter.
- Removes 4 unused `GET_ACCESSOR`/`SET_ACCESSOR` imports that are no longer needed after migration.

Net: 5 files changed, +20/-28.

### Migrated call sites
- `tsz-parser/src/parser/node_access.rs` — `NodeArena::get_accessor` type guard
- `tsz-checker/src/symbols/scope_finder.rs` — 3 sites
- `tsz-checker/src/symbols/scope_finder_contexts.rs` — 2 sites
- `tsz-checker/src/classes/super_checker.rs` — 1 site
- `tsz-emitter/src/transforms/private_fields_es5.rs` — 1 site

### Intentionally skipped
Patterns where the left-hand side is a bare `u16` kind rather than a `Node` (e.g. `k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR`) — the new helper is defined on `Node`, so those are left as-is.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] wasm32 rustc warnings gate
- [x] arch-guard
- [x] `cargo nextest run` — 19318 tests passing