### PR TITLE
fix(parser): asterisk as binary operator, as/satisfies as identifiers in primary position

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1630,14 +1630,15 @@ impl ParserState {
                     UnaryExprData { operator, operand },
                 )
             }
-            SyntaxKind::AsteriskToken => {
-                // `*` is not a standalone unary operator in expression position.
-                // Report TS1109 at the `*`, then recover by skipping it so the
-                // following token can still become the operand expression.
-                self.error_expression_expected();
-                self.next_token();
-                self.parse_unary_expression()
-            }
+            // `*` is only a binary operator (multiplication, etc.). Fall through to
+            // the default path so `parse_primary_expression`'s `is_binary_operator`
+            // branch reports TS1109 and returns a missing LHS without advancing,
+            // matching tsc's `parsePrimaryExpression -> createMissingNode` flow.
+            // The outer `parse_binary_expression_chain` then consumes `*` as a
+            // binary operator, which is the correct tree shape for recovery
+            // (e.g. `import type defer * as ns1 from "./a";` parses `* as`
+            // as a binary expression and produces `;' expected` on `ns1`,
+            // matching tsc).
             SyntaxKind::TypeOfKeyword | SyntaxKind::VoidKeyword | SyntaxKind::DeleteKeyword => {
                 let start_pos = self.token_pos();
                 let operator = self.token() as u16;
@@ -2803,6 +2804,22 @@ impl ParserState {
                 // without losing `case`/`default` tokens.
                 // ColonToken is a structural delimiter (case clauses, labels, type annotations)
                 // and must not be consumed as an error token.
+
+                // `as` and `satisfies` are contextual keywords that have binary
+                // operator precedence (for type assertions / satisfies checks) but
+                // can also appear as plain identifiers. In *primary* position,
+                // prefer identifier parsing — matching tsc's
+                // `parsePrimaryExpression -> parseIdentifier` which returns true
+                // from `isIdentifier()` for contextual keywords. Without this
+                // branch the subsequent `is_binary_operator` check would reject
+                // them and emit a spurious TS1109.
+                if matches!(
+                    self.token(),
+                    SyntaxKind::AsKeyword | SyntaxKind::SatisfiesKeyword
+                ) {
+                    return self.parse_identifier_name();
+                }
+
                 if self.is_binary_operator() {
                     // Binary operator at expression start means missing LHS.
                     // Emit TS1109 matching tsc's parsePrimaryExpression behavior.

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -2327,6 +2327,9 @@ fn expr_prefix_update_repeated_operator_same_line_anchors_inner_update() {
 
 #[test]
 fn object_spread_invalid_asterisk_recovers_to_operand_expression() {
+    // `let o8 = { ...*o };` — `*` at the start of the spread operand is a
+    // binary operator with a missing LHS. tsc's recovery produces a
+    // BinaryExpression (missing * o), and we match that tree shape.
     let source = "let o8 = { ...*o };";
     let (parser, root) = parse_source(source);
     let diagnostics = parser.get_diagnostics();
@@ -2358,12 +2361,25 @@ fn object_spread_invalid_asterisk_recovers_to_operand_expression() {
     assert_eq!(spread.kind, syntax_kind_ext::SPREAD_ASSIGNMENT);
     let spread_data = arena.get_spread(spread).expect("spread data");
     let operand = arena.get(spread_data.expression).expect("spread operand");
+    // Match tsc: the `*` is consumed as a binary operator with a missing LHS.
+    // The right-hand operand is the identifier `o`.
     assert_eq!(
         operand.kind,
-        SyntaxKind::Identifier as u16,
-        "recovery should keep the identifier operand after skipping the stray `*`"
+        syntax_kind_ext::BINARY_EXPRESSION,
+        "expected BinaryExpression for `*o` recovery, got kind={}",
+        operand.kind
     );
-    assert_eq!(node_text(arena, source, spread_data.expression), "o");
+    let binary = arena
+        .get_binary_expr(operand)
+        .expect("binary expression data");
+    assert_eq!(
+        binary.operator_token,
+        SyntaxKind::AsteriskToken as u16,
+        "operator should be `*`"
+    );
+    let right = arena.get(binary.right).expect("binary right");
+    assert_eq!(right.kind, SyntaxKind::Identifier as u16);
+    assert_eq!(node_text(arena, source, binary.right), "o");
 }
 
 #[test]

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -750,3 +750,110 @@ fn export_abstract_class_parses_cleanly() {
         "export abstract class C {{}} should parse cleanly, got {codes:?}"
     );
 }
+
+/// `import type defer * as ns from "..."` is invalid: `type` and `defer`
+/// cannot both modify the same import, and the namespace form is not allowed
+/// after `defer`. tsc enters `parseImportEqualsDeclaration` because the
+/// disambiguation concludes the name is `defer` and the next token (`*`) is
+/// not `,`/`from`. It then reports:
+///
+/// - TS1005 `'=' expected.` at `*` (the missing equals sign).
+/// - TS1005 `';' expected.` at `ns` (the binary-like `missing * as` ends
+///   and the next token starts a new expression statement).
+/// - TS1434 `Unexpected keyword or identifier.` at `from` (viable keyword
+///   in primary position followed by a string literal).
+///
+/// We must match that fingerprint exactly, not cascade an extra TS1434 at
+/// `as` from the earlier unary recovery.
+#[test]
+fn parse_import_type_defer_star_matches_tsc_recovery() {
+    let source = "import type defer * as ns1 from \"./a\";";
+    let (parser, _root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+
+    const TS1005: u32 = diagnostic_codes::EXPECTED;
+    const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+
+    let fingerprints: Vec<(u32, u32, &str)> = diags
+        .iter()
+        .map(|d| (d.code, d.start, d.message.as_str()))
+        .collect();
+
+    // TS1005 `'=' expected.` at `*` (pos 18, col 19).
+    assert!(
+        fingerprints
+            .iter()
+            .any(|(c, p, m)| *c == TS1005 && *p == 18 && m.contains("'='")),
+        "expected TS1005 `'=' expected.` at col 19 (pos 18), got {fingerprints:?}"
+    );
+    // TS1005 `';' expected.` at `ns1` (pos 23, col 24).
+    assert!(
+        fingerprints
+            .iter()
+            .any(|(c, p, m)| *c == TS1005 && *p == 23 && m.contains("';'")),
+        "expected TS1005 `';' expected.` at col 24 (pos 23), got {fingerprints:?}"
+    );
+    // TS1434 `Unexpected keyword or identifier.` at `from` (pos 27, col 28).
+    assert!(
+        fingerprints
+            .iter()
+            .any(|(c, p, _)| *c == TS1434 && *p == 27),
+        "expected TS1434 at col 28 (pos 27), got {fingerprints:?}"
+    );
+
+    // Must NOT emit any diagnostic at `as` (pos 20, col 21) — that was the
+    // spurious cascade from the old asterisk-recovery path.
+    assert!(
+        !fingerprints.iter().any(|(_, p, _)| *p == 20),
+        "must not emit a diagnostic at `as` (col 21); got {fingerprints:?}"
+    );
+
+    // We only expect three parser diagnostics total for this invalid syntax.
+    // Additional emits indicate a regression of the cascading recovery.
+    assert_eq!(
+        diags.len(),
+        3,
+        "expected exactly 3 parser diagnostics, got {diags:?}"
+    );
+}
+
+/// Confirm that an isolated `*` at statement start is treated as a binary
+/// operator with missing LHS — exactly one TS1109 (Expression expected) is
+/// emitted at the `*` and the trailing `foo` becomes a separate expression
+/// statement. This matches tsc's `parsePrimaryExpression -> createMissingNode`
+/// followed by binary-operator consumption.
+#[test]
+fn parse_leading_asterisk_at_statement_emits_single_expression_expected() {
+    let source = "* foo";
+    let (parser, _root) = parse_source(source);
+    let diags = parser.get_diagnostics();
+
+    const TS1109: u32 = diagnostic_codes::EXPRESSION_EXPECTED;
+
+    // One TS1109 at the `*` (pos 0).
+    let ts1109_count = diags.iter().filter(|d| d.code == TS1109).count();
+    assert!(
+        ts1109_count >= 1,
+        "expected at least one TS1109 for leading `*`, got {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|d| d.code == TS1109 && d.start == 0),
+        "expected TS1109 at the `*` (pos 0), got {diags:?}"
+    );
+}
+
+/// `as` and `satisfies` are contextual keywords: they can be used as plain
+/// identifiers. In primary expression position they must parse as identifiers
+/// rather than triggering the `is_binary_operator` missing-LHS path.
+#[test]
+fn parse_as_and_satisfies_as_identifiers_in_primary_position() {
+    for name in ["as", "satisfies"] {
+        let source = format!("const x = {name};");
+        let (parser, _root) = parse_source(&source);
+        let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+        assert!(
+            !codes.contains(&diagnostic_codes::EXPRESSION_EXPECTED),
+            "`const x = {name};` must not emit TS1109; got {codes:?}"
+        );
+    }
+}

--- a/scripts/session/pick-and-show.sh
+++ b/scripts/session/pick-and-show.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-and-show.sh — Pick a random conformance failure and show everything
+# =============================================================================
+#
+# One-stop script: picks a random failure from conformance-detail.json,
+# prints the path/codes/category summary, shows the test source, and then
+# runs the conformance runner with --verbose so the missing/extra
+# fingerprints are printed in the same invocation.
+#
+# Usage:
+#   scripts/session/pick-and-show.sh                # any failure
+#   scripts/session/pick-and-show.sh --seed 42      # reproducible
+#   scripts/session/pick-and-show.sh --code TS2322  # filter by error code
+#
+# See scripts/session/conformance-agent-prompt.md for the full process.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="$2"; shift 2 ;;
+        --code) CODE="$2"; shift 2 ;;
+        -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initializing..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+PICK_JSON="$(SEED="$SEED" CODE="$CODE" python3 - "$DETAIL" <<'PY'
+import json, os, random, sys
+
+detail_path = sys.argv[1]
+seed = os.environ.get("SEED") or None
+code = os.environ.get("CODE") or None
+
+with open(detail_path) as f:
+    failures = json.load(f).get("failures", {})
+
+def matches(entry):
+    if not code:
+        return True
+    all_codes = set(entry.get("e", [])) | set(entry.get("a", [])) \
+              | set(entry.get("m", [])) | set(entry.get("x", []))
+    return code in all_codes
+
+cands = [(p, e) for p, e in failures.items() if e and matches(e)]
+if not cands:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(cands)
+
+expected = entry.get("e", [])
+actual   = entry.get("a", [])
+missing  = entry.get("m", [])
+extra    = entry.get("x", [])
+
+if not expected and actual:        category = "false-positive"
+elif expected and not actual:      category = "all-missing"
+elif set(expected) == set(actual): category = "fingerprint-only"
+elif missing and not extra:        category = "only-missing"
+elif extra and not missing:        category = "only-extra"
+else:                              category = "wrong-code"
+
+print(json.dumps({
+    "path": path,
+    "filter": os.path.splitext(os.path.basename(path))[0],
+    "category": category,
+    "expected": expected,
+    "actual": actual,
+    "missing": missing,
+    "extra": extra,
+    "pool": len(cands),
+}))
+PY
+)"
+
+PATH_="$(printf '%s' "$PICK_JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin)["path"])')"
+FILTER="$(printf '%s' "$PICK_JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin)["filter"])')"
+CATEGORY="$(printf '%s' "$PICK_JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin)["category"])')"
+
+echo "==================== random pick ===================="
+printf '%s' "$PICK_JSON" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+print(f"path:     {d[\"path\"]}")
+print(f"category: {d[\"category\"]}")
+print(f"expected: {(\",\".join(d[\"expected\"]) or \"-\")}")
+print(f"actual:   {(\",\".join(d[\"actual\"]) or \"-\")}")
+print(f"missing:  {(\",\".join(d[\"missing\"]) or \"-\")}")
+print(f"extra:    {(\",\".join(d[\"extra\"]) or \"-\")}")
+print(f"pool:     {d[\"pool\"]}")
+'
+echo ""
+echo "==================== test source ===================="
+if [[ -f "$REPO_ROOT/$PATH_" ]]; then
+    sed -n '1,80p' "$REPO_ROOT/$PATH_"
+    LINES=$(wc -l < "$REPO_ROOT/$PATH_")
+    if [[ "$LINES" -gt 80 ]]; then
+        echo "... (truncated at 80 lines; total $LINES)"
+    fi
+else
+    echo "(source file missing: $PATH_)"
+fi
+echo ""
+echo "==================== verbose run ===================="
+exec "$REPO_ROOT/scripts/conformance/conformance.sh" run --filter "$FILTER" --verbose


### PR DESCRIPTION
## Summary

Align parser recovery at a stray `*` in expression position with tsc.

**Root cause in one sentence:** tsc's `parsePrimaryExpression` returns a missing-identifier node for `*` without advancing, so `*` is later consumed as a binary operator by `parseBinaryExpression`; `tsz`'s `parse_unary_expression` was short-circuiting that path with a custom "skip `*`, recurse on the next token" recovery — which cascaded an extra `TS1434` at the recursed operand. The specific failing target was `importDeferTypeConflict1`, where:

```ts
// tsc and now tsz both report exactly:
//   b.ts(1,19): error TS1005: '=' expected.
//   b.ts(1,24): error TS1005: ';' expected.
//   b.ts(1,28): error TS1434: Unexpected keyword or identifier.
import type defer * as ns1 from "./a";
```

Before the fix we also emitted `TS1434` at `as` (col 21) because the statement-level expression parser consumed `*` and made `as` the operand of a unary expression, which then missed a semicolon and triggered the cascading diagnostic.

## Fix

- **`parse_unary_expression`**: drop the special `AsteriskToken` case. `*` now falls through to `parse_primary_expression`, whose `is_binary_operator` branch reports `TS1109` and returns `NONE` without advancing. The outer binary-expression chain then consumes `*` as a multiplication operator — same tree shape tsc produces.
- **`parse_primary_expression`**: parse `as` and `satisfies` as plain identifiers when they appear in primary position. They have binary precedence (type assertion / `satisfies`) but are *contextual* keywords — tsc's `isIdentifier()` returns true for them, so they must not be rejected by the new missing-LHS path. Without this, after the above change we would emit `TS1109` at `as` in primary position.

## Conformance impact

**+6 tests flip FAIL → PASS** (12119 → 12125):
- `compiler/reservedWords2`
- `compiler/typeRootsFromNodeModulesInParentDirectory`
- `conformance/es6/for-ofStatements/for-of29`
- `conformance/importDefer/importDeferTypeConflict1` (the original picker target)
- `conformance/jsdoc/declarations/jsDeclarationsExportFormsErr`
- `projects/privacyCheck-SimpleReference/test`

No regressions in conformance, parser tests, or checker tests.

## Tests

- `parse_import_type_defer_star_matches_tsc_recovery` — locks the three-diagnostic fingerprint for the picker target and asserts no emission at `as`.
- `parse_leading_asterisk_at_statement_emits_single_expression_expected` — verifies the new primary-path recovery for a stray leading `*`.
- `parse_as_and_satisfies_as_identifiers_in_primary_position` — covers the contextual-keyword fallthrough (`const x = as;`, `const x = satisfies;`).
- `object_spread_invalid_asterisk_recovers_to_operand_expression` — updated assertion: the pre-fix test was locking in the tsz-specific "skip `*`, use next identifier" shape; it now asserts the tsc-aligned `BinaryExpression` shape with `*` operator and identifier on the right.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p tsz-parser --lib` — 553 pass
- [x] `cargo test -p tsz-checker --lib` — 2719 pass
- [x] Targeted conformance (`--filter importDeferTypeConflict1 --verbose`) — PASS
- [x] Full conformance suite — 12125/12582, **+6 vs baseline**, no regressions
- [ ] *Pre-existing* tsz-cli unit tests `collect_diagnostics_reports_default_lib_breakage_from_global_node_merge` and `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable` fail on the unchanged `main` branch too (verified by stashing this PR's changes and re-running). They are unrelated to this parser change: the first expects a `TS2430` from a `lib.dom` merge scenario, the second expects `TS5033` for a non-writable tsbuildinfo path which doesn't reproduce when the test runner runs as root (chmod-protected paths remain writable).

## Extras

Adds `scripts/session/pick-and-show.sh` — a tiny wrapper that picks one random conformance failure from `conformance-detail.json`, prints the category summary + test source, and runs the conformance runner with `--verbose` in a single invocation. Useful when starting a session on a fresh repo without jumping between multiple scripts.

https://claude.ai/code/session_013pMXTTh9DPqikxG96RbFyf

---
_Generated by [Claude Code](https://claude.ai/code/session_013pMXTTh9DPqikxG96RbFyf)_