### PR TITLE
docs(perf): loop prompt — Cache PR 3/4 (#1132) ships, Phase 1 step 3 (#1131) merged

### DIFF
--- a/docs/plan/perf-loop-prompt.md
+++ b/docs/plan/perf-loop-prompt.md
@@ -265,11 +265,13 @@ shape as Phase 1 step 2 PR #1066.
    `Arc<FxHashMap<&str, SmallVec<[(BinderIdx, SymbolId); 2]>>>` built
    at merge, plumb through `CheckerContext`. Multi-hour task; defer
    until Cache PR 3/4 lands (potential conflict on checker fields).
-7. **Investigate 3.28× regression** between fe3e457d3f (pre-session
-   baseline) and current main on `manyConstExports.ts` (77ms → 253ms
-   across 495 commits). Not from Arc-share migrations (neutral on
-   single-file noemit). Multi-hour bisect — defer unless explicitly
-   requested.
+7. **~~3.28× regression on manyConstExports — RESOLVED 2026-04-25:
+   was a CLI invocation error, not a regression.~~** Original measurement
+   used `tsz check --noemit <file>` which is invalid (CLI treats `check`
+   as a filename, hits TS6053 file-not-found error path). Correct form is
+   `tsz --noemit <file>`. Real measurement on current main (post-#1128):
+   80.8 ms ± 3.4 ms vs claimed 77.3 ms baseline = within noise. No
+   regression exists.
 
 This document should evolve. When a directive lands wrong (regression,
 review change, design pivot), update this file and re-feed it as the

--- a/docs/plan/perf-loop-prompt.md
+++ b/docs/plan/perf-loop-prompt.md
@@ -156,8 +156,11 @@ or branch with uncommitted work — only clean cargo caches.
 
 ### Cache infra (Phase 4 prerequisites):
 - **#1040 MERGED** — PR 1/4: canonical-pairs `TypeSubstitution` (deterministic content-hashable form)
-- **#1128 MERGED** (2026-04-25) — PR 2/4: `InstantiationCache` storage on `QueryCache` + `lookup_instantiation_cache`/`insert_instantiation_cache` on `QueryDatabase`. No entry-point wiring yet.
-- **PR 3/4 IN FLIGHT** (agent `cache-pr3-wire-opus`, 2026-04-25) — wire 5 entry points; perf win lands here.
+- **#1128 MERGED** (2026-04-25) — PR 2/4: `InstantiationCache` storage on `QueryCache` + `lookup_instantiation_cache`/`insert_instantiation_cache` on `QueryDatabase`. No entry-point wiring.
+- **#1132 OPEN** (2026-04-25) — PR 3/4: wire 5 entry points via `_cached` variants + `Option<&dyn QueryDatabase>` parameter (deviation from literal spec — strict signature change blocked by 116 cascading errors; `_cached` variants land same perf win without multi-day rewrite). Bench results vs prior tsz: paths.ts 115→58ms (-50%), deep-pick.ts 200→53ms (-74%, **flips tsgo-faster→tsz-faster 1.89×**), deep-readonly.ts 99→62ms (-37%). 6 hot-path callers wired in TypeEvaluator + SubtypeChecker.
+
+### Phase 1 — STABLE IDENTITY (continued, 2026-04-25):
+- **#1131 MERGED** (2026-04-25) — Phase 1 step 3: `identifier_source_display` migration (2 functions, 3 new tests including Phase 5 round-trip across arena reparse).
 
 ### Phase 2 — SKELETON IR consumers:
 - **#1127 MERGED** (2026-04-25) — Phase 2 step 1: `is_ambient_module` resolver served from `SkeletonIndex` alone (Phase 5 invariant test included). First skeleton consumer migrated.


### PR DESCRIPTION
## Summary
- Logs **#1131 MERGED** — Phase 1 step 3: `identifier_source_display` migration with Phase 5 round-trip test.
- Logs **#1132 OPEN** — Cache PR 3/4 with verified perf wins: paths.ts -50%, deep-pick.ts -74% (flips tsgo-faster → **tsz-faster 1.89×**), deep-readonly.ts -37%.
- Notes the agent's deviation from literal spec (added `_cached` variants instead of changing 5 entry-point signatures) and the rationale (~116 cascading compile errors in strict version).

## Test plan
- [x] Doc-only change.