### PR TITLE
perf(cli): parallelize build_cross_file_binders

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -586,10 +586,12 @@ pub(super) fn collect_diagnostics(
 
     // Pre-create all binders for cross-file resolution
     let all_binders: Arc<Vec<Arc<BinderState>>> = Arc::new({
-        let _span = tracing::info_span!("build_cross_file_binders").entered();
+        use rayon::prelude::*;
+        let _span =
+            tracing::info_span!("build_cross_file_binders", files = program.files.len()).entered();
         program
             .files
-            .iter()
+            .par_iter()
             .enumerate()
             .map(|(file_idx, file)| {
                 Arc::new(create_cross_file_lookup_binder_with_augmentations(


### PR DESCRIPTION
## Summary
Switches the cross-file binder build loop from `iter()` to rayon `par_iter()`, parallelizing binder construction across files. Also adds `files` to the tracing span for observability.

3-line change in `crates/tsz-cli/src/driver/check.rs`.

Recovered from `perf-parallelize-cross-file-binders` during the 2026-04-23 remote-branch audit. Applies cleanly to current main.

## Test plan
- [ ] CI: full cargo nextest (binder construction is the hot path on large programs)
- [ ] Benchmark comparison on multi-file inputs to confirm the win