### PR TITLE
fix(checker): reduce utility conditional applications in heritage display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -339,5 +339,9 @@ path = "tests/cross_module_nested_interface_tests.rs"
 name = "jsdoc_extends_constraint_tests"
 path = "tests/jsdoc_extends_constraint_tests.rs"
 
+[[test]]
+name = "override_intersection_display_tests"
+path = "tests/override_intersection_display_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/classes/class_abstract_checker.rs
+++ b/crates/tsz-checker/src/classes/class_abstract_checker.rs
@@ -406,7 +406,15 @@ impl<'a> CheckerState<'a> {
         _h_expr_idx: tsz_parser::parser::base::NodeIndex,
         type_arguments: Option<&tsz_parser::parser::base::NodeList>,
     ) -> String {
-        let base_str = self.format_type(instance_type);
+        // tsc applies `getReducedType` when displaying heritage instance types
+        // so conditional utility applications like `InstanceType<typeof Foo>`
+        // render as their concrete form (`Foo`). Mirror that by deeply
+        // evaluating nested meta-type applications inside intersection/object
+        // members — this is what makes `override19.ts` print
+        // `A & { context: Context; }` instead of
+        // `A & { context: InstanceType<typeof Context>; }`.
+        let display_type = self.simplify_heritage_instance_type_for_display(instance_type);
+        let base_str = self.format_type(display_type);
         if let Some(type_arguments) = type_arguments
             && !type_arguments.nodes.is_empty()
         {
@@ -429,6 +437,28 @@ impl<'a> CheckerState<'a> {
             }
         }
         base_str
+    }
+
+    /// Deep-evaluate meta-type applications (e.g. `InstanceType<typeof Foo>`)
+    /// that appear inside a heritage instance type so the printer can render
+    /// the reduced form that `tsc` shows. Only meta-typed leaves are
+    /// evaluated — concrete sub-structures are preserved verbatim so this
+    /// cannot widen or re-order object properties.
+    ///
+    /// Delegates to the solver via `query_boundaries::common::deep_reduce_for_display`
+    /// so the walker stays on the correct side of the checker/solver contract.
+    pub(crate) fn simplify_heritage_instance_type_for_display(
+        &mut self,
+        instance_type: TypeId,
+    ) -> TypeId {
+        match self.ctx.type_env.try_borrow() {
+            Ok(env) => crate::query_boundaries::common::deep_reduce_for_display(
+                self.ctx.types,
+                &*env,
+                instance_type,
+            ),
+            Err(_) => instance_type,
+        }
     }
 
     fn class_type_params_for_symbol(

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -324,6 +324,12 @@ impl<'a> CheckerState<'a> {
         } else {
             self.resolve_type_for_property_access(type_id)
         };
+        // tsc applies `getReducedType` when displaying heritage instance types,
+        // so utility conditional applications like `InstanceType<typeof Foo>`
+        // render in their concrete form (`Foo`). Mirror that behaviour for
+        // mixin heritage display so `A & { context: InstanceType<typeof
+        // Context>; }` prints as `A & { context: Context; }` (override19.ts).
+        let display_type = self.simplify_heritage_instance_type_for_display(display_type);
         self.format_type(display_type)
     }
 

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -69,6 +69,23 @@ pub(crate) fn instantiate_type(
     tsz_solver::instantiate_type(db, type_id, substitution)
 }
 
+/// Thin wrapper around `tsz_solver::deep_reduce_for_display`.
+///
+/// Deeply reduce meta-type applications (e.g. `InstanceType<typeof Foo>`)
+/// that appear inside `type_id` so the solver's type printer renders the
+/// concrete form that `tsc` shows in heritage diagnostics. The generic
+/// `TypeEvaluator` only visits the top-level node; this boundary helper
+/// walks composite wrappers (`Intersection`, `Union`, `Object`) and
+/// evaluates the inner `Application` / `Conditional` leaves using the
+/// caller-supplied `TypeResolver`.
+pub(crate) fn deep_reduce_for_display<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> TypeId {
+    tsz_solver::deep_reduce_for_display(db, resolver, type_id)
+}
+
 pub(crate) fn callable_shape_for_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/tests/override_intersection_display_tests.rs
+++ b/crates/tsz-checker/tests/override_intersection_display_tests.rs
@@ -118,3 +118,58 @@ class B extends Mixed {
         );
     }
 }
+
+/// When a mixin constructor's return type references a utility conditional
+/// application such as `InstanceType<C>`, tsc reduces the application to its
+/// concrete form (`Context`) when rendering the heritage instance type in
+/// override diagnostics. This mirrors the `override19.ts` conformance
+/// scenario: the diagnostic must render `A & { context: Context; }` rather
+/// than `A & { context: InstanceType<typeof Context>; }`.
+///
+/// The test uses a locally-defined alias with the same conditional body as
+/// the standard `InstanceType<T>` so it does not need the full lib loaded
+/// by the test harness.
+#[test]
+fn override_heritage_display_reduces_utility_conditional_application() {
+    let diags = get_diagnostics(
+        r#"
+type Foo = abstract new(...args: any) => any;
+type Inst<T extends Foo> = T extends abstract new (...args: any) => infer R ? R : any;
+declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
+   new (...args: any[]): { context: Inst<C> }
+}
+class Context {}
+class A {
+    doSomething() {}
+}
+class B extends CreateMixin(Context, A) {
+   override foo() {}
+}
+class C extends CreateMixin(Context, A) {
+    override doSomethang() {}
+}
+"#,
+    );
+
+    let override_diags: Vec<&str> = diags
+        .iter()
+        .filter(|(code, _)| *code == 4113 || *code == 4117)
+        .map(|(_, msg)| msg.as_str())
+        .collect();
+
+    assert!(
+        !override_diags.is_empty(),
+        "Expected TS4113/TS4117 diagnostics, got: {diags:?}"
+    );
+
+    for msg in &override_diags {
+        assert!(
+            msg.contains("A & { context: Context; }"),
+            "Expected reduced heritage display 'A & {{ context: Context; }}' in message, got: {msg}"
+        );
+        assert!(
+            !msg.contains("Inst<"),
+            "Should NOT render unreduced 'Inst<...>' in heritage display, got: {msg}"
+        );
+    }
+}

--- a/crates/tsz-solver/src/diagnostics/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/mod.rs
@@ -16,5 +16,6 @@
 pub mod builders;
 mod core;
 pub mod format;
+pub mod reduce;
 
 pub use self::core::*;

--- a/crates/tsz-solver/src/diagnostics/reduce.rs
+++ b/crates/tsz-solver/src/diagnostics/reduce.rs
@@ -1,0 +1,150 @@
+//! Deep reduction of meta-type applications for diagnostic display.
+//!
+//! This module provides a single public entry point used by the checker's
+//! heritage-display boundary: [`deep_reduce_for_display`].
+//!
+//! Motivation: `tsc` applies `getReducedType` while building the display name
+//! for a heritage instance type, so conditional utility applications such as
+//! `InstanceType<typeof Foo>` render in their concrete form (`Foo`) even when
+//! they appear nested inside an intersection or object member.
+//!
+//! `tsz`'s generic `TypeEvaluator` only evaluates the top-level node — it
+//! stops at `Intersection` / `Union` / `Object` wrappers. This walker
+//! descends into those composites and evaluates the leaves (`Application`,
+//! `Conditional`) using the caller's `TypeResolver`. Concrete sub-structures
+//! are preserved verbatim; only meta-typed leaves that fully reduce to a
+//! non-meta type are replaced.
+//!
+//! The walker is *display-only*: it never widens, normalises, or re-orders
+//! properties, and it is safe to call from diagnostic paths.
+
+use rustc_hash::FxHashSet;
+
+use crate::TypeDatabase;
+use crate::TypeResolver;
+use crate::evaluation::evaluate::TypeEvaluator;
+use crate::types::{PropertyInfo, TypeData, TypeId};
+
+/// Deeply reduce meta-type applications inside `type_id` using `resolver`.
+///
+/// Returns a `TypeId` with the same structural shape as `type_id`, except
+/// that any nested `Application` or `Conditional` that fully evaluates to a
+/// non-meta type via `evaluator.evaluate(...)` is replaced with the reduced
+/// form. If no leaf reduces, `type_id` is returned unchanged.
+///
+/// This is intended for diagnostic rendering paths where `tsc` applies
+/// `getReducedType`. Callers must pass a resolver that can follow
+/// `TypeData::Lazy` references (typically the checker's `TypeEnvironment`);
+/// a `NoopResolver` would be a no-op.
+pub fn deep_reduce_for_display<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> TypeId {
+    let mut visited = FxHashSet::default();
+    let mut evaluator = TypeEvaluator::with_resolver(db, resolver);
+    reduce_inner(db, &mut evaluator, type_id, &mut visited)
+}
+
+fn reduce_inner<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    evaluator: &mut TypeEvaluator<'_, R>,
+    type_id: TypeId,
+    visited: &mut FxHashSet<TypeId>,
+) -> TypeId {
+    if type_id.is_intrinsic() {
+        return type_id;
+    }
+    if !visited.insert(type_id) {
+        return type_id;
+    }
+
+    let key = db.lookup(type_id);
+    let result = match key {
+        Some(TypeData::Application(_) | TypeData::Conditional(_)) => {
+            let reduced = evaluator.evaluate(type_id);
+            if reduced == TypeId::ERROR || reduced == type_id {
+                type_id
+            } else {
+                match db.lookup(reduced) {
+                    Some(
+                        TypeData::Application(_) | TypeData::Conditional(_) | TypeData::Lazy(_),
+                    ) => type_id,
+                    _ => reduce_inner(db, evaluator, reduced, visited),
+                }
+            }
+        }
+        Some(TypeData::Intersection(list_id)) => {
+            let members = db.type_list(list_id);
+            let mut changed = false;
+            let new_members: Vec<TypeId> = members
+                .iter()
+                .map(|&m| {
+                    let r = reduce_inner(db, evaluator, m, visited);
+                    if r != m {
+                        changed = true;
+                    }
+                    r
+                })
+                .collect();
+            if changed {
+                crate::intern::type_factory::TypeFactory::new(db).intersection(new_members)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            let mut changed = false;
+            let new_members: Vec<TypeId> = members
+                .iter()
+                .map(|&m| {
+                    let r = reduce_inner(db, evaluator, m, visited);
+                    if r != m {
+                        changed = true;
+                    }
+                    r
+                })
+                .collect();
+            if changed {
+                crate::intern::type_factory::TypeFactory::new(db).union(new_members)
+            } else {
+                type_id
+            }
+        }
+        Some(TypeData::Object(shape_id)) | Some(TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = db.object_shape(shape_id);
+            let mut new_props: Vec<PropertyInfo> = Vec::with_capacity(shape.properties.len());
+            let mut changed = false;
+            for prop in shape.properties.iter() {
+                let new_read = reduce_inner(db, evaluator, prop.type_id, visited);
+                let new_write = if prop.write_type == prop.type_id {
+                    new_read
+                } else {
+                    reduce_inner(db, evaluator, prop.write_type, visited)
+                };
+                if new_read != prop.type_id || new_write != prop.write_type {
+                    changed = true;
+                    let mut updated = prop.clone();
+                    updated.type_id = new_read;
+                    updated.write_type = new_write;
+                    new_props.push(updated);
+                } else {
+                    new_props.push(prop.clone());
+                }
+            }
+            if !changed {
+                type_id
+            } else if matches!(key, Some(TypeData::ObjectWithIndex(_))) {
+                let mut new_shape = (*shape).clone();
+                new_shape.properties = new_props;
+                crate::intern::type_factory::TypeFactory::new(db).object_with_index(new_shape)
+            } else {
+                crate::intern::type_factory::TypeFactory::new(db).object(new_props)
+            }
+        }
+        _ => type_id,
+    };
+    visited.remove(&type_id);
+    result
+}

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -211,6 +211,7 @@ pub use diagnostics::builders::{
 };
 pub use diagnostics::format::TypeFormatter;
 pub use diagnostics::format::tracing_helpers::{RelationDisplay, TypeDisplay};
+pub use diagnostics::reduce::deep_reduce_for_display;
 pub use diagnostics::{
     DiagnosticArg, DiagnosticSeverity, PendingDiagnostic, PendingDiagnosticBuilder, SourceSpan,
 };


### PR DESCRIPTION
## Summary

`tsc` applies `getReducedType` when rendering a heritage instance type, so conditional utility applications such as `InstanceType<typeof Foo>` render in their concrete form (`Foo`) even when nested inside an intersection or object member. `tsz` previously left them unreduced, breaking parity on `override19.ts` and similar mixin-style tests.

The solver's generic `TypeEvaluator` only visits the top-level node — it stops at the outer `Intersection` / `Object` wrappers. This PR adds **`tsz_solver::deep_reduce_for_display`**: a small walker that descends into composite wrappers and evaluates nested `Application` / `Conditional` leaves using the caller's `TypeResolver`. Only leaves that fully reduce to a non-meta type are replaced; concrete sub-structures are preserved verbatim so no widening, re-ordering, or property merging can occur.

The checker calls it through a thin `query_boundaries::common::deep_reduce_for_display` wrapper right before formatting heritage instance display names (`format_single_display_type`, `format_heritage_instance_display`), matching the architectural contract: no raw solver internals in the checker, no `TypeData` pattern matching outside the solver.

### Before / After

```ts
type Foo = abstract new(...args: any) => any;
declare function CreateMixin<C extends Foo, T extends Foo>(
    Context: C,
    Base: T,
): T & { new (...args: any[]): { context: InstanceType<C> } };
class Context {}
class A { doSomething() {} }
class B extends CreateMixin(Context, A) {
    override foo() {} // base class name used in TS4113
}
```

Before:
```
error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: InstanceType<typeof Context>; }'.
```

After (matches tsc):
```
error TS4113: This member cannot have an 'override' modifier because it is not declared in the base class 'A & { context: Context; }'.
```

### Conformance impact

- **+2** tests flipped `FAIL → PASS` (`override19.ts` plus one collateral)
- **0** regressions (`FAIL → PASS` / `PASS → FAIL`)
- Final: 12096 → 12098

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-checker --lib` — 2677 passed, 0 failed, 9 skipped
- [x] `cargo nextest run -p tsz-solver --lib` — 5278 passed, 0 failed, 7 skipped
- [x] Architecture contract tests (`test_checker_sources_forbid_solver_internal_imports_typekey_usage_and_raw_interning`, `test_solver_imports_go_through_query_boundaries`) — pass
- [x] New unit test `override_heritage_display_reduces_utility_conditional_application` in `crates/tsz-checker/tests/override_intersection_display_tests.rs` — pass
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — net `+2` tests vs baseline, no regressions

https://claude.ai/code/session_01XAwfEwwRqEv5zeEZxksbKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAwfEwwRqEv5zeEZxksbKK)_