### PR TITLE
fix(conformance): TS2411 overload rendering + TS2322 number-index optional

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -12,6 +12,9 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// A JSDoc template parameter: `(name, has_default, constraint_expr)`.
+type JsDocTemplateParam = (String, bool, Option<String>);
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_jsdoc_extends_tag_type_arguments(&mut self, class_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -195,11 +198,8 @@ impl<'a> CheckerState<'a> {
         let (Some(arg_shape), Some(constraint_shape)) = (arg_shape, constraint_shape) else {
             return false;
         };
-        let arg_props: rustc_hash::FxHashMap<_, _> = arg_shape
-            .properties
-            .iter()
-            .map(|p| (p.name, p))
-            .collect();
+        let arg_props: rustc_hash::FxHashMap<_, _> =
+            arg_shape.properties.iter().map(|p| (p.name, p)).collect();
         for constraint_prop in &constraint_shape.properties {
             let Some(arg_prop) = arg_props.get(&constraint_prop.name) else {
                 if !constraint_prop.optional {
@@ -307,7 +307,7 @@ impl<'a> CheckerState<'a> {
     fn resolve_jsdoc_extends_target_template_params(
         &mut self,
         base_name: &str,
-    ) -> Option<Vec<(String, bool, Option<String>)>> {
+    ) -> Option<Vec<JsDocTemplateParam>> {
         use tsz_binder::symbol_flags;
 
         let sym_id = self.ctx.binder.file_locals.get(base_name).or_else(|| {
@@ -356,10 +356,8 @@ impl<'a> CheckerState<'a> {
     /// comment. Supports the `{Constraint}` prefix with balanced-brace
     /// matching so object-literal constraints (`{Foo: {...}}`) are captured
     /// intact. Names sharing a line share the constraint.
-    fn parse_jsdoc_template_params_with_constraints(
-        jsdoc: &str,
-    ) -> Vec<(String, bool, Option<String>)> {
-        let mut out: Vec<(String, bool, Option<String>)> = Vec::new();
+    fn parse_jsdoc_template_params_with_constraints(jsdoc: &str) -> Vec<JsDocTemplateParam> {
+        let mut out: Vec<JsDocTemplateParam> = Vec::new();
         for line in jsdoc.lines() {
             let trimmed = line.trim().trim_start_matches('*').trim();
             let Some(rest) = trimmed.strip_prefix("@template") else {
@@ -527,12 +525,11 @@ impl<'a> CheckerState<'a> {
                 }
 
                 let rest_offset = rest.as_ptr() as usize - comment_text.as_ptr() as usize;
-                if rest.starts_with('{') {
+                if let Some(inner) = rest.strip_prefix('{') {
                     // Walk brace-balanced so nested `{...}` inside the
                     // annotation (e.g. `@extends {A<{x:number}>}`) are kept
                     // intact. The previous `rest.find('}')` truncated at the
                     // inner closing `}` and silently dropped the remainder.
-                    let inner = &rest[1..];
                     let mut depth = 1usize;
                     let mut close = None;
                     for (idx, ch) in inner.char_indices() {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -758,95 +758,96 @@ impl<'a> CheckerState<'a> {
 
             // Extract property name, name node index, property type, and
             // whether this member is static.
-            let (prop_name, name_idx, prop_type, is_static_member) =
-                if member_node.kind == syntax_kind_ext::PROPERTY_SIGNATURE {
-                    let Some(sig) = self.ctx.arena.get_signature(member_node) else {
-                        continue;
-                    };
-                    let name = self.get_member_name_text(sig.name).unwrap_or_default();
-                    let prop_type = if sig.type_annotation.is_some() {
-                        self.get_type_from_type_node(sig.type_annotation)
-                    } else {
-                        self.get_type_of_node(member_idx)
-                    };
-                    (name, sig.name, prop_type, false)
-                } else if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
-                    let Some(sig) = self.ctx.arena.get_signature(member_node) else {
-                        continue;
-                    };
-                    let name = self.get_member_name_text(sig.name).unwrap_or_default();
-                    let prop_type = self.get_type_of_interface_member_simple(member_idx);
-                    (name, sig.name, prop_type, false)
-                } else if member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
-                    let Some(prop) = self.ctx.arena.get_property_decl(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&prop.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(prop.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(prop.name).unwrap_or_default();
-                    let prop_type = if let Some(declared_type) =
-                        self.effective_class_property_declared_type(member_idx, prop)
-                    {
-                        declared_type
-                    } else {
-                        self.get_type_of_node(member_idx)
-                    };
-                    (name, prop.name, prop_type, is_static)
-                } else if member_node.kind == syntax_kind_ext::METHOD_DECLARATION {
-                    let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&method.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(method.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(method.name).unwrap_or_default();
-                    let prop_type = self.get_type_of_function(member_idx);
-                    (name, method.name, prop_type, is_static)
-                } else if member_node.kind == syntax_kind_ext::GET_ACCESSOR
-                    || member_node.kind == syntax_kind_ext::SET_ACCESSOR
-                {
-                    let Some(accessor) = self.ctx.arena.get_accessor(member_node) else {
-                        continue;
-                    };
-                    let is_static = self.has_static_modifier(&accessor.modifiers);
-                    if let Some(name_node) = self.ctx.arena.get(accessor.name)
-                        && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
-                    {
-                        continue;
-                    }
-                    let name = self.get_member_name_text(accessor.name).unwrap_or_default();
-                    let prop_type = if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
-                        if accessor.type_annotation.is_some() {
-                            self.get_type_from_type_node(accessor.type_annotation)
-                        } else {
-                            self.infer_getter_return_type(accessor.body)
-                        }
-                    } else {
-                        let type_ann = accessor
-                            .parameters
-                            .nodes
-                            .first()
-                            .and_then(|&param_idx| self.ctx.arena.get(param_idx))
-                            .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
-                            .map(|param| param.type_annotation)
-                            .unwrap_or(NodeIndex::NONE);
-                        if type_ann.is_some() {
-                            self.get_type_from_type_node(type_ann)
-                        } else {
-                            self.get_type_of_node(member_idx)
-                        }
-                    };
-                    (name, accessor.name, prop_type, is_static)
-                } else {
+            let (prop_name, name_idx, prop_type, is_static_member) = if member_node.kind
+                == syntax_kind_ext::PROPERTY_SIGNATURE
+            {
+                let Some(sig) = self.ctx.arena.get_signature(member_node) else {
                     continue;
                 };
+                let name = self.get_member_name_text(sig.name).unwrap_or_default();
+                let prop_type = if sig.type_annotation.is_some() {
+                    self.get_type_from_type_node(sig.type_annotation)
+                } else {
+                    self.get_type_of_node(member_idx)
+                };
+                (name, sig.name, prop_type, false)
+            } else if member_node.kind == syntax_kind_ext::METHOD_SIGNATURE {
+                let Some(sig) = self.ctx.arena.get_signature(member_node) else {
+                    continue;
+                };
+                let name = self.get_member_name_text(sig.name).unwrap_or_default();
+                let prop_type = self.merged_method_signature_type(iface_type, &name, member_idx);
+                (name, sig.name, prop_type, false)
+            } else if member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
+                let Some(prop) = self.ctx.arena.get_property_decl(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&prop.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(prop.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(prop.name).unwrap_or_default();
+                let prop_type = if let Some(declared_type) =
+                    self.effective_class_property_declared_type(member_idx, prop)
+                {
+                    declared_type
+                } else {
+                    self.get_type_of_node(member_idx)
+                };
+                (name, prop.name, prop_type, is_static)
+            } else if member_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                let Some(method) = self.ctx.arena.get_method_decl(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&method.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(method.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(method.name).unwrap_or_default();
+                let prop_type = self.get_type_of_function(member_idx);
+                (name, method.name, prop_type, is_static)
+            } else if member_node.kind == syntax_kind_ext::GET_ACCESSOR
+                || member_node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                let Some(accessor) = self.ctx.arena.get_accessor(member_node) else {
+                    continue;
+                };
+                let is_static = self.has_static_modifier(&accessor.modifiers);
+                if let Some(name_node) = self.ctx.arena.get(accessor.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::PrivateIdentifier as u16
+                {
+                    continue;
+                }
+                let name = self.get_member_name_text(accessor.name).unwrap_or_default();
+                let prop_type = if member_node.kind == syntax_kind_ext::GET_ACCESSOR {
+                    if accessor.type_annotation.is_some() {
+                        self.get_type_from_type_node(accessor.type_annotation)
+                    } else {
+                        self.infer_getter_return_type(accessor.body)
+                    }
+                } else {
+                    let type_ann = accessor
+                        .parameters
+                        .nodes
+                        .first()
+                        .and_then(|&param_idx| self.ctx.arena.get(param_idx))
+                        .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                        .map(|param| param.type_annotation)
+                        .unwrap_or(NodeIndex::NONE);
+                    if type_ann.is_some() {
+                        self.get_type_from_type_node(type_ann)
+                    } else {
+                        self.get_type_of_node(member_idx)
+                    }
+                };
+                (name, accessor.name, prop_type, is_static)
+            } else {
+                continue;
+            };
 
             // Symbol-keyed properties are NOT checked against string or number
             // index signatures, but they ARE checked against symbol index

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1741,6 +1741,26 @@ impl<'a> CheckerState<'a> {
         TypeId::ANY
     }
 
+    /// Prefer the merged method type (with all overloads) from `iface_type`
+    /// over the single-node `get_type_of_interface_member_simple` result.
+    ///
+    /// For `interface I { bar(): any; bar(): any; [s: string]: number; }`
+    /// this returns the Callable `{ (): any; (): any; }` that tsc displays
+    /// in TS2411, instead of just `() => any` from the first signature.
+    pub(crate) fn merged_method_signature_type(
+        &mut self,
+        iface_type: TypeId,
+        name: &str,
+        member_idx: NodeIndex,
+    ) -> TypeId {
+        if let tsz_solver::operations::property::PropertyAccessResult::Success { type_id, .. } =
+            self.resolve_property_access_with_env(iface_type, name)
+        {
+            return type_id;
+        }
+        self.get_type_of_interface_member_simple(member_idx)
+    }
+
     /// Get the type of an interface member.
     ///
     /// Returns an object type containing the member. For method signatures,

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -4120,6 +4120,52 @@ function foo<T, U>(x: T) {
 }
 
 #[test]
+fn ts2322_optional_property_vs_number_index_preserves_implicit_undefined() {
+    // tsc: `{ 1?: string }` assigned to `{ [k: number]: string }` must error
+    // because the optional `1` contributes `string | undefined` to the check
+    // against the number index value type `string`. Regression test for
+    // `optionalPropertyAssignableToStringIndexSignature.ts`.
+    let source = r#"
+declare let probablyArray: { [key: number]: string };
+declare let numberLiteralKeys: { 1?: string };
+probablyArray = numberLiteralKeys;
+"#;
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let diagnostics = with_lib_contexts(source, "test.ts", options);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for optional numeric property vs number index, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts2322_optional_string_property_vs_string_index_still_ok() {
+    // Regression guard: tsc allows `{ k1?: string }` assigned to
+    // `{ [k: string]: string }` because the string index strips the implicit
+    // `| undefined` contributed by the optional flag.
+    let source = r#"
+declare let optionalProperties: { k1?: string };
+let stringDictionary: { [key: string]: string } = optionalProperties;
+"#;
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let diagnostics = with_lib_contexts(source, "test.ts", options);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected no TS2322 for `{{ k1?: string }}` vs string index, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn exact_optional_property_write_uses_ts2412() {
     let source = r#"
 interface U2 {

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -227,3 +227,28 @@ var x: { z: I; [s: string]: { x: any; y: any; } };
 // Note: Inherited member vs index signature is tested via conformance tests
 // (e.g. inheritedMembersAndIndexSignaturesFromDifferentBases.ts) since it
 // requires full lib type resolution that unit tests don't provide.
+
+#[test]
+fn test_ts2411_method_overload_displays_merged_signatures() {
+    // When an interface method has multiple overload signatures, the TS2411
+    // message must render the property's type as `{ (): any; (): any; }`
+    // (matching tsc) instead of just the first signature's `() => any`.
+    // Regression test for interfaceMemberValidation.ts.
+    let source = r#"
+interface foo {
+    bar(): any;
+    bar(): any;
+    [s: string]: number;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for `bar` overloads vs string index");
+    assert!(
+        ts2411.1.contains("{ (): any; (): any; }"),
+        "TS2411 must render merged overload type as `{{ (): any; (): any; }}`, got: {}",
+        ts2411.1
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -798,12 +798,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
                     // Note: tsc does NOT reject readonly properties against writable
                     // number index targets during assignability checks.
-                    // Strip undefined from optional property types (same as string index).
-                    let raw_prop_type = if prop.optional {
-                        crate::narrowing::utils::remove_undefined(self.interner, prop.type_id)
-                    } else {
-                        prop.type_id
-                    };
+                    // For NUMBER index signatures, optional properties carry an implicit
+                    // `| undefined` that must flow into the check (tsc: `{ 1?: string }`
+                    // vs `{ [k: number]: string }` fails on `string | undefined <: string`).
+                    let raw_prop_type = self.optional_property_type(prop);
                     let prop_type =
                         self.bind_property_receiver_this(source_receiver, raw_prop_type);
                     let target_value =
@@ -1125,15 +1123,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 continue;
             }
 
-            // Strip `undefined` from optional property types when checking against
-            // index signatures. In tsc, optional properties are compatible with index
-            // signatures that don't include `undefined`.
-            let raw_prop_type = if prop.optional {
+            // For NUMBER index signatures, optional properties carry an implicit
+            // `| undefined` that must flow into the check (e.g. `{ 1?: string }`
+            // vs `{ [k: number]: string }` fails on `string | undefined <: string`).
+            // For STRING index signatures, tsc strips the implicit `| undefined`
+            // so `{ b?: number }` is assignable to `{ [k: string]: number }`.
+            let string_prop_type = if prop.optional {
                 crate::narrowing::utils::remove_undefined(self.interner, prop.type_id)
             } else {
                 prop.type_id
             };
-            let prop_type = self.bind_property_receiver_this(source_receiver, raw_prop_type);
+            let string_prop_type =
+                self.bind_property_receiver_this(source_receiver, string_prop_type);
+            let number_prop_type = if prop.optional {
+                self.bind_property_receiver_this(source_receiver, self.optional_property_type(prop))
+            } else {
+                string_prop_type
+            };
             let allow_bivariant = prop.is_method;
 
             if let Some(number_idx) = number_index {
@@ -1143,7 +1149,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 if is_numeric
                     && !self
                         .check_subtype_with_method_variance(
-                            prop_type,
+                            number_prop_type,
                             target_value,
                             allow_bivariant,
                         )
@@ -1165,7 +1171,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let target_value =
                     self.bind_property_receiver_this(target_receiver, string_idx.value_type);
                 if !self
-                    .check_subtype_with_method_variance(prop_type, target_value, allow_bivariant)
+                    .check_subtype_with_method_variance(
+                        string_prop_type,
+                        target_value,
+                        allow_bivariant,
+                    )
                     .is_true()
                 {
                     return SubtypeResult::False;

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -6354,8 +6354,15 @@ fn test_infer_generic_number_index_from_optional_property() {
     )]);
 
     let result = infer_generic_function(&interner, &mut subtype, &func, &[object_literal]);
-    // In tsc, optional properties do not contribute `undefined` to index signature inference.
-    assert_eq!(result, TypeId::NUMBER);
+    // tsc inference infers T = number from the optional property, but the
+    // overall assignment `{ 0?: number }` → `{ [k: number]: T }` errors
+    // because NUMBER index signatures preserve the implicit `| undefined`
+    // contributed by the optional flag and `number | undefined` is not
+    // assignable to `number`. `infer_generic_function` returns ERROR when
+    // the call fails its final assignability check (matching tsc's TS2322
+    // emission on this case — see
+    // `optionalPropertyAssignableToStringIndexSignature.ts`).
+    assert_eq!(result, TypeId::ERROR);
 }
 
 #[test]
@@ -6824,9 +6831,13 @@ fn test_infer_generic_index_signatures_from_optional_mixed_properties() {
     ]);
 
     let result = infer_generic_function(&interner, &mut subtype, &func, &[object_literal]);
-    // Index signature candidates use union semantics: T and U get unions of all
-    // matching property types, so the call succeeds (no assignability failure).
-    assert_ne!(result, TypeId::ERROR);
+    // Inference picks up T from the numeric-named prop and U from the string
+    // index, but the overall call fails its final assignability check because
+    // the optional numeric property `0?: string` contributes `string | undefined`
+    // to the NUMBER-index compatibility check and is not assignable to the
+    // inferred `T = string`. Matches tsc's TS2322 on the `probablyArray =
+    // numberLiteralKeys` case in optionalPropertyAssignableToStringIndexSignature.
+    assert_eq!(result, TypeId::ERROR);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two independent conformance fixes from a solver/checker session:

- **TS2411 — render overloaded method type via merged interface.** The index-signature compat check was reporting the first overload's Function type instead of tsc's merged `{ (): any; (): any; }` display. Route the lookup through a new `merged_method_signature_type` helper that asks the containing interface for the merged Callable, falling back to per-node when unresolvable. Fixes `interfaceMemberValidation.ts`. (Drive-by: introduces `JsDocTemplateParam` alias in `jsdoc_heritage.rs` to appease clippy.)
- **TS2322 — preserve implicit `| undefined` for optional props vs NUMBER index.** tsc is asymmetric: STRING index strips the implicit undefined from optional props, NUMBER index preserves it. tsz was stripping symmetrically via `remove_undefined`, masking the NUMBER-index error. In `objects.rs`, `check_properties_against_index_signatures` and `check_number_index_compatibility` now use `optional_property_type(prop)` on the NUMBER side (STRING side unchanged). Fixes the `probablyArray = numberLiteralKeys` case in `optionalPropertyAssignableToStringIndexSignature.ts`. Two solver operation tests that asserted the pre-fix behavior are updated to expect `TypeId::ERROR`, matching tsc.

The second fingerprint in `optionalPropertyAssignableToStringIndexSignature.ts` (`{ k1?: undefined }` assigned directly to `{ [k: string]: string }`) needs implicit-vs-explicit undefined tracking on `PropertyInfo` and is left for a follow-up to keep this PR regression-free.

## Test plan

- [ ] `ts2322_tests` pass (covers `optionalPropertyAssignableToStringIndexSignature.ts` number-index case)
- [ ] `ts2411_tests` pass (covers `interfaceMemberValidation.ts`)
- [ ] `operations_tests` pass with updated assertions
- [ ] No regressions in broader conformance suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)