### PR TITLE
arch(checker): migrate class_extends_any_base from NodeIndex to StableLocation (Phase 1 step 2)

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use crate::control_flow::FlowGraph;
 use crate::diagnostics::{Diagnostic, diagnostic_codes};
 use crate::module_resolution::module_specifier_candidates;
+use tsz_binder::symbols::StableLocation;
 use tsz_binder::{BinderState, SymbolId};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
@@ -874,6 +875,62 @@ impl<'a> CheckerContext<'a> {
                 .then(|| binders.get(idx).map(Arc::as_ref))
                 .flatten()
         })
+    }
+
+    /// Resolve a [`StableLocation`] to a concrete `(NodeIndex, &NodeArena)`
+    /// without going through [`tsz_binder::Symbol::value_declaration`] or
+    /// [`tsz_binder::Symbol::declarations`].
+    ///
+    /// This is the Phase 1 step-2 bridge helper for the
+    /// [global query graph architecture][plan]: consumers that used to read
+    /// `symbol.primary_declaration()` (a raw `NodeIndex`) can instead read
+    /// `symbol.stable_value_declaration` or `symbol.stable_declarations` and
+    /// rehydrate the `NodeIndex` on demand. The resolved arena survives
+    /// declaration-arena reshuffles because the lookup is driven by
+    /// `(file_idx, pos, end)` rather than arena-local index identity.
+    ///
+    /// Returns `None` when:
+    /// - `loc.is_known()` is false (pos/end both zero — unknown span),
+    /// - the requested arena is not available (`all_arenas` not populated
+    ///   and the location's `file_idx` is not the current file's), or
+    /// - no node in the resolved arena matches `(pos, end)` exactly.
+    ///
+    /// When `loc.file_idx == u32::MAX` (single-file binding or not yet
+    /// stamped), the current arena is used. This mirrors the fallback
+    /// behavior of [`Self::get_arena_for_file`] for `u32::MAX`.
+    ///
+    /// The scan is currently O(N) over `arena.nodes`. The only caller at
+    /// the moment (`CheckerState::class_extends_any_base`) is on the TS2551
+    /// "Did you mean?" diagnostic path, which is cold. A span-index can be
+    /// added later if hot paths migrate to this helper.
+    ///
+    /// [plan]: ../../../../../docs/plan/global-query-graph-architecture.md
+    pub fn node_at_stable_location(&self, loc: StableLocation) -> Option<(NodeIndex, &NodeArena)> {
+        if !loc.is_known() {
+            return None;
+        }
+        let arena = if loc.has_file_idx() {
+            // Only trust the stamped file_idx when we have the arena table
+            // to resolve against. If `all_arenas` is absent (single-file
+            // mode or cross-arena delegation not yet initialized), fall
+            // back to the current arena — same contract as
+            // `get_arena_for_file`.
+            if self.all_arenas.is_some() {
+                self.get_arena_for_file(loc.file_idx)
+            } else {
+                self.arena
+            }
+        } else {
+            // Unstamped: use the current arena. This matches how
+            // `class_extends_any_base` and similar legacy consumers
+            // resolved `symbol.primary_declaration()` against
+            // `self.ctx.arena`.
+            self.arena
+        };
+        let node_idx = arena.nodes.iter().enumerate().find_map(|(i, node)| {
+            (node.pos == loc.pos && node.end == loc.end).then_some(NodeIndex(i as u32))
+        })?;
+        Some((node_idx, arena))
     }
 
     /// Get the file index that owns a specific arena.

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -68,6 +68,25 @@ impl<'a> CheckerState<'a> {
     ///
     /// In that case TypeScript treats unknown member accesses as `any` and does not
     /// surface typo suggestions (TS2551).
+    ///
+    /// ## Phase 1 step-2: `StableLocation`-based declaration lookup
+    ///
+    /// This consumer reads [`tsz_binder::Symbol::stable_value_declaration`]
+    /// (with a fallback to the first entry of
+    /// [`tsz_binder::Symbol::stable_declarations`]) instead of
+    /// `symbol.primary_declaration()`. The resulting `StableLocation`
+    /// carries `(file_idx, pos, end)` and is rehydrated to a concrete
+    /// `NodeIndex` on demand via
+    /// [`CheckerContext::node_at_stable_location`][nasl]. This is the
+    /// first consumer migrated under the
+    /// [global query graph plan][plan] (Phase 1 step 2, following
+    /// PR #1055). Heritage-clause tree walking is still arena-bound and
+    /// fundamentally requires a live `NodeIndex`, so the helper returns
+    /// one. The load-bearing change is that declaration *identity* no
+    /// longer comes from the symbol's arena-dependent `NodeIndex`.
+    ///
+    /// [nasl]: crate::context::CheckerContext::node_at_stable_location
+    /// [plan]: ../../../../docs/plan/global-query-graph-architecture.md
     pub(super) fn class_extends_any_base(&mut self, type_id: TypeId) -> bool {
         use tsz_binder::symbol_flags;
         use tsz_scanner::SyntaxKind;
@@ -85,32 +104,70 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let Some(decl_idx) = symbol.primary_declaration() else {
-            return false;
-        };
-        let Some(class_decl) = self.ctx.arena.get_class_at(decl_idx) else {
-            return false;
-        };
-        let Some(heritage_clauses) = &class_decl.heritage_clauses else {
-            return false;
+        // Phase 1 step-2: identify the primary class declaration via its
+        // `StableLocation`, not via `symbol.primary_declaration()`. Prefer
+        // `stable_value_declaration` when set; otherwise fall back to the
+        // first `stable_declarations` entry — mirroring the existing
+        // `primary_declaration()` preference order. The parallel
+        // `stable_*` fields are populated in lockstep by the binder, so
+        // this is equivalent whenever the legacy `NodeIndex` fields are
+        // populated.
+        let stable_loc = if symbol.stable_value_declaration.is_known() {
+            symbol.stable_value_declaration
+        } else {
+            match symbol.stable_declarations.first() {
+                Some(loc) if loc.is_known() => *loc,
+                _ => return false,
+            }
         };
 
-        for &clause_idx in &heritage_clauses.nodes {
-            let Some(clause) = self.ctx.arena.get_heritage_clause_at(clause_idx) else {
-                continue;
+        // Resolve the `StableLocation` to a live `(NodeIndex, arena)` pair
+        // and collect the candidate `extends` expression node indices. We
+        // eagerly collect `expr_idx` values into a small vector so that the
+        // arena borrow is released before any `&mut self` calls below
+        // (`get_type_of_node`). A future phase can push this rehydration
+        // further down or replace it entirely with a query-side class
+        // summary.
+        let extends_expr_indices: smallvec::SmallVec<[NodeIndex; 2]> = {
+            let Some((decl_idx, arena)) = self.ctx.node_at_stable_location(stable_loc) else {
+                return false;
             };
-            if clause.token != SyntaxKind::ExtendsKeyword as u16 {
-                continue;
-            }
-            let Some(&type_idx) = clause.types.nodes.first() else {
-                continue;
+            let Some(class_decl) = arena.get_class_at(decl_idx) else {
+                return false;
             };
-            let expr_idx =
-                if let Some(expr_type_args) = self.ctx.arena.get_expr_type_args_at(type_idx) {
+            let Some(heritage_clauses) = &class_decl.heritage_clauses else {
+                return false;
+            };
+
+            let mut out = smallvec::SmallVec::new();
+            for &clause_idx in &heritage_clauses.nodes {
+                let Some(clause) = arena.get_heritage_clause_at(clause_idx) else {
+                    continue;
+                };
+                if clause.token != SyntaxKind::ExtendsKeyword as u16 {
+                    continue;
+                }
+                let Some(&type_idx) = clause.types.nodes.first() else {
+                    continue;
+                };
+                let expr_idx = if let Some(expr_type_args) = arena.get_expr_type_args_at(type_idx) {
                     expr_type_args.expression
                 } else {
                     type_idx
                 };
+                out.push(expr_idx);
+            }
+            out
+        };
+
+        // NOTE: `get_type_of_node` still operates against
+        // `self.ctx.arena` (the current file's arena). Cross-file
+        // class-extends-any detection was a pre-existing latent
+        // limitation and is out of scope for this Phase 1 step-2
+        // migration. The `StableLocation` rehydration above returns
+        // the same arena whenever the class is in the current file —
+        // which is the case for every caller today.
+        for expr_idx in extends_expr_indices {
             if self.get_type_of_node(expr_idx) == TypeId::ANY {
                 return true;
             }
@@ -822,5 +879,164 @@ fn get_lib_for_type_property(type_name: &str, prop_name: &str) -> Option<&'stati
             _ => None,
         },
         _ => None,
+    }
+}
+
+// =============================================================================
+// Phase 1 step-2 regression tests: `StableLocation` rehydration
+// =============================================================================
+//
+// These tests validate the migration of `class_extends_any_base` away from
+// the arena-dependent `Symbol::primary_declaration(): NodeIndex` toward the
+// file-stable `Symbol::stable_value_declaration` / `stable_declarations`
+// fields introduced by PR #1055. The critical invariant they lock in is
+// that a `StableLocation` captured from one binder/arena pair can be
+// resolved against a freshly re-parsed arena of the same source — the
+// Phase 5 "bounded arena residency" precondition.
+
+#[cfg(test)]
+mod tests {
+    use crate::context::{CheckerContext, CheckerOptions};
+    use tsz_binder::BinderState;
+    use tsz_parser::ParserState;
+    use tsz_solver::TypeInterner;
+
+    /// Resolving `Symbol::stable_value_declaration` for a class via the new
+    /// `node_at_stable_location` helper must return the same class node
+    /// that `Symbol::value_declaration` points at in the same binder.
+    #[test]
+    fn stable_value_declaration_resolves_to_class_node() {
+        let source = "class Foo extends Bar {}\n".to_string();
+
+        let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+
+        let sym_id = binder.file_locals.get("Foo").expect("class symbol Foo");
+        let symbol = binder.symbols.get(sym_id).expect("symbol data");
+        let stable = symbol.stable_value_declaration;
+        assert!(
+            stable.is_known(),
+            "class Foo must have a known stable_value_declaration span"
+        );
+        let legacy_node_idx = symbol.value_declaration;
+        assert!(
+            legacy_node_idx.is_some(),
+            "class Foo must have a populated value_declaration (NodeIndex)"
+        );
+
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena,
+            &binder,
+            &types,
+            "syn.ts".to_string(),
+            CheckerOptions::default(),
+        );
+
+        let (resolved_idx, resolved_arena) = ctx
+            .node_at_stable_location(stable)
+            .expect("node_at_stable_location must resolve the class span");
+
+        assert_eq!(
+            resolved_idx, legacy_node_idx,
+            "StableLocation must rehydrate to the same NodeIndex as value_declaration"
+        );
+        let resolved_node = resolved_arena
+            .get(resolved_idx)
+            .expect("resolved NodeIndex must exist in arena");
+        assert_eq!(resolved_node.pos, stable.pos);
+        assert_eq!(resolved_node.end, stable.end);
+    }
+
+    /// The load-bearing Phase 5 scenario: capture a `StableLocation` from
+    /// one arena, drop it (simulated by a fresh parser), and re-resolve
+    /// the same `(pos, end)` against a newly parsed arena. The
+    /// rehydrated `NodeIndex` must point at a node with matching span.
+    ///
+    /// This proves `node_at_stable_location` does NOT depend on arena
+    /// identity — only on the `(file_idx, pos, end)` triple.
+    #[test]
+    fn stable_location_round_trips_across_arena_reparse() {
+        let source = "class Foo extends Bar {}\nclass Qux {}\n".to_string();
+
+        // Capture a StableLocation for `Foo` from the first binder, then
+        // let the first arena/binder go out of scope.
+        let captured = {
+            let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+            let root = parser.parse_source_file();
+            let arena = parser.get_arena();
+            let mut binder = BinderState::new();
+            binder.bind_source_file(arena, root);
+            let sym_id = binder.file_locals.get("Foo").expect("class symbol Foo");
+            let symbol = binder.symbols.get(sym_id).expect("symbol data");
+            symbol.stable_value_declaration
+        };
+        assert!(
+            captured.is_known(),
+            "captured StableLocation must carry a real (pos, end) span"
+        );
+
+        // Fresh parse + bind of the identical source. The captured
+        // StableLocation must resolve in this new arena.
+        let mut parser = ParserState::new("syn.ts".to_string(), source);
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena,
+            &binder,
+            &types,
+            "syn.ts".to_string(),
+            CheckerOptions::default(),
+        );
+
+        let (resolved_idx, resolved_arena) = ctx
+            .node_at_stable_location(captured)
+            .expect("captured StableLocation must rehydrate against a freshly parsed arena");
+        let node = resolved_arena
+            .get(resolved_idx)
+            .expect("resolved NodeIndex must exist in the new arena");
+        assert_eq!(node.pos, captured.pos);
+        assert_eq!(node.end, captured.end);
+
+        // The new binder's `value_declaration` NodeIndex should agree
+        // with the helper's resolution — binder population is
+        // deterministic for identical source text.
+        let sym_id = binder
+            .file_locals
+            .get("Foo")
+            .expect("class symbol Foo in reparsed binder");
+        let new_symbol = binder
+            .symbols
+            .get(sym_id)
+            .expect("symbol data in reparsed binder");
+        assert_eq!(
+            resolved_idx, new_symbol.value_declaration,
+            "re-resolution must agree with the re-parsed binder's NodeIndex"
+        );
+    }
+
+    /// `node_at_stable_location` must return `None` for the sentinel
+    /// `StableLocation::NONE` (unknown span) so consumers can treat it as
+    /// a clean "no declaration" signal.
+    #[test]
+    fn stable_location_none_resolves_to_none() {
+        let arena = tsz_parser::parser::node::NodeArena::new();
+        let binder = BinderState::new();
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            &arena,
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let none = tsz_binder::symbols::StableLocation::NONE;
+        assert!(ctx.node_at_stable_location(none).is_none());
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -94,9 +94,7 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(&enum_member_text);
             } else if has_initializer && self.is_import_meta_url_expression(initializer) {
                 self.write(": string");
-            } else if has_initializer
-                && self.initializer_is_global_this_identifier(initializer)
-            {
+            } else if has_initializer && self.initializer_is_global_this_identifier(initializer) {
                 // `const x = globalThis` — tsc emits `: typeof globalThis`.
                 // The solver otherwise resolves `globalThis` to `any` in the
                 // emit boundary, producing a less-informative annotation.


### PR DESCRIPTION
## Summary

- Phase 1 step 2 from [`docs/plan/global-query-graph-architecture.md`](docs/plan/global-query-graph-architecture.md), following PR #1055 (Phase 1 step 1) which added `Symbol::stable_declarations` / `Symbol::stable_value_declaration`.
- Demonstrates the `NodeIndex` → `StableLocation` migration pattern on **one** small, self-contained consumer: `CheckerState::class_extends_any_base` in `crates/tsz-checker/src/error_reporter/suggestions.rs`.
- Adds a reusable bridge helper `CheckerContext::node_at_stable_location(loc) -> Option<(NodeIndex, &NodeArena)>` in `crates/tsz-checker/src/context/core.rs` that future migrations can also use.
- **No behavior change expected.** The migrated path is structurally equivalent to the old one whenever the binder populates `stable_value_declaration` in lockstep with `value_declaration` — which PR #1055 locks in as a hard invariant.

## Why this consumer

- Smallest surface area in the prompt's candidate list — exactly **one** call to `symbol.primary_declaration()` in a ~50-line function.
- Cold path (only runs when emitting TS2551 \"Did you mean?\" suggestions on class types), so the rehydration cost (currently O(N) span scan) is acceptable for v1.
- Clean module boundary — testable in isolation without wiring the full multi-file checker.
- Exercises the round-trip pattern end-to-end: stable loc → arena → `NodeIndex` → heritage-clause walk.

## What's still NodeIndex-bound here

- The heritage-clause tree walk (`arena.get_class_at`, `arena.get_heritage_clause_at`, `arena.get_expr_type_args_at`) is fundamentally AST-bound and keeps using `NodeIndex` locally — but the `NodeIndex` now comes from the **rehydrated arena**, not from the symbol's stored `NodeIndex`. That's the load-bearing change.
- `self.get_type_of_node(expr_idx)` still runs against `self.ctx.arena` (the current file's arena). Cross-file class-extends-any detection was a **pre-existing latent limitation** and is explicitly out of scope for this PR.

## Tests

New `#[cfg(test)] mod tests` block in `suggestions.rs` (gated by `#[cfg(test)]` so the architecture-contract `query_boundaries` policy correctly exempts the test-only `tsz_solver::TypeInterner` import):

- `stable_value_declaration_resolves_to_class_node` — helper returns the same `NodeIndex` that `value_declaration` would have returned.
- `stable_location_round_trips_across_arena_reparse` — captures a `StableLocation` from one binder/arena, drops them, re-parses the same source with a fresh arena, and verifies the captured location still resolves correctly. **This is the load-bearing Phase 5 scenario** (bounded arena residency / evict-and-rehydrate).
- `stable_location_none_resolves_to_none` — sentinel handling.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run -p tsz-checker --lib` — 2715 tests pass (no regressions)
- [x] `cargo nextest run -p tsz-binder --lib` — 245 tests pass (Phase 1 step 1 invariants intact)
- [x] `cargo nextest run -p tsz-core --lib` — 2929 tests pass
- [x] Pre-commit hook (fmt + clippy + wasm32 lint + checker boundary guardrail + nextest precommit profile) passes — 13184 tests
- [ ] CI verifies `scripts/session/verify-all.sh` (full conformance + emit + LSP)

## References

- PR #1055 — Phase 1 step 1 (`StableLocation` on `Symbol`)
- [`docs/plan/global-query-graph-architecture.md`](docs/plan/global-query-graph-architecture.md) — full 6-phase plan
- [`docs/plan/perf-loop-prompt.md`](docs/plan/perf-loop-prompt.md) §\"Open questions / next concrete work\"

## Discovered gaps

None — `Symbol::stable_value_declaration` and `Symbol::stable_declarations` are populated as documented for the consumer's input (class symbols in the local binder). All three new tests pass on the first attempt.