### PR TITLE
[codex] preserve jsx constructor props inference

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/core/fixtures.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/fixtures.rs
@@ -846,3 +846,186 @@ namespace N1 {
         "Generic inference should keep the namespace-local ComponentClass<P> construct signature even when unrelated top-level type aliases are present. Actual diagnostics: {diagnostics:#?}"
     );
 }
+
+#[test]
+fn test_jsx_element_constructor_union_assigns_to_function_or_construct_union_parameter() {
+    let source = r#"
+interface ExactProps {
+    value: "A" | "B";
+}
+interface FunctionComponent<P = {}> {
+    (props: P): any;
+}
+interface ComponentClass<P = {}> {
+    new (props: P): any;
+}
+type JSXElementConstructor<P> =
+    | ((props: P) => any)
+    | (new (props: P) => any);
+
+declare let wrapper: JSXElementConstructor<ExactProps>;
+declare let accepts: FunctionComponent<ExactProps> | ComponentClass<ExactProps> | string;
+accepts = wrapper;
+"#;
+
+    let diagnostics = compile_and_get_diagnostics(source);
+
+    assert!(
+        !has_error(&diagnostics, 2322) && !has_error(&diagnostics, 2345),
+        "JSXElementConstructor<P> should be assignable to FunctionComponent<P> | ComponentClass<P> | string without TS2322/TS2345. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_jsx_element_constructor_union_assigns_to_function_or_construct_union_parameter_in_strict_mode()
+ {
+    let source = r#"
+interface ExactProps {
+    value: "A" | "B";
+}
+interface FunctionComponent<P = {}> {
+    (props: P): any;
+}
+interface ComponentClass<P = {}> {
+    new (props: P): any;
+}
+type JSXElementConstructor<P> =
+    | ((props: P) => any)
+    | (new (props: P) => any);
+
+declare let wrapper: JSXElementConstructor<ExactProps>;
+declare let accepts: FunctionComponent<ExactProps> | ComponentClass<ExactProps> | string;
+accepts = wrapper;
+"#;
+
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_error(&diagnostics, 2322) && !has_error(&diagnostics, 2345),
+        "JSXElementConstructor<P> should remain assignable in strict mode. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_jsx_element_constructor_union_infers_props_for_create_element_like_call() {
+    let source = r#"
+// @target: es2015
+// @strict: true
+// @noEmit: true
+
+interface ExactProps {
+  value: "A" | "B";
+}
+interface FunctionComponent<P = {}> {
+  (props: P): ReactElement<any> | null;
+}
+declare class Component<P> {
+  constructor(props: P);
+}
+interface ComponentClass<P = {}> {
+  new (props: P): Component<P>;
+}
+
+interface ReactElement<
+  T extends string | JSXElementConstructor<any> =
+    | string
+    | JSXElementConstructor<any>,
+> {
+  type: T;
+}
+
+type JSXElementConstructor<P> =
+  | ((props: P) => ReactElement<any> | null)
+  | (new (props: P) => Component<any>);
+
+declare function createElementIsolated<P extends {}>(
+  type: FunctionComponent<P> | ComponentClass<P> | string,
+  props?: P | null,
+): void;
+
+declare let WrapperIsolated: JSXElementConstructor<ExactProps>;
+createElementIsolated(WrapperIsolated, { value: "C" });
+"#;
+
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts2322_count = diagnostics.iter().filter(|(code, _)| *code == 2322).count();
+    let ts2345_count = diagnostics.iter().filter(|(code, _)| *code == 2345).count();
+
+    assert_eq!(
+        ts2345_count, 0,
+        "createElement-like inference should accept JSXElementConstructor<P> as the first argument. Actual diagnostics: {diagnostics:#?}"
+    );
+    assert_eq!(
+        ts2322_count, 1,
+        "Expected the prop value mismatch to surface as one TS2322 after first-argument inference succeeds. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_jsx_element_constructor_union_with_explicit_type_argument_accepts_valid_props() {
+    let source = r#"
+// @target: es2015
+// @strict: true
+// @noEmit: true
+
+interface ExactProps {
+  value: "A" | "B";
+}
+interface FunctionComponent<P = {}> {
+  (props: P): ReactElement<any> | null;
+}
+declare class Component<P> {
+  constructor(props: P);
+}
+interface ComponentClass<P = {}> {
+  new (props: P): Component<P>;
+}
+
+interface ReactElement<
+  T extends string | JSXElementConstructor<any> =
+    | string
+    | JSXElementConstructor<any>,
+> {
+  type: T;
+}
+
+type JSXElementConstructor<P> =
+  | ((props: P) => ReactElement<any> | null)
+  | (new (props: P) => Component<any>);
+
+declare function createElementIsolated<P extends {}>(
+  type: FunctionComponent<P> | ComponentClass<P> | string,
+  props?: P | null,
+): void;
+
+declare let WrapperIsolated: JSXElementConstructor<ExactProps>;
+createElementIsolated<ExactProps>(WrapperIsolated, { value: "A" });
+"#;
+
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "Explicit type arguments should bypass inference and accept JSXElementConstructor<ExactProps>. Actual diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -353,7 +353,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return;
         }
 
-        // If target is an inference placeholder, add lower bound: source <: var
+        // If target is an inference placeholder, add lower bound: source <: var.
+        // `InferenceContext::add_candidate` already routes through contra-candidates
+        // when `in_contra_mode` is active.
         if let Some(&var) = var_map.get(&target) {
             ctx.add_candidate(var, source, priority);
             return;

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -968,6 +968,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             })
         }
 
+        fn signatures_match_for_contextual_union(
+            left: &FunctionShape,
+            right: &FunctionShape,
+        ) -> bool {
+            if left.type_params != right.type_params || left.params.len() != right.params.len() {
+                return false;
+            }
+
+            left.params.iter().zip(right.params.iter()).all(|(l, r)| {
+                l.type_id == r.type_id && l.optional == r.optional && l.rest == r.rest
+            })
+        }
+
         struct ContextualSignatureVisitor<'a> {
             db: &'a dyn TypeDatabase,
             arg_count: Option<usize>,
@@ -1154,26 +1167,43 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
             fn visit_union(&mut self, list_id: u32) -> Self::Output {
                 let members = self.db.type_list(TypeListId(list_id));
-                let mut callable_member: Option<FunctionShape> = None;
+                let mut member_shapes = Vec::new();
 
                 for &member in members.iter() {
                     if member.is_nullable() || matches!(member, TypeId::VOID | TypeId::NEVER) {
                         continue;
                     }
 
-                    let shape = self.visit_guarded(member)?;
-
-                    if callable_member.is_some() {
-                        // Optional callback unions like `Fn | undefined` should preserve
-                        // the callable shape, but we intentionally stay conservative for
-                        // true unions of multiple callable members.
-                        return None;
+                    if let Some(shape) = self.visit_guarded(member) {
+                        member_shapes.push(shape);
                     }
-
-                    callable_member = Some(shape);
                 }
 
-                callable_member
+                if member_shapes.is_empty() {
+                    return None;
+                }
+
+                // Match tsc's contextual union signature behavior: ignore
+                // non-callable members and, when any call signature is available,
+                // ignore construct-only members. This lets unions like
+                // `FunctionComponent<P> | ComponentClass<P> | string` contribute
+                // the callable `P` shape needed for inference while still
+                // preserving pure-constructor unions for `new`-style contexts.
+                let prefer_call = member_shapes.iter().any(|shape| !shape.is_constructor);
+                let filtered_shapes: Vec<_> = member_shapes
+                    .into_iter()
+                    .filter(|shape| shape.is_constructor != prefer_call)
+                    .collect();
+                let first = filtered_shapes.first()?;
+                if filtered_shapes
+                    .iter()
+                    .skip(1)
+                    .any(|shape| !signatures_match_for_contextual_union(first, shape))
+                {
+                    return None;
+                }
+
+                combine_function_shapes(self.db, filtered_shapes, self.arg_count)
             }
         }
 

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -89,6 +89,73 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .unwrap_or(lower_bounds[0])
     }
 
+    pub(super) fn should_prefer_single_contra_candidate_for_direct_inference(
+        &mut self,
+        lower_bounds: &[TypeId],
+        inferred: TypeId,
+        contra: TypeId,
+    ) -> bool {
+        if lower_bounds.len() <= 1 {
+            return false;
+        }
+
+        if !matches!(self.interner.lookup(inferred), Some(TypeData::Union(_))) {
+            return false;
+        }
+
+        let mut saw_fresh_literal_candidate = false;
+        let mut saw_concrete_lower_bound = false;
+
+        for &bound in lower_bounds {
+            if matches!(bound, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+                continue;
+            }
+
+            saw_concrete_lower_bound = true;
+
+            if self.checker.is_assignable_to(bound, contra) {
+                continue;
+            }
+
+            if self.is_fresh_direct_object_or_array_literal_candidate(bound) {
+                saw_fresh_literal_candidate = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        saw_concrete_lower_bound && saw_fresh_literal_candidate
+    }
+
+    pub(super) fn select_single_contra_candidate_direct_inference_type(
+        &mut self,
+        lower_bounds: &[TypeId],
+        contra: TypeId,
+    ) -> TypeId {
+        lower_bounds
+            .iter()
+            .copied()
+            .find(|bound| {
+                !matches!(*bound, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR)
+                    && !self.is_fresh_direct_object_or_array_literal_candidate(*bound)
+                    && self.checker.is_assignable_to(*bound, contra)
+            })
+            .unwrap_or(contra)
+    }
+
+    fn is_fresh_direct_object_or_array_literal_candidate(&self, ty: TypeId) -> bool {
+        match self.interner.lookup(ty) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => self
+                .interner
+                .object_shape(shape_id)
+                .flags
+                .contains(ObjectFlags::FRESH_LITERAL),
+            Some(TypeData::Tuple(_)) => true,
+            _ => false,
+        }
+    }
+
     fn should_preserve_nullable_direct_inference_result(
         &self,
         lower_bounds: &[TypeId],

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1429,10 +1429,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             } else {
                                 ty
                             };
-                            if direct_param_vars.contains(&var)
-                                && has_usable_contra_candidates
-                                && lower_bounds.len() == 1
-                            {
+                            if direct_param_vars.contains(&var) && has_usable_contra_candidates {
                                 let contra_types = infer_ctx.get_contra_candidate_types(var);
                                 let concrete_contra: Vec<_> = contra_types
                                     .into_iter()
@@ -1445,8 +1442,27 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                     .collect();
                                 if concrete_contra.len() == 1 {
                                     let contra = concrete_contra[0];
+                                    if self
+                                        .should_prefer_single_contra_candidate_for_direct_inference(
+                                            &lower_bounds,
+                                            ty,
+                                            contra,
+                                        )
+                                    {
+                                        ty = self
+                                            .select_single_contra_candidate_direct_inference_type(
+                                                &lower_bounds,
+                                                contra,
+                                            );
+                                        let root = infer_ctx.table.find(var);
+                                        let mut info = infer_ctx.table.probe_value(root);
+                                        info.resolved = Some(ty);
+                                        infer_ctx.table.union_value(root, info);
+                                    }
+
                                     let mut needs_broader_due_dependent_constraint = false;
-                                    if self.checker.is_assignable_to(ty, contra)
+                                    if lower_bounds.len() == 1
+                                        && self.checker.is_assignable_to(ty, contra)
                                         && !self.checker.is_assignable_to(contra, ty)
                                     {
                                         for (other_tp, &other_var) in

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -622,6 +622,41 @@ fn test_get_contextual_signature_with_compat_checker_matches_call_evaluator() {
 }
 
 #[test]
+fn test_get_contextual_signature_union_ignores_noncallable_and_constructor_members_when_call_exists()
+ {
+    let interner = TypeInterner::new();
+    let props_type = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        TypeId::STRING,
+    )]);
+    let call_member = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(props_type)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let construct_member = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(props_type)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: true,
+        is_method: false,
+    });
+    let contextual = interner.union(vec![call_member, construct_member, TypeId::STRING]);
+
+    let sig = CallEvaluator::<CompatChecker>::get_contextual_signature(&interner, contextual)
+        .expect("expected contextual signature from callable union member");
+    assert_eq!(sig.params.len(), 1);
+    assert_eq!(sig.params[0].type_id, props_type);
+    assert!(!sig.is_constructor);
+}
+
+#[test]
 fn test_call_rest_parameter_allows_zero_args() {
     let interner = TypeInterner::new();
     let mut subtype = CompatChecker::new(&interner);
@@ -3538,6 +3573,99 @@ fn test_infer_generic_function_param_from_overloaded_callable() {
 
     let result = infer_generic_function(&interner, &mut subtype, &func, &[callable_arg]);
     assert_eq!(result, TypeId::STRING);
+}
+
+#[test]
+fn test_infer_generic_function_from_union_call_or_construct_argument() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+
+    let value_type = interner.union(vec![
+        interner.literal_string("A"),
+        interner.literal_string("B"),
+    ]);
+    let exact_props = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        value_type,
+    )]);
+
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+
+    let target_call = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(t_type)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let target_construct = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(t_type)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: true,
+        is_method: false,
+    });
+
+    let func = FunctionShape {
+        type_params: vec![t_param],
+        params: vec![
+            ParamInfo {
+                name: Some(interner.intern_string("type")),
+                type_id: interner.union(vec![target_call, target_construct, TypeId::STRING]),
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("props")),
+                type_id: t_type,
+                optional: false,
+                rest: false,
+            },
+        ],
+        this_type: None,
+        return_type: t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    };
+
+    let source_call = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(exact_props)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let source_construct = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(exact_props)],
+        this_type: None,
+        return_type: TypeId::ANY,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: true,
+        is_method: false,
+    });
+    let jsx_element_constructor = interner.union(vec![source_call, source_construct]);
+
+    let result = infer_generic_function(
+        &interner,
+        &mut checker,
+        &func,
+        &[jsx_element_constructor, exact_props],
+    );
+    assert_eq!(result, exact_props);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
`tsz` was treating `JSXElementConstructor<P>` unions as an ambiguous callable/construct union during contextual inference and then preserving an over-broad direct union for `P`; `tsc` ignores non-callable members, prefers the callable contextual signature, and keeps the stable contravariant props shape so the first argument succeeds and the props mismatch reports as `TS2322`.

## Repro
```ts
interface ExactProps {
  value: "A" | "B";
}
interface FunctionComponent<P = {}> {
  (props: P): any;
}
interface ComponentClass<P = {}> {
  new (props: P): any;
}
type JSXElementConstructor<P> =
  | ((props: P) => any)
  | (new (props: P) => any);

declare function createElementIsolated<P extends {}>(
  type: FunctionComponent<P> | ComponentClass<P> | string,
  props?: P | null,
): void;

declare let wrapper: JSXElementConstructor<ExactProps>;
createElementIsolated(wrapper, { value: "C" });
// tsc: TS2322 on the props object, not TS2345 on wrapper
```

## Validation
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `cargo nextest run --package tsz-checker --lib`
- `cargo nextest run --package tsz-solver --lib`
- `./scripts/conformance/conformance.sh run --filter "coAndContraVariantInferences6" --verbose`
- `./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
