### PR TITLE
fix(checker): canonicalize well-known symbol keys for TS2320 cross-base conflict

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -286,7 +286,7 @@ impl<'a> CheckerState<'a> {
                         || member_node.kind == PROPERTY_SIGNATURE)
                         && let Some(sig) = decl_arena.get_signature(member_node)
                         && let Some(name) =
-                            crate::types_domain::queries::core::get_literal_property_name(
+                            crate::types_domain::queries::core::get_literal_or_well_known_property_name(
                                 decl_arena, sig.name,
                             )
                     {
@@ -668,10 +668,12 @@ impl<'a> CheckerState<'a> {
                     let Some(sig) = iface_arena.get_signature(member_node) else {
                         continue;
                     };
-                    let Some(name) = crate::types_domain::queries::core::get_literal_property_name(
-                        iface_arena,
-                        sig.name,
-                    ) else {
+                    let Some(name) =
+                        crate::types_domain::queries::core::get_literal_or_well_known_property_name(
+                            iface_arena,
+                            sig.name,
+                        )
+                    else {
                         continue;
                     };
                     *base_method_counts.entry(name).or_insert(0) += 1;
@@ -683,51 +685,53 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
 
-                    let (member_key, member_type, member_optional) =
-                        if member_node.kind == CALL_SIGNATURE {
-                            (
-                                String::from("__call__"),
-                                instantiate_type(
-                                    self.ctx.types,
-                                    self.get_type_of_node(member_idx),
-                                    &substitution,
-                                ),
-                                false,
-                            )
-                        } else if member_node.kind == METHOD_SIGNATURE
-                            || member_node.kind == PROPERTY_SIGNATURE
-                        {
-                            let Some(sig) = iface_arena.get_signature(member_node) else {
-                                continue;
-                            };
-                            let Some(name) =
-                                crate::types_domain::queries::core::get_literal_property_name(
+                    let (member_key, member_type, member_optional) = if member_node.kind
+                        == CALL_SIGNATURE
+                    {
+                        (
+                            String::from("__call__"),
+                            instantiate_type(
+                                self.ctx.types,
+                                self.get_type_of_node(member_idx),
+                                &substitution,
+                            ),
+                            false,
+                        )
+                    } else if member_node.kind == METHOD_SIGNATURE
+                        || member_node.kind == PROPERTY_SIGNATURE
+                    {
+                        let Some(sig) = iface_arena.get_signature(member_node) else {
+                            continue;
+                        };
+                        // Well-known symbol keys compare as equal across bases for TS2320.
+                        let Some(name) =
+                                crate::types_domain::queries::core::get_literal_or_well_known_property_name(
                                     iface_arena,
                                     sig.name,
                                 )
                             else {
                                 continue;
                             };
-                            (
-                                name,
-                                self.delegate_cross_arena_interface_member_simple_type(
-                                    iface_decl_idx,
-                                    member_idx,
-                                    iface_arena,
-                                    Some(&substitution_args),
-                                )
-                                .unwrap_or_else(|| {
-                                    instantiate_type(
-                                        self.ctx.types,
-                                        self.get_type_of_interface_member_simple(member_idx),
-                                        &substitution,
-                                    )
-                                }),
-                                sig.question_token,
+                        (
+                            name,
+                            self.delegate_cross_arena_interface_member_simple_type(
+                                iface_decl_idx,
+                                member_idx,
+                                iface_arena,
+                                Some(&substitution_args),
                             )
-                        } else {
-                            continue;
-                        };
+                            .unwrap_or_else(|| {
+                                instantiate_type(
+                                    self.ctx.types,
+                                    self.get_type_of_interface_member_simple(member_idx),
+                                    &substitution,
+                                )
+                            }),
+                            sig.question_token,
+                        )
+                    } else {
+                        continue;
+                    };
 
                     // Skip members already seen at a closer level in this base chain
                     if !seen_member_keys.insert(member_key.clone()) {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -62,6 +62,59 @@ pub(crate) fn get_literal_property_name(arena: &NodeArena, name_idx: NodeIndex) 
     None
 }
 
+/// Like [`get_literal_property_name`] but also maps `[Symbol.<name>]`
+/// computed property names to the canonical `[Symbol.<name>]` key so
+/// TS2320/TS2430 heritage checks match well-known-symbol members across
+/// bases. User-defined `unique symbol` bindings still need symbol
+/// resolution and are out of scope here.
+pub(crate) fn get_literal_or_well_known_property_name(
+    arena: &NodeArena,
+    name_idx: NodeIndex,
+) -> Option<String> {
+    if let Some(name) = get_literal_property_name(arena, name_idx) {
+        return Some(name);
+    }
+    let name_node = arena.get(name_idx)?;
+    if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+        return None;
+    }
+    let mut expr = arena.get_computed_property(name_node)?.expression;
+    // Peel parentheses.
+    while let Some(node) = arena.get(expr)
+        && node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+    {
+        expr = arena.get_parenthesized(node)?.expression;
+    }
+    let node = arena.get(expr)?;
+    if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+    {
+        return None;
+    }
+    let access = arena.get_access_expr(node)?;
+    if arena
+        .get_identifier(arena.get(access.expression)?)?
+        .escaped_text
+        != "Symbol"
+    {
+        return None;
+    }
+    let name_node = arena.get(access.name_or_argument)?;
+    if let Some(ident) = arena.get_identifier(name_node) {
+        return Some(format!("[Symbol.{}]", ident.escaped_text));
+    }
+    if matches!(
+        name_node.kind,
+        k if k == SyntaxKind::StringLiteral as u16
+            || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+    ) && let Some(lit) = arena.get_literal(name_node)
+        && !lit.text.is_empty()
+    {
+        return Some(format!("[Symbol.{}]", lit.text));
+    }
+    None
+}
+
 /// Check if a property name node is syntactically a string key (not numeric).
 /// Handles direct string literals and computed property names with string literal expressions.
 pub(crate) fn is_string_property_name_node(arena: &NodeArena, name_idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/tests/ts2320_tests.rs
+++ b/crates/tsz-checker/tests/ts2320_tests.rs
@@ -314,3 +314,48 @@ interface MoverShaker extends Mover, Shaker { }
         "Expected TS2320 for class + interface bases with conflicting members"
     );
 }
+
+/// Reproduces `conformance/es6/Symbols/symbolProperty35.ts`.
+///
+/// `[Symbol.toStringTag]()` in two different bases with different return
+/// types is a TS2320 conflict. The cross-base comparison has to canonicalize
+/// the computed-property key (`[Symbol.toStringTag]`) so keys from both
+/// bases match; previously we bailed on computed keys and missed the
+/// conflict entirely.
+#[test]
+fn ts2320_well_known_symbol_method_conflict_across_bases() {
+    let source = r#"
+interface I1 {
+    [Symbol.toStringTag](): { x: string }
+}
+interface I2 {
+    [Symbol.toStringTag](): { x: number }
+}
+
+interface I3 extends I1, I2 { }
+"#;
+    assert!(
+        has_error(source, 2320),
+        "Expected TS2320 for `[Symbol.toStringTag]` methods with conflicting return types across bases"
+    );
+}
+
+/// Regression: two bases declaring `[Symbol.iterator]` with the *same*
+/// return type must NOT produce TS2320 (no conflict).
+#[test]
+fn ts2320_no_false_positive_for_matching_well_known_symbol_method() {
+    let source = r#"
+interface I1 {
+    [Symbol.iterator](): { next(): { value: number; done: boolean } }
+}
+interface I2 {
+    [Symbol.iterator](): { next(): { value: number; done: boolean } }
+}
+
+interface I3 extends I1, I2 { }
+"#;
+    assert!(
+        !has_error(source, 2320),
+        "Did not expect TS2320 when two bases declare matching `[Symbol.iterator]` methods"
+    );
+}


### PR DESCRIPTION
## Summary

```ts
interface I1 { [Symbol.toStringTag](): { x: string } }
interface I2 { [Symbol.toStringTag](): { x: number } }
interface I3 extends I1, I2 {}   // tsc: TS2320
```

The cross-base member-conflict check in `class_checker_compat.rs` pulls member keys via `get_literal_property_name`, which bails on computed property names (returns `None`). As a result, well-known symbol keys like `[Symbol.toStringTag]` never enter `inherited_member_sources`, the two base declarations are treated as unrelated members, and we miss TS2320 entirely.

- Add `get_literal_or_well_known_property_name` in `types/queries/core.rs` that first tries the existing literal-name resolver, then falls back to a purely-AST extractor that returns `[Symbol.<name>]` for `Symbol.X` / `Symbol["X"]` computed property expressions (peeling parentheses).
- Route the derived-members scan and per-base processing in `class_checker_compat.rs` through the new helper so members keyed on the same well-known symbol compare as equal across bases.
- Does not handle user-defined `unique symbol` bindings (still needs symbol resolution via the existing checker-side path `resolve_computed_property_name_in_arena`); AST-level canonicalization covers the well-known `Symbol.X` keys TS2320 cares about.

Flips `conformance/es6/Symbols/symbolProperty35.ts` from "all-missing" (TS2320 expected, nothing emitted) to PASS.

## Test plan

- [x] 2 new unit tests in `crates/tsz-checker/tests/ts2320_tests.rs`:
  - `ts2320_well_known_symbol_method_conflict_across_bases` — TS2320 fires when two bases declare `[Symbol.toStringTag]()` with conflicting return types.
  - `ts2320_no_false_positive_for_matching_well_known_symbol_method` — regression guard: no TS2320 when two bases declare matching `[Symbol.iterator]()` methods.
- [x] All 17 TS2320 tests pass (existing + new).
- [x] `cargo nextest run --package tsz-checker` — 5010 tests, 0 regressions.
- [x] Targeted conformance: `symbolProperty35.ts` flipped to PASS.
- [ ] Full conformance + emit + fourslash (CI will exercise them).