### PR TITLE
fix(checker): skip TS1210 for `arguments` parameter property

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -144,7 +144,17 @@ impl<'a> CheckerState<'a> {
             //                       ^^^^^^^^^^
             //   error TS1210: Code contained in a class is evaluated in JavaScript's
             //   strict mode which does not allow this use of 'arguments'.
-            if use_class_strict_message && ident.escaped_text == "arguments" {
+            //
+            // Skip when the parameter has a parameter-property modifier
+            // (`public`/`private`/`protected`/`readonly`/`override`) — that form
+            // is a shorthand field declaration (e.g. `constructor(public arguments: ASTList)`)
+            // and tsc does not emit TS1210 for those. See parserRealSource11.ts.
+            if use_class_strict_message
+                && ident.escaped_text == "arguments"
+                && self
+                    .find_first_parameter_property_modifier(&param.modifiers)
+                    .is_none()
+            {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
                 if let Some((pos, end)) = self.ctx.get_node_span(param.name) {
                     self.ctx.error(


### PR DESCRIPTION
## Summary
Fix-forward for #996 (merged as 28e2fc4529).

#996 added a TS1210 emission for `arguments` as a class-method parameter name, but did not gate on parameter-property modifiers. A parameter like

```ts
constructor(public arguments: ASTList) { ... }
```

is a field-declaration shorthand, not a general parameter reference, and tsc does not emit TS1210 for those. As a result, #996 regressed `parserRealSource11.ts` (two `public arguments: ASTList` constructor parameters inside the TypeScript 1.x compiler source):

```
expected: [TS1011]
actual:   [TS1011, TS1210]   ← extra TS1210 at positions 520:29 and 985:29
```

## Fix
Gate the TS1210 emission on `find_first_parameter_property_modifier(&param.modifiers).is_none()` — the same helper already used by `check_parameter_properties` for TS2374.

## Validation
- `parseClassDeclarationInStrictModeByDefaultInES6.ts` (#996's original target) — still passes.
- `parserRealSource11.ts` (#996's regression) — now passes.
- Local validation plan: full conformance + `cargo nextest run -p tsz-checker` once CI spins up.