### PR TITLE
fix(checker): clear per-module TS2307 dedupe on each import-equals site

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -44,6 +44,10 @@ name = "ts1210_arguments_param_in_class_tests"
 path = "tests/ts1210_arguments_param_in_class_tests.rs"
 
 [[test]]
+name = "ts2307_per_site_dedup_tests"
+path = "tests/ts2307_per_site_dedup_tests.rs"
+
+[[test]]
 name = "ts2769_anchor_disagreeing_overloads_tests"
 path = "tests/ts2769_anchor_disagreeing_overloads_tests.rs"
 

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -154,6 +154,20 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        // Each `import X = require("...")` statement reports TS2307 at its own
+        // site. Clear the per-module dedupe up front so that a second
+        // statement importing the same unresolved module (for example, an
+        // `import im2 = require("...")` inside a `declare module "m1"`
+        // augmentation whose outer file already imported the same name)
+        // still emits TS2307 — matching tsc's per-site behavior. The dedupe
+        // remains effective *within* a single statement to suppress
+        // cascading emissions.
+        if let Some(module_name) = self.get_require_module_specifier(import.module_specifier) {
+            self.ctx
+                .modules_with_ts2307_emitted
+                .remove(module_name.as_str());
+        }
+
         // TS1294: erasableSyntaxOnly — import equals declarations are not erasable.
         if self.ctx.compiler_options.erasable_syntax_only
             && !self.ctx.is_ambient_declaration(stmt_idx)

--- a/crates/tsz-checker/tests/ts2307_per_site_dedup_tests.rs
+++ b/crates/tsz-checker/tests/ts2307_per_site_dedup_tests.rs
@@ -1,0 +1,65 @@
+//! Ensure TS2307 "Cannot find module" is emitted per import-equals site, not
+//! deduplicated by module name across the whole file.
+//!
+//! Reproduces `importDeclRefereingExternalModuleWithNoResolve.ts`, where the
+//! same unresolved specifier `"externalModule"` appears in two distinct
+//! `import X = require(...)` statements — one at file level, one inside a
+//! `declare module "m1"` augmentation. tsc reports TS2307 at both sites. tsz
+//! was deduplicating by module name across the entire file and only reported
+//! the first.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+#[test]
+fn ts2307_dedup_set_is_cleared_at_start_of_each_import_equals_check() {
+    // Drives the core invariant behind the fix for
+    // `importDeclRefereingExternalModuleWithNoResolve.ts`: each
+    // `import X = require("...")` must not be suppressed by a previous
+    // statement's TS2307 emission of the same module name. We observe
+    // this by seeding `modules_with_ts2307_emitted` before check, letting
+    // the checker run, and asserting the seed entry is gone — proving the
+    // dedup is cleared on each statement entry. Full integration coverage
+    // (two TS2307 emissions at distinct positions) lives in the
+    // conformance test `importDeclRefereingExternalModuleWithNoResolve`.
+    let source = r#"import b = require("externalModule");
+declare module "m1" {
+    import im2 = require("externalModule");
+}
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+    checker
+        .ctx
+        .modules_with_ts2307_emitted
+        .insert("externalModule".to_string());
+    assert!(
+        checker
+            .ctx
+            .modules_with_ts2307_emitted
+            .contains("externalModule"),
+        "seed should be present before check"
+    );
+
+    checker.check_source_file(root);
+
+    assert!(
+        !checker
+            .ctx
+            .modules_with_ts2307_emitted
+            .contains("externalModule"),
+        "check_import_equals_declaration should clear the per-module dedupe entry for each statement, so the set must no longer contain `externalModule` after checking"
+    );
+}


### PR DESCRIPTION
## Summary
- `importDeclRefereingExternalModuleWithNoResolve.ts` imports the same unresolved specifier `"externalModule"` from two distinct `import X = require(...)` sites. tsc reports TS2307 on both; tsz reported only the first because the file-scoped `modules_with_ts2307_emitted` dedupe set was never cleared between statements.
- Conformance **+24** (12089 vs 12065 baseline).

## Root cause
`modules_with_ts2307_emitted` exists to suppress *within-statement* cascading emissions (multiple resolution attempts during one statement). It was never cleared across statements, so the second `require("externalModule")` found the module name already present and skipped emission — unlike tsc which reports per site.

## Fix
At the top of `check_import_equals_declaration` (`crates/tsz-checker/src/declarations/import/equals.rs`), `remove()` the current specifier from `modules_with_ts2307_emitted`. Mirrors the identical pattern already in `module_checker.rs` for re-exports: *"Re-exports report TS2307 per declaration site. Clear the per-module dedupe entry up front so each `export ... from "x"` statement gets one chance…"*. Within-statement cascade suppression is preserved — the first emission still re-inserts the entry.

## Reproducer
```ts
import b = require("externalModule");
// tsc: TS2307     tsz before: TS2307     tsz after: TS2307
declare module "m1" {
    import im2 = require("externalModule");
    // tsc: TS2307   tsz before: (silent)   tsz after: TS2307
}
```

## Impact (verify-all)
- **Conformance: +24** (12089 vs 12065 baseline).
- Emit: JS +0, DTS **+16**.
- Fourslash: unchanged (50/50).
- Pre-commit: all suites green.

## Test plan
- [x] New `crates/tsz-checker/tests/ts2307_per_site_dedup_tests.rs`: seeds the dedupe set before `check_source_file`, asserts the checker clears the entry on the import-equals statement.
- [x] `./scripts/conformance/conformance.sh run --filter importDeclRefereingExternalModuleWithNoResolve --verbose`: 1/1 PASS.
- [x] `scripts/session/verify-all.sh`: all 6 suites pass, conformance +24, no regressions.