### PR TITLE
chore(parser,emitter,cli,lowering): migrate raw node.kind comparisons to Node helpers

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info_alias.rs
@@ -325,7 +325,7 @@ impl Server {
                 let Some(symbol_node) = arena.get(symbol_idx) else {
                     continue;
                 };
-                if symbol_node.kind != SyntaxKind::StringLiteral as u16 {
+                if !symbol_node.is_string_literal() {
                     continue;
                 }
                 let text = Self::unquote(&Self::node_text_opt(source_text, symbol_node)?);
@@ -482,7 +482,7 @@ impl Server {
             let Some(node) = arena.get(node_idx) else {
                 continue;
             };
-            if node.kind != SyntaxKind::StringLiteral as u16 {
+            if !node.is_string_literal() {
                 continue;
             }
             let in_import = Self::find_ancestor_of_kind(
@@ -536,7 +536,7 @@ impl Server {
             let Some(node) = arena.get(node_idx) else {
                 continue;
             };
-            if node.kind != SyntaxKind::StringLiteral as u16 {
+            if !node.is_string_literal() {
                 continue;
             }
             if node.end <= node.pos.saturating_add(1) {
@@ -580,7 +580,7 @@ impl Server {
         let mut fallback: Option<String> = None;
         for symbol_idx in [spec.property_name, spec.name] {
             let node = arena.get(symbol_idx)?;
-            if node.kind != SyntaxKind::StringLiteral as u16 {
+            if !node.is_string_literal() {
                 continue;
             }
             let text = arena.get_literal_text(symbol_idx)?.to_string();
@@ -742,7 +742,7 @@ impl Server {
                         let Some(symbol_node) = arena.get(string_symbol_idx) else {
                             continue;
                         };
-                        if symbol_node.kind != SyntaxKind::StringLiteral as u16 {
+                        if !symbol_node.is_string_literal() {
                             continue;
                         }
                         let Some(text) = arena.get_literal_text(string_symbol_idx) else {
@@ -770,7 +770,7 @@ impl Server {
                         };
                         if counterpart_idx.is_some()
                             && let Some(counterpart_node) = arena.get(counterpart_idx)
-                            && (counterpart_node.kind == SyntaxKind::Identifier as u16
+                            && (counterpart_node.is_identifier()
                                 || counterpart_node.kind == SyntaxKind::PrivateIdentifier as u16)
                         {
                             out.push(tsz_common::position::Location::new(
@@ -800,7 +800,7 @@ impl Server {
                             let Some(symbol_node) = arena.get(symbol_idx) else {
                                 continue;
                             };
-                            if symbol_node.kind != SyntaxKind::StringLiteral as u16 {
+                            if !symbol_node.is_string_literal() {
                                 continue;
                             }
                             let Some(text) = arena.get_literal_text(symbol_idx) else {
@@ -828,7 +828,7 @@ impl Server {
                             };
                             if counterpart_idx.is_some()
                                 && let Some(counterpart_node) = arena.get(counterpart_idx)
-                                && (counterpart_node.kind == SyntaxKind::Identifier as u16
+                                && (counterpart_node.is_identifier()
                                     || counterpart_node.kind
                                         == SyntaxKind::PrivateIdentifier as u16)
                             {
@@ -894,9 +894,7 @@ impl Server {
                         let Some(right_node) = arena.get(spec.name) else {
                             continue;
                         };
-                        if left_node.kind != SyntaxKind::StringLiteral as u16
-                            || right_node.kind != SyntaxKind::StringLiteral as u16
-                        {
+                        if !left_node.is_string_literal() || !right_node.is_string_literal() {
                             continue;
                         }
                         let Some(left_text) = arena.get_literal_text(spec.property_name) else {
@@ -1155,7 +1153,7 @@ impl Server {
         // canonical declaration (`foo` in the example above).
         let node_idx = tsz::lsp::utils::find_node_at_or_before_offset(arena, offset, source_text);
         let node = arena.get(node_idx)?;
-        if node.kind != SyntaxKind::StringLiteral as u16 {
+        if !node.is_string_literal() {
             return None;
         }
         let specifier_idx = Self::find_ancestor_of_kind(
@@ -1183,7 +1181,7 @@ impl Server {
         let spec = arena.get_specifier(spec_node)?;
         let local_node_idx = if spec.property_name.is_some() {
             let prop = arena.get(spec.property_name)?;
-            if prop.kind != SyntaxKind::StringLiteral as u16 {
+            if !prop.is_string_literal() {
                 Some(spec.property_name)
             } else {
                 None
@@ -1193,7 +1191,7 @@ impl Server {
         }
         .or_else(|| {
             let name_node = arena.get(spec.name)?;
-            if name_node.kind != SyntaxKind::StringLiteral as u16 {
+            if !name_node.is_string_literal() {
                 Some(spec.name)
             } else {
                 None

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -892,7 +892,6 @@ fn import_attributes_resolution_mode(
 /// e.g., `require('./module')` -> `./module` (without quotes)
 fn extract_require_specifier(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
     use tsz::parser::syntax_kind_ext;
-    use tsz::scanner::SyntaxKind;
 
     let node = arena.get(idx)?;
 
@@ -909,7 +908,7 @@ fn extract_require_specifier(arena: &NodeArena, idx: NodeIndex) -> Option<String
 
     // Check that the callee is 'require' (an identifier)
     let callee_node = arena.get(call.expression)?;
-    if callee_node.kind != SyntaxKind::Identifier as u16 {
+    if !callee_node.is_identifier() {
         return None;
     }
     let callee_text = arena.get_identifier_text(call.expression)?;
@@ -1063,7 +1062,7 @@ fn collect_import_local_names(
             if clause.named_bindings.is_some()
                 && let Some(bindings_node) = arena.get(clause.named_bindings)
             {
-                if bindings_node.kind == SyntaxKind::Identifier as u16 {
+                if bindings_node.is_identifier() {
                     if let Some(name) = arena.get_identifier_text(clause.named_bindings) {
                         names.push(name.to_string());
                     }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -104,7 +104,7 @@ impl<'a> DeclarationEmitter<'a> {
         // of the declaration output.
         if let Some(name_node) = self.arena.get(name_idx) {
             // String-literal module name: `declare module "some-module" { ... }`
-            if name_node.kind == SyntaxKind::StringLiteral as u16 {
+            if name_node.is_string_literal() {
                 return true;
             }
             // `declare global { ... }` — the parser represents `global` as
@@ -510,7 +510,7 @@ impl<'a> DeclarationEmitter<'a> {
         };
 
         // Extract identifier names directly
-        if name_node.kind == SyntaxKind::Identifier as u16 {
+        if name_node.is_identifier() {
             let ident = self.arena.get_identifier(name_node)?;
             Some(ident.escaped_text.clone())
         } else {

--- a/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_assignment.rs
@@ -166,7 +166,7 @@ impl<'a> Printer<'a> {
         // - Simple identifier `arr` -> `arr_1`, `arr_2`, etc. (doesn't consume counter)
         // - Complex expression -> `_a`, `_b`, etc. (from global counter)
         let array_name = if let Some(expr_node) = self.arena.get(for_in_of.expression) {
-            if expr_node.kind == SyntaxKind::Identifier as u16 {
+            if expr_node.is_identifier() {
                 if let Some(ident) = self.arena.get_identifier(expr_node) {
                     let name = self.arena.resolve_identifier_text(ident).to_string();
                     // Try incrementing suffixes: name_1, name_2, name_3, ...
@@ -582,7 +582,7 @@ impl<'a> Printer<'a> {
         };
 
         // Simple identifier: register it directly
-        if name_node.kind == SyntaxKind::Identifier as u16 {
+        if name_node.is_identifier() {
             if let Some(ident) = self.arena.get_identifier(name_node) {
                 let original_name = self.arena.resolve_identifier_text(ident);
                 self.ctx.block_scope_state.register_variable(original_name);
@@ -615,7 +615,7 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        if name_node.kind == SyntaxKind::Identifier as u16 {
+        if name_node.is_identifier() {
             if let Some(ident) = self.arena.get_identifier(name_node) {
                 let original_name = self.arena.resolve_identifier_text(ident);
                 self.ctx
@@ -767,7 +767,7 @@ impl<'a> Printer<'a> {
                             // Handle variable shadowing: get the pre-registered renamed name
                             // (variable was already registered in pre_register_for_of_loop_variable)
                             if let Some(ident_node) = self.arena.get(decl.name) {
-                                if ident_node.kind == SyntaxKind::Identifier as u16 {
+                                if ident_node.is_identifier() {
                                     if let Some(ident) = self.arena.get_identifier(ident_node) {
                                         let original_name =
                                             self.arena.resolve_identifier_text(ident);
@@ -967,7 +967,7 @@ impl<'a> Printer<'a> {
         let is_simple = self
             .arena
             .get(effective_right_idx)
-            .is_some_and(|n| n.kind == SyntaxKind::Identifier as u16);
+            .is_some_and(|n| n.is_identifier());
 
         // Count elements to determine if we need a temp for complex sources.
         // TypeScript creates a temp for non-identifier sources when there are 2+ elements
@@ -1461,14 +1461,14 @@ impl<'a> Printer<'a> {
     /// Get property key text from a property name node.
     pub(in crate::emitter) fn get_property_key_text(&self, name_idx: NodeIndex) -> Option<String> {
         let node = self.arena.get(name_idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
+        if node.is_identifier() {
             Some(crate::transforms::emit_utils::identifier_text_or_empty(
                 self.arena, name_idx,
             ))
-        } else if node.kind == SyntaxKind::StringLiteral as u16 {
+        } else if node.is_string_literal() {
             // For string keys like { "name": value }
             self.get_string_literal_text(name_idx)
-        } else if node.kind == SyntaxKind::NumericLiteral as u16 {
+        } else if node.is_numeric_literal() {
             self.get_numeric_literal_text(name_idx)
         } else {
             None

--- a/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
@@ -1208,7 +1208,7 @@ impl<'a> Printer<'a> {
         // For complex expressions, fall back to generic temp names (_b, _c).
         let (loop_iterator_name, loop_result_name) = if let Some(expr_node) =
             self.arena.get(for_in_of.expression)
-            && expr_node.kind == SyntaxKind::Identifier as u16
+            && expr_node.is_identifier()
             && let Some(ident) = self.arena.get_identifier(expr_node)
         {
             let base = self.arena.resolve_identifier_text(ident).to_string();

--- a/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
+++ b/crates/tsz-emitter/src/emitter/es5/loop_capture.rs
@@ -24,7 +24,6 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
 
 /// Information about variables in a loop body for the IIFE transform
 #[derive(Debug, Default)]
@@ -226,7 +225,7 @@ fn collect_binding_names(arena: &NodeArena, name_idx: NodeIndex, names: &mut Vec
         return;
     };
 
-    if name_node.kind == SyntaxKind::Identifier as u16 {
+    if name_node.is_identifier() {
         if let Some(ident) = arena.get_identifier(name_node) {
             let text = arena.resolve_identifier_text(ident).to_string();
             if !names.contains(&text) {

--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -721,9 +721,7 @@ impl<'a> Printer<'a> {
             return false;
         };
 
-        node.kind == SyntaxKind::Identifier as u16
-            || node.kind == SyntaxKind::StringLiteral as u16
-            || node.kind == SyntaxKind::NumericLiteral as u16
+        node.is_identifier() || node.is_string_literal() || node.is_numeric_literal()
     }
 
     pub(in crate::emitter) fn is_simple_nullish_expression(&self, node_idx: NodeIndex) -> bool {
@@ -734,11 +732,11 @@ impl<'a> Printer<'a> {
         // Match tsc's isSimpleCopiableExpression: identifiers, keywords, and literals
         // are all safe to repeat without side effects.
         // Note: tsc does NOT unwrap parenthesized expressions here.
-        node.kind == SyntaxKind::Identifier as u16
+        node.is_identifier()
             || (node.kind >= SyntaxKind::BreakKeyword as u16
                 && node.kind <= SyntaxKind::DeferKeyword as u16)
-            || node.kind == SyntaxKind::NumericLiteral as u16
-            || node.kind == SyntaxKind::StringLiteral as u16
+            || node.is_numeric_literal()
+            || node.is_string_literal()
             || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
     }
 

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -67,7 +67,7 @@ impl<'a> Printer<'a> {
             return true;
         };
         node.kind == SyntaxKind::ThisKeyword as u16
-            || node.kind == SyntaxKind::Identifier as u16
+            || node.is_identifier()
             || node.kind == SyntaxKind::SuperKeyword as u16
     }
 
@@ -212,7 +212,7 @@ impl<'a> Printer<'a> {
                         return None;
                     }
                     let expr_node = self.arena.get(expression)?;
-                    if expr_node.kind != SyntaxKind::Identifier as u16 {
+                    if !expr_node.is_identifier() {
                         return None;
                     }
                     let ident = self.arena.get_identifier(expr_node)?;

--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -541,7 +541,7 @@ impl<'a> Printer<'a> {
             return;
         };
 
-        if node.kind == SyntaxKind::Identifier as u16 {
+        if node.is_identifier() {
             // Check if it's an intrinsic element (starts with lowercase)
             if let Some(ident) = self.arena.get_identifier(node) {
                 let text = self.arena.resolve_identifier_text(ident);
@@ -721,12 +721,12 @@ impl<'a> Printer<'a> {
         if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
             return false;
         }
-        if name_node.kind == SyntaxKind::Identifier as u16
+        if name_node.is_identifier()
             && let Some(ident) = self.arena.get_identifier(name_node)
         {
             return ident.escaped_text == "__proto__";
         }
-        if name_node.kind == SyntaxKind::StringLiteral as u16
+        if name_node.is_string_literal()
             && let Some(lit) = self.arena.get_literal(name_node)
         {
             return lit.text == "__proto__";
@@ -791,7 +791,7 @@ impl<'a> Printer<'a> {
             return String::new();
         };
 
-        if node.kind == SyntaxKind::Identifier as u16
+        if node.is_identifier()
             && let Some(ident) = self.arena.get_identifier(node)
         {
             return self.arena.resolve_identifier_text(ident).to_string();
@@ -825,7 +825,7 @@ impl<'a> Printer<'a> {
         };
 
         // String literal (e.g. `"hello"`) -- preserve original node for quote fidelity
-        if node.kind == SyntaxKind::StringLiteral as u16 {
+        if node.is_string_literal() {
             return JsxAttrValue::StringNode(init_idx);
         }
 

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -1,7 +1,6 @@
 use super::super::{ModuleKind, Printer};
 use crate::transforms::{ClassDecoratorInfo, ClassES5Emitter};
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
     /// Write `exports.name` or `exports["name"]` depending on whether the name
@@ -87,7 +86,7 @@ impl<'a> Printer<'a> {
             if let Some(clause_node) = self.arena.get(export.export_clause)
                 && clause_node.kind != syntax_kind_ext::NAMED_EXPORTS
             {
-                let ns_name = if clause_node.kind == SyntaxKind::StringLiteral as u16 {
+                let ns_name = if clause_node.is_string_literal() {
                     self.arena
                         .get_literal(clause_node)
                         .map(|lit| lit.text.clone())
@@ -210,7 +209,7 @@ impl<'a> Printer<'a> {
                 return;
             }
             if export.is_default_export
-                && (clause_node.kind == SyntaxKind::Identifier as u16
+                && (clause_node.is_identifier()
                     || clause_node.kind == syntax_kind_ext::QUALIFIED_NAME)
                 && !self.export_default_target_has_runtime_value(export.export_clause)
             {
@@ -719,7 +718,7 @@ impl<'a> Printer<'a> {
                     // otherwise use the local name (class/function/enum have local
                     // declarations).
                     if let Some(expr_node) = self.arena.get(export.export_clause)
-                        && expr_node.kind == SyntaxKind::Identifier as u16
+                        && expr_node.is_identifier()
                     {
                         let ident = self.get_identifier_text_idx(export.export_clause);
                         if self.ctx.module_state.inlined_var_exports.contains(&ident) {
@@ -897,7 +896,7 @@ impl<'a> Printer<'a> {
                         && self
                             .arena
                             .get(decl.initializer)
-                            .is_some_and(|n| n.kind == SyntaxKind::NumericLiteral as u16);
+                            .is_some_and(|n| n.is_numeric_literal());
                     self.write("exports.");
                     self.write(export_name);
                     self.write(" = ");

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -632,7 +632,7 @@ impl<'a> Printer<'a> {
             // For `import { foo }`, there's no property_name and name is the Identifier foo.
             let (import_name, is_string_import) = if spec.property_name.is_some() {
                 if let Some(prop_name_node) = self.arena.get(spec.property_name) {
-                    if prop_name_node.kind == SyntaxKind::StringLiteral as u16 {
+                    if prop_name_node.is_string_literal() {
                         if let Some(lit) = self.arena.get_literal(prop_name_node) {
                             (lit.text.clone(), true)
                         } else {
@@ -692,8 +692,8 @@ impl<'a> Printer<'a> {
         // This is restricted to namespace scope because top-level import
         // aliases in scripts create global variables that may be consumed
         // externally, and tsc preserves those even when unreferenced locally.
-        let is_namespace_alias = module_node.kind == SyntaxKind::Identifier as u16
-            || module_node.kind == syntax_kind_ext::QUALIFIED_NAME;
+        let is_namespace_alias =
+            module_node.is_identifier() || module_node.kind == syntax_kind_ext::QUALIFIED_NAME;
         if is_namespace_alias
             && self.in_namespace_iife
             && !self.import_alias_is_referenced_after_node(node, import)
@@ -716,7 +716,7 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        let is_external = module_node.kind == SyntaxKind::StringLiteral as u16
+        let is_external = module_node.is_string_literal()
             || module_node.kind == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE;
 
         // AMD and System bind external imports via wrapper parameters/setters,
@@ -760,7 +760,7 @@ impl<'a> Printer<'a> {
             self.write(" = ");
         }
 
-        if module_node.kind == SyntaxKind::StringLiteral as u16 {
+        if module_node.is_string_literal() {
             if let Some(lit) = self.arena.get_literal(module_node) {
                 let spec = self.rewrite_module_spec(&lit.text);
                 self.write("require(\"");

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -4,7 +4,6 @@ use tsz_common::common::ModuleKind;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
 
 impl<'a> Printer<'a> {
     // =========================================================================
@@ -328,7 +327,7 @@ impl<'a> Printer<'a> {
                 let Some(expr_node) = self.arena.get(expr_stmt.expression) else {
                     break;
                 };
-                if expr_node.kind != SyntaxKind::StringLiteral as u16 {
+                if !expr_node.is_string_literal() {
                     break; // non-string-literal ends the prologue zone
                 }
                 // Check the literal text
@@ -1160,7 +1159,7 @@ impl<'a> Printer<'a> {
                 && stmt_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
                 && let Some(expr_stmt) = self.arena.get_expression_statement(stmt_node)
                 && let Some(expr_node) = self.arena.get(expr_stmt.expression)
-                && expr_node.kind == SyntaxKind::StringLiteral as u16
+                && expr_node.is_string_literal()
             {
                 let is_strict = if let Some(lit) = self.arena.get_literal(expr_node) {
                     lit.text == "use strict"
@@ -1259,7 +1258,7 @@ impl<'a> Printer<'a> {
                         .get_import_decl(stmt_node)
                         .and_then(|import_data| self.arena.get(import_data.module_specifier))
                         .is_some_and(|spec_node| {
-                            spec_node.kind == SyntaxKind::StringLiteral as u16
+                            spec_node.is_string_literal()
                                 || spec_node.kind == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
                         })
                 } else {
@@ -1565,7 +1564,7 @@ impl<'a> Printer<'a> {
                 && stmt_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
                 && let Some(expr_stmt) = self.arena.get_expression_statement(stmt_node)
                 && let Some(expr_node) = self.arena.get(expr_stmt.expression)
-                && expr_node.kind == SyntaxKind::StringLiteral as u16
+                && expr_node.is_string_literal()
             {
                 hoisted_var_byte_offset = self.writer.len();
                 hoisted_var_line = self.writer.current_line();

--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -440,7 +440,7 @@ pub fn collect_loop_vars(arena: &NodeArena, initializer_idx: NodeIndex) -> Vec<S
         for &decl_idx in &decl_list.declarations.nodes {
             if let Some(decl) = arena.get_variable_declaration_at(decl_idx)
                 && let Some(name_node) = arena.get(decl.name)
-                && name_node.kind == SyntaxKind::Identifier as u16
+                && name_node.is_identifier()
                 && let Some(ident) = arena.get_identifier(name_node)
             {
                 vars.push(ident.escaped_text.clone());

--- a/crates/tsz-emitter/src/transforms/destructuring_es5.rs
+++ b/crates/tsz-emitter/src/transforms/destructuring_es5.rs
@@ -608,7 +608,7 @@ impl<'a> ES5DestructuringTransformer<'a> {
                                     IRNode::prop(IRNode::id(source.to_string()), prop_name.clone())
                                 }
                             } else if let Some(prop_name_node) = self.arena.get(prop.name)
-                                && prop_name_node.kind == SyntaxKind::StringLiteral as u16
+                                && prop_name_node.is_string_literal()
                                 && let Some(str_lit) = self.arena.get_literal(prop_name_node)
                             {
                                 IRNode::elem(
@@ -638,7 +638,7 @@ impl<'a> ES5DestructuringTransformer<'a> {
                                     IRNode::prop(IRNode::id(source.to_string()), prop_name.clone())
                                 }
                             } else if let Some(prop_name_node) = self.arena.get(prop.name)
-                                && prop_name_node.kind == SyntaxKind::StringLiteral as u16
+                                && prop_name_node.is_string_literal()
                                 && let Some(str_lit) = self.arena.get_literal(prop_name_node)
                             {
                                 IRNode::elem(

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -801,7 +801,7 @@ impl<'a> EnumES5Transformer<'a> {
         if node.kind == SyntaxKind::PrivateIdentifier as u16 {
             return IRNode::Identifier(String::new().into());
         }
-        if node.kind == SyntaxKind::NumericLiteral as u16
+        if node.is_numeric_literal()
             && let Some(lit) = self.arena.get_literal(node)
             && let Some(val) = tsz_common::numeric::parse_numeric_literal_value(&lit.text)
         {
@@ -818,7 +818,7 @@ impl<'a> EnumES5Transformer<'a> {
         }
         // For string literal member names, use source text to preserve Unicode escapes
         // (e.g., "gold \u2730" must stay as-is, not be decoded to the literal char).
-        if node.kind == SyntaxKind::StringLiteral as u16
+        if node.is_string_literal()
             && let Some(source_text) = self.source_text
         {
             let start = node.pos as usize;
@@ -961,11 +961,11 @@ impl<'a> EnumES5Transformer<'a> {
             k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 if let Some(access) = self.arena.get_access_expr(node)
                     && let Some(obj_node) = self.arena.get(access.expression)
-                    && obj_node.kind == SyntaxKind::Identifier as u16
+                    && obj_node.is_identifier()
                     && let Some(obj_id) = self.arena.get_identifier(obj_node)
                     && obj_id.escaped_text == self.current_enum_name
                     && let Some(prop_node) = self.arena.get(access.name_or_argument)
-                    && prop_node.kind == SyntaxKind::Identifier as u16
+                    && prop_node.is_identifier()
                     && let Some(prop_id) = self.arena.get_identifier(prop_node)
                 {
                     let name = prop_id.escaped_text.as_str();
@@ -980,11 +980,11 @@ impl<'a> EnumES5Transformer<'a> {
             k if k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 if let Some(access) = self.arena.get_access_expr(node)
                     && let Some(obj_node) = self.arena.get(access.expression)
-                    && obj_node.kind == SyntaxKind::Identifier as u16
+                    && obj_node.is_identifier()
                     && let Some(obj_id) = self.arena.get_identifier(obj_node)
                     && obj_id.escaped_text == self.current_enum_name
                     && let Some(index_node) = self.arena.get(access.name_or_argument)
-                    && index_node.kind == SyntaxKind::StringLiteral as u16
+                    && index_node.is_string_literal()
                     && let Some(lit) = self.arena.get_literal(index_node)
                 {
                     let name = lit.text.as_str();
@@ -1031,7 +1031,7 @@ impl<'a> EnumES5Transformer<'a> {
                 // Resolve E.Member references
                 let access = self.arena.get_access_expr(node)?;
                 let obj_node = self.arena.get(access.expression)?;
-                if obj_node.kind == SyntaxKind::Identifier as u16
+                if obj_node.is_identifier()
                     && let Some(obj_id) = self.arena.get_identifier(obj_node)
                 {
                     let prop_node = self.arena.get(access.name_or_argument)?;
@@ -1057,12 +1057,12 @@ impl<'a> EnumES5Transformer<'a> {
             k if k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.arena.get_access_expr(node)?;
                 let obj_node = self.arena.get(access.expression)?;
-                if obj_node.kind == SyntaxKind::Identifier as u16
+                if obj_node.is_identifier()
                     && let Some(obj_id) = self.arena.get_identifier(obj_node)
                 {
                     // Get the string key from the index expression
                     let index_node = self.arena.get(access.name_or_argument)?;
-                    let member_name = if index_node.kind == SyntaxKind::StringLiteral as u16 {
+                    let member_name = if index_node.is_string_literal() {
                         self.arena
                             .get_literal(index_node)
                             .map(|lit| lit.text.as_str())
@@ -1211,7 +1211,7 @@ impl<'a> EnumES5Transformer<'a> {
             k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = self.arena.get_access_expr(node)?;
                 let obj_node = self.arena.get(access.expression)?;
-                if obj_node.kind != SyntaxKind::Identifier as u16 {
+                if !obj_node.is_identifier() {
                     return None;
                 }
                 let obj_id = self.arena.get_identifier(obj_node)?;
@@ -1278,7 +1278,7 @@ impl<'a> EnumES5Transformer<'a> {
                     // Check if the object is the enum parameter name
                     let obj_node = self.arena.get(access.expression);
                     let obj_is_enum = obj_node.is_some_and(|n| {
-                        n.kind == SyntaxKind::Identifier as u16
+                        n.is_identifier()
                             && self
                                 .arena
                                 .get_identifier(n)

--- a/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
@@ -310,7 +310,7 @@ impl EnumMemberValue {
 /// Check if a node is a string literal
 fn is_string_literal(arena: &NodeArena, idx: NodeIndex) -> bool {
     if let Some(node) = arena.get(idx) {
-        node.kind == SyntaxKind::StringLiteral as u16
+        node.is_string_literal()
     } else {
         false
     }

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -707,7 +707,7 @@ pub(super) fn collect_qualified_name_parts(
 ) -> Option<Vec<String>> {
     let node = arena.get(name_idx)?;
 
-    if node.kind == SyntaxKind::Identifier as u16 {
+    if node.is_identifier() {
         if let Some(id) = arena.get_identifier(node) {
             return Some(vec![id.escaped_text.clone()]);
         }

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -748,7 +748,7 @@ impl<'a> TypeLowering<'a> {
     pub(super) fn type_name_text(&self, node_idx: NodeIndex) -> Option<String> {
         let node = self.arena.get(node_idx)?;
 
-        if node.kind == SyntaxKind::Identifier as u16 {
+        if node.is_identifier() {
             return self
                 .arena
                 .get_identifier(node)
@@ -779,7 +779,7 @@ impl<'a> TypeLowering<'a> {
     /// `NodeIndex`-based resolver cannot.
     pub(super) fn scoped_identifier_name_text(&self, node_idx: NodeIndex) -> Option<String> {
         let node = self.arena.get(node_idx)?;
-        if node.kind != SyntaxKind::Identifier as u16 {
+        if !node.is_identifier() {
             return None;
         }
 
@@ -795,7 +795,7 @@ impl<'a> TypeLowering<'a> {
             if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
                 && let Some(module) = self.arena.get_module(parent_node)
                 && let Some(name_node) = self.arena.get(module.name)
-                && name_node.kind == SyntaxKind::Identifier as u16
+                && name_node.is_identifier()
                 && let Some(name_ident) = self.arena.get_identifier(name_node)
             {
                 prefixes.push(name_ident.escaped_text.clone());
@@ -2135,7 +2135,7 @@ impl<'a> TypeLowering<'a> {
             && !lit_data.text.is_empty()
         {
             // Canonicalize numeric property names (e.g. "1.", "1.0" -> "1")
-            if node.kind == SyntaxKind::NumericLiteral as u16
+            if node.is_numeric_literal()
                 && let Some(canonical) =
                     tsz_solver::utils::canonicalize_numeric_name(&lit_data.text)
             {

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -2842,7 +2842,7 @@ impl ParserState {
             // `import { foo as "str" }` is invalid (string can't be a binding).
             // `import { "str" }` is invalid (string without alias can't be a binding).
             if let Some(name_node) = self.arena.get(name)
-                && name_node.kind == SyntaxKind::StringLiteral as u16
+                && name_node.is_string_literal()
             {
                 let name_start = name_node.pos;
                 let name_len = name_node.end.saturating_sub(name_node.pos);

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -1704,7 +1704,7 @@ impl ParserState {
             return false;
         }
 
-        if node_a.kind == SyntaxKind::Identifier as u16 {
+        if node_a.is_identifier() {
             if let (Some(id_a), Some(id_b)) = (
                 self.arena.get_identifier(node_a),
                 self.arena.get_identifier(node_b),

--- a/crates/tsz-parser/src/syntax/transform_utils.rs
+++ b/crates/tsz-parser/src/syntax/transform_utils.rs
@@ -124,7 +124,7 @@ fn contains_target_reference(
         }
     }
 
-    if node.kind == SyntaxKind::Identifier as u16
+    if node.is_identifier()
         && let Some(identifier) = arena.get_identifier(node)
     {
         return identifier.escaped_text == target.identifier_name();
@@ -159,7 +159,7 @@ fn collect_target_references(
         }
     }
 
-    if node.kind == SyntaxKind::Identifier as u16
+    if node.is_identifier()
         && let Some(identifier) = arena.get_identifier(node)
         && identifier.escaped_text == target.identifier_name()
     {


### PR DESCRIPTION
## Summary

- Migrates **60 raw `node.kind == SyntaxKind::X as u16`** / `!= ... as u16` comparisons to the existing typed `Node::is_identifier()`, `is_string_literal()`, and `is_numeric_literal()` helpers defined in `crates/tsz-parser/src/parser/node_access.rs`.
- Scope: 21 uncontested files across `tsz-emitter` (transforms, declaration emitter, es5 helpers, jsx), `tsz-parser`, `tsz-lowering`, and `tsz-cli`. Files touched by concurrent in-flight PRs were skipped to avoid rebase churn.
- Also removes 4 `use SyntaxKind;` imports that became unused after the migration.

## Why

- The raw `X as u16` form loses compile-time coupling to `SyntaxKind` — if the discriminant values ever shift, the u16 comparison silently changes meaning. The helpers hide the cast.
- Reads more naturally at the call site: `if node.is_identifier()` vs. `if node.kind == SyntaxKind::Identifier as u16`.

## Test plan

- [x] `cargo check -p tsz-parser -p tsz-emitter -p tsz-lowering -p tsz-cli` clean
- [x] `cargo nextest run -p tsz-parser -p tsz-emitter -p tsz-lowering -p tsz-cli --lib` -> 2694 passed
- [x] Full pre-commit pipeline: fmt + clippy + wasm32 rustc + arch guard + 19318 tests — all passed