### PR TITLE
perf(binder): Arc-wrap global_augmentations to share across per-file binders

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -59,7 +59,7 @@ impl BinderState {
                 // as global augmentations, just like interfaces and namespaces.
                 // This enables cross-file conflict detection with UMD exports.
                 if self.in_global_augmentation {
-                    self.global_augmentations
+                    Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
                         .push(crate::state::GlobalAugmentation::new(idx));
@@ -84,7 +84,7 @@ impl BinderState {
                 // This mirrors the interface hoisting at bind_interface_declaration.
                 if self.in_global_augmentation {
                     self.file_locals.set(name.to_string(), sym_id);
-                    self.global_augmentations
+                    Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
                         .push(crate::state::GlobalAugmentation::new(idx));
@@ -114,7 +114,7 @@ impl BinderState {
                         );
                         if self.in_global_augmentation {
                             self.file_locals.set(name.to_string(), sym_id);
-                            self.global_augmentations
+                            Arc::make_mut(&mut self.global_augmentations)
                                 .entry(name.to_string())
                                 .or_default()
                                 .push(crate::state::GlobalAugmentation::new(ident_idx));
@@ -831,7 +831,7 @@ impl BinderState {
             // If we're inside a global augmentation block, track this as an augmentation
             // that should merge with lib.d.ts symbols at type resolution time
             if self.in_global_augmentation {
-                self.global_augmentations
+                Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
                     .push(crate::state::GlobalAugmentation::new(idx));
@@ -845,7 +845,7 @@ impl BinderState {
                 && !self.is_external_module
                 && Self::is_built_in_global_type(name)
             {
-                self.global_augmentations
+                Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
                     .push(crate::state::GlobalAugmentation::new(idx));
@@ -940,7 +940,7 @@ impl BinderState {
             // If we're inside a global augmentation block, track this as an augmentation
             // that should merge with lib.d.ts symbols at type resolution time
             if self.in_global_augmentation {
-                self.global_augmentations
+                Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
                     .push(crate::state::GlobalAugmentation::new(idx));

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -218,7 +218,7 @@ impl BinderState {
                     .insert(idx.0, is_exported);
 
                 if self.in_global_augmentation {
-                    self.global_augmentations
+                    Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.clone())
                         .or_default()
                         .push(crate::state::GlobalAugmentation::new(idx));

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -234,7 +234,7 @@ impl BinderState {
                 // declare_symbol takes is_exported flag.
                 if self.in_global_augmentation {
                     self.file_locals.set(name.to_string(), sym_id);
-                    self.global_augmentations
+                    Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
                         .push(crate::state::GlobalAugmentation::new(idx));

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -196,7 +196,7 @@ impl BinderState {
             node_scope_ids: FxHashMap::with_capacity_and_hasher(64, Default::default()),
             current_scope_id: ScopeId::NONE,
             debugger: ModuleResolutionDebugger::new(),
-            global_augmentations: FxHashMap::default(),
+            global_augmentations: Arc::new(FxHashMap::default()),
             in_global_augmentation: false,
             module_augmentations: Arc::new(FxHashMap::default()),
             in_module_augmentation: false,
@@ -262,7 +262,7 @@ impl BinderState {
         self.node_scope_ids.clear();
         self.current_scope_id = ScopeId::NONE;
         self.debugger.clear();
-        self.global_augmentations.clear();
+        Arc::make_mut(&mut self.global_augmentations).clear();
         self.in_global_augmentation = false;
         Arc::make_mut(&mut self.module_augmentations).clear();
         self.in_module_augmentation = false;
@@ -433,7 +433,7 @@ impl BinderState {
             node_scope_ids: FxHashMap::default(),
             current_scope_id: ScopeId::NONE,
             debugger: ModuleResolutionDebugger::new(),
-            global_augmentations: FxHashMap::default(),
+            global_augmentations: Arc::new(FxHashMap::default()),
             in_global_augmentation: false,
             module_augmentations: Arc::new(FxHashMap::default()),
             in_module_augmentation: false,

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -280,7 +280,11 @@ pub struct BinderState {
     // ===== Global Augmentations =====
     /// Tracks interface/type declarations inside `declare global` blocks that should
     /// merge with lib.d.ts symbols. Maps interface name to augmentation declarations.
-    pub global_augmentations: FxHashMap<String, Vec<GlobalAugmentation>>,
+    ///
+    /// Wrapped in `Arc` so the merged cross-file map can be shared across N
+    /// per-file binders without deep-cloning. Mutations go through
+    /// `Arc::make_mut` (zero-cost when refcount=1, which is always during binding).
+    pub global_augmentations: Arc<FxHashMap<String, Vec<GlobalAugmentation>>>,
 
     /// Flag indicating we're currently binding inside a `declare global` block
     pub(crate) in_global_augmentation: bool,
@@ -808,7 +812,7 @@ pub struct ResolutionStats {
 pub struct BinderStateScopeInputs {
     pub scopes: Vec<Scope>,
     pub node_scope_ids: FxHashMap<u32, ScopeId>,
-    pub global_augmentations: FxHashMap<String, Vec<GlobalAugmentation>>,
+    pub global_augmentations: Arc<FxHashMap<String, Vec<GlobalAugmentation>>>,
     pub module_augmentations: Arc<FxHashMap<String, Vec<ModuleAugmentation>>>,
     pub augmentation_target_modules: Arc<FxHashMap<SymbolId, String>>,
     pub module_exports: Arc<FxHashMap<String, SymbolTable>>,

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1452,7 +1452,12 @@ pub(super) struct MergedAugmentations {
     /// `Arc::clone` instead of deep-cloning the entire map into each binder.
     pub augmentation_target_modules:
         std::sync::Arc<rustc_hash::FxHashMap<tsz::binder::SymbolId, String>>,
-    pub global_augmentations: rustc_hash::FxHashMap<String, Vec<tsz::binder::GlobalAugmentation>>,
+    /// Cross-file merged global augmentations.
+    ///
+    /// Wrapped in `Arc` so per-file binders can share the merged map via
+    /// `Arc::clone` instead of deep-cloning the entire map into each binder.
+    pub global_augmentations:
+        std::sync::Arc<rustc_hash::FxHashMap<String, Vec<tsz::binder::GlobalAugmentation>>>,
 }
 
 impl MergedAugmentations {
@@ -1501,7 +1506,7 @@ impl MergedAugmentations {
         Self {
             module_augmentations: std::sync::Arc::new(module_augmentations),
             augmentation_target_modules: std::sync::Arc::new(augmentation_target_modules),
-            global_augmentations,
+            global_augmentations: std::sync::Arc::new(global_augmentations),
         }
     }
 }

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -495,7 +495,7 @@ pub struct BindResult {
     /// Shorthand ambient modules (`declare module "foo"` without body)
     pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     /// Global augmentations (interface declarations inside `declare global` blocks)
-    pub global_augmentations: FxHashMap<String, Vec<crate::binder::GlobalAugmentation>>,
+    pub global_augmentations: Arc<FxHashMap<String, Vec<crate::binder::GlobalAugmentation>>>,
     /// Module augmentations (interface/type declarations inside `declare module 'x'` blocks)
     /// Maps module specifier -> [`ModuleAugmentation`]
     pub module_augmentations: Arc<FxHashMap<String, Vec<crate::binder::ModuleAugmentation>>>,
@@ -630,7 +630,7 @@ impl BindResult {
         }
 
         // global_augmentations
-        for (k, v) in &self.global_augmentations {
+        for (k, v) in self.global_augmentations.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             size += v.capacity() * std::mem::size_of::<crate::binder::GlobalAugmentation>();
         }
@@ -1474,7 +1474,7 @@ impl BoundFile {
         }
 
         // global_augmentations
-        for (k, v) in &self.global_augmentations {
+        for (k, v) in self.global_augmentations.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             size += v.capacity() * std::mem::size_of::<crate::binder::GlobalAugmentation>();
         }
@@ -3200,7 +3200,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
             scopes: remapped_scopes,
             node_scope_ids: result.node_scope_ids.clone(),
             parse_diagnostics: result.parse_diagnostics.clone(),
-            global_augmentations: result.global_augmentations.clone(),
+            global_augmentations: (*result.global_augmentations).clone(),
             module_augmentations,
             augmentation_target_modules: result
                 .augmentation_target_modules
@@ -4689,7 +4689,7 @@ pub fn create_binder_from_bound_file(
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
-            global_augmentations: file.global_augmentations.clone(),
+            global_augmentations: Arc::new(file.global_augmentations.clone()),
             module_augmentations: Arc::new(file.module_augmentations.clone()),
             augmentation_target_modules: Arc::new(file.augmentation_target_modules.clone()),
             module_exports: program.module_exports.clone(),
@@ -4780,7 +4780,7 @@ pub fn create_binder_from_bound_file_with_shared(
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
-            global_augmentations: file.global_augmentations.clone(),
+            global_augmentations: Arc::new(file.global_augmentations.clone()),
             module_augmentations: Arc::new(file.module_augmentations.clone()),
             augmentation_target_modules: Arc::new(file.augmentation_target_modules.clone()),
             module_exports: program.module_exports.clone(),

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -8490,7 +8490,7 @@ var e: Date = c.b();
         crate::binder::state::BinderStateScopeInputs {
             scopes: file1_bound.scopes.clone(),
             node_scope_ids: file1_bound.node_scope_ids.clone(),
-            global_augmentations: file1_bound.global_augmentations.clone(),
+            global_augmentations: std::sync::Arc::new(file1_bound.global_augmentations.clone()),
             module_augmentations: std::sync::Arc::new(file1_bound.module_augmentations.clone()),
             augmentation_target_modules: std::sync::Arc::new(
                 file1_bound.augmentation_target_modules.clone(),

--- a/crates/tsz-lsp/src/project/core.rs
+++ b/crates/tsz-lsp/src/project/core.rs
@@ -407,7 +407,7 @@ impl ProjectFile {
             b.declaration_arenas.len() * (std::mem::size_of::<(SymbolId, NodeIndex)>() + 32 + 8);
 
         // global_augmentations
-        for (k, v) in &b.global_augmentations {
+        for (k, v) in b.global_augmentations.iter() {
             size += k.capacity() + 8;
             size += v.capacity() * std::mem::size_of::<tsz_binder::GlobalAugmentation>();
         }


### PR DESCRIPTION
## Summary

Mirrors the Arc-wrap pattern in #932, #935, #944, #948, #954, #960, #973, #975.

The CLI driver merges per-file `global_augmentations` into a single cross-file map once per compilation, then deep-clones into every one of N per-file checker binders. On large repos with many `declare global` blocks this is one more chunk of the per-binder allocation tax.

## Changes
- Makes the field `Arc<FxHashMap<String, Vec<GlobalAugmentation>>>` on `BinderState`, `BinderStateScopeInputs`, `BindResult`, and `MergedAugmentations`.
- Routes mutation sites through `Arc::make_mut` (zero-cost when refcount=1):
  - `state/core.rs::reset` (clear)
  - `binding/declaration.rs` (6 sites)
  - `modules/import_export.rs`, `modules/binding.rs`
- Wraps the `MergedAugmentations` accumulator in `Arc::new`.
- Updates the iter site in tsz-lsp to use `.iter()`.

## Test plan
- [x] `cargo nextest run -p tsz-binder -p tsz-core -p tsz-checker` (8247 passed, 47 skipped)
- [x] Pre-commit hook (clippy + nextest + arch guardrails) green