### PR TITLE
teammate-B: Fix Property Decl Annotation Display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -120,6 +120,10 @@ name = "ts2322_tests"
 path = "tests/ts2322_tests.rs"
 
 [[test]]
+name = "ts2322_property_decl_annotation_tests"
+path = "tests/ts2322_property_decl_annotation_tests.rs"
+
+[[test]]
 name = "spread_rest_tests"
 path = "tests/spread_rest_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -249,7 +249,14 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let sym_id = self.resolve_identifier_symbol(expr_idx)?;
+        // Primary: scope-chain resolution (works for variables, parameters, etc.)
+        // Fallback: node_symbols direct lookup for declaration-site identifiers.
+        // Class property names are filtered out by scope-chain resolution (they're
+        // class members, not plain values), but `node_symbols` always maps every
+        // declaration-site name to its symbol — giving us the right symbol here.
+        let sym_id = self
+            .resolve_identifier_symbol(expr_idx)
+            .or_else(|| self.ctx.binder.node_symbols.get(&expr_idx.0).copied())?;
         let symbol = self.get_cross_file_symbol(sym_id)?;
         let owner_binder = self
             .ctx
@@ -367,6 +374,20 @@ impl<'a> CheckerState<'a> {
                 return node_text_in_arena(decl_arena, var_decl.type_annotation).and_then(|text| {
                     self.sanitize_type_annotation_text_for_diagnostic(text, allow_object_shapes)
                 });
+            }
+
+            // Class property declarations: `public scopeGetter: () => SymbolScope = null`
+            // The symbol's value_declaration is the PROPERTY_DECLARATION node itself.
+            // tsc shows the declared annotation text in TS2322 messages, not the
+            // evaluated type (which may be `() => error` for unresolved names).
+            if let Some(prop_decl) = decl_arena.get_property_decl(decl)
+                && prop_decl.type_annotation.is_some()
+            {
+                return node_text_in_arena(decl_arena, prop_decl.type_annotation).and_then(
+                    |text| {
+                        self.sanitize_type_annotation_text_for_diagnostic(text, allow_object_shapes)
+                    },
+                );
             }
         }
 
@@ -1524,6 +1545,15 @@ impl<'a> CheckerState<'a> {
             // correctly produces namespace-qualified enum names.
             if crate::query_boundaries::common::enum_def_id(self.ctx.types, target).is_some() {
                 return self.format_assignability_type_for_message(target, source);
+            }
+            // When the evaluated display contains our internal "error" sentinel
+            // (from unresolved type names like `() => SymbolScope` where `SymbolScope`
+            // is not defined), prefer the declared annotation text. tsc shows the
+            // original annotation, not the evaluated error type.
+            // Only applies when the annotation itself does not contain "error" (which
+            // would indicate the user actually wrote a type named `error`).
+            if fallback.contains("error") && !display.contains("error") {
+                return self.format_annotation_like_type(&display);
             }
             return fallback;
         }

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1617,14 +1617,15 @@ fn checker_files_stay_under_loc_limit() {
         ("assignability/assignment_checker.rs", 2083),
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
-        ("error_reporter/core/diagnostic_source.rs", 2009),
+        ("error_reporter/core/diagnostic_source.rs", 2020),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),
         // Pushed over the 2000-LOC default by recent JSDoc/CommonJS source-display
         // changes (#679) and subsequent display-parity fixes (#682, #688, #690);
         // ceiling tracks current state so the gate can ratchet down.
-        ("error_reporter/core/diagnostic_source.rs", 2046),
+        // Updated to 2020 by fix for class property annotation display in TS2322.
+        ("error_reporter/core/diagnostic_source.rs", 2020),
         // Grew past 2000 from recent contextual function type fixes (#688);
         // ceiling tracks current state.
         ("types/function_type.rs", 2039),

--- a/crates/tsz-checker/tests/ts2322_property_decl_annotation_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_property_decl_annotation_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for TS2322 diagnostic messages showing the declared annotation text
+//! for class property declarations, even when the annotation references
+//! unresolved type names.
+//!
+//! Regression: for class properties like `public f: () => SymbolScope = null`,
+//! when `SymbolScope` is undefined (TS2304), the TS2322 message was incorrectly
+//! showing `() => error` (the evaluated type with our internal error sentinel)
+//! instead of `() => SymbolScope` (the source annotation text).
+//!
+//! Root cause: `declared_type_annotation_text_for_expression_with_options` used
+//! scope-chain resolution (`resolve_identifier_symbol`) which correctly filters
+//! out class member symbols to avoid false positive identifier resolution in
+//! expression contexts. But for declaration-site lookup, we need the direct
+//! `node_symbols` mapping, which always maps declaration-site identifiers to
+//! their declared symbols.
+
+fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let mut parser =
+        tsz_parser::parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = tsz_solver::TypeInterner::new();
+    let mut checker = tsz_checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        tsz_checker::context::CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Class property with a function type annotation that references an unresolved
+/// type should show the annotation text in TS2322, not the internal `error` sentinel.
+#[test]
+fn ts2322_class_prop_func_annotation_with_unresolved_return_type() {
+    // `SymbolScope` is not defined → TS2304. The TS2322 for `null` assignment
+    // must display `() => SymbolScope`, not `() => error`.
+    let source = r#"
+class EnclosingScopeContext {
+    public scopeGetter: () => SymbolScope = null;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(code, _)| *code == 2322).collect();
+
+    assert!(!ts2322.is_empty(), "expected at least one TS2322");
+    for (_, msg) in &ts2322 {
+        assert!(
+            !msg.contains("error"),
+            "TS2322 message should not contain internal 'error' sentinel: {msg}"
+        );
+        assert!(
+            msg.contains("SymbolScope"),
+            "TS2322 message should show annotation text '() => SymbolScope': {msg}"
+        );
+    }
+}
+
+/// Two class properties with unresolved types in their function annotations.
+#[test]
+fn ts2322_class_prop_multiple_func_annotations_with_unresolved_types() {
+    let source = r#"
+class Context {
+    public scopeGetter: () => SymbolScope = null;
+    public objectLiteralScopeGetter: () => SymbolScope = null;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(code, _)| *code == 2322).collect();
+
+    assert_eq!(
+        ts2322.len(),
+        2,
+        "expected two TS2322 errors, got: {ts2322:?}"
+    );
+    for (_, msg) in &ts2322 {
+        assert!(
+            !msg.contains("error"),
+            "TS2322 message must not contain 'error' sentinel: {msg}"
+        );
+        assert!(
+            msg.contains("SymbolScope"),
+            "TS2322 message must show annotation '() => SymbolScope': {msg}"
+        );
+    }
+}
+
+/// When the annotation type IS resolved, no regression: should still work normally.
+#[test]
+fn ts2322_class_prop_func_annotation_resolved_type() {
+    let source = r#"
+class Context {
+    public getter: () => string = null;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(code, _)| *code == 2322).collect();
+
+    assert!(!ts2322.is_empty(), "expected at least one TS2322");
+    for (_, msg) in &ts2322 {
+        assert!(
+            msg.contains("string"),
+            "TS2322 should show the resolved type '() => string': {msg}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Property Decl Annotation Display

## Merge stats
- Ahead of origin/main: 1 commits
- Behind origin/main: 44 commits
