### PR TITLE
fix(parser): emit TS1109 when prefix unary operator has missing operand

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1606,19 +1606,20 @@ impl ParserState {
                     self.parse_unary_expression()
                 };
                 if operand.is_none() {
-                    if is_update_operator {
-                        // For `++`/`--` with no operand (e.g., `a++ ++;`), emit TS1109
-                        // unconditionally. Bypass should_report_error() because `++;`
-                        // is a distinct syntactic unit — the TS1109 must not be
-                        // suppressed by a prior TS1005 for `';' expected` at `++`.
-
-                        self.parse_error_at_current_token(
-                            "Expression expected.",
-                            diagnostic_codes::EXPRESSION_EXPECTED,
-                        );
-                    } else {
-                        self.error_expression_expected();
-                    }
+                    // When a prefix unary operator has no operand, emit TS1109 at
+                    // the current position unconditionally. tsc emits this via
+                    // parsePrimaryExpression's default case -> createMissingNode,
+                    // which uses only exact-position dedup (no distance-based
+                    // suppression). Bypass should_report_error() so a prior
+                    // TS1005 at the operator itself (e.g. `,` expected at `~` in
+                    // `var a = q~;`) does not swallow the distinct missing-operand
+                    // error. parse_error_at already dedupes at the same position,
+                    // so this won't double up when the recursive call already
+                    // reported at the same token.
+                    self.parse_error_at_current_token(
+                        "Expression expected.",
+                        diagnostic_codes::EXPRESSION_EXPECTED,
+                    );
                 }
                 let end_pos = self.token_end();
 

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -3773,3 +3773,111 @@ fn test_ts1125_untagged_template_emits_errors() {
         ts1125_diagnostics
     );
 }
+
+#[test]
+fn test_prefix_unary_without_operand_emits_ts1109_after_prior_ts1005() {
+    // `var a = q~;` — after parsing `var a = q`, the `~` triggers TS1005
+    // (',' expected) in the variable declaration list. Recovery then re-enters
+    // statement parsing and treats `~;` as a prefix-unary expression with a
+    // missing operand. tsc emits TS1109 at the `;` even though TS1005 was just
+    // reported one column earlier; our distance-based error suppression used
+    // to swallow the TS1109 because the two positions are within three
+    // characters. Verify both diagnostics are now emitted.
+    let source = "var a = q~;\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let ts1005_count = diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::EXPECTED)
+        .count();
+    let ts1109_count = diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::EXPRESSION_EXPECTED)
+        .count();
+
+    assert_eq!(
+        ts1005_count, 1,
+        "Expected exactly one TS1005 (',' expected) for `var a = q~;`, got diagnostics: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts1109_count, 1,
+        "Expected TS1109 (Expression expected) at the `;` after `~` for `var a = q~;`, got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_prefix_unary_tilde_missing_operand_emits_ts1109_after_initializer() {
+    // `var b =~;` — the initializer is parsed as `~` with a missing operand.
+    // tsc emits TS1109 at the `;`. This path has no prior parser error so it
+    // does not exercise the suppression-bypass, but it pins down the baseline
+    // behaviour alongside the prior-error variant above.
+    let source = "var b =~;\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let ts1109_count = diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::EXPRESSION_EXPECTED)
+        .count();
+
+    assert_eq!(
+        ts1109_count, 1,
+        "Expected exactly one TS1109 at the `;` for `var b =~;`, got diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_bitwise_not_invalid_operations_matches_tsc_diagnostics() {
+    // Matches the conformance test
+    // TypeScript/tests/cases/conformance/expressions/unaryOperators/
+    // bitwiseNotOperator/bitwiseNotOperatorInvalidOperations.ts after the
+    // test runner strips the `// @target:` directive. tsc emits exactly four
+    // diagnostics:
+    //   (5,10) TS1005 ',' expected.
+    //   (5,11) TS1109 Expression expected.
+    //   (8,27) TS1134 Variable declaration expected.
+    //   (11,9) TS1109 Expression expected.
+    let source = "\
+// Unary operator ~
+var q;
+
+// operand before ~
+var a = q~;  //expect error
+
+// multiple operands after ~
+var mul = ~[1, 2, \"abc\"], \"\";  //expect error
+
+// miss an operand
+var b =~;
+";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let line_map = LineMap::build(source);
+
+    let mut fingerprints: Vec<(u32, u32, u32)> = diagnostics
+        .iter()
+        .map(|d| {
+            let pos = line_map.offset_to_position(d.start, source);
+            (d.code, pos.line + 1, pos.character + 1)
+        })
+        .collect();
+    fingerprints.sort();
+
+    let mut expected = vec![
+        (diagnostic_codes::EXPECTED, 5, 10),
+        (diagnostic_codes::EXPRESSION_EXPECTED, 5, 11),
+        (diagnostic_codes::VARIABLE_DECLARATION_EXPECTED, 8, 27),
+        (diagnostic_codes::EXPRESSION_EXPECTED, 11, 9),
+    ];
+    expected.sort();
+
+    assert_eq!(
+        fingerprints, expected,
+        "Diagnostic fingerprints must match tsc exactly, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Two previously fingerprint-only conformance failures
(`bitwiseNotOperatorInvalidOperations`, `negateOperatorInvalidOperations`)
were missing one `TS1109 Expression expected.` diagnostic each. tsc emits
that diagnostic at the position of the missing operand of a prefix unary
operator (`~`, `!`, `+`, `-`); tsz's parser was suppressing it whenever
another parse error had been reported within ~3 columns just before the
operator.

### Root cause

`parse_unary_expression` previously called `error_expression_expected()`
when the recursive operand parse returned `NodeIndex::NONE`. That helper
goes through `should_report_error()`, which uses a distance-based
suppression heuristic (`ERROR_SUPPRESSION_DISTANCE = 3`). For input like:

```ts
// @target: es2015
var q;
var a = q~;        // expected: TS1005 at `~`, TS1109 at `;`
var mul = ~[1, 2, "abc"], "";
var b =~;          // expected: TS1109 at `;`
```

the parser first emits `TS1005 ',' expected.` at `~` while recovering
the variable declaration list. Statement-level recovery then re-enters
`parse_unary_expression` for `~;`. The recursive call returns `NONE`
(primary expression is at `is_at_expression_end`), but
`error_expression_expected()` saw `last_error_pos` still anchored at
`~` (distance = 1) and dropped the diagnostic.

tsc takes a different path: it always reaches
`parsePrimaryExpression`'s default identifier-fallback, which calls
`createMissingNode` → `parseErrorAtPosition`. That helper only dedupes
at the *exact* same position — there is no distance window — so the
companion `TS1109` always lands.

### Fix

In `parse_unary_expression`, the `++`/`--` branch already bypassed the
suppression with `parse_error_at_current_token` for the same reason
(comment in place). Apply the same logic to the
`+ | - | ~ | !` branch: when the operand is `None`, emit
`TS1109 Expression expected.` at the current token directly. Position-
level dedup in `parse_error_at` still prevents double-reporting when the
recursive call already emitted at the same byte offset, so JSX recovery
tests like `test_js_unary_tilde_then_malformed_jsx_reports_ts1003` keep
their current behaviour.

### Tests

Three new tests in `crates/tsz-parser/tests/parser_improvement_tests.rs`:

- `test_prefix_unary_without_operand_emits_ts1109_after_prior_ts1005`
  — locks in the regression case (`var a = q~;`).
- `test_prefix_unary_tilde_missing_operand_emits_ts1109_after_initializer`
  — pins the no-prior-error baseline (`var b =~;`).
- `test_bitwise_not_invalid_operations_matches_tsc_diagnostics`
  — full fingerprint match against tsc for the conformance test body.

All 544 `tsz-parser` tests pass (3 new + 541 existing).

### Conformance impact

- `bitwiseNotOperatorInvalidOperations.ts` — **PASS** (was
  fingerprint-only).
- `negateOperatorInvalidOperations.ts` — **PASS** (was
  fingerprint-only — same root cause, free win).
- All 69 unary-operator conformance tests still pass (100%).
- Targeted runs over Operator/parser/Expression filters hold their
  baseline (no `PASS → FAIL` flips).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --package tsz-parser` (544 passed)
- [x] `./scripts/conformance/conformance.sh run --filter "bitwiseNotOperatorInvalidOperations" --verbose` (1/1 PASS)
- [x] `./scripts/conformance/conformance.sh run --filter "negateOperatorInvalidOperations"` (PASS)
- [x] `./scripts/conformance/conformance.sh run --filter "unary" --max 100` (69/69 PASS)
- [ ] Full conformance suite (`scripts/safe-run.sh ./scripts/conformance/conformance.sh run`) — left for CI; targeted regression checks above showed no flips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpmYHnn9Nspa5459SQwFCm)_