### PR TITLE
[do not merge] refactor(emitter/tests): add parse_and_print helper; migrate declarations_class tests

### DIFF
--- a/docs/DRY_AUDIT_2026-04-21.md
+++ b/docs/DRY_AUDIT_2026-04-21.md
@@ -122,7 +122,7 @@ Do not use `git commit --trailer`. The final commit should include all dirty fil
 
 ### Active Loop Claims
 
-- None currently recorded. Replace this line with a dated claim when starting a loop iteration.
+- 2026-04-25 · branch: `claude/modest-archimedes-D2RBt` · Item: §tsz-emitter test fixture — add `parse_and_print` helper to `src/output/printer.rs` and migrate all 31 tests in `tests/declarations_class.rs` off hand-rolled `ParserState::new`/`Printer::new` boilerplate · PR title: `[do not merge] refactor(emitter/tests): add parse_and_print helper; migrate declarations_class tests`
 
 ## Progress Log — Landed Since 2026-04-21
 


### PR DESCRIPTION
## Summary
- Claims a DRY cleanup slice from `docs/DRY_AUDIT_2026-04-21.md`.
- Implementation will follow in this PR.

## Planned Scope
- Item: §tsz-emitter test fixture consolidation (Phase 2)
- Add `parse_and_print(source, opts)` helper to `crates/tsz-emitter/src/output/printer.rs` alongside the existing `lower_and_print` helper
- Migrate all 31 tests in `crates/tsz-emitter/tests/declarations_class.rs` off the 7-line hand-rolled `ParserState::new` / `Printer::new` boilerplate onto the new helper

## Coordination
- Duplicate-work check: reviewed open and recently merged PRs before starting — no overlap found (open PRs #1152/#1153/#1154 cover solver/checker test fixtures, not emitter)
- Tracking edit: `docs/DRY_AUDIT_2026-04-21.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EneSejM81irnf631hLb9XN)_