### PR TITLE
fix(checker): widen literal return types before Promise wrapping in async inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,10 @@ name = "generator_annotation_mismatch_display_tests"
 path = "tests/generator_annotation_mismatch_display_tests.rs"
 
 [[test]]
+name = "async_return_widening_tests"
+path = "tests/async_return_widening_tests.rs"
+
+[[test]]
 name = "ts2769_anchor_disagreeing_overloads_tests"
 path = "tests/ts2769_anchor_disagreeing_overloads_tests.rs"
 

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -2482,8 +2482,31 @@ impl<'a> CheckerState<'a> {
             // returns Promise<T> (e.g., `async () => fetch(url)`), the runtime
             // awaits it to get T, then the async wrapper produces Promise<T> —
             // NOT Promise<Promise<T>>. Unwrap any existing Promise layer first.
-            if let Some(inner) = self.unwrap_promise_type(final_return_type) {
-                final_return_type = inner;
+            let had_promise_wrapper =
+                if let Some(inner) = self.unwrap_promise_type(final_return_type) {
+                    final_return_type = inner;
+                    true
+                } else {
+                    false
+                };
+            // Widen literal return types before re-wrapping in Promise, matching
+            // tsc's async return-type inference: `async () => 0` infers
+            // `() => Promise<number>`, not `() => Promise<0>`. Skip widening when
+            // the body already produced a `Promise<T>` — the inner T either came
+            // from contextual typing (which preserved literals intentionally) or
+            // from a Promise-returning expression whose type is already stable.
+            // Also preserve `unique symbol` types: tsc does not widen them to
+            // `symbol` in async return-type inference; widening breaks
+            // `uniqueSymbolsDeclarations.ts` (the solver's generic widen_type
+            // walks UniqueSymbol → SYMBOL, which is right for mutable-binding
+            // contexts but wrong here).
+            if !had_promise_wrapper
+                && !crate::query_boundaries::common::is_unique_symbol_type(
+                    self.ctx.types,
+                    final_return_type,
+                )
+            {
+                final_return_type = self.widen_literal_type(final_return_type);
             }
             // Resolve the real Promise type from lib files when available,
             // so that the return type is structurally compatible with PromiseLike<T>.

--- a/crates/tsz-checker/tests/async_return_widening_tests.rs
+++ b/crates/tsz-checker/tests/async_return_widening_tests.rs
@@ -1,0 +1,124 @@
+//! Tests for literal widening in unannotated async function return types.
+//!
+//! tsc widens literal return types before wrapping in `Promise<T>`:
+//!   `async () => 0`        infers `() => Promise<number>` (not `Promise<0>`)
+//!   `async () => { return "y"; }` infers `() => Promise<string>` (not `Promise<"y">`)
+//!
+//! tsz previously kept the literal form (`Promise<0>` / `Promise<"y">`), which
+//! showed up as fingerprint-only divergence in TS2345 / TS2322 messages for
+//! `f(async () => { return 0 })` where `f: (p: () => string) => void`.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+#[test]
+fn async_arrow_literal_return_widens_in_ts2345() {
+    // `f(async () => { return 0 })` against `(p: () => string) => void`:
+    // the TS2345 diagnostic must display the inferred argument type with the
+    // inner return widened to `number`, NOT preserved as literal `0`.
+    // The Promise-wrapper name may render as `Promise<...>` (with lib types
+    // loaded) or `object<...>` (the synthetic fallback used when no lib is
+    // loaded) — either is fine; the invariant under test is widening.
+    let source = r#"
+declare function f(p: () => string): void;
+f(async () => { return 0 });
+"#;
+    let diags = get_diagnostics(source);
+    let ts2345: Vec<_> = diags.iter().filter(|(code, _)| *code == 2345).collect();
+    assert!(
+        !ts2345.is_empty(),
+        "expected a TS2345 for async arrow argument mismatch, got: {diags:#?}"
+    );
+    let msg = ts2345[0].1.as_str();
+    assert!(
+        msg.contains("<number>"),
+        "expected widened `<number>` in inferred async return, got: {msg}"
+    );
+    assert!(
+        !msg.contains("<0>"),
+        "literal return `0` must be widened to `number` before Promise wrapping, got: {msg}"
+    );
+}
+
+#[test]
+fn async_arrow_string_literal_return_widens() {
+    // `async () => "y"` should widen inner to `string`, not preserve `"y"`.
+    let source = r#"
+declare function g(p: () => number): void;
+g(async () => { return "y" });
+"#;
+    let diags = get_diagnostics(source);
+    let ts2345: Vec<_> = diags.iter().filter(|(code, _)| *code == 2345).collect();
+    assert!(
+        !ts2345.is_empty(),
+        "expected a TS2345 for async arrow string return vs number param, got: {diags:#?}"
+    );
+    let msg = ts2345[0].1.as_str();
+    assert!(
+        msg.contains("<string>"),
+        "expected widened `<string>` in inferred async return, got: {msg}"
+    );
+    assert!(
+        !msg.contains("<\"y\">"),
+        "literal return `\"y\"` must be widened to `string` before Promise wrapping, got: {msg}"
+    );
+}
+
+#[test]
+fn async_arrow_returning_promise_expression_preserves_inner() {
+    // When an async function returns an already-Promise-wrapped value, the
+    // outer Promise wrapping preserves the inner type (no double-wrap, no
+    // spurious widening).
+    let source = r#"
+interface Promise<T> {}
+interface Foo { bar: number }
+declare function makePromise(): Promise<Foo>;
+declare function h(p: () => string): void;
+h(async () => makePromise());
+"#;
+    let diags = get_diagnostics(source);
+    // Surfaces as TS2322 or TS2345 depending on which elaboration path wins;
+    // the invariant under test is that the inner `Foo` survives unchanged
+    // (not widened, not re-wrapped twice).
+    let mismatch: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| (*code == 2345 || *code == 2322) && msg.contains("Foo"))
+        .collect();
+    assert!(
+        !mismatch.is_empty(),
+        "expected a TS2322/TS2345 mentioning Foo for async arrow returning Promise<Foo>, got: {diags:#?}"
+    );
+    let msg = mismatch[0].1.as_str();
+    assert!(
+        msg.contains("<Foo>"),
+        "async-return of Promise<Foo> must preserve inner `Foo`, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary
- Unannotated async arrow functions infer `() => Promise<T>`. tsc widens literal return types before wrapping — `async () => 0` infers `() => Promise<number>`, not `() => Promise<0>`. tsz was preserving the literal form.
- Fix applies `widen_literal_type` in `infer_function_type`'s async path, gated on "body did not already produce a `Promise<T>`" so contextually-typed Promise-returning expressions keep their inner type intact.
- Conformance **+17**, emit DTS +16 on `verify-all`.

## Root cause
In `crates/tsz-checker/src/types/function_type.rs:2478-2506`, the async path unwraps a pre-existing `Promise<T>` wrapper, then re-wraps in `Promise<...>`. Widening was never applied to the inner type. Compare to the generator path at line 2449-2467, which widens via `widen_literal_type` before building the `Generator<Y, R, N>` application. This PR brings async parity with generators.

## Reproducer
```ts
declare function f(p: () => string): void;
f(async () => { return 0 });
// tsc:       Argument of type '() => Promise<number>' is not assignable to parameter of type '() => string'.
// tsz before: Argument of type '() => Promise<0>'      is not assignable to parameter of type '() => string'.
// tsz after:  Argument of type '() => Promise<number>' is not assignable to parameter of type '() => string'.
```

## Impact (verify-all)
- Conformance: **+17** (12082 vs 12065 baseline).
- Emit: JS +0, DTS **+16**.
- Fourslash: npm-install transient in this run; unrelated to the fix.
- Unit tests: 21,207 / 21,207 pass.

## Test plan
- [x] New `crates/tsz-checker/tests/async_return_widening_tests.rs` with three tests: literal number widens, literal string widens, Promise-returning expression inner preserved.
- [x] `./scripts/conformance/conformance.sh run --filter asyncArrowFunction_allowJs --verbose` confirms the TS2345 fingerprint on line 26 now matches tsc (`Promise<number>` instead of `Promise<0>`).
- [x] `scripts/safe-run.sh cargo nextest run`: 21,207 tests pass.

## Secondary change
Extends the nextest slow-timeout override to `test(default_lib_validation)` (two sibling tests that load the full es2015 default libs and sit at the 60s debug-build edge). Same pattern used for other heavy default-lib tests.

## Scope note
`asyncArrowFunction_allowJs.ts` has two further fingerprint-only divergences in its `/** @type */` JSDoc paths — tsc reports per-return-statement TS2322 inside the JSDoc-annotated async lambdas, tsz reports a whole-function-signature TS2322 at the `const` declaration. That is a distinct JSDoc @type diagnostic anchoring issue and is out of scope for this PR.