### PR TITLE
fix(checker): emit TS1003/TS8023/TS2339 for empty JSDoc @augments tag (+16 conformance)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -344,6 +344,10 @@ name = "cross_module_nested_interface_tests"
 path = "tests/cross_module_nested_interface_tests.rs"
 
 [[test]]
+name = "jsdoc_augments_empty_tests"
+path = "tests/jsdoc_augments_empty_tests.rs"
+
+[[test]]
 name = "jsdoc_extends_constraint_tests"
 path = "tests/jsdoc_extends_constraint_tests.rs"
 

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1516,7 +1516,28 @@ impl<'a> CheckerState<'a> {
                 };
 
                 if jsdoc_type_name.is_empty() {
-                    continue;
+                    // Empty @extends/@augments tag (e.g. `/** @augments */`):
+                    // emit TS1003 + TS8023 at the position right after the tag keyword.
+                    let error_pos = comment.pos + after as u32;
+
+                    self.ctx.error(
+                        error_pos,
+                        1,
+                        diagnostic_messages::IDENTIFIER_EXPECTED.to_string(),
+                        diagnostic_codes::IDENTIFIER_EXPECTED,
+                    );
+
+                    let message = format_message(
+                        diagnostic_messages::JSDOC_DOES_NOT_MATCH_THE_EXTENDS_CLAUSE,
+                        &[tag, "", &actual_name],
+                    );
+                    self.ctx.error(
+                        error_pos,
+                        1,
+                        message,
+                        diagnostic_codes::JSDOC_DOES_NOT_MATCH_THE_EXTENDS_CLAUSE,
+                    );
+                    return;
                 }
 
                 // Strip type arguments: "Foo<Bar>" → "Foo"

--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -605,6 +605,59 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Returns `true` when the class has a JSDoc `@augments`/`@extends` tag
+    /// whose type argument is empty (e.g. `/** @augments */`).  tsc treats
+    /// such a tag as an invalid override of the structural `extends` clause,
+    /// which prevents base-class property merging.
+    pub(crate) fn has_empty_jsdoc_augments_tag(&self, class_idx: NodeIndex) -> bool {
+        let sf = match self.ctx.arena.source_files.first() {
+            Some(sf) => sf,
+            None => return false,
+        };
+        let source_text: &str = &sf.text;
+        let comments = &sf.comments;
+        let node = match self.ctx.arena.get(class_idx) {
+            Some(n) => n,
+            None => return false,
+        };
+
+        use tsz_common::comments::{get_leading_comments_from_cache, is_jsdoc_comment};
+        let leading = get_leading_comments_from_cache(comments, node.pos, source_text);
+        let comment = match leading.last() {
+            Some(c) => c,
+            None => return false,
+        };
+        if !is_jsdoc_comment(comment, source_text) {
+            return false;
+        }
+
+        let comment_text = comment.get_text(source_text);
+        for tag in ["augments", "extends"] {
+            let needle = format!("@{tag}");
+            for (match_pos, _) in comment_text.match_indices(&needle) {
+                let after = match_pos + needle.len();
+                if after >= comment_text.len() {
+                    return true;
+                }
+                let next_ch = comment_text[after..]
+                    .chars()
+                    .next()
+                    .expect("after < len checked above");
+                if next_ch.is_ascii_alphanumeric() {
+                    continue;
+                }
+                if self
+                    .attached_jsdoc_extends_or_augments_tag(class_idx)
+                    .is_none()
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+        false
+    }
+
     fn type_params_for_jsdoc_extends_name(
         &mut self,
         base_name: &str,

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -1478,8 +1478,12 @@ impl<'a> CheckerState<'a> {
             });
         }
 
-        // Merge base class instance properties (derived members take precedence)
-        if let Some(ref heritage_clauses) = class.heritage_clauses {
+        // Merge base class instance properties (derived members take precedence).
+        // In JS files, an empty @augments/@extends tag overrides the structural
+        // extends clause — tsc does not merge base-class properties in that case.
+        let skip_heritage_merge =
+            self.ctx.is_js_file() && self.has_empty_jsdoc_augments_tag(class_idx);
+        if !skip_heritage_merge && let Some(ref heritage_clauses) = class.heritage_clauses {
             for &clause_idx in &heritage_clauses.nodes {
                 let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
                     continue;

--- a/crates/tsz-checker/tests/jsdoc_augments_empty_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_augments_empty_tests.rs
@@ -1,0 +1,101 @@
+use tsz_checker::context::CheckerOptions;
+
+fn check_js_with_jsdoc(source: &str) -> Vec<(u32, String)> {
+    let mut parser = tsz_parser::parser::ParserState::new("a.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = tsz_solver::TypeInterner::new();
+    let options = CheckerOptions {
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    let mut checker = tsz_checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "a.js".to_string(),
+        options,
+    );
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+#[test]
+fn empty_augments_emits_ts1003_and_ts8023() {
+    let source = r#"
+class A { constructor() { this.x = 0; } }
+/** @augments */
+class B extends A {
+    m() {
+        this.x
+    }
+}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let codes: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(codes.contains(&1003), "expected TS1003, got {codes:?}");
+    assert!(codes.contains(&8023), "expected TS8023, got {codes:?}");
+}
+
+#[test]
+fn empty_augments_prevents_base_property_merge() {
+    let source = r#"
+class A { constructor() { this.x = 0; } }
+/** @augments */
+class B extends A {
+    m() {
+        this.x
+    }
+}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let codes: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        codes.contains(&2339),
+        "expected TS2339 for this.x on B with empty @augments, got {codes:?}"
+    );
+}
+
+#[test]
+fn valid_augments_allows_base_property_access() {
+    let source = r#"
+class A { constructor() { this.x = 0; } }
+/** @augments {A} */
+class B extends A {
+    m() {
+        this.x
+    }
+}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let codes: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        !codes.contains(&2339),
+        "should NOT emit TS2339 when @augments is valid, got {codes:?}"
+    );
+}
+
+#[test]
+fn no_augments_allows_base_property_access() {
+    let source = r#"
+class A { constructor() { this.x = 0; } }
+class B extends A {
+    m() {
+        this.x
+    }
+}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let codes: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        !codes.contains(&2339),
+        "should NOT emit TS2339 when no @augments tag, got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Emit TS1003 ("Identifier expected") and TS8023 ("JSDoc '@augments ' does not match the 'extends A' clause") when `@augments`/`@extends` has no type argument
- Skip base-class property merging in JS files when an empty `@augments`/`@extends` tag is present, causing TS2339 for inherited property access (matching tsc behavior)
- Net +16 conformance tests passing, 0 real regressions

## Root cause

When a JS class has `/** @augments */` (empty tag), two things were wrong:

1. **Diagnostics**: `check_jsdoc_extends_name_mismatch` silently skipped the empty-name case with `continue` instead of emitting TS1003 + TS8023
2. **Type construction**: `get_class_instance_type_inner` unconditionally merged base-class constructor-assigned properties regardless of JSDoc validity — tsc treats an empty `@augments` tag as an invalid override that prevents inheritance

```ts
// @allowJs: true
// @checkJs: true
// @Filename: /a.js
class A { constructor() { this.x = 0; } }
/** @augments */
class B extends A {
    m() {
        this.x // TS2339: Property 'x' does not exist on type 'B'.
    }
}
// Also: TS1003 + TS8023 on the @augments tag
```

## Changes

- `core.rs`: Emit TS1003 + TS8023 when JSDoc `@augments`/`@extends` type argument is empty
- `jsdoc_heritage.rs`: Add `has_empty_jsdoc_augments_tag()` helper
- `class_type/core.rs`: Skip heritage property merging in JS files when empty tag detected
- 4 unit tests covering empty tag, valid tag, and no-tag cases

## Test plan

- [x] `jsdocAugmentsMissingType` conformance test passes (was all-missing)
- [x] All 7 `jsdocAugments*` conformance tests pass
- [x] 200-test quick regression check: 200/200 pass
- [x] Full conformance: 12112/12582 (96.3%), net +16
- [x] 2704 checker unit tests pass
- [x] 4 new unit tests pass
- [x] Pre-existing regression (`generatorYieldContextualType`) confirmed unrelated

https://claude.ai/code/session_01LGZ5hJXjPTBSc2MjsxXRwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGZ5hJXjPTBSc2MjsxXRwX)_