### PR TITLE
chore(cli): drop now-unused symbols_with_non_local_declarations set

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1546,12 +1546,6 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
         }
     }
 
-    let symbols_with_non_local_declarations: rustc_hash::FxHashSet<tsz::binder::SymbolId> =
-        declaration_arenas
-            .keys()
-            .map(|&(sym_id, _)| sym_id)
-            .collect();
-
     // Share the program-wide symbol_arenas via Arc::clone — O(1) instead of
     // building a per-file filtered map. The previous filter dropped entries
     // where the symbol was already local (arena pointer equal to file.arena
@@ -1559,7 +1553,6 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
     // point lookups (`binder.symbol_arenas.get(&sym_id)`), and the checker
     // has no iter consumers of this map. Drops ~O(N_files × N_symbols)
     // iteration on large repos.
-    let _ = symbols_with_non_local_declarations; // kept for declaration_arenas use above
     let symbol_arenas = Arc::clone(&program.symbol_arenas);
 
     // Pre-size to avoid repeated rehashing when merging globals into the


### PR DESCRIPTION
## Summary

#986 (symbol_arenas Arc-share) eliminated the only consumer of this per-file `FxHashSet` — it had been used to gate which `symbol_arenas` entries were copied into the per-binder map, but with the Arc share we just clone the full map by reference and the filter is gone.

The set was kept around with a `let _ = ...; // kept for declaration_arenas use above` placeholder in case the `declaration_arenas` migration ever revives it; that migration will build whatever index it needs from `program.declaration_arenas` directly, not from this set, so deleting it now is safe.

Saves the per-binder allocation of a `FxHashSet<SymbolId>` plus the `declaration_arenas.keys()` iteration that produced it. Tiny win individually, real on 6086-file projects (~6086 small allocations + iterations dropped).

## Test plan
- [x] `cargo check -p tsz-cli` clean
- [x] Pre-commit hook (clippy + nextest + arch guardrails) green