### PR TITLE
fix(checker): emit TS7055 for yield* empty array in non-strict generators

### DIFF
--- a/crates/tsz-checker/src/dispatch_yield.rs
+++ b/crates/tsz-checker/src/dispatch_yield.rs
@@ -456,10 +456,27 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // generator yield type must come from actual body yields, not context
                     // (see function_type.rs comment on final_generator_yield_type).
                     if let Some(ref i) = info {
+                        // In non-strict mode (strictNullChecks: false), an empty iterable
+                        // like `[]` produces `never[]` (element type: `never`). But tsc
+                        // treats the element type as `undefined` for generator yield
+                        // inference in non-strict mode — "In non-strict mode, `[]` produces
+                        // the type `undefined[]` which is implicitly any." (TypeScript docs).
+                        //
+                        // When we encounter `yield* []`, the element type is `never` but
+                        // should be treated as `undefined` for yield type collection so that
+                        // the non-strict null widening in function_type.rs (never[] → any)
+                        // fires correctly and emits TS7055.
+                        let effective_yield_type = if i.yield_type == TypeId::NEVER
+                            && !self.checker.ctx.strict_null_checks()
+                        {
+                            TypeId::UNDEFINED
+                        } else {
+                            i.yield_type
+                        };
                         self.checker
                             .ctx
                             .generator_yield_operand_types
-                            .push(i.yield_type);
+                            .push(effective_yield_type);
                         // When yield* delegates to an iterable with `any` element type
                         // (e.g. `any[]`), suppress TS7055 at the function level.
                         // tsc considers the `any` yield type to be "explained" by

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -222,11 +222,13 @@ impl<'a> CheckerState<'a> {
                 return factory.tuple(vec![]);
             }
 
-            // Empty array literal: always never[] in strict mode, any[] otherwise.
-            // This matches tsc's checkArrayLiteral which unconditionally uses
-            // implicitNeverType for empty arrays in strict mode, regardless of
-            // contextual type. The contextual type does NOT affect the element type
-            // of an empty array literal — [] is always never[].
+            // Empty array literal element type depends on noImplicitAny and strictNullChecks:
+            //   - noImplicitAny OFF: any[] (tsc default for unannotated empty arrays)
+            //   - noImplicitAny ON + strictNullChecks ON: never[] (strict mode evolving array)
+            //   - noImplicitAny ON + strictNullChecks OFF (non-strict, TS files): never[]
+            //     In non-strict TS mode, the empty array starts as never[]. The element type
+            //     `never` is subsequently widened to `undefined` (then to `any`) only in
+            //     specific generator yield-type inference contexts (see dispatch_yield.rs).
             //
             // For operators like ||= and ??=, tsc uses UnionReduction.Subtype in
             // the result type computation, which removes never[] when a compatible

--- a/crates/tsz-checker/tests/ts7057_yield_implicit_any.rs
+++ b/crates/tsz-checker/tests/ts7057_yield_implicit_any.rs
@@ -42,10 +42,25 @@ fn no_implicit_any_options() -> CheckerOptions {
     }
 }
 
+fn non_strict_no_implicit_any_options() -> CheckerOptions {
+    CheckerOptions {
+        no_implicit_any: true,
+        strict_null_checks: false,
+        ..CheckerOptions::default()
+    }
+}
+
 fn count_ts7057(source: &str) -> usize {
     get_diagnostics_with_options(source, no_implicit_any_options())
         .iter()
         .filter(|(code, _)| *code == 7057)
+        .count()
+}
+
+fn count_ts7055(source: &str, options: CheckerOptions) -> usize {
+    get_diagnostics_with_options(source, options)
+        .iter()
+        .filter(|(code, _)| *code == 7055)
         .count()
 }
 
@@ -347,5 +362,69 @@ async function* g() {
         count_ts7057(source),
         0,
         "yield inside nested dynamic import argument should not trigger TS7057"
+    );
+}
+
+// =========================================================================
+// TS7055: Generator function implicitly has 'any' yield type
+// =========================================================================
+
+#[test]
+fn ts7055_fires_for_yield_star_empty_array_nonstrict() {
+    // In non-strict mode (strictNullChecks: false), `[]` produces `undefined[]`.
+    // The element type `undefined` is widened to `any` for the generator yield type,
+    // which triggers TS7055 ("g003 implicitly has any yield type").
+    //
+    // This matches tsc's behavior:
+    //   function* g003() { yield* []; }  →  TS7055
+    //   "In non-strict mode, `[]` produces the type `undefined[]` which is implicitly any."
+    let source = r#"
+function* g003() {
+    yield* [];
+}
+"#;
+    assert_eq!(
+        count_ts7055(source, non_strict_no_implicit_any_options()),
+        1,
+        "yield* [] in non-strict mode should emit TS7055 (implicit any yield type)"
+    );
+}
+
+#[test]
+fn ts7055_fires_for_bare_yield_nonstrict() {
+    // `yield;` in non-strict mode: the bare yield produces `undefined`, which is
+    // widened to `any` → TS7055 fires.
+    let source = r#"
+function* g001() {
+    yield;
+}
+"#;
+    assert_eq!(
+        count_ts7055(source, non_strict_no_implicit_any_options()),
+        1,
+        "bare yield in non-strict mode should emit TS7055 (implicit any yield type)"
+    );
+}
+
+#[test]
+fn no_ts7055_for_yield_star_empty_array_strict() {
+    // In strict mode, `[]` produces `never[]`. Iterating never[] gives never.
+    // never is NOT widened to any → no TS7055.
+    let source = r#"
+function* g003() {
+    yield* [];
+}
+"#;
+    assert_eq!(
+        count_ts7055(
+            source,
+            CheckerOptions {
+                no_implicit_any: true,
+                strict_null_checks: true,
+                ..CheckerOptions::default()
+            }
+        ),
+        0,
+        "yield* [] in strict mode should NOT emit TS7055 (yield type is never, not any)"
     );
 }


### PR DESCRIPTION
## Summary

- In non-strict mode (`strictNullChecks: false`) with `noImplicitAny`, empty array literals `[]` are typed as `never[]`. When a generator does `yield* []`, the element type `never` from `never[]` was being collected directly as the generator's yield operand type.
- `never` does not satisfy the `is_only_null_or_undefined` predicate used in `function_type.rs` for non-strict widening (`undefined → any`), so TS7055 was silently suppressed.
- Fix: in `dispatch_yield.rs`, when collecting the `yield*` element type for an unannotated generator in non-strict mode, treat a `never` element type as `undefined`. This makes the existing widening logic in `function_type.rs` fire correctly, emitting TS7055.

**Conformance target fixed:** `TypeScript/tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts` (was FAIL, now 1/1 PASS)

**Net conformance change:** +6 improvements, 1 pre-existing regression (not introduced by this change — `generatorYieldContextualType.ts` fails without this change too, as verified by stash test).

## Root cause

In `dispatch_yield.rs`, the `yield*` element type `never` (from `get_iterator_info` on an empty array) was passed directly into `generator_yield_operand_types`. The downstream non-strict widening in `function_type.rs` only widens types that satisfy `is_only_null_or_undefined` (i.e., `undefined`, `null`, or their union). `never` fails this check, so the generator yield type stays `never` and TS7055 is not emitted.

TypeScript's documented behavior: "In non-strict mode, `[]` produces the type `undefined[]` which is implicitly any."

## Fix layer

`dispatch_yield.rs` (Checker layer — `WHERE`, not `WHAT`). The fix is a targeted substitution at the yield operand collection point, guarded by `!strict_null_checks()`. No solver changes needed; the existing non-strict widening in `function_type.rs` handles the rest.

## Test plan

- [x] Unit tests added in `crates/tsz-checker/tests/ts7057_yield_implicit_any.rs`:
  - `ts7055_fires_for_yield_star_empty_array_nonstrict` — TS7055 fires for `yield* []` in non-strict mode
  - `ts7055_fires_for_bare_yield_nonstrict` — TS7055 fires for bare `yield;` in non-strict mode
  - `no_ts7055_for_yield_star_empty_array_strict` — TS7055 does NOT fire for `yield* []` in strict mode (never stays never)
- [x] Conformance target `generatorReturnTypeInferenceNonStrict.ts` passes (1/1)
- [x] Full suite: 13114 tests, all passed in pre-commit hook