### PR TITLE
[codex] widen merge receiver literal arguments

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -299,6 +299,24 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn normalize_property_receiver_application_display_alias(&mut self, ty: TypeId) -> TypeId {
+        let Some(app) = query::type_application(self.ctx.types, ty) else {
+            return ty;
+        };
+
+        let args: Vec<_> = app
+            .args
+            .iter()
+            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
+            .collect();
+
+        if args == app.args {
+            ty
+        } else {
+            self.ctx.types.factory().application(app.base, args)
+        }
+    }
+
     fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
         let evaluated = self.evaluate_type_with_env(ty);
         if evaluated != ty {
@@ -404,6 +422,8 @@ impl<'a> CheckerState<'a> {
         if changed {
             let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
+                let alias_origin =
+                    self.normalize_property_receiver_application_display_alias(alias_origin);
                 if query::type_application(self.ctx.types, alias_origin).is_some() {
                     self.ctx
                         .types

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -543,6 +543,12 @@ o2.p4;
         !ts2339.1.contains("Omit<"),
         "Expected TS2339 receiver to avoid the expanded Omit surface.\nActual diagnostics: {diagnostics:#?}"
     );
+    assert!(
+        ts2339
+            .1
+            .contains("merge<merge<{ p1: number; }, { p2: number; }>, { p3: number; }>"),
+        "Expected TS2339 receiver to widen inferred merge literal arguments.\nActual diagnostics: {diagnostics:#?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Normalizes preserved display-alias applications after TS2339 receiver object arguments are widened.
- Tightens the merge receiver regression so inferred object literal arguments display as widened primitive properties.

## Why

`longObjectInstantiationChain1` still had a shallow fingerprint mismatch for `o2.p4`: the structural display type was widened, but its preserved alias pointed back to the original `merge<{ p1: 1 }, { p2: 2 }>` application and reintroduced literal arguments during formatting.

## Validation

- `cargo test -p tsz-checker --test conformance_issues test_ts2339_preserves_merge_alias_receiver_for_instantiation_chain -- --nocapture --test-threads=1`
- `cargo test -p tsz-checker --test conformance_issues test_ts2339_ -- --nocapture --test-threads=1`
- `./scripts/conformance/conformance.sh run --filter longObjectInstantiationChain1 --workers 1 --verbose` (shallow `o2.p4` fingerprint cleared; remaining failures are the known deep chain truncation fingerprints)
- `cargo fmt --check`
- `git diff --check`
