### PR TITLE
perf(cli): share program-wide symbol_arenas via Arc instead of per-file build

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -184,7 +184,7 @@ impl BinderState {
             current_scope_idx: 0,
             node_symbols: FxHashMap::with_capacity_and_hasher(256, Default::default()),
             module_declaration_exports_publicly: FxHashMap::default(),
-            symbol_arenas: FxHashMap::default(),
+            symbol_arenas: Arc::new(FxHashMap::default()),
             declaration_arenas: FxHashMap::default(),
             cross_file_node_symbols: FxHashMap::default(),
             node_flow: FxHashMap::with_capacity_and_hasher(128, Default::default()),
@@ -250,7 +250,7 @@ impl BinderState {
         self.current_scope_idx = 0;
         self.node_symbols.clear();
         self.module_declaration_exports_publicly.clear();
-        self.symbol_arenas.clear();
+        Arc::make_mut(&mut self.symbol_arenas).clear();
         self.declaration_arenas.clear();
         self.cross_file_node_symbols.clear();
         self.node_flow.clear();
@@ -421,7 +421,7 @@ impl BinderState {
             current_scope_idx: 0,
             node_symbols,
             module_declaration_exports_publicly: FxHashMap::default(),
-            symbol_arenas: FxHashMap::default(),
+            symbol_arenas: Arc::new(FxHashMap::default()),
             declaration_arenas: FxHashMap::default(),
             cross_file_node_symbols: FxHashMap::default(),
             node_flow: FxHashMap::default(),

--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -265,8 +265,7 @@ impl BinderState {
                     .insert(new_id, (lib_binder_ptr, local_id));
 
                 // Track which arena contains this symbol's declarations (legacy - stores last arena)
-                self.symbol_arenas
-                    .insert(new_id, Arc::clone(&lib_ctx.arena));
+                Arc::make_mut(&mut self.symbol_arenas).insert(new_id, Arc::clone(&lib_ctx.arena));
             }
         }
 

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -248,8 +248,12 @@ pub struct BinderState {
     pub node_symbols: FxHashMap<u32, SymbolId>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
-    /// Symbol-to-arena mapping for cross-file declaration lookup (legacy, stores last arena)
-    pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    /// Symbol-to-arena mapping for cross-file declaration lookup (legacy, stores last arena).
+    ///
+    /// Wrapped in `Arc` so the merged cross-file map can be shared across N
+    /// per-file binders without deep-cloning. Mutations go through
+    /// `Arc::make_mut` (zero-cost when refcount=1, which is always during binding).
+    pub symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     /// Declaration-to-arena mapping for precise cross-file declaration lookup
     /// Key: (`SymbolId`, `NodeIndex` of declaration) -> Arena(s) containing that declaration
     /// This is needed when a symbol (like Array) is declared across multiple lib files.
@@ -835,7 +839,7 @@ pub struct BinderStateScopeInputs {
     pub reexports: Arc<FileReexportsMap>,
     pub wildcard_reexports: Arc<WildcardReexportsMap>,
     pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,
-    pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    pub symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     pub declaration_arenas: DeclarationArenaMap,
     pub cross_file_node_symbols: CrossFileNodeSymbols,
     pub shorthand_ambient_modules: Arc<FxHashSet<String>>,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2645,7 +2645,7 @@ fn build_lib_bound_file_for_interface_checks(
         source_file: lib_file.root_index,
         arena: Arc::clone(&lib_file.arena),
         node_symbols,
-        symbol_arenas: program.symbol_arenas.clone(),
+        symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),
         scopes: Vec::new(),

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1552,16 +1552,15 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
             .map(|&(sym_id, _)| sym_id)
             .collect();
 
-    let symbol_arenas: rustc_hash::FxHashMap<tsz::binder::SymbolId, Arc<tsz_parser::NodeArena>> =
-        program
-            .symbol_arenas
-            .iter()
-            .filter_map(|(&sym_id, arena)| {
-                let has_non_local_decl = symbols_with_non_local_declarations.contains(&sym_id);
-                (has_non_local_decl || !Arc::ptr_eq(arena, &file.arena))
-                    .then(|| (sym_id, Arc::clone(arena)))
-            })
-            .collect();
+    // Share the program-wide symbol_arenas via Arc::clone — O(1) instead of
+    // building a per-file filtered map. The previous filter dropped entries
+    // where the symbol was already local (arena pointer equal to file.arena
+    // and no cross-file decl), but keeping them is harmless: consumers do
+    // point lookups (`binder.symbol_arenas.get(&sym_id)`), and the checker
+    // has no iter consumers of this map. Drops ~O(N_files × N_symbols)
+    // iteration on large repos.
+    let _ = symbols_with_non_local_declarations; // kept for declaration_arenas use above
+    let symbol_arenas = Arc::clone(&program.symbol_arenas);
 
     // Pre-size to avoid repeated rehashing when merging globals into the
     // file-local table. The merged map ends up holding (file_locals ∪ globals);

--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -83,7 +83,7 @@ pub(crate) fn emit_outputs(
     // This enables the declaration emitter's portability check to resolve
     // cross-file symbols (e.g., imported types from node_modules) to their
     // source file paths, which is required for TS2883 diagnostics.
-    let global_symbol_arenas = context.program.symbol_arenas.clone();
+    let global_symbol_arenas = (*context.program.symbol_arenas).clone();
 
     // Collect file paths that contain module augmentations.
     // The declaration emitter uses this to preserve side-effect imports for

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -486,7 +486,7 @@ pub struct BindResult {
     /// Export visibility of namespace/module declaration nodes after binder rules.
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     /// Symbol-to-arena mapping for cross-file declaration lookup (including lib symbols)
-    pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    pub symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     /// Declaration-to-arena mapping for precise cross-file declaration lookup
     pub declaration_arenas: DeclarationArenaMap,
     /// Persistent scopes for stateless checking
@@ -1559,8 +1559,11 @@ pub struct MergedProgram {
     pub files: Vec<BoundFile>,
     /// Global symbol arena (all symbols from all files, with remapped IDs)
     pub symbols: SymbolArena,
-    /// Symbol-to-arena mapping for declaration lookup (legacy, stores last arena)
-    pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    /// Symbol-to-arena mapping for declaration lookup (legacy, stores last arena).
+    ///
+    /// Wrapped in `Arc` so per-file checker binders can share the merged map
+    /// via `Arc::clone` (O(1)) instead of building a per-file derived map.
+    pub symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     /// Declaration-to-arena mapping for precise cross-file declaration lookup
     /// Key: (`SymbolId`, `NodeIndex` of declaration) -> Arena(s) containing that declaration
     pub declaration_arenas: DeclarationArenaMap,
@@ -2590,7 +2593,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
 
         // Copy symbol_arenas entries from user file, remapping IDs
         // This propagates lib symbol arena mappings that were created during merge_lib_symbols
-        for (&old_sym_id, arena) in &result.symbol_arenas {
+        for (&old_sym_id, arena) in result.symbol_arenas.iter() {
             if let Some(&new_sym_id) = id_remap.get(&old_sym_id) {
                 symbol_arenas
                     .entry(new_sym_id)
@@ -3167,7 +3170,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
             .collect();
 
         let mut remapped_symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>> = FxHashMap::default();
-        for (&old_sym_id, arena) in &result.symbol_arenas {
+        for (&old_sym_id, arena) in result.symbol_arenas.iter() {
             if let Some(&new_sym_id) = id_remap.get(&old_sym_id) {
                 let has_non_local_decl = symbols_with_non_local_declarations.contains(&new_sym_id);
                 if has_non_local_decl || !Arc::ptr_eq(arena, &result.arena) {
@@ -3273,7 +3276,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
     MergedProgram {
         files,
         symbols: global_symbols,
-        symbol_arenas,
+        symbol_arenas: Arc::new(symbol_arenas),
         declaration_arenas,
         cross_file_node_symbols,
         globals,
@@ -3899,7 +3902,7 @@ fn build_lib_bound_file_for_interface_checks(
         source_file: lib_file.root_index,
         arena: Arc::clone(&lib_file.arena),
         node_symbols,
-        symbol_arenas: program.symbol_arenas.clone(),
+        symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),
         scopes: Vec::new(),
@@ -4671,7 +4674,7 @@ pub fn create_binder_from_bound_file(
     file_idx: usize,
 ) -> BinderState {
     let declaration_arenas = file.declaration_arenas.clone();
-    let symbol_arenas = file.symbol_arenas.clone();
+    let symbol_arenas = Arc::new(file.symbol_arenas.clone());
 
     // Get file locals for this specific file
     let mut file_locals = SymbolTable::new();
@@ -4767,7 +4770,7 @@ pub fn create_binder_from_bound_file_with_shared(
     _shared: &SharedBinderData,
 ) -> BinderState {
     let declaration_arenas = file.declaration_arenas.clone();
-    let symbol_arenas = file.symbol_arenas.clone();
+    let symbol_arenas = Arc::new(file.symbol_arenas.clone());
 
     let mut file_locals = SymbolTable::new();
     if file_idx < program.file_locals.len() {

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -8502,7 +8502,7 @@ var e: Date = c.b();
             reexports: program.reexports.clone(),
             wildcard_reexports: program.wildcard_reexports.clone(),
             wildcard_reexports_type_only: program.wildcard_reexports_type_only.clone(),
-            symbol_arenas: file1_bound.symbol_arenas.clone(),
+            symbol_arenas: std::sync::Arc::new(file1_bound.symbol_arenas.clone()),
             declaration_arenas,
             cross_file_node_symbols: program.cross_file_node_symbols.clone(),
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),


### PR DESCRIPTION
## Summary

`create_binder_from_bound_file_with_augmentations` was iterating `program.symbol_arenas` (potentially ~100K entries on large-ts-repo) for every per-file checker binder, building a filtered per-file map. Across 6086 files this was ~600M iter ops plus N×N `Arc::clone` churn — pure startup tax that the perf doc flagged as a sibling of the `declaration_arenas` hot spot.

## Changes

- Wraps `BinderState.symbol_arenas`, `BindResult.symbol_arenas`, and `MergedProgram.symbol_arenas` in `Arc<FxHashMap<...>>`.
- Replaces the per-file build with a single `Arc::clone(&program.symbol_arenas)`.
- Routes mutation sites through `Arc::make_mut` (zero-cost when refcount=1, which is always during binding).
- Per-file `BoundFile.symbol_arenas` stays as `FxHashMap` (small per-file data); per-binder construction in the parallel path wraps with `Arc::new(file.symbol_arenas.clone())` once.

## Safety

The previous filter dropped local-only entries (where the symbol's recorded arena equals the per-file arena and the symbol has no cross-file declaration). Keeping those entries is a no-op for consumers — every checker access of `binder.symbol_arenas` is a point lookup (`.get(&sym_id)`); no iter consumers exist. Including the local entry only ever returns the local arena that the consumer would have found anyway.

Mirrors the Arc-share treatment in #932/#935/#944/#948/#954/#960/#973/#975/#979.

## Test plan
- [x] `cargo nextest run -p tsz-binder -p tsz-core -p tsz-checker` (8255 passed, 47 skipped)
- [x] Pre-commit hook (clippy + nextest + arch guardrails) green