### PR TITLE
fix(checker): preserve literal types through contextual return type transport

### DIFF
--- a/crates/tsz-checker/src/types/computation/contextual.rs
+++ b/crates/tsz-checker/src/types/computation/contextual.rs
@@ -303,6 +303,19 @@ pub(crate) fn expression_needs_contextual_return_type(
         {
             true
         }
+        // Literal expressions benefit from contextual return typing to preserve
+        // literal types instead of widening. Without this, `return 0` in a
+        // generator expecting TReturn=0 would widen to `number`, and
+        // `() => 1` with contextual return `0|1|2` would lose the literal.
+        k if k == tsz_scanner::SyntaxKind::NumericLiteral as u16
+            || k == tsz_scanner::SyntaxKind::StringLiteral as u16
+            || k == tsz_scanner::SyntaxKind::TrueKeyword as u16
+            || k == tsz_scanner::SyntaxKind::FalseKeyword as u16
+            || k == tsz_scanner::SyntaxKind::BigIntLiteral as u16
+            || k == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
+        {
+            true
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

- Treat literal return expressions (numeric, string, boolean, bigint, template) as needing contextual return types in `expression_needs_contextual_return_type`, preventing premature widening when a contextual return type is available
- Fixes the contextual type transport for callback literals like `invoke(() => 1)` where `T` should be inferred as literal `1` (not widened `number`) when the contextual type is `0 | 1 | 2`
- Also fixes generator return literals: `function*() { return 0; }` with `TReturn=0` now preserves the literal instead of widening

## Details

`expression_needs_contextual_return_type` gates whether a return expression receives the contextual return type from its enclosing function. Previously, only complex expressions (array/object literals, calls, yields, templates) were included. Simple literal expressions were excluded, causing them to be widened to their base type (`1` → `number`, `"foo"` → `string`) even when the contextual return type would have preserved them.

This is part of the contextual typing transport pipeline — the contextual type flows from the call site through the callee's return type to the callback's return expression, and this gate was the final link where it was being dropped for literals.

## Test plan

- [x] All solver unit tests pass (5290 passed, 0 failed)
- [x] All checker unit tests pass (2719 passed, 0 failed)
- [x] Contextual typing conformance: 98/100 (matching baseline)
- [x] Inference conformance: 19/23 (improved from 18/23)
- [x] Generic conformance: 193/200 (matching baseline)
- [x] `invoke(() => 1)` with contextual `0|1|2` now correctly preserves literal
- [ ] Pre-commit hooks could not complete due to disk space constraints in the build environment (debug builds require ~25GB); CI will validate

https://claude.ai/code/session_01NFpUG5nNqGfQa7D5NCDaKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFpUG5nNqGfQa7D5NCDaKe)_