### PR TITLE
fix(solver): validate evaluated spread constraints for IndexAccess and KeyOf

### DIFF
--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -178,6 +178,88 @@ fn spread_type_param_constrained_to_string_is_invalid() {
     assert!(!is_valid_spread_type(&db, tp_id));
 }
 
+#[test]
+fn spread_index_access_uses_base_constraint_before_validation() {
+    // `T["text"]` where `T extends { text: string }` resolves to a primitive
+    // base constraint and is invalid for object rest, while `T["object"]`
+    // resolves to an object constraint and remains valid.
+    let db = TypeInterner::new();
+    let text = db.intern_string("text");
+    let object = db.intern_string("object");
+    let object_type = db.object(vec![]);
+    let constraint = db.object(vec![
+        PropertyInfo {
+            name: text,
+            type_id: TypeId::STRING,
+            write_type: TypeId::STRING,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 0,
+            is_string_named: false,
+        },
+        PropertyInfo {
+            name: object,
+            type_id: object_type,
+            write_type: object_type,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 1,
+            is_string_named: false,
+        },
+    ]);
+    let tp = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    };
+    let tp_id = db.type_param(tp);
+
+    let text_access = db.index_access(tp_id, db.literal_string("text"));
+    assert!(!is_valid_spread_type(&db, text_access));
+
+    let object_access = db.index_access(tp_id, db.literal_string("object"));
+    assert!(is_valid_spread_type(&db, object_access));
+}
+
+#[test]
+fn spread_keyof_type_param_is_invalid() {
+    // `keyof T` is a property-key primitive union, not an object-like source.
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let constraint = db.object(vec![PropertyInfo {
+        name: prop,
+        type_id: TypeId::STRING,
+        write_type: TypeId::STRING,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: 0,
+        is_string_named: false,
+    }]);
+    let tp = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    };
+    let tp_id = db.type_param(tp);
+    let keyof_tp = db.keyof(tp_id);
+
+    assert!(!is_valid_spread_type(&db, keyof_tp));
+}
+
 // =============================================================================
 // Template literal types and string intrinsics (not spreadable)
 // =============================================================================

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -3,6 +3,7 @@
 //! This module contains the implementation of type query functions.
 //! The parent `mod.rs` re-exports everything; callers should use `type_queries::*`.
 
+use crate::evaluation::evaluate::evaluate_type;
 use crate::types::{IntrinsicKind, LiteralValue};
 use crate::{QueryDatabase, TypeData, TypeDatabase, TypeId};
 
@@ -420,12 +421,13 @@ pub fn is_symbol_or_unique_symbol(db: &dyn TypeDatabase, type_id: TypeId) -> boo
 /// - Object types, arrays, tuples, functions, callables, mapped types
 /// - `object` intrinsic (non-primitive)
 /// - Type parameters whose constraint is spreadable
+/// - Indexed access types whose evaluated base constraint is spreadable
 /// - Unions where non-falsy members are all spreadable
 /// - Intersections where all members are spreadable
 ///
 /// Returns `false` for primitive types (`number`, `string`, `boolean`, etc.),
-/// literals that aren't definitely-falsy, `unknown`, and types that resolve
-/// to these after constraint resolution.
+/// literals that aren't definitely-falsy, `keyof` types, `unknown`, and types
+/// that resolve to these after constraint resolution.
 pub fn is_valid_spread_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     is_valid_spread_type_impl(db, type_id, 0)
 }
@@ -537,6 +539,17 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
                 .all(|&m| is_valid_spread_type_impl(db, m, depth + 1))
         }
         Some(TypeData::ReadonlyType(inner)) => is_valid_spread_type_impl(db, inner, depth + 1),
+        // tsc applies `getBaseConstraintOrType` before checking spread flags.
+        // For type operators that can evaluate against a concrete constraint
+        // (for example `T["x"]` where `T extends { x: Obj }`), validate the
+        // evaluated constraint. If evaluation cannot reduce the operator, do
+        // not assume it is object-like. For `keyof T`, evaluation yields
+        // property-key primitives, which the recursive primitive handling
+        // rejects.
+        Some(TypeData::IndexAccess(_, _) | TypeData::KeyOf(_)) => {
+            let evaluated = evaluate_type(db, resolved);
+            evaluated != resolved && is_valid_spread_type_impl(db, evaluated, depth + 1)
+        }
         // Everything else is spreadable: object types, arrays, tuples, functions,
         // callables, mapped types, type parameters (unconstrained ones reach here
         // and are valid per tsc's InstantiableNonPrimitive), lazy refs, applications, etc.


### PR DESCRIPTION
## Summary
- `is_valid_spread_type` now matches tsc's `getBaseConstraintOrType` step before the spread-flag check: `IndexAccess` and `KeyOf` are evaluated, then their result is re-validated. Unevaluable operators stay non-spreadable rather than getting silently accepted.
- Adds two unit tests in `type_queries_spread_tests.rs` covering `T["x"]` (object vs primitive constraint) and `keyof T` (always invalid — yields a property-key primitive union).

## Why
Without this, a generic `T["x"]` with a primitive constraint or `keyof T` would silently slip past spread validation, leaving invalid spread sources unflagged. tsc rejects both via constraint resolution before the spread-flag walk.

## Provenance
Salvaged from automation worktree `automation/conformance-agent-20260422-165238-315`, which was generated by the conformance loop but never opened a PR before the loop process was terminated. The companion CLI test-alignment commit on that branch is already in `main` from a separate PR, so only the solver fix is being upstreamed here.

## Test plan
- [x] `cargo nextest run -p tsz-solver -E 'test(spread)'` — 59/59 pass, including the two new tests `spread_index_access_uses_base_constraint_before_validation` and `spread_keyof_type_param_is_invalid`.
- [ ] CI: full workspace nextest + conformance.