### PR TITLE
fix(solver): pad missing trailing type args with parameter defaults in display

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -1031,39 +1031,65 @@ impl<'a> TypeFormatter<'a> {
                     base_str.as_ref(),
                     "Iterable" | "IterableIterator" | "AsyncIterable" | "AsyncIterableIterator"
                 );
-                let def_type_params: Option<Vec<TypeParamInfo>> = if !should_elide_defaults {
-                    None
-                } else if let Some(TypeData::Lazy(def_id)) = base_key {
-                    self.def_store.and_then(|ds| ds.get_type_params(def_id))
-                } else if let Some(def_store) = self.def_store {
-                    def_store
-                        .find_def_for_type(app.base)
-                        .and_then(|id| def_store.get_type_params(id))
+                // Load the base's declared type parameters. We need them in two
+                // situations:
+                //   1) `should_elide_defaults` — trim trailing args that equal
+                //      their parameter defaults (for the 4 iterable globals).
+                //   2) `app.args.len() < params.len()` — pad missing trailing
+                //      args with their parameter defaults so tsc-style output
+                //      shows all args (e.g. `Iterator<string>` renders as
+                //      `Iterator<string, any, any>` when `TReturn = TNext = any`).
+                let def_type_params: Option<Vec<TypeParamInfo>> =
+                    if let Some(TypeData::Lazy(def_id)) = base_key {
+                        self.def_store.and_then(|ds| ds.get_type_params(def_id))
+                    } else if let Some(def_store) = self.def_store {
+                        def_store
+                            .find_def_for_type(app.base)
+                            .and_then(|id| def_store.get_type_params(id))
+                    } else {
+                        None
+                    };
+
+                // Build the display arg list, padding missing trailing args
+                // with their parameter defaults when available.
+                let display_args: Vec<TypeId> = if let Some(params) = def_type_params.as_ref()
+                    && params.len() > app.args.len()
+                {
+                    let mut out: Vec<TypeId> = app.args.to_vec();
+                    for param in params.iter().skip(app.args.len()) {
+                        // Only pad when the missing parameter carries a default;
+                        // stop at the first parameter without a default.
+                        let Some(default) = param.default else {
+                            break;
+                        };
+                        out.push(default);
+                    }
+                    out
                 } else {
-                    None
+                    app.args.to_vec()
                 };
 
                 let visible_arg_count = if let Some(params) = def_type_params.as_ref()
-                    && params.len() == app.args.len()
+                    && should_elide_defaults
+                    && params.len() == display_args.len()
                 {
-                    let mut n = app.args.len();
+                    let mut n = display_args.len();
                     while n > 0 {
                         let idx = n - 1;
                         let Some(default) = params[idx].default else {
                             break;
                         };
-                        if app.args[idx] != default {
+                        if display_args[idx] != default {
                             break;
                         }
                         n -= 1;
                     }
                     n
                 } else {
-                    app.args.len()
+                    display_args.len()
                 };
 
-                let args: Vec<Cow<'static, str>> = app
-                    .args
+                let args: Vec<Cow<'static, str>> = display_args
                     .iter()
                     .take(visible_arg_count)
                     .map(|&arg| self.format(arg))

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -1708,6 +1708,53 @@ fn format_application_single_arg() {
 }
 
 #[test]
+fn format_application_pads_missing_args_with_param_defaults() {
+    // When the Application carries fewer args than the base's declared type
+    // parameters, the formatter should pad missing trailing args with their
+    // parameter defaults. Matches tsc's display: `Iterator<string>` renders
+    // as `Iterator<string, any, any>` given `Iterator<T, TReturn = any,
+    // TNext = any>`. Regression test for for-of29.ts.
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let iter_name = db.intern_string("Iter");
+    let t_param = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let treturn_param = TypeParamInfo {
+        name: db.intern_string("TReturn"),
+        constraint: None,
+        default: Some(TypeId::ANY),
+        is_const: false,
+    };
+    let tnext_param = TypeParamInfo {
+        name: db.intern_string("TNext"),
+        constraint: None,
+        default: Some(TypeId::ANY),
+        is_const: false,
+    };
+    let iter_body = db.object(vec![]); // structural body isn't relevant to the display test
+    let iter_def = crate::def::DefinitionInfo::type_alias(
+        iter_name,
+        vec![t_param, treturn_param, tnext_param],
+        iter_body,
+    );
+    let iter_def_id = def_store.register(iter_def);
+    let base = db.lazy(iter_def_id);
+    let app = db.application(base, vec![TypeId::STRING]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    let result = fmt.format(app);
+    assert_eq!(
+        result, "Iter<string, any, any>",
+        "Missing trailing args must be padded with parameter defaults. Got: {result}"
+    );
+}
+
+#[test]
 fn format_application_two_args() {
     let db = TypeInterner::new();
     let mut fmt = TypeFormatter::new(&db);


### PR DESCRIPTION
## Summary

tsc displays `Iterator<string>` as **`Iterator<string, any, any>`** when the base declares `Iterator<T, TReturn = any, TNext = any>` — it fills in missing trailing type arguments from their parameter defaults for error messages. tsz was printing the raw arg list (`Iterator<string>`), which diverged from tsc's output in TS2488/TS2322/TS2345 diagnostics that reference generic types instantiated with partial arguments.

```ts
declare var iterableWithOptionalIterator: {
    [Symbol.iterator]?(): Iterator<string>
};
for (var v of iterableWithOptionalIterator) { }
// tsc: Type '{ [Symbol.iterator]?(): Iterator<string, any, any>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
// tsz (before): Type '{ [Symbol.iterator]?(): Iterator<string>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
```

## Fix

Extend `format` for `TypeData::Application` in `diagnostics/format/mod.rs`:
1. Always load the base's declared type parameters when a def store is available (previously only loaded for the 4 iterable globals that require default-elision).
2. When `app.args.len() < params.len()`, pad missing trailing args with their parameter defaults (stop at the first param without a default).
3. The existing default-elision pass for `Iterable` / `IterableIterator` / `AsyncIterable` / `AsyncIterableIterator` now runs over the padded arg list so its `params.len() == args.len()` precondition still holds.

## Test plan
- [x] New unit test `format_application_pads_missing_args_with_param_defaults` in `diagnostics/format/tests.rs` locks the behavior at the solver level.
- [x] `cargo nextest run -p tsz-solver --lib format` — 144/144 pass.
- [x] `./scripts/conformance/conformance.sh run` — **conformance +1** (for-of29.ts), no regressions.