### PR TITLE
fix async jsdoc contextual return type

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -835,7 +835,20 @@ impl<'a> CheckerState<'a> {
                             let func = checker.ctx.arena.get_function(init_node)?;
                             let body_node = checker.ctx.arena.get(func.body)?;
                             if body_node.kind == syntax_kind_ext::BLOCK {
-                                return Some(false);
+                                // For block-body functions, check if the body
+                                // already emitted TS2322 (e.g., from return
+                                // statement checks against a contextual return
+                                // type). When it did, the outer assignment-level
+                                // TS2322 is redundant.
+                                return Some(
+                                    checker.ctx.diagnostics[init_snap.diagnostics_len..]
+                                        .iter()
+                                        .any(|diag| {
+                                            diag.start >= body_node.pos
+                                                && diag.start < body_node.end
+                                                && matches!(diag.code, 2322 | 2339)
+                                        }),
+                                );
                             }
                             Some(
                                 checker.ctx.diagnostics[init_snap.diagnostics_len..]
@@ -929,6 +942,23 @@ impl<'a> CheckerState<'a> {
                                 if elaborated_elements {
                                     // Elaboration emitted per-element TS2322 errors on the specific
                                     // mismatching array/tuple elements. Skip the generic TS2322.
+                                } else if function_initializer_body_has_error {
+                                    // The function initializer already produced the canonical body
+                                    // diagnostic (for example on an expression-bodied arrow or
+                                    // block-body function with return statement errors). Skip
+                                    // the redundant outer assignment TS2322 and elaboration.
+                                } else if initializer_is_function
+                                    && jsdoc_declared_type.is_some()
+                                    && checker.async_function_jsdoc_return_type_suppression(
+                                        checked_init_type,
+                                        declared_type,
+                                    )
+                                {
+                                    // Async function with JSDoc non-Promise return type:
+                                    // tsc reports TS1064 for the async/return-type mismatch
+                                    // and checks body return statements, but does NOT emit
+                                    // TS2322 at the assignment level for the Promise wrapping
+                                    // difference.
                                 } else if initializer_is_function
                                     && !checker.is_assignable_to(checked_init_type, declared_type)
                                     && checker.try_elaborate_assignment_source_error(
@@ -938,10 +968,6 @@ impl<'a> CheckerState<'a> {
                                 {
                                     // Function initializer return elaboration emitted the canonical
                                     // nested TS2322 for a mismatching returned literal/expression.
-                                } else if function_initializer_body_has_error {
-                                    // The function initializer already produced the canonical body
-                                    // diagnostic (for example on an expression-bodied arrow). Skip
-                                    // the redundant outer assignment TS2322.
                                 } else {
                                     // Run excess property check first for object literal
                                     // initializers. In tsc, TS2353 (excess property) takes
@@ -2400,6 +2426,31 @@ impl<'a> CheckerState<'a> {
                     name_node.kind,
                 );
             }
+        }
+    }
+
+    /// Check whether an async function initializer's type differs from the
+    /// declared JSDoc type only because of Promise wrapping on the return type.
+    /// When that is the case, tsc reports TS1064 (async return type must be
+    /// Promise) but suppresses the assignment-level TS2322.
+    pub(crate) fn async_function_jsdoc_return_type_suppression(
+        &mut self,
+        init_type: TypeId,
+        declared_type: TypeId,
+    ) -> bool {
+        let init_return =
+            crate::query_boundaries::common::return_type_for_type(self.ctx.types, init_type);
+        let declared_return =
+            crate::query_boundaries::common::return_type_for_type(self.ctx.types, declared_type);
+        let (Some(init_ret), Some(decl_ret)) = (init_return, declared_return) else {
+            return false;
+        };
+        // Check if the init return type is Promise<T> where T is assignable
+        // to the declared return type.
+        if let Some(unwrapped) = self.unwrap_promise_type(init_ret) {
+            self.is_assignable_to(unwrapped, decl_ret)
+        } else {
+            false
         }
     }
 }

--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -1054,3 +1054,61 @@ var a = M.Point;
         );
     }
 }
+
+#[cfg(test)]
+mod async_jsdoc_return_type_tests {
+    use crate::test_utils::check_js_source_diagnostics;
+
+    #[test]
+    fn async_block_body_jsdoc_return_mismatch_reports_at_return_statement() {
+        let source = r#"
+/** @type {function(): string} */
+const c = async () => {
+    return 0
+}
+"#;
+        let ts2322 = check_js_source_diagnostics(source)
+            .into_iter()
+            .filter(|d| d.code == 2322)
+            .collect::<Vec<_>>();
+        assert_eq!(ts2322.len(), 1, "Expected exactly 1 TS2322: {ts2322:?}");
+        assert!(
+            ts2322[0].message_text.contains("'number'")
+                && ts2322[0].message_text.contains("'string'"),
+            "Expected 'number' not assignable to 'string', got: {}",
+            ts2322[0].message_text
+        );
+    }
+
+    #[test]
+    fn async_block_body_jsdoc_matching_return_no_ts2322() {
+        let source = r#"
+/** @type {function(): string} */
+const d = async () => {
+    return ""
+}
+"#;
+        let ts2322 = check_js_source_diagnostics(source)
+            .into_iter()
+            .filter(|d| d.code == 2322)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ts2322.len(),
+            0,
+            "Expected no TS2322 when return matches declared type: {ts2322:?}"
+        );
+    }
+
+    #[test]
+    fn async_expression_body_jsdoc_return_mismatch() {
+        let source = r#"
+/** @type {function(): string} */
+const b = async () => 0
+"#;
+        let ts2322 = check_js_source_diagnostics(source)
+            .into_iter()
+            .filter(|d| d.code == 2322)
+            .collect::<Vec<_>>();
+        assert_eq!(ts2322.len(), 1, "Expected exactly 1 TS2322: {ts2322:?}");
+    }
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1834,11 +1834,26 @@ impl<'a> CheckerState<'a> {
                 let original_type = annotated_return_type.unwrap_or(return_type);
                 self.unwrap_promise_type(original_type)
                     .unwrap_or(return_type)
+            } else if is_async_for_context
+                && has_contextual_return
+                && return_context_for_circularity
+                    .is_some_and(|t| t != TypeId::VOID && t != TypeId::ANY && t != TypeId::UNKNOWN)
+            {
+                // Contextually-typed async function (e.g., JSDoc @type or callback):
+                // use the contextual return type (already unwrapped from Promise)
+                // for body return-statement checking. This matches tsc's behavior
+                // where `return 0` in `async (): string => { return 0 }` is checked
+                // against `string`, not the inferred type.
+                return_context_for_circularity.expect("is_some_and guard ensures Some")
+            } else if is_async_for_context
+                && has_contextual_return
+                && return_context_for_circularity == Some(TypeId::VOID)
+            {
+                // Async void-return contextual callbacks are allowed to return values.
+                TypeId::ANY
             } else if is_async_for_context {
-                // For contextually-typed async functions (no explicit annotation),
-                // also unwrap Promise from the return type. For unions like
-                // Promise<T> | StateMachine<T>, unwrap each Promise member to get
-                // T | StateMachine<T> as the effective body return type.
+                // For non-contextually-typed async functions, unwrap Promise from
+                // the inferred return type for body checking.
                 self.unwrap_async_return_type_for_body(return_type)
             } else if contextual_void_return_exception {
                 // Contextual `() => void` callbacks are allowed to return values.


### PR DESCRIPTION
## Summary
- Changes from `fix/async-jsdoc-contextual-return-type` are included.
- This PR remains open because work is not fully merged into `main`.

## Merge stats
- Ahead of `main`: 1
- Behind `main`: 41