### PR TITLE
fix(emitter): preserve `typeof X` in arrow/function param annotations during dts inference

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1091,50 +1091,6 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
-    /// Recursively check if a type node (or any of its children) is a
-    /// `typeof X` `TypeQuery`. Covers the common compound forms
-    /// (unions, intersections, arrays, parens, type-reference type args).
-    fn type_node_contains_type_query(&self, type_idx: NodeIndex) -> bool {
-        let Some(type_node) = self.arena.get(type_idx) else {
-            return false;
-        };
-        let k = type_node.kind;
-        if k == syntax_kind_ext::TYPE_QUERY {
-            return true;
-        }
-        if (k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE)
-            && let Some(c) = self.arena.get_composite_type(type_node)
-        {
-            return c
-                .types
-                .nodes
-                .iter()
-                .copied()
-                .any(|i| self.type_node_contains_type_query(i));
-        }
-        if k == syntax_kind_ext::ARRAY_TYPE
-            && let Some(a) = self.arena.get_array_type(type_node)
-        {
-            return self.type_node_contains_type_query(a.element_type);
-        }
-        if k == syntax_kind_ext::PARENTHESIZED_TYPE
-            && let Some(p) = self.arena.get_wrapped_type(type_node)
-        {
-            return self.type_node_contains_type_query(p.type_node);
-        }
-        if k == syntax_kind_ext::TYPE_REFERENCE
-            && let Some(r) = self.arena.get_type_ref(type_node)
-            && let Some(ref args) = r.type_arguments
-        {
-            return args
-                .nodes
-                .iter()
-                .copied()
-                .any(|i| self.type_node_contains_type_query(i));
-        }
-        false
-    }
-
     pub(in crate::declaration_emitter) fn function_initializer_returns_unique_identifier(
         &self,
         initializer: NodeIndex,
@@ -1155,6 +1111,57 @@ impl<'a> DeclarationEmitter<'a> {
             && self
                 .function_body_unique_return_identifier(func.body)
                 .is_some()
+    }
+
+    /// Recursively check whether a type AST subtree contains a `TYPE_QUERY`
+    /// (i.e. a `typeof X` form). Walks the common composing forms — unions,
+    /// intersections, parens, arrays, tuples, optional/rest — so callers can
+    /// detect typeof anywhere in a parameter annotation.
+    pub(in crate::declaration_emitter) fn type_node_contains_type_query(
+        &self,
+        type_idx: NodeIndex,
+    ) -> bool {
+        if type_idx.is_none() {
+            return false;
+        }
+        let Some(type_node) = self.arena.get(type_idx) else {
+            return false;
+        };
+        if type_node.kind == syntax_kind_ext::TYPE_QUERY {
+            return true;
+        }
+        if (type_node.kind == syntax_kind_ext::UNION_TYPE
+            || type_node.kind == syntax_kind_ext::INTERSECTION_TYPE)
+            && let Some(comp) = self.arena.get_composite_type(type_node)
+        {
+            return comp
+                .types
+                .nodes
+                .iter()
+                .any(|&t| self.type_node_contains_type_query(t));
+        }
+        if (type_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            || type_node.kind == syntax_kind_ext::OPTIONAL_TYPE
+            || type_node.kind == syntax_kind_ext::REST_TYPE)
+            && let Some(wrapped) = self.arena.get_wrapped_type(type_node)
+        {
+            return self.type_node_contains_type_query(wrapped.type_node);
+        }
+        if type_node.kind == syntax_kind_ext::ARRAY_TYPE
+            && let Some(arr) = self.arena.get_array_type(type_node)
+        {
+            return self.type_node_contains_type_query(arr.element_type);
+        }
+        if type_node.kind == syntax_kind_ext::TUPLE_TYPE
+            && let Some(tup) = self.arena.get_tuple_type(type_node)
+        {
+            return tup
+                .elements
+                .nodes
+                .iter()
+                .any(|&t| self.type_node_contains_type_query(t));
+        }
+        false
     }
 
     pub(in crate::declaration_emitter) fn refine_invokable_return_type_from_identifier(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
@@ -1074,3 +1074,23 @@ class C {
         "must not degrade to property syntax for const enum computed method: {output}"
     );
 }
+
+#[test]
+fn test_arrow_initializer_preserves_typeof_in_param_annotation() {
+    // Regression: a `const f = (x: typeof something) => ...` must preserve
+    // the `typeof something` in the inferred dts parameter type. The
+    // type-printer path collapses TypeQuery into the resolved value type,
+    // so we route through the AST-based function-initializer path when any
+    // parameter annotation contains a `typeof`.
+    let output = emit_dts_with_binding(
+        r#"
+declare function foo(n: number): number;
+
+const printFn = (action: typeof foo) => { action(1); };
+"#,
+    );
+    assert!(
+        output.contains("typeof foo"),
+        "arrow parameter `typeof X` must be preserved in dts: {output}"
+    );
+}


### PR DESCRIPTION
## Summary
During declaration-file inference, arrow/function parameter annotations written as `typeof X` were being collapsed to the annotated symbol's type rather than retained as `typeof X`. This PR preserves the syntactic `typeof` form in dts output.

Includes a `comprehensive_parity` test covering the case.

Recovered from `fix-emit-typeof-in-arrow-param-annotation` during the 2026-04-23 remote-branch audit. Applies cleanly to current main.

## Test plan
- [x] New test in `crates/tsz-emitter/tests/comprehensive_parity.rs`
- [ ] CI: full cargo nextest