### PR TITLE
teammate-Y: Fix Symbol Key String Index Inference

### DIFF
--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -1464,3 +1464,30 @@ const a = f({ d: [] });
         "const type param with empty array should not produce false TS2322. Got: {diags:#?}"
     );
 }
+
+// ─── Symbol-keyed property exclusion from string-index inference ─────────────
+
+#[test]
+fn object_values_with_symbol_keyed_intersection_no_false_ts2345() {
+    // Regression: calling a function that expects T with a value inferred from
+    // Object.values on a type that has both a unique-symbol property and a
+    // string index signature must NOT include the symbol property value type
+    // in the inferred T.
+    //
+    // Previously `true` was included in T from `{ [sym]?: true }`, causing
+    // a false TS2345 where tsc emits none.
+    //
+    // Reproduces: unionTypeInference.ts repro from #32752
+    let source = r#"
+declare const sym: unique symbol;
+type WithSym<T> = { [sym]?: true } & T;
+declare function f<T>(x: WithSym<{ [s: string]: T }>): T;
+declare const input: WithSym<{ [s: string]: string }>;
+const result: string = f(input);
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345 || *code == 2322),
+        "symbol property in intersection must not cause false type error. Got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -439,8 +439,19 @@ impl<'a> InferenceContext<'a> {
                 //
                 // Named class/interface instance types are excluded — they must
                 // declare an explicit index signature.
+                //
+                // Symbol-keyed properties (stored with "__unique_" prefix) must be
+                // excluded: they do not participate in string index signatures.
+                // e.g. `{ [sym]?: true }` should not contribute `true` when inferring
+                // T from `{ [s: string]: T }`.
                 if has_implicit_index && !source_shape.properties.is_empty() {
                     for p in &source_shape.properties {
+                        // Skip symbol-keyed properties — they are not reachable via
+                        // a string index and must not pollute string-index inference.
+                        let prop_name_str = self.interner.resolve_atom(p.name);
+                        if prop_name_str.starts_with("__unique_") {
+                            continue;
+                        }
                         // For optional properties, strip `undefined` from optionality.
                         // tsc: `{ a: string, b?: number }` infers T as `string | number`
                         // (not `string | number | undefined`).
@@ -549,11 +560,20 @@ impl<'a> InferenceContext<'a> {
             None
         };
 
-        if !source.properties.is_empty() {
+        // Collect only string/number-named properties for mapped-type inference.
+        // Symbol-keyed properties (stored with "__unique_" prefix) must be excluded:
+        // they do not participate in string/number key spaces and must not
+        // contribute to constraint (`K`) or template (`T`) inference.
+        let string_named_props: Vec<_> = source
+            .properties
+            .iter()
+            .filter(|p| !self.interner.resolve_atom(p.name).starts_with("__unique_"))
+            .collect();
+
+        if !string_named_props.is_empty() {
             // Infer the constraint type (K) from the union of source property names
             // e.g., for { foo: string, bar: number }, K = "foo" | "bar"
-            let name_literals: Vec<TypeId> = source
-                .properties
+            let name_literals: Vec<TypeId> = string_named_props
                 .iter()
                 .map(|p| self.interner.literal_string_atom(p.name))
                 .collect();
@@ -571,7 +591,7 @@ impl<'a> InferenceContext<'a> {
             // contribute a different type for T, the result should be their union
             // (e.g., Box<number> | Box<string> | Box<boolean>), not a single "best" type.
             let template_priority = InferencePriority::MappedType;
-            for prop in &source.properties {
+            for prop in &string_named_props {
                 let key_literal = self.interner.literal_string_atom(prop.name);
                 let subst = TypeSubstitution::single(mapped.type_param.name, key_literal);
                 let instantiated_template =

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -569,6 +569,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let idx_priority = crate::types::InferencePriority::MappedType;
 
         for (i, prop) in source_props.iter().enumerate() {
+            // Skip symbol-keyed properties (stored with "__unique_" prefix).
+            // Symbol-keyed properties are NOT accessible via string or numeric index
+            // signatures, so they must not contribute to index-signature inference.
+            // e.g. `{ [sym]?: true }` must not add `true` as a candidate for T
+            // when inferring against `{ [s: string]: T }`.
+            let prop_name_str = self.interner.resolve_atom(prop.name);
+            if prop_name_str.starts_with("__unique_") {
+                continue;
+            }
+
             // For optional properties, strip `undefined` from the type before contributing
             // to index signature inference. When inferring T from `{ a: string, b?: number }`
             // against `{ [x: string]: T }`, tsc infers T = string | number (not


### PR DESCRIPTION
## Summary
- Fix Symbol Key String Index Inference

## Merge stats
- Ahead of origin/main: 1 commits
- Behind origin/main: 40 commits
