### PR TITLE
fix variable decl global this typeof

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -1118,6 +1118,23 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    /// True when `expr_idx` is a bare `globalThis` identifier. Used by variable
+    /// declaration emit to render `const x = globalThis` as `: typeof globalThis`
+    /// — without this check, the solver's fallback gives the emit path only
+    /// `any`, dropping the `globalThis` information tsc preserves in .d.ts.
+    pub(in crate::declaration_emitter) fn initializer_is_global_this_identifier(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        let Some(ident) = self.arena.get_identifier(node) else {
+            return false;
+        };
+        ident.escaped_text == "globalThis"
+    }
+
     pub(in crate::declaration_emitter) fn is_import_meta_url_expression(
         &self,
         expr_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -94,6 +94,13 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(&enum_member_text);
             } else if has_initializer && self.is_import_meta_url_expression(initializer) {
                 self.write(": string");
+            } else if has_initializer
+                && self.initializer_is_global_this_identifier(initializer)
+            {
+                // `const x = globalThis` — tsc emits `: typeof globalThis`.
+                // The solver otherwise resolves `globalThis` to `any` in the
+                // emit boundary, producing a less-informative annotation.
+                self.write(": typeof globalThis");
             } else if is_const_null_or_undefined
                 || (has_initializer && self.invalid_const_enum_object_access(initializer))
                 || (has_initializer


### PR DESCRIPTION
## Summary
- Changes from `fix/variable-decl-global-this-typeof` are included.
- This PR remains open because work is not fully merged into `main`.

## Merge stats
- Ahead of `main`: 1
- Behind `main`: 11