### PR TITLE
fix(emitter): elide empty unused non-exported inner namespaces in .d.ts

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -240,6 +240,30 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         }
 
+        // Elide empty, non-exported, non-declare inner namespaces nested
+        // inside another non-ambient namespace, when nothing references them.
+        // tsc emits nothing for `namespace A { }` in that position: the body
+        // has no declarations to contribute to the type surface, and nothing
+        // depends on it by name. Used by declFileWithInternalModuleNameConflicts*
+        // where an empty inner `namespace A { }` exists only for source-level
+        // name resolution.
+        //
+        // Keep the namespace when:
+        //   - it's exported
+        //   - the source carried `declare`
+        //   - we're inside an ambient/`declare` namespace (ambient contexts
+        //     preserve structure — e.g. declarationEmitLocalClassHasRequiredDeclare)
+        //   - it's referenced by an exported member (e.g.
+        //     aliasInaccessibleModule: `export import X = N` keeps `namespace N`)
+        if !is_exported
+            && !self.arena.is_declare(&module.modifiers)
+            && self.inside_non_ambient_namespace
+            && self.is_module_body_effectively_empty(module.body)
+            && !self.is_ns_member_used_by_exports(module_idx)
+        {
+            return;
+        }
+
         self.write_indent();
         if !self.inside_declare_namespace {
             if is_exported {
@@ -423,6 +447,25 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         self.write_line();
+    }
+
+    /// True when a module body walks down to an empty block (or is missing
+    /// entirely). Dotted name chains like `namespace A.B.C { }` recurse
+    /// through nested `ModuleDeclaration` bodies until the inner
+    /// `ModuleBlock` is reached; every level must be empty.
+    fn is_module_body_effectively_empty(&self, body_idx: NodeIndex) -> bool {
+        if !body_idx.is_some() {
+            return true;
+        }
+        let Some(body_node) = self.arena.get(body_idx) else {
+            return true;
+        };
+        if let Some(nested) = self.arena.get_module(body_node) {
+            return self.is_module_body_effectively_empty(nested.body);
+        }
+        self.arena
+            .get_module_block(body_node)
+            .is_none_or(|block| block.statements.as_ref().is_none_or(|s| s.nodes.is_empty()))
     }
 
     pub(crate) fn emit_import_equals_declaration(
@@ -1093,11 +1136,23 @@ impl<'a> DeclarationEmitter<'a> {
                         // In non-ambient namespaces, non-exported declarations
                         // are only emitted in .d.ts if they are referenced by
                         // exported members (via used_symbols). Namespace
-                        // declarations are always visible.
+                        // declarations are normally visible, but an empty
+                        // non-exported inner namespace is elided by
+                        // `emit_module_declaration_with_export` (it has no
+                        // members to contribute and no reason to appear in
+                        // the type surface); matching that elision here
+                        // prevents the elided decl from triggering a false
+                        // mixed-export scope-marker.
                         if non_ambient {
-                            if stmt_node.kind == syntax_kind_ext::MODULE_DECLARATION
-                                || self.is_ns_member_used_by_exports(stmt_idx)
-                            {
+                            let counts_as_non_exported =
+                                if stmt_node.kind == syntax_kind_ext::MODULE_DECLARATION {
+                                    self.arena.get_module(stmt_node).is_none_or(|m| {
+                                        !self.is_module_body_effectively_empty(m.body)
+                                    })
+                                } else {
+                                    self.is_ns_member_used_by_exports(stmt_idx)
+                                };
+                            if counts_as_non_exported {
                                 has_non_exported = true;
                             }
                         } else {


### PR DESCRIPTION
## Summary
tsc emits nothing for a nested `namespace A { }` that is empty, non-exported, non-declare, inside a non-ambient namespace, and not referenced by the exported API surface. tsz was preserving such declarations, leading to output like

```ts
// source
namespace X.A.B.C {
    namespace A { }           // empty, non-exported, unused
    export class W implements X.A.C.Z { }
}
```

```ts
// tsz before
declare namespace X.A.B.C {
    namespace A { }
    export class W implements X.A.C.Z { }
    export {};
}

// tsc / tsz after
declare namespace X.A.B.C {
    class W implements X.A.C.Z { }
}
```

## Change
- `emit_module_declaration_with_export`: add a guard that returns early for empty non-exported inner namespaces (after `should_emit_public_api_module`, before writing the declaration). Helper `is_module_body_effectively_empty` walks dotted-name module chains, checking every level is empty.
- `module_body_has_scope_marker`: don't treat a `MODULE_DECLARATION` that will be elided as a non-exported member — otherwise the pre-scan emits a spurious `export {};` scope marker.

## Preserved cases
- `aliasInaccessibleModule`: `export import X = N` marks `N` as used → `is_ns_member_used_by_exports(module_idx)` guard preserves it.
- `declarationEmitLocalClassHasRequiredDeclare`: `export declare namespace A { namespace X { } }` sits in an ambient context (`inside_non_ambient_namespace = false`) so the guard doesn't apply.
- `test_namespace_non_exported_type_used_by_export_emits_scope_marker`: unchanged — the non-exported `type W` is not a namespace, and `type W` is explicitly referenced by an exported `var p: W`.

## Validation
- `cargo nextest run -p tsz-emitter` — 1432/1432 pass
- Full DTS emit run against pristine `origin/main`:
  - **+1 PASS** (`declareDottedModuleName`)
  - **0 regressions**
- Known-unchanged: `declFileWithInternalModuleNameConflictsInExtendsClause1/2` still fail. The elision guard is correct for those tests, but `is_ns_member_used_by_exports(module_idx)` returns `true` for the inner `namespace A` even though nothing references it — likely a symbol-resolution false positive (the `A` here conflicts with the `A` segment in the outer `X.A.B.C` dotted name). That's a separate root cause worth following up — see [inline comment thread].

## Test plan
- [x] `cargo nextest run -p tsz-emitter`
- [ ] CI full conformance (thirdface-ai-oauth)