### PR TITLE
chore(parser): add NodeArena::is_declare helper and migrate callers

### DIFF
--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -110,11 +110,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        if self
-            .ctx
-            .arena
-            .has_modifier_ref(module.modifiers.as_ref(), SyntaxKind::DeclareKeyword)
-        {
+        if self.ctx.arena.is_declare_ref(module.modifiers.as_ref()) {
             return true;
         }
 

--- a/crates/tsz-checker/src/state/state_checking/dts_rules.rs
+++ b/crates/tsz-checker/src/state/state_checking/dts_rules.rs
@@ -82,10 +82,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            let has_declare = self
-                .ctx
-                .arena
-                .has_modifier(modifiers, tsz_scanner::SyntaxKind::DeclareKeyword);
+            let has_declare = self.ctx.arena.is_declare(modifiers);
             let has_export = self
                 .ctx
                 .arena

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -88,11 +88,7 @@ impl<'a> CheckerState<'a> {
             use crate::diagnostics::{diagnostic_messages, format_message};
 
             // TS8009: Modifiers like 'declare' can only be used in TypeScript files
-            if self
-                .ctx
-                .arena
-                .has_modifier(&prop.modifiers, tsz_scanner::SyntaxKind::DeclareKeyword)
-            {
+            if self.ctx.arena.is_declare(&prop.modifiers) {
                 let message = format_message(
                     diagnostic_messages::THE_MODIFIER_CAN_ONLY_BE_USED_IN_TYPESCRIPT_FILES,
                     &["declare"],

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -81,10 +81,7 @@ impl<'a> CheckerState<'a> {
         // `T[keyof T]["foo"]` in return types. Limited to declare functions to
         // avoid triggering side effects from type evaluation in function bodies.
         if let Some(func) = self.ctx.arena.get_function(node)
-            && self
-                .ctx
-                .arena
-                .has_modifier(&func.modifiers, tsz_scanner::SyntaxKind::DeclareKeyword)
+            && self.ctx.arena.is_declare(&func.modifiers)
             && func.type_annotation != tsz_parser::parser::NodeIndex::NONE
         {
             self.check_type_node(func.type_annotation);

--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -153,11 +153,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Skip ambient enums (they use TS1066)
-        if self
-            .ctx
-            .arena
-            .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.ctx.arena.is_declare(&enum_data.modifiers) {
             return;
         }
 

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -725,9 +725,9 @@ impl<'a> CheckerState<'a> {
                 // Check if parent is a module with `declare` modifier
                 if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
                     && let Some(m) = arena.get_module(parent_node)
-                    && m.modifiers.as_ref().is_some_and(|mods| {
-                        arena.has_modifier_ref(Some(mods), SyntaxKind::DeclareKeyword)
-                    })
+                    && m.modifiers
+                        .as_ref()
+                        .is_some_and(|mods| arena.is_declare_ref(Some(mods)))
                 {
                     return true;
                 }
@@ -744,9 +744,10 @@ impl<'a> CheckerState<'a> {
                     let has_direct_export = m.modifiers.as_ref().is_some_and(|mods| {
                         arena.has_modifier_ref(Some(mods), SyntaxKind::ExportKeyword)
                     });
-                    let has_declare = m.modifiers.as_ref().is_some_and(|mods| {
-                        arena.has_modifier_ref(Some(mods), SyntaxKind::DeclareKeyword)
-                    });
+                    let has_declare = m
+                        .modifiers
+                        .as_ref()
+                        .is_some_and(|mods| arena.is_declare_ref(Some(mods)));
                     Some(
                         has_direct_export
                             || has_declare
@@ -761,9 +762,10 @@ impl<'a> CheckerState<'a> {
                 let has_direct_export = f.modifiers.as_ref().is_some_and(|mods| {
                     arena.has_modifier_ref(Some(mods), SyntaxKind::ExportKeyword)
                 });
-                let has_declare = f.modifiers.as_ref().is_some_and(|mods| {
-                    arena.has_modifier_ref(Some(mods), SyntaxKind::DeclareKeyword)
-                });
+                let has_declare = f
+                    .modifiers
+                    .as_ref()
+                    .is_some_and(|mods| arena.is_declare_ref(Some(mods)));
                 has_direct_export
                     || has_declare
                     || is_inside_export_decl()
@@ -773,9 +775,10 @@ impl<'a> CheckerState<'a> {
                 let has_direct_export = c.modifiers.as_ref().is_some_and(|mods| {
                     arena.has_modifier_ref(Some(mods), SyntaxKind::ExportKeyword)
                 });
-                let has_declare = c.modifiers.as_ref().is_some_and(|mods| {
-                    arena.has_modifier_ref(Some(mods), SyntaxKind::DeclareKeyword)
-                });
+                let has_declare = c
+                    .modifiers
+                    .as_ref()
+                    .is_some_and(|mods| arena.is_declare_ref(Some(mods)));
                 has_direct_export
                     || has_declare
                     || is_inside_export_decl()
@@ -785,9 +788,10 @@ impl<'a> CheckerState<'a> {
                 let has_direct_export = e.modifiers.as_ref().is_some_and(|mods| {
                     arena.has_modifier_ref(Some(mods), SyntaxKind::ExportKeyword)
                 });
-                let has_declare = e.modifiers.as_ref().is_some_and(|mods| {
-                    arena.has_modifier_ref(Some(mods), SyntaxKind::DeclareKeyword)
-                });
+                let has_declare = e
+                    .modifiers
+                    .as_ref()
+                    .is_some_and(|mods| arena.is_declare_ref(Some(mods)));
                 has_direct_export
                     || has_declare
                     || is_inside_export_decl()

--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -210,9 +210,7 @@ impl<'a> DeclarationEmitter<'a> {
         // separately inside `should_emit_public_api_module`.
         if !is_exported
             && self.public_api_filter_enabled()
-            && self
-                .arena
-                .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
+            && self.arena.is_declare(&module.modifiers)
         {
             let is_identifier_namespace = self
                 .arena
@@ -349,9 +347,7 @@ impl<'a> DeclarationEmitter<'a> {
             // A namespace is ambient if it has `declare`, or if the source
             // is a .d.ts file, or if it's nested inside an ambient namespace
             // (but NOT if it's nested inside a non-ambient namespace).
-            let is_ambient_ns = self
-                .arena
-                .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
+            let is_ambient_ns = self.arena.is_declare(&module.modifiers)
                 || self.source_is_declaration_file
                 || (prev_inside_declare_namespace && !prev_inside_non_ambient_namespace);
             if is_ambient_ns {
@@ -394,9 +390,7 @@ impl<'a> DeclarationEmitter<'a> {
                 // body when there is a mix of exported and non-exported
                 // members (the "scope-fix marker").
                 // Use emission-time tracking instead of source analysis.
-                let is_ambient_module = self
-                    .arena
-                    .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
+                let is_ambient_module = self.arena.is_declare(&module.modifiers)
                     || self.source_is_declaration_file
                     || (prev_inside_declare_namespace && !prev_inside_non_ambient_namespace);
 

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -1315,11 +1315,7 @@ impl<'a> DeclarationEmitter<'a> {
         if self.should_emit_export_keyword() {
             self.write("export ");
         }
-        if self
-            .arena
-            .has_modifier(&alias.modifiers, SyntaxKind::DeclareKeyword)
-            && !self.inside_declare_namespace
-        {
+        if self.arena.is_declare(&alias.modifiers) && !self.inside_declare_namespace {
             self.write("declare ");
         }
         self.write("type ");

--- a/crates/tsz-emitter/src/declaration_emitter/interfaces.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/interfaces.rs
@@ -36,9 +36,7 @@ impl<'a> DeclarationEmitter<'a> {
             self.write("export ");
         }
         // Preserve the `declare` modifier from the source when present
-        let has_declare = self
-            .arena
-            .has_modifier(&iface.modifiers, SyntaxKind::DeclareKeyword);
+        let has_declare = self.arena.is_declare(&iface.modifiers);
         if has_declare {
             self.write("declare ");
         }

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -15,10 +15,7 @@ impl<'a> Printer<'a> {
         };
 
         // Skip ambient declarations (declare class)
-        if self
-            .arena
-            .has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&class.modifiers) {
             self.skip_comments_for_erased_node(node);
             return;
         }

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -117,9 +117,7 @@ impl<'a> Printer<'a> {
                     .arena
                     .get(prop_data.name)
                     .is_none_or(|n| n.kind != SyntaxKind::PrivateIdentifier as u16)
-                && !self
-                    .arena
-                    .has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword)
+                && !self.arena.is_declare(&prop_data.modifiers)
             {
                 let Some(name_node) = self.arena.get(prop_data.name) else {
                     continue;

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -18,10 +18,7 @@ impl<'a> Printer<'a> {
         };
 
         // Skip ambient declarations (declare function)
-        if self
-            .arena
-            .has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&func.modifiers) {
             self.skip_comments_for_erased_node(node);
             return;
         }
@@ -318,10 +315,7 @@ impl<'a> Printer<'a> {
         };
 
         // Skip ambient enums (always erased) and const enums (erased unless preserveConstEnums)
-        if self
-            .arena
-            .has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&enum_decl.modifiers) {
             self.skip_comments_for_erased_node(node);
             return;
         }

--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -70,10 +70,7 @@ impl<'a> Printer<'a> {
         };
 
         // Skip ambient module declarations (declare namespace/module)
-        if self
-            .arena
-            .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&module.modifiers) {
             self.skip_comments_for_erased_node(node);
             return;
         }
@@ -1062,10 +1059,7 @@ impl<'a> Printer<'a> {
         &self,
         module: &tsz_parser::parser::node::ModuleData,
     ) -> bool {
-        if self
-            .arena
-            .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&module.modifiers) {
             return self.ambient_module_body_has_runtime_value(module.body);
         }
 
@@ -1279,9 +1273,7 @@ impl<'a> Printer<'a> {
                 if self.get_identifier_text_idx(class.name) != name {
                     return None;
                 }
-                let runtime = !self
-                    .arena
-                    .has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword);
+                let runtime = !self.arena.is_declare(&class.modifiers);
                 Some((runtime, None))
             }
             k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
@@ -1289,10 +1281,7 @@ impl<'a> Printer<'a> {
                 if self.get_identifier_text_idx(func.name) != name {
                     return None;
                 }
-                let runtime = !self
-                    .arena
-                    .has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
-                    && func.body.is_some();
+                let runtime = !self.arena.is_declare(&func.modifiers) && func.body.is_some();
                 Some((runtime, None))
             }
             k if k == syntax_kind_ext::ENUM_DECLARATION => {
@@ -1300,9 +1289,7 @@ impl<'a> Printer<'a> {
                 if self.get_identifier_text_idx(enum_decl.name) != name {
                     return None;
                 }
-                let runtime = !self
-                    .arena
-                    .has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword)
+                let runtime = !self.arena.is_declare(&enum_decl.modifiers)
                     && !self
                         .arena
                         .has_modifier(&enum_decl.modifiers, SyntaxKind::ConstKeyword);
@@ -1327,9 +1314,7 @@ impl<'a> Printer<'a> {
                 // Structure: VariableStatement → declarations: [VariableDeclarationList]
                 //            VariableDeclarationList → declarations: [VariableDeclaration, ...]
                 let var_stmt = self.arena.get_variable(stmt_node)?;
-                let is_declare = self
-                    .arena
-                    .has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword);
+                let is_declare = self.arena.is_declare(&var_stmt.modifiers);
                 for &list_or_decl_idx in &var_stmt.declarations.nodes {
                     let Some(list_or_decl_node) = self.arena.get(list_or_decl_idx) else {
                         continue;

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -1118,10 +1118,7 @@ impl<'a> Printer<'a> {
         };
 
         // Skip ambient declarations (declare function)
-        if self
-            .arena
-            .has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&func.modifiers) {
             return;
         }
 

--- a/crates/tsz-emitter/src/emitter/source_file/const_enums.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/const_enums.rs
@@ -193,10 +193,7 @@ impl<'a> Printer<'a> {
         }
 
         // Skip ambient (declare) enums — they may reference values from other files
-        if self
-            .arena
-            .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&enum_data.modifiers) {
             return;
         }
 

--- a/crates/tsz-emitter/src/enums/checker.rs
+++ b/crates/tsz-emitter/src/enums/checker.rs
@@ -74,9 +74,7 @@ impl<'a> EnumChecker<'a> {
         let is_const = self
             .arena
             .has_modifier(&enum_data.modifiers, SyntaxKind::ConstKeyword);
-        let is_ambient = self
-            .arena
-            .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword);
+        let is_ambient = self.arena.is_declare(&enum_data.modifiers);
 
         // Evaluate enum values
         let mut evaluator = EnumEvaluator::new(self.arena);

--- a/crates/tsz-emitter/src/enums/transform.rs
+++ b/crates/tsz-emitter/src/enums/transform.rs
@@ -128,10 +128,7 @@ impl<'a> EnumTransformer<'a> {
         };
 
         // Check for ambient (declare enum) - always erased
-        if self
-            .arena
-            .has_modifier(&enum_data.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&enum_data.modifiers) {
             return true;
         }
 

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -776,10 +776,7 @@ impl<'a> LoweringPass<'a> {
         }
 
         // Skip ambient declarations (declare class)
-        if self
-            .arena
-            .has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&class.modifiers) {
             return;
         }
 
@@ -1144,9 +1141,7 @@ impl<'a> LoweringPass<'a> {
         };
 
         // Skip ambient and const enums (declare/const enums are erased)
-        if self
-            .arena
-            .has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword)
+        if self.arena.is_declare(&enum_decl.modifiers)
             || self.has_const_modifier(&enum_decl.modifiers)
         {
             return;
@@ -1222,10 +1217,7 @@ impl<'a> LoweringPass<'a> {
         };
 
         // Skip ambient declarations (declare namespace/module)
-        if self
-            .arena
-            .has_modifier(&module_decl.modifiers, SyntaxKind::DeclareKeyword)
-        {
+        if self.arena.is_declare(&module_decl.modifiers) {
             return;
         }
 

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -1264,9 +1264,7 @@ impl<'a> LoweringPass<'a> {
                             && self
                                 .arena
                                 .has_modifier(&var_stmt.modifiers, SyntaxKind::ExportKeyword)
-                            && !self
-                                .arena
-                                .has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword)
+                            && !self.arena.is_declare(&var_stmt.modifiers)
                         {
                             return true;
                         }
@@ -1276,9 +1274,7 @@ impl<'a> LoweringPass<'a> {
                             && self
                                 .arena
                                 .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
-                            && !self
-                                .arena
-                                .has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
+                            && !self.arena.is_declare(&func.modifiers)
                         {
                             return true;
                         }
@@ -1288,9 +1284,7 @@ impl<'a> LoweringPass<'a> {
                             && self
                                 .arena
                                 .has_modifier(&class.modifiers, SyntaxKind::ExportKeyword)
-                            && !self
-                                .arena
-                                .has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword)
+                            && !self.arena.is_declare(&class.modifiers)
                         {
                             return true;
                         }
@@ -1300,9 +1294,7 @@ impl<'a> LoweringPass<'a> {
                             && self
                                 .arena
                                 .has_modifier(&enum_decl.modifiers, SyntaxKind::ExportKeyword)
-                            && !self
-                                .arena
-                                .has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword)
+                            && !self.arena.is_declare(&enum_decl.modifiers)
                             && !self.has_const_modifier(&enum_decl.modifiers)
                         {
                             return true;
@@ -1313,9 +1305,7 @@ impl<'a> LoweringPass<'a> {
                             && self
                                 .arena
                                 .has_modifier(&module.modifiers, SyntaxKind::ExportKeyword)
-                            && !self
-                                .arena
-                                .has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
+                            && !self.arena.is_declare(&module.modifiers)
                         {
                             return true;
                         }

--- a/crates/tsz-emitter/src/transforms/module_commonjs.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs.rs
@@ -236,7 +236,7 @@ fn collect_export_name_from_declaration(
     match decl_node.kind {
         k if k == syntax_kind_ext::CLASS_DECLARATION => {
             if let Some(class) = arena.get_class(decl_node) {
-                if arena.has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword) {
+                if arena.is_declare(&class.modifiers) {
                     return;
                 }
                 if let Some(name) = get_identifier_text(arena, class.name) {
@@ -246,7 +246,7 @@ fn collect_export_name_from_declaration(
         }
         k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
             if let Some(func) = arena.get_function(decl_node) {
-                if arena.has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword) {
+                if arena.is_declare(&func.modifiers) {
                     return;
                 }
                 // Skip overload signatures (no body) — if the implementation
@@ -263,7 +263,7 @@ fn collect_export_name_from_declaration(
         }
         k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
             if let Some(var_stmt) = arena.get_variable(decl_node) {
-                if arena.has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword) {
+                if arena.is_declare(&var_stmt.modifiers) {
                     return;
                 }
                 for &decl_idx in &var_stmt.declarations.nodes {
@@ -273,7 +273,7 @@ fn collect_export_name_from_declaration(
         }
         k if k == syntax_kind_ext::ENUM_DECLARATION => {
             if let Some(enum_decl) = arena.get_enum(decl_node) {
-                if arena.has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword) {
+                if arena.is_declare(&enum_decl.modifiers) {
                     return;
                 }
                 if arena.has_modifier(&enum_decl.modifiers, SyntaxKind::ConstKeyword)
@@ -288,7 +288,7 @@ fn collect_export_name_from_declaration(
         }
         k if k == syntax_kind_ext::MODULE_DECLARATION => {
             if let Some(module) = arena.get_module(decl_node) {
-                if arena.has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword) {
+                if arena.is_declare(&module.modifiers) {
                     return;
                 }
                 if !super::emit_utils::is_instantiated_module_ext(
@@ -777,7 +777,7 @@ pub fn collect_export_names_with_options(
             k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
                 if let Some(var_stmt) = arena.get_variable(node)
                     && arena.has_modifier(&var_stmt.modifiers, SyntaxKind::ExportKeyword)
-                    && !arena.has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword)
+                    && !arena.is_declare(&var_stmt.modifiers)
                 {
                     for &decl_idx in &var_stmt.declarations.nodes {
                         collect_declaration_names(arena, decl_idx, &mut exports);
@@ -792,7 +792,7 @@ pub fn collect_export_names_with_options(
             k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                 if let Some(func) = arena.get_function(node)
                     && arena.has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
-                    && !arena.has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
+                    && !arena.is_declare(&func.modifiers)
                     && func.body.is_some()
                     && let Some(name) = get_identifier_text(arena, func.name)
                     && !exports.contains(&name)
@@ -804,7 +804,7 @@ pub fn collect_export_names_with_options(
             k if k == syntax_kind_ext::CLASS_DECLARATION => {
                 if let Some(class) = arena.get_class(node)
                     && arena.has_modifier(&class.modifiers, SyntaxKind::ExportKeyword)
-                    && !arena.has_modifier(&class.modifiers, SyntaxKind::DeclareKeyword)
+                    && !arena.is_declare(&class.modifiers)
                     && let Some(name) = get_identifier_text(arena, class.name)
                 {
                     exports.push(name);
@@ -814,7 +814,7 @@ pub fn collect_export_names_with_options(
             k if k == syntax_kind_ext::ENUM_DECLARATION => {
                 if let Some(enum_decl) = arena.get_enum(node)
                     && arena.has_modifier(&enum_decl.modifiers, SyntaxKind::ExportKeyword)
-                    && !arena.has_modifier(&enum_decl.modifiers, SyntaxKind::DeclareKeyword)
+                    && !arena.is_declare(&enum_decl.modifiers)
                     && (preserve_const_enums
                         || !arena.has_modifier(&enum_decl.modifiers, SyntaxKind::ConstKeyword))
                     && let Some(name) = get_identifier_text(arena, enum_decl.name)
@@ -826,7 +826,7 @@ pub fn collect_export_names_with_options(
             k if k == syntax_kind_ext::MODULE_DECLARATION => {
                 if let Some(module) = arena.get_module(node)
                     && arena.has_modifier(&module.modifiers, SyntaxKind::ExportKeyword)
-                    && !arena.has_modifier(&module.modifiers, SyntaxKind::DeclareKeyword)
+                    && !arena.is_declare(&module.modifiers)
                     && super::emit_utils::is_instantiated_module_ext(
                         arena,
                         module.body,
@@ -922,7 +922,7 @@ pub fn collect_export_names_categorized(
         if node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
             if let Some(func) = arena.get_function(node)
                 && arena.has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
-                && !arena.has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
+                && !arena.is_declare(&func.modifiers)
                 && func.body.is_some()
                 && let Some(name) = get_identifier_text(arena, func.name)
                 && !func_exports.iter().any(|(e, _)| e == &name)
@@ -941,7 +941,7 @@ pub fn collect_export_names_categorized(
             && let Some(clause_node) = arena.get(export_decl.export_clause)
             && clause_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
             && let Some(func) = arena.get_function(clause_node)
-            && !arena.has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
+            && !arena.is_declare(&func.modifiers)
             && func.body.is_some()
             && let Some(name) = get_identifier_text(arena, func.name)
             && !func_exports.iter().any(|(e, _)| e == &name)
@@ -959,7 +959,7 @@ pub fn collect_export_names_categorized(
             && let Some(clause_node) = arena.get(export_decl.export_clause)
             && clause_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
             && let Some(func) = arena.get_function(clause_node)
-            && !arena.has_modifier(&func.modifiers, SyntaxKind::DeclareKeyword)
+            && !arena.is_declare(&func.modifiers)
             && func.body.is_some() // skip overload signatures (no body)
             && let Some(name) = get_identifier_text(arena, func.name)
         {
@@ -1029,7 +1029,7 @@ pub fn collect_export_names_categorized(
                 let var_has_name = |n: &Node| -> bool {
                     if n.kind == syntax_kind_ext::VARIABLE_STATEMENT
                         && let Some(var_stmt) = arena.get_variable(n)
-                        && !arena.has_modifier(&var_stmt.modifiers, SyntaxKind::DeclareKeyword)
+                        && !arena.is_declare(&var_stmt.modifiers)
                     {
                         let mut names = Vec::new();
                         for &decl_idx in &var_stmt.declarations.nodes {

--- a/crates/tsz-parser/src/parser/node_modifiers.rs
+++ b/crates/tsz-parser/src/parser/node_modifiers.rs
@@ -63,6 +63,25 @@ impl NodeArena {
         None
     }
 
+    /// Check whether a modifier list contains `declare`.
+    ///
+    /// Shortcut for `has_modifier(modifiers, SyntaxKind::DeclareKeyword)`,
+    /// the most common single-kind query across the emitter lowering and
+    /// declaration-file pipelines (ambient-namespace detection, CommonJS
+    /// lowering, const-enum gating).
+    #[inline]
+    #[must_use]
+    pub fn is_declare(&self, modifiers: &Option<NodeList>) -> bool {
+        self.has_modifier(modifiers, SyntaxKind::DeclareKeyword)
+    }
+
+    /// Like [`is_declare`](Self::is_declare) but accepts `Option<&NodeList>`.
+    #[inline]
+    #[must_use]
+    pub fn is_declare_ref(&self, modifiers: Option<&NodeList>) -> bool {
+        self.has_modifier_ref(modifiers, SyntaxKind::DeclareKeyword)
+    }
+
     /// Extract the visibility level from a modifier list.
     ///
     /// Scans for `private` or `protected` keywords; returns `Public` if neither is found.


### PR DESCRIPTION
## Summary

- Adds `NodeArena::is_declare(&Option<NodeList>)` and `is_declare_ref(Option<&NodeList>)` wrappers around `has_modifier(..., DeclareKeyword)` — the second-most common single-kind modifier query after `static` (added in #970).
- Migrates 55 call sites across 20 uncontested checker + emitter files; multi-line `.has_modifier(\n    &x.modifiers,\n    SyntaxKind::DeclareKeyword,\n)` calls collapse to a single line, producing a net **-52 LOC**.
- Files touched by concurrent in-flight PRs (#921, #924, #931, #943, #955, #959, #963, #970, #972) were intentionally skipped to avoid rebase churn; those sites can land in a follow-up once those PRs merge.

## Why

`DeclareKeyword` gates a lot of emitter and checker decisions (ambient namespace detection, CommonJS lowering, const-enum handling, .d.ts behavior). Centralizing the query into a named predicate makes intent clearer at the call site and gives a single place to audit future rule changes.

## Test plan

- [x] `cargo check -p tsz-parser -p tsz-checker -p tsz-emitter` clean
- [x] `cargo nextest run -p tsz-parser -p tsz-emitter --lib` → 1941 passed
- [x] Full pre-commit pipeline: fmt + clippy + wasm32 rustc + arch guard + 19318 tests — all passed