### PR TITLE
feat(core): wire DepGraph into MergedProgram for incremental invalida…

### DIFF
--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -1386,6 +1386,8 @@ fn bind_file_with_libs(
 
 // Skeleton types are in the skeleton submodule
 use super::skeleton::*;
+// Dependency graph built from skeleton import_sources
+use super::dep_graph::DepGraph;
 
 /// A bound file ready for type checking
 pub struct BoundFile {
@@ -1656,10 +1658,44 @@ pub struct MergedProgram {
     /// and stored here so downstream consumers can begin migrating off arena-backed
     /// lookups toward skeleton-based queries.
     pub skeleton_index: Option<SkeletonIndex>,
+    /// Dependency graph derived from skeleton `import_sources`.
+    ///
+    /// Built using `DepGraph::build_simple` during merge (name-matching heuristic).
+    /// Provides topological ordering for incremental invalidation and ordered
+    /// checking. `None` only if no skeletons were extracted (should not happen
+    /// in the normal pipeline).
+    pub dep_graph: Option<DepGraph>,
     /// Sum of `BindResult::estimated_size_bytes()` across all input files, computed
     /// before the merge consumes per-file data. This captures the pre-merge memory
     /// footprint so it can be compared to the post-merge `MergedProgram` residency.
     pub pre_merge_bind_total_bytes: usize,
+}
+
+impl MergedProgram {
+    /// Return the topological file ordering from the dependency graph.
+    ///
+    /// Dependencies come before dependents. Files in cycles are appended
+    /// in stable (input) order. Returns `None` if no dep graph was computed.
+    #[must_use]
+    pub fn topological_file_order(&self) -> Option<super::dep_graph::TopoResult> {
+        self.dep_graph.as_ref().map(|dg| dg.topological_order())
+    }
+
+    /// Return the set of file indices that directly depend on the given file.
+    ///
+    /// These are files that `import` from the target file. Useful for
+    /// incremental invalidation: when `file_idx` changes, its dependents
+    /// may need re-checking.
+    #[must_use]
+    pub fn dependents_of(&self, file_idx: usize) -> Option<&rustc_hash::FxHashSet<usize>> {
+        self.dep_graph.as_ref().map(|dg| dg.dependents(file_idx))
+    }
+
+    /// Return the set of file indices that the given file depends on.
+    #[must_use]
+    pub fn dependencies_of(&self, file_idx: usize) -> Option<&rustc_hash::FxHashSet<usize>> {
+        self.dep_graph.as_ref().map(|dg| dg.dependencies(file_idx))
+    }
 }
 
 /// Check if two symbols can be merged across multiple files.
@@ -1973,6 +2009,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
     // per-file symbol/augmentation/re-export data without any remapping.
     let skeletons: Vec<FileSkeleton> = results.iter().map(|r| extract_skeleton(r)).collect();
     let skeleton_index = reduce_skeletons(&skeletons);
+    let dep_graph = DepGraph::build_simple(&skeletons);
 
     // Capture aggregate pre-merge memory footprint before we start consuming data.
     let pre_merge_bind_total_bytes: usize = results.iter().map(|r| r.estimated_size_bytes()).sum();
@@ -3347,6 +3384,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         semantic_defs,
         definition_store,
         skeleton_index: Some(skeleton_index),
+        dep_graph: Some(dep_graph),
         pre_merge_bind_total_bytes,
     }
 }

--- a/crates/tsz-core/src/parallel/residency.rs
+++ b/crates/tsz-core/src/parallel/residency.rs
@@ -45,6 +45,18 @@ pub struct MergedProgramResidencyStats {
     /// Total estimated size of unique `NodeArena` allocations in bytes.
     /// Computed by calling `estimated_size_bytes()` on each deduplicated arena.
     pub unique_arena_estimated_bytes: usize,
+    /// Whether a dependency graph was computed from skeleton import sources.
+    pub has_dep_graph: bool,
+    /// Number of import edges in the dependency graph.
+    pub dep_graph_edge_count: usize,
+    /// Number of root files (no in-graph dependencies) in the dep graph.
+    pub dep_graph_root_count: usize,
+    /// Whether the dependency graph is acyclic (a DAG).
+    pub dep_graph_is_acyclic: bool,
+    /// Number of cycle groups (SCCs with >1 member) in the dep graph.
+    pub dep_graph_cycle_count: usize,
+    /// Number of unresolved import specifiers in the dep graph.
+    pub dep_graph_unresolved_count: usize,
 }
 
 impl MergedProgram {
@@ -94,6 +106,27 @@ impl MergedProgram {
         let total_bound_file_bytes: usize =
             self.files.iter().map(|f| f.estimated_size_bytes()).sum();
 
+        let (
+            has_dep_graph,
+            dep_edge_count,
+            dep_root_count,
+            dep_is_acyclic,
+            dep_cycle_count,
+            dep_unresolved,
+        ) = if let Some(ref dg) = self.dep_graph {
+            let topo = dg.topological_order();
+            (
+                true,
+                dg.edge_count,
+                dg.roots().len(),
+                topo.is_acyclic,
+                topo.cycles.len(),
+                dg.unresolved_specifiers.len(),
+            )
+        } else {
+            (false, 0, 0, true, 0, 0)
+        };
+
         MergedProgramResidencyStats {
             file_count: self.files.len(),
             bound_file_arena_count: self.files.len(),
@@ -112,6 +145,12 @@ impl MergedProgram {
             pre_merge_bind_total_bytes: self.pre_merge_bind_total_bytes,
             total_bound_file_bytes,
             unique_arena_estimated_bytes,
+            has_dep_graph,
+            dep_graph_edge_count: dep_edge_count,
+            dep_graph_root_count: dep_root_count,
+            dep_graph_is_acyclic: dep_is_acyclic,
+            dep_graph_cycle_count: dep_cycle_count,
+            dep_graph_unresolved_count: dep_unresolved,
         }
     }
 }
@@ -215,6 +254,12 @@ mod tests {
             pre_merge_bind_total_bytes: 300,
             total_bound_file_bytes: 200,
             unique_arena_estimated_bytes: 0,
+            has_dep_graph: false,
+            dep_graph_edge_count: 0,
+            dep_graph_root_count: 0,
+            dep_graph_is_acyclic: true,
+            dep_graph_cycle_count: 0,
+            dep_graph_unresolved_count: 0,
         };
         assert_eq!(budget.assess(&stats), MemoryPressure::Low);
     }
@@ -239,6 +284,12 @@ mod tests {
             pre_merge_bind_total_bytes: 1500,
             total_bound_file_bytes: 1000,
             unique_arena_estimated_bytes: 0,
+            has_dep_graph: false,
+            dep_graph_edge_count: 0,
+            dep_graph_root_count: 0,
+            dep_graph_is_acyclic: true,
+            dep_graph_cycle_count: 0,
+            dep_graph_unresolved_count: 0,
         };
         assert_eq!(budget.assess(&stats), MemoryPressure::High);
     }
@@ -259,6 +310,12 @@ mod tests {
             pre_merge_bind_total_bytes: 50_000,
             total_bound_file_bytes: 20_000,
             unique_arena_estimated_bytes: 0,
+            has_dep_graph: false,
+            dep_graph_edge_count: 0,
+            dep_graph_root_count: 0,
+            dep_graph_is_acyclic: true,
+            dep_graph_cycle_count: 0,
+            dep_graph_unresolved_count: 0,
         };
         // Savings = pre_merge - skeleton = 50000 - 1000 = 49000
         assert_eq!(ResidencyBudget::eviction_savings(&stats), 49_000);
@@ -280,6 +337,12 @@ mod tests {
             pre_merge_bind_total_bytes: 50_000,
             total_bound_file_bytes: 20_000,
             unique_arena_estimated_bytes: 0,
+            has_dep_graph: false,
+            dep_graph_edge_count: 0,
+            dep_graph_root_count: 0,
+            dep_graph_is_acyclic: true,
+            dep_graph_cycle_count: 0,
+            dep_graph_unresolved_count: 0,
         };
         assert_eq!(ResidencyBudget::eviction_savings(&stats), 0);
     }

--- a/crates/tsz-core/tests/parallel_tests.rs
+++ b/crates/tsz-core/tests/parallel_tests.rs
@@ -8661,3 +8661,129 @@ function run(configuration: server.IConfiguration) {
         consumer.diagnostics
     );
 }
+
+// =========================================================================
+// Dependency Graph Integration Tests
+// =========================================================================
+
+#[test]
+fn test_merged_program_has_dep_graph() {
+    let files = vec![
+        ("a.ts".to_string(), "let a = 1;".to_string()),
+        ("b.ts".to_string(), "let b = 2;".to_string()),
+    ];
+
+    let bind_results = parse_and_bind_parallel(files);
+    let program = merge_bind_results(bind_results);
+
+    assert!(
+        program.dep_graph.is_some(),
+        "MergedProgram should have a dep_graph"
+    );
+    let dg = program.dep_graph.as_ref().unwrap();
+    assert_eq!(dg.node_count, 2);
+}
+
+#[test]
+fn test_merged_program_dep_graph_captures_imports() {
+    let files = vec![
+        (
+            "utils.ts".to_string(),
+            "export function helper() { return 42; }".to_string(),
+        ),
+        (
+            "main.ts".to_string(),
+            "import { helper } from './utils'; helper();".to_string(),
+        ),
+    ];
+
+    let bind_results = parse_and_bind_parallel(files);
+    let program = merge_bind_results(bind_results);
+
+    let dg = program.dep_graph.as_ref().expect("should have dep_graph");
+    assert_eq!(dg.node_count, 2);
+    // The dep graph should have captured some topology
+    // (exact edge resolution depends on the simple name-matching heuristic)
+}
+
+#[test]
+fn test_merged_program_topological_order_available() {
+    let files = vec![
+        ("a.ts".to_string(), "export const a = 1;".to_string()),
+        ("b.ts".to_string(), "export const b = 2;".to_string()),
+        ("c.ts".to_string(), "export const c = 3;".to_string()),
+    ];
+
+    let bind_results = parse_and_bind_parallel(files);
+    let program = merge_bind_results(bind_results);
+
+    let topo = program
+        .topological_file_order()
+        .expect("should have topological order");
+
+    // All three files should appear in the order
+    assert_eq!(topo.order.len(), 3);
+    // No imports between them, so no cycles
+    assert!(topo.is_acyclic);
+    assert!(topo.cycles.is_empty());
+}
+
+#[test]
+fn test_merged_program_dependents_and_dependencies() {
+    let files = vec![
+        ("a.ts".to_string(), "let a = 1;".to_string()),
+        ("b.ts".to_string(), "let b = 2;".to_string()),
+    ];
+
+    let bind_results = parse_and_bind_parallel(files);
+    let program = merge_bind_results(bind_results);
+
+    // Both should return Some (dep graph exists)
+    let deps_of_0 = program.dependencies_of(0);
+    assert!(deps_of_0.is_some());
+
+    let dependents_of_0 = program.dependents_of(0);
+    assert!(dependents_of_0.is_some());
+}
+
+#[test]
+fn test_residency_stats_include_dep_graph_info() {
+    let files = vec![
+        ("a.ts".to_string(), "export const a = 1;".to_string()),
+        ("b.ts".to_string(), "export const b = 2;".to_string()),
+    ];
+
+    let bind_results = parse_and_bind_parallel(files);
+    let program = merge_bind_results(bind_results);
+    let stats = program.residency_stats();
+
+    assert!(
+        stats.has_dep_graph,
+        "residency stats should report dep graph"
+    );
+    // Independent files should have no edges
+    assert!(stats.dep_graph_is_acyclic);
+    assert_eq!(stats.dep_graph_cycle_count, 0);
+    // Both files are roots (no in-graph deps)
+    assert_eq!(stats.dep_graph_root_count, 2);
+}
+
+#[test]
+fn test_dep_graph_deterministic_across_runs() {
+    let files = vec![
+        ("a.ts".to_string(), "let x = 1;".to_string()),
+        ("b.ts".to_string(), "let y = 2;".to_string()),
+        ("c.ts".to_string(), "let z = 3;".to_string()),
+    ];
+
+    let results1 = parse_and_bind_parallel(files.clone());
+    let program1 = merge_bind_results(results1);
+    let topo1 = program1.topological_file_order().unwrap();
+
+    let results2 = parse_and_bind_parallel(files);
+    let program2 = merge_bind_results(results2);
+    let topo2 = program2.topological_file_order().unwrap();
+
+    assert_eq!(topo1.order, topo2.order);
+    assert_eq!(topo1.is_acyclic, topo2.is_acyclic);
+}


### PR DESCRIPTION
…tion

Build a dependency graph from skeleton import_sources during merge_bind_results and store it on MergedProgram. This enables downstream consumers (LSP, incremental CLI) to answer "which files depend on this file?" and "what is the topological check order?" without re-walking ASTs or re-resolving imports.

Changes:
- Add `dep_graph: Option<DepGraph>` field to MergedProgram
- Build DepGraph via `DepGraph::build_simple` during merge
- Add convenience methods: topological_file_order(), dependents_of(), dependencies_of()
- Extend MergedProgramResidencyStats with dep graph counters (edge_count, root_count, is_acyclic, cycle_count, unresolved_count)
- 6 new integration tests covering dep graph availability, topological ordering, dependency queries, residency reporting, and determinism

The legacy check_files_parallel path is unchanged — this wires up infrastructure for Phase 3 incremental invalidation.

https://claude.ai/code/session_015u7SHvuREmXzkwxzev1ZTS