### PR TITLE
perf(binder,cli): Arc-share flow_nodes to eliminate per-file materialization

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -1569,16 +1569,20 @@ impl BinderState {
         F: FnOnce(&mut Self),
     {
         let prev_flow = self.current_flow;
-        let start_flow = self.flow_nodes.alloc(flow_flags::START);
+        let start_flow = {
+            let flow_nodes = std::sync::Arc::make_mut(&mut self.flow_nodes);
+            let start_flow = flow_nodes.alloc(flow_flags::START);
 
-        // For closures (arrow functions and function expressions), capture the enclosing flow
-        // so that const/let variables can preserve narrowing from the outer scope
-        if capture_enclosing
-            && prev_flow.is_some()
-            && let Some(start_node) = self.flow_nodes.get_mut(start_flow)
-        {
-            start_node.antecedent.push(prev_flow);
-        }
+            // For closures (arrow functions and function expressions), capture the enclosing flow
+            // so that const/let variables can preserve narrowing from the outer scope
+            if capture_enclosing
+                && prev_flow.is_some()
+                && let Some(start_node) = flow_nodes.get_mut(start_flow)
+            {
+                start_node.antecedent.push(prev_flow);
+            }
+            start_flow
+        };
 
         // Save and clear return_targets so that return statements inside
         // non-IIFE functions don't redirect to an enclosing IIFE's return target.

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -46,7 +46,7 @@ impl BinderStateScopeInputs {
         Self {
             scopes,
             node_scope_ids,
-            flow_nodes: FlowNodeArena::new(),
+            flow_nodes: Arc::new(FlowNodeArena::new()),
             ..Self::default()
         }
     }
@@ -177,7 +177,7 @@ impl BinderState {
             declared_modules: FxHashSet::default(),
             is_external_module: false,
             is_strict_scope: false,
-            flow_nodes,
+            flow_nodes: Arc::new(flow_nodes),
             current_flow: FlowNodeId::NONE,
             unreachable_flow,
             scope_chain: Vec::with_capacity(32),
@@ -243,8 +243,11 @@ impl BinderState {
         self.declared_modules.clear();
         self.is_external_module = false;
         self.is_strict_scope = false;
-        self.flow_nodes.clear();
-        self.unreachable_flow = self.flow_nodes.alloc(flow_flags::UNREACHABLE);
+        {
+            let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+            flow_nodes.clear();
+            self.unreachable_flow = flow_nodes.alloc(flow_flags::UNREACHABLE);
+        }
         self.current_flow = FlowNodeId::NONE;
         self.scope_chain.clear();
         self.current_scope_idx = 0;
@@ -414,7 +417,7 @@ impl BinderState {
             declared_modules: FxHashSet::default(),
             is_external_module: false,
             is_strict_scope: false,
-            flow_nodes,
+            flow_nodes: Arc::new(flow_nodes),
             current_flow: FlowNodeId::NONE,
             unreachable_flow,
             scope_chain: Vec::new(),
@@ -1038,7 +1041,7 @@ impl BinderState {
         }
 
         // Create START flow node for the file
-        let start_flow = self.flow_nodes.alloc(flow_flags::START);
+        let start_flow = Arc::make_mut(&mut self.flow_nodes).alloc(flow_flags::START);
         self.current_flow = start_flow;
         self.is_external_module = Self::source_file_is_external_module(arena, root);
 

--- a/crates/tsz-binder/src/state/flow_helpers.rs
+++ b/crates/tsz-binder/src/state/flow_helpers.rs
@@ -5,6 +5,7 @@
 
 use super::BinderState;
 use crate::{FlowNodeId, flow_flags};
+use std::sync::Arc;
 use tsz_parser::NodeIndex;
 
 impl BinderState {
@@ -14,12 +15,12 @@ impl BinderState {
 
     /// Create a branch label flow node for merging control flow paths.
     pub(crate) fn create_branch_label(&mut self) -> FlowNodeId {
-        self.flow_nodes.alloc(flow_flags::BRANCH_LABEL)
+        Arc::make_mut(&mut self.flow_nodes).alloc(flow_flags::BRANCH_LABEL)
     }
 
     /// Create a loop label flow node for back-edges.
     pub(crate) fn create_loop_label(&mut self) -> FlowNodeId {
-        self.flow_nodes.alloc(flow_flags::LOOP_LABEL)
+        Arc::make_mut(&mut self.flow_nodes).alloc(flow_flags::LOOP_LABEL)
     }
 
     /// Create a flow condition node for tracking type narrowing.
@@ -29,8 +30,9 @@ impl BinderState {
         antecedent: FlowNodeId,
         condition: NodeIndex,
     ) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flags);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flags);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.antecedent.push(antecedent);
             node.node = condition;
         }
@@ -44,10 +46,14 @@ impl BinderState {
         fallthrough: FlowNodeId,
         clause: NodeIndex,
     ) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::SWITCH_CLAUSE);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
-            node.node = clause;
-        }
+        let id = {
+            let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+            let id = flow_nodes.alloc(flow_flags::SWITCH_CLAUSE);
+            if let Some(node) = flow_nodes.get_mut(id) {
+                node.node = clause;
+            }
+            id
+        };
         self.add_antecedent(id, pre_switch);
         self.add_antecedent(id, fallthrough);
         id
@@ -55,11 +61,13 @@ impl BinderState {
 
     /// Create a flow node for an assignment.
     pub(crate) fn create_flow_assignment(&mut self, assignment: NodeIndex) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::ASSIGNMENT);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let current_flow = self.current_flow;
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flow_flags::ASSIGNMENT);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.node = assignment;
-            if self.current_flow.is_some() {
-                node.antecedent.push(self.current_flow);
+            if current_flow.is_some() {
+                node.antecedent.push(current_flow);
             }
         }
         id
@@ -67,11 +75,13 @@ impl BinderState {
 
     /// Create a flow node for a call expression.
     pub(crate) fn create_flow_call(&mut self, call: NodeIndex) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::CALL);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let current_flow = self.current_flow;
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flow_flags::CALL);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.node = call;
-            if self.current_flow.is_some() {
-                node.antecedent.push(self.current_flow);
+            if current_flow.is_some() {
+                node.antecedent.push(current_flow);
             }
         }
         id
@@ -79,11 +89,13 @@ impl BinderState {
 
     /// Create a flow node for array mutation (e.g. push/splice).
     pub(crate) fn create_flow_array_mutation(&mut self, call: NodeIndex) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::ARRAY_MUTATION);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let current_flow = self.current_flow;
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flow_flags::ARRAY_MUTATION);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.node = call;
-            if self.current_flow.is_some() {
-                node.antecedent.push(self.current_flow);
+            if current_flow.is_some() {
+                node.antecedent.push(current_flow);
             }
         }
         id
@@ -91,11 +103,13 @@ impl BinderState {
 
     /// Create a flow node for await expression (async suspension point).
     pub(crate) fn create_flow_await_point(&mut self, await_expr: NodeIndex) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::AWAIT_POINT);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let current_flow = self.current_flow;
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flow_flags::AWAIT_POINT);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.node = await_expr;
-            if self.current_flow.is_some() {
-                node.antecedent.push(self.current_flow);
+            if current_flow.is_some() {
+                node.antecedent.push(current_flow);
             }
         }
         id
@@ -103,11 +117,13 @@ impl BinderState {
 
     /// Create a flow node for yield expression (generator suspension point).
     pub(crate) fn create_flow_yield_point(&mut self, yield_expr: NodeIndex) -> FlowNodeId {
-        let id = self.flow_nodes.alloc(flow_flags::YIELD_POINT);
-        if let Some(node) = self.flow_nodes.get_mut(id) {
+        let current_flow = self.current_flow;
+        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
+        let id = flow_nodes.alloc(flow_flags::YIELD_POINT);
+        if let Some(node) = flow_nodes.get_mut(id) {
             node.node = yield_expr;
-            if self.current_flow.is_some() {
-                node.antecedent.push(self.current_flow);
+            if current_flow.is_some() {
+                node.antecedent.push(current_flow);
             }
         }
         id
@@ -118,7 +134,7 @@ impl BinderState {
         if antecedent.is_none() || antecedent == self.unreachable_flow {
             return;
         }
-        if let Some(node) = self.flow_nodes.get_mut(label)
+        if let Some(node) = Arc::make_mut(&mut self.flow_nodes).get_mut(label)
             && !node.antecedent.contains(&antecedent)
         {
             node.antecedent.push(antecedent);

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -243,8 +243,18 @@ pub struct BinderState {
     /// Whether the current scope is in strict mode (via "use strict" directive or --alwaysStrict).
     /// In strict mode, function declarations inside blocks are block-scoped, not hoisted.
     pub(crate) is_strict_scope: bool,
-    /// Flow nodes for control flow analysis
-    pub flow_nodes: FlowNodeArena,
+    /// Flow nodes for control flow analysis.
+    ///
+    /// Wrapped in `Arc` so per-file binders constructed by the CLI driver
+    /// can share a single file's flow graph via `Arc::clone` instead of
+    /// deep-cloning `Vec<FlowNode>` (each `FlowNode` carries its own
+    /// `Vec<FlowNodeId>` antecedents, so the clone is allocation-heavy).
+    /// The driver builds ~2×N per-file binders (cross-file lookup +
+    /// per-file checking), so N-file projects previously paid 2N deep
+    /// clones of their flow graphs. Mutations during binding go through
+    /// `Arc::make_mut`, which is zero-cost while the refcount is 1
+    /// (always the case during a single binder's construction).
+    pub flow_nodes: Arc<FlowNodeArena>,
     /// Current flow node
     pub(crate) current_flow: FlowNodeId,
     /// Unreachable flow node
@@ -853,7 +863,7 @@ pub struct BinderStateScopeInputs {
     pub cross_file_node_symbols: CrossFileNodeSymbols,
     pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     pub modules_with_export_equals: FxHashSet<String>,
-    pub flow_nodes: FlowNodeArena,
+    pub flow_nodes: Arc<FlowNodeArena>,
     pub node_flow: FxHashMap<u32, FlowNodeId>,
     pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
     pub expando_properties: FxHashMap<String, FxHashSet<String>>,

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -6520,3 +6520,47 @@ fn arena_for_declaration_or_falls_back_when_unmapped() {
     // Helper matches the explicit Option-collapsing expression it replaces.
     assert!(binder.get_arena_for_declaration(sym_id, decl_idx).is_none());
 }
+
+#[test]
+fn flow_nodes_arc_share_is_zero_copy() {
+    // After binding, `BinderState.flow_nodes` is an `Arc<FlowNodeArena>`.
+    // Cloning the Arc to model the per-file binder reconstruction path
+    // (`flow_nodes: Arc::clone(&file.flow_nodes)` in
+    //  `check_utils::create_binder_from_bound_file_with_augmentations`)
+    // must be a pointer-equality share — no deep clone of the underlying
+    // `Vec<FlowNode>`. This is the invariant that saves ~2N deep clones
+    // on N-file projects.
+    let source = r"
+        function foo(x: number | string) {
+            if (typeof x === 'string') {
+                return x.length;
+            }
+            return x + 1;
+        }
+    ";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    // Sanity: binding produced multiple flow nodes (START, assignment,
+    // conditions, branch labels) for the control flow graph.
+    assert!(
+        binder.flow_nodes.len() > 3,
+        "expected multiple flow nodes for the narrowing example, got {}",
+        binder.flow_nodes.len()
+    );
+
+    // Cloning the Arc must be zero-copy: the inner pointer stays identical,
+    // and the strong count increases to 2 (original + clone).
+    assert_eq!(Arc::strong_count(&binder.flow_nodes), 1);
+    let shared = Arc::clone(&binder.flow_nodes);
+    assert_eq!(Arc::strong_count(&binder.flow_nodes), 2);
+    assert!(Arc::ptr_eq(&binder.flow_nodes, &shared));
+
+    // Read semantics still work through `Deref` — iterator count must
+    // match `.len()` without any materialization of a new arena.
+    assert_eq!(shared.iter().count(), binder.flow_nodes.len());
+    assert_eq!(shared.len(), binder.flow_nodes.len());
+}

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2654,7 +2654,7 @@ fn build_lib_bound_file_for_interface_checks(
         global_augmentations: FxHashMap::default(),
         module_augmentations: FxHashMap::default(),
         augmentation_target_modules: FxHashMap::default(),
-        flow_nodes: tsz::binder::FlowNodeArena::default(),
+        flow_nodes: std::sync::Arc::new(tsz::binder::FlowNodeArena::default()),
         node_flow: FxHashMap::default(),
         switch_clause_to_switch: FxHashMap::default(),
         is_external_module: lib_file.binder.is_external_module,

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1607,7 +1607,13 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
             cross_file_node_symbols: Default::default(),
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: Default::default(),
-            flow_nodes: file.flow_nodes.clone(),
+            // Per-binder `flow_nodes` is an Arc clone (atomic increment)
+            // instead of a deep clone of the underlying `Vec<FlowNode>`.
+            // Each `FlowNode` owns a `Vec<FlowNodeId>` antecedents, so
+            // the previous deep clone was allocation-heavy; on large
+            // repos it was paid ~2× per file (cross-file lookup +
+            // per-file checking binder).
+            flow_nodes: Arc::clone(&file.flow_nodes),
             node_flow: file.node_flow.clone(),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),
@@ -1730,7 +1736,10 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
             cross_file_node_symbols: Default::default(),
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: Default::default(),
-            flow_nodes: file.flow_nodes.clone(),
+            // Per-binder `flow_nodes` is an Arc clone; see
+            // `create_binder_from_bound_file_with_augmentations` for
+            // the rationale.
+            flow_nodes: Arc::clone(&file.flow_nodes),
             node_flow: file.node_flow.clone(),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -525,8 +525,16 @@ pub struct BindResult {
     pub lib_symbol_ids: Arc<FxHashSet<SymbolId>>,
     /// Reverse mapping from user-local lib symbol IDs to (`lib_binder_ptr`, `original_local_id`)
     pub lib_symbol_reverse_remap: FxHashMap<SymbolId, (usize, SymbolId)>,
-    /// Flow nodes for control flow analysis
-    pub flow_nodes: FlowNodeArena,
+    /// Flow nodes for control flow analysis.
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver
+    /// can share the underlying `FlowNodeArena` via `Arc::clone` (atomic
+    /// increment) instead of deep-cloning `Vec<FlowNode>` — each
+    /// `FlowNode` owns a `Vec<FlowNodeId>` antecedents, so the deep clone
+    /// was allocation-heavy on large projects. Mutations during binding
+    /// go through `Arc::make_mut` (free when refcount=1, the case during
+    /// a single file's binding).
+    pub flow_nodes: Arc<FlowNodeArena>,
     /// Node-to-flow mapping: tracks which flow node was active at each AST node
     pub node_flow: FxHashMap<u32, FlowNodeId>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
@@ -1405,8 +1413,16 @@ pub struct BoundFile {
     pub module_augmentations: FxHashMap<String, Vec<crate::binder::ModuleAugmentation>>,
     /// Maps symbols declared inside module augmentation blocks to their target module specifier
     pub augmentation_target_modules: FxHashMap<SymbolId, String>,
-    /// Flow nodes for control flow analysis
-    pub flow_nodes: FlowNodeArena,
+    /// Flow nodes for control flow analysis.
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver can
+    /// share this file's flow graph via `Arc::clone` (atomic increment)
+    /// instead of deep-cloning the underlying `Vec<FlowNode>` (each
+    /// `FlowNode` owns a `Vec<FlowNodeId>` antecedents). The driver builds
+    /// ~2×N per-file binders (cross-file lookup + per-file checking), so
+    /// on N-file projects this previously cost 2N deep clones of the
+    /// per-file flow graph.
+    pub flow_nodes: Arc<FlowNodeArena>,
     /// Node-to-flow mapping: tracks which flow node was active at each AST node
     pub node_flow: FxHashMap<u32, FlowNodeId>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
@@ -3911,7 +3927,7 @@ fn build_lib_bound_file_for_interface_checks(
         global_augmentations: FxHashMap::default(),
         module_augmentations: FxHashMap::default(),
         augmentation_target_modules: FxHashMap::default(),
-        flow_nodes: FlowNodeArena::default(),
+        flow_nodes: Arc::new(FlowNodeArena::default()),
         node_flow: FxHashMap::default(),
         switch_clause_to_switch: FxHashMap::default(),
         is_external_module: lib_file.binder.is_external_module,


### PR DESCRIPTION
## Summary

`BoundFile.flow_nodes: FlowNodeArena` was deep-cloned for every per-file binder constructed by the CLI driver:

```rust
flow_nodes: file.flow_nodes.clone(),
```

On a large project the driver builds ~2×N per-file binders (cross-file lookup pool + per-file checking binders), so on a 6086-file project every file's flow graph was deep-cloned ~2 times. Each `FlowNode` owns its own `Vec<FlowNodeId>` antecedents, so the deep clone was allocation-heavy (one allocation per flow node with antecedents, which is most of them).

This PR wraps the field in `Arc<FlowNodeArena>` end-to-end:
- `BinderState.flow_nodes: Arc<FlowNodeArena>`
- `BinderStateScopeInputs.flow_nodes: Arc<FlowNodeArena>`
- `BindResult.flow_nodes: Arc<FlowNodeArena>`
- `BoundFile.flow_nodes: Arc<FlowNodeArena>`

Mutations during binding (all in `tsz-binder`: `create_*_flow`, `add_antecedent`, `with_fresh_flow_inner`, the `alloc(START)` in `bind_source_file`, and `reset()` in `state/core.rs`) go through `Arc::make_mut`, which is essentially free while the refcount is 1 — the case during a single binder's construction.

After this:
- `binder.flow_nodes: ... file.flow_nodes.clone()` in `check_utils` is now `Arc::clone(&file.flow_nodes)` — atomic increment, no deep copy.
- All read sites (`.len()`, `.get(id)`, `.iter()`) still work via `Deref`.
- Post-binding the flow graph is read-only (no mutation in checker, cli, or core), so refcount growth during checking doesn't force any `make_mut` clone-on-write copies.

Same migration pattern as the prior Arc-share PRs (#932 lib_symbol_ids, #944 wildcard_reexports, #954 module_exports, #960 lib_binders, #973 module_augmentations, #979 global_augmentations, #986 symbol_arenas).

## Scope

- `crates/tsz-binder/src/binding/declaration.rs` — mutation sites use `Arc::make_mut`
- `crates/tsz-binder/src/state/core.rs`, `state/mod.rs`, `state/flow_helpers.rs` — field type + reset
- `crates/tsz-binder/src/state/tests.rs` — regression test (zero-copy assertion)
- `crates/tsz-cli/src/driver/check.rs`, `check_utils.rs` — `Arc::clone` at construction
- `crates/tsz-core/src/parallel/core.rs` — `Arc<FlowNodeArena>` flows through `BindResult` → `BoundFile`

+158 / −56 lines.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run -p tsz-binder -p tsz-core -p tsz-checker --lib` — 5871 tests pass
- [x] New regression test `state::tests::test_flow_nodes_arc_share_is_zero_copy` confirms the per-file Arc::clone is pointer-equal (no deep copy)
- [ ] Full `scripts/session/verify-all.sh` (running on baseline rebase to current main; agent's verify-all stalled in the prior session)

Note on verification: the agent that produced these commits ran `cargo check` and `cargo clippy` cleanly before stalling on the full verify-all. After rebasing onto current main I re-ran `cargo check`, `cargo clippy --all-targets -- -D warnings`, and the targeted unit tests above. CI should run the remaining suites; if any conformance regression appears I'll investigate.