### PR TITLE
[codex] preserve long merge receiver chains

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -579,6 +579,7 @@ impl<'a> CheckerState<'a> {
             let mut formatter = self
                 .ctx
                 .create_diagnostic_type_formatter()
+                .with_long_property_receiver_display()
                 .with_display_properties()
                 .with_skip_application_alias_names();
             return formatter.format(display_ty).into_owned();

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -560,6 +560,38 @@ impl<'a> CheckerState<'a> {
         Some(symbol.escaped_name.clone())
     }
 
+    fn property_receiver_application_chain_depth(&self, ty: TypeId) -> u32 {
+        let mut current = ty;
+        let mut depth = 0;
+        let mut guard = 0;
+
+        loop {
+            let application =
+                crate::query_boundaries::common::type_application(self.ctx.types, current).or_else(
+                    || {
+                        self.ctx.types.get_display_alias(current).and_then(|alias| {
+                            crate::query_boundaries::common::type_application(self.ctx.types, alias)
+                        })
+                    },
+                );
+            let Some(app) = application else {
+                break;
+            };
+
+            depth += 1;
+            guard += 1;
+            if guard > 128 {
+                break;
+            }
+            let Some(&next) = app.args.first() else {
+                break;
+            };
+            current = next;
+        }
+
+        depth
+    }
+
     pub(crate) fn format_property_receiver_type_for_diagnostic(&mut self, ty: TypeId) -> String {
         if let Some(module_name) = self.ctx.namespace_module_names.get(&ty) {
             return format!("typeof import(\"{module_name}\")");
@@ -576,10 +608,14 @@ impl<'a> CheckerState<'a> {
         if let Some(application_display) = application_display {
             let display_ty =
                 self.normalize_property_receiver_application_display_type(application_display);
+            let elision_end_depth = self
+                .property_receiver_application_chain_depth(display_ty)
+                .saturating_sub(4);
             let mut formatter = self
                 .ctx
                 .create_diagnostic_type_formatter()
                 .with_long_property_receiver_display()
+                .with_long_property_receiver_object_elision_end_depth(elision_end_depth)
                 .with_display_properties()
                 .with_skip_application_alias_names();
             return Self::truncate_property_receiver_display(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -582,7 +582,9 @@ impl<'a> CheckerState<'a> {
                 .with_long_property_receiver_display()
                 .with_display_properties()
                 .with_skip_application_alias_names();
-            return formatter.format(display_ty).into_owned();
+            return Self::truncate_property_receiver_display(
+                formatter.format(display_ty).into_owned(),
+            );
         }
         let has_object_shape =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty).is_some();

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -13,8 +13,17 @@ use tsz_solver::TypeId;
 impl<'a> CheckerState<'a> {
     pub(crate) fn truncate_property_receiver_display(display: String) -> String {
         const MAX_PROPERTY_RECEIVER_DISPLAY_CHARS: usize = 320;
-        if display.len() <= MAX_PROPERTY_RECEIVER_DISPLAY_CHARS || !display.starts_with("Omit<") {
+        let should_truncate = display.starts_with("Omit<") || display.starts_with("merge<");
+        if display.len() <= MAX_PROPERTY_RECEIVER_DISPLAY_CHARS || !should_truncate {
             return display;
+        }
+        if display.starts_with("merge<") {
+            let mut truncated: String = display
+                .chars()
+                .take(MAX_PROPERTY_RECEIVER_DISPLAY_CHARS - 2)
+                .collect();
+            truncated.push_str("..");
+            return truncated;
         }
         display
             .chars()

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -647,6 +647,55 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
 }
 
 #[test]
+fn test_ts2339_elides_long_merge_receiver_method_chain_shape_access() {
+    let mut source = String::from(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = Omit<base, keyof props & keyof base> & props;
+type Type<t> = {
+    shape: t;
+    merge: <r>(r: r) => Type<merge<t, r>>;
+};
+
+declare const o1: Type<{ p1: 1 }>;
+"#,
+    );
+    for i in 2..=30 {
+        source.push_str(&format!(
+            "const o{i} = o{}.merge({{ p{}: {} }});\n",
+            i - 1,
+            i,
+            i
+        ));
+    }
+    source.push_str("o30.shape.p31;\no30.shape.p38;\no30.shape.p50;\n");
+
+    let diagnostics = compile_and_get_diagnostics(&source);
+    assert!(
+        diagnostics.iter().filter(|(code, _)| *code == 2339).count() == 3,
+        "Expected TS2339 for missing long-chain shape properties.\nActual diagnostics: {diagnostics:#?}"
+    );
+    for (_, message) in diagnostics.iter().filter(|(code, _)| *code == 2339) {
+        assert!(
+            message.contains("{ p1: 1; }")
+                && message.contains("{ p2: number; }")
+                && message.contains("{ p5: number; }"),
+            "Expected TS2339 receiver to preserve the stable method-chain prefix.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ...; }") && message.contains("{ ....."),
+            "Expected TS2339 receiver to elide and truncate the middle method-chain arguments.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("{ p30: number; }") && !message.contains("<...,"),
+            "Expected TS2339 receiver not to keep the shallow suffix or raw ellipsis.\nActual message: {message}"
+        );
+    }
+}
+
+#[test]
 fn test_object_literal_source_display_preserves_quoted_numeric_property_names() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -604,26 +604,32 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
             i + 1
         ));
     }
-    source.push_str("o30.p38;\n");
+    source.push_str("o30.p38;\no30.p51;\n");
 
     let diagnostics = compile_and_get_diagnostics(&source);
-    let ts2339 = diagnostics
-        .iter()
-        .find(|(code, _)| *code == 2339)
-        .expect("expected TS2339 for missing p38");
     assert!(
-        ts2339.1.contains("merge<merge<merge<"),
-        "Expected TS2339 receiver to preserve the merge application chain.\nActual diagnostics: {diagnostics:#?}"
+        diagnostics.iter().filter(|(code, _)| *code == 2339).count() == 2,
+        "Expected TS2339 for both missing long-chain properties.\nActual diagnostics: {diagnostics:#?}"
     );
-    assert!(
-        ts2339.1.contains("{ ...; }"),
-        "Expected TS2339 receiver to elide deep object branches.\nActual diagnostics: {diagnostics:#?}"
-    );
-    assert!(
-        ts2339.1.len() < 420,
-        "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual diagnostics: {diagnostics:#?}",
-        ts2339.1.len()
-    );
+    for (_, message) in diagnostics.iter().filter(|(code, _)| *code == 2339) {
+        assert!(
+            message.matches("merge<").count() >= 25,
+            "Expected TS2339 receiver to preserve the long merge application chain.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ...; }"),
+            "Expected TS2339 receiver to elide deep object branches.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("<...,"),
+            "Expected TS2339 receiver not to collapse the older chain to a raw ellipsis.\nActual message: {message}"
+        );
+        assert!(
+            message.len() < 1400,
+            "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual message: {message}",
+            message.len()
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -617,15 +617,29 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
             "Expected TS2339 receiver to preserve the long merge application chain.\nActual message: {message}"
         );
         assert!(
+            message.contains("{ p1: number; }")
+                && message.contains("{ p2: number; }")
+                && message.contains("{ p5: number; }"),
+            "Expected TS2339 receiver to preserve the stable merge chain prefix.\nActual message: {message}"
+        );
+        assert!(
             message.contains("{ ...; }"),
-            "Expected TS2339 receiver to elide deep object branches.\nActual message: {message}"
+            "Expected TS2339 receiver to elide the middle merge object arguments.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("{ p31: number; }"),
+            "Expected TS2339 receiver to truncate before the shallow suffix.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ....."),
+            "Expected TS2339 receiver truncation to match tsc's merge-chain suffix.\nActual message: {message}"
         );
         assert!(
             !message.contains("<...,"),
             "Expected TS2339 receiver not to collapse the older chain to a raw ellipsis.\nActual message: {message}"
         );
         assert!(
-            message.len() < 1400,
+            message.len() < 390,
             "Expected TS2339 receiver to stay bounded.\nActual len: {}\nActual message: {message}",
             message.len()
         );

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -446,7 +446,7 @@ impl<'a> TypeFormatter<'a> {
         }
         let type_key = self.interner.lookup(type_id);
         if self.long_property_receiver_display
-            && (8..=55).contains(&self.current_depth)
+            && (8..=26).contains(&self.current_depth)
             && matches!(
                 type_key,
                 Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -110,6 +110,7 @@ pub struct TypeFormatter<'a> {
     /// When true, preserve a longer generic alias prefix while eliding nested
     /// structural object branches. Used for long property receiver diagnostics.
     long_property_receiver_display: bool,
+    long_property_receiver_object_elision_end_depth: u32,
 }
 
 impl<'a> TypeFormatter<'a> {
@@ -136,6 +137,7 @@ impl<'a> TypeFormatter<'a> {
             skip_intersection_display_alias: false,
             skip_conditional_application_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -215,6 +217,7 @@ impl<'a> TypeFormatter<'a> {
             skip_intersection_display_alias: false,
             skip_conditional_application_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -273,6 +276,14 @@ impl<'a> TypeFormatter<'a> {
     pub const fn with_long_property_receiver_display(mut self) -> Self {
         self.max_depth = 64;
         self.long_property_receiver_display = true;
+        self
+    }
+
+    pub const fn with_long_property_receiver_object_elision_end_depth(
+        mut self,
+        end_depth: u32,
+    ) -> Self {
+        self.long_property_receiver_object_elision_end_depth = end_depth;
         self
     }
 
@@ -446,7 +457,8 @@ impl<'a> TypeFormatter<'a> {
         }
         let type_key = self.interner.lookup(type_id);
         if self.long_property_receiver_display
-            && (8..=26).contains(&self.current_depth)
+            && (8..=self.long_property_receiver_object_elision_end_depth)
+                .contains(&self.current_depth)
             && matches!(
                 type_key,
                 Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))


### PR DESCRIPTION
## Summary

- Uses the existing long property receiver display mode when TS2339 formats a receiver through an application/display-alias surface.
- Strengthens the long merge receiver regression to catch suffix-only truncation and raw application ellipses.

## Why

The application receiver path normalized `merge<...>` surfaces but formatted them with the default depth limit. On left-recursive merge chains, that consumed depth walking into the older chain and collapsed the receiver to an outer suffix around `p25` through `p31`.

## Validation

- `cargo test -p tsz-checker --test conformance_issues test_ts2339_elides_long_merge_receiver_instantiation_chain -- --nocapture --test-threads=1`
- `cargo test -p tsz-checker --test conformance_issues test_ts2339_ -- --nocapture --test-threads=1`
- `./scripts/conformance/conformance.sh run --filter longObjectInstantiationChain1 --workers 1 --verbose` (suffix/raw-ellipsis collapse fixed; remaining mismatch is the separate object-elision window for the innermost merge arguments)
- `cargo fmt --check`
- `git diff --check`
