### PR TITLE
fix(checker): await must not drill past non-Promise generic applications

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -40,6 +40,10 @@ name = "async_return_widening_tests"
 path = "tests/async_return_widening_tests.rs"
 
 [[test]]
+name = "await_generic_non_promise_no_false_ts2339_tests"
+path = "tests/await_generic_non_promise_no_false_ts2339_tests.rs"
+
+[[test]]
 name = "ts1210_arguments_param_in_class_tests"
 path = "tests/ts1210_arguments_param_in_class_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -329,23 +329,19 @@ impl<'a> CheckerState<'a> {
             return Some(awaited);
         }
 
-        // Fallback for generic applications where complex unwrapping failed.
-        // This preserves type parameters from generic applications even when we can't
-        // verify Promise-likeness. For cases like `Task<T>` where unwrapping
-        // fails, we return `T` instead of falling back to None/full type.
-        if let query::PromiseTypeKind::Application { args, .. } =
-            query::classify_promise_type(self.ctx.types, return_type)
-        {
-            // If we have type arguments, return the first one as a fallback.
-            // This preserves generic type parameters even when Promise verification fails.
-            if let Some(&first_arg) = args.first() {
-                return Some(first_arg);
-            }
-        }
-
         // If we can't extract the type argument from a Promise-like type,
         // return None instead of ANY/UNKNOWN (consistent with Task 4-6 changes)
-        // This allows the caller (await expressions) to use UNKNOWN as fallback
+        // This allows the caller (await expressions) to use UNKNOWN as fallback.
+        //
+        // A previous "fallback for generic applications" path unconditionally
+        // returned `args.first()` for *any* generic Application whose base
+        // wasn't identified as Promise-like. That caused `await
+        // Promise<Box<T>>` to unwrap to `T` (via a second fallback on
+        // `Box<T>`) instead of stopping at `Box<T>` — producing false TS2339s
+        // like `Property 'data' does not exist on type 'number'` for
+        // `interface Box<T> { data: T }`. Removed: if a type isn't recognized
+        // as Promise-like, the await loop must stop rather than assume the
+        // first type argument is the awaited payload.
         None
     }
 

--- a/crates/tsz-checker/tests/await_generic_non_promise_no_false_ts2339_tests.rs
+++ b/crates/tsz-checker/tests/await_generic_non_promise_no_false_ts2339_tests.rs
@@ -1,0 +1,80 @@
+//! `await Promise<Interface<T>>` must unwrap to `Interface<T>`, not further
+//! drill into `T`.
+//!
+//! Regression: `promise_like_return_type_argument`'s "fallback for generic
+//! applications" path unconditionally returned `args.first()` for any
+//! Application whose base wasn't recognized as Promise-like. That caused the
+//! await loop to re-enter with the first type argument, producing false
+//! TS2339 diagnostics like:
+//!
+//!   interface Box<T> { data: T; }
+//!   async function `f()` {
+//!       const p: Promise<Box<number>> = null as any;
+//!       const r = await p;
+//!       r.data;   // tsz (before fix): TS2339 "does not exist on type 'number'"
+//!   }
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn get_diagnostic_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn await_promise_of_generic_interface_preserves_interface_type() {
+    // Minimal repro from `destructureOfVariableSameAsShorthand.ts`.
+    let source = r#"
+interface Box<T> { data: T; }
+async function f() {
+    const p: Promise<Box<number>> = null as any;
+    const r = await p;
+    const body = r.data;
+}
+"#;
+    let codes = get_diagnostic_codes(source);
+    assert!(
+        !codes.contains(&2339),
+        "unexpected TS2339 after `await p` where p: Promise<Box<number>> — the await loop must stop at Box<number>, not unwrap further into `number`. got: {codes:?}"
+    );
+}
+
+#[test]
+fn await_promise_of_generic_interface_with_default_param_preserves_type() {
+    // Mirrors the conformance fixture: the interface has a default type arg
+    // and the function uses multi-level type-parameter defaults. This locks
+    // in that the fix works even in the presence of type-parameter default
+    // chains, not just when explicit args are supplied.
+    let source = r#"
+interface AxiosResponse<T = never> { data: T; }
+declare function get<T = never, R = AxiosResponse<T>>(): Promise<R>;
+async function main() {
+    const response = await get();
+    const body = response.data;
+}
+"#;
+    let codes = get_diagnostic_codes(source);
+    assert!(
+        !codes.contains(&2339),
+        "unexpected TS2339 after `await get()` — response must type as AxiosResponse<never>, not `never`. got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `destructureOfVariableSameAsShorthand.ts` (and 27 other conformance tests) was failing on false TS2339: tsz erroneously unwrapped `Promise<Box<T>>` all the way down to `T`.
- Root cause: `promise_like_return_type_argument` had an unconditional fallback that returned `args.first()` for ANY generic Application, even when the base was clearly not Promise-like.
- Removing the overly-aggressive fallback flips **+28** conformance tests.

## Root cause
Final branch of `promise_like_return_type_argument` in `crates/tsz-checker/src/checkers/promise_checker.rs`:

```rust
// Fallback for generic applications where complex unwrapping failed.
// […] For cases like `Task<T>` where unwrapping fails, we return `T`
// instead of falling back to None/full type.
if let query::PromiseTypeKind::Application { args, .. } =
    query::classify_promise_type(self.ctx.types, return_type)
{
    if let Some(&first_arg) = args.first() {
        return Some(first_arg);
    }
}
```

The comment *claimed* this was for Promise-subclass failures, but the code never actually verified the base was Promise-related. So `Box<number>` unwrapped to `number`, the await loop continued, and `.data` access failed on `number` instead of succeeding on `Box<number>`.

## Reproducer
```ts
interface Box<T> { data: T; }
async function f() {
    const p: Promise<Box<number>> = null as any;
    const r = await p;
    r.data;
    // tsz before: error TS2339 "does not exist on type 'number'"
    // tsz after:  OK (r: Box<number>, r.data: number)
}
```

## Impact (verify-all)
- Conformance: **+28** (12093 vs 12065 baseline).
- Emit: JS +0, DTS **+16**.
- Fourslash: unchanged (50/50).
- Unit tests: all pass.

## Test plan
- [x] New `crates/tsz-checker/tests/await_generic_non_promise_no_false_ts2339_tests.rs` with two cases: plain `Promise<Box<T>>` and the multi-level type-parameter-default pattern (`get<T = never, R = AxiosResponse<T>>`).
- [x] `./scripts/conformance/conformance.sh run --filter destructureOfVariableSameAsShorthand --verbose`: 1/1 PASS.
- [x] `scripts/session/verify-all.sh`: conformance +28, no regressions, all 6 suites pass.

Recognized Promise-like types (direct `PROMISE_BASE`, Lazy(defid) with a promise-like name, TypeQuery, type aliases to Promise, classes extending Promise, object/thenable structural inspection) all continue to unwrap correctly via the preceding branches. Only the unconditional generic-Application fallback is removed.