### PR TITLE
fix(checker): elaborate object-literal properties for typed destructuring var decls

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -888,24 +888,42 @@ impl<'a> CheckerState<'a> {
                                 declared_type,
                                 var_decl.initializer,
                             ) {
-                                let skip_generic_outer_error = checker
-                                    .ctx
-                                    .arena
-                                    .get(var_decl.name)
-                                    .and_then(|pattern_node| {
-                                        checker.ctx.arena.get_binding_pattern(pattern_node)
-                                    })
-                                    .is_some_and(|pattern| {
-                                        pattern.elements.nodes.is_empty()
-                                            && var_decl.type_annotation.is_some()
-                                    });
-                                if !skip_generic_outer_error {
-                                    let _ = checker.check_assignable_or_report_generic_at(
-                                        checked_init_type,
-                                        declared_type,
-                                        var_decl.initializer,
-                                        decl_idx,
-                                    );
+                                // For object-literal initializers in destructuring
+                                // variable declarations, tsc drills into per-property
+                                // TS2322 errors rather than a single whole-type error.
+                                // e.g. `var {a1, a2}: {a1: number, a2: string} = {a1: true, a2: 1}`
+                                // reports at `true` and `1`, not at the outer object literal.
+                                let object_elaborated =
+                                    checker.ctx.arena.get(var_decl.initializer).is_some_and(
+                                        |init_node| {
+                                            init_node.kind
+                                                == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                                        },
+                                    ) && checker
+                                        .try_elaborate_object_literal_properties_for_var_init(
+                                            var_decl.initializer,
+                                            declared_type,
+                                        );
+                                if !object_elaborated {
+                                    let skip_generic_outer_error = checker
+                                        .ctx
+                                        .arena
+                                        .get(var_decl.name)
+                                        .and_then(|pattern_node| {
+                                            checker.ctx.arena.get_binding_pattern(pattern_node)
+                                        })
+                                        .is_some_and(|pattern| {
+                                            pattern.elements.nodes.is_empty()
+                                                && var_decl.type_annotation.is_some()
+                                        });
+                                    if !skip_generic_outer_error {
+                                        let _ = checker.check_assignable_or_report_generic_at(
+                                            checked_init_type,
+                                            declared_type,
+                                            var_decl.initializer,
+                                            decl_idx,
+                                        );
+                                    }
                                 }
                             }
                         } else {

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -4143,3 +4143,60 @@ u2.email = e;
         "Expected TS2412 for exact-optional property write mismatch, got: {diagnostics:#?}"
     );
 }
+
+#[test]
+fn destructuring_var_decl_with_type_annotation_elaborates_object_literal_properties() {
+    // tsc reports per-property TS2322 errors when a destructuring variable declaration
+    // has a type annotation and the object literal initializer has individual property
+    // type mismatches. Each error is anchored at the property name inside the RHS
+    // object literal (matching tsc's elaboration behavior).
+    // e.g. `var {a1, a2}: { a1: number, a2: string } = { a1: true, a2: 1 }`
+    // should report TWO errors (one for a1, one for a2), NOT one whole-type error.
+    let source = r#"var {a1, a2}: { a1: number, a2: string } = { a1: true, a2: 1 };"#;
+
+    let diagnostics = diagnostics_for_source(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+
+    assert_eq!(
+        ts2322.len(),
+        2,
+        "Expected two TS2322 errors (one per mismatched property), got: {diagnostics:?}"
+    );
+
+    // tsc anchors each error at the property name inside the RHS object literal.
+    // `{ a1: true, a2: 1 }` — errors at `a1` and `a2` property names.
+    // (same positions as tsc col 46 and col 56 in the conformance test)
+    let rhs_a1_pos = source
+        .find("{ a1: true")
+        .map(|p| p + 2) // skip "{ ", point at 'a'
+        .expect("RHS a1 property") as u32;
+    let rhs_a2_pos = source.find("a2: 1").expect("RHS a2 property") as u32;
+
+    assert!(
+        ts2322.iter().any(|d| d.start == rhs_a1_pos),
+        "Expected TS2322 anchored at RHS 'a1' property name (pos {rhs_a1_pos}), got starts: {:?}",
+        ts2322.iter().map(|d| d.start).collect::<Vec<_>>()
+    );
+    assert!(
+        ts2322.iter().any(|d| d.start == rhs_a2_pos),
+        "Expected TS2322 anchored at RHS 'a2' property name (pos {rhs_a2_pos}), got starts: {:?}",
+        ts2322.iter().map(|d| d.start).collect::<Vec<_>>()
+    );
+
+    // Check messages
+    assert!(
+        ts2322
+            .iter()
+            .any(|d| d.message_text.contains("'boolean'") && d.message_text.contains("'number'")),
+        "Expected 'boolean' not assignable to 'number' message. Got: {ts2322:?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|d| d.message_text.contains("'number'") && d.message_text.contains("'string'")),
+        "Expected 'number' not assignable to 'string' message. Got: {ts2322:?}"
+    );
+}


### PR DESCRIPTION
## Root cause

When a destructuring variable declaration has a type annotation and an object-literal RHS with per-property type mismatches, `tsc` reports **individual TS2322 errors** anchored at each mismatching property name inside the object literal. `tsz` was instead emitting a **single whole-type TS2322** at the outer binding pattern.

```ts
var {a1, a2}: { a1: number, a2: string } = { a1: true, a2: 1 }
//                                               ^^        ^
//  tsc reports here (property names in RHS)    col 46    col 56
```

**Before:** one `TS2322: Type '{ a1: boolean; a2: number; }' is not assignable to type '{ a1: number; a2: string; }'` at col 5.  
**After:** two `TS2322` errors — `'boolean' is not assignable to 'number'` at `a1:`, `'number' is not assignable to 'string'` at `a2:`.

## Fix

The `is_destructuring` branch in `check_variable_declaration_with_request` called `try_elaborate_initializer_elements` (array-only) and fell back to a generic error for object-literal initializers. Added a call to `try_elaborate_object_literal_properties_for_var_init` before the generic fallback, mirroring what the non-destructuring branch already does.

Change is in `crates/tsz-checker/src/state/variable_checking/core.rs`.

## Tests

- New unit test `destructuring_var_decl_with_type_annotation_elaborates_object_literal_properties` in `ts2322_tests.rs`
- Conformance test `destructuringVariableDeclaration2.ts` flips from FAIL (fingerprint-only) to PASS
- All 13118 pre-commit unit tests pass
- No regressions in `--filter destructuring` suite (159/174, same as baseline)