### PR TITLE
fix(checker): anchor TS2567 partner at the original declaration across re-export chains

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -40,6 +40,10 @@ name = "async_return_widening_tests"
 path = "tests/async_return_widening_tests.rs"
 
 [[test]]
+name = "ts2567_augmentation_enum_cross_arena_decl_tests"
+path = "tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs"
+
+[[test]]
 name = "await_generic_non_promise_no_false_ts2339_tests"
 path = "tests/await_generic_non_promise_no_false_ts2339_tests.rs"
 

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -770,35 +770,52 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                                                     | symbol_flags::CONST_ENUM
                                                     | symbol_flags::MODULE))
                                                 != 0;
-                                            let first_decl = symbol.declarations.first().copied();
-                                            let owner_arena =
-                                                self.ctx.get_arena_for_file(owner_idx as u32);
-                                            let owner_file = owner_arena
+                                            // Symbol declarations are arena-local to the
+                                            // symbol's binding file (`decl_file_idx`), which
+                                            // may differ from `owner_idx` — the exporting
+                                            // module that `resolve_export_in_file` landed on
+                                            // after walking `export * from "..."` re-exports.
+                                            // Use `decl_file_idx` when it disagrees so the
+                                            // node lookup happens in the correct arena. tsc
+                                            // anchors the partner TS2567 on the *original*
+                                            // class/interface/function declaration.
+                                            let decl_file_idx = if symbol.decl_file_idx != u32::MAX
+                                            {
+                                                symbol.decl_file_idx as usize
+                                            } else {
+                                                owner_idx
+                                            };
+                                            let decl_arena =
+                                                self.ctx.get_arena_for_file(decl_file_idx as u32);
+                                            let owner_file = decl_arena
                                                 .source_files
                                                 .first()
                                                 .map(|sf| sf.file_name.clone());
-                                            let existing_name_span = first_decl
-                                                .and_then(|d| owner_arena.get(d))
-                                                .and_then(|n| {
-                                                    use tsz_parser::parser::syntax_kind_ext;
+                                            // Search all declarations for one whose AST node
+                                            // lives in `decl_arena` and matches one of the
+                                            // declaration kinds we anchor TS2567 on.
+                                            use tsz_parser::parser::syntax_kind_ext;
+                                            let existing_name_span =
+                                                symbol.declarations.iter().find_map(|&d| {
+                                                    let n = decl_arena.get(d)?;
                                                     let name_idx = if n.kind
                                                         == syntax_kind_ext::CLASS_DECLARATION
                                                     {
-                                                        owner_arena.get_class(n).map(|c| c.name)
+                                                        decl_arena.get_class(n).map(|c| c.name)
                                                     } else if n.kind
                                                         == syntax_kind_ext::INTERFACE_DECLARATION
                                                     {
-                                                        owner_arena.get_interface(n).map(|i| i.name)
+                                                        decl_arena.get_interface(n).map(|i| i.name)
                                                     } else if n.kind
                                                         == syntax_kind_ext::FUNCTION_DECLARATION
                                                     {
-                                                        owner_arena.get_function(n).map(|f| f.name)
+                                                        decl_arena.get_function(n).map(|f| f.name)
                                                     } else {
                                                         None
-                                                    };
-                                                    name_idx.and_then(|nm| owner_arena.get(nm))
-                                                })
-                                                .map(|nm| (nm.pos, nm.end - nm.pos));
+                                                    }?;
+                                                    let nm = decl_arena.get(name_idx)?;
+                                                    Some((nm.pos, nm.end - nm.pos))
+                                                });
                                             let span = match (owner_file, existing_name_span) {
                                                 (Some(file), Some((pos, len))) => {
                                                     Some((file, pos, len))

--- a/crates/tsz-checker/tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs
+++ b/crates/tsz-checker/tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs
@@ -1,0 +1,60 @@
+//! TS2567 "Enum declarations can only merge with namespace or other enum
+//! declarations" — partner diagnostic anchoring across module arenas.
+//!
+//! When a module augmentation's `export enum Foo { }` resolves to an existing
+//! class/function/interface via a wildcard-re-export chain, tsc anchors the
+//! partner TS2567 at the *original* declaration (e.g., the `Foo` identifier
+//! of `export class Foo` in the source file), not only at the augmentation
+//! site. tsz was failing to emit the partner diagnostic because its node
+//! lookup used the re-export-chain-resolved file's arena instead of the
+//! arena actually owning the declaration nodes (`symbol.decl_file_idx`).
+//!
+//! This test doesn't exercise the full cross-file conformance runner path
+//! (the harness is single-file), but asserts the no-regression case:
+//! augmentation declared against a local class in a single file still emits
+//! TS2567 correctly.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn get_diagnostic_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn augmentation_enum_merged_with_class_still_emits_ts2567() {
+    // Single-file baseline: the augmentation path still works when the
+    // original class and the augmentation are in the same file. (The
+    // cross-file variant is exercised by the
+    // `moduleAugmentationEnumClassMergeOfReexportIsError` conformance test.)
+    let source = r#"
+export class Foo {}
+declare module "./test" {
+    export enum Foo { A, B, C }
+}
+"#;
+    let codes = get_diagnostic_codes(source);
+    assert!(
+        codes.contains(&2567),
+        "augmentation-enum merging with an existing class must emit TS2567; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `moduleAugmentationEnumClassMergeOfReexportIsError.ts` expected TS2567 at BOTH the augmentation's `export enum Foo` AND the original `export class Foo` in the exporting file. tsz emitted only the first.
- Root cause: cross-arena node-index lookup. `resolve_export_in_file` returns `(sym_id, file_idx)` for the module that lexically resolved the export, but a symbol's `declarations` are indices into the arena named by `symbol.decl_file_idx`, which differs when the export was walked through a `export * from "..."` wildcard re-export.
- Fix: use `symbol.decl_file_idx` arena to look up declaration nodes; iterate all declarations to find one of the anchor-eligible kinds.
- Conformance **+1**, emit JS +1, DTS +16.

## Reproducer
```ts
// file.ts:
export class Foo {}                   // tsc + tsz (after fix): TS2567 here (col 14)

// reexport.ts:
export * from "./file";               // wildcard re-export

// augment.ts:
declare module "./reexport" {
    export enum Foo { A, B, C }       // tsc + tsz (both): TS2567 here
}
```

## Root cause
In `crates/tsz-checker/src/declarations/declarations_module.rs`, the partner-TS2567 emission derived `owner_idx` from `resolve_export_in_file`'s return — the index of the module that named the export. For the re-export chain `augment.ts → reexport.ts → file.ts`, `owner_idx` landed on `reexport.ts`. But the class declaration nodes live in `file.ts`'s arena. `owner_arena.get(decl_idx)` returned None → `existing_name_span` was None → partner diagnostic silently dropped.

## Fix
Use `symbol.decl_file_idx` (falling back to `owner_idx` when unset) for the arena lookup. Also iterate *all* `symbol.declarations` rather than just `first()` to pick the class/interface/function node even when post-bind symbol merges have added other-arena declarations to the symbol.

## Impact (verify-all)
- Conformance: **+1** (12097 vs 12096 baseline).
- Emit: JS **+1**, DTS **+16**.
- Fourslash: unchanged (50/50).
- Unit tests: 5025/5025 pass.

## Test plan
- [x] New `crates/tsz-checker/tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs` locks the single-file regression.
- [x] `./scripts/conformance/conformance.sh run --filter moduleAugmentationEnumClassMergeOfReexportIsError --verbose`: 1/1 PASS.
- [x] `scripts/session/verify-all.sh`: all 6 suites pass, no regressions.