### PR TITLE
chore(checker,lsp): migrate raw symbol flag bit-tests to has_any_flags

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_super.rs
+++ b/crates/tsz-checker/src/types/computation/access_super.rs
@@ -192,7 +192,7 @@ impl<'a> CheckerState<'a> {
             let Some(symbol) = self.ctx.binder.symbols.get(sym_id) else {
                 continue;
             };
-            if symbol.flags & symbol_flags::CLASS == 0 {
+            if !symbol.has_any_flags(symbol_flags::CLASS) {
                 continue;
             }
             // Same-file classes only — cross-file references have no runtime

--- a/crates/tsz-checker/src/types/computation/complex_constructors.rs
+++ b/crates/tsz-checker/src/types/computation/complex_constructors.rs
@@ -868,7 +868,7 @@ impl<'a> CheckerState<'a> {
             .resolve_identifier(self.ctx.arena, expr_idx)
             .or_else(|| self.ctx.binder.get_node_symbol(expr_idx))?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::CLASS == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return None;
         }
         if let Some(&instance_type) = self.ctx.symbol_instance_types.get(&sym_id) {
@@ -910,7 +910,7 @@ impl<'a> CheckerState<'a> {
             .or_else(|| self.ctx.binder.get_node_symbol(expr_idx))
             .or_else(|| self.resolve_qualified_symbol(expr_idx))?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::CLASS == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return None;
         }
 
@@ -997,7 +997,7 @@ impl<'a> CheckerState<'a> {
             }
             if let Some(sym_id) = callable_shape.symbol
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-                && (symbol.flags & symbol_flags::ABSTRACT) != 0
+                && symbol.has_any_flags(symbol_flags::ABSTRACT)
             {
                 return true;
             }
@@ -1006,7 +1006,7 @@ impl<'a> CheckerState<'a> {
         if let Some(def_id) = query::lazy_def_id(self.ctx.types, type_id)
             && let Some(sym_id) = self.ctx.def_to_symbol_id(def_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && symbol.flags & symbol_flags::TYPE_ALIAS != 0
+            && symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && let Some(body_type) = def.body
         {
@@ -1016,7 +1016,7 @@ impl<'a> CheckerState<'a> {
         match query::classify_for_abstract_check(self.ctx.types, type_id) {
             query::AbstractClassCheckKind::TypeQuery(sym_ref) => {
                 if let Some(symbol) = self.ctx.binder.get_symbol(SymbolId(sym_ref.0))
-                    && symbol.flags & symbol_flags::ABSTRACT != 0
+                    && symbol.has_any_flags(symbol_flags::ABSTRACT)
                 {
                     return true;
                 }

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -1072,8 +1072,8 @@ impl<'a> CheckerState<'a> {
                     self.get_type_of_symbol(sym_id)
                 }
             } else if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-                && (symbol.flags & symbol_flags::ENUM) != 0
-                && (symbol.flags & symbol_flags::ENUM_MEMBER) == 0
+                && symbol.has_any_flags(symbol_flags::ENUM)
+                && !symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
             {
                 self.enum_object_type(sym_id)
                     .inspect(|&enum_obj| {

--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -421,7 +421,7 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
             // UMD export merged with a variable declaration from `declare global`
-            (sym.flags & symbol_flags::VARIABLE) != 0
+            sym.has_any_flags(symbol_flags::VARIABLE)
         };
 
         // Check lib_contexts (lib files + some user files)
@@ -610,7 +610,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             if symbol.escaped_name != name
-                || (symbol.flags & symbol_flags::VALUE) == 0
+                || !symbol.has_any_flags(symbol_flags::VALUE)
                 || symbol.is_umd_export
             {
                 continue;

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -297,7 +297,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             {
                 // Check if name matches and symbol has STATIC flag
-                if symbol.escaped_name == name && (symbol.flags & symbol_flags::STATIC != 0) {
+                if symbol.escaped_name == name && (symbol.has_any_flags(symbol_flags::STATIC)) {
                     return true;
                 }
             }
@@ -312,7 +312,7 @@ impl<'a> CheckerState<'a> {
             if let Some(sym_id) = self.ctx.binder.get_node_symbol(member_idx)
                 && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                 && symbol.escaped_name == name
-                && (symbol.flags & symbol_flags::STATIC == 0)
+                && (!symbol.has_any_flags(symbol_flags::STATIC))
             {
                 return true;
             }

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -125,7 +125,7 @@ impl<'a> CheckerState<'a> {
         // Use resolve_type_to_symbol_id instead of get_ref_symbol
         let sym_id = self.ctx.resolve_type_to_symbol_id(type_id)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::ENUM == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM) {
             return None;
         }
         Some(sym_id)
@@ -135,19 +135,19 @@ impl<'a> CheckerState<'a> {
         let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)?;
         let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        ((symbol.flags & symbol_flags::ENUM) != 0
-            && (symbol.flags & symbol_flags::ENUM_MEMBER) == 0)
-            .then_some(sym_id)
+        (symbol.has_any_flags(symbol_flags::ENUM)
+            && !symbol.has_any_flags(symbol_flags::ENUM_MEMBER))
+        .then_some(sym_id)
     }
 
     pub(crate) fn enum_symbol_from_enumish_type(&self, type_id: TypeId) -> Option<SymbolId> {
         let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, type_id)?;
         let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if (symbol.flags & symbol_flags::ENUM_MEMBER) != 0 {
+        if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
             return Some(symbol.parent);
         }
-        ((symbol.flags & symbol_flags::ENUM) != 0).then_some(sym_id)
+        (symbol.has_any_flags(symbol_flags::ENUM)).then_some(sym_id)
     }
 
     pub(crate) fn apparent_enum_instance_type(&self, type_id: TypeId) -> Option<TypeId> {
@@ -239,7 +239,7 @@ impl<'a> CheckerState<'a> {
     /// Returns None if the symbol is not an enum or has no members.
     pub(crate) fn enum_kind(&self, sym_id: SymbolId) -> Option<EnumKind> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::ENUM == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM) {
             return None;
         }
 
@@ -333,7 +333,7 @@ impl<'a> CheckerState<'a> {
             .get_node_symbol(member_decl)
             .or_else(|| self.ctx.binder.get_node_symbol(member.name))
             && let Some(symbol) = self.ctx.binder.get_symbol(member_sym)
-            && symbol.flags & symbol_flags::ENUM_MEMBER != 0
+            && symbol.has_any_flags(symbol_flags::ENUM_MEMBER)
             && symbol.parent.is_some()
             && let Some(auto_value) = self.compute_auto_increment_value(symbol.parent, member_decl)
         {
@@ -442,7 +442,7 @@ impl<'a> CheckerState<'a> {
                     |_| true,
                 )?;
                 let symbol = self.ctx.binder.get_symbol(sym_id)?;
-                if symbol.flags & symbol_flags::ENUM_MEMBER != 0 {
+                if symbol.has_any_flags(symbol_flags::ENUM_MEMBER) {
                     let member_decl = symbol.value_declaration;
 
                     // Check memoization cache first.
@@ -678,7 +678,7 @@ impl<'a> CheckerState<'a> {
         if node.kind == SyntaxKind::Identifier as u16 {
             let sym_id = self.resolve_identifier_symbol(expr_idx)?;
             let symbol = self.ctx.binder.get_symbol(sym_id)?;
-            if symbol.flags & symbol_flags::CLASS != 0 {
+            if symbol.has_any_flags(symbol_flags::CLASS) {
                 return Some(sym_id);
             }
         }
@@ -711,7 +711,7 @@ impl<'a> CheckerState<'a> {
         }
         let sym_id = self.resolve_identifier_symbol(left_idx)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::CLASS != 0 {
+        if symbol.has_any_flags(symbol_flags::CLASS) {
             return Some(sym_id);
         }
         if symbol.flags
@@ -765,7 +765,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::CLASS == 0 {
+        if !symbol.has_any_flags(symbol_flags::CLASS) {
             return None;
         }
         let decl_idx = symbol.primary_declaration()?;
@@ -2006,7 +2006,7 @@ impl<'a> CheckerState<'a> {
         property_name: &str,
     ) -> Option<TypeId> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if symbol.flags & symbol_flags::ENUM == 0 {
+        if !symbol.has_any_flags(symbol_flags::ENUM) {
             return None;
         }
 

--- a/crates/tsz-lsp/src/completions/context.rs
+++ b/crates/tsz-lsp/src/completions/context.rs
@@ -654,30 +654,30 @@ impl<'a> Completions<'a> {
     pub(super) fn get_symbol_detail(&self, symbol: &tsz_binder::Symbol) -> Option<String> {
         use tsz_binder::symbol_flags;
 
-        if symbol.flags & symbol_flags::FUNCTION != 0 {
+        if symbol.has_any_flags(symbol_flags::FUNCTION) {
             Some("function".to_string())
-        } else if symbol.flags & symbol_flags::CLASS != 0 {
+        } else if symbol.has_any_flags(symbol_flags::CLASS) {
             Some("class".to_string())
-        } else if symbol.flags & symbol_flags::INTERFACE != 0 {
+        } else if symbol.has_any_flags(symbol_flags::INTERFACE) {
             Some("interface".to_string())
-        } else if symbol.flags & symbol_flags::REGULAR_ENUM != 0
-            || symbol.flags & symbol_flags::CONST_ENUM != 0
+        } else if symbol.has_any_flags(symbol_flags::REGULAR_ENUM)
+            || symbol.has_any_flags(symbol_flags::CONST_ENUM)
         {
             Some("enum".to_string())
-        } else if symbol.flags & symbol_flags::TYPE_ALIAS != 0 {
+        } else if symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
             Some("type".to_string())
-        } else if symbol.flags & symbol_flags::TYPE_PARAMETER != 0 {
+        } else if symbol.has_any_flags(symbol_flags::TYPE_PARAMETER) {
             Some("type parameter".to_string())
-        } else if symbol.flags & symbol_flags::METHOD != 0 {
+        } else if symbol.has_any_flags(symbol_flags::METHOD) {
             Some("method".to_string())
-        } else if symbol.flags & symbol_flags::PROPERTY != 0 {
+        } else if symbol.has_any_flags(symbol_flags::PROPERTY) {
             Some("property".to_string())
-        } else if symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0 {
+        } else if symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
             Some("let/const".to_string())
-        } else if symbol.flags & symbol_flags::FUNCTION_SCOPED_VARIABLE != 0 {
+        } else if symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE) {
             Some("var".to_string())
-        } else if symbol.flags & symbol_flags::VALUE_MODULE != 0
-            || symbol.flags & symbol_flags::NAMESPACE_MODULE != 0
+        } else if symbol.has_any_flags(symbol_flags::VALUE_MODULE)
+            || symbol.has_any_flags(symbol_flags::NAMESPACE_MODULE)
         {
             Some("module".to_string())
         } else {
@@ -693,7 +693,7 @@ impl<'a> Completions<'a> {
         use tsz_parser::parser::flags::node_flags;
 
         let mut mods = Vec::new();
-        if symbol.flags & symbol_flags::EXPORT_VALUE != 0 {
+        if symbol.has_any_flags(symbol_flags::EXPORT_VALUE) {
             mods.push("export");
         }
         // Check declaration node for ambient (declare) and deprecated
@@ -710,19 +710,19 @@ impl<'a> Completions<'a> {
                 mods.push("declare");
             }
         }
-        if symbol.flags & symbol_flags::ABSTRACT != 0 {
+        if symbol.has_any_flags(symbol_flags::ABSTRACT) {
             mods.push("abstract");
         }
-        if symbol.flags & symbol_flags::STATIC != 0 {
+        if symbol.has_any_flags(symbol_flags::STATIC) {
             mods.push("static");
         }
-        if symbol.flags & symbol_flags::PRIVATE != 0 {
+        if symbol.has_any_flags(symbol_flags::PRIVATE) {
             mods.push("private");
         }
-        if symbol.flags & symbol_flags::PROTECTED != 0 {
+        if symbol.has_any_flags(symbol_flags::PROTECTED) {
             mods.push("protected");
         }
-        if symbol.flags & symbol_flags::OPTIONAL != 0 {
+        if symbol.has_any_flags(symbol_flags::OPTIONAL) {
             mods.push("optional");
         }
         if mods.is_empty() {

--- a/crates/tsz-lsp/src/highlighting/semantic_tokens.rs
+++ b/crates/tsz-lsp/src/highlighting/semantic_tokens.rs
@@ -359,14 +359,14 @@ impl<'a> SemanticTokensProvider<'a> {
         let mut modifiers = 0u32;
 
         // Check for const variable -> READONLY modifier
-        if symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0
+        if symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
             && self.is_const_variable(ident_idx)
         {
             modifiers |= semantic_token_modifiers::READONLY;
         }
 
         // Check for exported symbol
-        if symbol.is_exported || symbol.flags & symbol_flags::EXPORT_VALUE != 0 {
+        if symbol.is_exported || symbol.has_any_flags(symbol_flags::EXPORT_VALUE) {
             modifiers |= semantic_token_modifiers::DEFAULT_LIBRARY; // Using DEFAULT_LIBRARY as export indicator
         }
 
@@ -392,7 +392,7 @@ impl<'a> SemanticTokensProvider<'a> {
         let mut modifiers = 0u32;
 
         // Check for const variable -> READONLY modifier
-        if symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE != 0 {
+        if symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
             // Check the declaration to see if it's const
             if let Some(decl_idx) = symbol.declarations.first()
                 && let Some(decl_node) = self.arena.get(*decl_idx)

--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -1123,7 +1123,7 @@ impl<'a> HoverProvider<'a> {
                     .resolve_identifier(self.arena, var_decl.initializer)
             })?;
         let init_symbol = self.binder.get_symbol(init_sym_id)?;
-        if (init_symbol.flags & symbol_flags::FUNCTION) == 0
+        if !init_symbol.has_any_flags(symbol_flags::FUNCTION)
             || !self.symbol_has_namespace_merge(init_symbol)
         {
             return None;
@@ -1265,7 +1265,7 @@ impl<'a> HoverProvider<'a> {
             exports.iter().any(|(_, sym_id)| {
                 self.binder
                     .get_symbol(*sym_id)
-                    .is_some_and(|export_symbol| (export_symbol.flags & symbol_flags::VALUE) != 0)
+                    .is_some_and(|export_symbol| export_symbol.has_any_flags(symbol_flags::VALUE))
             })
         })
     }

--- a/crates/tsz-lsp/src/navigation/implementation.rs
+++ b/crates/tsz-lsp/src/navigation/implementation.rs
@@ -126,11 +126,11 @@ impl<'a> GoToImplementationProvider<'a> {
     pub fn determine_target_kind(&self, symbol: &tsz_binder::Symbol) -> Option<TargetKind> {
         use tsz_binder::symbol_flags;
 
-        if symbol.flags & symbol_flags::INTERFACE != 0 {
+        if symbol.has_any_flags(symbol_flags::INTERFACE) {
             return Some(TargetKind::Interface);
         }
 
-        if symbol.flags & symbol_flags::CLASS != 0 {
+        if symbol.has_any_flags(symbol_flags::CLASS) {
             // Check if the class is abstract by examining its declarations
             for &decl_idx in &symbol.declarations {
                 if let Some(ext) = self.arena.get_extended(decl_idx)

--- a/crates/tsz-lsp/src/rename/core.rs
+++ b/crates/tsz-lsp/src/rename/core.rs
@@ -724,7 +724,7 @@ impl<'a> RenameProvider<'a> {
                 false
             });
         if is_top_level
-            && (symbol.flags & symbol_flags::EXPORT_VALUE != 0 || is_export_specifier_alias)
+            && (symbol.has_any_flags(symbol_flags::EXPORT_VALUE) || is_export_specifier_alias)
         {
             let module_name = self
                 .file_name

--- a/crates/tsz-lsp/src/symbols/symbol_index.rs
+++ b/crates/tsz-lsp/src/symbols/symbol_index.rs
@@ -442,7 +442,7 @@ impl SymbolIndex {
         // `index_file`, so callers no longer need manual `add_import` calls.
         for (local_name, symbol_id) in binder.file_locals.iter() {
             if let Some(symbol) = binder.symbols.get(*symbol_id)
-                && symbol.flags & symbol_flags::ALIAS != 0
+                && symbol.has_any_flags(symbol_flags::ALIAS)
                 && let Some(ref source_module) = symbol.import_module
             {
                 let exported_name = symbol


### PR DESCRIPTION
## Summary

Continues the `Symbol::has_any_flags(mask)` migration wave (PR #921 covered `state/`, earlier waves covered `symbol_resolver_utils` and `heritage`). Collapses 52 hand-rolled \`(sym.flags & symbol_flags::X) != 0\` / \`== 0\` bit-tests across completions, hover, highlighting, navigation, rename, symbol_index, and several checker type/computation paths onto the existing helper.

Files touched (all outside the currently-open PR file-lists, so no rebase contention):
- \`crates/tsz-lsp/src/completions/context.rs\` (19 sites)
- \`crates/tsz-checker/src/types/utilities/enum_utils.rs\` (12 sites)
- \`crates/tsz-checker/src/types/computation/complex_constructors.rs\` (5)
- \`crates/tsz-lsp/src/highlighting/semantic_tokens.rs\` (3)
- \`crates/tsz-lsp/src/navigation/implementation.rs\` (2)
- \`crates/tsz-lsp/src/hover/core.rs\` (2)
- \`crates/tsz-checker/src/types/queries/core.rs\` (2)
- \`crates/tsz-checker/src/types/computation/identifier/{core,resolution}.rs\` (2 + 2)
- \`crates/tsz-lsp/src/symbols/symbol_index.rs\`, \`rename/core.rs\`, \`checker/types/computation/access_super.rs\` (1 each)

Pure refactor; semantics identical (\`(flags & MASK) != 0\` ≡ \`has_any_flags(MASK)\`).

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy -p tsz-lsp -p tsz-checker --all-targets -- -D warnings\`
- [x] \`cargo nextest run -p tsz-lsp -p tsz-checker\` — 8682 passed, 36 skipped
- [x] Pre-commit pipeline (fmt + clippy + wasm32 rustc + arch-guard) green