### PR TITLE
fix(resolver,checker): gate TS2307 → TS2792 override on a node-style resolution probe

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -253,23 +253,13 @@ impl<'a> CheckerState<'a> {
         }
 
         if let Some(error) = self.ctx.get_resolution_error(module_name) {
-            let use_2792 = self.ctx.compiler_options.implied_classic_resolution
-                || matches!(
-                    self.ctx.compiler_options.module,
-                    ModuleKind::AMD | ModuleKind::UMD | ModuleKind::System | ModuleKind::None
-                );
-            if use_2792
-                && error.code
-                    == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS
-            {
-                return (
-                    format_message(
-                        diagnostic_messages::CANNOT_FIND_MODULE_DID_YOU_MEAN_TO_SET_THE_MODULERESOLUTION_OPTION_TO_NODENEXT_O,
-                        &[module_name],
-                    ),
-                    diagnostic_codes::CANNOT_FIND_MODULE_DID_YOU_MEAN_TO_SET_THE_MODULERESOLUTION_OPTION_TO_NODENEXT_O,
-                );
-            }
+            // The resolver is the single source of truth for the TS2307 vs
+            // TS2792 choice: it probes for a matching `node_modules/<pkg>`
+            // ancestor before suggesting the nodenext hint, matching tsc's
+            // "would switching moduleResolution actually help?" gate. We no
+            // longer re-derive the code here from `implied_classic_resolution`
+            // alone — that produced TS2792 hints even for specifiers (like
+            // ambient-only modules) where nodenext wouldn't resolve them.
             return (error.message.clone(), error.code);
         }
 

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -1482,7 +1482,6 @@ impl<'a> CheckerState<'a> {
         module_specifier: &str,
         decl_node: NodeIndex,
     ) {
-        use crate::diagnostics::diagnostic_codes;
         use tsz_parser::parser::syntax_kind_ext;
 
         // Only emit if report_unresolved_imports is enabled
@@ -1608,23 +1607,18 @@ impl<'a> CheckerState<'a> {
         // Check for specific resolution error from driver (TS2834, TS2835, TS2792, etc.)
         // The driver's ModuleResolver may have a more specific error code than TS2307.
         if let Some(error) = self.ctx.get_resolution_error(module_specifier) {
-            // For Node.js built-in modules, use TS2591 instead of TS2307
+            // For Node.js built-in modules, use TS2591 instead of TS2307.
+            //
+            // The resolver is the source of truth for TS2307 vs TS2792: it
+            // already applies tsc's "would node-style resolution help?" check
+            // before suggesting the nodenext hint. Don't re-derive TS2792 here
+            // from `implied_classic_resolution` — doing so would over-trigger
+            // the hint for specifiers where switching resolution modes
+            // wouldn't actually resolve them (e.g., ambient-only modules).
             let (error_message, error_code) = {
                 let (msg, code) = self.module_not_found_diagnostic(module_specifier);
                 if code != error.code {
                     (msg, code) // module_not_found_diagnostic upgraded to TS2591
-                } else if error.code
-                    == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS
-                    && self.ctx.compiler_options.implied_classic_resolution
-                {
-                    use crate::diagnostics::{diagnostic_messages, format_message};
-                    (
-                        format_message(
-                            diagnostic_messages::CANNOT_FIND_MODULE_DID_YOU_MEAN_TO_SET_THE_MODULERESOLUTION_OPTION_TO_NODENEXT_O,
-                            &[module_specifier],
-                        ),
-                        diagnostic_codes::CANNOT_FIND_MODULE_DID_YOU_MEAN_TO_SET_THE_MODULERESOLUTION_OPTION_TO_NODENEXT_O,
-                    )
                 } else {
                     (error.message.clone(), error.code)
                 }

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -714,12 +714,31 @@ impl ModuleResolver {
                 // 6. Build final error from the failure
                 let mut diag = failure.to_diagnostic();
 
-                // Classic resolution override: TS2307 → TS2792
+                // Classic resolution override: TS2307 → TS2792.
+                //
+                // tsc only promotes "cannot find module" to the `moduleResolution`
+                // hint when a node-style resolution *would* have succeeded —
+                // i.e., when there's an ancestor `node_modules/<package>`
+                // directory that the current classic resolver can't reach. For
+                // bare specifiers with no matching node_modules entry, switching
+                // to `nodenext` wouldn't help, so tsc keeps plain TS2307.
+                //
+                // We approximate tsc's check with a filesystem probe: walk up
+                // from the containing file and look for a `node_modules/<pkg>`
+                // directory whose name matches the specifier's package name.
+                // This is the same signal tsc uses to decide the hint is useful.
                 if diag.code == CANNOT_FIND_MODULE && request.implied_classic_resolution {
-                    diag.code = MODULE_RESOLUTION_MODE_MISMATCH;
-                    diag.message = format!(
-                        "Cannot find module '{specifier}'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?"
-                    );
+                    let is_bare = !specifier.starts_with('.')
+                        && !specifier.starts_with('/')
+                        && !specifier.contains(':');
+                    let node_style_would_find =
+                        is_bare && self.has_node_modules_package_match(specifier, containing_file);
+                    if node_style_would_find {
+                        diag.code = MODULE_RESOLUTION_MODE_MISMATCH;
+                        diag.message = format!(
+                            "Cannot find module '{specifier}'. Did you mean to set the 'moduleResolution' option to 'nodenext', or to add aliases to the 'paths' option?"
+                        );
+                    }
                 }
 
                 // If the primary resolution found the file but JSX wasn't set,
@@ -731,6 +750,47 @@ impl ModuleResolver {
                 ModuleLookupResult::failed(diag.code, diag.message)
             }
         }
+    }
+
+    /// Walk ancestor directories of `containing_file` looking for a
+    /// `node_modules/<package>` directory whose name matches the bare
+    /// `specifier`'s package segment. Used to gate the TS2307 → TS2792
+    /// override: switching `moduleResolution` to `nodenext` only helps if
+    /// node-style resolution would have a candidate to find.
+    ///
+    /// Handles both plain (`foo` → `node_modules/foo`) and scoped
+    /// (`@scope/bar` → `node_modules/@scope/bar`) package names.
+    fn has_node_modules_package_match(&self, specifier: &str, containing_file: &Path) -> bool {
+        // Extract the package segment of the specifier (stop at the first `/`
+        // after the optional `@scope/` prefix).
+        let pkg_end = if let Some(stripped) = specifier.strip_prefix('@') {
+            // Scoped: need two path segments (`@scope/name`).
+            let rest_start = 1;
+            match stripped.find('/') {
+                Some(first_slash) => {
+                    let after_scope = &stripped[first_slash + 1..];
+                    let name_end = after_scope.find('/').unwrap_or(after_scope.len());
+                    rest_start + first_slash + 1 + name_end
+                }
+                None => return false,
+            }
+        } else {
+            specifier.find('/').unwrap_or(specifier.len())
+        };
+        let package_name = &specifier[..pkg_end];
+        if package_name.is_empty() {
+            return false;
+        }
+
+        let mut cursor = containing_file.parent();
+        while let Some(dir) = cursor {
+            let candidate = dir.join("node_modules").join(package_name);
+            if candidate.is_dir() {
+                return true;
+            }
+            cursor = dir.parent();
+        }
+        false
     }
 
     /// Check whether a fallback-resolved file needs an ESM extension error.

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -2339,10 +2339,12 @@ fn test_lookup_extension_suggestion_tsx_react_uses_js() {
 
 #[test]
 fn test_lookup_cjs_esm_mismatch_classic_resolution() {
-    // TS2792: classic resolution should produce moduleResolution mismatch
+    // TS2792: classic resolution + a matching `node_modules/<pkg>` ancestor
+    // should produce moduleResolution mismatch hint.
     let dir = std::env::temp_dir().join("tsz_lookup_cjs_esm_mismatch");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("node_modules").join("nonexistent")).unwrap();
     std::fs::write(dir.join("src/index.ts"), "import 'nonexistent';").unwrap();
 
     let options = ResolvedCompilerOptions {
@@ -2366,7 +2368,7 @@ fn test_lookup_cjs_esm_mismatch_classic_resolution() {
     let error = result.error.expect("should have an error");
     assert_eq!(
         error.code, MODULE_RESOLUTION_MODE_MISMATCH,
-        "classic resolution should produce TS2792, got TS{}",
+        "classic resolution with matching node_modules/<pkg> should produce TS2792, got TS{}",
         error.code
     );
     assert!(
@@ -4007,10 +4009,64 @@ fn test_lookup_should_try_fallback_not_for_hard_failures() {
 
 #[test]
 fn test_lookup_classic_implied_resolution_upgrades_to_ts2792() {
-    // When implied_classic_resolution is true and the module is not found,
-    // lookup() should upgrade TS2307 -> TS2792.
+    // When implied_classic_resolution is true AND a node-style resolution
+    // would find the package (via ancestor `node_modules/<pkg>/`), lookup()
+    // upgrades TS2307 → TS2792 to suggest the nodenext hint.
+    //
+    // Without a matching node_modules entry the override MUST NOT fire — see
+    // `test_lookup_classic_implied_resolution_without_node_modules_keeps_ts2307`
+    // below for the gated case.
     use std::fs;
     let dir = std::env::temp_dir().join("tsz_lookup_classic_ts2792");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::create_dir_all(dir.join("node_modules").join("some-pkg")).unwrap();
+    fs::write(dir.join("index.ts"), "import 'some-pkg';").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "some-pkg",
+        containing_file: &dir.join("index.ts"),
+        specifier_span: Span::new(8, 18),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: true,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+    let outcome = result.classify();
+
+    assert!(!outcome.is_resolved);
+    let error = outcome.error.expect("Expected error for missing module");
+    assert_eq!(
+        error.code, MODULE_RESOLUTION_MODE_MISMATCH,
+        "Expected TS2792 for implied classic resolution with matching node_modules/<pkg>, got TS{}",
+        error.code
+    );
+    assert!(
+        error.message.contains("moduleResolution"),
+        "TS2792 message should suggest moduleResolution option"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_lookup_classic_implied_resolution_without_node_modules_keeps_ts2307() {
+    // When implied_classic_resolution is true but there is NO matching
+    // node_modules/<pkg> ancestor, switching to nodenext wouldn't actually
+    // resolve the specifier — tsc emits plain TS2307 in this case. Matches
+    // the `typeRootsFromNodeModulesInParentDirectory.ts` conformance test
+    // where the only "matching" entry is an ambient module declaration
+    // inside an unrelated @types/<foo> package.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_lookup_classic_ts2307_no_node_modules");
     let _ = fs::remove_dir_all(&dir);
     fs::create_dir_all(&dir).unwrap();
     fs::write(dir.join("index.ts"), "import 'some-pkg';").unwrap();
@@ -4037,13 +4093,9 @@ fn test_lookup_classic_implied_resolution_upgrades_to_ts2792() {
     assert!(!outcome.is_resolved);
     let error = outcome.error.expect("Expected error for missing module");
     assert_eq!(
-        error.code, MODULE_RESOLUTION_MODE_MISMATCH,
-        "Expected TS2792 for implied classic resolution, got TS{}",
+        error.code, CANNOT_FIND_MODULE,
+        "Expected TS2307 when no matching node_modules/<pkg> exists under any ancestor, got TS{}",
         error.code
-    );
-    assert!(
-        error.message.contains("moduleResolution"),
-        "TS2792 message should suggest moduleResolution option"
     );
 
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary
- tsc only promotes "Cannot find module" (TS2307) to the nodenext hint (TS2792) when a node-style resolution *would* have resolved the specifier — i.e., when switching `moduleResolution` to `nodenext` would actually help.
- tsz was unconditionally overriding TS2307 → TS2792 whenever `implied_classic_resolution` was true, producing the wrong code on `typeRootsFromNodeModulesInParentDirectory.ts` and similar tests where the only "matching" entry is an ambient `declare module "xyz"` inside an unrelated `@types/<foo>` package — nodenext wouldn't resolve those either.
- Conformance **+20** (12085 vs 12065 baseline).

## Root cause
Three sites overrode TS2307 → TS2792:
1. `crates/tsz-core/src/module_resolver/mod.rs:717` (driver-level)
2. `crates/tsz-checker/src/declarations/import/core/helpers.rs:255` (checker fallback)
3. `crates/tsz-checker/src/state/type_resolution/module.rs:1616` (checker anchor path)

All three fired on `implied_classic_resolution` alone, without the "would node help?" probe tsc performs.

## Fix
Add `ModuleResolver::has_node_modules_package_match` that walks ancestor directories of the containing file looking for `node_modules/<package>` whose name matches the specifier's package segment (handles plain `foo` and scoped `@scope/bar`). Gate the resolver's override on that probe. Remove the two duplicate unconditional overrides in the checker so the resolver stays the single source of truth.

## Reproducer
```ts
// /src/a.ts  (no /src/node_modules, no /node_modules/xyz anywhere)
import { x } from "xyz";
// tsc:       error TS2307: Cannot find module 'xyz' or its corresponding type declarations.
// tsz before: error TS2792: Cannot find module 'xyz'. Did you mean to set the 'moduleResolution' option to 'nodenext', ...
// tsz after:  error TS2307: Cannot find module 'xyz' or its corresponding type declarations.
```

## Impact (verify-all)
- Conformance: **+20** (12085 vs 12065 baseline).
- Emit: JS +0, DTS **+16**.
- Fourslash: unchanged (50/50).
- Unit tests: 13,084 / 13,084 pass.

## Test plan
- [x] Existing `test_lookup_classic_implied_resolution_upgrades_to_ts2792` and `test_lookup_cjs_esm_mismatch_classic_resolution` updated to set up a matching `node_modules/<pkg>` directory — continue asserting TS2792 now with the gated condition met.
- [x] New `test_lookup_classic_implied_resolution_without_node_modules_keeps_ts2307` locks in the new gated TS2307 behavior.
- [x] `./scripts/conformance/conformance.sh run --filter typeRootsFromNodeModulesInParentDirectory --verbose` confirms code flip TS2792 → TS2307 (remaining divergence is a separate path-normalization issue, out of scope).
- [x] `scripts/safe-run.sh cargo nextest run`: all tests pass.