### PR TITLE
fix(checker): correct TS2322 fingerprints for async block-body arrows with JSDoc callable @type

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -834,9 +834,10 @@ impl<'a> CheckerState<'a> {
                             }
                             let func = checker.ctx.arena.get_function(init_node)?;
                             let body_node = checker.ctx.arena.get(func.body)?;
-                            if body_node.kind == syntax_kind_ext::BLOCK {
-                                return Some(false);
-                            }
+                            // For block bodies, check if any TS2322/TS2339 was emitted
+                            // inside the block during the initializer check. If so, the
+                            // body already produced the canonical diagnostic and the outer
+                            // declaration-level check should be skipped.
                             Some(
                                 checker.ctx.diagnostics[init_snap.diagnostics_len..]
                                     .iter()
@@ -848,6 +849,36 @@ impl<'a> CheckerState<'a> {
                             )
                         })
                         .unwrap_or(false);
+                    // For async function initializers in JS files with a JSDoc callable
+                    // type (e.g. `/** @type {function(): string} */`), tsc checks the
+                    // body return statements against the raw JSDoc return type, not the
+                    // whole-function type at the declaration level. The async wrapper
+                    // (`() => Promise<T>`) can never be directly assignable to a non-async
+                    // JSDoc type (`() => T`), so the outer declaration check always fails
+                    // — but tsc deliberately skips it and relies on body-level checks.
+                    // This matches tsc's behavior for `b` (concise body) which is handled
+                    // by `function_initializer_body_has_error`, and extends it to `c`/`d`
+                    // (block bodies) where the body check fires via check_return_statement.
+                    let is_async_block_body_with_jsdoc_callable_type = initializer_is_function
+                        && jsdoc_declared_type.is_some()
+                        && checker.is_js_file()
+                        && checker
+                            .ctx
+                            .arena
+                            .get(var_decl.initializer)
+                            .and_then(|n| checker.ctx.arena.get_function(n))
+                            .is_some_and(|f| {
+                                f.is_async
+                                    && checker
+                                        .ctx
+                                        .arena
+                                        .get(f.body)
+                                        .is_some_and(|b| b.kind == syntax_kind_ext::BLOCK)
+                            })
+                        && crate::query_boundaries::common::is_callable_type(
+                            checker.ctx.types.as_type_database(),
+                            declared_type,
+                        );
                     // Check assignability (skip for 'any' since anything is assignable to any,
                     // and skip for TypeId::ERROR since the type annotation failed to resolve).
                     // Note: we intentionally do NOT use type_contains_error() here because it
@@ -929,6 +960,12 @@ impl<'a> CheckerState<'a> {
                                 if elaborated_elements {
                                     // Elaboration emitted per-element TS2322 errors on the specific
                                     // mismatching array/tuple elements. Skip the generic TS2322.
+                                } else if is_async_block_body_with_jsdoc_callable_type {
+                                    // Async function with block body and JSDoc callable type:
+                                    // tsc checks return statements against the JSDoc return type
+                                    // inside the body (via check_return_statement). Any TS2322
+                                    // was already emitted there. Skip the outer declaration check
+                                    // since `() => Promise<T>` can never match `() => T` directly.
                                 } else if initializer_is_function
                                     && !checker.is_assignable_to(checked_init_type, declared_type)
                                     && checker.try_elaborate_assignment_source_error(

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1812,6 +1812,21 @@ impl<'a> CheckerState<'a> {
                 let original_type = annotated_return_type.unwrap_or(return_type);
                 self.unwrap_promise_type(original_type)
                     .unwrap_or(return_type)
+            } else if is_async_for_context
+                && has_contextual_return
+                && contextual_void_return_exception
+            {
+                // Contextual `() => void` for async callbacks: allow returning anything,
+                // the outer function-type assignability handles ergonomics.
+                TypeId::ANY
+            } else if is_async_for_context && has_contextual_return {
+                // For async functions with a non-void contextual return type (e.g., from
+                // `/** @type {function(): string} */ const c = async () => { return 0 }`),
+                // use the contextual return type directly as the expected body return type.
+                // The contextual return context was already unwrapped from Promise at
+                // line 1556-1557, so e.g. `string` from `function(): string` flows here
+                // and `check_return_statement` can report `number` is not `string`.
+                return_context_for_circularity.unwrap_or(TypeId::ANY)
             } else if is_async_for_context {
                 // For contextually-typed async functions (no explicit annotation),
                 // also unwrap Promise from the return type. For unions like

--- a/crates/tsz-checker/tests/jsdoc_type_tag_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_type_tag_tests.rs
@@ -453,3 +453,65 @@ var props = {};
         diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }
+
+// ─── async arrow + JSDoc callable type (asyncArrowFunction_allowJs.ts) ───────
+
+/// Concise-body async arrow returning wrong type should produce exactly one TS2322.
+/// `/** @type {function(): string} */ const b = async () => 0`
+/// tsc anchors the error at the declaration (col 11 = `async …`), not the body.
+#[test]
+fn test_async_concise_arrow_jsdoc_callable_wrong_return_type() {
+    let source = r#"
+/** @type {function(): string} */
+const b = async () => 0
+"#;
+    let diagnostics = check_js_with_libs(source);
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        1,
+        "Expected exactly 1 TS2322 for async concise arrow returning number with @type {{function(): string}}, got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// Block-body async arrow returning wrong type: tsc emits TS2322 at the `return` statement,
+/// NOT a secondary outer-declaration error.
+/// `/** @type {function(): string} */ const c = async () => { return 0 }`
+#[test]
+fn test_async_block_body_arrow_jsdoc_callable_wrong_return_type_single_error() {
+    let source = r#"
+/** @type {function(): string} */
+const c = async () => {
+    return 0
+}
+"#;
+    let diagnostics = check_js_with_libs(source);
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        1,
+        "Expected exactly 1 TS2322 (at return stmt) for async block-body arrow with wrong return type, got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// Block-body async arrow returning the CORRECT type should produce NO TS2322.
+/// `/** @type {function(): string} */ const d = async () => { return "" }`
+#[test]
+fn test_async_block_body_arrow_jsdoc_callable_correct_return_type_no_error() {
+    let source = r#"
+/** @type {function(): string} */
+const d = async () => {
+    return ""
+}
+"#;
+    let diagnostics = check_js_with_libs(source);
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        0,
+        "Expected 0 TS2322 for async block-body arrow correctly returning string, got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the conformance test `asyncArrowFunction_allowJs.ts` which had a fingerprint-only failure: tsc emits `TS2322 file.js:13:2 Type 'number' is not assignable to type 'string'` at the `return` statement inside a block-body async arrow, but tsz was missing that diagnostic.

Three root-cause bugs combined to produce wrong fingerprints:

1. **`function_initializer_body_has_error` returned `Some(false)` for block bodies** (hardcoded) — never suppressed the outer TS2322 check when the body already had an error. Fixed to scan diagnostics emitted inside the block for TS2322/TS2339.

2. **No mechanism to skip the outer declaration-level TS2322** for async+block-body+JSDoc-callable assignments. Added an `is_async_block_body_with_jsdoc_callable_type` guard: for `const c: () => string = async () => { ... }` in JS files, skip the outer type mismatch and let `check_return_statement` report on the individual `return` statements.

3. **`body_return_type` for async+contextual used inferred type instead of contextual return type.** In `function_type.rs`, the async branch for contextually-typed functions was computing `body_return_type` from the inferred `Promise<number>` (unwrapped to `number`), not the contextual `string` from `function(): string`. Added a `has_contextual_return` branch that uses `return_context_for_circularity` directly, so `check_return_statement` sees `string` as the expected type and correctly reports `number` is not `string`.

## Test plan

- [x] New unit tests in `jsdoc_type_tag_tests.rs`:
  - `test_async_concise_arrow_jsdoc_callable_wrong_return_type` — async `() => 0` with `@type {function(): string}` → exactly 1 TS2322
  - `test_async_block_body_arrow_jsdoc_callable_wrong_return_type_single_error` — async `() => { return 0 }` with `@type {function(): string}` → exactly 1 TS2322 at return stmt
  - `test_async_block_body_arrow_jsdoc_callable_correct_return_type_no_error` — async `() => { return "" }` → 0 TS2322
- [x] All 13117 pre-commit tests pass
- [x] Conformance: `asyncArrowFunction_allowJs.ts` now 1/1 pass (was fingerprint-only failure)