### PR TITLE
fix(checker,solver): TS2411 overload display + optional-prop undefined vs number index

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -12,6 +12,9 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// A JSDoc template parameter: `(name, has_default, constraint_expr)`.
+type JsDocTemplateParam = (String, bool, Option<String>);
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_jsdoc_extends_tag_type_arguments(&mut self, class_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -195,11 +198,8 @@ impl<'a> CheckerState<'a> {
         let (Some(arg_shape), Some(constraint_shape)) = (arg_shape, constraint_shape) else {
             return false;
         };
-        let arg_props: rustc_hash::FxHashMap<_, _> = arg_shape
-            .properties
-            .iter()
-            .map(|p| (p.name, p))
-            .collect();
+        let arg_props: rustc_hash::FxHashMap<_, _> =
+            arg_shape.properties.iter().map(|p| (p.name, p)).collect();
         for constraint_prop in &constraint_shape.properties {
             let Some(arg_prop) = arg_props.get(&constraint_prop.name) else {
                 if !constraint_prop.optional {
@@ -307,7 +307,7 @@ impl<'a> CheckerState<'a> {
     fn resolve_jsdoc_extends_target_template_params(
         &mut self,
         base_name: &str,
-    ) -> Option<Vec<(String, bool, Option<String>)>> {
+    ) -> Option<Vec<JsDocTemplateParam>> {
         use tsz_binder::symbol_flags;
 
         let sym_id = self.ctx.binder.file_locals.get(base_name).or_else(|| {
@@ -356,10 +356,8 @@ impl<'a> CheckerState<'a> {
     /// comment. Supports the `{Constraint}` prefix with balanced-brace
     /// matching so object-literal constraints (`{Foo: {...}}`) are captured
     /// intact. Names sharing a line share the constraint.
-    fn parse_jsdoc_template_params_with_constraints(
-        jsdoc: &str,
-    ) -> Vec<(String, bool, Option<String>)> {
-        let mut out: Vec<(String, bool, Option<String>)> = Vec::new();
+    fn parse_jsdoc_template_params_with_constraints(jsdoc: &str) -> Vec<JsDocTemplateParam> {
+        let mut out: Vec<JsDocTemplateParam> = Vec::new();
         for line in jsdoc.lines() {
             let trimmed = line.trim().trim_start_matches('*').trim();
             let Some(rest) = trimmed.strip_prefix("@template") else {
@@ -527,12 +525,11 @@ impl<'a> CheckerState<'a> {
                 }
 
                 let rest_offset = rest.as_ptr() as usize - comment_text.as_ptr() as usize;
-                if rest.starts_with('{') {
+                if let Some(inner) = rest.strip_prefix('{') {
                     // Walk brace-balanced so nested `{...}` inside the
                     // annotation (e.g. `@extends {A<{x:number}>}`) are kept
                     // intact. The previous `rest.find('}')` truncated at the
                     // inner closing `}` and silently dropped the remainder.
-                    let inner = &rest[1..];
                     let mut depth = 1usize;
                     let mut close = None;
                     for (idx, ch) in inner.char_indices() {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -758,95 +758,96 @@ impl<'a> CheckerState<'a> {
 
             // Extract property name, name node index, property type, and
             // whether this member is static.
-            let (prop_name, name_idx, prop_type, is_static_member) =
-                if member_node.kind == syntax_kind_ext::PROPERTY_SIGNATURE {
-                    let Some(sig) = self.ctx.arena.get_signature(member_node) else {
-                        continue;
-                    };
-                    let name = self.get_member_name_text(sig.name).unwrap_or_default();
-                    let prop_type = if sig.type_annotation.is_some() {
-                        self.get_type_from_type_node(sig.type_annotation)
-                    } else {
-                        self.get_type_of_node(member_idx)
-                    };
-                    (name, sig.name, prop_type, false)
-                } else if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
-                    let Some(sig) = self.ctx.arena.get_signature(member_node) else {
-                        continue;
-                    };
-                    let name = self.get_member_name_text(sig.name).unwrap_or_default();
-                    let prop_type = self.get_type_of_interface_member_simple(member_idx);
-                    (name, sig.name, prop_type, false)
-                } else if member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
-                    let Some(prop) = self.ctx.arena.get_property_decl(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&prop.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(prop.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(prop.name).unwrap_or_default();
-                    let prop_type = if let Some(declared_type) =
-                        self.effective_class_property_declared_type(member_idx, prop)
-                    {
-                        declared_type
-                    } else {
-                        self.get_type_of_node(member_idx)
-                    };
-                    (name, prop.name, prop_type, is_static)
-                } else if member_node.kind == syntax_kind_ext::METHOD_DECLARATION {
-                    let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&method.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(method.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(method.name).unwrap_or_default();
-                    let prop_type = self.get_type_of_function(member_idx);
-                    (name, method.name, prop_type, is_static)
-                } else if member_node.kind == syntax_kind_ext::GET_ACCESSOR
-                    || member_node.kind == syntax_kind_ext::SET_ACCESSOR
-                {
-                    let Some(accessor) = self.ctx.arena.get_accessor(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&accessor.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(accessor.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(accessor.name).unwrap_or_default();
-                    let prop_type = if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
-                        if accessor.type_annotation.is_some() {
-                            self.get_type_from_type_node(accessor.type_annotation)
-                        } else {
-                            self.infer_getter_return_type(accessor.body)
-                        }
-                    } else {
-                        let type_ann = accessor
-                            .parameters
-                            .nodes
-                            .first()
-                            .and_then(|&param_idx| self.ctx.arena.get(param_idx))
-                            .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
-                            .map(|param| param.type_annotation)
-                            .unwrap_or(NodeIndex::NONE);
-                        if type_ann.is_some() {
-                            self.get_type_from_type_node(type_ann)
-                        } else {
-                            self.get_type_of_node(member_idx)
-                        }
-                    };
-                    (name, accessor.name, prop_type, is_static)
-                } else {
+            let (prop_name, name_idx, prop_type, is_static_member) = if member_node.kind
+                == syntax_kind_ext::PROPERTY_SIGNATURE
+            {
+                let Some(sig) = self.ctx.arena.get_signature(member_node) else {
                     continue;
                 };
+                let name = self.get_member_name_text(sig.name).unwrap_or_default();
+                let prop_type = if sig.type_annotation.is_some() {
+                    self.get_type_from_type_node(sig.type_annotation)
+                } else {
+                    self.get_type_of_node(member_idx)
+                };
+                (name, sig.name, prop_type, false)
+            } else if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
+                let Some(sig) = self.ctx.arena.get_signature(member_node) else {
+                    continue;
+                };
+                let name = self.get_member_name_text(sig.name).unwrap_or_default();
+                let prop_type = self.merged_method_signature_type(iface_type, &name, member_idx);
+                (name, sig.name, prop_type, false)
+            } else if member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
+                let Some(prop) = self.ctx.arena.get_property_decl(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&prop.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(prop.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(prop.name).unwrap_or_default();
+                let prop_type = if let Some(declared_type) =
+                    self.effective_class_property_declared_type(member_idx, prop)
+                {
+                    declared_type
+                } else {
+                    self.get_type_of_node(member_idx)
+                };
+                (name, prop.name, prop_type, is_static)
+            } else if member_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&method.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(method.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(method.name).unwrap_or_default();
+                let prop_type = self.get_type_of_function(member_idx);
+                (name, method.name, prop_type, is_static)
+            } else if member_node.kind == syntax_kind_ext::GET_ACCESSOR
+                || member_node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                let Some(accessor) = self.ctx.arena.get_accessor(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&accessor.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(accessor.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(accessor.name).unwrap_or_default();
+                let prop_type = if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
+                    if accessor.type_annotation.is_some() {
+                        self.get_type_from_type_node(accessor.type_annotation)
+                    } else {
+                        self.infer_getter_return_type(accessor.body)
+                    }
+                } else {
+                    let type_ann = accessor
+                        .parameters
+                        .nodes
+                        .first()
+                        .and_then(|&param_idx| self.ctx.arena.get(param_idx))
+                        .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                        .map(|param| param.type_annotation)
+                        .unwrap_or(NodeIndex::NONE);
+                    if type_ann.is_some() {
+                        self.get_type_from_type_node(type_ann)
+                    } else {
+                        self.get_type_of_node(member_idx)
+                    }
+                };
+                (name, accessor.name, prop_type, is_static)
+            } else {
+                continue;
+            };
 
             // Symbol-keyed properties are NOT checked against string or number
             // index signatures, but they ARE checked against symbol index

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1741,6 +1741,26 @@ impl<'a> CheckerState<'a> {
         TypeId::ANY
     }
 
+    /// Prefer the merged method type (with all overloads) from `iface_type`
+    /// over the single-node `get_type_of_interface_member_simple` result.
+    ///
+    /// For `interface I { bar(): any; bar(): any; [s: string]: number; }`
+    /// this returns the Callable `{ (): any; (): any; }` that tsc displays
+    /// in TS2411, instead of just `() => any` from the first signature.
+    pub(crate) fn merged_method_signature_type(
+        &mut self,
+        iface_type: TypeId,
+        name: &str,
+        member_idx: NodeIndex,
+    ) -> TypeId {
+        if let tsz_solver::operations::property::PropertyAccessResult::Success { type_id, .. } =
+            self.resolve_property_access_with_env(iface_type, name)
+        {
+            return type_id;
+        }
+        self.get_type_of_interface_member_simple(member_idx)
+    }
+
     /// Get the type of an interface member.
     ///
     /// Returns an object type containing the member. For method signatures,

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -227,3 +227,28 @@ var x: { z: I; [s: string]: { x: any; y: any; } };
 // Note: Inherited member vs index signature is tested via conformance tests
 // (e.g. inheritedMembersAndIndexSignaturesFromDifferentBases.ts) since it
 // requires full lib type resolution that unit tests don't provide.
+
+#[test]
+fn test_ts2411_method_overload_displays_merged_signatures() {
+    // When an interface method has multiple overload signatures, the TS2411
+    // message must render the property's type as `{ (): any; (): any; }`
+    // (matching tsc) instead of just the first signature's `() => any`.
+    // Regression test for interfaceMemberValidation.ts.
+    let source = r#"
+interface foo {
+    bar(): any;
+    bar(): any;
+    [s: string]: number;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for `bar` overloads vs string index");
+    assert!(
+        ts2411.1.contains("{ (): any; (): any; }"),
+        "TS2411 must render merged overload type as `{{ (): any; (): any; }}`, got: {}",
+        ts2411.1
+    );
+}


### PR DESCRIPTION
Two independent fixes on the index-signature compatibility path; bundled
because they share the same ownership + tests touch the same file.

## Commit 1 — `fix(checker)`: render overloaded method type in TS2411 via merged interface

`TS2411` ("Property 'X' of type 'Y' is not assignable to ... index type") was
rendering only the first signature of a method overload set (`() => any`)
instead of the merged `{ (): any; (): any; }` display tsc emits.

The index-signature check iterated each `METHOD_SIGNATURE` node and asked for
its type via `get_type_of_interface_member_simple`, which returns a single
`Function` type for that node alone. The merged overload type (a `Callable`
with multiple call signatures) already lives on the containing `iface_type`.

Route the lookup through a new `merged_method_signature_type` helper that
asks the interface for the property via `resolve_property_access_with_env`
and falls back to the per-node type when the lookup fails.

Fixes `interfaceMemberValidation.ts`.

```ts
interface foo {
    bar(): any;
    bar(): any;
    [s: string]: number;
}
// tsc: TS2411 Property 'bar' of type '{ (): any; (): any; }' is not assignable to 'string' index type 'number'
// tsz (before): TS2411 Property 'bar' of type '() => any' is not assignable to 'string' index type 'number'
```

Drive-by: introduce `JsDocTemplateParam` alias in `jsdoc_heritage.rs` so the
pre-commit clippy gate passes.

## Commit 2 — `fix(solver)`: preserve implicit undefined for optional props vs NUMBER index

tsc treats the implicit `| undefined` from an optional property
asymmetrically between STRING and NUMBER index signatures:

- STRING index strips the implicit `| undefined`, so `{ b?: number }`
  remains assignable to `{ [k: string]: number }`.
- NUMBER index preserves it, so `{ 1?: string }` is NOT assignable to
  `{ [k: number]: string }` — `string | undefined <: string` fails.

tsz was stripping `undefined` symmetrically for both index kinds via
`remove_undefined`, masking the NUMBER-index error.

Fix the two object-vs-NUMBER-index-signature sites in
`crates/tsz-solver/src/relations/subtype/rules/objects.rs`:

- `check_properties_against_index_signatures` now uses
  `optional_property_type(prop)` for the NUMBER-index operand (STRING
  operand still strips).
- `check_number_index_compatibility`'s implicit-number-index fallback
  switches from `remove_undefined` to `optional_property_type`.

Partial fix for `optionalPropertyAssignableToStringIndexSignature.ts` —
adds the `probablyArray = numberLiteralKeys` TS2322 fingerprint. The
remaining missing fingerprint on that test (`{ k1?: undefined }` → `{ [k:
string]: string }`) requires distinguishing implicit-vs-explicit undefined
on optional STRING-indexed properties, which tsc handles via a context
rule not captured in `PropertyInfo`. Left for follow-up.

```ts
declare let probablyArray: { [key: number]: string };
declare let numberLiteralKeys: { 1?: string };
probablyArray = numberLiteralKeys; // tsc: TS2322 (now also tsz)
```

Two solver operation tests
(`test_infer_generic_number_index_from_optional_property` and
`test_infer_generic_index_signatures_from_optional_mixed_properties`)
asserted the pre-fix behaviour; updated to expect `TypeId::ERROR` (matching
tsc's TS2322).

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib ts2411` — 18/18 (includes new `test_ts2411_method_overload_displays_merged_signatures`).
- [x] `cargo nextest run -p tsz-checker --lib ts2322_optional` — passes, including new `ts2322_optional_property_vs_number_index_preserves_implicit_undefined` and `ts2322_optional_string_property_vs_string_index_still_ok` regression guard.
- [x] `cargo nextest run -p tsz-solver --lib` — 5278/5278 (solver ops tests updated to match tsc).
- [x] `./scripts/session/verify-all.sh` — formatting/clippy/conformance (+1)/emit (JS +1, DTS +16)/LSP (=50) all pass.