### PR TITLE
fix(emitter,dts): strip full module path from import-type qualified names

### DIFF
--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -372,9 +372,17 @@ impl<'a> TypePrinter<'a> {
         module_path: &str,
         qualified_name: &'b str,
     ) -> &'b str {
-        // Get the last segment of the module path (e.g., "url" from "@types/url")
+        // Try the full module path first (handles slash-containing specifiers
+        // like `ext/other`, where the qualified name starts with the full
+        // path). Matches typesVersionsDeclarationEmit.ambient.
+        if let Some(rest) = qualified_name.strip_prefix(module_path)
+            && let Some(stripped) = rest.strip_prefix('.')
+            && !stripped.is_empty()
+        {
+            return stripped;
+        }
+        // Then fall back to the last segment (e.g. "url" from "@types/url").
         let module_last = module_path.rsplit('/').next().unwrap_or(module_path);
-        // Check if qualified name starts with `<module_last>.`
         if let Some(rest) = qualified_name.strip_prefix(module_last)
             && let Some(stripped) = rest.strip_prefix('.')
             && !stripped.is_empty()


### PR DESCRIPTION
## Summary
- For modules with slash-bearing specifiers like `ext/other`, try stripping the full module path before falling back to the last segment.
- Fixes `import(\"ext/other\").ext/other.B` → `import(\"ext/other\").B`.

## Why
The qualified symbol name carries the full path (e.g. `ext/other.B`). The existing prefix-strip only checked the last segment (`other`), so the prefix wasn't stripped and the path got duplicated inside the dotted access.

## Delta
- DTS: +1 / 0 regressions (full suite, fixes typesVersionsDeclarationEmit.ambient).

## Test plan
- [x] Full DTS run shows +1 with no regressions.
- [x] tsz-emitter unit tests pass.
- [ ] CI passes.