### PR TITLE
fix(checker): apply all discriminants for excess property narrowing

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -973,24 +973,39 @@ impl<'a> CheckerState<'a> {
         let direct_discriminants =
             self.object_literal_direct_unit_discriminants(obj_literal_idx, explicit_property_names);
 
+        // Apply all discriminants sequentially to progressively narrow the set of
+        // matching union members. This matches tsc's behavior for objects with
+        // multiple discriminant properties like `{ p1: 'left', p2: false }` against
+        // `{ p1: 'left'; p2: true; p3: number } | { p1: 'right'; p2: false; p4: string } | { p1: 'left'; p2: boolean }`:
+        // - `p1: 'left'` narrows to members [0, 2]
+        // - `p2: false` further narrows [0, 2] to [2] (member 0 has p2: true, not assignable)
+        // Result: only member 2 is applicable, and excess property check uses that
+        // narrowed set for the error message.
+        let mut active_indices: Vec<usize> = (0..union_shapes.len()).collect();
+        let mut did_narrow = false;
+
         for (prop_name, prop_type) in direct_discriminants {
             let source_prop = source_props.iter().find(|prop| prop.name == prop_name);
             let Some(source_prop) = source_prop else {
                 continue;
             };
 
-            let mut target_prop_types = Vec::with_capacity(union_shapes.len());
-            for shape in union_shapes {
+            // Collect target property types only for the currently-active members.
+            // If any active member lacks the property, skip this discriminant.
+            let mut target_prop_types = Vec::with_capacity(active_indices.len());
+            let mut all_active_have_prop = true;
+            for &active_i in &active_indices {
+                let shape = &union_shapes[active_i];
                 let Some(target_prop) =
                     shape.properties.iter().find(|p| p.name == source_prop.name)
                 else {
-                    target_prop_types.clear();
+                    all_active_have_prop = false;
                     break;
                 };
                 target_prop_types.push(target_prop.type_id);
             }
 
-            if target_prop_types.len() != union_shapes.len() {
+            if !all_active_have_prop {
                 continue;
             }
 
@@ -999,18 +1014,26 @@ impl<'a> CheckerState<'a> {
             // assignable to. E.g., for { a: null } | { a: string }, source `a: null`
             // narrows to the first member because null is assignable to null but not
             // to string (in strict mode).
-            let matching_indices: Vec<usize> = target_prop_types
+            let new_active: Vec<usize> = target_prop_types
                 .iter()
                 .enumerate()
-                .filter_map(|(i, &target_ty)| self.is_subtype_of(prop_type, target_ty).then_some(i))
+                .filter_map(|(local_i, &target_ty)| {
+                    self.is_subtype_of(prop_type, target_ty)
+                        .then_some(active_indices[local_i])
+                })
                 .collect();
 
-            if !matching_indices.is_empty() && matching_indices.len() < union_shapes.len() {
-                return Some(matching_indices);
+            if !new_active.is_empty() && new_active.len() < active_indices.len() {
+                active_indices = new_active;
+                did_narrow = true;
             }
         }
 
-        None
+        if did_narrow && active_indices.len() < union_shapes.len() {
+            Some(active_indices)
+        } else {
+            None
+        }
     }
 
     fn try_union_index_signature_value_check(

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -705,6 +705,66 @@ foo({x: 1});
     );
 }
 
+/// Tests for multi-discriminant narrowing in excess property checks.
+/// When an object literal has multiple discriminant properties, tsc applies
+/// ALL of them sequentially to narrow the union before checking excess properties.
+#[test]
+fn multi_discriminant_excess_property_check_applies_all_discriminants() {
+    // Repro from TypeScript#32657 / conformance test excessPropertyCheckWithMultipleDiscriminants
+    // Two discriminants: p1 narrows to [member0, member2], then p2 further narrows to [member2].
+    let source = r#"
+type DisjointDiscriminants = { p1: 'left'; p2: true; p3: number } | { p1: 'right'; p2: false; p4: string } | { p1: 'left'; p2: boolean };
+
+const a: DisjointDiscriminants = {
+    p1: 'left',
+    p2: false,
+    p3: 42,
+    p4: "hello"
+};
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert!(!ts2353.is_empty(), "Expected TS2353, got: {diags:?}");
+    // After multi-discriminant narrowing: p1='left' and p2=false narrows to
+    // { p1: 'left'; p2: boolean } only. p3 is the first excess property in that member.
+    let msg = &ts2353[0].1;
+    assert!(
+        msg.contains("'p3'"),
+        "Expected excess property 'p3' (narrowed by both p1+p2 discriminants), got: {msg}"
+    );
+    // The display type should reference only the narrowed member
+    assert!(
+        msg.contains("p2: boolean") || msg.contains("boolean"),
+        "Expected display type to reflect discriminant-narrowed member, got: {msg}"
+    );
+}
+
+#[test]
+fn multi_discriminant_first_discriminant_only_case() {
+    // When only one discriminant applies (p1='right' narrows to a single member),
+    // excess check uses that single member.
+    let source = r#"
+type DisjointDiscriminants = { p1: 'left'; p2: true; p3: number } | { p1: 'right'; p2: false; p4: string } | { p1: 'left'; p2: boolean };
+
+const c: DisjointDiscriminants = {
+    p1: 'right',
+    p2: false,
+    p3: 42,
+    p4: "hello"
+};
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert!(!ts2353.is_empty(), "Expected TS2353, got: {diags:?}");
+    // p1='right' narrows to { p1: 'right'; p2: false; p4: string } only.
+    // p3 is excess in that member.
+    let msg = &ts2353[0].1;
+    assert!(
+        msg.contains("'p3'"),
+        "Expected excess property 'p3' for the right-narrowed member, got: {msg}"
+    );
+}
+
 #[test]
 fn intersection_with_index_signatures_nested_excess_property() {
     // When target is an intersection of types with string index signatures,


### PR DESCRIPTION
## Root cause

tsc applies **all** unit-literal discriminant properties from an object literal simultaneously when deciding which union members are applicable for excess property checking. The previous `discriminant_matching_union_member_indices` returned as soon as the **first** discriminant narrowed the union, missing any further refinement from additional discriminants.

Example:
```ts
type DisjointDiscriminants =
  | { p1: 'left'; p2: true; p3: number }
  | { p1: 'right'; p2: false; p4: string }
  | { p1: 'left'; p2: boolean };

const a: DisjointDiscriminants = { p1: 'left', p2: false, p3: 42, p4: "hello" };
```

- `p1: 'left'` narrows to members 0 and 2.
- `p2: false` further narrows to member 2 only (`{ p1: 'left'; p2: boolean }`).
- `p3` is excess in that final member → tsc reports `'p3' does not exist in type '{ p1: "left"; p2: boolean; }'` at line 41.

**Before this fix:** tsz stopped at `p1: 'left'` → kept members 0 and 2 → first excess was `p4` → wrong property reported at wrong position with the wrong type display.

## Fix

`discriminant_matching_union_member_indices` now maintains an `active_indices` set and applies each discriminant against only the already-narrowed members, progressively tightening the set. The display type in the TS2353 message reflects the fully narrowed union.

## Test

Two new unit tests in `ts2353_tests.rs`:
- `multi_discriminant_excess_property_check_applies_all_discriminants` — the `p1`+`p2` double-discriminant case
- `multi_discriminant_first_discriminant_only_case` — single unambiguous discriminant still works

## Verification

- Target conformance test: `excessPropertyCheckWithMultipleDiscriminants` → PASS (was fingerprint-only)
- Full suite: 12101/12582 passed (96.2%), up from 12096 (net +5)
- All 13115 unit tests pass