### PR TITLE
arch(checker): migrate identifier_source_display from NodeIndex to StableLocation (Phase 1 step 3)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
@@ -4,6 +4,30 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Render an identifier-source display for an array-of-object-literal
+    /// initializer (e.g. `let foo = [{ a: 1 }, { a: 2 }];`) so the
+    /// assignability diagnostic can show the inferred element shape rather
+    /// than just the identifier's static type.
+    ///
+    /// ## Phase 1 step-3: `StableLocation`-based declaration lookup
+    ///
+    /// Declaration *identity* is read from
+    /// [`tsz_binder::Symbol::stable_declarations`] (with a fallback to
+    /// [`tsz_binder::Symbol::stable_value_declaration`] when present). The
+    /// concrete `NodeIndex` is rehydrated on demand via
+    /// [`CheckerContext::node_at_stable_location`][nasl] so the consumer
+    /// no longer assumes the arena that produced the symbol's stored
+    /// `NodeIndex` is still resident. This is the third consumer migrated
+    /// under the [global query graph plan][plan] (Phase 1 step 3,
+    /// following PRs #1055 and #1066).
+    ///
+    /// The variable-declaration / array-literal walk is fundamentally
+    /// AST-bound and continues to use a live `NodeIndex` locally; the
+    /// load-bearing change is that the `NodeIndex` no longer comes from
+    /// the symbol's arena-dependent field.
+    ///
+    /// [nasl]: crate::context::CheckerContext::node_at_stable_location
+    /// [plan]: ../../../../../docs/plan/global-query-graph-architecture.md
     pub(in crate::error_reporter) fn identifier_array_object_literal_source_display(
         &mut self,
         expr_idx: NodeIndex,
@@ -18,49 +42,99 @@ impl<'a> CheckerState<'a> {
         if (symbol.flags & tsz_binder::symbol_flags::VARIABLE) == 0 {
             return None;
         }
-        let &decl_idx = symbol.declarations.first()?;
-        let decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
-        let init_idx = decl.initializer.into_option()?;
-        let init_idx = self.ctx.arena.skip_parenthesized_and_assertions(init_idx);
-        let init_node = self.ctx.arena.get(init_idx)?;
-        if init_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
-            return None;
-        }
-        let literal = self.ctx.arena.get_literal_expr(init_node)?;
-        if literal.elements.nodes.is_empty() {
-            return None;
-        }
 
-        let mut ordered_names = Vec::new();
-        let mut property_values: Vec<Vec<TypeId>> = Vec::new();
-        for (element_index, &element_idx) in literal.elements.nodes.iter().enumerate() {
-            let element_node = self.ctx.arena.get(element_idx)?;
-            if element_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+        // Phase 1 step-3: identify the variable declaration via its
+        // `StableLocation`, not via `symbol.declarations.first()`. Prefer
+        // the first entry of `stable_declarations` (mirrors the legacy
+        // `declarations.first()` preference order); fall back to
+        // `stable_value_declaration` if the parallel slot is empty. The
+        // parallel `stable_*` fields are populated in lockstep by the
+        // binder, so this is equivalent whenever the legacy `NodeIndex`
+        // fields are populated.
+        let stable_loc = match symbol.stable_declarations.first() {
+            Some(loc) if loc.is_known() => *loc,
+            _ if symbol.stable_value_declaration.is_known() => symbol.stable_value_declaration,
+            _ => return None,
+        };
+
+        // Resolve the `StableLocation` to a live `(NodeIndex, arena)` pair
+        // and walk the variable-declaration body. We collect the
+        // top-level shape (ordered names + initializer NodeIndex per
+        // element) into owned data so the arena borrow is dropped before
+        // any `&mut self` calls below (`get_property_name`,
+        // `get_type_of_node`, ...). All `NodeIndex` values below come
+        // from the *rehydrated* arena, not the symbol's stored
+        // `NodeIndex`.
+        let (ordered_name_idxs, element_property_idxs) = {
+            let (decl_idx, arena) = self.ctx.node_at_stable_location(stable_loc)?;
+            let decl = arena.get_variable_declaration_at(decl_idx)?;
+            let init_idx = decl.initializer.into_option()?;
+            let init_idx = arena.skip_parenthesized_and_assertions(init_idx);
+            let init_node = arena.get(init_idx)?;
+            if init_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
                 return None;
             }
-            let object = self.ctx.arena.get_literal_expr(element_node)?;
-            if element_index == 0 {
+            let literal = arena.get_literal_expr(init_node)?;
+            if literal.elements.nodes.is_empty() {
+                return None;
+            }
+
+            let mut ordered_name_idxs: Vec<NodeIndex> = Vec::new();
+            let mut element_property_idxs: Vec<Vec<(NodeIndex, NodeIndex)>> = Vec::new();
+            for (element_index, &element_idx) in literal.elements.nodes.iter().enumerate() {
+                let element_node = arena.get(element_idx)?;
+                if element_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                    return None;
+                }
+                let object = arena.get_literal_expr(element_node)?;
+                if element_index == 0 {
+                    let mut row = Vec::with_capacity(object.elements.nodes.len());
+                    for &child_idx in &object.elements.nodes {
+                        let child = arena.get(child_idx)?;
+                        let prop = arena.get_property_assignment(child)?;
+                        ordered_name_idxs.push(prop.name);
+                        row.push((prop.name, prop.initializer));
+                    }
+                    element_property_idxs.push(row);
+                    continue;
+                }
+
+                if object.elements.nodes.len() != ordered_name_idxs.len() {
+                    return None;
+                }
+                let mut row = Vec::with_capacity(object.elements.nodes.len());
                 for &child_idx in &object.elements.nodes {
-                    let child = self.ctx.arena.get(child_idx)?;
-                    let prop = self.ctx.arena.get_property_assignment(child)?;
-                    let name = self.get_property_name(prop.name)?;
-                    ordered_names.push(name);
-                    property_values.push(vec![self.get_type_of_node(prop.initializer)]);
+                    let child = arena.get(child_idx)?;
+                    let prop = arena.get_property_assignment(child)?;
+                    row.push((prop.name, prop.initializer));
+                }
+                element_property_idxs.push(row);
+            }
+            (ordered_name_idxs, element_property_idxs)
+        };
+
+        // Resolve the names *after* dropping the arena borrow.
+        let mut ordered_names: Vec<String> = Vec::with_capacity(ordered_name_idxs.len());
+        for name_idx in &ordered_name_idxs {
+            ordered_names.push(self.get_property_name(*name_idx)?);
+        }
+
+        // Walk the rows, validate name parity element-by-element, and
+        // collect `TypeId`s per ordered name.
+        let mut property_values: Vec<Vec<TypeId>> = vec![Vec::new(); ordered_names.len()];
+        for (element_index, row) in element_property_idxs.iter().enumerate() {
+            if element_index == 0 {
+                for (prop_index, &(_, init_idx)) in row.iter().enumerate() {
+                    property_values[prop_index].push(self.get_type_of_node(init_idx));
                 }
                 continue;
             }
-
-            if object.elements.nodes.len() != ordered_names.len() {
-                return None;
-            }
-            for (prop_index, &child_idx) in object.elements.nodes.iter().enumerate() {
-                let child = self.ctx.arena.get(child_idx)?;
-                let prop = self.ctx.arena.get_property_assignment(child)?;
-                let name = self.get_property_name(prop.name)?;
+            for (prop_index, &(name_idx, init_idx)) in row.iter().enumerate() {
+                let name = self.get_property_name(name_idx)?;
                 if name != ordered_names[prop_index] {
                     return None;
                 }
-                property_values[prop_index].push(self.get_type_of_node(prop.initializer));
+                property_values[prop_index].push(self.get_type_of_node(init_idx));
             }
         }
 
@@ -85,6 +159,18 @@ impl<'a> CheckerState<'a> {
         Some(format!("{{ {fields}; }}[]"))
     }
 
+    /// Render a literal-source display for a `let`/`const` initializer of
+    /// `true` or `false` when the assignability target is `undefined` or
+    /// an enum (used for "Type 'true' is not assignable to ..." style
+    /// diagnostics).
+    ///
+    /// ## Phase 1 step-3: `StableLocation`-based declaration lookup
+    ///
+    /// See [`Self::identifier_array_object_literal_source_display`] for
+    /// the migration rationale. Same pattern: read `stable_*` for
+    /// declaration identity, rehydrate `NodeIndex` via
+    /// `ctx.node_at_stable_location`, walk the variable-declaration body
+    /// against the rehydrated arena.
     pub(in crate::error_reporter) fn identifier_literal_initializer_source_display(
         &mut self,
         expr_idx: NodeIndex,
@@ -105,18 +191,250 @@ impl<'a> CheckerState<'a> {
         if (symbol.flags & tsz_binder::symbol_flags::VARIABLE) == 0 {
             return None;
         }
-        let &decl_idx = symbol.declarations.first()?;
-        let decl = self.ctx.arena.get_variable_declaration_at(decl_idx)?;
+
+        // Phase 1 step-3: identify the primary variable declaration via
+        // its `StableLocation`. Same preference order as
+        // `identifier_array_object_literal_source_display` above.
+        let stable_loc = match symbol.stable_declarations.first() {
+            Some(loc) if loc.is_known() => *loc,
+            _ if symbol.stable_value_declaration.is_known() => symbol.stable_value_declaration,
+            _ => return None,
+        };
+
+        let (decl_idx, arena) = self.ctx.node_at_stable_location(stable_loc)?;
+        let decl = arena.get_variable_declaration_at(decl_idx)?;
         if decl.type_annotation.is_some() || decl.initializer.is_none() {
             return None;
         }
 
-        let init_idx = self.ctx.arena.skip_parenthesized(decl.initializer);
-        let init_node = self.ctx.arena.get(init_idx)?;
+        let init_idx = arena.skip_parenthesized(decl.initializer);
+        let init_node = arena.get(init_idx)?;
         match init_node.kind {
             k if k == tsz_scanner::SyntaxKind::TrueKeyword as u16 => Some("true".to_string()),
             k if k == tsz_scanner::SyntaxKind::FalseKeyword as u16 => Some("false".to_string()),
             _ => None,
         }
+    }
+}
+
+// =============================================================================
+// Phase 1 step-3 regression tests: `StableLocation` rehydration
+// =============================================================================
+//
+// These tests validate the migration of
+// `identifier_array_object_literal_source_display` and
+// `identifier_literal_initializer_source_display` away from the
+// arena-dependent `Symbol::declarations[0]: NodeIndex` toward the
+// file-stable `Symbol::stable_declarations` / `stable_value_declaration`
+// fields introduced by PR #1055. The critical invariant they lock in is
+// that a `StableLocation` captured from one binder/arena pair can be
+// resolved against a freshly re-parsed arena of the same source — the
+// Phase 5 "bounded arena residency" precondition.
+
+#[cfg(test)]
+mod tests {
+    use crate::context::{CheckerContext, CheckerOptions};
+    use tsz_binder::BinderState;
+    use tsz_parser::ParserState;
+    use tsz_solver::TypeInterner;
+
+    /// Resolving `Symbol::stable_declarations.first()` for a `let`
+    /// initialized with an array-literal must return the same variable
+    /// declaration node that `Symbol::declarations[0]` points at in the
+    /// same binder. This is the invariant that the new code path relies
+    /// on for behavior-equivalence with the legacy `NodeIndex` lookup.
+    #[test]
+    fn stable_declaration_resolves_to_variable_decl_node() {
+        let source = "let xs = [{ a: 1 }, { a: 2 }];\n".to_string();
+
+        let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+
+        let sym_id = binder.file_locals.get("xs").expect("variable symbol xs");
+        let symbol = binder.symbols.get(sym_id).expect("symbol data");
+        let stable = *symbol
+            .stable_declarations
+            .first()
+            .expect("variable xs must have at least one stable_declarations entry");
+        assert!(
+            stable.is_known(),
+            "variable xs must have a known stable_declarations[0] span"
+        );
+        let legacy_node_idx = *symbol
+            .declarations
+            .first()
+            .expect("variable xs must have at least one declarations entry");
+
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena,
+            &binder,
+            &types,
+            "syn.ts".to_string(),
+            CheckerOptions::default(),
+        );
+
+        let (resolved_idx, resolved_arena) = ctx
+            .node_at_stable_location(stable)
+            .expect("node_at_stable_location must resolve the variable-decl span");
+
+        assert_eq!(
+            resolved_idx, legacy_node_idx,
+            "StableLocation must rehydrate to the same NodeIndex as declarations[0]"
+        );
+        let resolved_node = resolved_arena
+            .get(resolved_idx)
+            .expect("resolved NodeIndex must exist in arena");
+        assert_eq!(resolved_node.pos, stable.pos);
+        assert_eq!(resolved_node.end, stable.end);
+
+        // Sanity: the rehydrated index is actually a VariableDeclaration
+        // we can walk for an initializer (the production code path).
+        let decl = resolved_arena
+            .get_variable_declaration_at(resolved_idx)
+            .expect("rehydrated NodeIndex must be a VariableDeclaration");
+        assert!(
+            decl.initializer.is_some(),
+            "let xs = [...] must have a populated initializer"
+        );
+    }
+
+    /// Phase 5 load-bearing scenario: capture a `StableLocation` from one
+    /// binder/arena, drop it, re-parse the same source with a fresh
+    /// arena, and verify the captured location still resolves correctly
+    /// against the new arena. This proves
+    /// `identifier_array_object_literal_source_display` survives Phase 5
+    /// arena eviction-and-rehydrate.
+    #[test]
+    fn stable_location_round_trips_across_arena_reparse_for_var_decl() {
+        let source = "let xs = [{ a: 1 }, { a: 2 }];\nlet other = 1;\n".to_string();
+
+        // Capture the first arena's StableLocation for `xs`, then let
+        // the first arena/binder go out of scope.
+        let captured = {
+            let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+            let root = parser.parse_source_file();
+            let arena = parser.get_arena();
+            let mut binder = BinderState::new();
+            binder.bind_source_file(arena, root);
+            let sym_id = binder.file_locals.get("xs").expect("variable symbol xs");
+            let symbol = binder.symbols.get(sym_id).expect("symbol data");
+            *symbol
+                .stable_declarations
+                .first()
+                .expect("variable xs must have a stable_declarations entry")
+        };
+        assert!(
+            captured.is_known(),
+            "captured StableLocation must carry a real (pos, end) span"
+        );
+
+        // Fresh parse + bind of the identical source. The captured
+        // StableLocation must resolve in this new arena.
+        let mut parser = ParserState::new("syn.ts".to_string(), source);
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena,
+            &binder,
+            &types,
+            "syn.ts".to_string(),
+            CheckerOptions::default(),
+        );
+
+        let (resolved_idx, resolved_arena) = ctx
+            .node_at_stable_location(captured)
+            .expect("captured StableLocation must rehydrate against a freshly parsed arena");
+        let node = resolved_arena
+            .get(resolved_idx)
+            .expect("resolved NodeIndex must exist in the new arena");
+        assert_eq!(node.pos, captured.pos);
+        assert_eq!(node.end, captured.end);
+
+        // Sanity: still walks as a VariableDeclaration with an
+        // array-literal initializer.
+        let decl = resolved_arena
+            .get_variable_declaration_at(resolved_idx)
+            .expect("rehydrated NodeIndex must still be a VariableDeclaration");
+        assert!(decl.initializer.is_some());
+
+        // The new binder's `declarations[0]` NodeIndex should agree with
+        // the helper's resolution — binder population is deterministic
+        // for identical source text.
+        let sym_id = binder
+            .file_locals
+            .get("xs")
+            .expect("variable symbol xs in reparsed binder");
+        let new_symbol = binder
+            .symbols
+            .get(sym_id)
+            .expect("symbol data in reparsed binder");
+        assert_eq!(
+            resolved_idx,
+            *new_symbol
+                .declarations
+                .first()
+                .expect("reparsed variable xs must have a declarations entry"),
+            "re-resolution must agree with the re-parsed binder's NodeIndex"
+        );
+    }
+
+    /// Regression: a variable whose declaration has only an
+    /// `initializer` (no array-literal shape) should also survive the
+    /// `StableLocation` round-trip, exercising the
+    /// `identifier_literal_initializer_source_display` code path.
+    #[test]
+    fn stable_location_round_trips_for_boolean_initializer() {
+        let source = "let flag = true;\n".to_string();
+
+        let captured = {
+            let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+            let root = parser.parse_source_file();
+            let arena = parser.get_arena();
+            let mut binder = BinderState::new();
+            binder.bind_source_file(arena, root);
+            let sym_id = binder
+                .file_locals
+                .get("flag")
+                .expect("variable symbol flag");
+            let symbol = binder.symbols.get(sym_id).expect("symbol data");
+            *symbol
+                .stable_declarations
+                .first()
+                .expect("variable flag must have a stable_declarations entry")
+        };
+        assert!(captured.is_known());
+
+        let mut parser = ParserState::new("syn.ts".to_string(), source);
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(arena, root);
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena,
+            &binder,
+            &types,
+            "syn.ts".to_string(),
+            CheckerOptions::default(),
+        );
+
+        let (resolved_idx, resolved_arena) = ctx
+            .node_at_stable_location(captured)
+            .expect("captured StableLocation must rehydrate against the reparsed arena");
+        let decl = resolved_arena
+            .get_variable_declaration_at(resolved_idx)
+            .expect("rehydrated NodeIndex must be a VariableDeclaration");
+        // The initializer must be present (and untyped); this is exactly
+        // what `identifier_literal_initializer_source_display` checks
+        // before walking the initializer.
+        assert!(decl.initializer.is_some());
+        assert!(decl.type_annotation.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 step 3 from `docs/plan/global-query-graph-architecture.md`,
following PR #1066 which migrated `class_extends_any_base` and
introduced `CheckerContext::node_at_stable_location` as the bridge
helper.

This PR migrates two checker consumers in
`crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs`
off `Symbol::declarations[0]: NodeIndex` and onto the file-stable
`Symbol::stable_declarations[0]` / `stable_value_declaration` fields
introduced by PR #1055, rehydrating the concrete `NodeIndex` on demand
via the existing `node_at_stable_location` helper.

## Why this consumer

Picked per the prompt's "diagnostic-only consumers in
`error_reporter/`" candidate bucket. Smallest, cleanest module that
touches `symbol.declarations[N]`:

- One module, two functions, ~120 lines pre-migration.
- Both functions take an identifier `NodeIndex`, resolve its symbol,
  pick the variable's primary declaration, and walk the
  `VariableDeclaration` initializer to render an "identifier source"
  display string for assignability diagnostics.
- Cold path (only runs when emitting source-display variants of
  TS2322 / enum-assignment diagnostics).
- Self-contained: no cross-file or cross-arena gymnastics required.
- Two distinct walk shapes (array-of-object literal vs literal
  initializer) exercise the rehydration pattern twice in one PR.

Explicitly NOT picked (deferred to follow-up Phase 1 PRs):
- `lib_resolution.rs` (~1992 LOC, dozens of `symbol.declarations`
  reads, several already use `get_arena_for_declaration` cross-arena
  paths -- too large for one step).
- `state/type_resolution/symbol_types.rs` (~1472 LOC, `declarations`
  and `value_declaration` usage interleaved with merged-interface
  lowering and other complex paths -- needs multiple staged PRs).

## What changed

1. **`identifier_array_object_literal_source_display`** now reads
   `symbol.stable_declarations.first()` (with a fallback to
   `symbol.stable_value_declaration` mirroring the original
   preference order) and rehydrates `(NodeIndex, &NodeArena)` via
   `ctx.node_at_stable_location(stable_loc)` before walking the
   variable-declaration body. The walk collects the array-literal
   shape into owned `(NodeIndex, NodeIndex)` rows so the arena borrow
   is released before any `&mut self` calls below
   (`get_property_name`, `get_type_of_node`,
   `format_assignability_type_for_message`).

2. **`identifier_literal_initializer_source_display`** mirrors the
   same pattern for the boolean-initializer / enum-assignability
   path. Smaller surface -- no row collection needed because the
   initializer kind check is already arena-only.

3. **No changes to `Symbol`, `BinderState`, or `node_at_stable_location`.**
   This consumer migration is mechanical on top of the helper landed
   in #1066.

## What is still NodeIndex-bound in this consumer

- The variable-declaration walk (`arena.get_variable_declaration_at`,
  `arena.get_literal_expr`, `arena.get_property_assignment`,
  `arena.skip_parenthesized*`) is fundamentally AST-bound and
  continues to use a live `NodeIndex` -- but the `NodeIndex` is now
  rehydrated from the stable location, not read from the symbol's
  stored `NodeIndex`.
- `self.get_type_of_node(init_idx)` and
  `self.get_property_name(name_idx)` still operate against
  `self.ctx.arena` (the current file's arena). For variable
  declarations the symbol always lives in the same file as the
  reference, so the rehydrated arena is the current arena in
  practice; explicit cross-file rendering is out of scope for this
  Phase 1 step-3 PR.

## Tests

Three new unit tests in
`crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs`
under `#[cfg(test)] mod tests`:

- `stable_declaration_resolves_to_variable_decl_node` --
  `node_at_stable_location` returns the same `NodeIndex` that
  `symbol.declarations[0]` would have returned, against a
  `VariableDeclaration` with an array-literal initializer.
- `stable_location_round_trips_across_arena_reparse_for_var_decl` --
  **load-bearing Phase 5 scenario**: capture a `StableLocation` from
  one binder/arena pair, drop them, re-parse the same source with a
  fresh arena, and verify the captured location still resolves
  correctly. Proves this consumer survives Phase 5 arena
  eviction-and-rehydrate.
- `stable_location_round_trips_for_boolean_initializer` -- same
  round-trip for the second function's code path
  (`let flag = true;`).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run -p tsz-checker --lib` -- 2736 / 2736 passed
- [x] `cargo nextest run --profile precommit -E "package(tsz-checker) | package(tsz-emitter) | package(tsz-lsp)"` -- 13213 / 13213 passed
- [x] Three new round-trip tests prove `StableLocation` rehydration survives arena reparse (Phase 5 invariant)

## References

- PR #1055 -- Phase 1 step 1 (`StableLocation` on `Symbol`)
- PR #1066 -- Phase 1 step 2 (`class_extends_any_base` migration + `node_at_stable_location` bridge helper)
- `docs/plan/global-query-graph-architecture.md` -- full 6-phase plan