### PR TITLE
[codex] preserve contextual typing for thisless object-literal methods

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1425,21 +1425,61 @@ impl<'a> CheckerState<'a> {
                                 let spec_len = (specifier.len() + 2) as u32;
 
                                 if let Some(target_idx) = self.ctx.resolve_import_target(&specifier)
-                                    && let Some(target_binder) =
-                                        self.ctx.get_binder_for_file(target_idx)
-                                    && !target_binder.is_external_module
                                 {
-                                    let target_arena =
-                                        self.ctx.get_arena_for_file(target_idx as u32);
-                                    if let Some(target_sf) = target_arena.source_files.first() {
-                                        let display_name = target_sf
-                                            .file_name
+                                    let (is_external_module, display_name) =
+                                        if let Some(target_binder) =
+                                            self.ctx.get_binder_for_file(target_idx)
+                                        {
+                                            let target_arena =
+                                                self.ctx.get_arena_for_file(target_idx as u32);
+                                            let Some(target_sf) = target_arena.source_files.first()
+                                            else {
+                                                continue;
+                                            };
+                                            (
+                                                target_binder.is_external_module,
+                                                target_sf.file_name.clone(),
+                                            )
+                                        } else if target_idx == self.ctx.current_file_idx {
+                                            (
+                                                self.ctx.binder.is_external_module(),
+                                                self.ctx.file_name.clone(),
+                                            )
+                                        } else {
+                                            let Some(target_file_name) = self
+                                                .ctx
+                                                .global_file_name_index
+                                                .as_ref()
+                                                .and_then(|idx| {
+                                                    idx.iter().find_map(|(file_name, &file_idx)| {
+                                                        (file_idx == target_idx)
+                                                            .then(|| file_name.clone())
+                                                    })
+                                                })
+                                            else {
+                                                continue;
+                                            };
+                                            let Some(is_external_module) = self
+                                                .ctx
+                                                .is_external_module_by_file
+                                                .as_ref()
+                                                .and_then(|map| {
+                                                    map.get(&target_file_name).copied()
+                                                })
+                                            else {
+                                                continue;
+                                            };
+                                            (is_external_module, target_file_name)
+                                        };
+
+                                    if !is_external_module {
+                                        let display_name = display_name
                                             .rsplit('/')
                                             .next()
-                                            .unwrap_or(&target_sf.file_name)
+                                            .unwrap_or(&display_name)
                                             .rsplit('\\')
                                             .next()
-                                            .unwrap_or(&target_sf.file_name)
+                                            .unwrap_or(&display_name)
                                             .to_string();
                                         let message = crate::diagnostics::format_message(
                                             crate::diagnostics::diagnostic_messages::FILE_IS_NOT_A_MODULE,

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -541,9 +541,17 @@ impl<'a> CheckerState<'a> {
 
         let (is_external_module, file_name) = if symbol.decl_file_idx != u32::MAX {
             let file_idx = symbol.decl_file_idx as usize;
-            let binder = self.ctx.get_binder_for_file(file_idx)?;
-            let file_name = arena.source_files.first()?.file_name.clone();
-            (binder.is_external_module(), file_name)
+            if let Some(binder) = self.ctx.get_binder_for_file(file_idx) {
+                let file_name = arena.source_files.first()?.file_name.clone();
+                (binder.is_external_module(), file_name)
+            } else if file_idx == self.ctx.current_file_idx {
+                (
+                    self.ctx.binder.is_external_module(),
+                    self.ctx.file_name.clone(),
+                )
+            } else {
+                return None;
+            }
         } else {
             (
                 self.ctx.binder.is_external_module(),

--- a/crates/tsz-checker/src/state/cache_invalidation.rs
+++ b/crates/tsz-checker/src/state/cache_invalidation.rs
@@ -295,9 +295,11 @@ impl<'a> CheckerState<'a> {
                     self.invalidate_expression_for_contextual_retry(cond.when_false);
                 }
             }
-            k if k == syntax_kind_ext::SPREAD_ELEMENT => {
+            k if k == syntax_kind_ext::SPREAD_ELEMENT
+                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
                 self.invalidate_node_type_cache(idx);
-                if let Some(spread) = self.ctx.arena.get_unary_expr_ex(node) {
+                if let Some(spread) = self.ctx.arena.get_spread(node) {
                     self.invalidate_expression_for_contextual_retry(spread.expression);
                 }
             }
@@ -535,8 +537,10 @@ impl<'a> CheckerState<'a> {
                     self.clear_type_cache_recursive(cond.when_false);
                 }
             }
-            k if k == syntax_kind_ext::SPREAD_ELEMENT => {
-                if let Some(spread) = self.ctx.arena.get_unary_expr_ex(node) {
+            k if k == syntax_kind_ext::SPREAD_ELEMENT
+                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                if let Some(spread) = self.ctx.arena.get_spread(node) {
                     self.clear_type_cache_recursive(spread.expression);
                 }
             }

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1604,9 +1604,10 @@ impl<'a> CheckerState<'a> {
             // This prevents generic return type inference from being lost — e.g.,
             // querySelector<E>() returning E=Element instead of E=HTMLElement.
             //
-            // Closures need the same preservation: a later context-free pass can
-            // otherwise re-enter the same arrow/function expression, infer `any`
-            // parameters, and overwrite a previously-correct contextual signature.
+            // Closures, contextually typed object literals, and object-literal
+            // methods/accessors need the same preservation: a later context-free
+            // pass can otherwise re-enter the node, fall back to the generic
+            // owner type, and overwrite a previously-correct contextual result.
             if let Some(node) = self.ctx.arena.get(idx) {
                 use tsz_parser::parser::syntax_kind_ext;
                 if matches!(
@@ -1614,6 +1615,9 @@ impl<'a> CheckerState<'a> {
                     syntax_kind_ext::CALL_EXPRESSION
                         | syntax_kind_ext::ARROW_FUNCTION
                         | syntax_kind_ext::FUNCTION_EXPRESSION
+                        | syntax_kind_ext::METHOD_DECLARATION
+                        | syntax_kind_ext::GET_ACCESSOR
+                        | syntax_kind_ext::SET_ACCESSOR
                         | syntax_kind_ext::NON_NULL_EXPRESSION
                         | syntax_kind_ext::NEW_EXPRESSION
                 ) {

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -448,12 +448,33 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if let Some(property_type) =
-            crate::query_boundaries::state::checking::get_finite_mapped_property_type(
+        let target_key = self.ctx.types.literal_string_atom(prop_atom);
+        let instantiated_template =
+            crate::query_boundaries::state::checking::instantiate_mapped_template_for_property(
                 self.ctx.types,
-                mapped_id,
-                prop_name,
-            )
+                mapped.template,
+                mapped.type_param.name,
+                target_key,
+            );
+        let fast_path_is_concrete = !crate::query_boundaries::state::checking::needs_env_eval(
+            self.ctx.types,
+            instantiated_template,
+        ) && !crate::query_boundaries::common::contains_type_parameters(
+            self.ctx.types,
+            instantiated_template,
+        )
+            && !crate::query_boundaries::common::contains_lazy_or_recursive(
+                self.ctx.types,
+                instantiated_template,
+            );
+
+        if fast_path_is_concrete
+            && let Some(property_type) =
+                crate::query_boundaries::state::checking::get_finite_mapped_property_type(
+                    self.ctx.types,
+                    mapped_id,
+                    prop_name,
+                )
         {
             self.ctx
                 .narrowing_cache

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -8,6 +8,7 @@ use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::syntax::transform_utils::contains_this_reference;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
@@ -23,6 +24,47 @@ impl<'a> CheckerState<'a> {
         ctx_helper
             .get_property_type(&prop_name)
             .filter(|&ty| ty != TypeId::ANY && !self.type_contains_error(ty))
+    }
+
+    fn cached_object_literal_member_callable_type(&self, member_idx: NodeIndex) -> Option<TypeId> {
+        let member = self.ctx.arena.get(member_idx)?;
+        let parent = self.ctx.arena.get_extended(member_idx)?.parent;
+        let parent_node = self.ctx.arena.get(parent)?;
+        if parent_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+
+        let needs_contextual_this = match member.kind {
+            syntax_kind_ext::METHOD_DECLARATION => self
+                .ctx
+                .arena
+                .get_method_decl(member)
+                .is_some_and(|method| contains_this_reference(self.ctx.arena, method.body)),
+            syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => self
+                .ctx
+                .arena
+                .get_accessor(member)
+                .is_some_and(|accessor| contains_this_reference(self.ctx.arena, accessor.body)),
+            _ => false,
+        };
+        if !needs_contextual_this {
+            return None;
+        }
+
+        let cached = *self.ctx.node_types.get(&member_idx.0)?;
+        if crate::query_boundaries::checkers::call::get_contextual_signature(self.ctx.types, cached)
+            .is_none()
+        {
+            return None;
+        }
+
+        if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, cached)
+            || crate::query_boundaries::common::contains_infer_types(self.ctx.types, cached)
+        {
+            return None;
+        }
+
+        Some(cached)
     }
 
     #[allow(dead_code)]
@@ -621,8 +663,14 @@ impl<'a> CheckerState<'a> {
         // Extract parameter types from contextual type (for object literal methods)
         // This enables shorthand method parameter type inference
         let mut param_types: Vec<Option<TypeId>> = Vec::new();
-        let contextual_method_type =
-            self.contextual_class_member_type_from_request(request, method.name);
+        let contextual_method_type = self
+            .contextual_class_member_type_from_request(request, method.name)
+            .or_else(|| {
+                request
+                    .is_empty()
+                    .then(|| self.cached_object_literal_member_callable_type(member_idx))
+                    .flatten()
+            });
         let prototype_owner_this_type = if self.is_js_file() {
             self.js_prototype_owner_expression_for_node(member_idx)
                 .and_then(|owner_expr| self.js_prototype_owner_function_target(owner_expr))

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1023,7 +1023,7 @@ impl<'a> CheckerState<'a> {
         // Lazy(DefId) references become concrete types.  Then attempt property
         // access resolution with the resolved object.
         if let Some((obj, _idx)) = query::index_access_types(self.ctx.types, property_type) {
-            let obj_type = self.evaluate_type_with_resolution(obj);
+            let obj_type = self.evaluate_type_with_env(obj);
 
             let prop_name_arc = self.ctx.types.resolve_atom_ref(key_name);
             let prop_name: &str = &prop_name_arc;

--- a/crates/tsz-checker/src/types/computation/contextual.rs
+++ b/crates/tsz-checker/src/types/computation/contextual.rs
@@ -7,6 +7,7 @@
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::syntax::transform_utils::contains_this_reference;
 
 fn callee_needs_contextual_return_type(state: &CheckerState, callee_idx: NodeIndex) -> bool {
     use tsz_parser::parser::syntax_kind_ext;
@@ -61,7 +62,11 @@ pub(crate) fn is_contextually_sensitive(state: &CheckerState, idx: NodeIndex) ->
                         .and_then(|pn| state.ctx.arena.get_parameter(pn))
                         .is_some_and(|p| p.type_annotation.is_none())
                 });
+                let zero_param_contextual_this = method.parameters.nodes.is_empty()
+                    && method.type_annotation.is_none()
+                    && contains_this_reference(state.ctx.arena, method.body);
                 has_unannotated_params
+                    || zero_param_contextual_this
                     || (method.parameters.nodes.is_empty()
                         && method.type_annotation.is_none()
                         && function_body_needs_contextual_return_type(state, method.body))
@@ -166,7 +171,14 @@ pub(crate) fn is_contextually_sensitive(state: &CheckerState, idx: NodeIndex) ->
                                                 .and_then(|pn| state.ctx.arena.get_parameter(pn))
                                                 .is_some_and(|p| p.type_annotation.is_none())
                                         });
+                                    let zero_param_contextual_this = method
+                                        .parameters
+                                        .nodes
+                                        .is_empty()
+                                        && method.type_annotation.is_none()
+                                        && contains_this_reference(state.ctx.arena, method.body);
                                     if has_unannotated
+                                        || zero_param_contextual_this
                                         || (method.parameters.nodes.is_empty()
                                             && method.type_annotation.is_none()
                                             && function_body_needs_contextual_return_type(

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -339,6 +339,8 @@ impl<'a> CheckerState<'a> {
     ) -> Vec<PropertyInfo> {
         let resolved = self.resolve_type_for_property_access(type_id);
         let resolved = self.resolve_lazy_type(resolved);
+        let resolved = self.evaluate_type_with_env(resolved);
+        let resolved = self.resolve_type_for_property_access(resolved);
         self.ctx
             .types
             .collect_object_spread_properties(resolved)

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1426,7 +1426,16 @@ impl<'a> CheckerState<'a> {
             }
         });
 
-        let implicit_this = implicit_this.map(|tt| self.resolve_lazy_type(tt));
+        let implicit_this = implicit_this.map(|tt| {
+            let tt = self.resolve_lazy_type(tt);
+            if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, tt)
+                || crate::query_boundaries::common::contains_lazy_or_recursive(self.ctx.types, tt)
+            {
+                self.evaluate_type_with_env(tt)
+            } else {
+                tt
+            }
+        });
 
         let mut pushed_this_type_early = false;
         if let Some(tt) = implicit_this {
@@ -1447,13 +1456,21 @@ impl<'a> CheckerState<'a> {
             // This must happen before infer_return_type_from_body which evaluates body expressions.
             self.ctx.function_depth += 1;
             self.cache_parameter_types(&parameters.nodes, Some(&param_types));
-            let refresh_body_for_contextual_param_retyping =
-                is_closure && (ctx_helper.is_some() || func_jsdoc.is_some());
+            let refresh_body_for_contextual_param_retyping = (ctx_helper.is_some()
+                || func_jsdoc.is_some())
+                && (is_closure
+                    || matches!(
+                        node.kind,
+                        syntax_kind_ext::METHOD_DECLARATION
+                            | syntax_kind_ext::GET_ACCESSOR
+                            | syntax_kind_ext::SET_ACCESSOR
+                    ));
             if refresh_body_for_contextual_param_retyping {
-                // Function expressions are often visited once during environment building
-                // and again with contextual/JSDoc parameter types during checked mode.
-                // Re-evaluate the body from the shared cached parameter types so reads like
-                // `acceptNum(b)` see the same optionality/type-tag result as the signature.
+                // Contextually typed function-like bodies are often visited once during
+                // generic/context-free evaluation and again after a concrete contextual
+                // signature becomes available. Re-evaluate the body from the shared
+                // cached parameter/`this` types so reads like `this.options.suggestion`
+                // or `acceptNum(b)` don't stick with the stale generic pass result.
                 //
                 // Targeted invalidation: clear body only (not param symbols,
                 // which were just set by cache_parameter_types above).

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -776,72 +776,98 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
 
-                    // Use get_type_params_for_symbol to get the ORIGINAL TypeParam
-                    // TypeIds that match the ones in base_type's member signatures.
-                    // Previously we used push_type_parameters which creates NEW
-                    // TypeIds that don't match, causing substitution to be a no-op.
-                    let base_type_params = self.get_type_params_for_symbol(base_sym_id);
+                    // Prefer the already-lowered heritage type reference when type
+                    // arguments are present. This preserves the clause's explicit
+                    // instantiation (e.g. `Base<T, Foo<T>>`) without rebuilding it
+                    // from symbol metadata, which can lose substitutions for
+                    // inherited generic members.
+                    let direct_instantiated_base = (!type_args.is_empty())
+                        .then(|| self.get_type_from_type_node(type_idx))
+                        .filter(|&ty| ty != TypeId::ERROR && ty != TypeId::UNKNOWN);
 
-                    if type_args.len() < base_type_params.len() {
-                        for (param_index, param) in
-                            base_type_params.iter().enumerate().skip(type_args.len())
-                        {
-                            let fallback = param
-                                .default
-                                .or(param.constraint)
-                                .unwrap_or(TypeId::UNKNOWN);
-                            let substitution = TypeSubstitution::from_args(
-                                self.ctx.types,
-                                &base_type_params[..param_index],
-                                &type_args,
-                            );
-                            type_args.push(
-                                crate::query_boundaries::common::instantiate_type_preserving_meta(
+                    if let Some(direct_base) = direct_instantiated_base {
+                        base_type = direct_base;
+                    } else {
+                        // Use get_type_params_for_symbol to get the ORIGINAL TypeParam
+                        // TypeIds that match the ones in base_type's member signatures.
+                        // Previously we used push_type_parameters which creates NEW
+                        // TypeIds that don't match, causing substitution to be a no-op.
+                        let base_type_params = self.get_type_params_for_symbol(base_sym_id);
+
+                        if type_args.len() < base_type_params.len() {
+                            for (param_index, param) in
+                                base_type_params.iter().enumerate().skip(type_args.len())
+                            {
+                                let fallback = param
+                                    .default
+                                    .or(param.constraint)
+                                    .unwrap_or(TypeId::UNKNOWN);
+                                let substitution = TypeSubstitution::from_args(
                                     self.ctx.types,
-                                    fallback,
-                                    &substitution,
-                                ),
-                            );
+                                    &base_type_params[..param_index],
+                                    &type_args,
+                                );
+                                type_args.push(
+                                    crate::query_boundaries::common::instantiate_type_preserving_meta(
+                                        self.ctx.types,
+                                        fallback,
+                                        &substitution,
+                                    ),
+                                );
+                            }
                         }
-                    }
-                    if type_args.len() > base_type_params.len() {
-                        type_args.truncate(base_type_params.len());
-                    }
+                        if type_args.len() > base_type_params.len() {
+                            type_args.truncate(base_type_params.len());
+                        }
 
-                    let has_structural_self_arg = current_sym.is_some_and(|current_sym| {
-                        type_args.iter().copied().any(|arg| {
-                            self.type_requires_structure_of_symbol_for_base_type(arg, current_sym)
-                        })
-                    });
-
-                    let substitution =
-                        TypeSubstitution::from_args(self.ctx.types, &base_type_params, &type_args);
-                    base_type = instantiate_type(self.ctx.types, base_type, &substitution);
-                    let is_builtin_array_heritage =
-                        matches!(base_symbol_name.as_str(), "Array" | "ReadonlyArray");
-                    let requires_self = !is_builtin_array_heritage
-                        && current_sym.is_some_and(|current_sym| {
-                            has_structural_self_arg
-                                || self.type_requires_structure_of_symbol_for_base_type(
-                                    base_type,
+                        let has_structural_self_arg = current_sym.is_some_and(|current_sym| {
+                            type_args.iter().copied().any(|arg| {
+                                self.type_requires_structure_of_symbol_for_base_type(
+                                    arg,
                                     current_sym,
                                 )
+                            })
                         });
 
-                    if let Some(current_sym) = current_sym
-                        && requires_self
-                    {
-                        self.report_recursive_base_type_for_symbol(current_sym);
-                        self.report_instantiated_type_alias_mapped_constraint_cycles(
-                            base_sym_id,
+                        let substitution = TypeSubstitution::from_args(
+                            self.ctx.types,
                             &base_type_params,
                             &type_args,
-                            current_sym,
                         );
-                        derived_type = self.merge_interface_types(derived_type, base_type);
-                        continue;
-                    }
+                        base_type = if !type_args.is_empty()
+                            && crate::query_boundaries::common::is_lazy_type(
+                                self.ctx.types,
+                                base_type,
+                            ) {
+                            self.ctx.types.application(base_type, type_args.clone())
+                        } else {
+                            instantiate_type(self.ctx.types, base_type, &substitution)
+                        };
+                        let is_builtin_array_heritage =
+                            matches!(base_symbol_name.as_str(), "Array" | "ReadonlyArray");
+                        let requires_self = !is_builtin_array_heritage
+                            && current_sym.is_some_and(|current_sym| {
+                                has_structural_self_arg
+                                    || self.type_requires_structure_of_symbol_for_base_type(
+                                        base_type,
+                                        current_sym,
+                                    )
+                            });
 
+                        if let Some(current_sym) = current_sym
+                            && requires_self
+                        {
+                            self.report_recursive_base_type_for_symbol(current_sym);
+                            self.report_instantiated_type_alias_mapped_constraint_cycles(
+                                base_sym_id,
+                                &base_type_params,
+                                &type_args,
+                                current_sym,
+                            );
+                            derived_type = self.merge_interface_types(derived_type, base_type);
+                            continue;
+                        }
+                    }
                     derived_type = self.merge_interface_types(derived_type, base_type);
                 }
             }

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1288,6 +1288,79 @@ create({
     );
 }
 
+#[test]
+fn test_ts2783_spread_overwrites_in_thisless_generic_method_context() {
+    let source = r#"
+declare class Editor {
+  private _editor;
+}
+
+declare class EditorPlugin {
+  private _plugin;
+}
+
+interface SuggestionOptions {
+  editor: Editor;
+  char?: string;
+}
+
+declare function Suggestion(options: SuggestionOptions): EditorPlugin;
+
+type ExtensionConfig<Options> = {
+  addProseMirrorPlugins?: (this: {
+    options: Options;
+    editor: Editor;
+  }) => EditorPlugin[];
+};
+
+declare function createExtension<Options>(config: ExtensionConfig<Options>): void;
+
+createExtension<{ suggestion: SuggestionOptions }>({
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+"#;
+
+    let diagnostics = check_source(source);
+    let ts2339_count = diagnostics.iter().filter(|d| d.code == 2339).count();
+    let ts2345_count = diagnostics.iter().filter(|d| d.code == 2345).count();
+    let ts2783_count = diagnostics.iter().filter(|d| d.code == 2783).count();
+
+    assert_eq!(
+        ts2339_count,
+        0,
+        "Expected no TS2339 for contextual this in addProseMirrorPlugins, got diagnostics: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        ts2345_count,
+        0,
+        "Expected no TS2345 for the Suggestion() call, got diagnostics: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        ts2783_count,
+        1,
+        "Expected one spread-overwrite TS2783 diagnostic, got diagnostics: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Confirm TS2698 still fires in expression context (spreading a non-object).
 #[test]
 fn test_object_spread_of_non_object_in_expression_emits_ts2698() {

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1801,9 +1801,89 @@ pub(super) fn check_file_for_parallel<'a>(
     checker.ctx.report_unresolved_imports = true;
     checker.ctx.shared_lib_type_cache = Some(shared_lib_cache);
 
-    // Apply all project-level shared state in one call. This installs the
-    // shared DefinitionStore and runs warm_local_caches_from_shared_store().
-    project_env.apply_to(&mut checker.ctx);
+    if program.files.len() == 1 {
+        if !project_env.lib_contexts.is_empty() {
+            checker
+                .ctx
+                .set_lib_contexts_shared(Arc::clone(&project_env.lib_contexts));
+            checker
+                .ctx
+                .set_actual_lib_file_count(project_env.lib_contexts.len());
+        }
+        checker.ctx.set_typescript_dom_replacement_globals(
+            project_env.typescript_dom_replacement_globals.0,
+            project_env.typescript_dom_replacement_globals.1,
+            project_env.typescript_dom_replacement_globals.2,
+        );
+        checker
+            .ctx
+            .set_has_deprecation_diagnostics(project_env.has_deprecation_diagnostics);
+        checker
+            .ctx
+            .set_all_arenas(Arc::clone(&project_env.all_arenas));
+        if let Some(ref dm) = project_env.skeleton_declared_modules {
+            checker
+                .ctx
+                .set_declared_modules_from_skeleton(Arc::clone(dm));
+        }
+        if let Some(ref idx) = project_env.global_module_exports_index {
+            checker.ctx.global_module_exports_index = Some(Arc::clone(idx));
+        }
+        if let Some(ref idx) = project_env.global_module_binder_index {
+            checker.ctx.global_module_binder_index = Some(Arc::clone(idx));
+        }
+        if let Some(ref idx) = project_env.global_file_name_index {
+            checker.ctx.global_file_name_index = Some(Arc::clone(idx));
+        }
+        if let Some(ref m) = project_env.program_reexports {
+            checker.ctx.program_reexports = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = project_env.program_wildcard_reexports {
+            checker.ctx.program_wildcard_reexports = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = project_env.program_wildcard_reexports_type_only {
+            checker.ctx.program_wildcard_reexports_type_only = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = project_env.program_module_exports {
+            checker.ctx.program_module_exports = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = project_env.program_cross_file_node_symbols {
+            checker.ctx.program_cross_file_node_symbols = Some(Arc::clone(m));
+        }
+        if let Some(ref m) = project_env.program_alias_partners {
+            checker.ctx.program_alias_partners = Some(Arc::clone(m));
+        }
+        if let Some(ref store) = project_env.shared_definition_store {
+            checker.ctx.definition_store = Arc::clone(store);
+        }
+        if let Some(ref idx) = project_env.global_symbol_file_index {
+            checker.ctx.global_symbol_file_index = Some(Arc::clone(idx));
+        } else if !project_env.symbol_file_targets.is_empty() {
+            let mut targets = checker.ctx.cross_file_symbol_targets.borrow_mut();
+            for &(sym_id, owner_idx) in project_env.symbol_file_targets.iter() {
+                targets.insert(sym_id, owner_idx);
+            }
+        }
+        checker
+            .ctx
+            .set_resolved_module_paths(Arc::clone(&project_env.resolved_module_paths));
+        checker.ctx.set_resolved_module_request_paths(Arc::clone(
+            &project_env.resolved_module_request_paths,
+        ));
+        checker
+            .ctx
+            .set_resolved_module_errors(Arc::clone(&project_env.resolved_module_errors));
+        checker.ctx.set_resolved_module_request_errors(Arc::clone(
+            &project_env.resolved_module_request_errors,
+        ));
+        checker.ctx.is_external_module_by_file =
+            Some(Arc::clone(&project_env.is_external_module_by_file));
+        checker.ctx.file_is_esm_map = Some(Arc::clone(&project_env.file_is_esm_map));
+    } else {
+        // Apply all project-level shared state in one call. This installs the
+        // shared DefinitionStore and runs warm_local_caches_from_shared_store().
+        project_env.apply_to(&mut checker.ctx);
+    }
 
     // Per-file state that varies across files:
     checker.ctx.set_current_file_idx(file_idx);
@@ -4493,6 +4573,235 @@ const nestedTuple = type([["ark", "|>", (x) => x.length]])
         assert!(
             relevant.is_empty(),
             "Expected recursive mapped-type callback repro to keep context in collect_diagnostics, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_collect_diagnostics_preserves_thisless_generic_method_context() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(
+            &file_path,
+            r#"type LocalPartial<T> = { [P in keyof T]?: T[P] };
+type LocalRequired<T> = { [P in keyof T]-?: T[P] };
+type LocalParameters<T extends (...args: any) => any> = T extends (...args: infer P) => any
+  ? P
+  : never;
+type LocalReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R
+  ? R
+  : any;
+
+declare class Editor {
+  private _editor;
+}
+
+declare class EditorPlugin {
+  private _plugin;
+}
+
+type ParentConfig<T> = LocalPartial<{
+  [P in keyof T]: LocalRequired<T>[P] extends (...args: any) => any
+    ? (...args: LocalParameters<LocalRequired<T>[P]>) => LocalReturnType<LocalRequired<T>[P]>
+    : T[P];
+}>;
+
+interface ExtendableConfig<
+  Options = any,
+  Config extends
+    | ExtensionConfig<Options>
+    | ExtendableConfig<Options> = ExtendableConfig<Options, any>,
+> {
+  name: string;
+  addOptions?: (this: {
+    name: string;
+    parent: ParentConfig<Config>["addOptions"];
+  }) => Options;
+  addProseMirrorPlugins?: (this: {
+    options: Options;
+    editor: Editor;
+  }) => EditorPlugin[];
+}
+
+interface ExtensionConfig<Options = any>
+  extends ExtendableConfig<Options, ExtensionConfig<Options>> {}
+
+declare class Extension<Options = any> {
+  _options: Options;
+  static create<O = any>(config: Partial<ExtensionConfig<O>>): Extension<O>;
+  configure(options?: Partial<Options>): Extension<Options>;
+}
+
+interface SuggestionOptions {
+  editor: Editor;
+  char?: string;
+}
+
+declare function Suggestion(options: SuggestionOptions): EditorPlugin;
+
+Extension.create({
+  name: "slash-command",
+  addOptions() {
+    return {
+      suggestion: {
+        char: "/",
+      } as SuggestionOptions,
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+
+Extension.create({
+  name: "slash-command",
+  addOptions: () => {
+    return {
+      suggestion: {
+        char: "/",
+      } as SuggestionOptions,
+    };
+  },
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+
+const parentExtension = Extension.create({
+  name: "parentExtension",
+  addOptions() {
+    return { parent: "exists", overwrite: "parent" };
+  },
+});
+
+const childExtension = parentExtension.configure({
+  child: "exists-too",
+  overwrite: "child",
+});
+
+const parentExtension2 = Extension.create({
+  name: "parentExtension2",
+  addOptions: () => {
+    return { parent: "exists", overwrite: "parent" };
+  },
+});
+
+const childExtension2 = parentExtension2.configure({
+  child: "exists-too",
+  overwrite: "child",
+});
+"#,
+        )
+        .expect("write source");
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            type_reference_errors,
+            resolution_mode_errors,
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        let diagnostics = collect_diagnostics(
+            &program,
+            &resolved,
+            dir.path(),
+            None,
+            &checker_libs,
+            (false, false, false),
+            &type_cache_output,
+            false,
+        )
+        .diagnostics;
+
+        let ts2339_count = diagnostics
+            .iter()
+            .filter(|diag| diag.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE)
+            .count();
+        let ts2345_count = diagnostics
+            .iter()
+            .filter(|diag| {
+                diag.code
+                    == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+            })
+            .count();
+        let ts2353_count = diagnostics
+            .iter()
+            .filter(|diag| {
+                diag.code
+                    == diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE
+            })
+            .count();
+        let ts2783_count = diagnostics
+            .iter()
+            .filter(|diag| {
+                diag.code
+                    == diagnostic_codes::IS_SPECIFIED_MORE_THAN_ONCE_SO_THIS_USAGE_WILL_BE_OVERWRITTEN
+            })
+            .count();
+
+        assert_eq!(
+            ts2339_count, 0,
+            "Expected no TS2339 for contextual this in collect_diagnostics, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            ts2345_count, 0,
+            "Expected no TS2345 for Suggestion() calls in collect_diagnostics, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            ts2353_count, 2,
+            "Expected two TS2353 configure() excess-property diagnostics, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            ts2783_count, 2,
+            "Expected two TS2783 spread-overwrite diagnostics, got: {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics.len(),
+            4,
+            "Expected only the two TS2783 and two TS2353 diagnostics, got: {diagnostics:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
Fix `thislessFunctionsNotContextSensitive3` by keeping zero-arg object-literal methods that reference `this` contextually typed through checker retries and single-file CLI checking.

Invariant: zero-arg object-literal methods that reference `this` must keep their contextual `this` and body typing across checker retries and single-file CLI runs; otherwise `tsz` falls back to a generic owner pass and emits false `TS2345` instead of the expected downstream spread/object-literal diagnostics.

```ts
declare function define<C>(config: Partial<C>): void;

define<{
  addProseMirrorPlugins(this: {
    editor: typeof Editor;
    options: { suggestion: SuggestionOptions };
  }): typeof EditorPlugin[];
}>({
  addProseMirrorPlugins() {
    return Suggestion({
      editor: this.editor,
      ...this.options.suggestion,
    });
  },
});
```

Expected: no `TS2345` on `Suggestion(...)`; the remaining diagnostics are the spread/object-literal ones (`TS2783` / `TS2353`).

## Tests
- `cargo check --package tsz-checker`
- `cargo check --package tsz-solver`
- `cargo build --profile dist-fast --bin tsz`
- `scripts/safe-run.sh cargo nextest run --package tsz-checker --lib`
- `scripts/safe-run.sh cargo nextest run --package tsz-solver --lib`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "thislessFunctionsNotContextSensitive3" --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --max 200`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run 2>&1 | grep FINAL`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh diff`
