### PR TITLE
fix(checker): preserve literal type argument in TS2344 messages

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -272,6 +272,10 @@ name = "ts2344_self_referential_interface_constraint"
 path = "tests/ts2344_self_referential_interface_constraint.rs"
 
 [[test]]
+name = "ts2344_literal_type_message"
+path = "tests/ts2344_literal_type_message.rs"
+
+[[test]]
 name = "promise_constructor_capability_tests"
 path = "tests/promise_constructor_capability_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -786,8 +786,6 @@ impl<'a> CheckerState<'a> {
             if self.is_assignable_to(type_arg, evaluated_constraint) {
                 continue;
             }
-            let widened_arg =
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, type_arg);
             let error_anchor = type_args_list
                 .nodes
                 .get(i)
@@ -797,7 +795,7 @@ impl<'a> CheckerState<'a> {
                 error_anchor,
                 crate::diagnostics::diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
                 &[
-                    &self.format_type_diagnostic(widened_arg),
+                    &self.format_type_diagnostic(type_arg),
                     &self.format_type_diagnostic(constraint),
                 ],
             );

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -404,12 +404,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // tsc widens literal types to their base types in TS2344 messages:
-        // e.g., `42` → `number`, `"hello"` → `string`. This matches
-        // tsc's getBaseTypeOfLiteralType applied before typeToString.
-        let widened_arg =
-            crate::query_boundaries::common::widen_literal_type(self.ctx.types, type_arg);
-        let mut type_str = self.format_type_diagnostic(widened_arg);
+        let mut type_str = self.format_type_diagnostic(type_arg);
         // When the type arg node is a `typeof expr<Args>` (TYPE_QUERY with type args),
         // tsc includes "typeof" in the TS2344 message. The type formatter strips
         // "typeof" from Application(TypeQuery, args), so we prepend it here.

--- a/crates/tsz-checker/tests/ts2344_literal_type_message.rs
+++ b/crates/tsz-checker/tests/ts2344_literal_type_message.rs
@@ -1,0 +1,87 @@
+//! Regression: TS2344 messages must preserve literal type arguments rather
+//! than widening them to the base type. tsc's `checkTypeArgumentConstraints`
+//! passes the type argument to `typeToString` unchanged, so a constraint like
+//! `T extends "true"` violated by `"false"` yields:
+//!
+//!   Type '"false"' does not satisfy the constraint '"true"'.
+//!
+//! Previously we widened `"false"` to `string`, producing a nonsensical
+//! message when the constraint is itself a string-literal type.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+#[test]
+fn ts2344_preserves_string_literal_type_argument() {
+    let source = r#"
+type Foo<T extends "true", B> = { "true": Foo<T, Foo<T, B>> }[T];
+let f2: Foo<"false", {}>;
+"#;
+    let diags = compile_and_get_diagnostics(source);
+    let ts2344: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(
+        !ts2344.is_empty(),
+        "Expected TS2344 for '\"false\"' violating '\"true\"' constraint, got: {diags:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|(_, m)| m.contains("\"false\"") && m.contains("\"true\"")),
+        "Expected TS2344 message to preserve literal types (\"false\" / \"true\"), got: {ts2344:?}"
+    );
+    for (_, msg) in &ts2344 {
+        assert!(
+            !msg.contains("'string'") || msg.contains("\""),
+            "TS2344 message should not widen literal to 'string': {msg}"
+        );
+    }
+}
+
+#[test]
+fn ts2344_preserves_numeric_literal_type_argument() {
+    let source = r#"
+type Only42<T extends 42> = T;
+type X = Only42<7>;
+"#;
+    let diags = compile_and_get_diagnostics(source);
+    let ts2344: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(
+        !ts2344.is_empty(),
+        "Expected TS2344 for 7 violating 42 constraint, got: {diags:?}"
+    );
+    assert!(
+        ts2344
+            .iter()
+            .any(|(_, m)| m.contains("7") && m.contains("42")),
+        "Expected TS2344 message to preserve numeric literals (7 / 42), got: {ts2344:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `checkTypeArgumentConstraints` in tsc passes the type argument through `typeToString` unchanged; we were widening via `widen_literal_type` before formatting, so `F<\"false\">` against `T extends \"true\"` produced `Type 'string' does not satisfy the constraint '\"true\"'.` instead of `Type '\"false\"' does not satisfy the constraint '\"true\"'.`.
- The widening was stacked on top of tsc's own narrowing, and it's nonsensical when the constraint is itself a literal type (the whole point of the mismatch disappears once `\"false\"` becomes `string`).
- Removed the widening at both TS2344 emission sites (`error_reporter/generics.rs` and `checkers/generic_checker/mod.rs`). Conformance: `limitDeepInstantiations.ts` + sibling tests flip to PASS; `verify-all --quick` shows **+20 conformance** (21 gains; 1 pre-existing position mismatch on TS2769 that is unrelated to this codepath — see note below).

## Reproducer
```ts
type Foo<T extends "true", B> = { "true": Foo<T, Foo<T, B>> }[T];
let f2: Foo<"false", {}>;
// tsc:      Type '"false"' does not satisfy the constraint '"true"'.
// tsz before: Type 'string' does not satisfy the constraint '"true"'.
// tsz after:  Type '"false"' does not satisfy the constraint '"true"'.
```

## Impact (verify-all --quick)
- **Conformance: 12065 → 12085 (+20)**
- 21 new PASS, 1 pre-existing PASS→FAIL (`excessPropertiesInOverloads.ts`, TS2769 anchors at col 1 vs tsc's col 6 — completely separate codepath, drift against stale April 20 snapshot, not introduced by this PR).
- Full tsz-checker nextest: 5012/5012 pass.
- Pre-commit: 20005/20005 pass.
- Clippy / fmt / arch guards: green.

## Architecture note
Both call sites are diagnostic emission (`WHERE`), not semantic decisions (`WHAT`). No solver API changes; no boundary changes. Single-line deletion at each site (the widening call was additive cosmetic logic that didn't reflect tsc behaviour).

## Test plan
- [x] New Rust unit tests `ts2344_preserves_string_literal_type_argument` and `ts2344_preserves_numeric_literal_type_argument` in `crates/tsz-checker/tests/ts2344_literal_type_message.rs` — both fail before the change, pass after.
- [x] `cargo nextest run -p tsz-checker -E 'test(ts2344)'` → 44/44 pass (no regressions in existing ts2344 suites).
- [x] `./scripts/conformance/conformance.sh run --filter "limitDeepInstantiations" --verbose` → 1/1 PASS (fingerprint-only → PASS).
- [x] `scripts/session/verify-all.sh --quick` → conformance +20.