### PR TITLE
chore(cargo): add flame profile for samply/flamegraph profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,5 +111,28 @@ inherits = "dev"
 opt-level = 2
 debug = true
 
+# Profile-friendly release build for `samply`, `cargo flamegraph`,
+# or `dtrace`-based tools. Keep full DWARF debug info and symbols so
+# leaf frames resolve to Rust function names. Use:
+#
+#   cargo build --profile flame --bin tsz
+#   samply record --save-only -o /tmp/prof.json -- <path>/flame/tsz ...
+#   samply load /tmp/prof.json   # interactive, requires GUI
+#
+# Or piped through `inferno` for a flamegraph SVG:
+#
+#   samply record --save-only --output-format=collapsed -o /tmp/prof.txt \
+#     -- <path>/flame/tsz ...
+#   cat /tmp/prof.txt | inferno-flamegraph > flame.svg
+#
+# NOTE: keeping debug info means the binary is ~2-3× larger than the
+# stripped `dist` build. That's fine for local profiling; don't ship it.
+[profile.flame]
+inherits = "release"
+debug = 2             # full DWARF debug info
+strip = false         # keep symbols
+codegen-units = 1     # single codegen unit: function boundaries match source
+lto = "thin"          # match `dist-fast` for representative hot-path shape
+
 [profile.bench]
 lto = "thin"


### PR DESCRIPTION
## Summary

Per `docs/plan/perf-loop-prompt.md`: profiling on macOS without sudo is hard because release builds strip DWARF and `samply --save-only` can't symbolicate (leaf frames come out as `0xNNNN` or `OUTLINED_FUNCTION_*`). Adds a dedicated `flame` profile that inherits `release` but keeps:

- `debug = 2` — full DWARF
- `strip = false` — keep symbol table
- `codegen-units = 1` — preserve function boundaries
- `lto = "thin"` — match `dist-fast` for representative hot-path shape

## Usage

```bash
cargo build --profile flame --bin tsz
samply record --save-only -o /tmp/prof.json -- <path>/flame/tsz --noEmit ...
samply load /tmp/prof.json   # or pipe through inferno for SVG
```

## Why

Unblocks Check-phase profiling work that was abandoned in an earlier session: we found 80% of `manyConstExports` time is in Check with 0 cache hits, but had no attribution data. The `samply --save-only` path produced unsymbolicated profiles; `nm` on stripped Rust release binary mostly returned `OUTLINED_FUNCTION_*` names; `cargo flamegraph` needed dtrace/sudo. With this profile, future perf iterations can get real leaf-function hot-path data locally.

## Cost

Full `flame` build is ~2-3× slower than `release` (extra debug info gen) and produces a larger binary. Meant for local profiling only — not shipped.

## Test plan

- [x] `cargo check --profile flame -p tsz-cli --bin tsz` clean (40.55s)
- [ ] Full build timings deferred to CI if relevant

Pure build config; no code changes.