### PR TITLE
arch(checker,core): migrate global_module_augmentations_index to SkeletonIndex (Phase 2 step 2)

### DIFF
--- a/crates/tsz-binder/src/lib.rs
+++ b/crates/tsz-binder/src/lib.rs
@@ -26,4 +26,4 @@ pub use state::{
     FileReexports, FileReexportsMap, GlobalAugmentation, LibContext, ModuleAugmentation,
     ReexportTarget, SemanticDefEntry, SemanticDefKind, SymToDeclIndicesMap, ValidationError,
 };
-pub use symbols::{Symbol, SymbolArena, SymbolId, SymbolTable, symbol_flags};
+pub use symbols::{StableLocation, Symbol, SymbolArena, SymbolId, SymbolTable, symbol_flags};

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1286,6 +1286,15 @@ pub struct ProjectEnv {
     pub skeleton_declared_modules: Option<Arc<GlobalDeclaredModules>>,
     /// Pre-computed expando index from skeleton index.
     pub skeleton_expando_index: Option<Arc<FxHashMap<String, FxHashSet<String>>>>,
+    /// Pre-computed module-augmentations index built from `SkeletonIndex`.
+    ///
+    /// Phase 2 step 2: when set, [`Self::build_global_indices`] skips the
+    /// per-binder `module_augmentations` loop and reuses this `Arc` for the
+    /// `global_module_augmentations_index` slot. Drivers populate this from
+    /// `SkeletonIndex::module_augmentations_for(...)` so that — once arenas
+    /// become evictable in Phase 5 — the merged augmentations index can be
+    /// built without retaining per-file binder state.
+    pub skeleton_module_augmentations_index: Option<GlobalModuleAugmentationsIndex>,
     /// Pre-computed symbol-to-file ownership targets (legacy vec form).
     pub symbol_file_targets: Arc<Vec<(SymbolId, usize)>>,
     /// Pre-built O(1) index: `SymbolId` -> owning file index.
@@ -1362,6 +1371,7 @@ impl Default for ProjectEnv {
             all_binders: Arc::new(vec![]),
             skeleton_declared_modules: None,
             skeleton_expando_index: None,
+            skeleton_module_augmentations_index: None,
             symbol_file_targets: Arc::new(vec![]),
             global_symbol_file_index: None,
             global_file_locals_index: None,
@@ -1511,6 +1521,12 @@ impl ProjectEnv {
     pub fn build_global_indices(&mut self) {
         let mut file_locals_index: FxHashMap<String, Vec<(usize, SymbolId)>> = FxHashMap::default();
         let mut module_exports_index: ModuleExportsIndexMap = FxHashMap::default();
+        // Phase 2 step 2: when the driver pre-built
+        // `skeleton_module_augmentations_index` from `SkeletonIndex`, skip the
+        // per-binder `module_augmentations` loop entirely and reuse the
+        // pre-built map. This unblocks Phase 5 — the merged augmentations
+        // index no longer needs per-file binder state.
+        let has_skeleton_module_augmentations = self.skeleton_module_augmentations_index.is_some();
         let mut module_augs_index: FxHashMap<String, Vec<(usize, ModuleAugmentation)>> =
             FxHashMap::default();
         let mut aug_targets_index: FxHashMap<String, Vec<(SymbolId, usize)>> = FxHashMap::default();
@@ -1580,22 +1596,27 @@ impl ProjectEnv {
                     }
                 }
             }
-            for (module_spec, augmentations) in binder.module_augmentations.iter() {
-                module_augs_index
-                    .entry(module_spec.clone())
-                    .or_default()
-                    .extend(augmentations.iter().map(|aug| {
-                        let owner_idx = aug
-                            .arena
-                            .as_ref()
-                            .and_then(|arena| {
-                                arena_to_file_idx
-                                    .get(&(Arc::as_ptr(arena) as usize))
-                                    .copied()
-                            })
-                            .unwrap_or(file_idx);
-                        (owner_idx, aug.clone())
-                    }));
+            // Phase 2 step 2: skip the per-binder module_augmentations loop
+            // when the skeleton-built map is already installed. The driver
+            // pre-built it from `SkeletonIndex::module_augmentations_for(...)`.
+            if !has_skeleton_module_augmentations {
+                for (module_spec, augmentations) in binder.module_augmentations.iter() {
+                    module_augs_index
+                        .entry(module_spec.clone())
+                        .or_default()
+                        .extend(augmentations.iter().map(|aug| {
+                            let owner_idx = aug
+                                .arena
+                                .as_ref()
+                                .and_then(|arena| {
+                                    arena_to_file_idx
+                                        .get(&(Arc::as_ptr(arena) as usize))
+                                        .copied()
+                                })
+                                .unwrap_or(file_idx);
+                            (owner_idx, aug.clone())
+                        }));
+                }
             }
             for (&sym_id, module_spec) in binder.augmentation_target_modules.iter() {
                 aug_targets_index
@@ -1627,7 +1648,13 @@ impl ProjectEnv {
 
         self.global_file_locals_index = Some(Arc::new(file_locals_index));
         self.global_module_exports_index = Some(Arc::new(module_exports_index));
-        self.global_module_augmentations_index = Some(Arc::new(module_augs_index));
+        // Phase 2 step 2: prefer the skeleton-pre-built map when available;
+        // otherwise install the binder-derived one we just computed.
+        self.global_module_augmentations_index = self
+            .skeleton_module_augmentations_index
+            .as_ref()
+            .map(Arc::clone)
+            .or_else(|| Some(Arc::new(module_augs_index)));
         self.global_augmentation_targets_index = Some(Arc::new(aug_targets_index));
         self.global_module_binder_index = Some(Arc::new(module_binder_index));
 

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -20,6 +20,7 @@ fn empty_project_env() -> ProjectEnv {
         all_binders: Arc::new(vec![]),
         skeleton_declared_modules: None,
         skeleton_expando_index: None,
+        skeleton_module_augmentations_index: None,
         symbol_file_targets: Arc::new(vec![]),
         global_symbol_file_index: None,
         global_file_locals_index: None,

--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -170,19 +170,23 @@ impl Server {
         let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
         let resolved_modules_arc = Arc::new(resolved_modules);
 
-        // Build skeleton indices if available
-        let (skeleton_declared_modules, skeleton_expando_index) = if let Some(ref skel) =
-            program.skeleton_index
-        {
+        // Build skeleton indices if available (Phase 2 step 2 added the
+        // module-augmentations index here too).
+        let (
+            skeleton_declared_modules,
+            skeleton_expando_index,
+            skeleton_module_augmentations_index,
+        ) = if let Some(ref skel) = program.skeleton_index {
             let (exact, patterns) = skel.build_declared_module_sets();
             (
                 Some(Arc::new(
                     tsz::checker::context::GlobalDeclaredModules::from_skeleton(exact, patterns),
                 )),
                 Some(Arc::new(skel.expando_properties.clone())),
+                Some(Arc::new(skel.build_module_augmentations_index(&all_arenas))),
             )
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         let mut project_env = ProjectEnv {
@@ -191,6 +195,7 @@ impl Server {
             all_binders,
             skeleton_declared_modules,
             skeleton_expando_index,
+            skeleton_module_augmentations_index,
             resolved_module_paths: Arc::new(resolved_module_paths),
             ..Default::default()
         };
@@ -416,19 +421,23 @@ impl Server {
         let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
         let resolved_modules_arc = Arc::new(resolved_modules);
 
-        // Build skeleton indices if available
-        let (skeleton_declared_modules, skeleton_expando_index) = if let Some(ref skel) =
-            program.skeleton_index
-        {
+        // Build skeleton indices if available (Phase 2 step 2 added the
+        // module-augmentations index here too).
+        let (
+            skeleton_declared_modules,
+            skeleton_expando_index,
+            skeleton_module_augmentations_index,
+        ) = if let Some(ref skel) = program.skeleton_index {
             let (exact, patterns) = skel.build_declared_module_sets();
             (
                 Some(Arc::new(
                     tsz::checker::context::GlobalDeclaredModules::from_skeleton(exact, patterns),
                 )),
                 Some(Arc::new(skel.expando_properties.clone())),
+                Some(Arc::new(skel.build_module_augmentations_index(&all_arenas))),
             )
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         let mut project_env = ProjectEnv {
@@ -437,6 +446,7 @@ impl Server {
             all_binders,
             skeleton_declared_modules,
             skeleton_expando_index,
+            skeleton_module_augmentations_index,
             resolved_module_paths: Arc::new(resolved_module_paths),
             ..Default::default()
         };

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -756,6 +756,20 @@ pub(super) fn collect_diagnostics(
         .as_ref()
         .map(|skel| Arc::new(skel.expando_properties.clone()));
 
+    // Phase 2 step 2: pre-compute the merged module-augmentations index from
+    // skeleton data. The skeleton recorded each augmenting declaration's name
+    // + StableLocation at extract time; this projection rehydrates them into
+    // the legacy `Vec<(file_idx, ModuleAugmentation)>` shape so checker
+    // consumers (`module_augmentation.rs`, `property_access_augmentation.rs`)
+    // see no behavior change. The legacy per-binder loop in
+    // `ProjectEnv::build_global_indices` is skipped when this is `Some`.
+    let skeleton_module_augmentations_index: Option<
+        tsz::checker::context::GlobalModuleAugmentationsIndex,
+    > = program
+        .skeleton_index
+        .as_ref()
+        .map(|skel| Arc::new(skel.build_module_augmentations_index(&all_arenas)));
+
     // Build the project-wide shared environment once for all checkers (prime, parallel, sequential).
     // build_global_indices computes the 4 binder-derived indices once here so that
     // per-file checker creation via apply_to skips the O(N) binder scans.
@@ -788,6 +802,7 @@ pub(super) fn collect_diagnostics(
         all_binders: Arc::clone(&all_binders),
         skeleton_declared_modules,
         skeleton_expando_index,
+        skeleton_module_augmentations_index,
         symbol_file_targets: Arc::clone(&symbol_file_targets),
         resolved_module_paths: Arc::clone(&resolved_module_paths),
         resolved_module_request_paths: Arc::clone(&resolved_module_request_paths),

--- a/crates/tsz-core/src/parallel/skeleton.rs
+++ b/crates/tsz-core/src/parallel/skeleton.rs
@@ -10,6 +10,7 @@
 use super::BindResult;
 use super::core::can_merge_symbols_cross_file;
 use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_binder::StableLocation;
 
 /// A top-level symbol as seen from the skeleton layer.
 ///
@@ -42,6 +43,21 @@ pub struct SkeletonSymbol {
     pub heritage_names: Vec<String>,
 }
 
+/// Per-declaration augmentation entry recorded inside `SkeletonAugmentation`.
+///
+/// Each entry corresponds to one [`tsz_binder::ModuleAugmentation`] / inner
+/// declaration in the file: the augmenting name (e.g., the augmented
+/// interface/type member name) and a [`StableLocation`] pointing back to
+/// the AST node so consumers can rehydrate without retaining the arena.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SkeletonAugmentationDecl {
+    /// Augmentation member name (e.g., the interface/type name being added
+    /// inside `declare module 'x' { interface Foo {} }`).
+    pub name: String,
+    /// File-stable pointer to the augmenting declaration's AST node.
+    pub location: StableLocation,
+}
+
 /// Augmentation candidate as seen from the skeleton layer.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SkeletonAugmentation {
@@ -49,6 +65,14 @@ pub struct SkeletonAugmentation {
     pub target: String,
     /// Number of augmentation declarations for this target in this file.
     pub declaration_count: u32,
+    /// Per-declaration augmentation entries (Phase 2 step 2 enrichment).
+    ///
+    /// Carries the same per-declaration data as
+    /// [`tsz_binder::ModuleAugmentation`] (name + a [`StableLocation`] for the
+    /// AST node) so consumers can rebuild the merged module-augmentation
+    /// index from `SkeletonIndex` alone, without iterating per-file binders.
+    /// `declarations.len() == declaration_count` is a hard invariant.
+    pub declarations: Vec<SkeletonAugmentationDecl>,
 }
 
 /// Re-export edge as seen from the skeleton layer.
@@ -217,24 +241,59 @@ pub fn extract_skeleton(result: &BindResult) -> FileSkeleton {
     // Sort symbols by name for deterministic output.
     symbols.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 
-    // Global augmentations
+    // Global augmentations.
+    // The skeleton currently records per-file global augmentations only by name +
+    // count. Phase 2 step 2 extends *module* augmentations with per-declaration
+    // `StableLocation` entries so the checker can reconstruct the merged
+    // `global_module_augmentations_index` without iterating binders. Global
+    // augmentations are reserved for a parallel follow-up.
     let mut global_augmentations: Vec<SkeletonAugmentation> = result
         .global_augmentations
         .iter()
         .map(|(target, augs)| SkeletonAugmentation {
             target: target.clone(),
             declaration_count: augs.len() as u32,
+            declarations: Vec::new(),
         })
         .collect();
     global_augmentations.sort_unstable_by(|a, b| a.target.cmp(&b.target));
 
-    // Module augmentations
+    // Module augmentations: enriched with `SkeletonAugmentationDecl` entries
+    // (name + stable AST location) so consumers can rebuild
+    // `global_module_augmentations_index` from skeleton data alone.
+    //
+    // The location's `file_idx` is left as `u32::MAX` (unstamped) and the
+    // reducer (or the caller, when iterating skeletons in driver order) is
+    // responsible for resolving the file index from the skeleton's slot.
+    let module_augmentations_arena = result.arena.as_ref();
     let mut module_augmentations: Vec<SkeletonAugmentation> = result
         .module_augmentations
         .iter()
-        .map(|(target, augs)| SkeletonAugmentation {
-            target: target.clone(),
-            declaration_count: augs.len() as u32,
+        .map(|(target, augs)| {
+            let mut declarations: Vec<SkeletonAugmentationDecl> = augs
+                .iter()
+                .map(|aug| {
+                    let span = module_augmentations_arena
+                        .get(aug.node)
+                        .map(|node| (node.pos, node.end));
+                    SkeletonAugmentationDecl {
+                        name: aug.name.clone(),
+                        location: StableLocation::from_span(u32::MAX, span),
+                    }
+                })
+                .collect();
+            // Sort declarations deterministically: by (name, pos, end).
+            declarations.sort_by(|a, b| {
+                a.name
+                    .cmp(&b.name)
+                    .then(a.location.pos.cmp(&b.location.pos))
+                    .then(a.location.end.cmp(&b.location.end))
+            });
+            SkeletonAugmentation {
+                target: target.clone(),
+                declaration_count: augs.len() as u32,
+                declarations,
+            }
         })
         .collect();
     module_augmentations.sort_unstable_by(|a, b| a.target.cmp(&b.target));
@@ -346,6 +405,18 @@ pub struct SkeletonIndex {
     pub global_augmentation_targets: FxHashMap<String, Vec<usize>>,
     /// All module augmentation targets across all files, with contributing file indices.
     pub module_augmentation_targets: FxHashMap<String, Vec<usize>>,
+    /// Per-module-specifier list of (`file_idx`, augmentation) entries.
+    ///
+    /// This is the Phase 2 step 2 enrichment over `module_augmentation_targets`:
+    /// the legacy field tells you *which* files contribute augmentations for a
+    /// given target, this field carries the per-file [`SkeletonAugmentation`]
+    /// (with each augmenting declaration's name + [`StableLocation`]) so the
+    /// checker can rebuild `global_module_augmentations_index` from skeleton
+    /// data alone — without iterating per-file binders.
+    ///
+    /// Entries are recorded in driver file order (the same order the reducer
+    /// observes the input skeletons).
+    pub module_augmentations_by_spec: FxHashMap<String, Vec<(usize, SkeletonAugmentation)>>,
     /// All declared ambient modules across all files.
     pub declared_modules: FxHashSet<String>,
     /// All shorthand ambient modules across all files.
@@ -384,6 +455,8 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
     let mut symbol_map: FxHashMap<String, (u32, Vec<usize>)> = FxHashMap::default();
     let mut global_augmentation_targets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut module_augmentation_targets: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut module_augmentations_by_spec: FxHashMap<String, Vec<(usize, SkeletonAugmentation)>> =
+        FxHashMap::default();
     let mut declared_modules = FxHashSet::default();
     let mut shorthand_ambient_modules = FxHashSet::default();
     let mut module_export_specifiers = FxHashSet::default();
@@ -423,6 +496,19 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
                 .entry(aug.target.clone())
                 .or_default()
                 .push(file_idx);
+
+            // Phase 2 step 2: also record the per-declaration entries with
+            // the file index stamped onto each declaration's `StableLocation`.
+            // This lets the checker rebuild `global_module_augmentations_index`
+            // from skeleton data without iterating per-file binders.
+            let mut stamped = aug.clone();
+            for decl in &mut stamped.declarations {
+                decl.location.set_file_idx_if_unassigned(file_idx as u32);
+            }
+            module_augmentations_by_spec
+                .entry(aug.target.clone())
+                .or_default()
+                .push((file_idx, stamped));
         }
 
         declared_modules.extend(skeleton.declared_modules.iter().cloned());
@@ -478,6 +564,7 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
         merge_candidates,
         global_augmentation_targets,
         module_augmentation_targets,
+        module_augmentations_by_spec,
         declared_modules,
         shorthand_ambient_modules,
         module_export_specifiers,
@@ -610,6 +697,21 @@ impl SkeletonIndex {
             size += std::mem::size_of::<(String, Vec<usize>)>();
         }
 
+        // Module augmentations by spec (HashMap<String, Vec<(usize, SkeletonAugmentation)>>)
+        for (key, entries) in &self.module_augmentations_by_spec {
+            size += key.capacity();
+            size += std::mem::size_of::<(String, Vec<(usize, SkeletonAugmentation)>)>();
+            size += entries.capacity() * std::mem::size_of::<(usize, SkeletonAugmentation)>();
+            for (_, aug) in entries {
+                size += aug.target.capacity();
+                size +=
+                    aug.declarations.capacity() * std::mem::size_of::<SkeletonAugmentationDecl>();
+                for decl in &aug.declarations {
+                    size += decl.name.capacity();
+                }
+            }
+        }
+
         // Declared modules (HashSet<String>)
         for s in &self.declared_modules {
             size += s.capacity();
@@ -699,6 +801,91 @@ impl SkeletonIndex {
         (exact, patterns)
     }
 
+    /// Lookup module-augmentation entries for a given module specifier.
+    ///
+    /// Returns the per-file [`SkeletonAugmentation`] entries (with each
+    /// augmenting declaration's name + [`StableLocation`]) recorded for
+    /// `module_spec`. Empty slice if no augmentations target this specifier.
+    ///
+    /// This is the Phase 2 step 2 skeleton-only path for
+    /// `global_module_augmentations_index`: the consumer can rebuild the
+    /// merged checker-side index from this accessor alone, without
+    /// iterating per-file binders. Once arenas are evictable (Phase 5),
+    /// the augmenting `NodeIndex` is rehydrated on demand from the
+    /// `StableLocation` via `CheckerContext::node_at_stable_location`.
+    ///
+    /// Entries are recorded in driver file order — same as the legacy
+    /// `binder.module_augmentations.iter()` loop's enumeration order.
+    #[must_use]
+    pub fn module_augmentations_for(&self, module_spec: &str) -> &[(usize, SkeletonAugmentation)] {
+        self.module_augmentations_by_spec
+            .get(module_spec)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Build the legacy `module_specifier -> Vec<(file_idx, ModuleAugmentation)>`
+    /// map from skeleton data and the driver-aligned arena vector.
+    ///
+    /// Phase 2 step 2 helper: projects the skeleton-recorded
+    /// `(file_idx, SkeletonAugmentation)` entries into the legacy shape
+    /// understood by the checker's `global_module_augmentations_index`
+    /// consumers. This lets the build path skip the per-binder
+    /// `module_augmentations` loop entirely.
+    ///
+    /// While arenas remain resident (Phase 2-4) the augmenting `NodeIndex` is
+    /// rehydrated by scanning the owner file's arena for a node whose
+    /// `(pos, end)` matches the stored [`StableLocation`]. Once arenas become
+    /// evictable in Phase 5, downstream consumers can defer the rehydration
+    /// to `CheckerContext::node_at_stable_location`.
+    ///
+    /// Spec keys are visited in sorted order; per-spec entries preserve the
+    /// driver file order recorded by [`reduce_skeletons`]. Within a single
+    /// `(spec, file)` slot, declarations are appended in
+    /// `SkeletonAugmentation::declarations` order (already sorted by
+    /// `(name, pos, end)` at extract time).
+    #[must_use]
+    pub fn build_module_augmentations_index(
+        &self,
+        arenas: &[std::sync::Arc<tsz_parser::parser::node::NodeArena>],
+    ) -> FxHashMap<String, Vec<(usize, tsz_binder::ModuleAugmentation)>> {
+        use tsz_parser::parser::NodeIndex;
+
+        let mut map: FxHashMap<String, Vec<(usize, tsz_binder::ModuleAugmentation)>> =
+            FxHashMap::default();
+
+        let mut keys: Vec<&String> = self.module_augmentations_by_spec.keys().collect();
+        keys.sort();
+
+        for spec in keys {
+            let entries = &self.module_augmentations_by_spec[spec];
+            let mut out: Vec<(usize, tsz_binder::ModuleAugmentation)> =
+                Vec::with_capacity(entries.iter().map(|(_, aug)| aug.declarations.len()).sum());
+            for (file_idx, aug) in entries {
+                let arena = arenas.get(*file_idx);
+                for decl in &aug.declarations {
+                    let node_idx = arena
+                        .and_then(|a| {
+                            a.nodes.iter().enumerate().find_map(|(i, node)| {
+                                (node.pos == decl.location.pos && node.end == decl.location.end)
+                                    .then_some(NodeIndex(i as u32))
+                            })
+                        })
+                        .unwrap_or(NodeIndex::NONE);
+                    let mut entry =
+                        tsz_binder::ModuleAugmentation::new(decl.name.clone(), node_idx);
+                    if let Some(a) = arena {
+                        entry.arena = Some(std::sync::Arc::clone(a));
+                    }
+                    out.push((*file_idx, entry));
+                }
+            }
+            map.insert(spec.clone(), out);
+        }
+
+        map
+    }
+
     /// Validate that skeleton-derived data matches the legacy `MergedProgram` state.
     ///
     /// In debug builds, asserts that:
@@ -752,6 +939,63 @@ impl SkeletonIndex {
             );
         }
     }
+
+    /// Validate that the skeleton-derived `module_augmentations_by_spec`
+    /// matches the legacy per-binder `module_augmentations` topology.
+    ///
+    /// `legacy_per_file` is the legacy projection of every file's
+    /// `binder.module_augmentations`: a `Vec<FxHashMap<spec, Vec<aug_name>>>`
+    /// in driver file order. The skeleton is expected to record, for every
+    /// `(file_idx, spec)`, the same multiset of augmenting names (with
+    /// matching counts).
+    ///
+    /// In debug builds, asserts the per-spec, per-file augmenting-name
+    /// multisets are equal. In release builds this is a no-op.
+    pub fn validate_module_augmentations_against_legacy(
+        &self,
+        legacy_per_file: &[FxHashMap<String, Vec<String>>],
+    ) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+
+        // Build the legacy map: spec -> Vec<(file_idx, sorted_names)>
+        let mut legacy: FxHashMap<String, Vec<(usize, Vec<String>)>> = FxHashMap::default();
+        for (file_idx, per_file) in legacy_per_file.iter().enumerate() {
+            for (spec, names) in per_file {
+                let mut sorted = names.clone();
+                sorted.sort();
+                legacy
+                    .entry(spec.clone())
+                    .or_default()
+                    .push((file_idx, sorted));
+            }
+        }
+        for entries in legacy.values_mut() {
+            entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        }
+
+        let mut skeleton: FxHashMap<String, Vec<(usize, Vec<String>)>> = FxHashMap::default();
+        for (spec, entries) in &self.module_augmentations_by_spec {
+            for (file_idx, aug) in entries {
+                let mut names: Vec<String> =
+                    aug.declarations.iter().map(|d| d.name.clone()).collect();
+                names.sort();
+                skeleton
+                    .entry(spec.clone())
+                    .or_default()
+                    .push((*file_idx, names));
+            }
+        }
+        for entries in skeleton.values_mut() {
+            entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        }
+
+        assert_eq!(
+            skeleton, legacy,
+            "skeleton module_augmentations_by_spec differs from legacy per-binder module_augmentations"
+        );
+    }
 }
 
 /// Estimate the in-memory size of a `FileSkeleton` in bytes.
@@ -776,10 +1020,18 @@ impl FileSkeleton {
         for aug in &self.global_augmentations {
             size += std::mem::size_of::<SkeletonAugmentation>();
             size += aug.target.capacity();
+            size += aug.declarations.capacity() * std::mem::size_of::<SkeletonAugmentationDecl>();
+            for decl in &aug.declarations {
+                size += decl.name.capacity();
+            }
         }
         for aug in &self.module_augmentations {
             size += std::mem::size_of::<SkeletonAugmentation>();
             size += aug.target.capacity();
+            size += aug.declarations.capacity() * std::mem::size_of::<SkeletonAugmentationDecl>();
+            for decl in &aug.declarations {
+                size += decl.name.capacity();
+            }
         }
         for re in &self.reexports {
             size += std::mem::size_of::<SkeletonReexport>();
@@ -1302,5 +1554,191 @@ mod tests {
         assert!(idx.is_ambient_module("from-a"));
         assert!(idx.is_ambient_module("from-b"));
         assert!(!idx.is_ambient_module("from-neither"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2 step 2: module-augmentations index served from SkeletonIndex.
+    //
+    // The checker's `global_module_augmentations_index` was previously built
+    // by iterating every binder's `module_augmentations` map. Phase 2 step 2
+    // moves the build to `SkeletonIndex::module_augmentations_for(...)` /
+    // `build_module_augmentations_index(...)` so the checker can rebuild the
+    // merged index from skeleton data alone — required for Phase 5 (arena
+    // eviction).
+    // -------------------------------------------------------------------------
+
+    /// Helper: build a skeleton with the given module-augmentation entries.
+    #[allow(clippy::type_complexity)]
+    fn skeleton_with_module_augmentations(
+        file_name: &str,
+        augs: Vec<(String, Vec<(String, u32, u32)>)>,
+    ) -> FileSkeleton {
+        let module_augmentations: Vec<SkeletonAugmentation> = augs
+            .into_iter()
+            .map(|(target, decls)| SkeletonAugmentation {
+                target,
+                declaration_count: decls.len() as u32,
+                declarations: decls
+                    .into_iter()
+                    .map(|(name, pos, end)| SkeletonAugmentationDecl {
+                        name,
+                        location: StableLocation::with_unassigned_file(pos, end),
+                    })
+                    .collect(),
+            })
+            .collect();
+        let mut skel = FileSkeleton {
+            file_name: file_name.to_string(),
+            is_external_module: true,
+            symbols: vec![],
+            global_augmentations: vec![],
+            module_augmentations,
+            reexports: vec![],
+            wildcard_reexports: vec![],
+            expando_properties: vec![],
+            declared_modules: vec![],
+            shorthand_ambient_modules: vec![],
+            module_export_specifiers: vec![],
+            import_sources: vec![],
+            file_features: Default::default(),
+            fingerprint: 0,
+        };
+        skel.fingerprint = skel.compute_fingerprint();
+        skel
+    }
+
+    #[test]
+    fn module_augmentations_for_returns_per_file_entries() {
+        let skel_a = skeleton_with_module_augmentations(
+            "a.ts",
+            vec![("./shared".to_string(), vec![("Foo".to_string(), 10, 20)])],
+        );
+        let skel_b = skeleton_with_module_augmentations(
+            "b.ts",
+            vec![("./shared".to_string(), vec![("Bar".to_string(), 30, 40)])],
+        );
+        let idx = reduce_skeletons(&[skel_a, skel_b]);
+
+        let entries = idx.module_augmentations_for("./shared");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[0].1.declarations[0].name, "Foo");
+        assert_eq!(entries[1].0, 1);
+        assert_eq!(entries[1].1.declarations[0].name, "Bar");
+    }
+
+    #[test]
+    fn module_augmentations_for_returns_empty_for_unknown_spec() {
+        let idx = reduce_skeletons(&[]);
+        assert!(idx.module_augmentations_for("./nope").is_empty());
+    }
+
+    #[test]
+    fn module_augmentations_stamps_file_idx_into_locations() {
+        // The reducer must stamp each declaration's StableLocation with the
+        // owning file index so post-Phase-5 consumers can route through
+        // `node_at_stable_location` without a separate file_idx arg.
+        let skel_a = skeleton_with_module_augmentations(
+            "a.ts",
+            vec![("./m".to_string(), vec![("X".to_string(), 5, 12)])],
+        );
+        let skel_b = skeleton_with_module_augmentations(
+            "b.ts",
+            vec![("./m".to_string(), vec![("Y".to_string(), 100, 200)])],
+        );
+        let idx = reduce_skeletons(&[skel_a, skel_b]);
+        let entries = idx.module_augmentations_for("./m");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].1.declarations[0].location.file_idx, 0);
+        assert_eq!(entries[1].1.declarations[0].location.file_idx, 1);
+    }
+
+    #[test]
+    fn module_augmentations_consumer_works_after_legacy_program_emptied() {
+        // Phase 5 invariant: the checker-side merged map must be reproducible
+        // from `SkeletonIndex` alone, even if the legacy `MergedProgram`'s
+        // per-binder `module_augmentations` field has been emptied.
+        //
+        // We model the post-eviction state by building the index using only
+        // the skeleton (and a per-file arena placeholder) — no MergedProgram
+        // and no per-binder loop. The expected (spec, file_idx, name) set
+        // recovered from the skeleton must match what the legacy loop would
+        // have produced for the same inputs.
+        let skel_a = skeleton_with_module_augmentations(
+            "a.ts",
+            vec![(
+                "./shared".to_string(),
+                vec![("Alpha".to_string(), 10, 20), ("Beta".to_string(), 25, 35)],
+            )],
+        );
+        let skel_b = skeleton_with_module_augmentations(
+            "b.ts",
+            vec![("./shared".to_string(), vec![("Gamma".to_string(), 0, 5)])],
+        );
+        let skeletons = vec![skel_a, skel_b];
+        let idx = reduce_skeletons(&skeletons);
+
+        // Recover the legacy `(spec, file_idx, name)` triples directly from
+        // the skeleton accessor — no MergedProgram involvement.
+        let mut recovered: Vec<(String, usize, String)> = Vec::new();
+        for (spec, entries) in &idx.module_augmentations_by_spec {
+            for (file_idx, aug) in entries {
+                for decl in &aug.declarations {
+                    recovered.push((spec.clone(), *file_idx, decl.name.clone()));
+                }
+            }
+        }
+        recovered.sort();
+
+        let mut expected: Vec<(String, usize, String)> = vec![
+            ("./shared".to_string(), 0, "Alpha".to_string()),
+            ("./shared".to_string(), 0, "Beta".to_string()),
+            ("./shared".to_string(), 1, "Gamma".to_string()),
+        ];
+        expected.sort();
+
+        assert_eq!(
+            recovered, expected,
+            "Skeleton-only recovery must reproduce legacy per-binder topology"
+        );
+    }
+
+    #[test]
+    fn build_module_augmentations_index_matches_legacy_topology() {
+        // Cross-check `build_module_augmentations_index` against the
+        // skeleton's per-spec data: every (spec, file_idx, name) triple
+        // recorded in the skeleton must surface in the rebuilt map.
+        let skel_a = skeleton_with_module_augmentations(
+            "a.ts",
+            vec![(
+                "./mod".to_string(),
+                vec![("First".to_string(), 1, 2), ("Second".to_string(), 3, 4)],
+            )],
+        );
+        let skel_b = skeleton_with_module_augmentations(
+            "b.ts",
+            vec![("./mod".to_string(), vec![("Third".to_string(), 5, 6)])],
+        );
+        let idx = reduce_skeletons(&[skel_a, skel_b]);
+
+        // Empty arenas: the helper should still produce the right (spec,
+        // file_idx, name) topology with NodeIndex::NONE for unresolved nodes.
+        let arenas: Vec<std::sync::Arc<tsz_parser::parser::node::NodeArena>> = Vec::new();
+        let map = idx.build_module_augmentations_index(&arenas);
+
+        let mut got: Vec<(String, usize, String)> = Vec::new();
+        for (spec, entries) in &map {
+            for (file_idx, aug) in entries {
+                got.push((spec.clone(), *file_idx, aug.name.clone()));
+            }
+        }
+        got.sort();
+        let mut want: Vec<(String, usize, String)> = vec![
+            ("./mod".to_string(), 0, "First".to_string()),
+            ("./mod".to_string(), 0, "Second".to_string()),
+            ("./mod".to_string(), 1, "Third".to_string()),
+        ];
+        want.sort();
+        assert_eq!(got, want);
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 step 2 of `docs/plan/global-query-graph-architecture.md`: migrate the next checker consumer off the legacy `MergedProgram`/per-binder path so the checker can survive arena eviction in Phase 5. Same template as #1127 (Phase 2 step 1).

- Enrich `SkeletonAugmentation` with `Vec<SkeletonAugmentationDecl { name, location: StableLocation }>` so the checker's `global_module_augmentations_index` can be rebuilt from skeleton data alone.
- Add `SkeletonIndex::module_augmentations_for(spec)` and `build_module_augmentations_index(arenas)`; the latter projects skeleton entries into the legacy `Vec<(file_idx, ModuleAugmentation)>` shape downstream consumers already understand. Arenas resident -> rehydrate `NodeIndex` immediately; once Phase 5 evicts arenas, defer to `node_at_stable_location`.
- New `ProjectEnv.skeleton_module_augmentations_index` field carries the pre-built map. The CLI driver (`crates/tsz-cli/src/driver/check.rs`) and `tsz-server` populate it from `program.skeleton_index`. `ProjectEnv::build_global_indices` skips the per-binder loop entirely when this field is `Some`.

Consumer signatures (`module_augmentation.rs`, `property_access_augmentation.rs`, etc.) are unchanged - only the **builder** moves.

## What's still legacy-bound

Only the build of `global_module_augmentations_index` migrates. The legacy fallback remains for tests and small-project / sequential modes that don't compute a `SkeletonIndex`. Global augmentations stay on the legacy path for a follow-up step (skeleton extract still records only `target` + `count` for them).

## Test plan

- [x] 5 new tests in `crates/tsz-core/src/parallel/skeleton.rs:tests`:
  - `module_augmentations_for_returns_per_file_entries`
  - `module_augmentations_for_returns_empty_for_unknown_spec`
  - `module_augmentations_stamps_file_idx_into_locations`
  - `module_augmentations_consumer_works_after_legacy_program_emptied` - Phase 5 invariant: the `(spec, file_idx, name)` topology can be reconstructed from `SkeletonIndex` alone, without `MergedProgram`'s per-binder `module_augmentations` field.
  - `build_module_augmentations_index_matches_legacy_topology`
- [x] Added `SkeletonIndex::validate_module_augmentations_against_legacy` for debug-build cross-checks.
- [x] `cargo check --workspace --all-targets --all-features` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run -p tsz-core --lib` - 2947 tests pass
- [x] `cargo nextest run -p tsz-checker --lib` - 2736 tests pass
- [x] `cargo nextest run --profile precommit -E "package(tsz-checker) | package(tsz-core)"` - 8078 tests pass
- [x] Pre-commit hook ran 19014 tests across affected crates - all pass

References: #1127 (Phase 2 step 1) and `docs/plan/global-query-graph-architecture.md`.