### PR TITLE
teammate-AB: Fix Es Decorators Export Modifier Errors

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1257,7 +1257,8 @@ pub(super) fn collect_diagnostics(
                 .filter(|d| is_real_syntax_error(d.code))
                 .map(|d| d.start)
                 .collect();
-            let filtered_parse_diagnostics = filtered_parse_diagnostics(&file.parse_diagnostics);
+            let filtered_parse_diagnostics =
+                filtered_parse_diagnostics(&file.parse_diagnostics, program_has_real_syntax_errors);
             let is_js = is_js_file(Path::new(&file.file_name));
             let mut file_diagnostics = Vec::new();
             // For JS files, suppress TypeScript-grammar parser diagnostics.
@@ -1845,7 +1846,8 @@ pub(super) fn check_file_for_parallel<'a>(
         .filter(|d| is_real_syntax_error(d.code))
         .map(|d| d.start)
         .collect();
-    let filtered_parse_diagnostics = filtered_parse_diagnostics(&file.parse_diagnostics);
+    let filtered_parse_diagnostics =
+        filtered_parse_diagnostics(&file.parse_diagnostics, program_has_real_syntax_errors);
     let is_js = is_js_file(Path::new(&file.file_name));
 
     // For JS files, suppress parser diagnostics. tsc's parser is lenient

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1274,6 +1274,7 @@ pub(super) fn parse_diagnostic_to_checker(
 
 pub(super) fn filtered_parse_diagnostics(
     parse_diagnostics: &[ParseDiagnostic],
+    program_has_real_syntax_errors: bool,
 ) -> Vec<&ParseDiagnostic> {
     let has_real_syntax_error = parse_diagnostics
         .iter()
@@ -1311,7 +1312,13 @@ pub(super) fn filtered_parse_diagnostics(
             }
             // Suppress parser-emitted grammar codes that tsc would emit via
             // grammarErrorOnNode (checker-side, suppressed by hasParseDiagnostics).
-            if has_non_grammar_parse_error && is_parser_grammar_code(diagnostic.code) {
+            // This applies both per-file (when the current file has non-grammar errors)
+            // and program-wide (when any file in the program has real syntax errors).
+            // tsc's grammarErrorOnNode calls hasParseDiagnostics(sourceFile) which
+            // covers program-level parse errors; we mirror that behavior here.
+            if (has_non_grammar_parse_error || program_has_real_syntax_errors)
+                && is_parser_grammar_code(diagnostic.code)
+            {
                 return false;
             }
             // Suppress TS1359 for 'await' when other parse diagnostics exist.
@@ -1367,6 +1374,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1210 // Code contained in a class is evaluated in strict mode
         | 1212 // Identifier expected. '{0}' is a reserved word in strict mode
         | 1213 // Identifier expected. '{0}' is a reserved word in strict mode. Class definitions are automatically in strict mode.
+        | 8038 // Decorators may not appear after 'export' or 'export default' if they also appear before 'export'
         | 18037 // 'await' expression cannot be used inside a class static block
         | 18041 // A 'return' statement cannot be used inside a class static block
     )
@@ -2519,7 +2527,7 @@ export declare function __classPrivateFieldSet<T extends object, V>(receiver: T,
             },
         ];
 
-        let filtered = filtered_parse_diagnostics(&diagnostics);
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
         let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
         assert!(
             !codes.contains(&1359),
@@ -2543,7 +2551,7 @@ export declare function __classPrivateFieldSet<T extends object, V>(receiver: T,
             code: 1359,
         }];
 
-        let filtered = filtered_parse_diagnostics(&diagnostics);
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
         let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
         assert!(
             codes.contains(&1359),

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -6,6 +6,7 @@ use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 //
 /// switch/try/do statements, string literals, and expression statements.
 use super::state::{CONTEXT_FLAG_DISALLOW_IN, ParserState};
+use crate::parser::parse_rules::look_ahead_is;
 use crate::parser::{
     NodeIndex,
     node::{
@@ -401,7 +402,21 @@ impl ParserState {
                 self.parse_function_declaration_with_async_optional_name(true, None)
             }
             SyntaxKind::ClassKeyword => self.parse_class_declaration(),
-            SyntaxKind::AbstractKeyword => self.parse_abstract_class_declaration(),
+            SyntaxKind::AbstractKeyword => {
+                // When 'abstract' is followed by '@', it's `export default abstract @dec class` —
+                // an invalid pattern. tsc parses 'abstract' as an expression identifier and
+                // then emits TS1005 "';' expected." when it sees '@' where a semicolon is needed.
+                // Fall through to the default expression path which does exactly this.
+                if look_ahead_is(&mut self.scanner, self.current_token, |t| {
+                    t == SyntaxKind::AtToken
+                }) {
+                    let expr = self.parse_assignment_expression();
+                    self.parse_semicolon();
+                    expr
+                } else {
+                    self.parse_abstract_class_declaration()
+                }
+            }
             SyntaxKind::InterfaceKeyword => self.parse_interface_declaration(),
             SyntaxKind::AtToken => {
                 // export default @dec class {} — parse decorators then class
@@ -669,7 +684,55 @@ impl ParserState {
                 self.report_export_invalid_name_statement_expected(start_pos);
                 self.parse_module_declaration()
             }
-            SyntaxKind::AbstractKeyword => self.parse_abstract_class_declaration(),
+            SyntaxKind::AbstractKeyword => {
+                // When 'abstract' is followed by '@', it's `export abstract @dec class` —
+                // an invalid decorator placement. tsc emits:
+                //   TS1128 at the 'export' position (Declaration or statement expected.)
+                //   TS1434 at the 'abstract' position (Unexpected keyword or identifier.)
+                // then recovers by parsing 'abstract' as an expression statement.
+                if look_ahead_is(&mut self.scanner, self.current_token, |t| {
+                    t == SyntaxKind::AtToken
+                }) {
+                    self.parse_error_at(
+                        start_pos,
+                        6, // length of "export"
+                        "Declaration or statement expected.",
+                        diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                    );
+                    let abstract_pos = self.token_pos();
+                    self.parse_error_at(
+                        abstract_pos,
+                        8, // length of "abstract"
+                        "Unexpected keyword or identifier.",
+                        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+                    );
+                    // Consume 'abstract' as expression, skip rest of the bad statement
+                    self.next_token(); // consume 'abstract'
+                    // skip the rest: @dec class C14 {}
+                    while !self.is_token(SyntaxKind::SemicolonToken)
+                        && !self.is_token(SyntaxKind::EndOfFileToken)
+                        && !self.is_token(SyntaxKind::CloseBraceToken)
+                    {
+                        if self.is_token(SyntaxKind::OpenBraceToken) {
+                            // consume balanced {} block
+                            self.next_token();
+                            let mut depth = 1u32;
+                            while depth > 0 && !self.is_token(SyntaxKind::EndOfFileToken) {
+                                if self.is_token(SyntaxKind::OpenBraceToken) {
+                                    depth += 1;
+                                } else if self.is_token(SyntaxKind::CloseBraceToken) {
+                                    depth -= 1;
+                                }
+                                self.next_token();
+                            }
+                            break;
+                        }
+                        self.next_token();
+                    }
+                    return NodeIndex::NONE;
+                }
+                self.parse_abstract_class_declaration()
+            }
             SyntaxKind::DeclareKeyword => self.parse_export_declare_declaration(start_pos),
             SyntaxKind::VarKeyword
             | SyntaxKind::LetKeyword

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -808,6 +808,17 @@ impl ParserState {
                 _ => self.parse_expression_statement(),
             }
         } else {
+            // When 'abstract' at statement level is followed by '@' on the same line,
+            // tsc emits TS1434 "Unexpected keyword or identifier." at the 'abstract' position,
+            // then falls through to parse 'abstract' as an expression statement.
+            if look_ahead_is(&mut self.scanner, self.current_token, |t| {
+                t == SyntaxKind::AtToken
+            }) {
+                self.parse_error_at_current_token(
+                    "Unexpected keyword or identifier.",
+                    diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+                );
+            }
             self.parse_expression_statement()
         }
     }

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -648,3 +648,71 @@ fn import_async_equals_still_works() {
         "import async = require('mod') should parse cleanly, got {codes:?}"
     );
 }
+
+// === ES Decorator misplacement tests (tsc parity) ===
+
+/// `abstract @dec class C {}` at statement level should emit TS1434
+/// "Unexpected keyword or identifier." at the 'abstract' position.
+/// tsc treats `abstract @dec class` as invalid — `abstract` is an expression
+/// and `@dec class` can't follow without a semicolon.
+#[test]
+fn abstract_at_statement_level_before_decorator_emits_ts1434() {
+    let (parser, _root) = parse_source("abstract @dec class C {}");
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER),
+        "expected TS1434 for `abstract @dec class`, got {codes:?}"
+    );
+}
+
+/// `export abstract @dec class C {}` should emit:
+///   TS1128 "Declaration or statement expected." at the 'export' position
+///   TS1434 "Unexpected keyword or identifier." at the 'abstract' position
+#[test]
+fn export_abstract_before_decorator_emits_ts1128_and_ts1434() {
+    let (parser, _root) = parse_source("export abstract @dec class C {}");
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED),
+        "expected TS1128 for `export abstract @dec class`, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER),
+        "expected TS1434 for `export abstract @dec class`, got {codes:?}"
+    );
+}
+
+/// `export default abstract @dec class C {}` should emit TS1005 "';' expected."
+/// at the '@' position, because 'abstract' is parsed as an expression identifier
+/// and '@' is not a valid continuation without a semicolon.
+#[test]
+fn export_default_abstract_before_decorator_emits_ts1005() {
+    let (parser, _root) = parse_source("export default abstract @dec class C {}");
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&diagnostic_codes::EXPECTED),
+        "expected TS1005 (';' expected) for `export default abstract @dec class`, got {codes:?}"
+    );
+}
+
+/// `abstract class C {}` should still parse cleanly (no errors).
+#[test]
+fn abstract_class_parses_cleanly() {
+    let (parser, _root) = parse_source("abstract class C {}");
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        codes.is_empty(),
+        "abstract class C {{}} should parse cleanly, got {codes:?}"
+    );
+}
+
+/// `export abstract class C {}` should still parse cleanly (no errors).
+#[test]
+fn export_abstract_class_parses_cleanly() {
+    let (parser, _root) = parse_source("export abstract class C {}");
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        codes.is_empty(),
+        "export abstract class C {{}} should parse cleanly, got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Fix Es Decorators Export Modifier Errors

## Merge stats
- Ahead of origin/main: 1 commits
- Behind origin/main: 40 commits
