### PR TITLE
fix(bench,ci): export partial JSON on OOM/TERM so gh-pages still gets data

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -118,15 +118,24 @@ jobs:
       - name: Run benchmarks
         # Run the full benchmark suite (no --quick) so the website renders
         # all categories instead of the ~16-entry quick subset.
+        # `continue-on-error` so the upload step still runs when individual
+        # benches OOM the GitHub runner (e.g. `large-ts-repo`); the bench
+        # script's EXIT trap writes whatever rows DID complete to
+        # artifacts/bench-vs-tsgo-*.json before exiting.
         run: ./scripts/bench/bench-vs-tsgo.sh --json
         timeout-minutes: 75
+        continue-on-error: true
 
       - name: Upload benchmark data
+        # `if: always()` so we still upload the partial JSON written by the
+        # bench script's EXIT trap when the runner kills the bench midway.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-data
           path: artifacts/bench-vs-tsgo-*.json
           retention-days: 7
+          if-no-files-found: warn
 
   wasm:
     needs: check

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -746,9 +746,15 @@ run_project_benchmark() {
     rm -f "$json_file"
 }
 
+JSON_EXPORTED=false
 export_results_json() {
     [ "$JSON_OUTPUT" != true ] && return
     [ -z "$RESULTS_CSV" ] && return
+    # Idempotent: the EXIT trap may also call this after the in-band
+    # invocation; only one write is needed (and the second would just
+    # produce a duplicate timestamped file under artifacts/).
+    [ "$JSON_EXPORTED" = true ] && return
+    JSON_EXPORTED=true
 
     local default_file="$PROJECT_ROOT/artifacts/bench-vs-tsgo-$(date +%Y%m%d-%H%M%S).json"
     local out_file="${JSON_FILE:-$default_file}"
@@ -2373,11 +2379,19 @@ HEADER
 
 main() {
     check_prerequisites
-    
+
     # Create temp directory for synthetic files
     TEMP_DIR=$(mktemp -d)
-    trap "rm -rf $TEMP_DIR" EXIT
-    
+    # Always export the partial JSON on exit (including SIGTERM/SIGINT/OOM
+    # kills) so a long bench that gets cut off — e.g. by the GitHub Actions
+    # job timeout or the runner OOM killer on `large-ts-repo` — still
+    # surfaces the rows that DID complete. Without this, an exit at any
+    # point past the first benchmark would lose the entire dataset, leaving
+    # the gh-pages deploy with no fresh artifact.
+    trap "rm -rf $TEMP_DIR; export_results_json" EXIT
+    trap "exit 130" INT
+    trap "exit 143" TERM
+
     print_header "TypeScript Compiler Test Files"
     
     # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

The Apr 23 deploy run [24827263798](https://github.com/mohsen1/tsz/actions/runs/24827263798/job/72668300339) failed at the `large-ts-repo` benchmark — exit code 143 (SIGTERM, runner OOM kill). Without my fix, this loses **all ~75 bench rows that DID complete** because `export_results_json` only ran at the very end of `main()` and never got called when the script was killed mid-run. The artifact upload step then had nothing to upload, the build job downloaded no artifact, and the deploy fell back to the stale committed `benchmarks.json`.

## Changes

### `scripts/bench/bench-vs-tsgo.sh`
- Add an EXIT trap that calls `export_results_json` so a killed run still writes whatever rows accumulated in `RESULTS_CSV` before the signal.
- Make `export_results_json` idempotent (`JSON_EXPORTED` guard) so the in-band call at the end of `main()` and the trap don't both write.
- Forward INT/TERM to canonical exit codes so the EXIT trap fires.

### `.github/workflows/gh-pages.yml`
- `continue-on-error: true` on the bench step so a non-zero exit doesn't short-circuit the rest of the job.
- `if: always()` on the upload step so the partial artifact is still uploaded when bench gets killed.
- `if-no-files-found: warn` so the deploy doesn't loudly fail when the bench produced no rows at all (extreme edge case).

## Net effect

tsz.dev will get fresh per-deploy data — the rows that tsz can complete on the runner — instead of falling back to whatever was last committed to `crates/tsz-website/data/benchmarks.json`.

## Test plan
- [x] `bash -n scripts/bench/bench-vs-tsgo.sh` (syntax)
- [ ] After merge: dispatch the workflow and verify the deploy uses the fresh artifact even if bench step exits non-zero