### PR TITLE
fix(emitter,dts): walk arrow/function-expression annotations in variable analyzer

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
@@ -838,6 +838,31 @@ impl<'a> UsageAnalyzer<'a> {
             self.walk_inferred_type_or_related(&[decl_idx, decl.name]);
         }
 
+        // For arrow/function-expression initializers, walk the return-type
+        // and parameter-type annotations so their references survive elision.
+        // Without this, `export const f = (...): X<...> => ...` with `X` from
+        // an external import elides the import (the inferred TypeId may not
+        // expose the source-level reference). Matches
+        // declarationEmitRecursiveConditionalAliasPreserved.
+        if decl.initializer.is_some()
+            && let Some(init_node) = self.arena.get(decl.initializer)
+            && (init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION)
+            && let Some(func) = self.arena.get_function(init_node)
+        {
+            if func.type_annotation.is_some() {
+                self.analyze_type_node(func.type_annotation);
+            }
+            for &param_idx in &func.parameters.nodes {
+                if let Some(param_node) = self.arena.get(param_idx)
+                    && let Some(param) = self.arena.get_parameter(param_node)
+                    && param.type_annotation.is_some()
+                {
+                    self.analyze_type_node(param.type_annotation);
+                }
+            }
+        }
+
         if decl.initializer.is_some()
             && self.initializer_preserves_value_reference(decl.initializer)
         {


### PR DESCRIPTION
## Summary
- For `export const f = (...): X<...> => ...` (and function-expression equivalents), walk the initializer's return-type annotation and each parameter's type annotation in the usage analyzer.
- Without this, the variable's own inferred TypeId may not capture the source-level reference to `X`, and the import is elided.

## Why
The variable analyzer only looked at its own `type_annotation` and the inferred TypeId. Arrow-function return types and parameter types live on the initializer node, not the variable, so references there were invisible to the elision logic.

## Delta
- DTS: +1 / 0 regressions (full suite, fixes declarationEmitRecursiveConditionalAliasPreserved).
- Unit: 1434 passed, 2 skipped.

## Test plan
- [x] Full DTS run shows +1 with no regressions.
- [x] tsz-emitter unit tests pass.
- [ ] CI conformance lanes pass.