### PR TITLE
fix(resolver,checker): apply typesVersions to relative directory imports

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -1521,38 +1521,20 @@ impl<'a> CheckerState<'a> {
     // Re-export Cycle Detection
     // =========================================================================
 
-    /// Check re-export chains for circular dependencies.
+    /// Walk the re-export chain rooted at `module_name`, guarding against
+    /// infinite recursion on circular chains.
+    ///
+    /// tsc does not emit a diagnostic for circular `export * from` chains —
+    /// it simply treats the cycle as contributing no transitive exports. This
+    /// walker exists purely to keep exported-symbol collection from spinning
+    /// forever on self/mutually-referential packages (e.g. a typesVersions
+    /// subfolder that re-exports from the package root and vice versa).
     pub(crate) fn check_reexport_chain_for_cycles(
         &mut self,
         module_name: &str,
         visited: &mut FxHashSet<String>,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
         if visited.contains(module_name) {
-            let cycle_path: Vec<&str> = visited
-                .iter()
-                .map(std::string::String::as_str)
-                .chain(std::iter::once(module_name))
-                .collect();
-            let cycle_str = cycle_path.join(" -> ");
-            let message = format!(
-                "{}: {}",
-                diagnostic_messages::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS,
-                cycle_str
-            );
-
-            // Check if we've already emitted TS2307 for this module (prevents duplicate emissions)
-            let module_key = module_name.to_string();
-            if !self.ctx.modules_with_ts2307_emitted.contains(&module_key) {
-                self.ctx.modules_with_ts2307_emitted.insert(module_key);
-                self.error(
-                    0,
-                    0,
-                    message,
-                    diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS,
-                );
-            }
             return;
         }
 

--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -456,6 +456,91 @@ export class TimestampedUser extends Timestamped(User) {
 }
 
 #[test]
+fn test_compile_self_referential_wildcard_reexport_does_not_emit_ts2307() {
+    // Regression: when a package's typesVersions redirect + relative
+    // `export * from "../"` re-export loops back to the same file, tsz used
+    // to emit bogus TS2307 ("Cannot find module") diagnostics from its
+    // re-export cycle detector. tsc handles the cycle silently — it just
+    // treats the chain as contributing no transitive exports.
+    //
+    // See `typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts`.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ext_dir = dir.path().join("node_modules").join("ext");
+    fs::create_dir_all(ext_dir.join("ts3.1")).expect("create ts3.1 dir");
+    fs::write(
+        ext_dir.join("package.json"),
+        r#"{
+    "name": "ext",
+    "version": "1.0.0",
+    "types": "index",
+    "typesVersions": {
+        ">=3.1.0-0": { "*" : ["ts3.1/*"] }
+    }
+}"#,
+    )
+    .expect("write package.json");
+    fs::write(
+        ext_dir.join("index.d.ts"),
+        "export interface A {}\nexport function fa(): A;\n",
+    )
+    .expect("write index.d.ts");
+    fs::write(
+        ext_dir.join("other.d.ts"),
+        "export interface B {}\nexport function fb(): B;\n",
+    )
+    .expect("write other.d.ts");
+    fs::write(
+        ext_dir.join("ts3.1").join("index.d.ts"),
+        "export * from \"../\";\n",
+    )
+    .expect("write ts3.1/index.d.ts");
+    fs::write(
+        ext_dir.join("ts3.1").join("other.d.ts"),
+        "export * from \"../other\";\n",
+    )
+    .expect("write ts3.1/other.d.ts");
+    fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "esnext",
+    "declaration": true
+  },
+  "files": ["main.ts"]
+}"#,
+    )
+    .expect("write tsconfig");
+    fs::write(
+        dir.path().join("main.ts"),
+        r#"import { fa } from "ext";
+import { fb } from "ext/other";
+
+export const va = fa();
+export const vb = fb();
+"#,
+    )
+    .expect("write main.ts");
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from(["tsz", "--project", project.as_str(), "--pretty", "false"])
+        .expect("project args");
+    let result = compile(&args, dir.path()).expect("compile succeeds");
+
+    let ts2307: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            diag.code == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS
+        })
+        .collect();
+    assert!(
+        ts2307.is_empty(),
+        "Did not expect TS2307 for a self-referential `export * from` cycle. Got: {ts2307:?}"
+    );
+}
+
+#[test]
 fn test_compile_project_default_reexport_duplicate_crash_matches_ts2307_count() {
     let dir = tempfile::tempdir().expect("temp dir");
     fs::write(

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -8,7 +8,28 @@ use super::ModuleResolver;
 use super::request_types::{ModuleExtension, PackageType};
 use crate::config::ModuleResolutionKind;
 use crate::module_resolver_helpers::*;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+/// Collapse `.` and `..` segments without touching the filesystem. Used to
+/// keep resolved paths stable with the project-level file graph (which keys
+/// files by their canonical textual form).
+fn normalize_path_segments(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push("..");
+                }
+            }
+            Component::RootDir | Component::Normal(_) | Component::Prefix(_) => {
+                out.push(component.as_os_str());
+            }
+        }
+    }
+    out
+}
 
 impl ModuleResolver {
     // =========================================================================
@@ -184,16 +205,38 @@ impl ModuleResolver {
         if !path.is_dir() {
             return None;
         }
+        // Collapse `.`/`..` segments up front. Without this, a relative
+        // directory import like `../` joined inside typesVersions subfolders
+        // produces resolved paths with embedded `..` (e.g. `ts3.1/../ts3.1/..`)
+        // which the project file graph fails to match against the canonical
+        // spelling, manifesting as spurious TS2307s on re-exports.
+        let normalized = normalize_path_segments(path);
+        let path = normalized.as_path();
 
         let package_json_path = path.join("package.json");
         if package_json_path.exists()
             && let Ok(pj) = self.read_package_json(&package_json_path)
         {
-            if let Some(types) = pj
+            let types = pj
                 .types
-                .or(pj.typings)
-                .filter(|types| !types.trim().is_empty())
-            {
+                .clone()
+                .or_else(|| pj.typings.clone())
+                .filter(|types| !types.trim().is_empty());
+
+            // Apply typesVersions before the bare types/typings path. tsc's
+            // loadNodeModuleFromDirectoryWorker consults typesVersions when
+            // resolving a directory via package.json, matching the types field
+            // value (defaulting to "index") as the subpath. Without this, a
+            // relative import like `../` into a package with typesVersions
+            // bypasses the redirect, producing a divergent resolution from tsc.
+            if let Some(types_versions) = &pj.types_versions {
+                let subpath = types.as_deref().unwrap_or("index");
+                if let Some(resolved) = self.resolve_types_versions(path, subpath, types_versions) {
+                    return Some(resolved);
+                }
+            }
+
+            if let Some(types) = types {
                 let types_path = path.join(&types);
                 if let Some(resolved) = self.try_types_entry(&types_path) {
                     return Some(resolved);

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -1713,6 +1713,79 @@ fn test_resolver_empty_types_field_uses_types_versions() {
 }
 
 #[test]
+fn test_resolver_relative_directory_applies_types_versions() {
+    // Regression: a relative import resolving into a package root (e.g. `../`
+    // from inside a typesVersions-redirected directory) must re-apply
+    // typesVersions from the package's package.json. Without this, tsz
+    // bypasses the redirect and resolves straight to the bare `types` entry,
+    // diverging from tsc. See the TypeScript conformance test
+    // `typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts`.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_test_resolver_relative_dir_types_versions");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules").join("ext").join("ts3.1")).unwrap();
+
+    fs::write(
+        dir.join("node_modules").join("ext").join("package.json"),
+        r#"{
+            "name": "ext",
+            "version": "1.0.0",
+            "types": "index",
+            "typesVersions": {
+                ">=3.1.0-0": { "*": ["ts3.1/*"] }
+            }
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules").join("ext").join("index.d.ts"),
+        "export interface A {}\nexport function fa(): A;",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules")
+            .join("ext")
+            .join("ts3.1")
+            .join("index.d.ts"),
+        r#"export * from "../";"#,
+    )
+    .unwrap();
+
+    let options = crate::config::ResolvedCompilerOptions {
+        module_resolution: Some(crate::config::ModuleResolutionKind::Node),
+        types_versions_compiler_version: Some("3.1.0-dev".to_string()),
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let containing = dir
+        .join("node_modules")
+        .join("ext")
+        .join("ts3.1")
+        .join("index.d.ts");
+    let result = resolver.resolve("../", &containing, Span::new(0, 4));
+
+    let resolved = result.expect("relative directory import should resolve");
+    // tsc applies typesVersions here, mapping `../` → ts3.1/index.d.ts (which
+    // loops back to the current file). The key invariant is that the bare
+    // `index.d.ts` is NOT selected when typesVersions matches.
+    let expected = dir
+        .join("node_modules")
+        .join("ext")
+        .join("ts3.1")
+        .join("index.d.ts")
+        .canonicalize()
+        .unwrap();
+    let actual = resolved.resolved_path.canonicalize().unwrap();
+    assert_eq!(
+        actual, expected,
+        "expected typesVersions to redirect `../` to ts3.1/index.d.ts, got {:?}",
+        resolved.resolved_path,
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn test_resolver_subpath_ambient_module_falls_back_to_types_entry() {
     use std::fs;
     let dir = std::env::temp_dir().join("tsz_test_resolver_subpath_ambient_module");


### PR DESCRIPTION
## Summary

Target: `typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts` (FAIL → PASS).

Two connected fixes land in the same PR because fix #1 exposed the latent
bug addressed in fix #2:

1. **Resolver (`tsz-core`)** — `try_directory` now consults `package.json`'s
   `typesVersions` field before falling back to the bare `types`/`typings`
   path. tsc's `loadNodeModuleFromDirectoryWorker` performs this redirect
   for **any** directory resolution, including relative imports like `../`
   that land inside a typesVersions-redirected subfolder. Without it, a
   re-export from `node_modules/ext/ts3.1/index.d.ts` back to the package
   root slid past the redirect to `index.d.ts`, producing a diagnostic
   shape that diverged from tsc. `try_directory` also normalizes `.`/`..`
   segments up-front so the resolved path matches the canonical spelling
   the project graph uses.

2. **Checker (`tsz-checker`)** — `check_reexport_chain_for_cycles` no
   longer raises TS2307 when walking `export * from` chains hits a cycle.
   tsc treats circular re-exports as contributing no transitive exports,
   not as "cannot find module" errors. The old behaviour produced
   spurious `main.ts(1,1): TS2307` on any self-referencing chain (e.g.
   the typesVersions subfolder re-exporting the package root, which fix
   #1 now correctly routes back to the originating file).

```ts
// node_modules/ext/package.json
// { "types": "index", "typesVersions": { ">=3.1.0-0": { "*": ["ts3.1/*"] } } }
// node_modules/ext/ts3.1/index.d.ts
export * from "../";            // self-reference via typesVersions (cycle, empty re-export)
// main.ts
import { fa } from "ext";       // TS2305: 'fa' is not exported (no TS2307 noise)
```

Net conformance delta on the full suite: **+6 tests** (7 FAIL→PASS,
1 PASS→FAIL — the single regression was already failing on `main`; the
local `conformance-detail.json` baseline was stale).

FAIL → PASS:
- `typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts`
- `interfaceMemberValidation.ts`
- `moduleAugmentationEnumClassMergeOfReexportIsError.ts`
- `typeRootsFromNodeModulesInParentDirectory.ts`
- `useBeforeDeclaration_classDecorators.2.ts`
- `generatorTypeCheck63.ts`
- `override19.ts`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p tsz-core --lib` (2930/2930)
- [x] `cargo nextest run -p tsz-checker --lib` (2679/2679)
- [x] `cargo nextest run -p tsz-solver --lib` (5278/5278)
- [x] `cargo nextest run -p tsz-binder --lib` (236/236)
- [x] `./scripts/conformance/conformance.sh run --filter typesVersionsDeclarationEmit.multiFileBackReferenceToSelf --verbose` — PASSES
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — net +6

New unit tests:
- `tsz-core::module_resolver::tests::test_resolver_relative_directory_applies_types_versions`
- `tsz-cli::driver::core::tests::test_compile_self_referential_wildcard_reexport_does_not_emit_ts2307`

https://claude.ai/code/session_01Tq2MhzsFnA5mHTdmwU3aRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tq2MhzsFnA5mHTdmwU3aRA)_