### PR TITLE
fix(checker): widen intersection literal properties in assignability messages

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -850,7 +850,34 @@ impl<'a> CheckerState<'a> {
             return self.format_type_for_assignability_message(stripped);
         }
 
+        // For intersection types containing a fresh anonymous object member,
+        // use widened display when the target is NOT literal-sensitive.
+        // tsc widens `{ fooProp: "frizzlebizzle" } & Bar` to
+        // `{ fooProp: string } & Bar` when the target has non-literal property
+        // types, but preserves the literal when the target has literal types.
+        if crate::query_boundaries::common::is_intersection_type(
+            self.ctx.types.as_type_database(),
+            ty,
+        ) && !self.is_literal_sensitive_assignment_target(other)
+            && self.intersection_has_fresh_anonymous_object(ty)
+        {
+            return self.format_type_diagnostic_widened(ty);
+        }
+
         self.format_type_for_assignability_message(ty)
+    }
+
+    /// Check if an intersection type contains a fresh anonymous object member
+    /// (one with display_properties and no symbol name).
+    fn intersection_has_fresh_anonymous_object(&self, ty: TypeId) -> bool {
+        crate::query_boundaries::common::intersection_members(self.ctx.types.as_type_database(), ty)
+            .is_some_and(|members| {
+                members.iter().any(|&m| {
+                    self.ctx.types.get_display_properties(m).is_some()
+                        && crate::query_boundaries::common::object_shape_for_type(self.ctx.types, m)
+                            .is_some_and(|shape| shape.symbol.is_none())
+                })
+            })
     }
 
     fn class_constructor_symbol_for_assignment_display(


### PR DESCRIPTION
## Summary

- When displaying intersection types containing fresh object literal members in TS2322 error messages, use widened property types to match tsc's behavior
- tsc shows `{ fooProp: string } & Bar` (widened) when the target has non-literal property types, but preserves the literal `{ fooProp: "frizzlebizzle" } & Bar` when the target has literal types
- The fix checks whether the target type is literal-sensitive before deciding which display mode to use, matching tsc's context-dependent widening behavior

## Problem

In `errorMessagesIntersectionTypes01.ts`, tsc reports:
```
Type '{ fooProp: string; } & Bar' is not assignable to type 'FooBar'.
```
But tsz was reporting:
```
Type '{ fooProp: "frizzlebizzle"; } & Bar' is not assignable to type 'FooBar'.
```

The root cause: `format_assignability_type_for_message_internal` was using `format_type_diagnostic` (which enables display_properties, showing original literal types) for intersection types. For plain anonymous objects, the code already used `format_type_diagnostic_widened` to show widened property types — but intersections were excluded.

The fix adds an intersection-specific check in `format_assignability_type_for_message_internal` where the target type (`other`) is available, using `is_literal_sensitive_assignment_target` to decide whether to widen. This correctly handles both cases:
- `errorMessagesIntersectionTypes01` (target `fooProp: boolean` → non-literal → widen to `string`)
- `errorMessagesIntersectionTypes02` (target `fooProp: "hello" | "world"` → literal → preserve `"frizzlebizzle"`)

## Test plan

- [x] `errorMessagesIntersectionTypes01` now passes (was fingerprint-only failure)
- [x] `errorMessagesIntersectionTypes02` still passes (literal-sensitive target preserved)
- [x] `errorMessagesIntersectionTypes03` and `04` still pass
- [x] Architecture contract tests pass (uses `query_boundaries` wrappers, no direct `type_queries` calls)
- [x] Full conformance run: zero regressions
- [x] Clippy clean, wasm32 gate clean

Campaign: type-display-parity

https://claude.ai/code/session_01CUXWtysoTr1446Pt1DqxD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUXWtysoTr1446Pt1DqxD4)_