### PR TITLE
fix(parser): avoid checker cascade after TS8020 on JSDoc-legacy types

### DIFF
--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -598,22 +598,44 @@ impl ParserState {
 
         self.next_token(); // consume `function`
 
-        let parameters = if self.is_token(SyntaxKind::OpenParenToken) {
+        let mut is_constructor = false;
+        let mut constructor_return_type = NodeIndex::NONE;
+        let mut starting_param_index: u32 = 0;
+        let mut parameters = self.make_node_list(Vec::new());
+
+        if self.is_token(SyntaxKind::OpenParenToken) {
             self.parse_expected(SyntaxKind::OpenParenToken);
-            if self.is_token(SyntaxKind::CloseParenToken) {
-                self.make_node_list(Vec::new())
-            } else {
-                self.parse_type_parameter_list()
+
+            // JSDoc-legacy `function(new: R, …)` denotes a constructor type whose
+            // return type is R.  Detect the leading `new:` before normal param
+            // parsing so we can feed it back into the type as the construct
+            // signature's return type rather than treating `new` as a parameter
+            // name (which would inflate the arity and cascade into TS2554).
+            if self.is_token(SyntaxKind::NewKeyword) && self.next_token_is_colon_lookahead() {
+                is_constructor = true;
+                self.next_token(); // consume `new`
+                self.next_token(); // consume `:`
+                constructor_return_type = self.parse_type();
+                // Consume the trailing `,` if there are more params, otherwise
+                // fall through and let the `)` handling below close the list.
+                let _ = self.parse_optional(SyntaxKind::CommaToken);
+                starting_param_index = 1;
             }
-        } else {
-            self.make_node_list(Vec::new())
-        };
+
+            if !self.is_token(SyntaxKind::CloseParenToken) {
+                parameters = self.parse_jsdoc_legacy_function_parameters(starting_param_index);
+            }
+        }
 
         if self.is_token(SyntaxKind::CloseParenToken) {
             self.parse_expected(SyntaxKind::CloseParenToken);
         }
 
-        let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
+        // When `new:` consumed the return type already, ignore any further
+        // `: T` suffix (it would be a stray annotation).
+        let type_annotation = if is_constructor {
+            constructor_return_type
+        } else if self.parse_optional(SyntaxKind::ColonToken) {
             self.parse_type()
         } else {
             NodeIndex::NONE
@@ -621,8 +643,14 @@ impl ParserState {
 
         let end_pos = self.token_end();
 
+        let kind = if is_constructor {
+            syntax_kind_ext::CONSTRUCTOR_TYPE
+        } else {
+            syntax_kind_ext::FUNCTION_TYPE
+        };
+
         self.arena.add_function_type(
-            syntax_kind_ext::FUNCTION_TYPE,
+            kind,
             start_pos,
             end_pos,
             crate::parser::node::FunctionTypeData {
@@ -632,6 +660,129 @@ impl ParserState {
                 is_abstract: false,
             },
         )
+    }
+
+    /// Lookahead that returns true when the *next* token (after the current one)
+    /// is `:`.  Used to detect the `new:` and `this:` JSDoc function-type markers.
+    fn next_token_is_colon_lookahead(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let saved_token = self.current_token;
+        self.next_token();
+        let is_colon = self.is_token(SyntaxKind::ColonToken);
+        self.scanner.restore_state(snapshot);
+        self.current_token = saved_token;
+        is_colon
+    }
+
+    /// Parse a JSDoc-legacy function type parameter list such as
+    /// `(this: number, string, number)`.  Unlike a normal TS parameter list, entries
+    /// may be bare types (no `name:`) — tsc treats `function(T1, T2)` as
+    /// `(arg0: T1, arg1: T2) => …`.  Without synthesizing names for bare types the
+    /// checker would emit cascading TS7051 ("parameter has a name but no type") and
+    /// TS2300 ("duplicate identifier") on top of the TS8020 that was already
+    /// reported for this JSDoc syntax.  `starting_index` lets callers skip the
+    /// indices taken up by a preceding `new:` slot so bare names line up with
+    /// tsc's `argN` convention.
+    fn parse_jsdoc_legacy_function_parameters(&mut self, starting_index: u32) -> NodeList {
+        let mut params = Vec::new();
+        let mut index: u32 = starting_index;
+
+        while !self.is_token(SyntaxKind::CloseParenToken)
+            && !self.is_token(SyntaxKind::EndOfFileToken)
+        {
+            let param = self.parse_jsdoc_legacy_function_parameter(index);
+            params.push(param);
+            index += 1;
+            if !self.parse_optional(SyntaxKind::CommaToken) {
+                break;
+            }
+        }
+
+        self.make_node_list(params)
+    }
+
+    fn parse_jsdoc_legacy_function_parameter(&mut self, index: u32) -> NodeIndex {
+        let param_start = self.token_pos();
+        let dot_dot_dot_token = self.parse_optional(SyntaxKind::DotDotDotToken);
+
+        if self.looks_like_jsdoc_named_parameter() {
+            // Conventional `name [?]: type` entry (also covers `this: T` and `new: T`).
+            let name = if self.is_identifier_or_keyword() {
+                self.parse_identifier_name()
+            } else {
+                self.parse_identifier()
+            };
+            let question_token = self.parse_optional(SyntaxKind::QuestionToken);
+            let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
+                self.parse_type()
+            } else {
+                NodeIndex::NONE
+            };
+            let param_end = self.token_full_start();
+            self.arena.add_parameter(
+                syntax_kind_ext::PARAMETER,
+                param_start,
+                param_end,
+                crate::parser::node::ParameterData {
+                    modifiers: None,
+                    dot_dot_dot_token,
+                    name,
+                    question_token,
+                    type_annotation,
+                    initializer: NodeIndex::NONE,
+                },
+            )
+        } else {
+            // Bare type — synthesize an `argN` identifier so the checker sees a
+            // well-typed parameter rather than a nameless type that would cascade
+            // into TS7051 / TS2300 after the TS8020 we already emitted.
+            let name_pos = self.token_pos();
+            let type_annotation = self.parse_type();
+            let name = self.arena.add_identifier(
+                SyntaxKind::Identifier as u16,
+                name_pos,
+                name_pos,
+                crate::parser::node::IdentifierData {
+                    atom: Atom::NONE,
+                    escaped_text: format!("arg{index}"),
+                    original_text: None,
+                    type_arguments: None,
+                },
+            );
+            let param_end = self.token_full_start();
+            self.arena.add_parameter(
+                syntax_kind_ext::PARAMETER,
+                param_start,
+                param_end,
+                crate::parser::node::ParameterData {
+                    modifiers: None,
+                    dot_dot_dot_token,
+                    name,
+                    question_token: false,
+                    type_annotation,
+                    initializer: NodeIndex::NONE,
+                },
+            )
+        }
+    }
+
+    /// Lookahead: does the current token stream start with `name [?]:` — i.e. a
+    /// conventional parameter declaration — as opposed to a bare type?  Used to
+    /// decide how to parse entries in a JSDoc-legacy function type parameter list.
+    fn looks_like_jsdoc_named_parameter(&mut self) -> bool {
+        if !self.is_identifier_or_keyword() {
+            return false;
+        }
+        let snapshot = self.scanner.save_state();
+        let saved_token = self.current_token;
+        self.next_token();
+        if self.is_token(SyntaxKind::QuestionToken) {
+            self.next_token();
+        }
+        let is_colon = self.is_token(SyntaxKind::ColonToken);
+        self.scanner.restore_state(snapshot);
+        self.current_token = saved_token;
+        is_colon
     }
 
     fn should_parse_abstract_constructor_type(&mut self) -> bool {
@@ -721,14 +872,18 @@ impl ParserState {
         }
 
         let first_name = self.parse_type_identifier_or_keyword();
-        let type_name = self.parse_qualified_name_rest(first_name);
+        let (type_name, jsdoc_type_arguments) = self.parse_qualified_name_rest(first_name);
         // Only parse type arguments if `<` is on the same line (no preceding line break).
         // A line break before `<` means it's a new construct (e.g., a call signature
         // in a type literal), not type arguments for this type reference.
         // This matches tsc's `!scanner.hasPrecedingLineBreak()` check.
-        let type_arguments = (self.is_less_than_or_compound()
-            && !self.scanner.has_preceding_line_break())
-        .then(|| self.parse_type_arguments());
+        // `jsdoc_type_arguments` is Some when we already consumed `Foo.<T>` JSDoc-legacy
+        // type arguments while walking the qualified-name rest — prefer those so the
+        // caller sees a clean `Foo<T>` rather than a namespace access.
+        let type_arguments = jsdoc_type_arguments.or_else(|| {
+            (self.is_less_than_or_compound() && !self.scanner.has_preceding_line_break())
+                .then(|| self.parse_type_arguments())
+        });
 
         self.arena.add_type_ref(
             syntax_kind_ext::TYPE_REFERENCE,

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -384,8 +384,17 @@ impl ParserState {
 
     /// Parse qualified name rest: given a left name, parse `.Right.Rest` parts
     /// Handles: foo.Bar, A.B.C, etc.
-    pub(crate) fn parse_qualified_name_rest(&mut self, left: NodeIndex) -> NodeIndex {
+    ///
+    /// Returns `(qualified_name, jsdoc_type_arguments)`. When the dot is followed by
+    /// `<…>` (JSDoc-legacy `Foo.<T>` syntax), TS8020 is emitted and the type arguments
+    /// are bubbled up to the caller so the whole reference can be treated as `Foo<T>`
+    /// rather than a qualified-name namespace access (which would cascade into TS2702).
+    pub(crate) fn parse_qualified_name_rest(
+        &mut self,
+        left: NodeIndex,
+    ) -> (NodeIndex, Option<NodeList>) {
         let mut current = left;
+        let mut jsdoc_type_arguments: Option<NodeList> = None;
 
         while self.is_token(SyntaxKind::DotToken) {
             let start_pos = if let Some(node) = self.arena.get(current) {
@@ -394,69 +403,67 @@ impl ParserState {
                 self.token_pos()
             };
 
-            // Capture position right after the dot (before scanning to next token)
+            // Capture the span of the dot itself so JSDoc-legacy `Foo.<T>` diagnostics
+            // can anchor at the `.` (matching tsc) instead of the following `<`.
+            let dot_start = self.token_pos();
             let dot_end = self.token_end();
             self.next_token(); // consume .
+
+            // `Foo.<T>` is JSDoc-legacy syntax for `Foo<T>`.  Emit TS8020 at the `.`
+            // (matching tsc's anchor), consume the type arguments, and bubble them up
+            // to the caller instead of creating a `QualifiedName` — otherwise the
+            // checker sees `Foo.<synthetic>` and emits a cascading TS2702
+            // ("only refers to a type, but is being used as a namespace").
+            if self.is_token(SyntaxKind::LessThanToken) {
+                self.parse_error_at(
+                    dot_start,
+                    dot_end - dot_start,
+                    "JSDoc types can only be used inside documentation comments.",
+                    tsz_common::diagnostics::diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
+                );
+                jsdoc_type_arguments = Some(self.parse_type_arguments());
+                break;
+            }
 
             // Line break recovery: if there's a line break before the next token and it
             // looks like a new declaration (keyword followed by identifier on same line),
             // emit TS1003 and create a missing identifier instead of consuming the keyword.
             // This matches tsc's parseRightSideOfDot heuristic.
-            let right = if self.is_token(SyntaxKind::LessThanToken) {
-                let question_start = self.token_pos();
-                let question_end = self.token_end();
-                self.parse_error_at(
-                    question_start,
-                    question_end - question_start,
-                    "JSDoc types can only be used inside documentation comments.",
-                    tsz_common::diagnostics::diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-                );
-                let type_arguments = self.parse_type_arguments();
-                self.arena.add_identifier(
-                    SyntaxKind::Identifier as u16,
-                    dot_end,
-                    dot_end,
-                    crate::parser::node::IdentifierData {
-                        atom: tsz_common::interner::Atom::NONE,
-                        escaped_text: String::new(),
-                        original_text: None,
-                        type_arguments: Some(type_arguments),
-                    },
-                )
-            } else if self.scanner.has_preceding_line_break() && self.is_identifier_or_keyword() {
-                let snapshot = self.scanner.save_state();
-                let saved_token = self.current_token;
-                self.next_token();
-                let next_is_ident_on_same_line =
-                    !self.scanner.has_preceding_line_break() && self.is_identifier_or_keyword();
-                self.scanner.restore_state(snapshot);
-                self.current_token = saved_token;
-                if next_is_ident_on_same_line {
-                    // Looks like a new declaration — emit TS1003 at the position
-                    // right after the dot (matching tsc's reportAtCurrentPosition)
-                    self.parse_error_at(
-                        dot_end,
-                        0,
-                        "Identifier expected.",
-                        tsz_common::diagnostics::diagnostic_codes::IDENTIFIER_EXPECTED,
-                    );
-                    self.arena.add_identifier(
-                        SyntaxKind::Identifier as u16,
-                        dot_end,
-                        dot_end,
-                        crate::parser::node::IdentifierData {
-                            atom: tsz_common::interner::Atom::NONE,
-                            escaped_text: String::new(),
-                            original_text: None,
-                            type_arguments: None,
-                        },
-                    )
+            let right =
+                if self.scanner.has_preceding_line_break() && self.is_identifier_or_keyword() {
+                    let snapshot = self.scanner.save_state();
+                    let saved_token = self.current_token;
+                    self.next_token();
+                    let next_is_ident_on_same_line =
+                        !self.scanner.has_preceding_line_break() && self.is_identifier_or_keyword();
+                    self.scanner.restore_state(snapshot);
+                    self.current_token = saved_token;
+                    if next_is_ident_on_same_line {
+                        // Looks like a new declaration — emit TS1003 at the position
+                        // right after the dot (matching tsc's reportAtCurrentPosition)
+                        self.parse_error_at(
+                            dot_end,
+                            0,
+                            "Identifier expected.",
+                            tsz_common::diagnostics::diagnostic_codes::IDENTIFIER_EXPECTED,
+                        );
+                        self.arena.add_identifier(
+                            SyntaxKind::Identifier as u16,
+                            dot_end,
+                            dot_end,
+                            crate::parser::node::IdentifierData {
+                                atom: tsz_common::interner::Atom::NONE,
+                                escaped_text: String::new(),
+                                original_text: None,
+                                type_arguments: None,
+                            },
+                        )
+                    } else {
+                        self.parse_identifier_name()
+                    }
                 } else {
                     self.parse_identifier_name()
-                }
-            } else {
-                self.parse_identifier_name()
-            };
+                };
             let end_pos = self.token_full_start();
 
             current = self.arena.add_qualified_name(
@@ -470,7 +477,7 @@ impl ParserState {
             );
         }
 
-        current
+        (current, jsdoc_type_arguments)
     }
 
     // =========================================================================

--- a/crates/tsz-parser/tests/state_type_tests.rs
+++ b/crates/tsz-parser/tests/state_type_tests.rs
@@ -108,3 +108,102 @@ fn parse_construct_signature_with_arrow_reports_colon_expected_not_property_sign
         "Malformed construct signature should not fall back to TS1131, got {diagnostics:?}"
     );
 }
+
+// -----------------------------------------------------------------------------
+// JSDoc-legacy type error recovery — the invariants pinned down here come from
+// `tsc`.  When these patterns appear in a `.ts` file tsc emits TS8020 (and, for
+// some variants, TS17019/TS17020) *and nothing else*: the error should not
+// cascade into downstream diagnostics such as TS2702 ("used as a namespace"),
+// TS7051 ("parameter has a name but no type"), TS2300 ("duplicate identifier"),
+// or spurious TS2554 arity mismatches at call sites.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn jsdoc_dot_generic_type_reference_does_not_cascade_into_qualified_name() {
+    // `Array.<number>` is JSDoc syntax for `Array<number>`.  tsc emits a single
+    // TS8020 at the `.` and then treats the reference as the generic form.
+    let source = "var a: Array.<number> = [1, 2, 3];";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    let dot_pos = source.find('.').expect("expected `.`") as u32;
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == 8020 && d.start == dot_pos && d.length == 1),
+        "Expected TS8020 anchored at the `.`, got {diagnostics:?}"
+    );
+    // No other diagnostics should be emitted — the JSDoc `.<T>` pattern must
+    // collapse into a regular generic reference rather than a namespace access.
+    let others: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
+    assert!(
+        others.is_empty(),
+        "Array.<number> should produce only TS8020, got additional {others:?}"
+    );
+}
+
+#[test]
+fn jsdoc_legacy_function_type_with_bare_types_does_not_cascade() {
+    // `function(T1, T2): R` is tsc's JSDoc-legacy function-type form.  tsc
+    // treats the bare types as positional parameters with synthetic `argN`
+    // names (`(arg0: T1, arg1: T2) => R`) and emits only TS8020.  Our parser
+    // must mirror that — emitting TS7051 or TS2300 would be a cascade.
+    let source = "var g: function(number, number): number = (n, m) => n + m;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 8020),
+        "Expected TS8020 for JSDoc legacy function type, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.code != 17019 && d.code != 17020),
+        "Bare-type parameter list should not trigger postfix/prefix nullable diagnostics, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn jsdoc_legacy_function_type_with_this_binding_preserves_it() {
+    // `function(this: T, string)` — `this:` is a this-binding (index 0), and
+    // the bare `string` should be parsed as the 1-based `arg1: string` so the
+    // resulting call-site arity is 1, matching tsc.
+    let source = "var f: function(this: number, string): string;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 8020),
+        "Expected TS8020 for JSDoc legacy function type, got {diagnostics:?}"
+    );
+    // Only TS8020 should surface.  A cascading TS7051 for the bare `string`
+    // parameter would indicate the parameter lost its type annotation.
+    let unexpected: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
+    assert!(
+        unexpected.is_empty(),
+        "JSDoc `function(this: T, X)` should only emit TS8020, got {unexpected:?}"
+    );
+}
+
+#[test]
+fn jsdoc_legacy_function_type_with_new_marker_is_parsed_as_constructor() {
+    // `function(new: R, A)` denotes a constructor type whose return type is R.
+    // Without the `new:` shortcut the parser would model it as a 2-arity
+    // function `(new: R, A)`, which cascades into TS2554 at call sites such
+    // as `new ctor('hi')`.  The parser should only emit TS8020.
+    let source = "var c: function(new: number, string);";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 8020),
+        "Expected TS8020 for JSDoc legacy constructor function type, got {diagnostics:?}"
+    );
+    let unexpected: Vec<_> = diagnostics.iter().filter(|d| d.code != 8020).collect();
+    assert!(
+        unexpected.is_empty(),
+        "JSDoc `function(new: R, A)` should only emit TS8020, got {unexpected:?}"
+    );
+}


### PR DESCRIPTION
## Summary

`tsc` tolerates legacy JSDoc type syntax in `.ts` files by emitting a single
TS8020 (+ occasional TS17019/TS17020) and then recovering into a well-formed
type.  `tsz` emitted the right `TS8020` but handed the checker ASTs that
cascaded into extra diagnostics:

| JSDoc syntax                           | Extra diagnostics we emitted                             | Root cause in parser                                                                      |
| -------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| `Array.<T>`                            | `TS2702 'Array' only refers to a type, but is being used as a namespace here.` | `parse_qualified_name_rest` built a `QualifiedName` with a synthetic right-hand side. |
| `function(T1, T2): R`                  | `TS7051 Parameter has a name but no type.` / `TS2300 Duplicate identifier 'number'.` | Bare types were parsed as parameter *names* via `parse_type_parameter_list`.      |
| `function(new: R, …)`                  | `TS2554 Expected N arguments, but got …` at `new ctor(…)` sites | `new` was modelled as a parameter, inflating the construct arity.               |

tsc treats these shapes as `Foo<T>`, `(argN: T) => …`, and
`new (argN: T) => R` respectively.  This PR makes the parser produce the same
shapes during error recovery and anchors the TS8020 span at the `.` for
`Foo.<T>` to match tsc.

## Details

- `parse_qualified_name_rest` now returns `(NodeIndex, Option<NodeList>)`.
  When it sees `.<` it emits TS8020, consumes the type arguments, and bubbles
  them up to the caller so the reference collapses into a normal generic
  reference rather than a qualified name.
- `parse_jsdoc_legacy_function_type`:
  - Detects a leading `new :` marker and produces a `ConstructorType` whose
    return type is the RHS of the marker.
  - Delegates the rest of the parameter list to a new
    `parse_jsdoc_legacy_function_parameters`, which synthesizes `argN`
    identifiers for bare-type entries and parses `ident [?]: T` entries
    normally (covers `this: T` too).  Parameter indices include the `new:`
    / `this:` slot so the synthesized names line up with tsc (`arg1` after
    `this: T`, etc.).
- Anchors TS8020 for `Foo.<T>` at the `.` rather than the `<`.

## Example

```ts
// grammar error from checker
var ara: Array.<number> = [1, 2, 3];       // TS8020 at `.`, no TS2702
function hof(ctor: function(new: number, string)) {
    return new ctor('hi');                  // no cascading TS2554
}
function hof2(f: function(this: number, string): string) {
    return f(12, 'hullo');                  // TS2554 once (as tsc)
}
var g: function(number, number): number = (n, m) => n + m; // no TS7051/TS2300
```

## Impact

- Flips 4 conformance tests from FAIL to PASS.
- Moves `jsdocDisallowedInTypescript` from `wrong-code` into `fingerprint-only`
  (codes now match tsc; only the postfix-`?` → `T | null` message is still
  divergent, which is a separate issue).
- Unit tests added in `crates/tsz-parser/tests/state_type_tests.rs` cover
  each of the four invariants above.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p tsz-parser -p tsz-checker -p tsz-solver -p tsz-binder -p tsz-scanner -p tsz-core -p tsz-emitter -p tsz-lowering` — 16 132 tests pass
- [x] `./scripts/conformance/conformance.sh run` — `12 123/12 582 (96.4 %)`, baseline was `12 119`; **+4 improvements**, **0 regressions**
- [x] Targeted: `./scripts/conformance/conformance.sh run --filter jsdocDisallowedInTypescript --verbose` — codes match tsc, only one remaining fingerprint delta (postfix-`?` message)
- [x] `./scripts/emit/run.sh --max=50 --filter=jsdoc` — no new emit-baseline regressions

https://claude.ai/code/session_01AXmX1pqAsGDMaqr2cg21kK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmX1pqAsGDMaqr2cg21kK)_