### PR TITLE
chore(checker-tests): replace local check_with_options helpers with test_utils::check_source

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -5,5 +5,4 @@
 //! over direct `TypeInterner` access. Test code may use the re-exported
 //! `TypeInterner` type for scaffolding.
 
-#[cfg(test)]
 pub(crate) use tsz_solver::TypeInterner;

--- a/crates/tsz-checker/tests/class_member_closure_tests.rs
+++ b/crates/tsz-checker/tests/class_member_closure_tests.rs
@@ -7,31 +7,12 @@
 //!   - Override visibility/type checks (TS4112-TS4115, TS2416)
 //!   - Base/member closure consistency
 
-use crate::CheckerState;
 use crate::context::CheckerOptions;
-use tsz_binder::BinderState;
+use crate::test_utils::check_source;
 use tsz_common::diagnostics::Diagnostic;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
 
 fn check_with_options(source: &str, options: CheckerOptions) -> Vec<Diagnostic> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        options,
-    );
-    checker.ctx.set_lib_contexts(Vec::new());
-    checker.check_source_file(root);
-    checker.ctx.diagnostics.clone()
+    check_source(source, "test.ts", options)
 }
 
 fn check_strict(source: &str) -> Vec<Diagnostic> {

--- a/crates/tsz-checker/tests/contextual_tuple_tests.rs
+++ b/crates/tsz-checker/tests/contextual_tuple_tests.rs
@@ -1,14 +1,12 @@
-use tsz_binder::BinderState;
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::state::CheckerState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
 
-fn check_default(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+fn check_default(source: &str) -> Vec<Diagnostic> {
     check_with_options(source, CheckerOptions::default())
 }
 
-fn check_strict(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+fn check_strict(source: &str) -> Vec<Diagnostic> {
     check_with_options(
         source,
         CheckerOptions {
@@ -21,28 +19,8 @@ fn check_strict(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
     )
 }
 
-fn check_with_options(
-    source: &str,
-    options: CheckerOptions,
-) -> Vec<tsz_checker::diagnostics::Diagnostic> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        options,
-    );
-
-    checker.check_source_file(root);
-    checker.ctx.diagnostics.clone()
+fn check_with_options(source: &str, options: CheckerOptions) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", options)
 }
 
 /// tsc emits TS2345 for the `(a, b) =>` callback because the contextually-typed

--- a/crates/tsz-checker/tests/contextual_typing_tests.rs
+++ b/crates/tsz-checker/tests/contextual_typing_tests.rs
@@ -8,40 +8,17 @@
 //! The fix pushes `TypeId::ANY` as the return type context when the return type
 //! is purely inferred, so `check_return_statement` skips the circular check.
 
-use tsz_binder::BinderState;
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::state::CheckerState;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
 use tsz_common::common::ScriptTarget;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
 
-/// Helper: parse, bind, check with default options.
-fn check_default(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
-    check_with_options(source, CheckerOptions::default())
+fn check_default(source: &str) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
 }
 
-fn check_with_options(
-    source: &str,
-    options: CheckerOptions,
-) -> Vec<tsz_checker::diagnostics::Diagnostic> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        options,
-    );
-
-    checker.check_source_file(root);
-    checker.ctx.diagnostics.clone()
+fn check_with_options(source: &str, options: CheckerOptions) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", options)
 }
 
 /// Function returning nested array literals with different object shapes should
@@ -304,18 +281,9 @@ const fn2 =
   };
 "#;
 
-    let mut parser = ParserState::new("test.js".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.js".to_string(),
+    let diagnostics = check_source(
+        source,
+        "test.js",
         CheckerOptions {
             check_js: true,
             no_implicit_any: true,
@@ -324,9 +292,6 @@ const fn2 =
             ..Default::default()
         },
     );
-
-    checker.check_source_file(root);
-    let diagnostics = checker.ctx.diagnostics.clone();
     let ts2345_errors: Vec<_> = diagnostics.iter().filter(|d| d.code == 2345).collect();
 
     assert_eq!(

--- a/crates/tsz-checker/tests/never_returning_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/never_returning_narrowing_tests.rs
@@ -10,28 +10,13 @@
 //! those branches out.
 
 use crate::context::CheckerOptions;
-use crate::state::CheckerState;
 use crate::test_utils::check_source;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
 
 fn check_with_options(source: &str, options: CheckerOptions) -> Vec<u32> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        options,
-    );
-    checker.ctx.set_lib_contexts(Vec::new());
-    checker.check_source_file(root);
-    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+    check_source(source, "test.ts", options)
+        .iter()
+        .map(|d| d.code)
+        .collect()
 }
 
 fn check_strict(source: &str) -> Vec<u32> {

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -123,6 +123,7 @@ Do not use `git commit --trailer`. The final commit should include all dirty fil
 ### Active Loop Claims
 
 - **2026-04-25** · branch `claude/modest-archimedes-FFpmC` · **SHIPPED** → PR #1154 · audit §P0 Test-Harness Consolidation (tsz-checker) · `check_source_code_messages` helper + 10 test files migrated, `#[cfg(test)]` gate removed from `test_utils`
+- **2026-04-25** · branch `claude/modest-archimedes-QBaXl` · audit item: P0 §2 Shared Test Harnesses — "Some tests import a shared helper and still redefine a local version" · planned files/symbols: `crates/tsz-checker/src/test_utils.rs`, `crates/tsz-checker/tests/class_member_closure_tests.rs`, `crates/tsz-checker/tests/contextual_tuple_tests.rs`, `crates/tsz-checker/tests/contextual_typing_tests.rs`, `crates/tsz-checker/tests/never_returning_narrowing_tests.rs` · planned symbols: local `check_with_options` → `tsz_checker::test_utils::check_source` · draft PR title: `[do not merge] chore(checker-tests): replace local check_with_options helpers with test_utils::check_source`
 
 ## Progress Log — Landed Since 2026-04-21
 


### PR DESCRIPTION
## Summary

- Removes 4 duplicate 15-line `check_with_options` helper functions across checker test files, replacing them with calls to the shared `tsz_checker::test_utils::check_source`
- Unblocks integration test access to `test_utils` by removing the `#[cfg(test)]` gate on the module declaration in `lib.rs`
- Makes the `TypeInterner` re-export in `query_boundaries::type_construction` unconditional so `test_utils.rs` can import it via the compliant `crate::query_boundaries` path (satisfies the architecture contract test)
- Fixes a pre-existing `doc_markdown` clippy failure in `tsz-emitter` as housekeeping

## Files changed

- `crates/tsz-checker/src/lib.rs` — remove `#[cfg(test)]` gate from `test_utils` module
- `crates/tsz-checker/src/query_boundaries/type_construction.rs` — make `TypeInterner` re-export unconditional
- `crates/tsz-checker/tests/class_member_closure_tests.rs` — replace 15-line inline boilerplate
- `crates/tsz-checker/tests/contextual_tuple_tests.rs` — replace 15-line inline boilerplate
- `crates/tsz-checker/tests/contextual_typing_tests.rs` — replace 15-line inline boilerplate + inline JS setup
- `crates/tsz-checker/tests/never_returning_narrowing_tests.rs` — replace 15-line inline boilerplate
- `crates/tsz-emitter/src/declaration_emitter/exports/mod.rs` — fix pre-existing `doc_markdown` clippy lint

## Test plan

- [x] All 5137 tsz-checker tests pass (`cargo nextest run -p tsz-checker`)
- [x] Architecture contract test (`test_solver_imports_go_through_query_boundaries`) passes
- [x] Pre-commit hook passes: formatting, clippy, wasm32 gate, architecture guardrail, 13240 tests across 92 binaries

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4kTzwa9ipeTbcAsynxi4b)_