### PR TITLE
chore(checker): migrate to Symbol::has_any_flags

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -595,7 +595,7 @@ impl<'a> CheckerState<'a> {
         use tsz_binder::symbol_flags;
         let mut sym_id = sym_id;
         if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && symbol.flags & symbol_flags::ALIAS != 0
+            && symbol.has_any_flags(symbol_flags::ALIAS)
         {
             let mut visited_aliases = AliasCycleTracker::new();
             if let Some(target) = self.resolve_alias_symbol(sym_id, &mut visited_aliases) {

--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -774,7 +774,8 @@ impl<'a> CheckerState<'a> {
             .and_then(|sym_id| {
                 let lib_binders = self.get_lib_binders();
                 let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
-                ((symbol.flags & tsz_binder::symbol_flags::CLASS) != 0)
+                symbol
+                    .has_any_flags(tsz_binder::symbol_flags::CLASS)
                     .then(|| self.class_instance_type_from_symbol(sym_id))
                     .flatten()
             });

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -245,7 +245,7 @@ impl<'a> CheckerState<'a> {
             return fallback_type;
         };
 
-        if (symbol.flags & tsz_binder::symbol_flags::CLASS) == 0
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
             && let Some(name) = self.get_identifier_text_from_idx(tag_name_idx)
         {
             let expando_props = self.collect_expando_properties_for_root(&name);

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -1078,7 +1078,7 @@ impl<'a> CheckerState<'a> {
 
         let (import_module, import_name, escaped_name, decl_idx) =
             if let Some(symbol) = self.get_cross_file_symbol(sym_id) {
-                if (symbol.flags & symbol_flags::ALIAS) == 0 {
+                if !symbol.has_any_flags(symbol_flags::ALIAS) {
                     return Some(sym_id);
                 }
                 (
@@ -1090,7 +1090,7 @@ impl<'a> CheckerState<'a> {
             } else {
                 let lib_binders = self.get_lib_binders();
                 let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
-                if (symbol.flags & symbol_flags::ALIAS) == 0 {
+                if !symbol.has_any_flags(symbol_flags::ALIAS) {
                     return Some(sym_id);
                 }
                 (

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -56,7 +56,7 @@ impl<'a> CheckerState<'a> {
                             // if the alias body references Promise. This handles cases
                             // like `type MyPromise<T> = Promise<T>` where the Application
                             // base is the alias, not the underlying Promise interface.
-                            if symbol.flags & symbol_flags::TYPE_ALIAS != 0 {
+                            if symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
                                 return self.type_alias_resolves_to_promise(sym_id, symbol);
                             }
                         }
@@ -455,11 +455,11 @@ impl<'a> CheckerState<'a> {
             return Some(args.first().copied().unwrap_or(TypeId::UNKNOWN));
         }
 
-        if symbol.flags & symbol_flags::TYPE_ALIAS != 0 {
+        if symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
             return self.promise_like_type_argument_from_alias(sym_id, args, visited_aliases);
         }
 
-        if symbol.flags & symbol_flags::CLASS != 0 {
+        if symbol.has_any_flags(symbol_flags::CLASS) {
             return self.promise_like_type_argument_from_class_in_arena(
                 sym_id,
                 args,
@@ -911,7 +911,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(sym_id) = self.ctx.def_to_symbol_id(def_id)
                         && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
                     {
-                        if symbol.flags & symbol_flags::TYPE_ALIAS != 0 {
+                        if symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
                             return false; // Type alias — uncertain, use syntactic fallback
                         }
                         return true; // Class/interface — definitively not Promise
@@ -977,7 +977,7 @@ impl<'a> CheckerState<'a> {
                 {
                     // Avoid infinite loops
                     if let Some(body_symbol) = self.ctx.binder.get_symbol(body_sym_id)
-                        && body_symbol.flags & symbol_flags::TYPE_ALIAS != 0
+                        && body_symbol.has_any_flags(symbol_flags::TYPE_ALIAS)
                     {
                         return self.type_alias_resolves_to_promise(body_sym_id, body_symbol);
                     }

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -1017,8 +1017,8 @@ impl<'a> CheckerState<'a> {
             })
             .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
             .is_some_and(|symbol| {
-                (symbol.flags & tsz_binder::symbol_flags::ENUM) != 0
-                    && (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) == 0
+                symbol.has_any_flags(tsz_binder::symbol_flags::ENUM)
+                    && !symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
             });
 
         // TS2464: type must be string, number, symbol, or any (including literals).


### PR DESCRIPTION
## Summary
Small DRY sweep: migrates `promise_checker.rs` and `property_checker.rs` to use `Symbol::has_any_flags` instead of manual flag bitwise-AND patterns.

Recovered from `chore/dry-sweep-35` during the 2026-04-23 remote-branch audit. Applies cleanly to current main.

## Test plan
- [ ] No behavior change expected — equivalent boolean expressions
- [ ] CI: checker test suite