### PR TITLE
fix(checker): synthesized generator TNext defaults to unknown for non-generator annotations

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -32,6 +32,10 @@ stacker = "0.1.23"
 web-time = { workspace = true }
 
 [[test]]
+name = "generator_annotation_mismatch_display_tests"
+path = "tests/generator_annotation_mismatch_display_tests.rs"
+
+[[test]]
 name = "ts1362_false_positive_tests"
 path = "tests/ts1362_false_positive_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -1476,11 +1476,23 @@ impl<'a> CheckerState<'a> {
         });
         if let Some(base) = lazy_base {
             let yield_t = yield_type.unwrap_or(TypeId::ANY);
+            // TNext defaults to `unknown` when the declared return type has no
+            // extractable TYield (i.e., isn't Generator-like). This matches tsc:
+            // `function* g(): number {}` reports `Generator<any, any, unknown>`.
+            // When the declared return type IS Generator-like (provides TYield),
+            // tsc uses `any` for TNext — e.g. `function* g(): BadGenerator {}`
+            // (heritage Iterator<number>, Iterable<string>) reports
+            // `Generator<string, any, any>`.
+            let next_t = if yield_type.is_some() {
+                TypeId::ANY
+            } else {
+                TypeId::UNKNOWN
+            };
             let inferred_gen = self
                 .ctx
                 .types
                 .factory()
-                .application(base, vec![yield_t, TypeId::ANY, TypeId::ANY]);
+                .application(base, vec![yield_t, TypeId::ANY, next_t]);
             self.ensure_relation_input_ready(inferred_gen);
             self.ensure_relation_input_ready(declared_return_type);
             self.check_assignable_or_report(inferred_gen, declared_return_type, error_node);

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -956,11 +956,18 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or(TypeId::ERROR)
             };
             if generator_base != TypeId::ERROR {
-                let any_gen = self
-                    .ctx
-                    .types
-                    .factory()
-                    .application(generator_base, vec![TypeId::ANY, TypeId::ANY, TypeId::ANY]);
+                // For the pre-body protocol check, the declared annotation has no
+                // extractable TYield (the post-body path handles the yield-bearing
+                // cases). TNext therefore defaults to `unknown`, matching tsc's
+                // `Generator<any, any, unknown>` in `function* g(): number {}` and
+                // aligning with the post-body synthesis in
+                // `check_generator_return_type_assignability`. Keeping the two
+                // synthesized types identical lets the (start, code) diagnostic
+                // dedup collapse the redundant emission.
+                let any_gen = self.ctx.types.factory().application(
+                    generator_base,
+                    vec![TypeId::ANY, TypeId::ANY, TypeId::UNKNOWN],
+                );
 
                 // Fast path: if the return type is already recognized as a valid generator type,
                 // we don't need to do the complex structural subtyping check that fails due to overloads.

--- a/crates/tsz-checker/tests/generator_annotation_mismatch_display_tests.rs
+++ b/crates/tsz-checker/tests/generator_annotation_mismatch_display_tests.rs
@@ -1,0 +1,133 @@
+//! Type-display tests for TS2322 on generator functions whose declared
+//! return type isn't Generator-like (or is an iterator-like interface whose
+//! structure diverges from `Generator<Y, R, N>`).
+//!
+//! When a generator is annotated with a non-generator type (e.g., `number`),
+//! the diagnostic synthesizes a "what the body would produce" type of the
+//! form `Generator<TYield, TReturn, TNext>` and compares it against the
+//! declared return type. tsc uses `unknown` for the synthesized `TNext` when
+//! the declared return type exposes no `TYield` (non-generator-like), matching
+//! the `TNext`-from-body-when-no-yield-receivers convention. When the declared
+//! return type IS generator-like (and thus provides a `TYield`), tsc uses
+//! `any` for `TNext` instead.
+//!
+//! Baselines these lock in (from the TypeScript compiler baselines):
+//!   generatorTypeCheck6.ts:   `Generator<any, any, unknown>` vs `number`
+//!   generatorTypeCheck8.ts:   `Generator<string, any, any>` vs `BadGenerator`
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+const GENERATOR_STUBS: &str = r#"
+interface IteratorYieldResult<TYield> { done?: false; value: TYield; }
+interface IteratorReturnResult<TReturn> { done: true; value: TReturn; }
+type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
+interface Iterator<T, TReturn = any, TNext = undefined> {
+    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+    return?(value?: TReturn): IteratorResult<T, TReturn>;
+    throw?(e?: any): IteratorResult<T, TReturn>;
+}
+interface Iterable<T, TReturn = unknown, TNext = unknown> {
+    [Symbol.iterator](): Iterator<T, TReturn, TNext>;
+}
+interface IterableIterator<T, TReturn = any, TNext = undefined> extends Iterator<T, TReturn, TNext> {
+    [Symbol.iterator](): IterableIterator<T, TReturn, TNext>;
+}
+interface Generator<T = unknown, TReturn = any, TNext = any> extends IterableIterator<T, TReturn, TNext> {
+    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+    return(value: TReturn): IteratorResult<T, TReturn>;
+    throw(e: any): IteratorResult<T, TReturn>;
+    [Symbol.iterator](): Generator<T, TReturn, TNext>;
+}
+"#;
+
+fn get_diagnostics(user_source: &str) -> Vec<(u32, String)> {
+    let full_source = format!("{GENERATOR_STUBS}\n{user_source}");
+    let mut parser = ParserState::new("test.ts".to_string(), full_source);
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+#[test]
+fn empty_generator_annotated_with_number_reports_tnext_unknown() {
+    // `function* g1(): number { }` — no yields, no returns, no generator-shaped
+    // context. Synthesized body type should be `Generator<any, any, unknown>`,
+    // not `Generator<any, any, any>`.
+    let diags = get_diagnostics("function* g1(): number { }");
+    let ts2322: Vec<_> = diags.iter().filter(|(code, _)| *code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got {diags:#?}"
+    );
+    let (_, msg) = ts2322[0];
+    assert!(
+        msg.contains("Generator<any, any, unknown>"),
+        "expected body type to display as Generator<any, any, unknown>, got: {msg}"
+    );
+    assert!(
+        msg.contains("'number'"),
+        "expected mismatch against 'number', got: {msg}"
+    );
+}
+
+#[test]
+fn empty_generator_annotated_with_generator_like_keeps_tnext_any() {
+    // `function* g(): BadIter { }` where BadIter extends a single iterator-like
+    // interface — the declared return type exposes a TYield, so the synthesized
+    // body type keeps TNext = `any` (matching tsc's `Generator<T, any, any>`
+    // pattern). This locks in that the TNext fallback-to-`unknown` is gated on
+    // the absence of a yield type, not applied blanketly.
+    let source = r#"
+interface BadIter extends Iterator<number> {
+    extra: string;
+}
+function* g(): BadIter { }
+"#;
+    let diags = get_diagnostics(source);
+    // The mismatch can surface as TS2322 (not assignable) or TS2741 (property
+    // missing) depending on which elaboration path wins. Both render the
+    // synthesized body type.
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| (*code == 2322 || *code == 2741) && msg.contains("Generator<"))
+        .collect();
+    assert!(
+        !relevant.is_empty(),
+        "expected a TS2322/TS2741 rendering the synthesized Generator type, got {diags:#?}"
+    );
+    let msg = relevant[0].1.as_str();
+    // TNext must be `any` (not `unknown`) when a TYield was extractable from
+    // the declared annotation. TYield may print as `number` (from Iterator<number>)
+    // or reflect extraction fallbacks — the invariant under test is the TNext form.
+    assert!(
+        msg.contains(", any, any>"),
+        "expected TNext=any in synthesized Generator type, got: {msg}"
+    );
+    assert!(
+        !msg.contains(", any, unknown>"),
+        "TNext must remain `any` when declared annotation exposes a TYield, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- tsc reports `function* g(): number {}` with `Type 'Generator<any, any, unknown>' is not assignable to type 'number'.`; tsz was emitting `Generator<any, any, any>`, producing a fingerprint-only TS2322 divergence on `generatorTypeCheck6.ts`.
- Two synthesis sites (`compute_generator_body_return_type` in `function_declaration_checks.rs` and `check_generator_return_type_assignability` in `promise_checker.rs`) both hardcoded TNext = `any`. The pre-body emission wins the (start, code) dedup, so the post-body path alone couldn't fix the displayed form.
- Aligned both sites: TNext defaults to `unknown` when the declared annotation exposes no extractable TYield; TNext stays `any` when a TYield is available (preserves `generatorTypeCheck8` baseline `Generator<string, any, any>`).

## Root cause
`tsc` synthesizes the body type used in the TS2322 rendering. When no yield receivers exist and no Generator-shaped context exists, TNext falls back to `unknown`, consistent with the unannotated-generator construction path already in `function_type.rs:2467`. The annotated-generator path had the wrong default hardcoded.

## Reproducer
```ts
function* g1(): number { }
// tsc: Type 'Generator<any, any, unknown>' is not assignable to type 'number'.
// tsz before: Type 'Generator<any, any, any>' is not assignable to type 'number'.
// tsz after:  Type 'Generator<any, any, unknown>' is not assignable to type 'number'.
```

## Impact
- `generatorTypeCheck6.ts` flips fingerprint-only → PASS.
- `types.asyncGenerators.es2018.2.ts` baseline `'() => AsyncGenerator<string, void, any>' ... 'AsyncIterableIterator<number>'` is unaffected (has yields → TYield extracted → TNext stays `any`).
- `generatorTypeCheck8.ts` (BadGenerator) and `generatorTypeCheck31.ts` baselines preserved.
- `verify-all.sh`: conformance +2, emit DTS +16, fourslash no change, 19,969 checker/solver tests pass.

## Test plan
- [x] New `crates/tsz-checker/tests/generator_annotation_mismatch_display_tests.rs` locks both invariants (TNext=`unknown` when no extractable TYield; TNext=`any` when one is extractable).
- [x] `cargo nextest run --package tsz-checker` (all 4978 tests pass).
- [x] `./scripts/conformance/conformance.sh run --filter generatorTypeCheck` confirms `generatorTypeCheck6` passes.
- [x] `scripts/session/verify-all.sh` full run: conformance +2 (12067 vs 12065), no regressions.