### PR TITLE
chore(parser): add NodeArena::kind_at helper

### DIFF
--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1357,7 +1357,7 @@ impl<'a> CheckerState<'a> {
         if use_node_cache && let Some(&cached) = self.ctx.node_types.get(&idx.0) {
             // PERF: Single arena lookup for the cached path — all subsequent
             // checks reuse `node_kind` instead of re-fetching from the arena.
-            let node_kind = self.ctx.arena.get(idx).map(|n| n.kind).unwrap_or(0);
+            let node_kind = self.ctx.arena.kind_at(idx).unwrap_or(0);
 
             // PERF: Only Identifier and ThisKeyword can be narrowed by flow
             // analysis, and only property/element access + super are

--- a/crates/tsz-checker/src/state/state_checking/js_grammar.rs
+++ b/crates/tsz-checker/src/state/state_checking/js_grammar.rs
@@ -145,7 +145,7 @@ impl<'a> CheckerState<'a> {
                         );
                     } else if export_decl.export_clause.is_some() {
                         let inner = export_decl.export_clause;
-                        let inner_kind = self.ctx.arena.get(inner).map(|n| n.kind);
+                        let inner_kind = self.ctx.arena.kind_at(inner);
                         // For `export import X = require(...)`, emit TS8002 at the
                         // outer EXPORT_DECLARATION node so the span starts at `export`
                         // (matching tsc column offset).

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -289,7 +289,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                     && !export_decl.is_type_only
                     && !self.is_inside_namespace_declaration(export_idx)
                 {
-                    let clause_kind = self.ctx.arena.get(clause_idx).map(|n| n.kind);
+                    let clause_kind = self.ctx.arena.kind_at(clause_idx);
                     let clause_is_value_decl = clause_kind.is_some_and(|k| {
                         k == syntax_kind_ext::FUNCTION_DECLARATION
                             || k == syntax_kind_ext::CLASS_DECLARATION

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -27,17 +27,15 @@ impl<'a> CheckerState<'a> {
             self.ctx
                 .arena
                 .get(contextual_init)
-                .is_some_and(
-                    |init_node| match self.ctx.arena.get(pattern_idx).map(|n| n.kind) {
-                        Some(kind) if kind == syntax_kind_ext::ARRAY_BINDING_PATTERN => {
-                            init_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-                        }
-                        Some(kind) if kind == syntax_kind_ext::OBJECT_BINDING_PATTERN => {
-                            init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-                        }
-                        _ => false,
-                    },
-                );
+                .is_some_and(|init_node| match self.ctx.arena.kind_at(pattern_idx) {
+                    Some(kind) if kind == syntax_kind_ext::ARRAY_BINDING_PATTERN => {
+                        init_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                    }
+                    Some(kind) if kind == syntax_kind_ext::OBJECT_BINDING_PATTERN => {
+                        init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                    }
+                    _ => false,
+                });
 
         if !supports_pattern_context {
             return TypingRequest::NONE;
@@ -1533,7 +1531,7 @@ impl<'a> CheckerState<'a> {
             // TS7022: Structural circularity — `var a = { f: a }`.
             // TS7023: Return-type circularity — `var f = () => f()` or
             //         `var f = function() { return f(); }`.
-            let init_kind = self.ctx.arena.get(var_decl.initializer).map(|n| n.kind);
+            let init_kind = self.ctx.arena.kind_at(var_decl.initializer);
             let is_direct_deferred_initializer = init_kind.is_some_and(|kind| {
                 matches!(
                     kind,

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1990,7 +1990,7 @@ impl<'a> CheckerState<'a> {
                 // For elements with default initializers, use the default's type
                 // instead of `any` so the contextual type carries useful info
                 // (e.g., `{ f = (x: string) => x.length }` → f: (x: string) => number).
-                let name_kind = self.ctx.arena.get(name_idx).map(|n| n.kind);
+                let name_kind = self.ctx.arena.kind_at(name_idx);
                 let prop_type = if matches!(
                     name_kind,
                     Some(

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -365,7 +365,7 @@ impl<'a> CheckerState<'a> {
 
         // Overload candidates need signature-specific contextual typing.
         let force_bivariant_callbacks = matches!(
-            self.ctx.arena.get(unwrapped_callee).map(|n| n.kind),
+            self.ctx.arena.kind_at(unwrapped_callee),
             Some(
                 syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                     | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -686,7 +686,7 @@ impl<'a> CheckerState<'a> {
         // For direct calls on `never` (e.g., `f()` where `f: never`), emit TS2349.
         if callee_type == TypeId::NEVER {
             let is_method_call = matches!(
-                self.ctx.arena.get(callee_expr).map(|n| n.kind),
+                self.ctx.arena.kind_at(callee_expr),
                 Some(
                     syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                         | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -162,7 +162,7 @@ impl<'a> CheckerState<'a> {
 
         let unwrapped_tag = self.ctx.arena.skip_parenthesized_and_assertions(tagged.tag);
         let force_bivariant_callbacks = matches!(
-            self.ctx.arena.get(unwrapped_tag).map(|n| n.kind),
+            self.ctx.arena.kind_at(unwrapped_tag),
             Some(
                 syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                     | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -353,7 +353,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        let body_kind = self.ctx.arena.get(alias.type_node).map(|n| n.kind);
+        let body_kind = self.ctx.arena.kind_at(alias.type_node);
         let variance_supported = body_kind.is_some_and(|kind| {
             kind == syntax_kind_ext::TYPE_LITERAL
                 || kind == syntax_kind_ext::FUNCTION_TYPE

--- a/crates/tsz-cli/src/bin/tsz_server/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests.rs
@@ -1921,7 +1921,7 @@ fn test_alias_string_literal_navigation_uses_project_wide_resolution() {
         server.debug_resolve_export_alias_definition("/bar.ts", "./foo", "__<alias>");
     let probe_node =
         tsz::lsp::utils::find_node_at_or_before_offset(&arena, probe_off, &source_text);
-    let probe_kind = arena.get(probe_node).map(|n| n.kind).unwrap_or_default();
+    let probe_kind = arena.kind_at(probe_node).unwrap_or_default();
     let mut chain = Vec::new();
     let mut walk = probe_node;
     while walk.is_some() {

--- a/crates/tsz-cli/src/bin/tsz_server/tests_navigation.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_navigation.rs
@@ -165,7 +165,7 @@ fn test_alias_string_literal_navigation_uses_project_wide_resolution() {
         server.debug_resolve_export_alias_definition("/bar.ts", "./foo", "__<alias>");
     let probe_node =
         tsz::lsp::utils::find_node_at_or_before_offset(&arena, probe_off, &source_text);
-    let probe_kind = arena.get(probe_node).map(|n| n.kind).unwrap_or_default();
+    let probe_kind = arena.kind_at(probe_node).unwrap_or_default();
     let mut chain = Vec::new();
     let mut walk = probe_node;
     while walk.is_some() {

--- a/crates/tsz-emitter/src/emitter/es5/bindings.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings.rs
@@ -1413,7 +1413,7 @@ impl<'a> Printer<'a> {
             let unwrapped_name = self.unwrap_parenthesized_binding_pattern(elem.name);
             #[cfg(not(target_arch = "wasm32"))]
             if std::env::var_os("TSZ_DEBUG_EMIT").is_some() {
-                let elem_kind = self.arena.get(elem.name).map(|n| n.kind).unwrap_or(0);
+                let elem_kind = self.arena.kind_at(elem.name).unwrap_or(0);
                 tracing::debug!(
                     "downlevel-bp-element index={} elem_name={:?} unwrapped={:?} kind={}",
                     index,
@@ -1423,7 +1423,7 @@ impl<'a> Printer<'a> {
                 );
                 tracing::debug!(
                     "downlevel-bp-kind-bytes: elem={} unwrapped={}",
-                    self.arena.get(unwrapped_name).map(|n| n.kind).unwrap_or(0),
+                    self.arena.kind_at(unwrapped_name).unwrap_or(0),
                     SyntaxKind::Identifier as u16
                 );
             }

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -89,6 +89,16 @@ impl NodeArena {
         self.get(index).map(|n| (n.pos, n.end))
     }
 
+    /// Get the syntax kind (raw `u16`) of a node by index. Returns `None` if
+    /// the index is `NodeIndex::NONE` or out of bounds. Inherent mirror of
+    /// [`NodeAccess::kind`] — lets callers skip the trait import when they
+    /// only need the kind.
+    #[inline]
+    #[must_use]
+    pub fn kind_at(&self, index: NodeIndex) -> Option<u16> {
+        self.get(index).map(|n| n.kind)
+    }
+
     /// Get extended info for a node
     #[inline]
     #[must_use]

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -882,7 +882,7 @@ impl ParserState {
 
             // Check if 'await' is used as parameter name in a context where it's reserved
             // (static block or async context). This should emit TS1005 at the arrow position.
-            let name_kind = self.arena.get(name).map(|n| n.kind);
+            let name_kind = self.arena.kind_at(name);
             let is_await_param = name_kind == Some(SyntaxKind::AwaitKeyword as u16);
             let is_await_reserved =
                 is_await_param && (self.in_static_block_context() || self.in_async_context());

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -152,6 +152,11 @@ fn test_node_access_trait() {
     assert!(!arena.exists(NodeIndex::NONE));
 
     assert_eq!(arena.kind(ident_idx), Some(SyntaxKind::Identifier as u16));
+    assert_eq!(
+        arena.kind_at(ident_idx),
+        Some(SyntaxKind::Identifier as u16)
+    );
+    assert_eq!(arena.kind_at(NodeIndex::NONE), None);
     assert_eq!(arena.pos_end(ident_idx), Some((10, 20)));
     assert_eq!(arena.get_identifier_text(ident_idx), Some("testVar"));
 


### PR DESCRIPTION
## Summary
Adds `NodeArena::kind_at(NodeId) -> SyntaxKind` and migrates 13 raw kind-lookup call sites across checker / parser / emitter / CLI to use it.

Recovered from abandoned feature branch `chore/dry-next` during the 2026-04-23 remote-branch audit. Applies cleanly to current main.

## Test plan
- [ ] Existing `crates/tsz-parser/tests/node_tests.rs` covers the new helper
- [ ] CI: full cargo nextest