### PR TITLE
fix(checker): emit TS1238 for zero-arity ES class decorator

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -131,8 +131,14 @@ impl<'a> CheckerState<'a> {
                             class,
                         );
                     } else {
-                        // ES decorators: tsc anchors TS1238 at the decorator node (including @).
-                        self.check_es_class_decorator_arity(mod_idx, decorator_type);
+                        // ES decorators: tsc anchors TS1238 at the whole decorator
+                        // (including `@`) when the factory requires too many args, but
+                        // at the expression alone when the factory has zero parameters.
+                        self.check_es_class_decorator_arity(
+                            mod_idx,
+                            decorator.expression,
+                            decorator_type,
+                        );
                     }
                 }
             }
@@ -1521,6 +1527,7 @@ impl<'a> CheckerState<'a> {
     fn check_es_class_decorator_arity(
         &mut self,
         decorator_node: NodeIndex,
+        decorator_expression: NodeIndex,
         decorator_type: TypeId,
     ) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
@@ -1546,8 +1553,21 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .filter(|p| !p.optional && !p.rest)
                 .count();
-            // ES decorators receive (value, context) — max 2 args
-            if required_params > 2 {
+            // ES decorators are invoked with `(value, context)`.
+            //
+            // * When the factory has no parameters at all, the runtime call
+            //   `f(value, context)` passes extra args; tsc anchors the error
+            //   at the decorator expression (excluding `@`).
+            // * When the factory requires more than two parameters, the call
+            //   cannot supply them; tsc anchors the error at the whole
+            //   decorator (including `@`).
+            if shape.params.is_empty() {
+                self.error_at_node(
+                    decorator_expression,
+                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                );
+            } else if required_params > 2 {
                 self.error_at_node(
                     decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,

--- a/crates/tsz-checker/tests/ts1238_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_tests.rs
@@ -220,3 +220,68 @@ class C {
         "Expected TS1238 for generic decorator with incompatible call, got: {codes:?}"
     );
 }
+
+// === ES decorators (experimental_decorators: false) =======================
+//
+// ES decorators call the decorator factory with `(value, context)`.
+// A factory with zero parameters has no slot for `value`, so tsc flags
+// it as TS1238 even though a structural call would succeed by ignoring
+// the extra args. A factory requiring more than two parameters also
+// cannot be satisfied. 1 or 2 required parameters are fine.
+
+fn check_es_decorators(source: &str) -> Vec<u32> {
+    let mut parser =
+        tsz_parser::parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = tsz_solver::TypeInterner::new();
+    let mut checker = tsz_checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn ts1238_es_decorator_zero_arity_factory_emits_error() {
+    // `() => {}` has no parameter to receive the class target.
+    let codes = check_es_decorators("@(() => {})\nclass C {}\n");
+    assert!(
+        codes.contains(&1238),
+        "Expected TS1238 for zero-arity ES class decorator, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1238_es_decorator_one_or_two_required_params_no_error() {
+    for source in [
+        "@((a: any) => {})\nclass C {}\n",
+        "@((a: any, b: any) => {})\nclass C {}\n",
+    ] {
+        let codes = check_es_decorators(source);
+        assert!(
+            !codes.contains(&1238),
+            "Should not emit TS1238 for 1 or 2 required params, got: {codes:?} for {source}"
+        );
+    }
+}
+
+#[test]
+fn ts1238_es_decorator_too_many_required_params_emits_error() {
+    for source in [
+        "@((a: any, b: any, c: any) => {})\nclass C {}\n",
+        "@((a: any, b: any, c: any, ...d: any[]) => {})\nclass C {}\n",
+    ] {
+        let codes = check_es_decorators(source);
+        assert!(
+            codes.contains(&1238),
+            "Expected TS1238 for >2 required params, got: {codes:?} for {source}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- tsc rejects a zero-parameter ES class decorator (\`@(() => {})\`) with TS1238 because the factory has no slot to receive the class target — the runtime \`f(value, context)\` call leaves the target unbound even though JS will silently ignore it. We were only flagging decorators that *required* more than two parameters, so the zero-arity case slipped through.
- Added the \`shape.params.is_empty()\` branch to \`check_es_class_decorator_arity\` and anchored the diagnostic at the decorator *expression* (not the whole decorator node), matching tsc's baseline for the zero-arity case while preserving the whole-decorator anchor for the too-many-params case.
- Flips \`conformance/esDecorators/esDecorators-arguments.ts\` to PASS.

## Reproducer
```ts
@(() => {})                      // TS1238 now emitted (was missing)
@((a: any) => {})                // OK
@((a: any, b: any) => {})        // OK
@((a: any, b: any, c: any) => {}) // TS1238 (already caught)
class C1 {}
```

tsc expects:
```
esDecorators-arguments.ts(1,2): error TS1238: Unable to resolve signature of class decorator when called as an expression.
esDecorators-arguments.ts(4,1): error TS1238: Unable to resolve signature of class decorator when called as an expression.
esDecorators-arguments.ts(5,1): error TS1238: Unable to resolve signature of class decorator when called as an expression.
```

Before: only lines 4 and 5 emitted.
After: all three emitted, matching tsc's positions exactly (line 1 at col 2 = decorator expression; lines 4/5 at col 1 = whole decorator).

## Architecture note
Single \`WHERE\` change in the checker. No solver API changes; no boundary changes. The arity check already lived in \`class_checker\`; this just extends the branch with a symmetric zero-arity case and picks a different anchor node to match tsc's baseline positions.

## Test plan
- [x] 3 new Rust unit tests in \`crates/tsz-checker/tests/ts1238_tests.rs\`:
  - \`ts1238_es_decorator_zero_arity_factory_emits_error\`
  - \`ts1238_es_decorator_one_or_two_required_params_no_error\`
  - \`ts1238_es_decorator_too_many_required_params_emits_error\`
- [x] \`cargo nextest run -p tsz-checker --test ts1238_tests\` → 12/12 PASS.
- [x] \`cargo nextest run -p tsz-checker\` → 5015/5015 PASS.
- [x] Pre-commit gate: fmt + clippy + arch + 13088 tests all green.
- [x] \`./scripts/conformance/conformance.sh run --filter "esDecorators-arguments" --verbose\` → 1/1 PASS.