### PR TITLE
fix(solver): preserve source declaration order in reverse-mapped inference

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,7 +20,7 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.default.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation)'
 slow-timeout = { period = "90s", terminate-after = 2 }
 
 [profile.default.junit]
@@ -35,7 +35,7 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation)'
 slow-timeout = { period = "90s", terminate-after = 2 }
 
 # Quick profile for fast feedback during development

--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -245,3 +245,69 @@ oub.b;
         "Expected no TS18046 ('is of type unknown') for index-signature reverse mapped inference, got: {codes:?}"
     );
 }
+
+#[test]
+fn reverse_mapped_preserves_source_property_declaration_order_in_ts2353() {
+    // Regression test for reverseMappedTypeLimitedConstraint.ts:
+    // the excess-property (TS2353) diagnostic must render the inferred
+    // target type with properties in the *source argument's declaration
+    // order*, not in atom-id order.
+    //
+    // tsc baseline: `{ x: number; y: "y"; }`
+    // tsz pre-fix:  `{ y: "y"; x: number; }` (atom-id order leaking through
+    //               `constrain_reverse_mapped_type` dropping declaration_order)
+    //
+    // The `checked_` call below triggers reverse-mapped inference for U
+    // through `{ [K in keyof U & keyof T]: U[K] }` with T = {x: number, y: string}
+    // and the argument adding an excess `z` property.
+    let code = r#"
+const checkType_ = <T>() => <U extends T>(value: { [K in keyof U & keyof T]: U[K] }) => value;
+const checked_ = checkType_<{x: number, y: string}>()({
+  x: 1 as number,
+  y: "y",
+  z: "z",
+});
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), code.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = crate::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        crate::context::CheckerOptions::default(),
+    );
+    checker.check_source_file(root);
+
+    let ts2353: Vec<_> = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 2353)
+        .collect();
+    assert!(
+        !ts2353.is_empty(),
+        "expected TS2353 excess-property diagnostic for `z`, got: {:#?}",
+        checker.ctx.diagnostics
+    );
+    let msg = ts2353[0].message_text.as_str();
+    // The target type must render `x` before `y` — matching the argument
+    // literal's declaration order (which flows through U's inferred shape).
+    let x_pos = msg
+        .find("x:")
+        .expect("x: must appear in target type display");
+    let y_pos = msg
+        .find("y:")
+        .expect("y: must appear in target type display");
+    assert!(
+        x_pos < y_pos,
+        "expected `x` to appear before `y` in TS2353 target type; got message: {msg}"
+    );
+    assert!(
+        msg.contains("{ x: number; y: \"y\"; }"),
+        "expected target type to match tsc baseline `{{ x: number; y: \"y\"; }}`, got message: {msg}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -234,7 +234,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 is_class_prototype: false,
                 visibility: Visibility::Public,
                 parent_id: None,
-                declaration_order: 0,
+                // Preserve the source property's declaration order so the
+                // reverse-inferred candidate for T retains the original
+                // argument literal's ordering. Without this, re-interning
+                // rebuilds declaration_order from atom-id-sorted Vec
+                // positions, which later leaks into diagnostic type display
+                // (e.g. `{ y: "y"; x: number; }` instead of tsc's
+                // `{ x: number; y: "y"; }` for
+                // reverseMappedTypeLimitedConstraint.ts).
+                declaration_order: prop.declaration_order,
                 is_string_named: false,
             });
         }


### PR DESCRIPTION
## Summary
- When reverse-mapped inference builds T's candidate from `{ [K in keyof T]: Template<T[K]> }`, it was dropping the source property's `declaration_order`, leaking atom-id sort order into T's shape and into downstream type display.
- Fix: copy `prop.declaration_order` from source to the reversed PropertyInfo in `constrain_reverse_mapped_type`. One-field change; zero semantics impact.
- Conformance **+18** (12083 vs 12065 baseline) on a full run. `reverseMappedTypeLimitedConstraint.ts` flips from fingerprint-only → PASS.

## Root cause
`object_with_flags` canonicalizes property order by atom-id for hash identity but preserves each property's `declaration_order` field so downstream display code can restore source order. Reverse-mapped inference iterated `source_obj.properties` (already atom-id ordered) and pushed new PropertyInfo entries with `declaration_order: 0`. On re-interning, `object_with_flags` reassigned declaration_order from Vec positions — effectively baking the atom-id order into T's shape. When a later mapped-type evaluation used T as a homomorphic source, `collect_homomorphic_source_property_infos` sorted by the (wrong) declaration_order, rendering TS2353 targets like `{ y: "y"; x: number; }` instead of `{ x: number; y: "y"; }`.

## Reproducer
```ts
const checkType_ = <T>() => <U extends T>(value: { [K in keyof U & keyof T]: U[K] }) => value;
const checked_ = checkType_<{x: number, y: string}>()({
  x: 1 as number,
  y: "y",
  z: "z",
});
// tsc:       Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: "y"; }'.
// tsz before: ... type '{ y: "y"; x: number; }'.
// tsz after:  ... type '{ x: number; y: "y"; }'.
```

## Impact (verify-all)
- **Conformance: +18** (12083 vs 12065 baseline).
- Emit: JS +0, DTS **+16**.
- Fourslash: unchanged (50/50).
- Checker + Solver + all other unit tests: 21,198/21,198 pass.

## Test plan
- [x] New Rust unit test `reverse_mapped_preserves_source_property_declaration_order_in_ts2353` in `crates/tsz-checker/tests/reverse_mapped_inference_tests.rs` locks the invariant.
- [x] `./scripts/conformance/conformance.sh run --filter reverseMappedTypeLimitedConstraint --verbose` — 1/1 PASS.
- [x] `scripts/safe-run.sh cargo nextest run` — 21,198/21,198 tests pass.
- [x] Full `scripts/session/verify-all.sh`: conformance +18, emit DTS +16, fourslash unchanged.

## Secondary change
Extended the nextest `default` and `ci` slow-timeout overrides to cover `default_lib_validation_*` tests (two of them, both load the full es2015 default libs). These were already right at the 60s debug-build edge; this one-line fix's tiny perturbation tipped them over. 90s × 2 overrides match the existing pattern used for other heavy default-lib tests.