### PR TITLE
perf(checker,cli): Arc-share resolved_modules to eliminate per-file clone

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -744,8 +744,13 @@ impl<'a> CheckerContext<'a> {
 
     /// Set resolved module specifiers (module names that exist in the project).
     /// Used to suppress TS2307 errors for known modules.
-    pub fn set_resolved_modules(&mut self, modules: FxHashSet<String>) {
-        self.resolved_modules = Some(modules);
+    ///
+    /// Accepts either an owned `FxHashSet<String>` or an existing
+    /// `Arc<FxHashSet<String>>`. The production per-file CLI driver
+    /// shares the pre-bucketed set via `Arc::clone`; tests pass owned
+    /// sets and pay a single `Arc::new` wrapping.
+    pub fn set_resolved_modules(&mut self, modules: impl Into<Arc<FxHashSet<String>>>) {
+        self.resolved_modules = Some(modules.into());
     }
 
     /// Set resolved module errors map for cross-file import resolution.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1066,7 +1066,12 @@ pub struct CheckerContext<'a> {
     pub current_file_idx: usize,
 
     /// Resolved module specifiers for this file (multi-file CLI mode).
-    pub resolved_modules: Option<FxHashSet<String>>,
+    ///
+    /// Wrapped in `Arc` so the CLI per-file driver can share the
+    /// pre-bucketed `resolved_modules_per_file[file_idx]` entry without
+    /// deep-cloning the `FxHashSet<String>` contents per file. Child
+    /// checkers (cross-arena delegation) bump the refcount.
+    pub resolved_modules: Option<Arc<FxHashSet<String>>>,
 
     /// Track value exports declared in module augmentations for duplicate detection.
     /// Keyed by a canonical module key (resolved file index or specifier).

--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -221,7 +221,7 @@ impl Server {
             project_env.apply_to(&mut checker.ctx);
             checker
                 .ctx
-                .set_resolved_modules((*resolved_modules_arc).clone());
+                .set_resolved_modules(Arc::clone(&resolved_modules_arc));
             checker.ctx.set_current_file_idx(file_idx);
             checker.check_source_file(file.source_file);
 
@@ -466,7 +466,7 @@ impl Server {
             project_env.apply_to(&mut checker.ctx);
             checker
                 .ctx
-                .set_resolved_modules((*resolved_modules_arc).clone());
+                .set_resolved_modules(Arc::clone(&resolved_modules_arc));
             checker.ctx.set_current_file_idx(file_idx);
             checker.check_source_file(file.source_file);
 

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -572,7 +572,13 @@ pub(super) fn collect_diagnostics(
     // (~120 K total entries) that ballooned into ~700 M hashset
     // iterations across all checkers; the per-file checker scaled with
     // the size of the WHOLE program rather than its own import count.
-    let resolved_modules_per_file: Arc<Vec<rustc_hash::FxHashSet<String>>> = Arc::new({
+    // Per-file `Arc<FxHashSet<String>>` so the per-file checker can share
+    // the bucketed set via `Arc::clone` into `ctx.resolved_modules` without
+    // a deep copy of the contents. On 6086 files × avg 20 specifiers this
+    // avoids ~120K `String` clones + hashset insertions at the per-file
+    // `check_file_for_parallel` entry. Build the owned buckets first, then
+    // wrap each in `Arc::new` in one pass.
+    let resolved_modules_per_file: Arc<Vec<Arc<rustc_hash::FxHashSet<String>>>> = Arc::new({
         let _span = tracing::info_span!(
             "bucket_resolved_modules_per_file",
             files = program.files.len()
@@ -586,7 +592,7 @@ pub(super) fn collect_diagnostics(
                 set.insert(specifier.clone());
             }
         }
-        by_file
+        by_file.into_iter().map(Arc::new).collect()
     });
 
     // Pre-compute per-file TS7016 diagnostics for CJS require() calls.
@@ -1198,11 +1204,12 @@ pub(super) fn collect_diagnostics(
             checker.ctx.file_is_esm = project_env.file_is_esm_map.get(&file.file_name).copied();
 
             // Use the per-file pre-bucketed map; see the parallel path for the
-            // O(N²) → O(1) rationale.
-            let resolved_modules: rustc_hash::FxHashSet<String> = resolved_modules_per_file
+            // O(N²) → O(1) rationale. `Arc::clone` here is a single atomic
+            // increment — no deep copy of the contents.
+            let resolved_modules: Arc<rustc_hash::FxHashSet<String>> = resolved_modules_per_file
                 .get(file_idx)
                 .cloned()
-                .unwrap_or_default();
+                .unwrap_or_else(|| Arc::new(rustc_hash::FxHashSet::default()));
             checker.ctx.resolved_modules = Some(resolved_modules);
             // TSC suppresses many semantic diagnostics across the whole program when any
             // file has a real syntax parse error; mirror that behavior using the program-level
@@ -1695,7 +1702,7 @@ pub(super) struct CheckFileForParallelContext<'a> {
     /// `resolved_module_specifiers` set, which made each per-file checker
     /// scale with the size of the WHOLE program rather than its own
     /// import count.
-    resolved_modules_per_file: &'a Arc<Vec<rustc_hash::FxHashSet<String>>>,
+    resolved_modules_per_file: &'a Arc<Vec<Arc<rustc_hash::FxHashSet<String>>>>,
     shared_lib_cache: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>>,
     /// Shared cross-file query cache for multi-file projects.
     /// Eliminates redundant type evaluations and relation checks across files.
@@ -1777,10 +1784,13 @@ pub(super) fn check_file_for_parallel<'a>(
     // Use the pre-bucketed `resolved_modules_per_file[file_idx]` instead of
     // re-filtering the program-wide cross-file set per file. The bucketed
     // version is built once in `collect_diagnostics` and shared via `Arc`.
-    let resolved_modules: FxHashSet<String> = resolved_modules_per_file
+    // Per-file `Arc::clone` is a single atomic increment — no deep copy of
+    // the `FxHashSet<String>` contents. Saves ~120K string clones on the
+    // 6086-file large-ts-repo fixture.
+    let resolved_modules: Arc<FxHashSet<String>> = resolved_modules_per_file
         .get(file_idx)
         .cloned()
-        .unwrap_or_default();
+        .unwrap_or_else(|| Arc::new(FxHashSet::default()));
 
     // apply_to (below) installs the project-wide shared DefinitionStore and
     // warms the per-file caches from it. Use the deferred constructor so we


### PR DESCRIPTION
## Summary

`CheckerContext.resolved_modules` was `Option<FxHashSet<String>>`, deep-cloned into every per-file checker. The CLI driver's `check_file_for_parallel` had:

```rust
let resolved_modules: FxHashSet<String> = resolved_modules_per_file
    .get(file_idx)
    .cloned()               // deep clone of inner FxHashSet
    .unwrap_or_default();
checker.ctx.resolved_modules = Some(resolved_modules);
```

On the 6086-file large-ts-repo fixture with an average of ~20 import specifiers per file, that's ~120K `String` clones + `FxHashSet` insertions per full build. The LSP server path was worse: `(*resolved_modules_arc).clone()` unwrapped an existing Arc then deep-cloned its contents.

## Changes

- `CheckerContext.resolved_modules: Option<FxHashSet<String>>` → `Option<Arc<FxHashSet<String>>>`
- `set_resolved_modules` signature: `FxHashSet<String>` → `impl Into<Arc<FxHashSet<String>>>` so tests can still pass owned sets (single `Arc::new` wrapping) while production call sites pass `Arc::clone`.
- `resolved_modules_per_file`: `Arc<Vec<FxHashSet<String>>>` → `Arc<Vec<Arc<FxHashSet<String>>>>`. Extra `Arc::new` runs once per file during build; savings are at every per-file checker construction (6086×).
- CLI per-file setup (`driver/check.rs:1780` and `:1208`): becomes `Arc::clone` — atomic increment, no deep copy.
- LSP server path (`tsz_server/check.rs:224, 469`): `(*arc).clone()` → `Arc::clone(&arc)`, recovering the full benefit of the existing Arc.

## Consumer safety

All read sites use `.contains(key)` via `Deref`. Zero mutations on `resolved_modules` exist in the checker. Same migration pattern as prior Arc-share PRs (#932 lib_symbol_ids, #954 module_exports, #960 lib_binders, #986 symbol_arenas, #1039 flow_nodes, #1043 declaration_arenas).

## Scope

4 files, +33 / −13.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run -p tsz-checker --lib` — 2715 tests pass
- [x] `cargo nextest run -p tsz-core module_resolution` — 94 tests pass
- [ ] Full `scripts/session/verify-all.sh` deferred to CI.

The pre-existing tsc version mismatch failures (`tsz-cli::tsc_compat_tests::tsc_parity_version*`, `tsc_parity_ts6046_*`) are unrelated — tsz is at v6.0.2 while tsc is at 5.9.3.