### PR TITLE
fix(solver): don't quote decimal/scientific numeric property names

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -974,7 +974,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     /// Whether `export = <expr>` can emit `<expr>` directly. True for entity
-    /// names (Identifier, qualified PropertyAccess), false for value
+    /// names (Identifier, qualified `PropertyAccess`), false for value
     /// expressions (object/array literals, calls, primitives) which require
     /// synthesizing a `_default` const with the inferred type.
     fn export_equals_expression_emits_directly(&self, expr_idx: NodeIndex) -> bool {
@@ -983,12 +983,11 @@ impl<'a> DeclarationEmitter<'a> {
         };
         match expr_node.kind {
             k if k == SyntaxKind::Identifier as u16 => true,
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => self
-                .arena
-                .get_access_expr(expr_node)
-                .is_some_and(|access| {
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                self.arena.get_access_expr(expr_node).is_some_and(|access| {
                     self.export_equals_expression_emits_directly(access.expression)
-                }),
+                })
+            }
             _ => false,
         }
     }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -22,6 +22,56 @@ use tracing::trace;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
+/// Returns `true` if `name` parses as a JavaScript decimal numeric literal —
+/// integer, decimal, or scientific notation. tsc displays such property names
+/// without quotes (e.g., `9.671406556917009e+24: boolean` rather than the
+/// quoted form). Excludes hex/octal/binary literal *forms* like `0x1F` because
+/// those are not how property names appear after the parser canonicalises them
+/// to their decimal/string representation.
+fn is_decimal_numeric_literal(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut i = 0;
+    // Optional leading sign — JS property names never carry one, but tolerate
+    // it so callers don't need to strip first.
+    if matches!(bytes[i], b'+' | b'-') {
+        i += 1;
+    }
+    let int_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    let had_int = i > int_start;
+    let mut had_frac = false;
+    if i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        let frac_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        had_frac = i > frac_start;
+    }
+    if !had_int && !had_frac {
+        return false;
+    }
+    if i < bytes.len() && matches!(bytes[i], b'e' | b'E') {
+        i += 1;
+        if i < bytes.len() && matches!(bytes[i], b'+' | b'-') {
+            i += 1;
+        }
+        let exp_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == exp_start {
+            return false;
+        }
+    }
+    i == bytes.len()
+}
+
 /// Returns `true` if a property name needs to be quoted in type display
 /// (i.e. it is not a valid JS identifier or numeric literal).
 fn needs_property_name_quotes(name: &str) -> bool {
@@ -33,8 +83,10 @@ fn needs_property_name_quotes(name: &str) -> bool {
     if name.starts_with('[') && name.ends_with(']') {
         return false;
     }
-    // Numeric property names don't need quotes
-    if name.chars().all(|ch| ch.is_ascii_digit()) {
+    // Decimal numeric literals (`123`, `1.5`, `9.671e+24`) display without
+    // quotes — they round-trip through the JS lexer as numeric literal property
+    // names.
+    if is_decimal_numeric_literal(name) {
         return false;
     }
     let mut chars = name.chars();

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -73,6 +73,24 @@ fn needs_property_name_quotes_basic() {
 }
 
 #[test]
+fn needs_property_name_quotes_decimal_and_scientific() {
+    // tsc displays numeric literal property names without quotes.
+    // Decimals:
+    assert!(!super::needs_property_name_quotes("1.5"));
+    assert!(!super::needs_property_name_quotes("0.123"));
+    assert!(!super::needs_property_name_quotes(".5"));
+    // Scientific notation — large numbers in object types.
+    assert!(!super::needs_property_name_quotes("9.671406556917009e+24"));
+    assert!(!super::needs_property_name_quotes("1e5"));
+    assert!(!super::needs_property_name_quotes("1.2E-3"));
+    // Not a valid numeric literal — must be quoted.
+    assert!(super::needs_property_name_quotes("1.2.3"));
+    assert!(super::needs_property_name_quotes("1e"));
+    assert!(super::needs_property_name_quotes("0x1F"));
+    assert!(super::needs_property_name_quotes("0b1010"));
+}
+
+#[test]
 fn tuple_type_alias_preserved_in_format() {
     let db = TypeInterner::new();
     let def_store = crate::def::DefinitionStore::new();


### PR DESCRIPTION
## Summary

`needs_property_name_quotes` only treated all-ASCII-digit names as unquoted, so property names like `1.5`, `9.671406556917009e+24`, `1e5` were wrapped in quotes in error messages. tsc displays them bare — they are valid JS numeric-literal property names.

```ts
const obj = { 9.671e+24: true };
obj.foo;
// tsc: type '{ 9.671e+24: boolean; }'   (unquoted)
// tsz (before): type '{ \"9.671e+24\": boolean; }'   (incorrectly quoted)
```

## Fix

Added an `is_decimal_numeric_literal` helper that recognises integer / decimal / scientific-notation forms and routes through the new check before the identifier rule. Hex / octal / binary forms (`0x1F`, `0b1010`) intentionally stay quoted — those don't appear as canonicalised property names anyway, since the parser stores numeric property names in their decimal form.

## Test plan

- [x] Added `needs_property_name_quotes_decimal_and_scientific` covering `1.5`, `0.123`, `.5`, `9.671406556917009e+24`, `1e5`, `1.2E-3`, plus negatives (`1.2.3`, `1e`, `0x1F`, `0b1010`).
- [x] Existing `needs_property_name_quotes_basic` still passes.
- [x] Full conformance: 12126 → 12129 (+3 tests pass: `coAndContraVariantInferences2`, `coAndContraVariantInferences4`, `inferenceDoesNotAddUndefinedOrNull`).
- [x] No regressions across full conformance, emit, fourslash.