### PR TITLE
fix(checker): widen literal TReturn in generator return-type inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,10 @@ name = "generator_annotation_mismatch_display_tests"
 path = "tests/generator_annotation_mismatch_display_tests.rs"
 
 [[test]]
+name = "generator_return_type_widening_tests"
+path = "tests/generator_return_type_widening_tests.rs"
+
+[[test]]
 name = "async_return_widening_tests"
 path = "tests/async_return_widening_tests.rs"
 

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -2457,7 +2457,19 @@ impl<'a> CheckerState<'a> {
                     && return_type != TypeId::UNDEFINED
                     && !(return_type == TypeId::ANY && early_gen_return_type.is_some())
                 {
-                    Some(return_type)
+                    // Widen literal body-inferred returns before assembling the
+                    // Generator<Y, R, N> type: `return 1;` produces TReturn =
+                    // number, not 1. Matches tsc's generator return-type
+                    // widening. Unique symbols are preserved.
+                    let widened = if crate::query_boundaries::common::is_unique_symbol_type(
+                        self.ctx.types,
+                        return_type,
+                    ) {
+                        return_type
+                    } else {
+                        self.widen_literal_type(return_type)
+                    };
+                    Some(widened)
                 } else {
                     None
                 };

--- a/crates/tsz-checker/tests/generator_return_type_widening_tests.rs
+++ b/crates/tsz-checker/tests/generator_return_type_widening_tests.rs
@@ -1,0 +1,105 @@
+//! Tests for literal-return widening in generator return-type inference.
+//!
+//! `function*() { return 1; }` should infer `Generator<never, number, any>`
+//! (widened), not `Generator<never, 1, any>`. Matches tsc's async wrapper
+//! widening applied in the same file.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+const GENERATOR_STUBS: &str = r#"
+interface IteratorYieldResult<TYield> { done?: false; value: TYield; }
+interface IteratorReturnResult<TReturn> { done: true; value: TReturn; }
+type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
+interface Iterator<T, TReturn = any, TNext = undefined> {
+    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+    return?(value?: TReturn): IteratorResult<T, TReturn>;
+    throw?(e?: any): IteratorResult<T, TReturn>;
+}
+interface Iterable<T, TReturn = unknown, TNext = unknown> {
+    [Symbol.iterator](): Iterator<T, TReturn, TNext>;
+}
+interface IterableIterator<T, TReturn = any, TNext = undefined> extends Iterator<T, TReturn, TNext> {
+    [Symbol.iterator](): IterableIterator<T, TReturn, TNext>;
+}
+interface Generator<T = unknown, TReturn = any, TNext = any> extends IterableIterator<T, TReturn, TNext> {
+    next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+    return(value: TReturn): IteratorResult<T, TReturn>;
+    throw(e: any): IteratorResult<T, TReturn>;
+    [Symbol.iterator](): Generator<T, TReturn, TNext>;
+}
+"#;
+
+fn get_diagnostics(user_source: &str) -> Vec<(u32, String)> {
+    let full_source = format!("{GENERATOR_STUBS}\n{user_source}");
+    let mut parser = ParserState::new("test.ts".to_string(), full_source);
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        Default::default(),
+    );
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+#[test]
+fn generator_return_literal_widens_tresult_to_number() {
+    // Assignment to a non-Generator-typed target produces a TS2322 whose
+    // source type is the synthesized `Generator<T, R, N>` from the body.
+    // With the fix, the literal `1` widens to `number`, so the error
+    // message shows `Generator<..., number, ...>` (not `..., 1, ...`).
+    let source = r#"
+const g: number = function*() { return 1; }();
+"#;
+    let diags = get_diagnostics(source);
+    let ts2322: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "Expected TS2322 for generator assigned to number, got: {diags:?}"
+    );
+    // The message refers to the body-inferred return type. The widened form
+    // should mention `number` (the widened type) not just `1` (literal).
+    let has_number = ts2322.iter().any(|(_, m)| m.contains("number"));
+    let has_only_literal_one = ts2322
+        .iter()
+        .all(|(_, m)| m.contains(" 1,") || m.contains(" 1>"));
+    assert!(
+        has_number,
+        "Expected TS2322 message to mention widened 'number' TReturn, got: {ts2322:?}"
+    );
+    assert!(
+        !has_only_literal_one,
+        "TS2322 message should not preserve literal '1' as TReturn after widening: {ts2322:?}"
+    );
+}
+
+#[test]
+fn generator_return_literal_string_widens_to_string() {
+    let source = r#"
+const g: number = function*() { return "hello"; }();
+"#;
+    let diags = get_diagnostics(source);
+    let ts2322: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "Expected TS2322 for generator returning literal string assigned to number, got: {diags:?}"
+    );
+    assert!(
+        ts2322.iter().any(|(_, m)| m.contains("string")),
+        "Expected TS2322 message to mention widened 'string' TReturn, got: {ts2322:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- tsc widens literal body-inferred returns when assembling the synthesized `Generator<Y, R, N>` type: `function*() { return 1 }` infers `Generator<never, number, any>`, not `Generator<never, 1, any>`.
- Aligns the generator branch of `types/function_type.rs` with the async-wrapper widening that already lives a few lines below (`self.widen_literal_type(final_return_type)` on the `async` path).
- Flips `conformance/es6/yieldExpressions/generatorTypeCheck63.ts` to PASS.

## Reproducer
```ts
const g: number = function*() { return 1; }();
// tsc:  Generator<never, number, any> is not assignable to number.
// before: Generator<never, 1, any> is not assignable to number.
// after:  Generator<never, number, any> is not assignable to number.
```

## Architecture
Single change to the `body_return_t` branch of the unannotated-generator return-type builder: widen the body-inferred literal before wrapping in `Generator<Y, R, N>`. Preserves `unique symbol` (matching async treatment). All solver behavior unchanged.

## Test plan
- [x] New unit tests in `crates/tsz-checker/tests/generator_return_type_widening_tests.rs`:
  - `generator_return_literal_widens_tresult_to_number`
  - `generator_return_literal_string_widens_to_string`
- [x] `cargo nextest run -p tsz-checker`: 5030/5030 pass.
- [x] `./scripts/conformance/conformance.sh run --filter "generatorTypeCheck63" --verbose`: 1/1 PASS.