### PR TITLE
perf(solver): canonical-pairs form of TypeSubstitution (PR 1/4 of instantiate_type cache)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -18,6 +18,7 @@ use crate::types::{
     TypeData, TypeId, TypeParamInfo, TypePredicate,
 };
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 use tsz_common::interner::Atom;
 
 /// Maximum depth for recursive type instantiation.
@@ -192,6 +193,38 @@ impl TypeSubstitution {
     /// This is useful for building new substitutions based on existing ones.
     pub const fn map(&self) -> &FxHashMap<Atom, TypeId> {
         &self.map
+    }
+
+    /// Produce the canonical, content-hashable form of this substitution.
+    ///
+    /// Returns a `SmallVec` of `(name, type_id)` pairs sorted by `Atom`.
+    /// Sorting removes insertion-order dependence — the underlying
+    /// `FxHashMap` does not iterate in a deterministic order, so two maps
+    /// with the same contents but different insertion sequences would
+    /// otherwise produce different iteration shapes.
+    ///
+    /// PR 1 of the `instantiate_type` cross-call cache
+    /// (`docs/plan/perf-instantiate-type-cache-design.md`). The returned
+    /// form is the eventual cache key seed; PR 2 will key
+    /// `QueryCache::instantiation_cache` on an `Arc<[(Atom, TypeId)]>`
+    /// built directly from this output. Substitution *interning* (a
+    /// `u32` handle) intentionally does **not** live here — the cache
+    /// lifetime is owned by `QueryCache`, not the global `TypeInterner`.
+    ///
+    /// Most substitutions have 1-4 entries (matching the shape of the
+    /// existing `application_eval_cache`), so the `SmallVec<[_; 4]>`
+    /// inline buffer avoids a heap allocation for the common case.
+    #[must_use]
+    pub fn canonical_pairs(&self) -> SmallVec<[(Atom, TypeId); 4]> {
+        let mut pairs: SmallVec<[(Atom, TypeId); 4]> = self
+            .map
+            .iter()
+            .map(|(&name, &type_id)| (name, type_id))
+            .collect();
+        // Keys are unique (`FxHashMap`), so sorting by `Atom` alone is
+        // enough to canonicalize. `Atom` is `Ord` (u32 newtype).
+        pairs.sort_unstable_by_key(|(name, _)| *name);
+        pairs
     }
 }
 

--- a/crates/tsz-solver/tests/instantiate_tests.rs
+++ b/crates/tsz-solver/tests/instantiate_tests.rs
@@ -2220,3 +2220,136 @@ fn test_instantiate_homomorphic_mapped_with_any_union_array_constrained() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// PR 1 canonical-form substitution tests
+// ---------------------------------------------------------------------------
+//
+// These cover `TypeSubstitution::canonical_pairs`. PR 1 is pure refactoring —
+// it adds the deterministic, content-hashable form that PR 2 will use as the
+// key seed for `QueryCache::instantiation_cache`. Substitution *interning*
+// intentionally does NOT live on `TypeInterner`; the eventual cache is
+// owned by `QueryCache` so it participates in `clear()` and size accounting
+// (see `docs/plan/perf-instantiate-type-cache-design.md`).
+
+#[test]
+fn test_canonical_equal_subst_same_pairs() {
+    // Two substitutions with the same {name -> type_id} entries inserted in
+    // different orders must canonicalize to the same SmallVec sequence.
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let u_name = interner.intern_string("U");
+
+    let mut a = TypeSubstitution::new();
+    a.insert(t_name, TypeId::NUMBER);
+    a.insert(u_name, TypeId::STRING);
+
+    let mut b = TypeSubstitution::new();
+    b.insert(u_name, TypeId::STRING);
+    b.insert(t_name, TypeId::NUMBER);
+
+    let pairs_a = a.canonical_pairs();
+    let pairs_b = b.canonical_pairs();
+    assert_eq!(
+        pairs_a.as_slice(),
+        pairs_b.as_slice(),
+        "same entries, different insertion order must canonicalize identically",
+    );
+    assert_eq!(pairs_a.len(), 2);
+}
+
+#[test]
+fn test_canonical_distinct_subst_different_pairs() {
+    // {"T" -> number} and {"T" -> string} must produce different canonical pairs.
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+
+    let mut a = TypeSubstitution::new();
+    a.insert(t_name, TypeId::NUMBER);
+
+    let mut b = TypeSubstitution::new();
+    b.insert(t_name, TypeId::STRING);
+
+    assert_ne!(
+        a.canonical_pairs().as_slice(),
+        b.canonical_pairs().as_slice(),
+        "distinct type bindings must have distinct canonical pairs",
+    );
+}
+
+#[test]
+fn test_canonical_empty_is_empty_slice() {
+    // The empty substitution's canonical form is the empty slice. PR 2 will
+    // short-circuit this case on the cache side without allocating; PR 1 just
+    // guarantees the empty input → empty output property.
+    let empty = TypeSubstitution::new();
+    let pairs = empty.canonical_pairs();
+    assert!(
+        pairs.is_empty(),
+        "empty substitution must canonicalize to empty"
+    );
+}
+
+#[test]
+fn test_canonical_stable_across_iter_order() {
+    // Insert three entries in several orderings; all must produce the same
+    // canonical pairs. With three keys the `FxHashMap` iteration order varies
+    // enough to exercise the canonicalization path.
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let u_name = interner.intern_string("U");
+    let v_name = interner.intern_string("V");
+
+    let orderings: &[[(tsz_common::interner::Atom, TypeId); 3]] = &[
+        [
+            (t_name, TypeId::NUMBER),
+            (u_name, TypeId::STRING),
+            (v_name, TypeId::BOOLEAN),
+        ],
+        [
+            (u_name, TypeId::STRING),
+            (t_name, TypeId::NUMBER),
+            (v_name, TypeId::BOOLEAN),
+        ],
+        [
+            (v_name, TypeId::BOOLEAN),
+            (u_name, TypeId::STRING),
+            (t_name, TypeId::NUMBER),
+        ],
+        [
+            (v_name, TypeId::BOOLEAN),
+            (t_name, TypeId::NUMBER),
+            (u_name, TypeId::STRING),
+        ],
+    ];
+
+    let canonical_pairs: Vec<_> = orderings
+        .iter()
+        .map(|entries| {
+            let mut s = TypeSubstitution::new();
+            for &(name, ty) in entries {
+                s.insert(name, ty);
+            }
+            s.canonical_pairs()
+        })
+        .collect();
+
+    // All orderings must produce identical canonical sequences.
+    let first = &canonical_pairs[0];
+    for pairs in &canonical_pairs[1..] {
+        assert_eq!(
+            pairs.as_slice(),
+            first.as_slice(),
+            "insertion order must not change canonical pairs",
+        );
+    }
+
+    // The canonical pairs must themselves be sorted by Atom.
+    let mut sorted = first.clone();
+    sorted.sort_unstable_by_key(|(name, _)| *name);
+    assert_eq!(
+        first.as_slice(),
+        sorted.as_slice(),
+        "canonical pairs must be sorted by Atom",
+    );
+}


### PR DESCRIPTION
## Summary

PR 1 of the `instantiate_type` cross-call cache, per the design doc at `docs/plan/perf-instantiate-type-cache-design.md` (merged as #1007 with revisions). **Pure refactor — no behavior change, no perf impact in isolation.** Lays the foundation for PRs 2–4 which add cache storage on `QueryCache` (PR 2) and wire it into the five entry points (PR 3).

## What this PR adds

- `TypeSubstitution::canonical_pairs(&self) -> SmallVec<[(Atom, TypeId); 4]>` — a deterministic, content-hashable form of the substitution, sorted by `Atom`. Two substitutions with the same `{name → type_id}` entries in different insertion orders produce identical pair sequences.
- 4 unit tests in `crates/tsz-solver/tests/instantiate_tests.rs`:
  - `test_canonical_equal_subst_same_pairs` — insertion order does not matter
  - `test_canonical_distinct_subst_different_pairs` — distinct bindings have distinct canonical pairs
  - `test_canonical_empty_is_empty_slice` — empty subst → empty slice
  - `test_canonical_stable_across_iter_order` — three-entry subst is stable across several insertion orderings and always sorted by `Atom`

## Design correction vs the original PR 1 plan

The original proposal (a `u32 InternedSubstId` backed by a new interner on `TypeInterner`) would have put cache-lifetime state on the permanent-identity store. `TypeInterner` survives `QueryCache::clear()` and is not counted in `QueryCache::estimated_size_bytes()`, so interning there would grow unbounded on large repos. The revised design (in #1007) puts the substitution interner — if needed at all — on `QueryCache`, where it can participate in `clear()` and size accounting.

PR 1 therefore ships only the canonical-pairs primitive. PR 2 will consume it directly as the key seed for `QueryCache::instantiation_cache` without needing a `u32` handle. If profiling later shows the `SmallVec` hash is a hot path, a `QueryCache`-local intern table is the right follow-up.

Existing fast paths (`TypeParameter` direct substitution lookup and `IndexAccess(T, P)` in `instantiate_type`) are untouched; when PR 3 wires cache probing it will go after those fast paths, not before.

## Test plan

- [x] `cargo check -p tsz-solver` — clean
- [x] `cargo clippy -p tsz-solver --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run -p tsz-solver --lib` — 5288 tests pass (incl. the 4 new ones)
- [ ] Full `scripts/session/verify-all.sh` — agent ran cargo check + clippy + nextest cleanly before stalling on the full verify-all in the prior session; CI to verify the rest. Pure refactor — no behavior change expected.