### PR TITLE
fix(checker): detect TS2456 circularity through `typeof` queries

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -104,6 +104,10 @@ name = "type_alias_namespace_merge_tests"
 path = "tests/type_alias_namespace_merge_tests.rs"
 
 [[test]]
+name = "type_alias_typeof_circular_tests"
+path = "tests/type_alias_typeof_circular_tests.rs"
+
+[[test]]
 name = "namespace_qualified_diagnostic_tests"
 path = "tests/namespace_qualified_diagnostic_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -536,6 +536,32 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Type query (typeof X): per the TS spec, "a type query directly depends
+        // on the type of the referenced entity". When the alias body is a
+        // TYPE_QUERY at the top level (`type T = typeof X`) pointing at a
+        // non-self variable, look at that variable's annotation AST and check
+        // whether it references any alias on the resolution chain. We inspect
+        // the AST rather than evaluate x's type to avoid re-entering type alias
+        // resolution for x → typeof x → alias.
+        if let Some(node) = self.ctx.arena.get(type_node)
+            && node.kind == syntax_kind_ext::TYPE_QUERY
+            && let Some(type_query) = self.ctx.arena.get_type_query(node)
+        {
+            let entity_idx = type_query.expr_name;
+            // The entity in `typeof X` is a value identifier — use the
+            // value-position resolver, not the type-position one.
+            if entity_idx != NodeIndex::NONE
+                && let Some(query_raw) = self.resolve_value_symbol_for_lowering(entity_idx)
+            {
+                let query_sym_id = SymbolId(query_raw);
+                if query_sym_id != sym_id
+                    && self.typeof_target_annotation_refs_resolution_chain(query_sym_id)
+                {
+                    return true;
+                }
+            }
+        }
+
         // Skip evaluation when the type contains a TypeQuery (typeof) referencing
         // the symbol being checked. TypeQuery accesses the VALUE namespace, not the
         // TYPE namespace, so `type X = Static<typeof X>` (where `const X` also exists)
@@ -678,6 +704,114 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Walk the AST node tree under `root_idx` and return the SymbolId of any
+    /// type-reference/identifier that resolves to a member of
+    /// `ctx.symbol_resolution_set` and represents a type alias. Descends through
+    /// arrays, tuples, type literals, etc. so that `T5[]` is detected as
+    /// referencing `T5`.
+    fn ast_finds_resolution_chain_alias(&self, root_idx: NodeIndex) -> Option<SymbolId> {
+        let mut stack = vec![root_idx];
+        while let Some(node_idx) = stack.pop() {
+            let Some(node) = self.ctx.arena.get(node_idx) else {
+                continue;
+            };
+            // Look at TYPE_REFERENCE or bare Identifier — both can name a type alias.
+            let lookup_target_idx = if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+                self.ctx.arena.get_type_ref(node).map(|tr| tr.type_name)
+            } else if node.kind == SyntaxKind::Identifier as u16 {
+                Some(node_idx)
+            } else {
+                None
+            };
+            if let Some(target_idx) = lookup_target_idx
+                && let Some(sym_raw) = self.resolve_type_symbol_for_lowering(target_idx)
+            {
+                let sym_id = SymbolId(sym_raw);
+                if self.ctx.symbol_resolution_set.contains(&sym_id) {
+                    let is_type_alias = self
+                        .ctx
+                        .binder
+                        .get_symbol(sym_id)
+                        .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0);
+                    if is_type_alias {
+                        return Some(sym_id);
+                    }
+                }
+            }
+            // A TYPE_REFERENCE with type arguments creates a generic
+            // instantiation boundary — descend into its children only if the
+            // ref itself isn't the chain target.
+            for child_idx in self.ctx.arena.get_children(node_idx) {
+                stack.push(child_idx);
+            }
+        }
+        None
+    }
+
+    /// True when the `typeof X` target's variable annotation references any type
+    /// alias in the current resolution chain. Marks the chain as circular when
+    /// found. AST-only — never resolves x's type, to avoid re-entering alias
+    /// resolution.
+    fn typeof_target_annotation_refs_resolution_chain(&mut self, var_sym_id: SymbolId) -> bool {
+        let decls: Vec<NodeIndex> = match self.ctx.binder.get_symbol(var_sym_id) {
+            Some(symbol) => symbol.declarations.clone(),
+            None => return false,
+        };
+        let mut hit: Option<SymbolId> = None;
+        for decl_idx in decls {
+            let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            if decl_node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+                continue;
+            }
+            let annotation_idx = self
+                .ctx
+                .arena
+                .get_variable_declaration(decl_node)
+                .map(|vd| vd.type_annotation);
+            let Some(annotation_idx) = annotation_idx else {
+                continue;
+            };
+            if annotation_idx == NodeIndex::NONE {
+                continue;
+            }
+            if let Some(found) = self.ast_finds_resolution_chain_alias(annotation_idx) {
+                hit = Some(found);
+                break;
+            }
+        }
+        let Some(found_sym_id) = hit else {
+            return false;
+        };
+        // Mark all aliases on the resolution stack between target and current as circular.
+        let stack_snapshot: Vec<SymbolId> = self.ctx.symbol_resolution_stack.to_vec();
+        let mut found_target = false;
+        for stack_sym in stack_snapshot {
+            if stack_sym == found_sym_id {
+                found_target = true;
+            }
+            if found_target {
+                let is_alias = self
+                    .ctx
+                    .binder
+                    .get_symbol(stack_sym)
+                    .is_some_and(|s| s.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0);
+                if is_alias {
+                    self.ctx.circular_type_aliases.insert(stack_sym);
+                    if let Some(did) = self.ctx.get_existing_def_id(stack_sym) {
+                        self.ctx.definition_store.mark_circular_def(did);
+                    }
+                }
+            }
+        }
+        self.ctx.circular_type_aliases.insert(found_sym_id);
+        if let Some(did) = self.ctx.get_existing_def_id(found_sym_id) {
+            self.ctx.definition_store.mark_circular_def(did);
+        }
+        true
     }
 
     /// Check if a non-generic type alias with a mapped type body is circular.

--- a/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
+++ b/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
@@ -1,0 +1,98 @@
+//! Tests for TS2456 circular reference detection through `typeof` queries.
+//!
+//! Per the TypeScript spec, "a type query directly depends on the type of the
+//! referenced entity". When a type alias is `typeof X` and `X`'s annotation
+//! references the same alias, tsc emits TS2456. This test locks in the
+//! AST-based detection path that walks through `var x: T[]` annotations.
+
+fn get_error_codes(source: &str) -> Vec<u32> {
+    let mut parser =
+        tsz_parser::parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = tsz_solver::TypeInterner::new();
+    let mut checker = tsz_checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        tsz_checker::context::CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn test_ts2456_typeof_alias_references_self_through_array() {
+    // type T = typeof x; var x: T[]
+    // The alias body `typeof x` resolves to x's type which is `T[]` —
+    // T directly depends on x's type, x's annotation contains T, so circular.
+    // tsc emits TS2456 at the alias name.
+    let src = r#"
+        var x: T[] = [];
+        type T = typeof x;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        codes.contains(&2456),
+        "Expected TS2456 (circularly references itself), got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_no_ts2456_when_typeof_target_uses_tuple_wrapping() {
+    // Cycle goes through structurally-wrapping types (tuple element + generic
+    // Application). tsc considers these structurally deferred and does NOT emit
+    // TS2456. Our AST-based check only fires when x's annotation directly
+    // references an alias on the resolution chain — tuple element nodes still
+    // recurse, so this test guards against marking the leaf alias `T8 = C<T6>`
+    // as circular when the cycle is ultimately broken by `C<T6>`'s generic
+    // application.
+    let src = r#"
+        class C<T> {}
+        type T6 = T7 | number;
+        type T7 = typeof yy;
+        var yy: [string, T8[]];
+        type T8 = C<T6>;
+    "#;
+    let codes = get_error_codes(src);
+    // tsc does not emit TS2456 for this constellation. We mirror that.
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 (tsc emits none), got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_no_ts2456_when_typeof_target_does_not_reference_alias() {
+    // typeof on a variable whose annotation is unrelated should not emit TS2456.
+    let src = r#"
+        var x: number = 0;
+        type T = typeof x;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 when typeof target is unrelated, got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_no_ts2456_when_typeof_self_referencing_var_is_value() {
+    // `type X = ...` and `const X = ...` (merged value+type) — typeof X on
+    // the value side should not produce TS2456 at the type alias.
+    let src = r#"
+        type X = number;
+        const X = 1;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 for merged value+type with typeof self, got: {codes:?}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -974,7 +974,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     /// Whether `export = <expr>` can emit `<expr>` directly. True for entity
-    /// names (Identifier, qualified PropertyAccess), false for value
+    /// names (Identifier, qualified `PropertyAccess`), false for value
     /// expressions (object/array literals, calls, primitives) which require
     /// synthesizing a `_default` const with the inferred type.
     fn export_equals_expression_emits_directly(&self, expr_idx: NodeIndex) -> bool {
@@ -983,12 +983,11 @@ impl<'a> DeclarationEmitter<'a> {
         };
         match expr_node.kind {
             k if k == SyntaxKind::Identifier as u16 => true,
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => self
-                .arena
-                .get_access_expr(expr_node)
-                .is_some_and(|access| {
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                self.arena.get_access_expr(expr_node).is_some_and(|access| {
                     self.export_equals_expression_emits_directly(access.expression)
-                }),
+                })
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary

`type T = typeof x; var x: T[]` is a circular reference per the TS spec (a type query directly depends on the type of the referenced entity). tsc emits TS2456 for it; tsz did not.

## Root cause

`is_direct_circular_reference` only walked `Lazy(DefId)` refs and structural composite types. When the alias body is a `TYPE_QUERY` AST node, the resolved type is `TypeQuery(x_sym)` (or, after flow-aware resolution, `Array(Lazy(T))`). Neither path was instrumented to follow x's annotation back to the alias being defined, so the cycle stayed invisible.

## Fix

Added an AST-based check inside `is_direct_circular_reference_inner`: when `type_node` is a `TYPE_QUERY` pointing at a non-self variable, walk that variable's type-annotation AST and look for type references to any alias on `ctx.symbol_resolution_set`. If found, mark the chain circular and return `true`. Stays purely syntactic — never re-enters type alias resolution for x → typeof x → alias, which would just hit the depth guard and return false.

```ts
var x: T5[] = []
type T5 = typeof x   // TS2456 — circular
```

## Test plan

- [x] New unit tests in `type_alias_typeof_circular_tests`:
  - `test_ts2456_typeof_alias_references_self_through_array` — locks in the positive case
  - `test_no_ts2456_when_typeof_target_does_not_reference_alias` — negative
  - `test_no_ts2456_when_typeof_self_referencing_var_is_value` — merged value+type
  - `test_no_ts2456_when_typeof_target_uses_tuple_wrapping` — structurally-deferred chain (matches tsc, which doesn't flag)
- [x] Targeted conformance: `directDependenceBetweenTypeAliases.ts` now passes (was fingerprint-only, missing TS2456 at `T5`)
- [x] Full conformance: 12126 → 12127 (+1, no regressions)
- [x] `cargo nextest run -p tsz-checker --lib`: 2738/2738 pass
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean