### PR TITLE
fix ts2493 param destructuring default

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -210,6 +210,28 @@ impl<'a> CheckerState<'a> {
         flow_boundary::add_undefined_for_indexed_access(self.ctx.types, ty)
     }
 
+    /// Returns true when the given binding pattern is the name of a function
+    /// parameter that has a default initializer (e.g. `function f([x, y] = [])
+    /// {}`). In that case tsc does not emit TS2493 for out-of-bounds element
+    /// access into the inferred default tuple — the binding elements become
+    /// implicitly any (TS7031) instead.
+    fn binding_pattern_in_parameter_with_default(&self, pattern_idx: NodeIndex) -> bool {
+        let Some(ext) = self.ctx.arena.get_extended(pattern_idx) else {
+            return false;
+        };
+        let parent_idx = ext.parent;
+        let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+            return false;
+        };
+        if parent_node.kind != syntax_kind_ext::PARAMETER {
+            return false;
+        }
+        self.ctx
+            .arena
+            .get_parameter(parent_node)
+            .is_some_and(|param| param.initializer.is_some())
+    }
+
     pub(crate) fn normalize_parameter_binding_pattern_source_type(
         &self,
         pattern_idx: NodeIndex,
@@ -973,9 +995,17 @@ impl<'a> CheckerState<'a> {
                     // Also skip when the index is in bounds — ERROR may just mean the
                     // element type itself is an error (e.g. from an unresolved property),
                     // not that the index is out of range.
+                    //
+                    // Also skip TS2493 when the binding pattern is a PARAMETER whose
+                    // type was inferred from a default initializer (e.g. `function
+                    // f([x, y] = []) {}`). tsc treats the binding elements as
+                    // implicitly any (TS7031) rather than tuple-out-of-bounds here.
+                    let in_parameter_with_default =
+                        self.binding_pattern_in_parameter_with_default(pattern_idx);
                     if !has_rest_tail
                         && element_data.initializer.is_none()
                         && element_index >= elems.len()
+                        && !in_parameter_with_default
                     {
                         let tuple_type_str = self.format_type(array_like);
                         self.error_at_node(

--- a/crates/tsz-checker/tests/binding_pattern_inference_tests.rs
+++ b/crates/tsz-checker/tests/binding_pattern_inference_tests.rs
@@ -225,6 +225,37 @@ trans(({a, b = 10}) => a);
 }
 
 #[test]
+fn test_parameter_destructuring_with_default_tuple_skips_ts2493() {
+    // Regression test for destructuringWithLiteralInitializers2.ts:
+    // Parameter `function f01([x, y] = []) {}` should NOT emit TS2493 for the
+    // out-of-bounds element access into `[]`. tsc treats the binding elements
+    // as implicitly any (TS7031) instead.
+    let source = r#"
+function f01([x, y] = []) {}
+function f10([x = 0, y] = []) {}
+function f11([x, y] = [1]) {}
+"#;
+    let diagnostics = compile_and_get_diagnostics(
+        source,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts2493_errors: Vec<&(u32, String)> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2493)
+        .collect();
+    assert!(
+        ts2493_errors.is_empty(),
+        "Parameter destructuring with default tuple must not emit TS2493. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_destructuring_assignment_defaults_skip_ts2493_for_empty_array_literal_rhs() {
     let source = r#"
 class A {

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -556,7 +556,7 @@ impl<'a> TypePrinter<'a> {
         // `number | string` prints as `string | number`. Non-primitive members
         // keep their original relative order because a sort comparator that
         // returns "equal" for them is stable.
-        fn primitive_rank(id: TypeId) -> Option<u32> {
+        const fn primitive_rank(id: TypeId) -> Option<u32> {
             // Mirrors tsc's TypeFlags bit values in ascending order.
             match id {
                 TypeId::ANY => Some(1),


### PR DESCRIPTION
## Summary
- Changes from `fix/ts2493-param-destructuring-default` are included.
- This PR remains open because work is not fully merged into `main`.

## Merge stats
- Ahead of `main`: 1
- Behind `main`: 13