### PR TITLE
refactor(checker): clean up stale arch_guard refs and add property-ac…

### DIFF
--- a/crates/tsz-checker/tests/property_access_boundaries.rs
+++ b/crates/tsz-checker/tests/property_access_boundaries.rs
@@ -124,3 +124,82 @@ fn type_has_property_query() {
     assert!(type_has_property(&types, obj, "x"));
     assert!(!type_has_property(&types, obj, "y"));
 }
+
+#[test]
+fn type_has_property_union_requires_all_members() {
+    let types = TypeInterner::new();
+
+    let name_atom = types.intern_string("name");
+    let age_atom = types.intern_string("age");
+
+    let obj_with_name = types.object(vec![tsz_solver::PropertyInfo {
+        name: name_atom,
+        type_id: TypeId::STRING,
+        ..Default::default()
+    }]);
+    let obj_with_both = types.object(vec![
+        tsz_solver::PropertyInfo {
+            name: name_atom,
+            type_id: TypeId::STRING,
+            ..Default::default()
+        },
+        tsz_solver::PropertyInfo {
+            name: age_atom,
+            type_id: TypeId::NUMBER,
+            ..Default::default()
+        },
+    ]);
+
+    let union_type = types.union(vec![obj_with_name, obj_with_both]);
+    assert!(type_has_property(&types, union_type, "name"));
+    assert!(!type_has_property(&types, union_type, "age"));
+    assert!(!type_has_property(&types, union_type, "missing"));
+}
+
+#[test]
+fn tuple_element_union_and_array_element_type() {
+    let types = TypeInterner::new();
+
+    let single = types.tuple(vec![TupleElement {
+        type_id: TypeId::BOOLEAN,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    assert_eq!(
+        tuple_element_type_union(&types, single),
+        Some(TypeId::BOOLEAN)
+    );
+
+    let empty = types.tuple(vec![]);
+    assert_eq!(tuple_element_type_union(&types, empty), Some(TypeId::NEVER));
+
+    assert_eq!(tuple_element_type_union(&types, TypeId::STRING), None);
+
+    let arr = types.array(TypeId::NUMBER);
+    assert_eq!(array_element_type(&types, arr), Some(TypeId::NUMBER));
+    assert_eq!(array_element_type(&types, single), None);
+}
+
+#[test]
+fn def_id_and_application_queries() {
+    let types = TypeInterner::new();
+
+    let lazy1 = types.lazy(DefId(100));
+    let lazy2 = types.lazy(DefId(200));
+    assert_eq!(def_id(&types, lazy1), Some(DefId(100)));
+    assert_eq!(def_id(&types, lazy2), Some(DefId(200)));
+    assert_eq!(def_id(&types, TypeId::STRING), None);
+
+    let app = types.application(lazy1, vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(application_first_arg(&types, app), Some(TypeId::STRING));
+
+    let app_single = types.application(lazy1, vec![TypeId::BOOLEAN]);
+    assert_eq!(
+        application_first_arg(&types, app_single),
+        Some(TypeId::BOOLEAN)
+    );
+
+    assert_eq!(application_first_arg(&types, TypeId::ANY), None);
+    assert_eq!(application_first_arg(&types, lazy1), None);
+}

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -45,8 +45,6 @@ CHECKS = [
             "exclude_files": {
                 # These files use .lookup() in tracing::trace! macros for debug output only
                 "crates/tsz-checker/src/types/computation/complex.rs",
-                # ClassSummary::lookup() — not a solver interner lookup
-                "crates/tsz-checker/src/types/property_access_type.rs",
                 # Pre-existing: class member lookup in class_checker
                 "crates/tsz-checker/src/classes/class_checker.rs",
                 "crates/tsz-checker/src/classes/class_checker_compat.rs",
@@ -419,7 +417,6 @@ LINE_LIMIT_CHECKS = [
             # Pre-existing oversized files captured as the current ratchet baseline.
             "crates/tsz-checker/src/checkers/generic_checker.rs",
             "crates/tsz-checker/src/types/property_access_helpers.rs",
-            "crates/tsz-checker/src/types/property_access_type.rs",
             "crates/tsz-checker/src/types/utilities/core.rs",
             "crates/tsz-checker/src/types/computation/binary.rs",
             "crates/tsz-checker/src/types/computation/object_literal.rs",


### PR DESCRIPTION
…cess boundary tests

Remove stale exclusion entries for the deleted property_access_type.rs from arch_guard.py (lookup and LOC-limit lists). The file was previously split into property_access_type/resolve.rs which already has its own entries.

Add focused boundary tests: union type_has_property semantics (ALL members required), tuple element union extraction, array vs tuple element distinction, and DefId/application indexed-access queries.

https://claude.ai/code/session_013qj18zEzFd2PBrLdg5tiVB