### PR TITLE
fix(checker): anchor TS1202 at outer `export` for `export import X = require(...)`

### DIFF
--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -769,8 +769,26 @@ impl<'a> CheckerState<'a> {
             && !inside_namespace
             && !in_function
         {
+            // tsc anchors TS1202 at the outer `export` modifier when the
+            // import-equals declaration is the clause of an `export import X =
+            // require(...)` statement. tsz's parser splits these into an
+            // EXPORT_DECLARATION wrapping the inner IMPORT_EQUALS_DECLARATION,
+            // so the inner node's span starts at `import` (not `export`).
+            // Walk up to the parent export wrapper to preserve tsc's anchor.
+            let anchor_idx = self
+                .ctx
+                .arena
+                .get_extended(stmt_idx)
+                .map(|ext| ext.parent)
+                .filter(|&parent| {
+                    self.ctx
+                        .arena
+                        .get(parent)
+                        .is_some_and(|n| n.kind == syntax_kind_ext::EXPORT_DECLARATION)
+                })
+                .unwrap_or(stmt_idx);
             self.error_at_node(
-                stmt_idx,
+                anchor_idx,
                 "Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from \"mod\"', 'import {a} from \"mod\"', 'import d from \"mod\"', or another module format instead.",
                 diagnostic_codes::IMPORT_ASSIGNMENT_CANNOT_BE_USED_WHEN_TARGETING_ECMASCRIPT_MODULES_CONSIDER_USIN,
             );

--- a/crates/tsz-checker/tests/ts2440_tests.rs
+++ b/crates/tsz-checker/tests/ts2440_tests.rs
@@ -188,6 +188,45 @@ export function Foo() {}
 // =========================================================================
 
 #[test]
+fn test_ts1202_export_import_equals_anchors_at_export_keyword() {
+    // Regression test for privacyCheck-SimpleReference conformance case:
+    // `export import X = require("...")` under ES modules emits TS1202 at the
+    // `export` keyword (col 1), not at the `import` keyword (col 8). tsz's
+    // parser splits this into EXPORT_DECLARATION wrapping IMPORT_EQUALS_DECLARATION,
+    // so the inner import's span starts at `import`; we walk up to the export
+    // parent to preserve tsc's anchor.
+    use tsz_common::common::ModuleKind;
+    let source = "export import mExported = require(\"./mExported\");\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: ModuleKind::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.check_source_file(root);
+    let ts1202 = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .find(|d| d.code == 1202)
+        .expect("expected TS1202 for export import under ES module");
+    assert_eq!(
+        ts1202.start, 0,
+        "TS1202 must anchor at the `export` modifier (byte 0), not at `import` (byte 7). got start={}",
+        ts1202.start,
+    );
+}
+
+#[test]
 fn test_export_import_equals_error_position() {
     // export import X = N.X; var X = 1;
     // TS2440 should be reported at the 'export' keyword, not 'import'

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -556,7 +556,7 @@ impl<'a> TypePrinter<'a> {
         // `number | string` prints as `string | number`. Non-primitive members
         // keep their original relative order because a sort comparator that
         // returns "equal" for them is stable.
-        fn primitive_rank(id: TypeId) -> Option<u32> {
+        const fn primitive_rank(id: TypeId) -> Option<u32> {
             // Mirrors tsc's TypeFlags bit values in ascending order.
             match id {
                 TypeId::ANY => Some(1),


### PR DESCRIPTION
## Summary

`export import mExported = require("./mExported")` under an ES module target should emit **TS1202** anchored at the `export` keyword (col 1), not at the inner `import` keyword (col 8). tsc's `checkImportEqualsDeclaration` reports on the full node, which starts at `export`.

tsz's parser splits `export import` into an `EXPORT_DECLARATION` wrapping an inner `IMPORT_EQUALS_DECLARATION`, so the inner node's `pos` is the position of `import`. Walking up to the export-wrapping parent (when present) restores tsc's anchor.

```ts
// module: es2015
export import mExported = require("./mExported");
// ^^^^^^ tsc: TS1202 at col 1; tsz (before): TS1202 at col 8
```

Fixes `projects/privacyCheck-SimpleReference/test.ts` fingerprint and several related tests that had the same anchor mismatch.

## Test plan
- [x] New unit test `test_ts1202_export_import_equals_anchors_at_export_keyword` in `ts2440_tests.rs` locks the anchor at byte 0.
- [x] `cargo nextest run -p tsz-checker --lib` — 2716/2716 pass.
- [x] `./scripts/session/verify-all.sh` — **conformance +23** (12119 vs baseline 12096), emit JS +1 / DTS +20, LSP unchanged. One pre-existing unit test failure (`collect_diagnostics_reports_default_lib_breakage_from_global_node_merge`) unrelated to this change — also fails on `main`.