### PR TITLE
fix(checker): attribute TS1361/TS1362 to innermost direct type-only marker

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,10 @@ name = "ts1362_false_positive_tests"
 path = "tests/ts1362_false_positive_tests.rs"
 
 [[test]]
+name = "ts1361_chain_attribution_tests"
+path = "tests/ts1361_chain_attribution_tests.rs"
+
+[[test]]
 name = "ts1238_tests"
 path = "tests/ts1238_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -363,6 +363,13 @@ impl<'a> CheckerState<'a> {
 
         let lib_binders = self.get_lib_binders();
 
+        // Whenever an alias is known to be cross-file type-only but no
+        // `import type` / `export type` syntactic marker could be pinpointed
+        // on any alias in the chain, default to TS1362 (Export) at the end.
+        // This preserves the historical "blanket Export" behaviour while
+        // letting a direct `import type` marker win when present.
+        let mut saw_unclassified_cross_file_type_only = false;
+
         // Walk the alias chain to find the first type-only import or export.
         for alias_sym_id in &visited {
             let symbol = match self
@@ -374,48 +381,25 @@ impl<'a> CheckerState<'a> {
                 None => continue,
             };
 
-            // Only applies to alias symbols explicitly marked type-only
-            // Check this FIRST — if the local symbol is marked type-only from
-            // `import type`, that takes precedence over export-side type-only.
+            // Only applies to alias symbols explicitly marked type-only.
+            // A plain `export { X as Y }` that merely re-exports a type-only
+            // symbol is not itself a direct marker — fall through to the
+            // next alias in `visited` in that case.
             if symbol.has_any_flags(symbol_flags::ALIAS) && symbol.is_type_only {
-                // Walk up from the symbol's declaration to determine if it came from
-                // an import or export statement.
+                let arena = self
+                    .ctx
+                    .binder
+                    .symbol_arenas
+                    .get(&alias_sym_id)
+                    .map(|arc| &**arc)
+                    .unwrap_or(self.ctx.arena);
+
                 for &decl in &symbol.declarations {
                     if decl.is_none() {
                         continue;
                     }
-                    let mut current = decl;
-                    let mut guard = 0;
-
-                    // Get the arena for this declaration if it's from a different file
-                    let arena = self
-                        .ctx
-                        .binder
-                        .symbol_arenas
-                        .get(&alias_sym_id)
-                        .map(|arc| &**arc)
-                        .unwrap_or(self.ctx.arena);
-
-                    while guard < 16 {
-                        guard += 1;
-                        let Some(node) = arena.get(current) else {
-                            break;
-                        };
-                        if node.kind == syntax_kind_ext::IMPORT_DECLARATION
-                            || node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                        {
-                            return Some(TypeOnlyKind::Import);
-                        }
-                        if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
-                            return Some(TypeOnlyKind::Export);
-                        }
-                        let Some(ext) = arena.get_extended(current) else {
-                            break;
-                        };
-                        if ext.parent.is_none() {
-                            break;
-                        }
-                        current = ext.parent;
+                    if let Some(kind) = Self::find_direct_type_only_marker(arena, decl) {
+                        return Some(kind);
                     }
                 }
             }
@@ -435,15 +419,15 @@ impl<'a> CheckerState<'a> {
                 if !is_namespace_binding
                     && self.is_export_type_only_across_binders(module_specifier, &export_name)
                 {
-                    // Determine whether the type-only came from `import type` or `export type`
-                    // in the target module. Resolve the export symbol and walk its declarations.
                     if let Some(kind) =
                         self.classify_cross_file_type_only_kind(module_specifier, &export_name)
                     {
                         return Some(kind);
                     }
-                    // Default to Export if we can't determine the kind
-                    return Some(TypeOnlyKind::Export);
+                    // Record the hit but keep iterating other aliases. A
+                    // later alias (e.g. a local `import type { ... }`)
+                    // may expose a direct marker that we prefer.
+                    saw_unclassified_cross_file_type_only = true;
                 }
             }
         }
@@ -526,6 +510,15 @@ impl<'a> CheckerState<'a> {
             return Some(TypeOnlyKind::Export);
         }
 
+        // Final fallback for cross-file type-only chains whose direct
+        // marker we could not locate (e.g. the chain terminates at a
+        // cloned class symbol whose declarations no longer include the
+        // `export type { ... }` specifier). `tsc` defaults to TS1362 in
+        // that case.
+        if saw_unclassified_cross_file_type_only {
+            return Some(TypeOnlyKind::Export);
+        }
+
         None
     }
 
@@ -578,12 +571,14 @@ impl<'a> CheckerState<'a> {
 
     /// Determine whether a cross-file type-only export came from `import type`
     /// (TS1361) or `export type` (TS1362) by resolving the target module and
-    /// walking the export symbol's declarations.
+    /// walking the export symbol's alias chain for a direct type-only marker.
     fn classify_cross_file_type_only_kind(
         &self,
         module_specifier: &str,
         export_name: &str,
     ) -> Option<TypeOnlyKind> {
+        use tsz_binder::symbol_flags;
+
         let target_file_idx = self.ctx.resolve_import_target(module_specifier)?;
         let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
         let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
@@ -592,49 +587,137 @@ impl<'a> CheckerState<'a> {
         let exports_table = self
             .ctx
             .module_exports_for_module(target_binder, &target_file_name)?;
-        let sym_id = exports_table.get(export_name)?;
-        let sym = target_binder
-            .get_symbol(sym_id)
-            .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
+        let mut current_sym_id = exports_table.get(export_name)?;
 
-        if !sym.is_type_only {
-            return None;
-        }
+        // Follow the alias chain within the target module: `export { C as D }`
+        // wraps a symbol that may itself be a type-only import. We want to
+        // attribute to the innermost *direct* `import type` / `export type`
+        // marker, not the plain re-export.
+        let mut visited = AliasCycleTracker::new();
+        while !visited.contains(&current_sym_id) {
+            visited.push(current_sym_id);
 
-        // Walk the symbol's declarations to find the import/export that made it type-only
-        let decl_arena = target_binder
-            .symbol_arenas
-            .get(&sym_id)
-            .map(|arc| &**arc)
-            .unwrap_or(target_arena);
+            let sym = target_binder
+                .get_symbol(current_sym_id)
+                .or_else(|| self.ctx.binder.get_symbol(current_sym_id))?;
 
-        for &decl in &sym.declarations {
-            if decl.is_none() {
+            if !sym.is_type_only {
+                return None;
+            }
+
+            let decl_arena = target_binder
+                .symbol_arenas
+                .get(&current_sym_id)
+                .map(|arc| &**arc)
+                .unwrap_or(target_arena);
+
+            for &decl in &sym.declarations {
+                if decl.is_none() {
+                    continue;
+                }
+                if let Some(kind) = Self::find_direct_type_only_marker(decl_arena, decl) {
+                    return Some(kind);
+                }
+            }
+
+            // No direct marker on this alias. If the symbol is an ALIAS,
+            // try to follow it to the next link in the chain.
+            // `resolve_import_symbol` handles import-backed aliases;
+            // pure-export aliases like `export { C as D }` without a
+            // `from` clause are not import-backed, so we fall through.
+            if sym.has_any_flags(symbol_flags::ALIAS) {
+                let Some(next_sym_id) = target_binder.resolve_import_symbol(current_sym_id) else {
+                    break;
+                };
+                if next_sym_id == current_sym_id {
+                    break;
+                }
+                current_sym_id = next_sym_id;
                 continue;
             }
-            let mut current = decl;
-            let mut guard = 0;
-            while guard < 16 {
-                guard += 1;
-                let Some(node) = decl_arena.get(current) else {
-                    break;
-                };
-                if node.kind == syntax_kind_ext::IMPORT_DECLARATION {
-                    return Some(TypeOnlyKind::Import);
-                }
-                if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
-                    return Some(TypeOnlyKind::Export);
-                }
-                let Some(ext) = decl_arena.get_extended(current) else {
-                    break;
-                };
-                if ext.parent.is_none() {
-                    break;
-                }
-                current = ext.parent;
-            }
+
+            // Non-alias type-only symbol (e.g. a symbol cloned for
+            // `export type { X as Y }` — its declarations point at the
+            // original non-type-only source, so the walk cannot reach
+            // the `export type` specifier). Default to TS1362: the
+            // type-only-ness originated on the export side.
+            return Some(TypeOnlyKind::Export);
         }
 
+        None
+    }
+
+    /// Walk upward from a declaration node and return the nearest enclosing
+    /// `import type` / `export type` marker, if any.
+    ///
+    /// A marker is "direct" when the syntax itself uses the `type` keyword:
+    /// the `ImportClause`, `ImportEqualsDeclaration`, `ExportDeclaration`,
+    /// or the individual `ImportSpecifier` / `ExportSpecifier`. A plain
+    /// `export { X as Y }` that happens to re-export a type-only symbol is
+    /// *not* a direct marker — the responsibility lies further up the
+    /// alias chain (e.g. the original `import type`).
+    fn find_direct_type_only_marker(
+        arena: &tsz_parser::parser::NodeArena,
+        start: NodeIndex,
+    ) -> Option<TypeOnlyKind> {
+        let mut current = start;
+        let mut guard = 0;
+        while guard < 16 {
+            guard += 1;
+            let node = arena.get(current)?;
+
+            // Inline specifier form: `import { type X }` / `export { type X }`.
+            if let Some(spec) = arena.get_specifier(node)
+                && spec.is_type_only
+            {
+                return Some(if node.kind == syntax_kind_ext::IMPORT_SPECIFIER {
+                    TypeOnlyKind::Import
+                } else {
+                    TypeOnlyKind::Export
+                });
+            }
+
+            // `import type { X } from ...` — the flag lives on the clause.
+            if let Some(clause) = arena.get_import_clause(node)
+                && clause.is_type_only
+            {
+                return Some(TypeOnlyKind::Import);
+            }
+
+            // `import type X = require(...)` — the flag lives on the
+            // import-equals node itself.
+            if node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+                if let Some(imp) = arena.get_import_decl(node)
+                    && imp.is_type_only
+                {
+                    return Some(TypeOnlyKind::Import);
+                }
+                break;
+            }
+
+            // Plain `import { X }` without `type`: the clause above
+            // already answered. No further information above the
+            // declaration.
+            if node.kind == syntax_kind_ext::IMPORT_DECLARATION {
+                break;
+            }
+
+            // `export type { X }` — flag on the export declaration.
+            if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+                if let Some(exp) = arena.get_export_decl(node)
+                    && exp.is_type_only
+                {
+                    return Some(TypeOnlyKind::Export);
+                }
+                break;
+            }
+
+            let ext = arena.get_extended(current)?;
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+        }
         None
     }
 

--- a/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
+++ b/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
@@ -1,0 +1,164 @@
+//! TS1361 vs TS1362 attribution across multi-file alias chains.
+//!
+//! Invariant: when a value use of `X` is rejected because `X` is type-only,
+//! the checker walks the alias chain and attributes the error to the
+//! innermost declaration that *directly* uses a `type` keyword —
+//! `import type`, `export type`, `import { type X }`, `export { type X }`,
+//! or `import type X = require(...)`. A plain `export { Y as X }` or
+//! `import { X }` that merely re-exports or re-imports a type-only symbol
+//! is not a direct marker — the chain walk must continue past it.
+//!
+//! Reproduces `conformance/externalModules/typeOnly/chained.ts`.
+
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::module_resolution::build_module_resolution_maps;
+use tsz_checker::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn compile_module_files(files: &[(&str, &str)], entry_idx: usize) -> Vec<(u32, String)> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        module: ModuleKind::CommonJS,
+        ..CheckerOptions::default()
+    };
+
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[entry_idx]);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code != 2318)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Chain: `export type {{ A as B }}` → plain `export {{ B as C }}` →
+/// `import type {{ C }}` + plain `export {{ C as D }}` → `import {{ D }}; new D()`.
+///
+/// `tsc` attributes the error to the innermost `import type` (TS1361), not
+/// the outermost `export type` (TS1362). The plain re-exports in between
+/// are not direct markers.
+#[test]
+fn chained_type_only_attributes_to_innermost_import_type() {
+    let a = r#"
+class A { a!: string }
+export type { A as B };
+export type Z = A;
+"#;
+    let b = r#"
+import { Z as Y } from './a';
+export { B as C } from './a';
+"#;
+    let c = r#"
+import type { C } from './b';
+export { C as D };
+"#;
+    let d = r#"
+import { D } from './c';
+new D();
+"#;
+
+    let diagnostics = compile_module_files(
+        &[("./a.ts", a), ("./b.ts", b), ("./c.ts", c), ("./d.ts", d)],
+        3,
+    );
+
+    let ts1361 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1361)
+        .collect::<Vec<_>>();
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1362)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ts1361.len(),
+        1,
+        "Expected exactly one TS1361 attributing to the `import type` marker. \
+         Got TS1361={ts1361:?}, TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+    assert!(
+        ts1362.is_empty(),
+        "Did not expect TS1362 — the outer `export type` is not the nearest direct marker. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+}
+
+/// Sanity check: when the only direct type-only marker in the chain is
+/// `export type`, TS1362 is still the correct attribution.
+#[test]
+fn export_type_only_chain_still_attributes_to_export_type() {
+    let a = r#"
+class A { a!: string }
+export type { A as B };
+"#;
+    let b = r#"
+import { B } from './a';
+new B();
+"#;
+
+    let diagnostics = compile_module_files(&[("./a.ts", a), ("./b.ts", b)], 1);
+
+    let ts1361 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1361)
+        .collect::<Vec<_>>();
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 1362)
+        .collect::<Vec<_>>();
+
+    assert!(
+        ts1361.is_empty(),
+        "Did not expect TS1361 when no `import type` appears in the chain. \
+         Got TS1361={ts1361:?}, all={diagnostics:?}",
+    );
+    assert_eq!(
+        ts1362.len(),
+        1,
+        "Expected TS1362 for `export type` chain. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+}


### PR DESCRIPTION
## Summary

- When a value use of `X` is rejected because `X` is type-only, the checker walks the alias chain to decide TS1361 ("imported using `import type`") vs TS1362 ("exported using `export type`"). Previously the walk returned the first `IMPORT_DECLARATION` / `EXPORT_DECLARATION` it encountered based purely on node kind — a plain `export { C as D }` whose re-exported symbol happened to be type-only was misattributed to `export type` (TS1362) even when the real origin was an `import type` earlier in the chain.
- `tsc` attributes these errors to the innermost syntactic marker that actually uses a `type` keyword. This change matches that behavior by extracting a shared helper (`find_direct_type_only_marker`) that only returns a kind when `is_type_only` is set on the `ImportClause`, `ImportEqualsDeclaration`, `ExportDeclaration`, or the inline specifier; plain imports/exports are transparent and the walk continues.
- Teaches `classify_cross_file_type_only_kind` to follow the alias chain within the target module (via `resolve_import_symbol`) so plain `export { C as D }` delegates to the `import type { C }` it wraps. Non-alias type-only symbols (e.g. the clone for `export type { Foo as "module.exports" }`) keep the existing TS1362 attribution since their declarations no longer expose the `export type` specifier.
- Defers the blanket "cross-file type-only ⇒ TS1362" fallback in the outer loop: previously it fired on the first alias whose cross-file check returned empty; now the loop keeps iterating so a later alias carrying a direct `import type` marker can win. The fallback is still applied at the very end when no alias in the chain has a direct marker.

## Test plan

- [x] New unit tests in `crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs` cover the direct in-process multi-file case (unit tests verify the per-file binder path).
- [x] `cargo nextest run --package tsz-checker` — 4978 tests, no new regressions (2 pre-existing failures in `test_ts2322_keeps_outer_object_error_for_direct_index_access_target` are unrelated).
- [x] `scripts/session/verify-all.sh --quick` — all suites pass, conformance improves +2 tests (`jsFunctionWithPrototypeNoErrorTruncationNoCrash.ts`, `restInvalidArgumentType.ts`) vs baseline 12065.
- [ ] Full emit + fourslash (skipped in `--quick`, CI will exercise them).

```ts
// a.ts
class A { a!: string }
export type { A as B };

// b.ts
export { B as C } from './a';

// c.ts
import type { C } from './b';
export { C as D };

// d.ts
import { D } from './c';
new D();
// tsc:            TS1361 'D' cannot be used as a value because it was imported using 'import type'.
// tsz before:     TS1362 'D' ... exported using 'export type'.
// tsz after:      TS1361 'D' ... imported using 'import type'.
```