### PR TITLE
fix(binder): merge flags from `declare global` blocks in external module lib files

### DIFF
--- a/crates/tsz-binder/Cargo.toml
+++ b/crates/tsz-binder/Cargo.toml
@@ -33,5 +33,9 @@ path = "tests/flow_tests.rs"
 name = "scopes_tests"
 path = "tests/scopes_tests.rs"
 
+[[test]]
+name = "lib_merge_external_module_tests"
+path = "tests/lib_merge_external_module_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -62,7 +62,7 @@ impl BinderState {
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
-                        .push(crate::state::GlobalAugmentation::new(idx));
+                        .push(crate::state::GlobalAugmentation::new(idx, flags));
                 }
 
                 let sym_id = self.declare_symbol(arena, name, flags, idx, is_exported);
@@ -87,7 +87,7 @@ impl BinderState {
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
-                        .push(crate::state::GlobalAugmentation::new(idx));
+                        .push(crate::state::GlobalAugmentation::new(idx, flags));
                 }
             } else {
                 let flags = if is_block_scoped {
@@ -117,7 +117,7 @@ impl BinderState {
                             Arc::make_mut(&mut self.global_augmentations)
                                 .entry(name.to_string())
                                 .or_default()
-                                .push(crate::state::GlobalAugmentation::new(ident_idx));
+                                .push(crate::state::GlobalAugmentation::new(ident_idx, flags));
                         }
                     }
                 }
@@ -834,7 +834,10 @@ impl BinderState {
                 Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
-                    .push(crate::state::GlobalAugmentation::new(idx));
+                    .push(crate::state::GlobalAugmentation::new(
+                        idx,
+                        symbol_flags::INTERFACE,
+                    ));
             }
 
             // In script files (non-module files), top-level interface declarations that match
@@ -848,7 +851,10 @@ impl BinderState {
                 Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
-                    .push(crate::state::GlobalAugmentation::new(idx));
+                    .push(crate::state::GlobalAugmentation::new(
+                        idx,
+                        symbol_flags::INTERFACE,
+                    ));
             }
 
             // Rule #44: Track module augmentation interfaces
@@ -943,7 +949,10 @@ impl BinderState {
                 Arc::make_mut(&mut self.global_augmentations)
                     .entry(name.to_string())
                     .or_default()
-                    .push(crate::state::GlobalAugmentation::new(idx));
+                    .push(crate::state::GlobalAugmentation::new(
+                        idx,
+                        symbol_flags::TYPE_ALIAS,
+                    ));
             }
 
             // Rule #44: Track module augmentation type aliases

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -218,10 +218,11 @@ impl BinderState {
                     .insert(idx.0, is_exported);
 
                 if self.in_global_augmentation {
+                    let aug_flags = symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE;
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.clone())
                         .or_default()
-                        .push(crate::state::GlobalAugmentation::new(idx));
+                        .push(crate::state::GlobalAugmentation::new(idx, aug_flags));
                 }
 
                 let flags = symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE;

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -237,7 +237,10 @@ impl BinderState {
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
-                        .push(crate::state::GlobalAugmentation::new(idx));
+                        .push(crate::state::GlobalAugmentation::new(
+                            idx,
+                            symbol_flags::ALIAS,
+                        ));
                 }
             }
         }

--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -143,6 +143,13 @@ impl BinderState {
             // `export {}`), build a set of declaration NodeIndices from
             // `declare global { ... }` blocks. Module-scoped declarations
             // must NOT be merged into existing global symbols.
+            // Also build a per-name map of flags contributed by `declare global`
+            // declarations, so we can selectively merge those flags without
+            // contaminating globals with module-scoped flags (e.g. the module-
+            // scoped `class Iterator` must not add CLASS to the global
+            // `interface Iterator` from es2015.iterable.d.ts, but the
+            // `var Iterator: IteratorConstructor` from `declare global` must
+            // add FUNCTION_SCOPED_VARIABLE so Iterator is usable as a value).
             let global_aug_nodes: Option<rustc_hash::FxHashSet<tsz_parser::NodeIndex>> =
                 if lib_ctx.binder.is_external_module {
                     let mut nodes = rustc_hash::FxHashSet::default();
@@ -152,6 +159,22 @@ impl BinderState {
                         }
                     }
                     Some(nodes)
+                } else {
+                    None
+                };
+            // Per-name flags from `declare global` entries.
+            let global_aug_flags: Option<rustc_hash::FxHashMap<&str, u32>> =
+                if lib_ctx.binder.is_external_module {
+                    let mut flags_map: rustc_hash::FxHashMap<&str, u32> =
+                        rustc_hash::FxHashMap::default();
+                    for (name, augs) in lib_ctx.binder.global_augmentations.iter() {
+                        let mut combined = 0u32;
+                        for aug in augs {
+                            combined |= aug.flags;
+                        }
+                        flags_map.insert(name.as_str(), combined);
+                    }
+                    Some(flags_map)
                 } else {
                     None
                 };
@@ -191,7 +214,18 @@ impl BinderState {
                                             arenas.push(Arc::clone(&lib_ctx.arena));
                                         }
                                     }
-                                    // Do NOT merge flags from external module symbols.
+                                    // Merge only the flags that originate from `declare global`
+                                    // declarations, not module-scoped ones. For example,
+                                    // `declare global { var Iterator: IteratorConstructor }`
+                                    // should add FUNCTION_SCOPED_VARIABLE to the global Iterator
+                                    // symbol, but the module-scoped `class Iterator` should not
+                                    // add CLASS.
+                                    if let Some(ref gaf) = global_aug_flags
+                                        && let Some(&gflags) =
+                                            gaf.get(lib_sym.escaped_name.as_str())
+                                    {
+                                        existing_mut.flags |= gflags;
+                                    }
                                 } else {
                                     existing_mut.flags |= lib_sym.flags;
                                     for &decl in &lib_sym.declarations {
@@ -206,14 +240,35 @@ impl BinderState {
                                         }
                                     }
                                 }
-                                // Update value_declaration if not set
-                                if existing_mut.value_declaration.is_none()
-                                    && lib_sym.value_declaration.is_some()
-                                {
-                                    existing_mut.set_value_declaration(
-                                        lib_sym.value_declaration,
-                                        lib_sym.value_declaration_span,
-                                    );
+                                // Update value_declaration if not set.
+                                // For external module libs, only use a value_declaration
+                                // that originates from `declare global`, not a module-
+                                // scoped class/function that happens to share the name.
+                                if existing_mut.value_declaration.is_none() {
+                                    if let Some(ref aug_nodes) = global_aug_nodes {
+                                        if let Some(augs) = lib_ctx
+                                            .binder
+                                            .global_augmentations
+                                            .get(&lib_sym.escaped_name)
+                                        {
+                                            for aug in augs {
+                                                if (aug.flags & symbol_flags::VALUE) != 0
+                                                    && aug_nodes.contains(&aug.node)
+                                                {
+                                                    existing_mut.set_value_declaration(
+                                                        aug.node,
+                                                        lib_sym.first_declaration_span,
+                                                    );
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    } else if lib_sym.value_declaration.is_some() {
+                                        existing_mut.set_value_declaration(
+                                            lib_sym.value_declaration,
+                                            lib_sym.value_declaration_span,
+                                        );
+                                    }
                                 }
                             }
                             existing_id

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -159,21 +159,30 @@ pub struct GlobalAugmentation {
     pub node: NodeIndex,
     /// The arena containing this declaration (None = current file's arena, Some = cross-file)
     pub arena: Option<Arc<NodeArena>>,
+    /// Symbol flags this augmentation contributes (e.g., INTERFACE for interface declarations,
+    /// `FUNCTION_SCOPED_VARIABLE` for `var` declarations). Used during lib merging to selectively
+    /// merge only flags from `declare global` blocks in external module lib files.
+    pub flags: u32,
 }
 
 impl GlobalAugmentation {
     /// Create a new global augmentation without arena context (during binding).
     #[must_use]
-    pub const fn new(node: NodeIndex) -> Self {
-        Self { node, arena: None }
+    pub const fn new(node: NodeIndex, flags: u32) -> Self {
+        Self {
+            node,
+            arena: None,
+            flags,
+        }
     }
 
     /// Create a new global augmentation with arena context (during merge).
     #[must_use]
-    pub const fn with_arena(node: NodeIndex, arena: Arc<NodeArena>) -> Self {
+    pub const fn with_arena(node: NodeIndex, arena: Arc<NodeArena>, flags: u32) -> Self {
         Self {
             node,
             arena: Some(arena),
+            flags,
         }
     }
 }

--- a/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
+++ b/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
@@ -1,0 +1,173 @@
+//! Tests for lib symbol merging of external module lib files.
+//!
+//! Verifies that `declare global` blocks in external module lib files
+//! (those with `export {}`) correctly merge flags and value declarations
+//! into the global symbol table, while module-scoped symbols are excluded.
+
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_binder::state::LibContext;
+use tsz_binder::symbol_flags;
+use tsz_parser::parser::ParserState;
+
+fn bind_source(source: &str) -> (Arc<tsz_parser::parser::node::NodeArena>, BinderState) {
+    let mut parser = ParserState::new("test.d.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = Arc::new(parser.get_arena().clone());
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&arena, root);
+    (arena, binder)
+}
+
+fn make_lib_context(
+    arena: &Arc<tsz_parser::parser::node::NodeArena>,
+    binder: &BinderState,
+) -> LibContext {
+    LibContext {
+        arena: Arc::clone(arena),
+        binder: Arc::new(binder.clone()),
+    }
+}
+
+#[test]
+fn declare_global_var_merges_value_flag_into_existing_interface() {
+    // Simulate es2015.iterable.d.ts: defines Iterator as an interface
+    let (base_arena, base_binder) = bind_source(
+        "interface Iterator<T, TReturn = any, TNext = any> {
+            next(...args: [] | [TNext]): { done: boolean; value: T };
+        }",
+    );
+
+    // Simulate esnext.iterator.d.ts: external module with declare global
+    let (ext_arena, ext_binder) = bind_source(
+        "export {};
+        declare abstract class Iterator<T, TResult = undefined, TNext = unknown> {
+            abstract next(value?: TNext): { done: boolean; value: T };
+        }
+        interface Iterator<T, TResult, TNext> {}
+        type IteratorObjectConstructor = typeof Iterator;
+        declare global {
+            interface IteratorConstructor extends IteratorObjectConstructor {}
+            var Iterator: IteratorConstructor;
+        }",
+    );
+
+    // Verify the external module binder has the expected state
+    assert!(ext_binder.is_external_module);
+    assert!(
+        ext_binder.global_augmentations.contains_key("Iterator"),
+        "Iterator should be in global_augmentations"
+    );
+
+    // Create the main binder and merge lib contexts
+    let mut main_binder = BinderState::new();
+    let base_ctx = make_lib_context(&base_arena, &base_binder);
+    let ext_ctx = make_lib_context(&ext_arena, &ext_binder);
+    main_binder.merge_lib_contexts_into_binder(&[base_ctx, ext_ctx]);
+
+    // The merged Iterator symbol should have both INTERFACE and VALUE flags
+    let iter_sym_id = main_binder
+        .file_locals
+        .get("Iterator")
+        .expect("Iterator should be in file_locals");
+    let iter_sym = main_binder
+        .symbols
+        .get(iter_sym_id)
+        .expect("Iterator symbol should exist");
+
+    assert!(
+        iter_sym.has_any_flags(symbol_flags::INTERFACE),
+        "Iterator should have INTERFACE flag (from base lib)"
+    );
+    assert!(
+        iter_sym.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE),
+        "Iterator should have FUNCTION_SCOPED_VARIABLE flag (from declare global var)"
+    );
+    // The CLASS flag from the module-scoped abstract class should NOT be merged
+    assert!(
+        !iter_sym.has_any_flags(symbol_flags::CLASS),
+        "Iterator should NOT have CLASS flag (module-scoped, not from declare global)"
+    );
+}
+
+#[test]
+fn declare_global_interface_merges_into_existing_interface() {
+    // Simulate a base lib with a minimal IteratorObject interface
+    let (base_arena, base_binder) = bind_source(
+        "interface IteratorObject<T, TReturn = unknown, TNext = unknown> {
+            [Symbol.iterator](): IteratorObject<T, TReturn, TNext>;
+        }",
+    );
+
+    // External module with declare global adding methods to IteratorObject
+    let (ext_arena, ext_binder) = bind_source(
+        "export {};
+        declare global {
+            interface IteratorObject<T, TReturn, TNext> {
+                map<U>(fn: (value: T) => U): IteratorObject<U, undefined, unknown>;
+                filter(fn: (value: T) => boolean): IteratorObject<T, undefined, unknown>;
+            }
+        }",
+    );
+
+    assert!(ext_binder.is_external_module);
+    assert!(
+        ext_binder
+            .global_augmentations
+            .contains_key("IteratorObject")
+    );
+
+    let mut main_binder = BinderState::new();
+    let base_ctx = make_lib_context(&base_arena, &base_binder);
+    let ext_ctx = make_lib_context(&ext_arena, &ext_binder);
+    main_binder.merge_lib_contexts_into_binder(&[base_ctx, ext_ctx]);
+
+    let sym_id = main_binder
+        .file_locals
+        .get("IteratorObject")
+        .expect("IteratorObject should be in file_locals");
+    let sym = main_binder
+        .symbols
+        .get(sym_id)
+        .expect("IteratorObject symbol should exist");
+
+    assert!(
+        sym.has_any_flags(symbol_flags::INTERFACE),
+        "IteratorObject should have INTERFACE flag"
+    );
+    // Should have declarations from both lib files
+    assert!(
+        sym.declarations.len() >= 2,
+        "IteratorObject should have declarations from both libs, got {}",
+        sym.declarations.len()
+    );
+}
+
+#[test]
+fn module_scoped_symbols_excluded_from_file_locals() {
+    // External module lib with module-scoped type alias
+    let (ext_arena, ext_binder) = bind_source(
+        "export {};
+        type ModuleScopedType = string;
+        declare global {
+            interface GlobalInterface {}
+        }",
+    );
+
+    assert!(ext_binder.is_external_module);
+
+    let mut main_binder = BinderState::new();
+    let ext_ctx = make_lib_context(&ext_arena, &ext_binder);
+    main_binder.merge_lib_contexts_into_binder(&[ext_ctx]);
+
+    // GlobalInterface should be visible
+    assert!(
+        main_binder.file_locals.has("GlobalInterface"),
+        "GlobalInterface from declare global should be in file_locals"
+    );
+    // ModuleScopedType should NOT be visible
+    assert!(
+        !main_binder.file_locals.has("ModuleScopedType"),
+        "Module-scoped type should NOT be in file_locals"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1498,6 +1498,7 @@ impl MergedAugmentations {
                         tsz::binder::GlobalAugmentation::with_arena(
                             aug.node,
                             Arc::clone(&file.arena),
+                            aug.flags,
                         )
                     }));
             }

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -4654,6 +4654,7 @@ impl SharedBinderData {
                         crate::binder::GlobalAugmentation::with_arena(
                             aug.node,
                             Arc::clone(&file.arena),
+                            aug.flags,
                         )
                     }));
             }


### PR DESCRIPTION
## Summary

- Fix lib merge to selectively merge symbol flags from `declare global` blocks in external module lib files (e.g., `esnext.iterator.d.ts`)
- Add `flags` field to `GlobalAugmentation` to track what each augmentation entry contributes
- Fix `value_declaration` propagation for external module libs to prefer global augmentation nodes over module-scoped class nodes
- Net conformance: **+5 tests** (12096 → 12101)

## Root cause

External module lib files like `esnext.iterator.d.ts` use `export {}` (making them modules) plus `declare global { ... }` to expose symbols globally. The lib merge correctly filtered declarations to only include those from `declare global` blocks, but blanket-skipped **all** flag merging for external modules. This prevented `var Iterator: IteratorConstructor` inside `declare global` from adding the `FUNCTION_SCOPED_VARIABLE` flag to the global `Iterator` symbol.

Without the value flag, `Iterator` was treated as type-only, causing:
- **TS2585**: `'Iterator' only refers to a type` (false positive)
- **TS2689**: `Cannot extend an interface 'Iterator'` (false positive)

```ts
// @target: esnext
// Before fix: TS2585 + TS2689
// After fix: correct behavior (Iterator recognized as value + class)
const iter = Iterator.from([1, 2, 3]);
class MyIter extends Iterator<number> {
  next() { return { done: false, value: 0 } as const; }
}
```

## Test plan

- [x] 3 new unit tests in `tsz-binder` covering flag merging, interface merging, and module-scoped exclusion
- [x] All 362 binder tests pass
- [x] All 2679 checker tests pass
- [x] All 5278 solver tests pass
- [x] Clippy clean (zero warnings)
- [x] wasm32 check passes
- [x] Architecture guardrails pass
- [x] Full conformance: 12101/12582 (96.2%), net +5

https://claude.ai/code/session_01YEsdbtAbs3Q4XcLC16yZVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEsdbtAbs3Q4XcLC16yZVs)_