### PR TITLE
chore(parser): add NodeArena::is_static helper and migrate callers

### DIFF
--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -616,9 +616,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         };
 
         if let Some(mods) = modifiers {
-            self.ctx
-                .arena
-                .has_modifier(&mods, SyntaxKind::StaticKeyword)
+            self.ctx.arena.is_static(&mods)
         } else {
             false
         }

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1117,14 +1117,11 @@ impl<'a> DeclarationEmitter<'a> {
             }
 
             let is_static = if let Some(prop) = self.arena.get_property_decl(member_node) {
-                self.arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
+                self.arena.is_static(&prop.modifiers)
             } else if let Some(method) = self.arena.get_method_decl(member_node) {
-                self.arena
-                    .has_modifier(&method.modifiers, SyntaxKind::StaticKeyword)
+                self.arena.is_static(&method.modifiers)
             } else if let Some(accessor) = self.arena.get_accessor(member_node) {
-                self.arena
-                    .has_modifier(&accessor.modifiers, SyntaxKind::StaticKeyword)
+                self.arena.is_static(&accessor.modifiers)
             } else {
                 false
             };

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -383,11 +383,7 @@ impl<'a> DeclarationEmitter<'a> {
         method_idx: NodeIndex,
         method: &tsz_parser::parser::node::MethodDeclData,
     ) -> bool {
-        if !self.source_is_js_file
-            || !self
-                .arena
-                .has_modifier(&method.modifiers, SyntaxKind::StaticKeyword)
-        {
+        if !self.source_is_js_file || !self.arena.is_static(&method.modifiers) {
             return false;
         }
         self.js_augmented_static_method_nodes.contains(&method_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -1177,10 +1177,7 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             };
             if let Some(prop) = self.arena.get_property_decl(member_node) {
-                if self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
-                {
+                if self.arena.is_static(&prop.modifiers) {
                     continue;
                 }
                 let Some(prop_name_node) = self.arena.get(prop.name) else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
@@ -1880,10 +1880,7 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(method) = self.arena.get_method_decl(member_node) else {
                 continue;
             };
-            if !self
-                .arena
-                .has_modifier(&method.modifiers, SyntaxKind::StaticKeyword)
-            {
+            if !self.arena.is_static(&method.modifiers) {
                 continue;
             }
             let Some(method_name) = self.get_identifier_text(method.name) else {

--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -690,9 +690,7 @@ impl<'a> Printer<'a> {
                 continue;
             }
 
-            let is_static = self
-                .arena
-                .has_modifier(modifiers, SyntaxKind::StaticKeyword);
+            let is_static = self.arena.is_static(modifiers);
 
             let member_name = self.get_decorator_member_name(name_idx);
             if member_name.is_empty() {

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -187,9 +187,7 @@ impl<'a> Printer<'a> {
                 if lower_auto_accessors_to_weakmap && class_name.is_empty() {
                     continue;
                 }
-                let is_static = self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword);
+                let is_static = self.arena.is_static(&prop.modifiers);
                 let Some(name_node) = self.arena.get(prop.name) else {
                     continue;
                 };
@@ -545,8 +543,7 @@ impl<'a> Printer<'a> {
                 self.arena.get(member_idx).is_some_and(|m| {
                     m.kind == syntax_kind_ext::PROPERTY_DECLARATION
                         && self.arena.get_property_decl(m).is_some_and(|p| {
-                            self.arena
-                                .has_modifier(&p.modifiers, SyntaxKind::StaticKeyword)
+                            self.arena.is_static(&p.modifiers)
                                 && !self
                                     .arena
                                     .has_modifier(&p.modifiers, SyntaxKind::AbstractKeyword)
@@ -689,9 +686,7 @@ impl<'a> Printer<'a> {
                             return None;
                         }
                         let prop = self.arena.get_property_decl(member_node)?;
-                        if !self
-                            .arena
-                            .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
+                        if !self.arena.is_static(&prop.modifiers)
                             || self
                                 .arena
                                 .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
@@ -975,10 +970,7 @@ impl<'a> Printer<'a> {
                         Vec::new()
                     };
 
-                    if self
-                        .arena
-                        .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
-                    {
+                    if self.arena.is_static(&prop.modifiers) {
                         // At ES2022+, static fields are emitted as `static { this.f = v; }`
                         // blocks inside the class body, not as external assignments.
                         if !needs_static_block_lowering {
@@ -1325,15 +1317,13 @@ impl<'a> Printer<'a> {
                 }) && (self.ctx.options.target as u32) >= (ScriptTarget::ES2022 as u32))
                 // Static fields at ES2022+ are emitted inline as `static { this.f = v; }`
                 // blocks, not deferred to external assignments.
-                && (!self.arena.has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
+                && (!self.arena.is_static(&prop.modifiers)
                     || needs_static_block_lowering)
             {
                 // For static properties, save leading and trailing comments before
                 // skipping so they can be emitted when the initialization is moved
                 // after the class body.
-                let is_static = self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword);
+                let is_static = self.arena.is_static(&prop.modifiers);
                 if is_static {
                     let leading = self.collect_leading_comments(member_node.pos);
                     if let Some(entry) = static_field_inits

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -88,10 +88,7 @@ impl<'a> Printer<'a> {
 
         if needs_async_lowering || needs_async_generator_lowering {
             // Emit static modifier if present
-            if self
-                .arena
-                .has_modifier(&method.modifiers, SyntaxKind::StaticKeyword)
-            {
+            if self.arena.is_static(&method.modifiers) {
                 self.write("static ");
             }
         } else {
@@ -403,9 +400,7 @@ impl<'a> Printer<'a> {
         // For ES2022+ targets, static fields with initializers are emitted as
         // `static { this.fieldName = value; }` blocks (class static initialization blocks).
         // This preserves the correct `this` and `super` binding inside the class body.
-        let is_static = self
-            .arena
-            .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword);
+        let is_static = self.arena.is_static(&prop.modifiers);
         let target_es2022_plus = (self.ctx.options.target as u32) >= (ScriptTarget::ES2022 as u32);
 
         let is_private_field = self

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -477,9 +477,7 @@ impl<'a> Printer<'a> {
                                 && member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION
                                 && let Some(prop) = self.arena.get_property_decl(member_node)
                                 && prop.initializer.is_some()
-                                && self
-                                    .arena
-                                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
+                                && self.arena.is_static(&prop.modifiers)
                                 && !self
                                     .arena
                                     .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -902,9 +902,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 continue;
             }
 
-            let is_static = self
-                .arena
-                .has_modifier(modifiers, SyntaxKind::StaticKeyword);
+            let is_static = self.arena.is_static(modifiers);
 
             let member_name = get_identifier_text(self.arena, name_idx);
             let Some(member_name) = member_name else {
@@ -1585,10 +1583,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 }
                 let prop_data = self.arena.get_property_decl(member_node)?;
                 // Skip static properties
-                if self
-                    .arena
-                    .has_modifier(&prop_data.modifiers, SyntaxKind::StaticKeyword)
-                {
+                if self.arena.is_static(&prop_data.modifiers) {
                     return None;
                 }
                 // Skip abstract properties (they don't exist at runtime)
@@ -2705,7 +2700,7 @@ fn collect_accessor_pairs(
             && let Some(accessor_data) = arena.get_accessor(member_node)
         {
             // Check static modifier matches what we're collecting
-            let is_static = arena.has_modifier(&accessor_data.modifiers, SyntaxKind::StaticKeyword);
+            let is_static = arena.is_static(&accessor_data.modifiers);
             if is_static != collect_static {
                 continue;
             }
@@ -2768,7 +2763,7 @@ fn collect_auto_accessor_fields(
         if is_private_identifier(arena, prop_data.name) {
             continue;
         }
-        if arena.has_modifier(&prop_data.modifiers, SyntaxKind::StaticKeyword) {
+        if arena.is_static(&prop_data.modifiers) {
             continue;
         }
         let has_accessor = arena.has_modifier(&prop_data.modifiers, SyntaxKind::AccessorKeyword);

--- a/crates/tsz-emitter/src/transforms/es_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators.rs
@@ -1130,9 +1130,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
             }
             if node.kind == syntax_kind_ext::PROPERTY_DECLARATION
                 && let Some(prop) = self.arena.get_property_decl(node)
-                && self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::StaticKeyword)
+                && self.arena.is_static(&prop.modifiers)
             {
                 return true;
             }
@@ -1481,9 +1479,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 continue;
             }
 
-            let is_static = self
-                .arena
-                .has_modifier(&modifiers, SyntaxKind::StaticKeyword);
+            let is_static = self.arena.is_static(&modifiers);
             let (name, is_private) = self.resolve_member_name(name_idx);
 
             result.push(DecoratedMember {

--- a/crates/tsz-parser/src/parser/node_modifiers.rs
+++ b/crates/tsz-parser/src/parser/node_modifiers.rs
@@ -63,6 +63,17 @@ impl NodeArena {
         None
     }
 
+    /// Check whether a modifier list contains `static`.
+    ///
+    /// Shortcut for `has_modifier(modifiers, SyntaxKind::StaticKeyword)`, the
+    /// most common single-kind query in the emitter and class lowering
+    /// pipelines.
+    #[inline]
+    #[must_use]
+    pub fn is_static(&self, modifiers: &Option<NodeList>) -> bool {
+        self.has_modifier(modifiers, SyntaxKind::StaticKeyword)
+    }
+
     /// Extract the visibility level from a modifier list.
     ///
     /// Scans for `private` or `protected` keywords; returns `Public` if neither is found.


### PR DESCRIPTION
## Summary

- `arena.has_modifier(&X.modifiers, SyntaxKind::StaticKeyword)` was the single most duplicated modifier query in the emitter / class-lowering pipelines — rustfmt frequently wrapped it across three lines.
- Add `NodeArena::is_static(&modifiers)` alongside the existing `has_modifier`, `has_modifier_ref`, `find_modifier`, and `get_visibility_from_modifiers` helpers.
- Migrate 24 call sites across 11 files; net **-32 lines**.
- Skipped files owned by in-flight PRs: `private_fields_es5.rs` (#959), `class_es5_ir_members.rs` (#931), `state_checking/core.rs` (#925), `flow_graph_builder/expressions.rs` (#924), `code_action_extract_interface.rs` (#943). Those sites will migrate in a follow-up once the respective PRs land.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run` — 21154 passed, 77 skipped
- [x] Grep confirms no `has_modifier(..., SyntaxKind::StaticKeyword)` remains in non-conflict files