### PR TITLE
perf(binder): Arc-wrap module_augmentations to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -49,7 +49,7 @@ impl BinderState {
                 if self.in_module_augmentation
                     && let Some(ref module_spec) = self.current_augmented_module
                 {
-                    self.module_augmentations
+                    Arc::make_mut(&mut self.module_augmentations)
                         .entry(module_spec.clone())
                         .or_default()
                         .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
@@ -154,7 +154,7 @@ impl BinderState {
                 if self.in_module_augmentation
                     && let Some(ref module_spec) = self.current_augmented_module
                 {
-                    self.module_augmentations
+                    Arc::make_mut(&mut self.module_augmentations)
                         .entry(module_spec.clone())
                         .or_default()
                         .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
@@ -616,7 +616,7 @@ impl BinderState {
                 if self.in_module_augmentation
                     && let Some(ref module_spec) = self.current_augmented_module
                 {
-                    self.module_augmentations
+                    Arc::make_mut(&mut self.module_augmentations)
                         .entry(module_spec.clone())
                         .or_default()
                         .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
@@ -856,7 +856,7 @@ impl BinderState {
             if self.in_module_augmentation
                 && let Some(ref module_spec) = self.current_augmented_module
             {
-                self.module_augmentations
+                Arc::make_mut(&mut self.module_augmentations)
                     .entry(module_spec.clone())
                     .or_default()
                     .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
@@ -950,7 +950,7 @@ impl BinderState {
             if self.in_module_augmentation
                 && let Some(ref module_spec) = self.current_augmented_module
             {
-                self.module_augmentations
+                Arc::make_mut(&mut self.module_augmentations)
                     .entry(module_spec.clone())
                     .or_default()
                     .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
@@ -1058,7 +1058,7 @@ impl BinderState {
             if self.in_module_augmentation
                 && let Some(ref module_spec) = self.current_augmented_module
             {
-                self.module_augmentations
+                Arc::make_mut(&mut self.module_augmentations)
                     .entry(module_spec.clone())
                     .or_default()
                     .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -5,6 +5,7 @@
 
 use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
+use std::sync::Arc;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
@@ -86,7 +87,7 @@ impl BinderState {
                 && let Some(ref module_spec) = self.current_augmented_module
                 && let Some(name) = Self::get_identifier_name(arena, module.name)
             {
-                self.module_augmentations
+                Arc::make_mut(&mut self.module_augmentations)
                     .entry(module_spec.clone())
                     .or_default()
                     .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -198,7 +198,7 @@ impl BinderState {
             debugger: ModuleResolutionDebugger::new(),
             global_augmentations: FxHashMap::default(),
             in_global_augmentation: false,
-            module_augmentations: FxHashMap::default(),
+            module_augmentations: Arc::new(FxHashMap::default()),
             in_module_augmentation: false,
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),
@@ -264,7 +264,7 @@ impl BinderState {
         self.debugger.clear();
         self.global_augmentations.clear();
         self.in_global_augmentation = false;
-        self.module_augmentations.clear();
+        Arc::make_mut(&mut self.module_augmentations).clear();
         self.in_module_augmentation = false;
         self.current_augmented_module = None;
         self.lib_binders.clear();
@@ -415,7 +415,7 @@ impl BinderState {
             debugger: ModuleResolutionDebugger::new(),
             global_augmentations: FxHashMap::default(),
             in_global_augmentation: false,
-            module_augmentations: FxHashMap::default(),
+            module_augmentations: Arc::new(FxHashMap::default()),
             in_module_augmentation: false,
             current_augmented_module: None,
             augmentation_target_modules: FxHashMap::default(),

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -288,7 +288,12 @@ pub struct BinderState {
     // ===== Module Augmentations (Rule #44) =====
     /// Tracks interface/type declarations inside `declare module 'x'` blocks that should
     /// merge with the target module's symbols. Maps module specifier to augmentations.
-    pub module_augmentations: FxHashMap<String, Vec<ModuleAugmentation>>,
+    ///
+    /// Wrapped in `Arc` so the merged cross-file augmentation map can be shared
+    /// across N per-file binders without deep-cloning. Mutations go through
+    /// `Arc::make_mut` (zero-cost when the refcount is 1, which is always
+    /// during binding).
+    pub module_augmentations: Arc<FxHashMap<String, Vec<ModuleAugmentation>>>,
 
     /// Flag indicating we're currently binding inside a module augmentation block
     pub(crate) in_module_augmentation: bool,
@@ -800,7 +805,7 @@ pub struct BinderStateScopeInputs {
     pub scopes: Vec<Scope>,
     pub node_scope_ids: FxHashMap<u32, ScopeId>,
     pub global_augmentations: FxHashMap<String, Vec<GlobalAugmentation>>,
-    pub module_augmentations: FxHashMap<String, Vec<ModuleAugmentation>>,
+    pub module_augmentations: Arc<FxHashMap<String, Vec<ModuleAugmentation>>>,
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
     pub module_exports: FxHashMap<String, SymbolTable>,
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1821,7 +1821,7 @@ mod index_tests {
     #[test]
     fn global_module_augmentations_index_merges_across_binders() {
         let mut binder1 = BinderState::new();
-        binder1.module_augmentations.insert(
+        std::sync::Arc::make_mut(&mut binder1.module_augmentations).insert(
             "./module-a".to_string(),
             vec![ModuleAugmentation::new(
                 "MyInterface".to_string(),
@@ -1829,7 +1829,7 @@ mod index_tests {
             )],
         );
         let mut binder2 = BinderState::new();
-        binder2.module_augmentations.insert(
+        std::sync::Arc::make_mut(&mut binder2.module_augmentations).insert(
             "./module-a".to_string(),
             vec![ModuleAugmentation::new(
                 "MyOtherInterface".to_string(),
@@ -1851,11 +1851,11 @@ mod index_tests {
     #[test]
     fn global_module_augmentations_index_separates_module_specifiers() {
         let mut binder = BinderState::new();
-        binder.module_augmentations.insert(
+        std::sync::Arc::make_mut(&mut binder.module_augmentations).insert(
             "./module-a".to_string(),
             vec![ModuleAugmentation::new("Foo".to_string(), NodeIndex(10))],
         );
-        binder.module_augmentations.insert(
+        std::sync::Arc::make_mut(&mut binder.module_augmentations).insert(
             "./module-b".to_string(),
             vec![ModuleAugmentation::new("Bar".to_string(), NodeIndex(20))],
         );

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -121,7 +121,7 @@ impl<'a> CheckerState<'a> {
 
         if let Some(all_binders) = self.ctx.all_binders.as_ref() {
             for (augmenting_file_idx, binder) in all_binders.iter().enumerate() {
-                for (module_spec, augmentations) in &binder.module_augmentations {
+                for (module_spec, augmentations) in binder.module_augmentations.iter() {
                     for aug in augmentations {
                         consider_augmentation(module_spec, augmenting_file_idx, aug);
                     }
@@ -130,7 +130,7 @@ impl<'a> CheckerState<'a> {
             return resolved;
         }
 
-        for (module_spec, augmentations) in &self.ctx.binder.module_augmentations {
+        for (module_spec, augmentations) in self.ctx.binder.module_augmentations.iter() {
             for aug in augmentations {
                 consider_augmentation(module_spec, augmentation_owner_file_idx(aug), aug);
             }

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -320,7 +320,7 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or(self.ctx.current_file_idx)
         };
 
-        for (module_spec, augmentations) in &self.ctx.binder.module_augmentations {
+        for (module_spec, augmentations) in self.ctx.binder.module_augmentations.iter() {
             for augmentation in augmentations {
                 consider_augmentation(
                     module_spec,
@@ -344,7 +344,7 @@ impl<'a> CheckerState<'a> {
                 if augmenting_file_idx == self.ctx.current_file_idx {
                     continue;
                 }
-                for (module_spec, augmentations) in &binder.module_augmentations {
+                for (module_spec, augmentations) in binder.module_augmentations.iter() {
                     for augmentation in augmentations {
                         consider_augmentation(module_spec, augmenting_file_idx, augmentation);
                     }

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1440,7 +1440,12 @@ pub(super) const fn is_checker_grammar_code_suppressed_in_js(code: u32) -> bool 
 /// Pre-computed merged augmentation data shared across all per-file binders.
 /// Computing this once avoids `O(N_files²)` iteration in [`create_binder_from_bound_file`].
 pub(super) struct MergedAugmentations {
-    pub module_augmentations: rustc_hash::FxHashMap<String, Vec<tsz::binder::ModuleAugmentation>>,
+    /// Cross-file merged module augmentations.
+    ///
+    /// Wrapped in `Arc` so per-file binders can share the merged map via
+    /// `Arc::clone` instead of deep-cloning the entire map into each binder.
+    pub module_augmentations:
+        std::sync::Arc<rustc_hash::FxHashMap<String, Vec<tsz::binder::ModuleAugmentation>>>,
     pub augmentation_target_modules: rustc_hash::FxHashMap<tsz::binder::SymbolId, String>,
     pub global_augmentations: rustc_hash::FxHashMap<String, Vec<tsz::binder::GlobalAugmentation>>,
 }
@@ -1489,7 +1494,7 @@ impl MergedAugmentations {
         }
 
         Self {
-            module_augmentations,
+            module_augmentations: std::sync::Arc::new(module_augmentations),
             augmentation_target_modules,
             global_augmentations,
         }

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -498,7 +498,7 @@ pub struct BindResult {
     pub global_augmentations: FxHashMap<String, Vec<crate::binder::GlobalAugmentation>>,
     /// Module augmentations (interface/type declarations inside `declare module 'x'` blocks)
     /// Maps module specifier -> [`ModuleAugmentation`]
-    pub module_augmentations: FxHashMap<String, Vec<crate::binder::ModuleAugmentation>>,
+    pub module_augmentations: Arc<FxHashMap<String, Vec<crate::binder::ModuleAugmentation>>>,
     /// Maps symbols declared inside module augmentation blocks to their target module specifier
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
     /// Re-exports: tracks `export { x } from 'module'` declarations
@@ -636,7 +636,7 @@ impl BindResult {
         }
 
         // module_augmentations
-        for (k, v) in &self.module_augmentations {
+        for (k, v) in self.module_augmentations.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             size += v.capacity() * std::mem::size_of::<crate::binder::ModuleAugmentation>();
             for aug in v {
@@ -1480,7 +1480,7 @@ impl BoundFile {
         }
 
         // module_augmentations
-        for (k, v) in &self.module_augmentations {
+        for (k, v) in self.module_augmentations.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             size += v.capacity() * std::mem::size_of::<crate::binder::ModuleAugmentation>();
             for aug in v {
@@ -4688,7 +4688,7 @@ pub fn create_binder_from_bound_file(
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
             global_augmentations: file.global_augmentations.clone(),
-            module_augmentations: file.module_augmentations.clone(),
+            module_augmentations: Arc::new(file.module_augmentations.clone()),
             augmentation_target_modules: file.augmentation_target_modules.clone(),
             module_exports: program.module_exports.clone(),
             module_declaration_exports_publicly: file.module_declaration_exports_publicly.clone(),
@@ -4779,7 +4779,7 @@ pub fn create_binder_from_bound_file_with_shared(
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
             global_augmentations: file.global_augmentations.clone(),
-            module_augmentations: file.module_augmentations.clone(),
+            module_augmentations: Arc::new(file.module_augmentations.clone()),
             augmentation_target_modules: file.augmentation_target_modules.clone(),
             module_exports: program.module_exports.clone(),
             module_declaration_exports_publicly: file.module_declaration_exports_publicly.clone(),

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -8491,7 +8491,7 @@ var e: Date = c.b();
             scopes: file1_bound.scopes.clone(),
             node_scope_ids: file1_bound.node_scope_ids.clone(),
             global_augmentations: file1_bound.global_augmentations.clone(),
-            module_augmentations: file1_bound.module_augmentations.clone(),
+            module_augmentations: std::sync::Arc::new(file1_bound.module_augmentations.clone()),
             augmentation_target_modules: file1_bound.augmentation_target_modules.clone(),
             module_exports: program.module_exports.clone(),
             module_declaration_exports_publicly: file1_bound


### PR DESCRIPTION
## Summary

Mirrors the lib_symbol_ids treatment in #932, the shorthand_ambient_modules treatment in #935, the wildcard_reexports treatment in #944, the reexports treatment in #948, the module_exports treatment in #954, and the lib_binders treatment in #960.

The CLI driver merges per-file `module_augmentations` into a single cross-file `MergedAugmentations.module_augmentations` map once per compilation, then deep-clones that map into every one of N per-file checker binders. On large repos with many ambient modules this is a substantial allocation tax — N copies of a structurally identical map.

## Changes

- Makes the field `Arc<FxHashMap<String, Vec<ModuleAugmentation>>>` on `BinderState`, `BinderStateScopeInputs`, `BindResult`, and `MergedAugmentations`.
- Routes mutation sites through `Arc::make_mut` (zero-cost when refcount=1, which is always during binding):
  - `state/core.rs::reset` (clear)
  - `binding/declaration.rs` (6 sites: variable/interface/namespace declarations inside `declare module` blocks)
  - `modules/binding.rs` (anonymous-module promotion path)
- Wraps the `MergedAugmentations` accumulator in `Arc::new` once at construction so per-file binders can `Arc::clone` (O(1)) instead of deep-cloning.
- Updates the four iter sites in the checker to use `.iter()` since `Arc<HashMap>` doesn't implement `IntoIterator` for `&Self`.

## Test plan
- [x] `cargo nextest run -p tsz-binder -p tsz-core -p tsz-checker` (8247 passed, 47 skipped)
- [x] `scripts/conformance/conformance.sh run --filter moduleAugmentation --max 30` (no regression)
- [x] Pre-commit hook (clippy + nextest + arch guardrails) green