### PR TITLE
chore(binder): migrate remaining node_symbols raw lookups to get_node_symbol

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -191,7 +191,7 @@ impl<'a> CheckerState<'a> {
                 .map_or(current_arena, |arena| arena.as_ref())
         }
 
-        let iface_sym_id = self.ctx.binder.node_symbols.get(&_iface_idx.0).copied();
+        let iface_sym_id = self.ctx.binder.get_node_symbol(_iface_idx);
 
         // Get heritage clauses (extends) — must have at least one across all declarations
         if iface_data.heritage_clauses.is_none() {

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -309,7 +309,7 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            let import_alias_sym_id = self.ctx.binder.node_symbols.get(&stmt_idx.0).copied();
+            let import_alias_sym_id = self.ctx.binder.get_node_symbol(stmt_idx);
             should_emit_module_not_found = if inside_namespace {
                 self.namespace_import_alias_is_referenced(
                     containing_module_node,
@@ -466,7 +466,7 @@ impl<'a> CheckerState<'a> {
         // with the same name and check if any non-import has VALUE flags.
         if let Some(ref name) = import_name {
             // Get the symbol for this import
-            let import_sym_id = self.ctx.binder.node_symbols.get(&stmt_idx.0).copied();
+            let import_sym_id = self.ctx.binder.get_node_symbol(stmt_idx);
             // Find the enclosing scope of the import statement
             let import_scope = self
                 .ctx

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -2351,7 +2351,7 @@ impl<'a> FlowAnalyzer<'a> {
             if node.kind == syntax_kind_ext::CLASS_DECLARATION
                 || node.kind == syntax_kind_ext::CLASS_EXPRESSION
             {
-                return self.binder.node_symbols.get(&current.0).copied();
+                return self.binder.get_node_symbol(current);
             }
         }
         None

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -975,7 +975,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        self.ctx.binder.node_symbols.get(&clause_idx.0).copied()
+        self.ctx.binder.get_node_symbol(clause_idx)
     }
 
     fn default_export_wrapper_expression(

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
@@ -1410,7 +1410,7 @@ impl<'a> UsageAnalyzer<'a> {
                 });
         }
 
-        self.binder.node_symbols.get(&expr_idx.0).copied()
+        self.binder.get_node_symbol(expr_idx)
     }
 
     /// Walk an inferred type from the type cache.

--- a/crates/tsz-lsp/src/completions/member.rs
+++ b/crates/tsz-lsp/src/completions/member.rs
@@ -508,7 +508,7 @@ impl<'a> Completions<'a> {
         &self,
         expr_idx: NodeIndex,
     ) -> Option<tsz_binder::SymbolId> {
-        if let Some(sym_id) = self.binder.node_symbols.get(&expr_idx.0).copied() {
+        if let Some(sym_id) = self.binder.get_node_symbol(expr_idx) {
             return Some(sym_id);
         }
 

--- a/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
+++ b/crates/tsz-lsp/src/hierarchy/call_hierarchy.rs
@@ -145,8 +145,8 @@ impl<'a> CallHierarchyProvider<'a> {
 
         let name_idx = self.get_function_name_idx(func_idx);
         let target_symbol_id = name_idx
-            .and_then(|idx| self.binder.node_symbols.get(&idx.0).copied())
-            .or_else(|| self.binder.node_symbols.get(&func_idx.0).copied());
+            .and_then(|idx| self.binder.get_node_symbol(idx))
+            .or_else(|| self.binder.get_node_symbol(func_idx));
         let target_namespace_hint = self.enclosing_namespace_name(func_idx);
         let target_member_container_hint = self.member_container_hint_for_callable(func_idx);
         let target_is_member_like =

--- a/crates/tsz-lsp/src/navigation/definition.rs
+++ b/crates/tsz-lsp/src/navigation/definition.rs
@@ -643,13 +643,10 @@ impl<'a> GoToDefinition<'a> {
                             !c.is_alphanumeric() && c != '_' && c != '$'
                         });
                         if text == member_name {
-                            if let Some(sym_id) = self.binder.node_symbols.get(&name_idx.0).copied()
-                            {
+                            if let Some(sym_id) = self.binder.get_node_symbol(name_idx) {
                                 return Some(sym_id);
                             }
-                            if let Some(sym_id) =
-                                self.binder.node_symbols.get(&member_idx.0).copied()
-                            {
+                            if let Some(sym_id) = self.binder.get_node_symbol(member_idx) {
                                 return Some(sym_id);
                             }
                         }
@@ -685,13 +682,10 @@ impl<'a> GoToDefinition<'a> {
                             !c.is_alphanumeric() && c != '_' && c != '$'
                         });
                         if text == member_name {
-                            if let Some(sym_id) = self.binder.node_symbols.get(&name_idx.0).copied()
-                            {
+                            if let Some(sym_id) = self.binder.get_node_symbol(name_idx) {
                                 return Some(sym_id);
                             }
-                            if let Some(sym_id) =
-                                self.binder.node_symbols.get(&member_idx.0).copied()
-                            {
+                            if let Some(sym_id) = self.binder.get_node_symbol(member_idx) {
                                 return Some(sym_id);
                             }
                         }


### PR DESCRIPTION
## Summary
Sweeps the `BinderState::node_symbols.get(&X.0).copied()` pattern that iteration 4 (PR #941) left behind outside the binder crate. `BinderState::get_node_symbol(NodeIndex) -> Option<SymbolId>` is already `pub` and does the same work.

Net: 8 files, 11 call sites, +13/-19.

### Sites migrated
- **checker**
  - `flow/control_flow/core.rs`
  - `declarations/import/equals.rs` (2 sites)
  - `classes/class_checker_compat.rs`
  - `state/type_analysis/computed_helpers_binding.rs`
- **emitter**
  - `declaration_emitter/usage_analyzer.rs`
- **lsp**
  - `completions/member.rs`
  - `hierarchy/call_hierarchy.rs` (2 sites)
  - `navigation/definition.rs` (4 sites)

### Intentionally skipped
Binder-owned sites (`tsz-binder/src/...`) currently have overlapping open Arc-wrap PRs (#935, #948, #954, #960). Migrating them here would force rebase conflicts — leaving those for a later iteration once those PRs merge.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] wasm32 rustc warnings gate
- [x] arch-guard
- [x] `cargo nextest run` (affected-crates) — 13039 tests passing