### PR TITLE
fix(scanner): detect git merge conflict markers in JSX children

### DIFF
--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -2382,7 +2382,19 @@ impl ScannerState {
             let c = self.char_code_unchecked(self.pos);
 
             // Stop on JSX special characters
-            if c == CharacterCodes::OPEN_BRACE || c == CharacterCodes::LESS_THAN {
+            if c == CharacterCodes::OPEN_BRACE {
+                break;
+            }
+            if c == CharacterCodes::LESS_THAN {
+                // Git merge conflict markers appearing in JSX children must be
+                // reported as TS1185 rather than mis-parsed as the start of a
+                // new JSX element. Matches tsc's scanJsxToken (see
+                // TypeScript/src/compiler/scanner.ts `scanJsxToken`).
+                if self.is_conflict_marker_trivia() {
+                    self.scan_conflict_marker_trivia();
+                    self.token = SyntaxKind::ConflictMarkerTrivia;
+                    return self.token;
+                }
                 break;
             }
 

--- a/crates/tsz-scanner/tests/scanner_impl_tests.rs
+++ b/crates/tsz-scanner/tests/scanner_impl_tests.rs
@@ -343,6 +343,66 @@ fn re_scan_jsx_token_single_line_text() {
 }
 
 #[test]
+fn scan_jsx_token_reports_merge_conflict_marker_in_children() {
+    // A Git merge conflict marker appearing as a JSX child must be reported
+    // as TS1185 by the JSX scanner, not mis-scanned as the start of a new
+    // JSX element. Regression test for conflictMarkerTrivia3.tsx.
+    let source = "<div>\n<<<<<<< HEAD\n=======\nfoo\n>>>>>>> branch".to_string();
+    let mut scanner = ScannerState::new(source, true);
+
+    assert_eq!(scanner.scan(), SyntaxKind::LessThanToken);
+    assert_eq!(scanner.scan(), SyntaxKind::Identifier); // div
+    assert_eq!(scanner.scan(), SyntaxKind::GreaterThanToken);
+
+    // Re-scan as JSX — must return ConflictMarkerTrivia with token start at
+    // the trivia (newline) right after the `>`, matching tsc's scanJsxToken.
+    let full_start_before_rescan = scanner.get_token_full_start();
+    let token = scanner.re_scan_jsx_token(true);
+    assert_eq!(token, SyntaxKind::ConflictMarkerTrivia);
+    assert_eq!(
+        scanner.get_token_start(),
+        full_start_before_rescan,
+        "ConflictMarkerTrivia token must start at full_start_pos (end of `>`), \
+         so the parser anchors TS1005 `'</' expected.` there"
+    );
+
+    let marker_diag = scanner
+        .get_scanner_diagnostics()
+        .iter()
+        .find(|d| d.code == 1185)
+        .expect("expected TS1185 `Merge conflict marker encountered.`");
+    assert_eq!(
+        marker_diag.pos, 6,
+        "TS1185 must anchor at the `<` of the `<<<<<<<` marker, not at the \
+         prior `\\n` trivia"
+    );
+}
+
+#[test]
+fn scan_jsx_token_non_start_of_line_less_than_is_not_conflict_marker() {
+    // `<<<<<<<` not at start of a line is ordinary content (a `<` in JSX text
+    // breaks the text; no TS1185 should be emitted). Guards against broadening
+    // the fix into false positives on normal JSX content.
+    let source = ">abc<<<<<<<< HEAD".to_string();
+    let mut scanner = ScannerState::new(source, true);
+
+    scanner.scan(); // >
+    scanner.scan(); // abc identifier
+
+    // Rescan as JSX text — the `<` stops the text, the marker is not at line
+    // start so it's NOT detected as a conflict marker.
+    let token = scanner.re_scan_jsx_token(true);
+    assert_eq!(token, SyntaxKind::JsxText);
+    assert!(
+        scanner
+            .get_scanner_diagnostics()
+            .iter()
+            .all(|d| d.code != 1185),
+        "no TS1185 should be emitted when `<<<<<<<` is not at start of line"
+    );
+}
+
+#[test]
 fn test_template_rescan_invalid_hex_escape() {
     use tsz_scanner::SyntaxKind;
     use tsz_scanner::scanner_impl::{ScannerState, TokenFlags};


### PR DESCRIPTION
## Summary

Detect Git merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`, `|||||||`) appearing as JSX children and report them as TS1185 instead of mis-parsing them as the start of a new JSX element. Matches `tsc`.

## Root cause

`scan_jsx_token` (`crates/tsz-scanner/src/scanner_impl.rs`) broke its text-scan loop on `<` without first checking `is_conflict_marker_trivia`. The main scanner already handles conflict markers at every relevant entry point (`<`, `>`, `=`, `|`), but the dedicated JSX-mode path did not — and `parse_jsx_children` uses that path for element children. So a `<<<<<<<` line inside `<div>` children was consumed as `LessThanToken` + `LessThanToken` + …, cascading into TS1003 / TS1139 / TS17008 / spurious TS1005 instead of the expected single TS1185 + TS1005 pair.

## Fix

In `scan_jsx_token`, when the text-scan loop encounters `<`, call `is_conflict_marker_trivia` before breaking. On hit: advance past the marker (emitting TS1185), return `ConflictMarkerTrivia`. This mirrors tsc's `scanJsxToken` at `TypeScript/src/compiler/scanner.ts:3728`. The token's `token_start` stays at `full_start_pos`, so the parser anchors its resulting TS1005 `'</' expected.` at the end of the opening element — matching tsc's column.

```ts
// @target: es2015
const x = <div>
<<<<<<< HEAD
```

Before (tsz):
```
TS1003 Identifier expected.                               (2:2)
TS1005 '</' expected.                                     (2:13)
TS1005 '>' expected.                                      (2:13)
TS1139 Type parameter declaration expected.               (2:6)
TS17008 JSX element 'div' has no corresponding closing tag. (1:12)
```

After (matches tsc):
```
TS1005 '</' expected.                                     (1:16)
TS1185 Merge conflict marker encountered.                 (2:1)
```

## Test plan

- [x] New scanner unit tests lock in the invariant:
  - `scan_jsx_token_reports_merge_conflict_marker_in_children`
  - `scan_jsx_token_non_start_of_line_less_than_is_not_conflict_marker`
- [x] 875/875 scanner + parser unit tests pass (`cargo nextest run -p tsz-scanner -p tsz-parser`)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check -p tsz-scanner --target wasm32-unknown-unknown --lib` — clean (RUSTFLAGS=-D warnings)
- [x] Architecture guardrails — passed via pre-commit hook
- [x] `./scripts/conformance/conformance.sh run --filter conflictMarkerTrivia3` — PASS (was FAIL)
- [x] `./scripts/conformance/conformance.sh run --filter conflictMarkerTrivia` — 3/4 pass; the remaining `conflictMarkerTrivia4.ts` is fingerprint-only (error codes match; `TS1109` position off by one line) and was already fingerprint-only before this change — independent of this fix.
- [x] JSX lane vs baseline: 0 regressions, +5 improvements.
- [x] 500-sample conformance smoke run: 496/500, no regressions vs baseline.

## Notes on verification environment

`scripts/session/verify-all.sh`'s unit-tests phase was killed by `scripts/safe-run.sh` (memory guard tripped at 19 GB / 16 GB limit on the 21 GB sandbox) — an environmental limit, not a test failure. The crates touched here are verified directly via `cargo nextest run -p tsz-scanner -p tsz-parser` (875/875 pass) and the conformance sample above.