### PR TITLE
fix(checker): narrowing past last assignment for let variables and TS7005 suppression

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -72,17 +72,75 @@ impl<'a> FlowAnalyzer<'a> {
         };
 
         // Parameters and destructured parameter bindings are eligible for
-        // "implicit const" treatment. `let`/`var` variables are excluded
-        // because they have edge cases (e.g., `let arguments = 100` shadowing
-        // built-in `arguments` with misresolved declared type). tsc also applies
-        // this to local `let` variables via `isPastLastAssignment()`, but that
-        // requires more careful handling of all assignment sites.
+        // "implicit const" treatment.
+        //
+        // tsc also applies this to local `let` variables via `isPastLastAssignment()`:
+        // if the variable is block-scoped (let), not exported, not a `var`, and none
+        // of its assignments happen inside a nested closure relative to the declaration
+        // scope, then the variable is "effectively const" at any closure created after
+        // the last assignment.
+        //
+        // `var` declarations, exported variables, and global-scope variables are
+        // excluded because they have broader visibility and hoisting semantics.
         //
         // For destructured parameters like `function f({ a })`: the symbol's
         // value_declaration points to the identifier `a`, whose parent chain is:
         //   Identifier → BINDING_ELEMENT → OBJECT_BINDING_PATTERN → PARAMETER
+
+        // Check if this is a `let` variable eligible for "narrowing past last assignment"
+        let is_let_var = if let Some(symbol) = self.binder.get_symbol(symbol_id) {
+            use tsz_binder::{ContainerKind, symbol_flags};
+            // BLOCK_SCOPED_VARIABLE covers both `let` and `const`. Since we already
+            // handled `const` above, this branch only fires for `let`.
+            let is_block_scoped_let = (symbol.flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                && (symbol.flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) == 0
+                && !symbol.is_exported;
+            if !is_block_scoped_let {
+                false
+            } else {
+                // Only apply "narrowing past last assignment" for variables declared
+                // inside a function body. Walk up the scope chain from the declaration
+                // until we hit a function boundary (eligible) or source-file/module
+                // boundary (not eligible). Block scopes that are nested inside a
+                // function are fine; block scopes at module level are not.
+                // This matches tsc's `isParameterOrMutableLocalVariable` behavior.
+                let decl_scope_id = self.binder.find_enclosing_scope(self.arena, decl_id);
+                let mut is_in_function_scope = false;
+                if let Some(mut scope_id) = decl_scope_id {
+                    for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
+                        let Some(scope) = self.binder.scopes.get(scope_id.0 as usize) else {
+                            break;
+                        };
+                        match scope.kind {
+                            ContainerKind::Function => {
+                                is_in_function_scope = true;
+                                break;
+                            }
+                            ContainerKind::SourceFile | ContainerKind::Module => {
+                                // Hit module/global boundary — not a local variable
+                                break;
+                            }
+                            ContainerKind::Block | ContainerKind::Class => {
+                                // Keep walking up
+                            }
+                        }
+                        let parent = scope.parent;
+                        if parent.is_none() {
+                            break;
+                        }
+                        scope_id = parent;
+                    }
+                }
+                is_in_function_scope
+            }
+        } else {
+            false
+        };
+
         let eligible = decl_node.kind == syntax_kind_ext::PARAMETER
-            || self.is_declaration_in_parameter(decl_id);
+            || self.is_declaration_in_parameter(decl_id)
+            || (is_let_var
+                && !self.has_assignment_in_nested_closure(symbol_id, decl_id, reference));
 
         if !eligible {
             return false;
@@ -199,6 +257,92 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         last_pos
+    }
+
+    /// Check whether any reassignment to the given symbol happens inside a nested
+    /// closure relative to `reference`.
+    ///
+    /// "Nested closure" means a function body that is lexically inside the function
+    /// that contains `reference`. If an assignment is in an inner arrow/function/class
+    /// method, the outer let binding could be mutated at an unpredictable time, so
+    /// closure narrowing is NOT safe to preserve.
+    ///
+    /// This implements the tsc `isPastLastAssignment` condition:
+    ///   "no assignment to x is in a nested function relative to the containing scope
+    ///    of the reference".
+    fn has_assignment_in_nested_closure(
+        &self,
+        _symbol_id: tsz_binder::SymbolId,
+        decl_id: NodeIndex,
+        reference: NodeIndex,
+    ) -> bool {
+        use tsz_binder::flow_flags;
+
+        // Find the function node that encloses the declaration (and therefore the
+        // reference, since declarations scope outward from references).
+        let decl_fn = self.find_enclosing_function_node(decl_id);
+
+        let flow_count = self.binder.flow_nodes.len();
+        for i in 0..flow_count {
+            let flow_id = tsz_binder::FlowNodeId(i as u32);
+            let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
+                continue;
+            };
+
+            if !flow.has_any_flags(flow_flags::ASSIGNMENT) {
+                continue;
+            }
+
+            // Skip initializations — only count reassignments
+            let Some(node) = self.arena.get(flow.node) else {
+                continue;
+            };
+            let kind = node.kind;
+            if kind == syntax_kind_ext::VARIABLE_DECLARATION
+                || kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST
+                || kind == syntax_kind_ext::PARAMETER
+            {
+                continue;
+            }
+
+            if self.assignment_targets_reference(flow.node, reference) {
+                let assign_fn = self.find_enclosing_function_node(flow.node);
+                // If the assignment's enclosing function is *different* from the
+                // declaration's enclosing function, the assignment is in a nested
+                // (or outer) function — closure narrowing is not safe.
+                if assign_fn != decl_fn {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Walk the parent chain from `node_idx` to find the nearest enclosing
+    /// function-like node (FUNCTION_DECLARATION, FUNCTION_EXPRESSION, ARROW_FUNCTION,
+    /// METHOD_DECLARATION, GET_ACCESSOR, SET_ACCESSOR, or CONSTRUCTOR).
+    ///
+    /// Returns `NodeIndex::NONE` if the node is at module/global scope.
+    fn find_enclosing_function_node(&self, node_idx: NodeIndex) -> NodeIndex {
+        let mut current = node_idx;
+        for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
+            let Some(ext) = self.arena.get_extended(current) else {
+                return NodeIndex::NONE;
+            };
+            let parent = ext.parent;
+            if parent.is_none() {
+                return NodeIndex::NONE;
+            }
+            let Some(parent_node) = self.arena.get(parent) else {
+                return NodeIndex::NONE;
+            };
+            if parent_node.is_function_like() {
+                return parent;
+            }
+            current = parent;
+        }
+        NodeIndex::NONE
     }
 
     /// Check if a variable is captured from an outer scope (vs declared locally).

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -298,7 +298,13 @@ impl<'a> CheckerState<'a> {
                     .and_then(|sym| sym.declarations.first().copied());
                 if let Some(decl_node) = decl_node {
                     let decl_fn = self.find_enclosing_function(decl_node);
-                    if ref_fn != decl_fn {
+                    // TS7005 should only fire when the closure is in a position where
+                    // the type is still ambiguous (i.e., the capture occurs before the
+                    // last assignment). Use the same guard as the first emission so
+                    // closures created after the last assignment don't get TS7005.
+                    if ref_fn != decl_fn
+                        && self.should_emit_pending_implicit_any_capture_diagnostic(idx, sym_id)
+                    {
                         emit_ts7005 = true;
                     }
                 }

--- a/crates/tsz-checker/tests/control_flow_tests.rs
+++ b/crates/tsz-checker/tests/control_flow_tests.rs
@@ -4471,5 +4471,222 @@ function test(someDerived: Derived1 | Derived2) {
 }
 
 // ============================================================================
+// NARROWING PAST LAST ASSIGNMENT TESTS
+// ============================================================================
+
+/// Test: `let` variable narrowed past its last assignment is treated as
+/// effectively const for closure purposes (tsc's "narrowing past last assignment").
+///
+/// When a `let` variable has its last assignment BEFORE a closure is created,
+/// and no assignments happen inside nested closures, the closure should see the
+/// narrowed type — not the full declared union.
+///
+/// This corresponds to tsc's `isPastLastAssignment()` + `isEffectivelyConst()` logic.
+///
+/// Regression: tsz was emitting TS18048 ("'i' is possibly 'undefined'") on `i + 1`
+/// because `let i: number | undefined; i = 0;` left the type as `number | undefined`
+/// inside the returned arrow, even though i's last assignment (to 0) predates the
+/// arrow function expression.
+#[test]
+fn test_let_narrowing_past_last_assignment_in_closure() {
+    use tsz_common::checker_options::CheckerOptions;
+
+    // Analogous to tsc's f10() in narrowingPastLastAssignment.ts:
+    //   function f10() {
+    //       let i: number | undefined;
+    //       i = 0;
+    //       return (k: number) => k === i + 1;
+    //   }
+    // Expected: no TS18048 on `i + 1` — i is effectively 0 (number) at the closure.
+    let source = r#"
+function f10() {
+    let i: number | undefined;
+    i = 0;
+    return (k: number) => k === i + 1;
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let interner = TypeInterner::new();
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let mut state = CheckerState::new(arena, &binder, &interner, "test.ts".to_string(), options);
+    state.check_source_file(root);
+
+    // TS18048 should NOT be emitted — `i` is narrowed to `number` past last assignment
+    let ts18048_errors: Vec<_> = state
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 18048)
+        .collect();
+    assert!(
+        ts18048_errors.is_empty(),
+        "Expected no TS18048 errors for 'let i narrowed past last assignment' but got {}: {:?}",
+        ts18048_errors.len(),
+        ts18048_errors
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Test: `let` with null-check narrowing before a closure.
+///
+/// When `let foo = possiblyNull(); if (foo == null) { foo = []; }` assigns a
+/// non-null value inside a guard, then the subsequent closure sees `foo` as
+/// the narrowed non-null type.
+///
+/// Regression: tsz emitted TS18048 ("'foo' is possibly 'undefined'") on
+/// `foo.push(v)` inside the forEach callback because the closure saw the
+/// declared type `Array<number> | undefined` rather than the narrowed `Array<number>`.
+#[test]
+fn test_let_narrowing_past_last_assignment_with_null_guard() {
+    use tsz_common::checker_options::CheckerOptions;
+
+    // Analogous to f12() in narrowingPastLastAssignment.ts:
+    //   function f12() {
+    //       const fooMap: Map<string, Array<number>> = new Map();
+    //       const values = [1, 2, 3, 4, 5];
+    //       let foo = fooMap.get("a");
+    //       if (foo == null) { foo = []; }
+    //       values.forEach(v => foo.push(v));
+    //   }
+    // Expected: no TS18048 on `foo.push(v)`
+    let source = r#"
+function f12() {
+    let foo: Array<number> | undefined = undefined;
+    if (foo == null) {
+        foo = [];
+    }
+    const values = [1, 2, 3];
+    values.forEach((v: number) => foo.push(v));
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let interner = TypeInterner::new();
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let mut state = CheckerState::new(arena, &binder, &interner, "test.ts".to_string(), options);
+    state.check_source_file(root);
+
+    // TS18048 should NOT be emitted — `foo` is narrowed to Array<number> at the closure
+    let ts18048_errors: Vec<_> = state
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 18048)
+        .collect();
+    assert!(
+        ts18048_errors.is_empty(),
+        "Expected no TS18048 for 'let foo narrowed past last assignment' but got {}: {:?}",
+        ts18048_errors.len(),
+        ts18048_errors
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Test: implicit-any `let` variable with two closures — only the FIRST closure
+/// (before the last assignment) should get TS7005; the SECOND (after the last
+/// assignment) should not, because the type is now known to be `number`.
+///
+/// Regression: tsz was emitting TS7005 for BOTH closures because the
+/// `reported_implicit_any_vars` path didn't re-check whether the capture
+/// point is past the last assignment.
+#[test]
+fn test_implicit_any_let_second_closure_no_ts7005() {
+    use tsz_common::checker_options::CheckerOptions;
+
+    // Analogous to f6() in narrowingPastLastAssignment.ts:
+    //   function f6() {
+    //       let x;              // TS7034 here
+    //       x = "abc";
+    //       action(() => { x }); // TS7005 here (before x=42)
+    //       x = 42;
+    //       action(() => { x /* number */ }); // NO TS7005 here
+    //   }
+    let source = r#"
+function action(f: Function) {}
+function f6() {
+    let x;
+    x = "abc";
+    action(() => { x });
+    x = 42;
+    action(() => { x });
+}
+"#;
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let arena = parser.get_arena();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(arena, root);
+
+    let interner = TypeInterner::new();
+    let options = CheckerOptions {
+        no_implicit_any: true,
+        ..CheckerOptions::default()
+    };
+    let mut state = CheckerState::new(arena, &binder, &interner, "test.ts".to_string(), options);
+    state.check_source_file(root);
+
+    // TS7034 should fire at the declaration (let x)
+    let ts7034_errors: Vec<_> = state
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 7034)
+        .collect();
+    assert_eq!(
+        ts7034_errors.len(),
+        1,
+        "Expected exactly 1 TS7034 error but got {}: {:?}",
+        ts7034_errors.len(),
+        ts7034_errors
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+
+    // TS7005 should fire at exactly 1 closure usage (the first one, before x=42)
+    let ts7005_errors: Vec<_> = state
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 7005)
+        .collect();
+    assert_eq!(
+        ts7005_errors.len(),
+        1,
+        "Expected exactly 1 TS7005 error (only the first closure) but got {}: {:?}",
+        ts7005_errors.len(),
+        ts7005_errors
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ============================================================================
 // FAILING TESTS - These tests FAIL to demonstrate the bugs exist
 // ============================================================================


### PR DESCRIPTION
## Root Cause

tsc implements "narrowing past last assignment": when a `let` variable's last assignment happens before a closure is created, and no assignments occur inside nested closures, the closure sees the narrowed type rather than resetting to the declared union type. tsz was not implementing this for `let` variables.

Three extra fingerprints were removed from `narrowingPastLastAssignment.ts`:

1. **TS18048 on `i + 1`** in `f10()`: `let i: number | undefined; i = 0; return (k) => k === i + 1` — `i` is narrowed to `number` past its last assignment.
2. **TS18048 on `foo.push(v)`** in `f12()`: `let foo = ...; if (foo == null) { foo = []; } values.forEach(v => foo.push(v))` — `foo` is narrowed to `Array<number>` past the last assignment.
3. **TS7005 on second closure** in `f6()`: `let x; x = "abc"; action(() => { x }); x = 42; action(() => { x })` — second closure is after the last assignment, type is `number`.

## Changes

### `crates/tsz-checker/src/flow/control_flow/type_guards.rs`

- **`is_effectively_const_for_narrowing`**: Extended eligibility from parameters-only to also cover `let` variables that are block-scoped, not exported, declared inside a function body (scope-walk excludes module/global scope via `ContainerKind`), and have no assignments in nested closures.
- **`has_assignment_in_nested_closure`** (new): Walks all ASSIGNMENT flow nodes; returns true if any matching assignment's enclosing function differs from the declaration's enclosing function.
- **`find_enclosing_function_node`** (new): Parent-chain walk to find the nearest function-like AST node.

### `crates/tsz-checker/src/types/computation/identifier/core.rs`

- **TS7005 suppression**: The `reported_implicit_any_vars` path now calls `should_emit_pending_implicit_any_capture_diagnostic` before emitting TS7005, matching the first-emission guard. Closures created after the last assignment no longer get a false-positive TS7005.

### `crates/tsz-checker/tests/control_flow_tests.rs`

Three new unit tests:
- `test_let_narrowing_past_last_assignment_in_closure` — verifies no TS18048 for `let i; i=0; return k => k === i+1`
- `test_let_narrowing_past_last_assignment_with_null_guard` — verifies no TS18048 for null-guard narrowed `let foo`
- `test_implicit_any_let_second_closure_no_ts7005` — verifies exactly 1 TS7034 + 1 TS7005 (not 2)

```ts
// Before fix: false TS18048 on i+1
function f10() {
    let i: number | undefined;
    i = 0;
    return (k: number) => k === i + 1;  // i is number here
}

// Before fix: false TS7005 on second closure
function f6() {
    let x;              // TS7034 (correct)
    x = "abc";
    action(() => { x }); // TS7005 (correct — ambiguous)
    x = 42;
    action(() => { x }); // was TS7005, should be clean (x is number)
}
```

## Test Results

- `narrowingPastLastAssignment.ts` conformance: **2/2 PASS** (was failing)
- 200-test regression: **200/200 PASS**
- Full checker unit suite: **2682/2682 PASS** (previously 8 failures in control_flow_tests, all fixed)
- Pre-commit: **13119/13119 PASS**