### PR TITLE
perf(binder): Arc-wrap lib_binders to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -1344,7 +1344,7 @@ impl BinderState {
         // If this is a lib symbol ID, check lib binders first to avoid
         // collision with local symbols at the same index
         if self.lib_symbol_ids.contains(&id) {
-            for lib_binder in &self.lib_binders {
+            for lib_binder in self.lib_binders.iter() {
                 if let Some(sym) = lib_binder.symbols.get(id) {
                     return Some(sym);
                 }
@@ -1352,7 +1352,7 @@ impl BinderState {
         }
 
         // Finally try lib binders for any remaining cases
-        for lib_binder in &self.lib_binders {
+        for lib_binder in self.lib_binders.iter() {
             if let Some(sym) = lib_binder.symbols.get(id) {
                 return Some(sym);
             }
@@ -1419,7 +1419,7 @@ impl BinderState {
         }
 
         // Legacy path: check lib binders directly (for backward compatibility)
-        for lib_binder in &self.lib_binders {
+        for lib_binder in self.lib_binders.iter() {
             if let Some(sym_id) = lib_binder.file_locals.get(name) {
                 return Some(sym_id);
             }
@@ -1455,7 +1455,7 @@ impl BinderState {
         }
 
         // Finally check our own lib binders
-        for lib_binder in &self.lib_binders {
+        for lib_binder in self.lib_binders.iter() {
             if let Some(sym_id) = lib_binder.file_locals.get(name) {
                 return Some(sym_id);
             }

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -202,7 +202,7 @@ impl BinderState {
             in_module_augmentation: false,
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),
-            lib_binders: Vec::new(),
+            lib_binders: Arc::new(Vec::new()),
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
@@ -267,7 +267,7 @@ impl BinderState {
         self.module_augmentations.clear();
         self.in_module_augmentation = false;
         self.current_augmented_module = None;
-        self.lib_binders.clear();
+        Arc::make_mut(&mut self.lib_binders).clear();
         Arc::make_mut(&mut self.lib_symbol_ids).clear();
         self.module_exports.clear();
         self.reexports.clear();
@@ -419,7 +419,7 @@ impl BinderState {
             in_module_augmentation: false,
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),
-            lib_binders: Vec::new(),
+            lib_binders: Arc::new(Vec::new()),
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports: FxHashMap::default(),
@@ -542,7 +542,7 @@ impl BinderState {
             in_module_augmentation: false,
             current_augmented_module: None,
             augmentation_target_modules,
-            lib_binders: Vec::new(),
+            lib_binders: Arc::new(Vec::new()),
             lib_symbol_ids: Arc::new(FxHashSet::default()),
             lib_symbol_reverse_remap: FxHashMap::default(),
             module_exports,
@@ -1563,7 +1563,7 @@ impl BinderState {
         // However, we keep lib_binders populated for backward compatibility
         // with any code that still iterates through them.
         for lib in lib_files {
-            self.lib_binders.push(Arc::clone(&lib.binder));
+            Arc::make_mut(&mut self.lib_binders).push(Arc::clone(&lib.binder));
         }
     }
 

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -305,7 +305,7 @@ pub struct BinderState {
 
     /// Lib binders for automatic lib symbol resolution.
     /// When `get_symbol()` doesn't find a symbol locally, it checks these lib binders.
-    pub lib_binders: Vec<Arc<Self>>,
+    pub lib_binders: Arc<Vec<Arc<Self>>>,
 
     /// Symbol IDs that originated from lib files.
     /// Used by `get_symbol()` to check `lib_binders` first for these IDs,

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -2139,7 +2139,7 @@ fn build_program_with_cache(
                     reexports: Default::default(),
                     wildcard_reexports: Default::default(),
                     wildcard_reexports_type_only: Default::default(),
-                    lib_binders: Vec::new(),
+                    lib_binders: std::sync::Arc::new(Vec::new()),
                     lib_arenas: Vec::new(),
                     lib_symbol_ids: Default::default(),
                     lib_symbol_reverse_remap: Default::default(),

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -303,7 +303,7 @@ fn synthesize_json_bind_result(file_name: String, source_text: String) -> BindRe
         reexports: binder.reexports,
         wildcard_reexports: binder.wildcard_reexports,
         wildcard_reexports_type_only: binder.wildcard_reexports_type_only,
-        lib_binders: Vec::new(),
+        lib_binders: Arc::new(Vec::new()),
         lib_arenas: Vec::new(),
         lib_symbol_ids: binder.lib_symbol_ids,
         lib_symbol_reverse_remap: binder.lib_symbol_reverse_remap,
@@ -509,7 +509,7 @@ pub struct BindResult {
     pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
     /// Lib binders for global type resolution (Array, String, etc.)
     /// These are merged from lib.d.ts files and enable cross-file symbol lookup
-    pub lib_binders: Vec<Arc<BinderState>>,
+    pub lib_binders: Arc<Vec<Arc<BinderState>>>,
     /// Arenas corresponding to each `lib_binder` (same order/length as `lib_binders`).
     /// Used by `merge_bind_results_ref` to populate `declaration_arenas` for lib symbols.
     pub lib_arenas: Vec<Arc<NodeArena>>,
@@ -794,7 +794,7 @@ pub fn parse_and_bind_parallel(files: Vec<(String, String)>) -> Vec<BindResult> 
                 reexports: binder.reexports,
                 wildcard_reexports: binder.wildcard_reexports,
                 wildcard_reexports_type_only: binder.wildcard_reexports_type_only,
-                lib_binders: Vec::new(), // No libs in this path
+                lib_binders: Arc::new(Vec::new()), // No libs in this path
                 lib_arenas: Vec::new(),
                 lib_symbol_ids: binder.lib_symbol_ids,
                 lib_symbol_reverse_remap: binder.lib_symbol_reverse_remap,
@@ -849,7 +849,7 @@ pub fn parse_and_bind_single(file_name: String, source_text: String) -> BindResu
         reexports: binder.reexports,
         wildcard_reexports: binder.wildcard_reexports,
         wildcard_reexports_type_only: binder.wildcard_reexports_type_only,
-        lib_binders: Vec::new(), // No libs in this path
+        lib_binders: Arc::new(Vec::new()), // No libs in this path
         lib_arenas: Vec::new(),
         lib_symbol_ids: binder.lib_symbol_ids,
         lib_symbol_reverse_remap: binder.lib_symbol_reverse_remap,
@@ -1582,7 +1582,7 @@ pub struct MergedProgram {
     pub wildcard_reexports_type_only: FxHashMap<String, Vec<(String, bool)>>,
     /// Lib binders for global type resolution (Array, String, Promise, etc.)
     /// These contain symbols from lib.d.ts files and enable resolution of built-in types
-    pub lib_binders: Vec<Arc<BinderState>>,
+    pub lib_binders: Arc<Vec<Arc<BinderState>>>,
     /// Global symbol IDs that originated from lib files (remapped to global arena IDs).
     /// `Arc`-wrapped so the CLI driver can install the same set into
     /// every per-file `BinderState.lib_symbol_ids` via `Arc::clone`
@@ -3273,7 +3273,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         reexports,
         wildcard_reexports,
         wildcard_reexports_type_only,
-        lib_binders,
+        lib_binders: Arc::new(lib_binders),
         lib_symbol_ids: Arc::new(global_lib_symbol_ids),
         type_interner,
         alias_partners,


### PR DESCRIPTION
## Summary
Sixth PR in the same proven Arc-wrap pattern after #932 (lib_symbol_ids), #935 (shorthand_ambient_modules), #944 (wildcard_reexports), #948 (reexports), and #954 (module_exports). The lib_binders vector (`Vec<Arc<BinderState>>`) is identical for every file in a project build; per-file `BinderState` reconstruction was cloning the outer `Vec` (which allocates) plus N atomic Arc increments.

## Changes
- Field is now `Arc<Vec<Arc<BinderState>>>` on `BinderState`, `BindResult`, and `MergedProgram`.
- Routes the binder mutation sites (clear, push) through `Arc::make_mut` (zero-cost when refcount is 1, which is always during binding).
- Wraps the merge accumulator in `Arc::new` once at `MergedProgram` construction.
- Adapts `for lib_binder in &self.lib_binders` iter sites to `self.lib_binders.iter()` (`Arc` doesn't auto-implement `IntoIterator` for `&Self`).

Pure plumbing. Consumer surface for `binder.lib_binders.iter()`, `.len()`, `.is_empty()` is unchanged thanks to `Deref`. No behavior change.

## Test plan
- [x] `cargo nextest run` (full pre-commit suite, 18777 tests passed)
- [x] Workspace clippy clean
- [ ] Conformance suite no-regression check post-merge