### PR TITLE
fix(checker): exempt parameter decorators from class-definition TDZ (TS2449)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -52,6 +52,10 @@ name = "await_generic_non_promise_no_false_ts2339_tests"
 path = "tests/await_generic_non_promise_no_false_ts2339_tests.rs"
 
 [[test]]
+name = "ts2449_parameter_decorator_no_tdz_tests"
+path = "tests/ts2449_parameter_decorator_no_tdz_tests.rs"
+
+[[test]]
 name = "ts1210_arguments_param_in_class_tests"
 path = "tests/ts1210_arguments_param_in_class_tests.rs"
 

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -587,6 +587,21 @@ impl<'a> CheckerState<'a> {
                 return false;
             }
             if node.kind == syntax_kind_ext::DECORATOR {
+                // Parameter decorators evaluate at a different time than
+                // class/method/accessor/property decorators and therefore
+                // are NOT in the class-definition TDZ. tsc does not report
+                // TS2449 for `@dec(C)` on a constructor/method parameter of
+                // class `C` (see
+                // `useBeforeDeclaration_classDecorators.2.ts` constructor /
+                // `method2` cases), even though the identical expression on
+                // a method or property decorator would fire. Detect the
+                // parameter-decorator case and bail out.
+                if let Some(decorator_ext) = self.ctx.arena.get_extended(current)
+                    && let Some(decorator_parent) = self.ctx.arena.get(decorator_ext.parent)
+                    && decorator_parent.kind == syntax_kind_ext::PARAMETER
+                {
+                    return false;
+                }
                 // Found a decorator. Check if it belongs to the class declaration
                 // or one of its members by walking up to see if we reach decl_idx.
                 let mut ancestor = current;

--- a/crates/tsz-checker/tests/ts2449_parameter_decorator_no_tdz_tests.rs
+++ b/crates/tsz-checker/tests/ts2449_parameter_decorator_no_tdz_tests.rs
@@ -1,0 +1,75 @@
+//! Parameter decorators on class members do NOT put their arguments in the
+//! class-definition TDZ: `@dec(C)` on a constructor/method parameter of class
+//! `C` must not report TS2449 "Class 'C' used before its declaration", even
+//! though the same expression on a method/property decorator does.
+//!
+//! Regression: tsz's `is_in_decorator_of_declaration` treated parameter
+//! decorators the same as member decorators, causing false TS2449s on the
+//! constructor/method-parameter cases in
+//! `useBeforeDeclaration_classDecorators.2.ts`.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_checker::context::CheckerOptions;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn get_diagnostic_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        experimental_decorators: true,
+        ..CheckerOptions::default()
+    };
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        options,
+    );
+
+    checker.check_source_file(root);
+
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn parameter_decorator_referencing_enclosing_class_no_ts2449() {
+    let source = r#"
+declare const dec: any;
+class C {
+    constructor(@dec(C) a: any) {}
+    static m1(@dec(C) a: any) {}
+    m2(@dec(C) a: any) {}
+}
+"#;
+    let codes = get_diagnostic_codes(source);
+    assert!(
+        !codes.contains(&2449),
+        "parameter decorators must not trigger TS2449 on the enclosing class; got: {codes:?}"
+    );
+}
+
+#[test]
+fn method_decorator_referencing_enclosing_class_still_emits_ts2449() {
+    // The narrowing is parameter-decorator-specific: method/property
+    // decorators continue to put the class in TDZ at class-body evaluation
+    // time. This locks in that the fix doesn't broaden to all decorators.
+    let source = r#"
+declare const dec: any;
+class C {
+    @dec(C) m() {}
+}
+"#;
+    let codes = get_diagnostic_codes(source);
+    assert!(
+        codes.contains(&2449),
+        "method decorator referencing the enclosing class still needs TS2449; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `useBeforeDeclaration_classDecorators.2.ts` specifies that `@dec(C)` on class *member* decorators (methods, accessors, properties) fires TS2449 "Class 'C' used before its declaration", but the same expression on a class *parameter* decorator does NOT. tsz was treating every decorator the same.
- Fix: exempt parameter decorators from the class-definition TDZ check.

## Root cause
`is_in_decorator_of_declaration` in `crates/tsz-checker/src/flow/flow_analysis/tdz.rs` returned true for any decorator that belonged to the class or one of its members. Parameter decorators on class member functions (constructor params, method params, static method params) are class-member decorators in the AST, so they hit the TDZ path and emitted TS2449. tsc evaluates parameter decorators at a different phase and does not consider them part of the class-definition TDZ.

## Reproducer
```ts
declare const dec: any;
class C {
    @dec(C) m() {}                    // tsc + tsz: TS2449    (unchanged)
    constructor(@dec(C) a: any) {}    // tsc: (no error)   tsz before: TS2449   tsz after: no error
    static m1(@dec(C) a: any) {}      // tsc: (no error)   tsz before: TS2449   tsz after: no error
    m2(@dec(C) a: any) {}             // tsc: (no error)   tsz before: TS2449   tsz after: no error
}
```

## Fix
When walking up from a usage site and encountering a `DECORATOR` node, check whether its immediate parent is a `PARAMETER` — if so, return false (not a class-definition TDZ site). The broader class-body decorator path (methods, accessors, properties) is unchanged.

## Impact
- `useBeforeDeclaration_classDecorators.2.ts` flips fingerprint-only → PASS.
- Pre-commit suite: 20,015 tests pass (all guardrails green).
- Full checker tests: 5023/5023 pass locally.

## Test plan
- [x] New `crates/tsz-checker/tests/ts2449_parameter_decorator_no_tdz_tests.rs` asserts both invariants: parameter decorators must not fire TS2449; member decorators still do.
- [x] `./scripts/conformance/conformance.sh run --filter useBeforeDeclaration_classDecorators.2 --verbose`: 1/1 PASS.
- [x] `cargo nextest run --package tsz-checker`: 5023 tests pass, no regressions.