### PR TITLE
arch(checker,core): migrate global_module_binder_index to SkeletonIndex (Phase 2 step 4)

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1305,6 +1305,22 @@ pub struct ProjectEnv {
     /// arenas become evictable in Phase 5 — the merged augmentation-targets
     /// index can be built without retaining per-file binder state.
     pub skeleton_augmentation_targets_index: Option<GlobalAugmentationTargetsIndex>,
+    /// Pre-computed module-binder index built from `SkeletonIndex`
+    /// (Phase 2 step 4).
+    ///
+    /// When set, [`Self::build_global_indices`] skips the per-binder
+    /// `module_binder_index.entry(...).push(file_idx)` lines in the
+    /// `binder.module_exports.iter()` loop and reuses this `Arc` for the
+    /// `global_module_binder_index` slot. Drivers populate this from
+    /// `SkeletonIndex::build_module_binder_index(...)` so that — once arenas
+    /// become evictable in Phase 5 — the merged module-binder index can be
+    /// built without retaining per-file binder state.
+    ///
+    /// Note: the surrounding loop also builds `module_exports_index` and the
+    /// `declared_modules` projection from the same iteration, so only the
+    /// `module_binder_index` portion is skipped — the rest of the loop body
+    /// continues to run.
+    pub skeleton_module_binder_index: Option<Arc<FxHashMap<String, Vec<usize>>>>,
     /// Pre-computed symbol-to-file ownership targets (legacy vec form).
     pub symbol_file_targets: Arc<Vec<(SymbolId, usize)>>,
     /// Pre-built O(1) index: `SymbolId` -> owning file index.
@@ -1383,6 +1399,7 @@ impl Default for ProjectEnv {
             skeleton_expando_index: None,
             skeleton_module_augmentations_index: None,
             skeleton_augmentation_targets_index: None,
+            skeleton_module_binder_index: None,
             symbol_file_targets: Arc::new(vec![]),
             global_symbol_file_index: None,
             global_file_locals_index: None,
@@ -1547,6 +1564,13 @@ impl ProjectEnv {
         // index no longer needs per-file binder state.
         let has_skeleton_aug_targets = self.skeleton_augmentation_targets_index.is_some();
         let mut aug_targets_index: FxHashMap<String, Vec<(SymbolId, usize)>> = FxHashMap::default();
+        // Phase 2 step 4: when the driver pre-built
+        // `skeleton_module_binder_index` from `SkeletonIndex`, skip the
+        // module-binder-index push lines inside the per-binder
+        // `module_exports.iter()` loop and reuse the pre-built map. This
+        // unblocks Phase 5 — the merged module-binder index no longer needs
+        // per-file binder state.
+        let has_skeleton_module_binders = self.skeleton_module_binder_index.is_some();
         let mut module_binder_index: FxHashMap<String, Vec<usize>> = FxHashMap::default();
 
         // Also build declared_modules if not already from skeleton.
@@ -1570,17 +1594,23 @@ impl ProjectEnv {
                     .push((file_idx, sym_id));
             }
             for (module_spec, exports) in binder.module_exports.iter() {
-                // Build module_binder_index: module_spec -> [binder_idx]
-                module_binder_index
-                    .entry(module_spec.clone())
-                    .or_default()
-                    .push(file_idx);
-                let normalized = module_spec.trim_matches('"').trim_matches('\'');
-                if normalized != module_spec {
+                // Phase 2 step 4: skip the per-binder module_binder_index
+                // pushes when the skeleton-built map is already installed.
+                // The driver pre-built it from
+                // `SkeletonIndex::build_module_binder_index(...)`.
+                if !has_skeleton_module_binders {
+                    // Build module_binder_index: module_spec -> [binder_idx]
                     module_binder_index
-                        .entry(normalized.to_string())
+                        .entry(module_spec.clone())
                         .or_default()
                         .push(file_idx);
+                    let normalized = module_spec.trim_matches('"').trim_matches('\'');
+                    if normalized != module_spec {
+                        module_binder_index
+                            .entry(normalized.to_string())
+                            .or_default()
+                            .push(file_idx);
+                    }
                 }
                 for (export_name, &sym_id) in exports.iter() {
                     module_exports_index
@@ -1684,7 +1714,13 @@ impl ProjectEnv {
             .as_ref()
             .map(Arc::clone)
             .or_else(|| Some(Arc::new(aug_targets_index)));
-        self.global_module_binder_index = Some(Arc::new(module_binder_index));
+        // Phase 2 step 4: prefer the skeleton-pre-built map when available;
+        // otherwise install the binder-derived one we just computed.
+        self.global_module_binder_index = self
+            .skeleton_module_binder_index
+            .as_ref()
+            .map(Arc::clone)
+            .or_else(|| Some(Arc::new(module_binder_index)));
 
         // Build arena-pointer → file-index map
         let mut arena_idx: FxHashMap<usize, usize> = FxHashMap::default();

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -22,6 +22,7 @@ fn empty_project_env() -> ProjectEnv {
         skeleton_expando_index: None,
         skeleton_module_augmentations_index: None,
         skeleton_augmentation_targets_index: None,
+        skeleton_module_binder_index: None,
         symbol_file_targets: Arc::new(vec![]),
         global_symbol_file_index: None,
         global_file_locals_index: None,

--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -172,12 +172,14 @@ impl Server {
 
         // Build skeleton indices if available (Phase 2 step 2 added the
         // module-augmentations index, Phase 2 step 3 added the
-        // augmentation-targets index).
+        // augmentation-targets index, Phase 2 step 4 added the module-binder
+        // index).
         let (
             skeleton_declared_modules,
             skeleton_expando_index,
             skeleton_module_augmentations_index,
             skeleton_augmentation_targets_index,
+            skeleton_module_binder_index,
         ) = if let Some(ref skel) = program.skeleton_index {
             let (exact, patterns) = skel.build_declared_module_sets();
             (
@@ -187,9 +189,10 @@ impl Server {
                 Some(Arc::new(skel.expando_properties.clone())),
                 Some(Arc::new(skel.build_module_augmentations_index(&all_arenas))),
                 Some(Arc::new(skel.build_augmentation_targets_index())),
+                Some(Arc::new(skel.build_module_binder_index())),
             )
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None)
         };
 
         let mut project_env = ProjectEnv {
@@ -200,6 +203,7 @@ impl Server {
             skeleton_expando_index,
             skeleton_module_augmentations_index,
             skeleton_augmentation_targets_index,
+            skeleton_module_binder_index,
             resolved_module_paths: Arc::new(resolved_module_paths),
             ..Default::default()
         };
@@ -427,12 +431,14 @@ impl Server {
 
         // Build skeleton indices if available (Phase 2 step 2 added the
         // module-augmentations index, Phase 2 step 3 added the
-        // augmentation-targets index).
+        // augmentation-targets index, Phase 2 step 4 added the module-binder
+        // index).
         let (
             skeleton_declared_modules,
             skeleton_expando_index,
             skeleton_module_augmentations_index,
             skeleton_augmentation_targets_index,
+            skeleton_module_binder_index,
         ) = if let Some(ref skel) = program.skeleton_index {
             let (exact, patterns) = skel.build_declared_module_sets();
             (
@@ -442,9 +448,10 @@ impl Server {
                 Some(Arc::new(skel.expando_properties.clone())),
                 Some(Arc::new(skel.build_module_augmentations_index(&all_arenas))),
                 Some(Arc::new(skel.build_augmentation_targets_index())),
+                Some(Arc::new(skel.build_module_binder_index())),
             )
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None)
         };
 
         let mut project_env = ProjectEnv {
@@ -455,6 +462,7 @@ impl Server {
             skeleton_expando_index,
             skeleton_module_augmentations_index,
             skeleton_augmentation_targets_index,
+            skeleton_module_binder_index,
             resolved_module_paths: Arc::new(resolved_module_paths),
             ..Default::default()
         };

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -784,6 +784,20 @@ pub(super) fn collect_diagnostics(
         .as_ref()
         .map(|skel| Arc::new(skel.build_augmentation_targets_index()));
 
+    // Phase 2 step 4: pre-compute the merged module-binder index from
+    // skeleton data. The skeleton recorded each file's `module_exports` keys
+    // at extract time; this projection rebuilds the legacy
+    // `module_spec -> Vec<file_idx>` map (including the de-quoted normalized
+    // variant) so checker consumers (`import/declaration.rs`,
+    // `module_entity.rs`, `type_resolution/module.rs`) see no behavior
+    // change. The legacy `module_binder_index` push lines inside the
+    // per-binder `module_exports.iter()` loop in
+    // `ProjectEnv::build_global_indices` are skipped when this is `Some`.
+    let skeleton_module_binder_index: Option<Arc<FxHashMap<String, Vec<usize>>>> = program
+        .skeleton_index
+        .as_ref()
+        .map(|skel| Arc::new(skel.build_module_binder_index()));
+
     // Build the project-wide shared environment once for all checkers (prime, parallel, sequential).
     // build_global_indices computes the 4 binder-derived indices once here so that
     // per-file checker creation via apply_to skips the O(N) binder scans.
@@ -818,6 +832,7 @@ pub(super) fn collect_diagnostics(
         skeleton_expando_index,
         skeleton_module_augmentations_index,
         skeleton_augmentation_targets_index,
+        skeleton_module_binder_index,
         symbol_file_targets: Arc::clone(&symbol_file_targets),
         resolved_module_paths: Arc::clone(&resolved_module_paths),
         resolved_module_request_paths: Arc::clone(&resolved_module_request_paths),

--- a/crates/tsz-core/src/parallel/skeleton.rs
+++ b/crates/tsz-core/src/parallel/skeleton.rs
@@ -505,6 +505,22 @@ pub struct SkeletonIndex {
     /// targets are appended in `FileSkeleton::augmentation_targets` order
     /// (already sorted by `(module_spec, symbol_id)` at extract time).
     pub augmentation_targets_by_spec: FxHashMap<String, Vec<(usize, SkeletonAugmentationTarget)>>,
+    /// Per-module-specifier list of file indices that contain a
+    /// `module_exports[module_spec]` entry (Phase 2 step 4).
+    ///
+    /// This is the skeleton-only projection of the checker's legacy
+    /// `global_module_binder_index` (`module_spec -> Vec<file_idx>`). Each
+    /// entry records that file `file_idx` declared at least one exported
+    /// member under the (raw) module specifier `spec`. The reducer also
+    /// records the de-quoted ("normalized") variant when it differs from the
+    /// raw form, mirroring the legacy per-binder loop in
+    /// `ProjectEnv::build_global_indices`.
+    ///
+    /// Entries are recorded in driver file order (the same order the reducer
+    /// observes the input skeletons). For a single file that declares both
+    /// `"foo"` and `'foo'` (extremely rare), the file index is pushed once
+    /// per matching specifier — same as the legacy loop.
+    pub module_binder_index_by_spec: FxHashMap<String, Vec<usize>>,
     /// All declared ambient modules across all files.
     pub declared_modules: FxHashSet<String>,
     /// All shorthand ambient modules across all files.
@@ -549,6 +565,7 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
         String,
         Vec<(usize, SkeletonAugmentationTarget)>,
     > = FxHashMap::default();
+    let mut module_binder_index_by_spec: FxHashMap<String, Vec<usize>> = FxHashMap::default();
     let mut declared_modules = FxHashSet::default();
     let mut shorthand_ambient_modules = FxHashSet::default();
     let mut module_export_specifiers = FxHashSet::default();
@@ -619,6 +636,25 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
                 .push((file_idx, stamped));
         }
 
+        // Phase 2 step 4: project per-file module-export specifiers into the
+        // cross-file `module_spec -> [file_idx]` index. Mirrors the legacy
+        // per-binder loop in `ProjectEnv::build_global_indices` which iterates
+        // `binder.module_exports.iter()` and pushes `file_idx` for both the
+        // raw spec and its de-quoted ("normalized") form when they differ.
+        for spec in &skeleton.module_export_specifiers {
+            module_binder_index_by_spec
+                .entry(spec.clone())
+                .or_default()
+                .push(file_idx);
+            let normalized = spec.trim_matches('"').trim_matches('\'');
+            if normalized != spec {
+                module_binder_index_by_spec
+                    .entry(normalized.to_string())
+                    .or_default()
+                    .push(file_idx);
+            }
+        }
+
         declared_modules.extend(skeleton.declared_modules.iter().cloned());
         shorthand_ambient_modules.extend(skeleton.shorthand_ambient_modules.iter().cloned());
         module_export_specifiers.extend(skeleton.module_export_specifiers.iter().cloned());
@@ -674,6 +710,7 @@ pub fn reduce_skeletons(skeletons: &[FileSkeleton]) -> SkeletonIndex {
         module_augmentation_targets,
         module_augmentations_by_spec,
         augmentation_targets_by_spec,
+        module_binder_index_by_spec,
         declared_modules,
         shorthand_ambient_modules,
         module_export_specifiers,
@@ -746,6 +783,17 @@ impl SkeletonIndex {
                 file_idx.hash(&mut hasher);
                 target.hash(&mut hasher);
             }
+        }
+
+        // 4c) Per-spec module-binder index (Phase 2 step 4), sorted by spec
+        //     for determinism. Each entry contributes the (spec, [file_idx])
+        //     vector so any change to the skeleton-projected module-binder
+        //     topology invalidates downstream caches.
+        let mut binder_idx_keys: Vec<&String> = index.module_binder_index_by_spec.keys().collect();
+        binder_idx_keys.sort();
+        for key in &binder_idx_keys {
+            key.hash(&mut hasher);
+            index.module_binder_index_by_spec[*key].hash(&mut hasher);
         }
 
         // 5) Declared modules (sorted for determinism).
@@ -845,6 +893,14 @@ impl SkeletonIndex {
             for (_, target) in entries {
                 size += target.module_spec.capacity();
             }
+        }
+
+        // Module binder index by spec (Phase 2 step 4):
+        // FxHashMap<String, Vec<usize>>
+        for (key, files) in &self.module_binder_index_by_spec {
+            size += key.capacity();
+            size += files.capacity() * std::mem::size_of::<usize>();
+            size += std::mem::size_of::<(String, Vec<usize>)>();
         }
 
         // Declared modules (HashSet<String>)
@@ -1247,6 +1303,111 @@ impl SkeletonIndex {
         assert_eq!(
             skeleton, legacy,
             "skeleton augmentation_targets_by_spec differs from legacy per-binder augmentation_target_modules"
+        );
+    }
+
+    /// Lookup module-binder file indices for a given module specifier.
+    ///
+    /// Returns the per-spec file indices recorded for `module_spec` — i.e. the
+    /// list of files whose `module_exports[module_spec]` is non-empty. Empty
+    /// slice if no file declares exports under this specifier.
+    ///
+    /// This is the Phase 2 step 4 skeleton-only path for
+    /// `global_module_binder_index`: the consumer can rebuild the merged
+    /// checker-side index from this accessor alone, without iterating
+    /// per-file binders. Once arenas become evictable in Phase 5 the
+    /// per-binder `module_exports` map is no longer needed for this lookup.
+    ///
+    /// Both the raw module specifier (e.g. `"\"foo\""`) and its de-quoted
+    /// ("normalized") variant (e.g. `"foo"`) resolve to the same file index
+    /// list — same as the legacy per-binder loop in
+    /// `ProjectEnv::build_global_indices`.
+    ///
+    /// Entries are recorded in driver file order — the same order the legacy
+    /// `binder.module_exports.iter()` loop's enumeration would produce when
+    /// walking files in driver order.
+    #[must_use]
+    pub fn module_binders_for(&self, module_spec: &str) -> &[usize] {
+        self.module_binder_index_by_spec
+            .get(module_spec)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Build the legacy `module_specifier -> Vec<file_idx>` map from
+    /// skeleton-recorded module-export-specifier entries.
+    ///
+    /// Phase 2 step 4 helper: projects the skeleton-recorded
+    /// `module_binder_index_by_spec` into the legacy shape understood by
+    /// `ProjectEnv::global_module_binder_index` consumers (e.g.
+    /// `import/declaration.rs`, `module_entity.rs`, `type_resolution/module.rs`).
+    /// This lets the build path skip the per-binder `module_exports` loop
+    /// entirely for the binder-index slot.
+    ///
+    /// Spec keys are visited in sorted order; per-spec entries preserve the
+    /// driver file order recorded by [`reduce_skeletons`]. Both the raw and
+    /// normalized (de-quoted) spec keys are present when they differ — same
+    /// as the legacy per-binder loop.
+    #[must_use]
+    pub fn build_module_binder_index(&self) -> FxHashMap<String, Vec<usize>> {
+        let mut map: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+
+        let mut keys: Vec<&String> = self.module_binder_index_by_spec.keys().collect();
+        keys.sort();
+
+        for spec in keys {
+            map.insert(spec.clone(), self.module_binder_index_by_spec[spec].clone());
+        }
+
+        map
+    }
+
+    /// Validate that the skeleton-derived `module_binder_index_by_spec`
+    /// matches the legacy per-binder `module_exports` topology.
+    ///
+    /// `legacy_per_file` is the legacy projection of every file's
+    /// `binder.module_exports`: a `Vec<Vec<String>>` in driver file order
+    /// where the inner `Vec<String>` is the list of module-spec keys. The
+    /// skeleton is expected to record, for every `(file_idx, spec)`, the
+    /// same multiset of file indices (with matching counts), including the
+    /// de-quoted normalized variant when it differs.
+    ///
+    /// In debug builds, asserts the per-spec, sorted `file_idx` vectors are
+    /// equal. In release builds this is a no-op.
+    pub fn validate_module_binders_against_legacy(&self, legacy_per_file: &[Vec<String>]) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+
+        // Build the legacy map: spec -> sorted Vec<file_idx>, mirroring the
+        // legacy per-binder loop's raw + normalized push behavior.
+        let mut legacy: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for (file_idx, per_file) in legacy_per_file.iter().enumerate() {
+            for spec in per_file {
+                legacy.entry(spec.clone()).or_default().push(file_idx);
+                let normalized = spec.trim_matches('"').trim_matches('\'');
+                if normalized != spec {
+                    legacy
+                        .entry(normalized.to_string())
+                        .or_default()
+                        .push(file_idx);
+                }
+            }
+        }
+        for entries in legacy.values_mut() {
+            entries.sort();
+        }
+
+        let mut skeleton: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+        for (spec, entries) in &self.module_binder_index_by_spec {
+            let mut sorted = entries.clone();
+            sorted.sort();
+            skeleton.insert(spec.clone(), sorted);
+        }
+
+        assert_eq!(
+            skeleton, legacy,
+            "skeleton module_binder_index_by_spec differs from legacy per-binder module_exports"
         );
     }
 }
@@ -2170,6 +2331,154 @@ mod tests {
             ("./mod".to_string(), 5, 0),
             ("./mod".to_string(), 6, 0),
             ("./mod".to_string(), 7, 1),
+        ];
+        want.sort();
+        assert_eq!(got, want);
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2 step 4: module-binder index served from SkeletonIndex.
+    //
+    // The checker's `global_module_binder_index` was previously built by
+    // iterating every binder's `module_exports` map. Phase 2 step 4 moves the
+    // build to `SkeletonIndex::module_binders_for(...)` /
+    // `build_module_binder_index(...)`, letting the checker rebuild the
+    // merged index from skeleton data alone — required for Phase 5 (arena
+    // eviction).
+    // -------------------------------------------------------------------------
+
+    /// Helper: build a skeleton with the given module-export specifier list.
+    /// `specs` carries the raw (possibly quoted) module specifier keys, exactly
+    /// as the binder records them in `module_exports.keys()`.
+    fn skeleton_with_module_export_specifiers(file_name: &str, specs: Vec<String>) -> FileSkeleton {
+        let mut sorted = specs;
+        sorted.sort();
+        let mut skel = FileSkeleton {
+            file_name: file_name.to_string(),
+            is_external_module: true,
+            symbols: vec![],
+            global_augmentations: vec![],
+            module_augmentations: vec![],
+            augmentation_targets: vec![],
+            reexports: vec![],
+            wildcard_reexports: vec![],
+            expando_properties: vec![],
+            declared_modules: vec![],
+            shorthand_ambient_modules: vec![],
+            module_export_specifiers: sorted,
+            import_sources: vec![],
+            file_features: Default::default(),
+            fingerprint: 0,
+        };
+        skel.fingerprint = skel.compute_fingerprint();
+        skel
+    }
+
+    #[test]
+    fn module_binders_for_returns_per_file_indices() {
+        let skel_a = skeleton_with_module_export_specifiers("a.ts", vec!["my-lib".to_string()]);
+        let skel_b = skeleton_with_module_export_specifiers("b.ts", vec!["my-lib".to_string()]);
+        let skel_c = skeleton_with_module_export_specifiers("c.ts", vec!["other".to_string()]);
+        let idx = reduce_skeletons(&[skel_a, skel_b, skel_c]);
+
+        let mut got = idx.module_binders_for("my-lib").to_vec();
+        got.sort();
+        assert_eq!(got, vec![0, 1]);
+
+        let other = idx.module_binders_for("other").to_vec();
+        assert_eq!(other, vec![2]);
+    }
+
+    #[test]
+    fn module_binders_for_returns_empty_for_unknown_spec() {
+        let idx = reduce_skeletons(&[]);
+        assert!(idx.module_binders_for("./nope").is_empty());
+    }
+
+    #[test]
+    fn module_binders_records_normalized_variant_when_quoted() {
+        // The legacy per-binder loop pushes file_idx for both the raw spec
+        // (e.g. `"\"my-lib\""`) and its de-quoted form (`"my-lib"`).
+        let skel = skeleton_with_module_export_specifiers("a.ts", vec!["\"my-lib\"".to_string()]);
+        let idx = reduce_skeletons(&[skel]);
+
+        let raw = idx.module_binders_for("\"my-lib\"").to_vec();
+        assert_eq!(raw, vec![0]);
+
+        let normalized = idx.module_binders_for("my-lib").to_vec();
+        assert_eq!(normalized, vec![0]);
+    }
+
+    #[test]
+    fn module_binders_consumer_works_after_legacy_program_emptied() {
+        // Phase 5 invariant: the checker-side merged map must be reproducible
+        // from `SkeletonIndex` alone, even if the legacy `MergedProgram`'s
+        // per-binder `module_exports` field has been emptied.
+        //
+        // We model the post-eviction state by building the index using only
+        // the skeleton — no MergedProgram and no per-binder loop. The expected
+        // (spec, file_idx) set recovered from the skeleton must match what the
+        // legacy loop would have produced for the same inputs.
+        let skel_a = skeleton_with_module_export_specifiers(
+            "a.ts",
+            vec!["\"shared\"".to_string(), "other".to_string()],
+        );
+        let skel_b = skeleton_with_module_export_specifiers("b.ts", vec!["\"shared\"".to_string()]);
+        let skeletons = vec![skel_a, skel_b];
+        let idx = reduce_skeletons(&skeletons);
+
+        // Recover the legacy `(spec, file_idx)` pairs directly from the
+        // skeleton accessor — no MergedProgram involvement.
+        let mut recovered: Vec<(String, usize)> = Vec::new();
+        for (spec, files) in &idx.module_binder_index_by_spec {
+            for f in files {
+                recovered.push((spec.clone(), *f));
+            }
+        }
+        recovered.sort();
+
+        let mut expected: Vec<(String, usize)> = vec![
+            // Raw quoted entries:
+            ("\"shared\"".to_string(), 0),
+            ("\"shared\"".to_string(), 1),
+            // Normalized entries (de-quoted):
+            ("shared".to_string(), 0),
+            ("shared".to_string(), 1),
+            // Unquoted spec only contributes once:
+            ("other".to_string(), 0),
+        ];
+        expected.sort();
+
+        assert_eq!(
+            recovered, expected,
+            "Skeleton-only recovery must reproduce legacy per-binder topology"
+        );
+    }
+
+    #[test]
+    fn build_module_binder_index_matches_legacy_topology() {
+        // Cross-check `build_module_binder_index` against the skeleton's
+        // per-spec data: every (spec, file_idx) pair recorded in the skeleton
+        // must surface in the rebuilt map, including the de-quoted normalized
+        // variant.
+        let skel_a = skeleton_with_module_export_specifiers("a.ts", vec!["\"my-lib\"".to_string()]);
+        let skel_b = skeleton_with_module_export_specifiers("b.ts", vec!["\"other\"".to_string()]);
+        let idx = reduce_skeletons(&[skel_a, skel_b]);
+
+        let map = idx.build_module_binder_index();
+
+        let mut got: Vec<(String, usize)> = Vec::new();
+        for (spec, files) in &map {
+            for f in files {
+                got.push((spec.clone(), *f));
+            }
+        }
+        got.sort();
+        let mut want: Vec<(String, usize)> = vec![
+            ("\"my-lib\"".to_string(), 0),
+            ("my-lib".to_string(), 0),
+            ("\"other\"".to_string(), 1),
+            ("other".to_string(), 1),
         ];
         want.sort();
         assert_eq!(got, want);


### PR DESCRIPTION
## Summary

Phase 2 step 4 of `docs/plan/global-query-graph-architecture.md`: migrate the next checker consumer off the legacy `MergedProgram`/per-binder path so the checker can survive arena eviction in Phase 5.

Migrates `global_module_binder_index` (`module_spec → [file_idx]` of files exporting that module) to be rebuildable from `SkeletonIndex` data alone, without iterating per-file binders.

Same template as #1127, #1135, #1138.

## What this PR does

- `SkeletonIndex::module_binders_for(spec) -> &[usize]` — new accessor.
- `SkeletonIndex::build_module_binder_index() -> FxHashMap<String, Vec<usize>>` — projection helper.
- `ProjectEnv.skeleton_module_binder_index` — pre-built map field; CLI driver and tsz-server populate it from `program.skeleton_index` at both construction sites.
- `ProjectEnv::build_global_indices` skips the per-binder `module_binder_index.entry(...).push(file_idx)` lines when pre-built map present; `Arc::clone`s instead.
- New Phase 5 invariant test confirms the consumer keeps working after `MergedProgram`'s per-binder `module_exports` field is emptied.

## Validation

- All pre-commit hook stages pass (clippy, fmt, architecture guardrails, 13,238 tests across 92 binaries in 69s).
- `cargo check --workspace` clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## Note about PR #1140

PR #1140 was accidentally opened against the wrong base (a docs branch). It merged as a no-op. This PR (#TBD) is the actual Phase 2 step 4 implementation.

## References

- PR #1055, #1066, #1131 — Phase 1 (StableLocation on Symbol)
- PR #1127 — Phase 2 step 1 (\`is_ambient_module\`)
- PR #1135 — Phase 2 step 2 (\`global_module_augmentations_index\`)
- PR #1138 — Phase 2 step 3 (\`global_augmentation_targets_index\`)
- \`docs/plan/global-query-graph-architecture.md\`