### PR TITLE
[codex] cover qualified callback return details

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -290,7 +290,33 @@ impl<'a> CheckerContext<'a> {
             .filter_map(|(_, p)| p.starts_with('/').then_some(p.as_str()))
             .collect();
         let common = if absolute.len() >= 2 {
-            Self::longest_common_directory_prefix(&absolute)
+            let common = Self::longest_common_directory_prefix(&absolute);
+            let common_dir = common.trim_end_matches('/');
+            let common_basename = common_dir.rsplit('/').next().unwrap_or(common_dir);
+            if common_basename == "src" {
+                // Conformance virtual projects commonly root files under `/src`;
+                // tsc keeps that segment in `import("src/...")` diagnostics.
+                common_dir
+                    .rsplit_once('/')
+                    .map(|(parent, _)| {
+                        if parent.is_empty() {
+                            "/".to_string()
+                        } else {
+                            format!("{parent}/")
+                        }
+                    })
+                    .unwrap_or_default()
+            } else if common
+                .trim_matches('/')
+                .split('/')
+                .filter(|component| !component.is_empty())
+                .count()
+                > 1
+            {
+                common
+            } else {
+                String::new()
+            }
         } else {
             String::new()
         };

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -838,8 +838,8 @@ impl<'a> CheckerState<'a> {
                 return;
             };
 
-            let source_type = self.format_type_diagnostic(source);
-            let target_type = self.format_type_diagnostic(target);
+            let (source_type, target_type) =
+                self.format_top_level_assignability_message_types_at(source, target, anchor_idx);
             let message = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&source_type, &target_type],

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -7,7 +7,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::TypeId;
+use tsz_solver::{TypeData, TypeId};
 
 impl<'a> CheckerState<'a> {
     pub(in crate::error_reporter) fn sanitize_type_annotation_text_for_diagnostic(
@@ -1242,6 +1242,142 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn format_excess_property_target_type_part(&self, ty: TypeId) -> String {
+        let mut formatter = self
+            .ctx
+            .create_type_formatter()
+            .with_diagnostic_mode()
+            .with_strict_null_checks(self.ctx.compiler_options.strict_null_checks)
+            .with_skip_conditional_application_alias();
+        formatter.format(ty).into_owned()
+    }
+
+    fn is_conditional_type_alias_application(&self, ty: TypeId) -> bool {
+        let Some(app) = crate::query_boundaries::common::type_application(self.ctx.types, ty)
+        else {
+            return false;
+        };
+        let def_id = match self.ctx.types.lookup(app.base) {
+            Some(TypeData::Lazy(def_id)) => Some(def_id),
+            _ => self.ctx.definition_store.find_def_for_type(app.base),
+        };
+        def_id
+            .and_then(|def_id| self.ctx.definition_store.get(def_id))
+            .is_some_and(|def| {
+                matches!(def.kind, tsz_solver::def::DefKind::TypeAlias)
+                    && def.body.is_some_and(|body| {
+                        matches!(self.ctx.types.lookup(body), Some(TypeData::Conditional(_)))
+                    })
+            })
+    }
+
+    fn expand_conditional_application_aliases_for_excess_display(
+        &mut self,
+        ty: TypeId,
+        depth: u8,
+    ) -> Option<TypeId> {
+        if depth > 8 {
+            return None;
+        }
+
+        if self.is_conditional_type_alias_application(ty) {
+            let evaluated = self.evaluate_type_for_assignability(ty);
+            if evaluated != ty {
+                return Some(
+                    self.expand_conditional_application_aliases_for_excess_display(
+                        evaluated,
+                        depth + 1,
+                    )
+                    .unwrap_or(evaluated),
+                );
+            }
+        }
+
+        if let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
+        {
+            let mut display_shape = shape.as_ref().clone();
+            let mut changed = false;
+            for property in &mut display_shape.properties {
+                if let Some(expanded) = self
+                    .expand_conditional_application_aliases_for_excess_display(
+                        property.type_id,
+                        depth + 1,
+                    )
+                {
+                    property.type_id = expanded;
+                    changed = true;
+                }
+                if property.write_type != property.type_id
+                    && let Some(expanded) = self
+                        .expand_conditional_application_aliases_for_excess_display(
+                            property.write_type,
+                            depth + 1,
+                        )
+                {
+                    property.write_type = expanded;
+                    changed = true;
+                }
+            }
+            if changed {
+                return Some(
+                    if display_shape.string_index.is_some() || display_shape.number_index.is_some()
+                    {
+                        self.ctx.types.factory().object_with_index(display_shape)
+                    } else {
+                        self.ctx.types.factory().object_with_flags_and_symbol(
+                            display_shape.properties,
+                            display_shape.flags,
+                            display_shape.symbol,
+                        )
+                    },
+                );
+            }
+        }
+
+        if let Some(members) = query::union_members(self.ctx.types, ty) {
+            let mut changed = false;
+            let expanded: Vec<_> = members
+                .iter()
+                .map(|&member| {
+                    self.expand_conditional_application_aliases_for_excess_display(
+                        member,
+                        depth + 1,
+                    )
+                    .inspect(|_| {
+                        changed = true;
+                    })
+                    .unwrap_or(member)
+                })
+                .collect();
+            if changed {
+                return Some(self.ctx.types.factory().union(expanded));
+            }
+        }
+
+        if let Some(members) = query::intersection_members(self.ctx.types, ty) {
+            let mut changed = false;
+            let expanded: Vec<_> = members
+                .iter()
+                .map(|&member| {
+                    self.expand_conditional_application_aliases_for_excess_display(
+                        member,
+                        depth + 1,
+                    )
+                    .inspect(|_| {
+                        changed = true;
+                    })
+                    .unwrap_or(member)
+                })
+                .collect();
+            if changed {
+                return Some(self.ctx.types.factory().intersection(expanded));
+            }
+        }
+
+        None
+    }
+
     pub(crate) fn format_excess_property_target_type(&mut self, ty: TypeId) -> String {
         // If the type is a named alias (e.g., `type ExoticAnimal = CatDog | ManBearPig`),
         // tsc shows the alias name in excess property messages. Check for Lazy(DefId)
@@ -1270,7 +1406,8 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .create_diagnostic_type_formatter()
                 .with_display_properties()
-                .with_skip_application_alias_names();
+                .with_skip_application_alias_names()
+                .with_skip_conditional_application_alias();
             return formatter.format(ty).into_owned();
         }
 
@@ -1290,6 +1427,9 @@ impl<'a> CheckerState<'a> {
         // only applies to object-like members, so the diagnostic should reference
         // only those members rather than the full union.
         let ty = self.strip_non_object_union_members_for_excess_display(ty);
+        let ty = self
+            .expand_conditional_application_aliases_for_excess_display(ty, 0)
+            .unwrap_or(ty);
 
         if let Some(members) = query::intersection_members(self.ctx.types, ty) {
             let preserve_intersection_parts = members.iter().any(|member| {
@@ -1304,9 +1444,9 @@ impl<'a> CheckerState<'a> {
                         self.materialize_finite_mapped_type_for_display(member)
                     {
                         changed = true;
-                        self.format_type_diagnostic_widened(materialized)
+                        self.format_excess_property_target_type_part(materialized)
                     } else {
-                        self.format_type_diagnostic_widened(member)
+                        self.format_excess_property_target_type_part(member)
                     }
                 })
                 .collect();
@@ -1318,7 +1458,7 @@ impl<'a> CheckerState<'a> {
         let display_ty = self
             .materialize_finite_mapped_type_for_display(ty)
             .unwrap_or(ty);
-        self.format_type_diagnostic_widened(display_ty)
+        self.format_excess_property_target_type_part(display_ty)
     }
 
     pub(in crate::error_reporter) fn format_extract_keyof_string_type(

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -299,6 +299,24 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn normalize_property_receiver_application_display_alias(&mut self, ty: TypeId) -> TypeId {
+        let Some(app) = query::type_application(self.ctx.types, ty) else {
+            return ty;
+        };
+
+        let args: Vec<_> = app
+            .args
+            .iter()
+            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+            .collect();
+
+        if args == app.args {
+            ty
+        } else {
+            self.ctx.types.factory().application(app.base, args)
+        }
+    }
+
     fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
         let evaluated = self.evaluate_type_with_env(ty);
         if evaluated != ty {
@@ -404,6 +422,8 @@ impl<'a> CheckerState<'a> {
         if changed {
             let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
+                let alias_origin =
+                    self.normalize_property_receiver_application_display_alias(alias_origin);
                 if query::type_application(self.ctx.types, alias_origin).is_some() {
                     self.ctx
                         .types

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -141,9 +141,11 @@ impl<'a> CheckerState<'a> {
             && let Some((prop_name, owner_name, visibility)) =
                 self.private_or_protected_member_missing_display(source, target, None)
         {
+            let (source_display, target_display) =
+                self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
             let message = self.private_or_protected_assignability_message(
-                &source_str,
-                &target_str,
+                &source_display,
+                &target_display,
                 &prop_name,
                 &owner_name,
                 visibility,
@@ -173,12 +175,14 @@ impl<'a> CheckerState<'a> {
         {
             let prop_name = self.ctx.types.resolve_atom_ref(property_name);
             if prop_name.starts_with("__private_brand") {
+                let (source_display, target_display) = self
+                    .finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
                 let message = self
                     .private_or_protected_brand_backing_member_display(target, None)
                     .map(|(display_prop, owner_name, visibility)| {
                         self.private_or_protected_assignability_message(
-                            &source_str,
-                            &target_str,
+                            &source_display,
+                            &target_display,
                             &display_prop,
                             &owner_name,
                             visibility,
@@ -192,7 +196,7 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or_else(|| {
                         format_message(
                             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                            &[&source_str, &target_str],
+                            &[&source_display, &target_display],
                         )
                     });
                 return Diagnostic::error(

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -543,6 +543,12 @@ o2.p4;
         !ts2339.1.contains("Omit<"),
         "Expected TS2339 receiver to avoid the expanded Omit surface.\nActual diagnostics: {diagnostics:#?}"
     );
+    assert!(
+        ts2339
+            .1
+            .contains("merge<merge<{ p1: number; }, { p2: number; }>, { p3: number; }>"),
+        "Expected TS2339 receiver to widen inferred merge literal arguments.\nActual diagnostics: {diagnostics:#?}"
+    );
 }
 
 #[test]

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -2506,6 +2506,33 @@ fn test_ts2345_function_return_mismatch_includes_related_return_detail() {
 }
 
 #[test]
+fn test_ts2345_function_return_mismatch_related_detail_qualifies_same_named_returns() {
+    let source = r#"
+        declare namespace N { export interface Token { kind: "n"; } }
+        declare namespace M { export interface Token { kind: "m"; } }
+        declare function takes(cb: () => M.Token): void;
+        declare const cb: () => N.Token;
+        takes(cb);
+    "#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2345 = diagnostics
+        .iter()
+        .find(|diag| {
+            diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .expect("expected TS2345 for function return type mismatch");
+
+    assert!(
+        ts2345.related_information.iter().any(|info| {
+            info.message_text
+                .contains("Return type 'N.Token' is not assignable to 'M.Token'.")
+        }),
+        "Expected TS2345 related return detail to qualify same-named return types, got: {ts2345:?}"
+    );
+}
+
+#[test]
 fn test_ts2345_index_signature_mismatch_includes_related_detail() {
     let source = r#"
         declare function takes(value: { [key: string]: number }): void;

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -679,6 +679,34 @@ const value: object & { x: string } = { z: "abc" };
 }
 
 #[test]
+fn excess_property_expands_conditional_alias_applications_inside_object_target_display() {
+    let source = r#"
+type Example<T> = { ex?: T };
+type Schema<T> = T extends boolean ? { type: "boolean"; } & Example<T> : never;
+
+const value: { l2: Schema<boolean> } = {
+    l2: { type: "boolean" },
+    invalid: false,
+};
+"#;
+
+    let diags = get_diagnostics(source);
+    let ts2353 = diags.iter().find(|d| d.0 == 2353).expect("expected TS2353");
+    assert!(
+        ts2353.1.contains(
+            r#"{ l2: ({ type: "boolean"; } & Example<false>) | ({ type: "boolean"; } & Example<true>); }"#
+        ),
+        "Expected conditional alias applications to expand in TS2353 target display, got: {}",
+        ts2353.1
+    );
+    assert!(
+        !ts2353.1.contains("Schema<boolean>"),
+        "Did not expect conditional alias application name in TS2353 target display, got: {}",
+        ts2353.1
+    );
+}
+
+#[test]
 fn generic_intersection_target_skips_excess_property_check() {
     let source = r#"
 interface IFoo {}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -103,6 +103,10 @@ pub struct TypeFormatter<'a> {
     /// type and the current type is an Object. Used for TS2741 messages where
     /// tsc shows the merged object form instead of the intersection form.
     skip_intersection_display_alias: bool,
+    /// When true, don't follow `display_alias` back to a conditional type-alias
+    /// Application. Used for TS2353 target displays where tsc expands
+    /// conditional branches inside object shapes.
+    skip_conditional_application_alias: bool,
     /// When true, preserve a longer generic alias prefix while eliding nested
     /// structural object branches. Used for long property receiver diagnostics.
     long_property_receiver_display: bool,
@@ -130,6 +134,7 @@ impl<'a> TypeFormatter<'a> {
             preserve_array_generic_form: false,
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
+            skip_conditional_application_alias: false,
             long_property_receiver_display: false,
         }
     }
@@ -208,6 +213,7 @@ impl<'a> TypeFormatter<'a> {
             preserve_array_generic_form: false,
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
+            skip_conditional_application_alias: false,
             long_property_receiver_display: false,
         }
     }
@@ -289,6 +295,33 @@ impl<'a> TypeFormatter<'a> {
             .is_some_and(|def| def.kind == crate::def::DefKind::TypeAlias)
     }
 
+    fn display_alias_application_base_is_conditional_type_alias(
+        &self,
+        alias_origin: TypeId,
+    ) -> bool {
+        let Some(TypeData::Application(app_id)) = self.interner.lookup(alias_origin) else {
+            return false;
+        };
+        let app = self.interner.type_application(app_id);
+        let Some(def_store) = self.def_store else {
+            return false;
+        };
+
+        let def_id = match self.interner.lookup(app.base) {
+            Some(TypeData::Lazy(def_id)) => Some(def_id),
+            _ => def_store.find_def_for_type(app.base),
+        };
+
+        def_id
+            .and_then(|def_id| def_store.get(def_id))
+            .is_some_and(|def| {
+                def.kind == crate::def::DefKind::TypeAlias
+                    && def.body.is_some_and(|body| {
+                        matches!(self.interner.lookup(body), Some(TypeData::Conditional(_)))
+                    })
+            })
+    }
+
     /// Skip type alias names for aliases whose body is a generic Application.
     /// Used in assignability messages where tsc shows the Application form.
     pub const fn with_skip_application_alias_names(mut self) -> Self {
@@ -301,6 +334,12 @@ impl<'a> TypeFormatter<'a> {
     /// in TS2741 messages, not the intersection form.
     pub const fn with_skip_intersection_display_alias(mut self) -> Self {
         self.skip_intersection_display_alias = true;
+        self
+    }
+
+    /// Don't follow display aliases back to conditional type-alias Applications.
+    pub const fn with_skip_conditional_application_alias(mut self) -> Self {
+        self.skip_conditional_application_alias = true;
         self
     }
 
@@ -555,12 +594,16 @@ impl<'a> TypeFormatter<'a> {
                     // The display_alias is set when an Application type is evaluated,
                     // and preserves the concrete type arguments from the instantiation.
                     if !def.type_params.is_empty() {
-                        if let Some(alias_origin) = self.interner.get_display_alias(type_id)
-                            && self.display_alias_visiting.insert(alias_origin)
-                        {
-                            let result = self.format(alias_origin);
-                            self.display_alias_visiting.remove(&alias_origin);
-                            return result;
+                        if let Some(alias_origin) = self.interner.get_display_alias(type_id) {
+                            let skip_alias = self.skip_conditional_application_alias
+                                && self.display_alias_application_base_is_conditional_type_alias(
+                                    alias_origin,
+                                );
+                            if !skip_alias && self.display_alias_visiting.insert(alias_origin) {
+                                let result = self.format(alias_origin);
+                                self.display_alias_visiting.remove(&alias_origin);
+                                return result;
+                            }
                         }
                         // For Mapped types with generic params (e.g., Partial<T>,
                         // Record<K, V>), fall through to structural formatting.
@@ -700,6 +743,8 @@ impl<'a> TypeFormatter<'a> {
             // application display (e.g. `AsyncGenerator<number, void, unknown>`).
             if (!is_simple_type || use_keyof_alias || use_application_alias)
                 && !skip_intersection_alias
+                && !(self.skip_conditional_application_alias
+                    && self.display_alias_application_base_is_conditional_type_alias(alias_origin))
                 && !(is_empty_object
                     && self.display_alias_application_base_is_type_alias(alias_origin))
                 && self.display_alias_visiting.insert(alias_origin)

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -821,11 +821,12 @@ impl<'a> TypeInstantiator<'a> {
                     }
                     // For `any`, we need to let evaluation handle it properly
                     // so it can distribute to both branches
-                    // TypeScript treats `boolean` as `true | false` for distributive conditionals
+                    // TypeScript treats `boolean` as `false | true` for distributive
+                    // conditional diagnostics.
                     if substituted == TypeId::BOOLEAN {
                         let cond_type = self.interner.conditional(cond);
                         let mut results = Vec::with_capacity(2);
-                        for &member in &[TypeId::BOOLEAN_TRUE, TypeId::BOOLEAN_FALSE] {
+                        for &member in &[TypeId::BOOLEAN_FALSE, TypeId::BOOLEAN_TRUE] {
                             if self.depth_exceeded {
                                 return TypeId::ERROR;
                             }


### PR DESCRIPTION
## Summary

Adds focused TS2345 coverage for callback return-type elaboration when two return types share the same short name in different namespaces.

## Why

The diagnostic renderer already qualifies same-named index and array element related details. This locks the same invariant for function return mismatch related information so future display changes do not collapse `N.Token` and `M.Token` back to bare `Token`.

## Validation

- `cargo test -p tsz-checker --test ts2322_tests test_ts2345_function_return_mismatch -- --nocapture --test-threads=1`
- `cargo fmt --check`
- `git diff --check`
