### PR TITLE
fix(checker): allow const+type-only-namespace merge without TS2451

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -359,5 +359,9 @@ path = "tests/override_intersection_display_tests.rs"
 name = "ts2451_cross_file_augmentation_tests"
 path = "tests/ts2451_cross_file_augmentation_tests.rs"
 
+[[test]]
+name = "ts2451_type_only_namespace_merge_tests"
+path = "tests/ts2451_type_only_namespace_merge_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -1534,6 +1534,208 @@ impl<'a> CheckerState<'a> {
         self.ctx.arena.is_namespace_instantiated(namespace_idx)
     }
 
+    /// Refined version of `is_namespace_declaration_instantiated` that resolves
+    /// `export { name }` specifiers to their target symbols. The parser-level
+    /// helper conservatively treats every named-export clause as instantiating;
+    /// tsc's `getModuleInstanceState` resolves each specifier and only reports
+    /// the namespace as instantiated when at least one specifier has value
+    /// meaning. This refinement matters for `declare const X` + `declare
+    /// namespace X { export { TypeAlias } }` merging.
+    pub(crate) fn is_namespace_declaration_value_instantiated(
+        &self,
+        namespace_idx: NodeIndex,
+    ) -> bool {
+        // Cheap path: parser says no runtime statements at all → not instantiated.
+        if !self.ctx.arena.is_namespace_instantiated(namespace_idx) {
+            return false;
+        }
+        // Otherwise: walk the body and treat named-export clauses precisely.
+        // If we couldn't introspect the body (corrupt/missing nodes), fall
+        // back to the parser-level conservative answer (true here, since the
+        // cheap path confirmed `is_namespace_instantiated`).
+        self.namespace_body_value_instantiated(namespace_idx)
+            .unwrap_or(true)
+    }
+
+    /// Walk a namespace declaration's body and decide whether any statement
+    /// produces runtime values, treating `export { ... }` as "needs runtime"
+    /// only if at least one specifier resolves to a value-meaning symbol.
+    ///
+    /// Returns `Some(true)` if value-instantiated, `Some(false)` if all
+    /// runtime statements are type-only, and `None` if the body is missing
+    /// or the structure is unexpected (caller should fall back).
+    fn namespace_body_value_instantiated(&self, namespace_idx: NodeIndex) -> Option<bool> {
+        let node = self.ctx.arena.get(namespace_idx)?;
+
+        // `export as namespace X` always creates a runtime global.
+        if node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION {
+            return Some(true);
+        }
+        if node.kind != syntax_kind_ext::MODULE_DECLARATION {
+            return Some(false);
+        }
+        let module_decl = self.ctx.arena.get_module(node)?;
+        let body_idx = module_decl.body;
+        if body_idx.is_none() {
+            return Some(false);
+        }
+        let body_node = self.ctx.arena.get(body_idx)?;
+
+        // Dotted namespace: `namespace Foo.Bar { ... }` — recurse into inner.
+        if body_node.kind == syntax_kind_ext::MODULE_DECLARATION {
+            return self.namespace_body_value_instantiated(body_idx);
+        }
+        if body_node.kind != syntax_kind_ext::MODULE_BLOCK {
+            return Some(false);
+        }
+        let module_block = self.ctx.arena.get_module_block(body_node)?;
+        let statements = module_block.statements.as_ref()?;
+
+        for &stmt_idx in &statements.nodes {
+            let stmt_node = match self.ctx.arena.get(stmt_idx) {
+                Some(n) => n,
+                None => continue,
+            };
+            if self.namespace_statement_creates_runtime_value(stmt_node, stmt_idx) {
+                return Some(true);
+            }
+        }
+        Some(false)
+    }
+
+    /// Mirror of `NodeArena::is_runtime_module_statement` that resolves the
+    /// named-export case rather than treating it as conservatively runtime.
+    fn namespace_statement_creates_runtime_value(
+        &self,
+        node: &tsz_parser::parser::node::Node,
+        node_idx: NodeIndex,
+    ) -> bool {
+        use syntax_kind_ext::{
+            CLASS_DECLARATION, ENUM_DECLARATION, EXPORT_DECLARATION, FUNCTION_DECLARATION,
+            IMPORT_DECLARATION, IMPORT_EQUALS_DECLARATION, INTERFACE_DECLARATION,
+            MODULE_DECLARATION, NAMED_EXPORTS, TYPE_ALIAS_DECLARATION, VARIABLE_STATEMENT,
+        };
+
+        match node.kind {
+            // Type-only declarations
+            k if k == INTERFACE_DECLARATION || k == TYPE_ALIAS_DECLARATION => false,
+            // Imports do not produce runtime values for the enclosing namespace.
+            k if k == IMPORT_DECLARATION || k == IMPORT_EQUALS_DECLARATION => false,
+            k if k == EXPORT_DECLARATION => {
+                let Some(export_decl) = self.ctx.arena.get_export_decl(node) else {
+                    return false;
+                };
+                // `export type { ... }` is always type-only.
+                if export_decl.is_type_only {
+                    return false;
+                }
+                // `export { x } from "mod"` re-exports a binding from another
+                // module. Without resolving the foreign module's symbols here
+                // we keep the parser's conservative answer (treat as runtime).
+                if !export_decl.module_specifier.is_none() {
+                    return true;
+                }
+                let Some(clause) = self.ctx.arena.get(export_decl.export_clause) else {
+                    return false;
+                };
+                match clause.kind {
+                    k if k == VARIABLE_STATEMENT
+                        || k == FUNCTION_DECLARATION
+                        || k == CLASS_DECLARATION
+                        || k == ENUM_DECLARATION =>
+                    {
+                        true
+                    }
+                    k if k == MODULE_DECLARATION => self
+                        .namespace_body_value_instantiated(export_decl.export_clause)
+                        .unwrap_or(true),
+                    k if k == NAMED_EXPORTS => self.named_exports_have_value_specifier(clause),
+                    _ => false,
+                }
+            }
+            // Nested namespace — recurse with the same precise check.
+            k if k == MODULE_DECLARATION => self
+                .namespace_body_value_instantiated(node_idx)
+                .unwrap_or_else(|| self.ctx.arena.is_namespace_instantiated(node_idx)),
+            // Variables/functions/classes/enums/expressions/etc. always runtime.
+            _ => true,
+        }
+    }
+
+    /// Resolve each specifier of a `NAMED_EXPORTS` clause and return true if
+    /// any of them refers to a symbol with value meaning. Specifiers marked
+    /// `export type {}` are skipped (always type-only).
+    fn named_exports_have_value_specifier(
+        &self,
+        named_exports: &tsz_parser::parser::node::Node,
+    ) -> bool {
+        let Some(named) = self.ctx.arena.get_named_imports(named_exports) else {
+            // Couldn't inspect — fall back to conservative (treat as runtime).
+            return true;
+        };
+        for &spec_idx in &named.elements.nodes {
+            let Some(spec_node) = self.ctx.arena.get(spec_idx) else {
+                continue;
+            };
+            if spec_node.kind != syntax_kind_ext::EXPORT_SPECIFIER {
+                continue;
+            }
+            let Some(spec) = self.ctx.arena.get_specifier(spec_node) else {
+                continue;
+            };
+            if spec.is_type_only {
+                continue;
+            }
+            // `property_name` is the source name (when aliased); fall back to
+            // `name` when the export isn't renamed.
+            let lookup_idx = if spec.property_name.is_none() {
+                spec.name
+            } else {
+                spec.property_name
+            };
+            if lookup_idx.is_none() {
+                // No identifier to resolve — conservative.
+                return true;
+            }
+            if self.specifier_target_has_value_meaning(lookup_idx) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Resolve the symbol targeted by an export specifier and return whether
+    /// it has any value-meaning flags. Unresolved bindings fall back to true
+    /// (conservative) so we never silently downgrade a namespace from
+    /// instantiated to non-instantiated when symbol resolution is incomplete.
+    fn specifier_target_has_value_meaning(&self, name_idx: NodeIndex) -> bool {
+        let Some(sym_id) = self.ctx.binder.resolve_identifier(self.ctx.arena, name_idx) else {
+            return true;
+        };
+        let lib_binders = self.get_lib_binders();
+        let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) else {
+            return true;
+        };
+        let value_mask = tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::VALUE_MODULE;
+        if (symbol.flags & value_mask) != 0 {
+            return true;
+        }
+        // A namespace symbol has value meaning only when it is actually
+        // instantiated — recurse into its declarations to check precisely.
+        if (symbol.flags & tsz_binder::symbol_flags::VALUE_MODULE) != 0 {
+            return symbol
+                .declarations
+                .iter()
+                .any(|&d| self.is_namespace_declaration_value_instantiated(d));
+        }
+        // ALIAS symbols (import equals, default import, etc.) require resolving
+        // the alias target. Conservatively treat as runtime if we can't tell.
+        if (symbol.flags & tsz_binder::symbol_flags::ALIAS) != 0 {
+            return true;
+        }
+        false
+    }
+
     /// Check if a method declaration has a body (is an implementation, not just a signature).
     ///
     /// ## Parameters

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1285,7 +1285,11 @@ impl<'a> CheckerState<'a> {
                         } else {
                             other_idx
                         };
-                        if self.is_namespace_declaration_instantiated(namespace_idx) {
+                        // Use the value-resolving variant: a namespace whose only
+                        // body is `export { TypeAlias }` resolves to a type-only
+                        // re-export and must not conflict with a value of the
+                        // same name (`declare const X` + `declare namespace X`).
+                        if self.is_namespace_declaration_value_instantiated(namespace_idx) {
                             if decl_is_local {
                                 conflicts.insert(decl_idx);
                             }

--- a/crates/tsz-checker/tests/ts2451_type_only_namespace_merge_tests.rs
+++ b/crates/tsz-checker/tests/ts2451_type_only_namespace_merge_tests.rs
@@ -1,0 +1,171 @@
+//! Regression tests for value+namespace merging where the namespace body is
+//! type-only (e.g. `export { TypeAlias }`).
+//!
+//! Background
+//! ----------
+//! `getModuleInstanceState` in `tsc` resolves each `export { name }` specifier
+//! to determine whether the named export carries value meaning. A namespace
+//! whose only runtime statements are named exports of type-only entities is
+//! NOT value-instantiated, so it can merge with a `const`/`let`/`var` of the
+//! same name without producing TS2451 ("Cannot redeclare block-scoped
+//! variable").
+//!
+//! Conformance test that motivated this regression: `compiler/
+//! namespacesWithTypeAliasOnlyExportsMerge.ts`. Before this fix the
+//! checker conservatively treated every `NAMED_EXPORTS` clause as
+//! value-instantiating and emitted a duplicate-identifier error against
+//! both the const and the namespace.
+
+use std::path::Path;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn load_lib_files() -> Vec<Arc<LibFile>> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let lib_paths = [
+        manifest_dir.join("../../TypeScript/lib/lib.es5.d.ts"),
+        manifest_dir.join("../../TypeScript/lib/lib.es2015.d.ts"),
+    ];
+    lib_paths
+        .iter()
+        .filter_map(|p| {
+            if p.exists() {
+                let content = std::fs::read_to_string(p).ok()?;
+                let name = p.file_name()?.to_string_lossy().to_string();
+                Some(Arc::new(LibFile::from_source(name, content)))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn check(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let lib_files = load_lib_files();
+    let mut binder = BinderState::new();
+    if lib_files.is_empty() {
+        binder.bind_source_file(parser.get_arena(), root);
+    } else {
+        binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    }
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    if !lib_files.is_empty() {
+        let lib_contexts: Vec<_> = lib_files
+            .iter()
+            .map(|lib| tsz_checker::context::LibContext {
+                arena: Arc::clone(&lib.arena),
+                binder: Arc::clone(&lib.binder),
+            })
+            .collect();
+        checker.ctx.set_lib_contexts(lib_contexts);
+    }
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.clone()
+}
+
+fn ts2451_diagnostics(
+    diags: &[tsz_checker::diagnostics::Diagnostic],
+) -> Vec<&tsz_checker::diagnostics::Diagnostic> {
+    diags.iter().filter(|d| d.code == 2451).collect()
+}
+
+#[test]
+fn const_merges_with_type_only_namespace() {
+    // A namespace whose only body is `export { TypeAlias }` is NOT
+    // value-instantiated and must not conflict with a const of the same name.
+    let source = "\
+        type A = number;\n\
+        declare const Q: number;\n\
+        declare namespace Q {\n\
+        \x20   export { A };\n\
+        }\n\
+        declare const try1: Q.A;\n\
+        export {};\n\
+    ";
+    let diags = check(source);
+    let ts2451 = ts2451_diagnostics(&diags);
+    assert!(
+        ts2451.is_empty(),
+        "expected no TS2451 for const+type-only-namespace merge, got: {:?}",
+        ts2451
+            .iter()
+            .map(|d| format!("TS2451 @ {} :: {}", d.start, d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn const_merges_with_aliased_type_only_namespace() {
+    // `export { A as B }` re-exports a type alias under a different name.
+    // The namespace body is still type-only.
+    let source = "\
+        type A = number;\n\
+        declare const Q3: number;\n\
+        declare namespace Q3 {\n\
+        \x20   export { A as B };\n\
+        }\n\
+        declare const try3: Q3.B;\n\
+        export {};\n\
+    ";
+    let diags = check(source);
+    let ts2451 = ts2451_diagnostics(&diags);
+    assert!(
+        ts2451.is_empty(),
+        "expected no TS2451 for const+aliased-type-only-namespace merge, got: {ts2451:?}"
+    );
+}
+
+#[test]
+fn const_conflicts_with_value_exporting_namespace() {
+    // Sanity: when the namespace body re-exports a value, the namespace IS
+    // value-instantiated and the merge is illegal — TS2451 must still fire.
+    // The exported `inner` is a value (a function declaration).
+    let source = "\
+        function inner() {}\n\
+        declare const X: number;\n\
+        namespace X {\n\
+        \x20   export { inner };\n\
+        }\n\
+        export {};\n\
+    ";
+    let diags = check(source);
+    let ts2451 = ts2451_diagnostics(&diags);
+    assert!(
+        !ts2451.is_empty(),
+        "expected TS2451 when namespace re-exports a value alongside a const \
+         of the same name, got: {diags:?}"
+    );
+}
+
+#[test]
+fn const_conflicts_with_namespace_containing_variable() {
+    // Sanity: a namespace whose body declares a runtime variable IS
+    // value-instantiated and must conflict with a same-name const.
+    let source = "\
+        declare const Y: number;\n\
+        namespace Y {\n\
+        \x20   export const inner = 0;\n\
+        }\n\
+        export {};\n\
+    ";
+    let diags = check(source);
+    let ts2451 = ts2451_diagnostics(&diags);
+    assert!(
+        !ts2451.is_empty(),
+        "expected TS2451 when namespace contains a runtime variable, got: {diags:?}"
+    );
+}

--- a/scripts/session/random-failure.sh
+++ b/scripts/session/random-failure.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# random-failure.sh — minimal one-shot random conformance failure picker.
+#
+# Differs from quick-pick.sh by being a small wrapper that prints a single
+# JSON-ish line and the verbose-run command. Use either; this one is tuned
+# for cheap shell consumption.
+#
+# Usage:
+#   scripts/session/random-failure.sh           # any failure
+#   scripts/session/random-failure.sh TS2322    # filter to a specific code
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+CODE="${1:-}"
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing — run scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+CODE="$CODE" python3 - "$DETAIL" <<'PY'
+import json, os, random, sys
+detail_path = sys.argv[1]
+code = os.environ.get("CODE") or None
+with open(detail_path) as f:
+    failures = json.load(f).get("failures", {})
+
+def matches(entry):
+    if not code:
+        return True
+    pool = set(entry.get("e", [])) | set(entry.get("a", []))
+    pool |= set(entry.get("m", [])) | set(entry.get("x", []))
+    return code in pool
+
+cands = [(p, e) for p, e in failures.items() if e and matches(e)]
+if not cands:
+    sys.exit("no matching failures")
+
+path, entry = random.choice(cands)
+filt = os.path.splitext(os.path.basename(path))[0]
+print(f"path={path}")
+print(f"expected={','.join(entry.get('e', [])) or '-'}")
+print(f"actual={','.join(entry.get('a', [])) or '-'}")
+print(f"missing={','.join(entry.get('m', [])) or '-'}")
+print(f"extra={','.join(entry.get('x', [])) or '-'}")
+print(f"verbose-run: ./scripts/conformance/conformance.sh run --filter \"{filt}\" --verbose")
+PY


### PR DESCRIPTION
## Summary

When `declare const X` shares its name with `declare namespace X { export { TypeAlias } }`, `tsc` allows the merge — the namespace body is type-only, so it has no value meaning and there is no block-scoped redeclaration. tsz was conservatively flagging every `NAMED_EXPORTS` clause as runtime-instantiating, producing two false `TS2451 "Cannot redeclare block-scoped variable"` diagnostics on the `const`/`namespace` pair.

This refactors the variable+namespace duplicate-identifier path to use a new checker-level helper `is_namespace_declaration_value_instantiated` that walks the namespace body and resolves each `export { name }` specifier to its target symbol. If every named export resolves to a type-only entity (type alias, interface, uninstantiated namespace), the namespace is treated as not value-instantiated. The parser-level `NodeArena::is_namespace_instantiated` keeps its conservative behaviour for callers that lack binder context.

```ts
type A = number;
declare const Q: number;
declare namespace Q {
    export { A };          // type-only re-export
}
declare const try1: Q.A;   // tsc: ok; tsz before this fix: TS2451 x2
```

```ts
// Sanity — value re-export still triggers TS2451:
function inner() {}
declare const X: number;
namespace X { export { inner }; }   // ✗ TS2451
```

### Conformance impact

Motivated by `TypeScript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts`. Before the change the test emitted `[TS2451, TS2749]`; after, only `[TS2749]` remains. The residual `TS2749` on `Q2.Q.A` is a separate qualified-name resolution bug for symbols that merge a value (`const`) with a namespace, and is not addressed here.

Full conformance suite: `12119 → 12126 (+7)`. The reported `reverseMappedTupleContext.ts` regression was verified to also fail on `main` without these changes (pre-existing flake unrelated to namespace merging).

### Files

- `crates/tsz-checker/src/types/type_checking/declarations.rs` — adds `is_namespace_declaration_value_instantiated` and helpers (`namespace_body_value_instantiated`, `namespace_statement_creates_runtime_value`, `named_exports_have_value_specifier`, `specifier_target_has_value_meaning`).
- `crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs` — switch the variable+namespace conflict gate (line ~1288) to the new helper.
- `crates/tsz-checker/tests/ts2451_type_only_namespace_merge_tests.rs` — 4 new tests:
  - `const_merges_with_type_only_namespace`
  - `const_merges_with_aliased_type_only_namespace`
  - `const_conflicts_with_value_exporting_namespace`
  - `const_conflicts_with_namespace_containing_variable`
- `scripts/session/random-failure.sh` — minimal one-shot random conformance-failure picker (complementary to `quick-pick.sh`).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --package tsz-checker --lib` — 2733 passed
- [x] `cargo nextest run --package tsz-checker --tests` — 5132 passed (incl. 4 new)
- [x] `cargo nextest run --package tsz-solver --lib` — 5296 passed
- [x] `cargo nextest run --package tsz-core --lib` — 2936 passed
- [x] `cargo nextest run --package tsz-binder --package tsz-parser --package tsz-scanner --package tsz-common --package tsz-emitter --package tsz-lowering` — 3113 passed
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — `12119 → 12126 (+7)`
- [x] `./scripts/conformance/conformance.sh run --filter "namespacesWithTypeAliasOnlyExportsMerge" --verbose` — extras drop from `[TS2451, TS2749]` to `[TS2749]`
- [x] Verify the one reported regression (`reverseMappedTupleContext.ts`) is unrelated by stashing the change and reproducing the failure on the unchanged tree
- [x] wasm32 rustc warnings gate
- [x] architecture guardrails (`scripts/arch/check-checker-boundaries.sh`)

The pre-commit hook was skipped (`TSZ_SKIP_HOOKS=1`) because its parallel `cargo nextest` build of all 100+ test crates exhausts the constrained sandbox's disk; every gate the hook runs was executed independently with `scripts/safe-run.sh` and recorded above.

https://claude.ai/code/session_01MbVXVP7QPgCkh16jU3Rx4t


---
_Generated by [Claude Code](https://claude.ai/code/session_01MbVXVP7QPgCkh16jU3Rx4t)_