### PR TITLE
chore(checker/tests): remove 10 duplicated local parse/bind/check wrappers

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -95,7 +95,7 @@ pub mod diagnostics {
     };
 }
 
-#[cfg(test)]
+#[doc(hidden)]
 pub mod test_utils;
 
 // Tests that don't depend on root crate's test_fixtures

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -5,7 +5,7 @@
 
 use crate::context::CheckerOptions;
 use crate::diagnostics::Diagnostic;
-use crate::query_boundaries::type_construction::TypeInterner;
+use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
 use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
@@ -63,5 +63,15 @@ pub fn check_source_codes(source: &str) -> Vec<u32> {
     check_source_diagnostics(source)
         .iter()
         .map(|d| d.code)
+        .collect()
+}
+
+/// Parse, bind, and type-check source, returning `(code, message_text)` pairs.
+///
+/// Convenience wrapper for tests that inspect both error codes and message text.
+pub fn check_source_code_messages(source: &str) -> Vec<(u32, String)> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
         .collect()
 }

--- a/crates/tsz-checker/tests/await_generic_non_promise_no_false_ts2339_tests.rs
+++ b/crates/tsz-checker/tests/await_generic_non_promise_no_false_ts2339_tests.rs
@@ -14,31 +14,7 @@
 //!       r.data;   // tsz (before fix): TS2339 "does not exist on type 'number'"
 //!   }
 
-use tsz_binder::BinderState;
-use tsz_checker::CheckerState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
-
-fn get_diagnostic_codes(source: &str) -> Vec<u32> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        Default::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
-}
+use tsz_checker::test_utils::check_source_codes;
 
 #[test]
 fn await_promise_of_generic_interface_preserves_interface_type() {
@@ -51,7 +27,7 @@ async function f() {
     const body = r.data;
 }
 "#;
-    let codes = get_diagnostic_codes(source);
+    let codes = check_source_codes(source);
     assert!(
         !codes.contains(&2339),
         "unexpected TS2339 after `await p` where p: Promise<Box<number>> — the await loop must stop at Box<number>, not unwrap further into `number`. got: {codes:?}"
@@ -72,7 +48,7 @@ async function main() {
     const body = response.data;
 }
 "#;
-    let codes = get_diagnostic_codes(source);
+    let codes = check_source_codes(source);
     assert!(
         !codes.contains(&2339),
         "unexpected TS2339 after `await get()` — response must type as AxiosResponse<never>, not `never`. got: {codes:?}"

--- a/crates/tsz-checker/tests/ts2320_tests.rs
+++ b/crates/tsz-checker/tests/ts2320_tests.rs
@@ -1,33 +1,9 @@
 //! Tests for TS2320: Interface inherits conflicting declarations from base types.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
-
-fn get_diagnostic_codes(source: &str) -> Vec<u32> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
-}
+use crate::test_utils::check_source_codes;
 
 fn has_error(source: &str, code: u32) -> bool {
-    get_diagnostic_codes(source).contains(&code)
+    check_source_codes(source).contains(&code)
 }
 
 #[test]

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -2,35 +2,10 @@
 //!
 //! Verifies that getter/setter accessors are checked against index signatures.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn has_error_with_code(source: &str, code: u32) -> bool {

--- a/crates/tsz-checker/tests/ts2428_tests.rs
+++ b/crates/tsz-checker/tests/ts2428_tests.rs
@@ -1,34 +1,9 @@
 //! Tests for TS2428, TS2411, TS2413: interface declaration merging diagnostics.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn has_error_with_code(source: &str, code: u32) -> bool {
@@ -270,10 +245,6 @@ namespace M3 {
 
 // ── TS2411 quoting tests ────────────────────────────────────────────────
 
-fn get_diagnostic_messages(source: &str) -> Vec<(u32, String)> {
-    get_diagnostics(source)
-}
-
 #[test]
 fn ts2411_single_quoted_property_name_preserved_in_diagnostic() {
     // TSC preserves quote style: `'a': number` → Property ''a'' of type ...
@@ -283,7 +254,7 @@ interface A2 {
     'a': number;
 }
 "#;
-    let diags = get_diagnostic_messages(source);
+    let diags = get_diagnostics(source);
     let ts2411_msgs: Vec<_> = diags.iter().filter(|d| d.0 == 2411).collect();
     assert!(
         !ts2411_msgs.is_empty(),
@@ -305,7 +276,7 @@ interface A {
     "-Infinity": string;
 }
 "#;
-    let diags = get_diagnostic_messages(source);
+    let diags = get_diagnostics(source);
     let ts2411_msgs: Vec<_> = diags.iter().filter(|d| d.0 == 2411).collect();
     assert!(
         !ts2411_msgs.is_empty(),
@@ -327,7 +298,7 @@ interface A {
     foo: string;
 }
 "#;
-    let diags = get_diagnostic_messages(source);
+    let diags = get_diagnostics(source);
     let ts2411_msgs: Vec<_> = diags.iter().filter(|d| d.0 == 2411).collect();
     assert!(
         !ts2411_msgs.is_empty(),
@@ -371,7 +342,7 @@ interface A {
     [x: string]: { length: string };
 }
 "#;
-    let diags = get_diagnostic_messages(source);
+    let diags = get_diagnostics(source);
     let ts2413_count = diags.iter().filter(|d| d.0 == 2413).count();
     assert!(
         ts2413_count <= 1,

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -3,36 +3,10 @@
 //! Verifies correct behavior for interface extension compatibility,
 //! including scope-aware type resolution in ambient modules.
 
-use crate::CheckerState;
-use crate::context::CheckerOptions;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn has_error_with_code(source: &str, code: u32) -> bool {

--- a/crates/tsz-checker/tests/ts2449_parameter_decorator_no_tdz_tests.rs
+++ b/crates/tsz-checker/tests/ts2449_parameter_decorator_no_tdz_tests.rs
@@ -8,35 +8,21 @@
 //! constructor/method-parameter cases in
 //! `useBeforeDeclaration_classDecorators.2.ts`.
 
-use tsz_binder::BinderState;
-use tsz_checker::CheckerState;
 use tsz_checker::context::CheckerOptions;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use tsz_checker::test_utils::check_source;
 
 fn get_diagnostic_codes(source: &str) -> Vec<u32> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let options = CheckerOptions {
-        experimental_decorators: true,
-        ..CheckerOptions::default()
-    };
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        options,
-    );
-
-    checker.check_source_file(root);
-
-    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
 }
 
 #[test]

--- a/crates/tsz-checker/tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs
+++ b/crates/tsz-checker/tests/ts2567_augmentation_enum_cross_arena_decl_tests.rs
@@ -14,31 +14,7 @@
 //! augmentation declared against a local class in a single file still emits
 //! TS2567 correctly.
 
-use tsz_binder::BinderState;
-use tsz_checker::CheckerState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
-
-fn get_diagnostic_codes(source: &str) -> Vec<u32> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        Default::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
-}
+use tsz_checker::test_utils::check_source_codes;
 
 #[test]
 fn augmentation_enum_merged_with_class_still_emits_ts2567() {
@@ -52,7 +28,7 @@ declare module "./test" {
     export enum Foo { A, B, C }
 }
 "#;
-    let codes = get_diagnostic_codes(source);
+    let codes = check_source_codes(source);
     assert!(
         codes.contains(&2567),
         "augmentation-enum merging with an existing class must emit TS2567; got: {codes:?}"

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -1,34 +1,9 @@
 //! Tests for TS2589: Type instantiation is excessively deep and possibly infinite.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn has_error_with_code(source: &str, code: u32) -> bool {

--- a/crates/tsz-checker/tests/ts2838_tests.rs
+++ b/crates/tsz-checker/tests/ts2838_tests.rs
@@ -3,35 +3,10 @@
 //! When `infer U` appears multiple times in the same conditional type extends clause,
 //! all declarations with explicit constraints must have the same constraint type.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn count_errors_with_code(source: &str, code: u32) -> usize {

--- a/crates/tsz-checker/tests/ts2839_tests.rs
+++ b/crates/tsz-checker/tests/ts2839_tests.rs
@@ -1,35 +1,10 @@
 //! Tests for TS2839: This condition will always return 'true'/'false'
 //! since JavaScript compares objects by reference, not value.
 
-use crate::CheckerState;
-use tsz_binder::BinderState;
-use tsz_parser::parser::ParserState;
-use tsz_solver::TypeInterner;
+use crate::test_utils::check_source_code_messages;
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let mut binder = BinderState::new();
-    binder.bind_source_file(parser.get_arena(), root);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        parser.get_arena(),
-        &binder,
-        &types,
-        "test.ts".to_string(),
-        crate::context::CheckerOptions::default(),
-    );
-
-    checker.check_source_file(root);
-
-    checker
-        .ctx
-        .diagnostics
-        .iter()
-        .map(|d| (d.code, d.message_text.clone()))
-        .collect()
+    check_source_code_messages(source)
 }
 
 fn has_error_with_code(source: &str, code: u32) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -974,7 +974,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     /// Whether `export = <expr>` can emit `<expr>` directly. True for entity
-    /// names (Identifier, qualified PropertyAccess), false for value
+    /// names (Identifier, qualified `PropertyAccess`), false for value
     /// expressions (object/array literals, calls, primitives) which require
     /// synthesizing a `_default` const with the inferred type.
     fn export_equals_expression_emits_directly(&self, expr_idx: NodeIndex) -> bool {
@@ -983,12 +983,11 @@ impl<'a> DeclarationEmitter<'a> {
         };
         match expr_node.kind {
             k if k == SyntaxKind::Identifier as u16 => true,
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => self
-                .arena
-                .get_access_expr(expr_node)
-                .is_some_and(|access| {
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                self.arena.get_access_expr(expr_node).is_some_and(|access| {
                     self.export_equals_expression_emits_directly(access.expression)
-                }),
+                })
+            }
             _ => false,
         }
     }

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -122,7 +122,7 @@ Do not use `git commit --trailer`. The final commit should include all dirty fil
 
 ### Active Loop Claims
 
-- **2026-04-25** · branch `claude/modest-archimedes-FFpmC` · audit §P0 Test-Harness Consolidation (tsz-checker) · add `check_source_code_messages` to `crates/tsz-checker/src/test_utils.rs` and migrate 10 checker test files (`ts2320_tests.rs`, `ts2567_augmentation_enum_cross_arena_decl_tests.rs`, `await_generic_non_promise_no_false_ts2339_tests.rs`, `ts2449_parameter_decorator_no_tdz_tests.rs`, `ts2838_tests.rs`, `ts2839_tests.rs`, `ts2589_tests.rs`, `ts2428_tests.rs`, `ts2411_tests.rs`, `ts2430_tests.rs`) off hand-rolled `ParserState::new`/`BinderState::new`/`CheckerState::new` wrappers onto the shared helpers · draft PR title: `[do not merge] chore(checker/tests): remove 10 duplicated local parse/bind/check wrappers`
+- **2026-04-25** · branch `claude/modest-archimedes-FFpmC` · **SHIPPED** → PR #1154 · audit §P0 Test-Harness Consolidation (tsz-checker) · `check_source_code_messages` helper + 10 test files migrated, `#[cfg(test)]` gate removed from `test_utils`
 
 ## Progress Log — Landed Since 2026-04-21
 
@@ -132,7 +132,8 @@ The sections below have had completed bullets removed. This log keeps a running 
 - `ScriptTarget` / `ModuleKind` / `ModuleResolutionKind` own canonical parse/display/numeric round-trip in `tsz-common` / `tsz-core::config`; six duplicated callsites migrated (#729).
 - Scripts side uses shared target/module enum conversions in emit runner (#771).
 
-**P0 §2 Shared Test Harnesses** — helper plumbing exists in places, but fixture migration is still largely not started.
+**P0 §2 Shared Test Harnesses**
+- `check_source_code_messages` added to `tsz-checker/src/test_utils.rs`; 10 checker test files migrated off hand-rolled `ParserState::new`/`BinderState::new`/`CheckerState::new` wrappers (~230 lines removed); `#[cfg(test)]` gate removed from `test_utils` so external integration tests can use `tsz_checker::test_utils::` (#1154).
 
 **P1 §3 LSP Provider Context** — not started.
 

--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -122,7 +122,7 @@ Do not use `git commit --trailer`. The final commit should include all dirty fil
 
 ### Active Loop Claims
 
-- None currently recorded. Replace this line with a dated claim when starting a loop iteration.
+- **2026-04-25** · branch `claude/modest-archimedes-FFpmC` · audit §P0 Test-Harness Consolidation (tsz-checker) · add `check_source_code_messages` to `crates/tsz-checker/src/test_utils.rs` and migrate 10 checker test files (`ts2320_tests.rs`, `ts2567_augmentation_enum_cross_arena_decl_tests.rs`, `await_generic_non_promise_no_false_ts2339_tests.rs`, `ts2449_parameter_decorator_no_tdz_tests.rs`, `ts2838_tests.rs`, `ts2839_tests.rs`, `ts2589_tests.rs`, `ts2428_tests.rs`, `ts2411_tests.rs`, `ts2430_tests.rs`) off hand-rolled `ParserState::new`/`BinderState::new`/`CheckerState::new` wrappers onto the shared helpers · draft PR title: `[do not merge] chore(checker/tests): remove 10 duplicated local parse/bind/check wrappers`
 
 ## Progress Log — Landed Since 2026-04-21
 


### PR DESCRIPTION
## Summary
- Adds `check_source_code_messages` helper to `crates/tsz-checker/src/test_utils.rs`
- Migrates 10 checker test files off hand-rolled `ParserState::new` / `BinderState::new` / `CheckerState::new` wrappers onto shared helpers
- Removes `#[cfg(test)]` gate on `test_utils` so external integration tests can import it via `tsz_checker::test_utils` (uses `query_boundaries::common::TypeInterner` which is always available)
- Eliminates ~230 lines of duplicated setup boilerplate; no behavior change

## Files changed
`ts2320_tests.rs`, `ts2567_augmentation_enum_cross_arena_decl_tests.rs`, `await_generic_non_promise_no_false_ts2339_tests.rs`, `ts2449_parameter_decorator_no_tdz_tests.rs`, `ts2838_tests.rs`, `ts2839_tests.rs`, `ts2589_tests.rs`, `ts2428_tests.rs`, `ts2411_tests.rs`, `ts2430_tests.rs`

## Audit ref
§P0 Test-Harness Consolidation — `docs/DRY_AUDIT_2026-04-21.md`

## Test plan
- [x] `cargo test -p tsz-checker` — all tests pass (internal + 3 external integration tests)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings
- [x] Pre-commit hook — all checks pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYmF8cYk6auPTVQxwtc9Qs)_