### PR TITLE
[codex] derive long merge receiver elision depth

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -560,6 +560,38 @@ impl<'a> CheckerState<'a> {
         Some(symbol.escaped_name.clone())
     }
 
+    fn property_receiver_application_chain_depth(&self, ty: TypeId) -> u32 {
+        let mut current = ty;
+        let mut depth = 0;
+        let mut guard = 0;
+
+        loop {
+            let application =
+                crate::query_boundaries::common::type_application(self.ctx.types, current).or_else(
+                    || {
+                        self.ctx.types.get_display_alias(current).and_then(|alias| {
+                            crate::query_boundaries::common::type_application(self.ctx.types, alias)
+                        })
+                    },
+                );
+            let Some(app) = application else {
+                break;
+            };
+
+            depth += 1;
+            guard += 1;
+            if guard > 128 {
+                break;
+            }
+            let Some(&next) = app.args.first() else {
+                break;
+            };
+            current = next;
+        }
+
+        depth
+    }
+
     pub(crate) fn format_property_receiver_type_for_diagnostic(&mut self, ty: TypeId) -> String {
         if let Some(module_name) = self.ctx.namespace_module_names.get(&ty) {
             return format!("typeof import(\"{module_name}\")");
@@ -576,10 +608,14 @@ impl<'a> CheckerState<'a> {
         if let Some(application_display) = application_display {
             let display_ty =
                 self.normalize_property_receiver_application_display_type(application_display);
+            let elision_end_depth = self
+                .property_receiver_application_chain_depth(display_ty)
+                .saturating_sub(4);
             let mut formatter = self
                 .ctx
                 .create_diagnostic_type_formatter()
                 .with_long_property_receiver_display()
+                .with_long_property_receiver_object_elision_end_depth(elision_end_depth)
                 .with_display_properties()
                 .with_skip_application_alias_names();
             return Self::truncate_property_receiver_display(

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -647,6 +647,55 @@ const o1 = merge({ p1: 1 }, { p2: 2 });
 }
 
 #[test]
+fn test_ts2339_elides_long_merge_receiver_method_chain_shape_access() {
+    let mut source = String::from(
+        r#"
+type Exclude<T, U> = T extends U ? never : T;
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type merge<base, props> = Omit<base, keyof props & keyof base> & props;
+type Type<t> = {
+    shape: t;
+    merge: <r>(r: r) => Type<merge<t, r>>;
+};
+
+declare const o1: Type<{ p1: 1 }>;
+"#,
+    );
+    for i in 2..=30 {
+        source.push_str(&format!(
+            "const o{i} = o{}.merge({{ p{}: {} }});\n",
+            i - 1,
+            i,
+            i
+        ));
+    }
+    source.push_str("o30.shape.p31;\no30.shape.p38;\no30.shape.p50;\n");
+
+    let diagnostics = compile_and_get_diagnostics(&source);
+    assert!(
+        diagnostics.iter().filter(|(code, _)| *code == 2339).count() == 3,
+        "Expected TS2339 for missing long-chain shape properties.\nActual diagnostics: {diagnostics:#?}"
+    );
+    for (_, message) in diagnostics.iter().filter(|(code, _)| *code == 2339) {
+        assert!(
+            message.contains("{ p1: 1; }")
+                && message.contains("{ p2: number; }")
+                && message.contains("{ p5: number; }"),
+            "Expected TS2339 receiver to preserve the stable method-chain prefix.\nActual message: {message}"
+        );
+        assert!(
+            message.contains("{ ...; }") && message.contains("{ ....."),
+            "Expected TS2339 receiver to elide and truncate the middle method-chain arguments.\nActual message: {message}"
+        );
+        assert!(
+            !message.contains("{ p30: number; }") && !message.contains("<...,"),
+            "Expected TS2339 receiver not to keep the shallow suffix or raw ellipsis.\nActual message: {message}"
+        );
+    }
+}
+
+#[test]
 fn test_object_literal_source_display_preserves_quoted_numeric_property_names() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -110,6 +110,7 @@ pub struct TypeFormatter<'a> {
     /// When true, preserve a longer generic alias prefix while eliding nested
     /// structural object branches. Used for long property receiver diagnostics.
     long_property_receiver_display: bool,
+    long_property_receiver_object_elision_end_depth: u32,
 }
 
 impl<'a> TypeFormatter<'a> {
@@ -136,6 +137,7 @@ impl<'a> TypeFormatter<'a> {
             skip_intersection_display_alias: false,
             skip_conditional_application_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -215,6 +217,7 @@ impl<'a> TypeFormatter<'a> {
             skip_intersection_display_alias: false,
             skip_conditional_application_alias: false,
             long_property_receiver_display: false,
+            long_property_receiver_object_elision_end_depth: 26,
         }
     }
 
@@ -273,6 +276,14 @@ impl<'a> TypeFormatter<'a> {
     pub const fn with_long_property_receiver_display(mut self) -> Self {
         self.max_depth = 64;
         self.long_property_receiver_display = true;
+        self
+    }
+
+    pub const fn with_long_property_receiver_object_elision_end_depth(
+        mut self,
+        end_depth: u32,
+    ) -> Self {
+        self.long_property_receiver_object_elision_end_depth = end_depth;
         self
     }
 
@@ -446,7 +457,8 @@ impl<'a> TypeFormatter<'a> {
         }
         let type_key = self.interner.lookup(type_id);
         if self.long_property_receiver_display
-            && (8..=26).contains(&self.current_depth)
+            && (8..=self.long_property_receiver_object_elision_end_depth)
+                .contains(&self.current_depth)
             && matches!(
                 type_key,
                 Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))


### PR DESCRIPTION
## Summary

- Derives the long receiver object-elision cutoff from the left-nested application depth instead of using one fixed depth.
- Follows application display aliases while measuring chain depth, matching the formatter path used for preserved merge aliases.
- Adds a method-chain `Type<merge<...>>.shape` regression for `longObjectInstantiationChain2`.

## Why

The direct merge chain and method/shape chain have the same tsc receiver shape but differ by one application level. A fixed cutoff that made chain1 pass elided `p5` too early in chain2. Measuring the actual application/display-alias chain keeps both cached fingerprints aligned.

## Validation

- `cargo test -p tsz-checker --test conformance_issues test_ts2339_elides_long_merge_receiver_ -- --nocapture --test-threads=1`
- `./scripts/conformance/conformance.sh run --filter longObjectInstantiationChain2 --workers 1 --verbose` (1/1 passed)
- `./scripts/conformance/conformance.sh run --filter longObjectInstantiationChain1 --workers 1 --verbose` (1/1 passed)
- `cargo test -p tsz-solver diagnostics::format -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
