### PR TITLE
fix(checker): preserve literal types in satisfies for direct literal operands

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -845,6 +845,28 @@ impl<'a> CheckerState<'a> {
         self.suppress_generic_return_context_for_direct_arg_overlap(&shape, args)
     }
 
+    /// Whether a node is a direct literal expression (numeric/string/boolean/bigint/null
+    /// keyword or no-substitution template). Used by `satisfies` handling to avoid
+    /// widening leaf literals via contextual typing, matching tsc's
+    /// `checkSatisfiesExpressionWorker` which returns fresh literal types from
+    /// `checkNumericLiteral`/`checkStringLiteral` etc. regardless of contextual type.
+    pub(crate) fn is_direct_literal_expression(&self, idx: NodeIndex) -> bool {
+        use tsz_scanner::SyntaxKind;
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        matches!(
+            node.kind,
+            k if k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::NumericLiteral as u16
+                || k == SyntaxKind::BigIntLiteral as u16
+                || k == SyntaxKind::TrueKeyword as u16
+                || k == SyntaxKind::FalseKeyword as u16
+                || k == SyntaxKind::NullKeyword as u16
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        )
+    }
+
     /// Whether an argument node needs contextual typing from the callee signature.
     ///
     /// Literal expressions need contextual typing to preserve literal types when

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1016,10 +1016,41 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         } else {
                             request.read().normal_origin().contextual_opt(None)
                         };
+                        // For `satisfies` expressions, preserve literal types in the inner
+                        // expression to match tsc's `checkSatisfiesExpressionWorker`, which
+                        // returns fresh literal types from `checkNumericLiteral` /
+                        // `checkStringLiteral` etc. regardless of contextual typing.
+                        // Without this, a bare literal like `1 satisfies number` would
+                        // get widened to `number` by the contextual-typing widening path,
+                        // producing `Type 'number' is not assignable to 'true'` for
+                        // `const x: true = 1 satisfies number` where tsc says `Type '1'`.
+                        //
+                        // We only preserve the TOP-LEVEL literal: if the operand is a
+                        // direct literal expression, disable literal widening while
+                        // checking it. For compound expressions (object/array literals,
+                        // arrows, etc.) we keep the existing behavior so nested property
+                        // values still widen under their own contextual typing rules
+                        // (matching tsc's `checkPropertyAssignment` widening).
+                        let is_satisfies = k == syntax_kind_ext::SATISFIES_EXPRESSION;
+                        let preserve_for_satisfies = is_satisfies && {
+                            let inner = self
+                                .checker
+                                .ctx
+                                .arena
+                                .skip_parenthesized_and_assertions(assertion.expression);
+                            self.checker.is_direct_literal_expression(inner)
+                        };
+                        let prev_preserve_literals = self.checker.ctx.preserve_literal_types;
+                        if preserve_for_satisfies {
+                            self.checker.ctx.preserve_literal_types = true;
+                        }
                         // Always type-check the expression for side effects / diagnostics.
                         let expr_type = self
                             .checker
                             .get_type_of_node_with_request(assertion.expression, &request);
+                        if preserve_for_satisfies {
+                            self.checker.ctx.preserve_literal_types = prev_preserve_literals;
+                        }
                         self.checker.ctx.in_const_assertion = prev_in_const_assertion;
                         if k == syntax_kind_ext::SATISFIES_EXPRESSION {
                             // TS8037: Type satisfaction expressions can only be used in TypeScript files

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -715,8 +715,18 @@ impl<'a> CheckerState<'a> {
             }
         };
 
-        // Mutate the top-level diagnostic to be TS1360
-        let src_str = self.format_type_for_assignability_message(source);
+        // Mutate the top-level diagnostic to be TS1360.
+        // When the target is not literal-sensitive (e.g. `1 satisfies boolean`),
+        // widen a bare literal source for display to match tsc, which reports
+        // `Type 'number' does not satisfy the expected type 'boolean'.`
+        // (tsc's `typeToString` widens fresh literal primitives when the target
+        // type does not preserve literal display.)
+        let display_source = if self.is_literal_sensitive_assignment_target(target) {
+            source
+        } else {
+            crate::query_boundaries::common::widen_literal_to_primitive(self.ctx.types, source)
+        };
+        let src_str = self.format_type_for_assignability_message(display_source);
         let tgt_str = self.format_type_for_assignability_message(target);
         use tsz_common::diagnostics::data::diagnostic_codes;
         use tsz_common::diagnostics::data::diagnostic_messages;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1066,6 +1066,14 @@ pub(crate) fn are_same_base_literal_kind(db: &dyn TypeDatabase, a: TypeId, b: Ty
     tsz_solver::type_queries::are_same_base_literal_kind(db, a, b)
 }
 
+// ── Literal widening to primitive ──
+
+/// Widen a literal type to its primitive base (`1` → `number`, `"x"` → `string`,
+/// `true` → `boolean`, `1n` → `bigint`). Non-literal types are returned unchanged.
+pub(crate) fn widen_literal_to_primitive(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::type_queries::widen_literal_to_primitive(db, type_id)
+}
+
 // ── Contextual literal classification ──
 
 pub(crate) use tsz_solver::type_queries::ContextualLiteralAllowKind;

--- a/crates/tsz-checker/src/tests/dispatch_tests.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests.rs
@@ -2065,3 +2065,95 @@ declare class RC<T extends "a" | "b"> {
         ts2339.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn satisfies_preserves_literal_type_for_direct_literal() {
+    // `1 satisfies number` should have type `1` (preserved), not `number` (widened).
+    // tsc: `checkSatisfiesExpressionWorker` calls `checkExpression` which returns
+    // fresh literal types from `checkNumericLiteral` regardless of contextual type.
+    // Assignment to a literal target `true` then shows source `'1'`, not `'number'`.
+    let diags = check_source_diagnostics(
+        r#"
+const a: true = 1 satisfies number;
+const b: true = "foo" satisfies string;
+const c: 2 = 1 satisfies number;
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        3,
+        "Expected 3 TS2322 errors for satisfies literal assignments, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+    // All three should preserve the source literal in the diagnostic (not widen).
+    assert!(
+        ts2322[0].message_text.contains("Type '1'"),
+        "Expected `Type '1'` preserved for `1 satisfies number`, got: {}",
+        ts2322[0].message_text
+    );
+    assert!(
+        ts2322[1].message_text.contains("Type '\"foo\"'"),
+        "Expected `Type '\"foo\"'` preserved for `\"foo\" satisfies string`, got: {}",
+        ts2322[1].message_text
+    );
+    assert!(
+        ts2322[2].message_text.contains("Type '1'"),
+        "Expected `Type '1'` preserved for `1 satisfies number` assigned to `2`, got: {}",
+        ts2322[2].message_text
+    );
+}
+
+#[test]
+fn satisfies_widens_source_for_ts1360_when_target_is_primitive() {
+    // For TS1360 (`Type X does not satisfy the expected type Y`), when Y is not a
+    // literal-sensitive type (e.g. `boolean`, `number`), tsc widens a bare literal
+    // source for display: `Type 'number' does not satisfy the expected type 'boolean'.`
+    // This preserves our existing match with tsc even though the internal type
+    // of `1 satisfies boolean` is now `1` (preserved literal) rather than `number`.
+    let diags = check_source_diagnostics(
+        r#"
+const x = 1 satisfies boolean;
+"#,
+    );
+    let ts1360: Vec<_> = diags.iter().filter(|d| d.code == 1360).collect();
+    assert_eq!(
+        ts1360.len(),
+        1,
+        "Expected 1 TS1360 error for `1 satisfies boolean`, got: {:?}",
+        ts1360.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+    assert!(
+        ts1360[0].message_text.contains("Type 'number'"),
+        "Expected source widened to 'number' in TS1360 message (target is non-literal `boolean`), got: {}",
+        ts1360[0].message_text
+    );
+    assert!(
+        ts1360[0].message_text.contains("'boolean'"),
+        "Expected target `boolean` in TS1360 message, got: {}",
+        ts1360[0].message_text
+    );
+}
+
+#[test]
+fn satisfies_result_type_is_assignable_to_target_literal_union() {
+    // `"A" satisfies string` should have type `"A"` so it remains assignable to
+    // a parameter of type `"A" | "B"`. Widening to `string` (the previous
+    // behavior) would produce a false TS2345.
+    let diags = check_source_diagnostics(
+        r#"
+declare function fn(s: "A" | "B"): void;
+fn("A" satisfies string);
+fn("C" satisfies string);
+"#,
+    );
+    // First call should succeed; second should fail with TS2345 (string literal
+    // "C" is not assignable to "A" | "B").
+    let ts2345: Vec<_> = diags.iter().filter(|d| d.code == 2345).collect();
+    assert_eq!(
+        ts2345.len(),
+        1,
+        "Expected exactly 1 TS2345 for the `\"C\"` call (not the `\"A\"` call), got: {:?}",
+        ts2345.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Root cause: `1 satisfies number` was widening its inner literal `1` to `number` because tsz's satisfies dispatcher passed `asserted_type` as contextual typing to the operand, which made `resolve_literal` widen (the `contextual_type_allows_literal` guard only preserves literals when the contextual type itself is literal-sensitive — `number` is not).
- tsc's `checkSatisfiesExpressionWorker` preserves literal types: `checkExpression` on a numeric/string literal always returns the fresh literal regardless of contextual typing.
- Fix is scoped narrowly: when the satisfies operand is a **direct leaf literal** (NumericLiteral / StringLiteral / TrueKeyword / FalseKeyword / NullKeyword / BigIntLiteral / NoSubstitutionTemplateLiteral), toggle `preserve_literal_types = true` for the single `get_type_of_node_with_request` call. Compound operands (object/array literals, arrows) keep the existing path so nested property values continue to widen under their own contextual-typing rules (matching tsc's `checkPropertyAssignment`).
- Also widen the source display in TS1360 (`Type X does not satisfy the expected type Y`) when the target is **not** literal-sensitive (e.g. `boolean`, `number`): `Type '1' does not satisfy the expected type 'boolean'` now renders as `Type 'number' does not satisfy the expected type 'boolean'`, matching tsc's `typeToString` widening for non-literal-sensitive targets.
- Exposed via a new `widen_literal_to_primitive` wrapper in `query_boundaries/common.rs` — keeps the checker layer from calling `tsz_solver::type_queries::*` directly (architecture contract test enforces this).

## Example

```ts
const a: true = 1 satisfies number;
// tsz now: Type '1' is not assignable to type 'true'.  (was: 'number')

const b: 2 = 1 satisfies number;
// tsz now: Type '1' is not assignable to type '2'.     (was: 'number')

declare function fn(s: "A" | "B"): void;
fn("A" satisfies string);
// no error — "A" preserved through satisfies.
//   Previously flagged TS2345: `Argument of type 'string' is not assignable
//   to parameter of type '"A" | "B"'.`

const x = 1 satisfies boolean;
// TS1360: Type 'number' does not satisfy the expected type 'boolean'.
// (literal '1' widened for display because target is non-literal-sensitive)
```

## Conformance

- Net **+5** tests pass vs. refreshed snapshot (12119 → 12124). Zero `PASS → FAIL` regressions.
- Improvements span several areas (reservedWords2, typeRootsFromNodeModulesInParentDirectory, for-of29, jsdoc declarations, privacyCheck) — the satisfies fix also unblocks cascading resolution in tests that use satisfies indirectly.
- Targeted originally by `TypeScript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts` (fingerprint-only failure). This fix removes the top-level `'number' vs '1'` divergence in that file; remaining deltas on that same test relate to separate property-elaboration widening rules not addressed here.

## Test plan

- [x] 3 new unit tests in `crates/tsz-checker/src/tests/dispatch_tests.rs`:
  - `satisfies_preserves_literal_type_for_direct_literal` — asserts `Type '1'` / `Type '"foo"'` stay literal when target is literal
  - `satisfies_widens_source_for_ts1360_when_target_is_primitive` — asserts TS1360 widens `1` → `number` when target is `boolean`
  - `satisfies_result_type_is_assignable_to_target_literal_union` — asserts `"A" satisfies string` remains assignable to `"A" | "B"`
- [x] All 2722 tsz-checker unit tests pass.
- [x] Architecture contract test `test_no_inline_type_queries_in_cleaned_modules` passes (checker now uses `query_boundaries::common::widen_literal_to_primitive` instead of direct solver call).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] Full conformance run: `12119 → 12124 (+5)`, no regressions.

https://claude.ai/code/session_01Kr4Gpj3hX8zvbfjRZVg6A9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr4Gpj3hX8zvbfjRZVg6A9)_