### PR TITLE
fix(checker): preserve literals against deferred conditional contextual types

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -356,6 +356,17 @@ impl<'a> CheckerState<'a> {
                 }
                 false
             }
+            // Deferred conditional: check both branches. Matches tsc's
+            // `isLiteralOfContextualType` recursing through the conditional's
+            // default constraint (approximately `true_type | false_type`).
+            // Reached when earlier evaluation couldn't resolve the conditional.
+            ContextualLiteralAllowKind::Conditional {
+                true_type,
+                false_type,
+            } => {
+                self.contextual_type_allows_literal_inner(true_type, literal_type, visited)
+                    || self.contextual_type_allows_literal_inner(false_type, literal_type, visited)
+            }
             ContextualLiteralAllowKind::NotAllowed => false,
         }
     }
@@ -1790,4 +1801,48 @@ fn is_boolean_context_for_boolean_literal(ctx_type: TypeId, literal_type: TypeId
         return false;
     }
     literal_type == TypeId::BOOLEAN_TRUE || literal_type == TypeId::BOOLEAN_FALSE
+}
+
+#[cfg(test)]
+mod deferred_conditional_literal_tests {
+    use crate::test_utils::check_source_codes;
+
+    /// Assigning a string literal to a deferred conditional whose false branch
+    /// is that exact literal must NOT widen the source to `string`. Matches
+    /// tsc's `isLiteralOfContextualType` recursing through conditional types.
+    ///
+    /// ```ts
+    /// type Foo<T> = T extends true ? string : "a";
+    /// function test<T>(x: Foo<T>) {
+    ///   x = "a"; // ok — both branches accept "a"
+    /// }
+    /// ```
+    #[test]
+    fn literal_preserved_when_target_is_deferred_conditional_with_literal_branch() {
+        let codes = check_source_codes(
+            r#"type Foo<T> = T extends true ? string : "a";
+               function test<T>(x: Foo<T>) {
+                 x = "a";
+               }"#,
+        );
+        assert!(
+            !codes.contains(&2322),
+            "Should not emit TS2322 when assigning matching literal to deferred conditional: {codes:?}"
+        );
+    }
+
+    /// Sanity check: assigning a non-matching `string` value still errors.
+    #[test]
+    fn deferred_conditional_still_errors_on_widened_source() {
+        let codes = check_source_codes(
+            r#"type Foo<T> = T extends true ? "b" : "a";
+               function test<T>(x: Foo<T>, s: string) {
+                 x = s;
+               }"#,
+        );
+        assert!(
+            codes.contains(&2322),
+            "Should emit TS2322 when assigning a `string` value to a literal-only deferred conditional: {codes:?}"
+        );
+    }
 }

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -340,6 +340,9 @@ mod boxed_augmentation_tests;
 #[path = "tests/classify_array_like_tests.rs"]
 mod classify_array_like_tests;
 #[cfg(test)]
+#[path = "tests/classify_contextual_literal_tests.rs"]
+mod classify_contextual_literal_tests;
+#[cfg(test)]
 #[path = "tests/classify_index_key_tests.rs"]
 mod classify_index_key_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/tests/classify_contextual_literal_tests.rs
+++ b/crates/tsz-solver/src/tests/classify_contextual_literal_tests.rs
@@ -1,0 +1,87 @@
+//! Tests for `classify_for_contextual_literal`.
+//!
+//! This classifier is used by the checker when deciding whether a literal
+//! expression should be preserved (kept as a literal type) or widened against
+//! its contextual type. When the contextual type is a deferred conditional
+//! type, tsc recurses through the conditional's default constraint. We expose
+//! a `Conditional { true_type, false_type }` variant so the checker can check
+//! both branches.
+
+use crate::intern::TypeInterner;
+use crate::type_queries::extended::{ContextualLiteralAllowKind, classify_for_contextual_literal};
+use crate::types::{ConditionalType, TypeData, TypeId, TypeParamInfo};
+
+fn type_param(interner: &TypeInterner, name: &str, constraint: Option<TypeId>) -> TypeId {
+    interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint,
+        default: None,
+        is_const: false,
+    }))
+}
+
+fn string_literal(interner: &TypeInterner, value: &str) -> TypeId {
+    interner.literal_string(value)
+}
+
+#[test]
+fn classify_contextual_literal_plain_union() {
+    let interner = TypeInterner::new();
+    let a_lit = string_literal(&interner, "a");
+    let b_lit = string_literal(&interner, "b");
+    let union = interner.union2(a_lit, b_lit);
+    assert!(matches!(
+        classify_for_contextual_literal(&interner, union),
+        ContextualLiteralAllowKind::Members(_)
+    ));
+}
+
+#[test]
+fn classify_contextual_literal_type_parameter() {
+    let interner = TypeInterner::new();
+    let t = type_param(&interner, "T", None);
+    assert!(matches!(
+        classify_for_contextual_literal(&interner, t),
+        ContextualLiteralAllowKind::TypeParameter { constraint: None }
+    ));
+}
+
+/// Deferred conditional types must expose their branches so the checker can
+/// check whether a literal is allowed by either branch.
+///
+/// For `Foo<T> = T extends true ? string : "a"`, the expression `"a"` must
+/// stay as literal `"a"` (not widen to `string`) when assigned to `Foo<T>`,
+/// because the `"a"` branch accepts it.
+#[test]
+fn classify_contextual_literal_deferred_conditional_exposes_branches() {
+    let interner = TypeInterner::new();
+    let t = type_param(&interner, "T", None);
+    let a_lit = string_literal(&interner, "a");
+    // T extends true ? string : "a"
+    let cond = interner.conditional(ConditionalType {
+        check_type: t,
+        extends_type: TypeId::BOOLEAN_TRUE,
+        true_type: TypeId::STRING,
+        false_type: a_lit,
+        is_distributive: true,
+    });
+    match classify_for_contextual_literal(&interner, cond) {
+        ContextualLiteralAllowKind::Conditional {
+            true_type,
+            false_type,
+        } => {
+            assert_eq!(true_type, TypeId::STRING);
+            assert_eq!(false_type, a_lit);
+        }
+        other => panic!("expected ContextualLiteralAllowKind::Conditional, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_contextual_literal_non_deferred_type_returns_not_allowed() {
+    let interner = TypeInterner::new();
+    assert!(matches!(
+        classify_for_contextual_literal(&interner, TypeId::NUMBER),
+        ContextualLiteralAllowKind::NotAllowed
+    ));
+}

--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -1149,6 +1149,15 @@ pub enum ContextualLiteralAllowKind {
     Application,
     /// Mapped type - needs evaluation
     Mapped,
+    /// Deferred conditional - check both branches.
+    /// Matches tsc's `isLiteralOfContextualType` which recurses through
+    /// `getConstraintOfConditionalType` (approximately `true_type | false_type`).
+    /// If the conditional could evaluate, the checker should prefer that; this
+    /// variant is the fallback when evaluation doesn't make progress.
+    Conditional {
+        true_type: TypeId,
+        false_type: TypeId,
+    },
     /// Template literal type - always allows string literals (pattern matching check
     /// happens later during assignability). This prevents premature widening of string
     /// literals like `"*hello*"` to `string` when the target is `` `*${string}*` ``.
@@ -1178,6 +1187,13 @@ pub fn classify_for_contextual_literal(
         }
         TypeData::Application(_) => ContextualLiteralAllowKind::Application,
         TypeData::Mapped(_) => ContextualLiteralAllowKind::Mapped,
+        TypeData::Conditional(cond_id) => {
+            let cond = db.conditional_type(cond_id);
+            ContextualLiteralAllowKind::Conditional {
+                true_type: cond.true_type,
+                false_type: cond.false_type,
+            }
+        }
         TypeData::TemplateLiteral(_) | TypeData::StringIntrinsic { .. } => {
             ContextualLiteralAllowKind::TemplateLiteral
         }


### PR DESCRIPTION
## Summary

When a literal expression's contextual type is a deferred conditional
type (`T extends U ? X : Y` that the evaluator can't resolve), the
classifier returned `NotAllowed`, causing literals like `"a"` to widen
to `string` and producing a spurious **TS2322** when the destination
was something like `Foo<T> = T extends true ? string : "a"`.

```ts
type Foo<T> = T extends true ? string : "a";
function test<T>(x: Foo<T>) {
  x = "a"; // tsc: ok; tsz was emitting TS2322
  x = (1 as unknown as string); // tsc: TS2322; still flagged
}
```

This matches tsc's `isLiteralOfContextualType`, which recurses through
the conditional's default constraint (≈ `true_type | false_type`).

## Root cause

`tsz_solver::type_queries::extended::classify_for_contextual_literal`
had no arm for `TypeData::Conditional`, so the checker's
`contextual_type_allows_literal_inner` fell through to `NotAllowed`
whenever the contextual type was a deferred conditional. The earlier
"`is_conditional_type` → evaluate → recurse" path can't resolve
deferred conditionals, so the literal was widened.

## Fix

Solver (`crates/tsz-solver/src/type_queries/extended.rs`):
- Added `ContextualLiteralAllowKind::Conditional { true_type, false_type }`
  variant.
- Mapped `TypeData::Conditional` → that variant in
  `classify_for_contextual_literal`.

Checker (`crates/tsz-checker/src/state/type_analysis/computed_helpers.rs`):
- Wired the new variant in `contextual_type_allows_literal_inner` to
  recurse on both branches. Either branch allowing the literal is
  enough — equivalent to consulting the conditional's default
  constraint, which is the rule tsc follows.

Architecture (per `.claude/CLAUDE.md`):
- Type-shape inspection lives in the solver (single classifier).
- Checker only orchestrates the recursion (no new ad-hoc heuristic).
- No new entry points to assignability; this only changes which
  literals survive into the existing `query_boundaries/assignability`
  pipeline.

## Tests

- `tsz-solver` unit test (`tests/classify_contextual_literal_tests.rs`):
  asserts the classifier exposes both branches for a deferred
  `T extends true ? string : "a"`, plus regression coverage for
  unions, type parameters, and primitives.
- `tsz-checker` unit test (`computed_helpers.rs`):
  - `literal_preserved_when_target_is_deferred_conditional_with_literal_branch`
    — fails before the fix, passes after.
  - `deferred_conditional_still_errors_on_widened_source` — guards
    against over-permissive preservation when neither branch matches.

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  — pass
- `cargo nextest run -p tsz-solver --lib` — 5282/5282 pass
- `cargo nextest run -p tsz-checker --lib` — 2681/2681 pass
- Conformance: **+5 net** (12096 → 12101). 6 new PASS, 1 reported
  PASS→FAIL is stale-snapshot noise (the test fails identically on
  `main` once verified by reverting the fix locally).
- Emit: jsPass +1, dtsPass +18.
- Fourslash (cap 50): 50/50.

The two pre-existing tsz-cli failures (`compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`,
`test_format_document_does_not_invalidate_fourslash_markers`) reproduce
on a fresh `git stash` of this branch — they're environment-specific
(running as root defeats `chmod 0o555`; fourslash timing) and unrelated
to this change.

## Test plan

- [x] Unit tests added in solver and checker pass and lock in the invariant.
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`.
- [x] Targeted conformance: `conditionalTypeAssignabilityWhenDeferred`
      no longer emits the spurious `x = "a"` error.
- [x] Full conformance suite: net +5 tests.
- [ ] Reviewer to spot-check `Foo<T> = T extends true ? string : "a"`
      style snippets for any remaining literal-preservation surprises.

https://claude.ai/code/session_016npLJ3KfLk7GfmfvT2CsuH

---
_Generated by [Claude Code](https://claude.ai/code/session_016npLJ3KfLk7GfmfvT2CsuH)_