### PR TITLE
fix(checker): use construct sig return type for empty JSX EAP

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -1181,18 +1181,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
             Some(ref name) if name.is_empty() => {
-                // Empty/invalid ElementAttributesProperty -> fall back to first construct param
-                // This matches tsc behavior: when ElementAttributesProperty is invalid,
-                // use the first parameter of the construct signature as the props type.
-                if let Some(first_param) = first_param_type {
-                    let param_type = self.evaluate_type_with_env(first_param);
-                    if param_type != TypeId::ANY && param_type != TypeId::ERROR {
-                        return Some(param_type);
-                    }
-                }
-                // Fall back to instance type if no valid first param
-                let evaluated_instance = self.evaluate_type_with_env(instance_type);
-                Some(evaluated_instance)
+                // Empty ElementAttributesProperty -> use the construct signature's
+                // return (instance) type as the attributes type. This matches tsc:
+                // `forcedLookupLocation === ""` returns `getReturnTypeOfSignature(sig)`.
+                Some(self.evaluate_type_with_env(instance_type))
             }
             Some(ref name) => {
                 // ElementAttributesProperty has a member -> access that property on instance
@@ -1414,7 +1406,12 @@ impl<'a> CheckerState<'a> {
                         &["ElementAttributesProperty"],
                     );
                 }
-                return Some(String::new());
+                // tsc's getJsxElementPropertiesName returns undefined when the
+                // EAP interface declares more than one property. That routes the
+                // attributes type back through the no-EAP branch (first
+                // construct-signature parameter), not the empty-EAP branch
+                // (instance type), so propagate `None` here.
+                return None;
             }
             // Return the name of the first (and typically only) property
             if let Some(first_prop) = shape.properties.first() {

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -485,6 +485,95 @@ fn jsx_invalid_element_attributes_property_props_assignability_anchors_at_tag_na
     );
 }
 
+/// Empty `JSX.ElementAttributesProperty` -> the construct signature's return
+/// (instance) type is the attributes type. tsc:
+/// `forcedLookupLocation === "" ? getReturnTypeOfSignature(sig) : ...`.
+///
+/// `<Obj2 x={10} />` checks `{ x: number }` against the instance type
+/// `{ q?: number }`, producing TS2322 with the instance type — not the
+/// constructor's first parameter type.
+#[test]
+fn jsx_empty_element_attributes_property_uses_instance_type() {
+    let diagnostics = check_jsx(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface ElementAttributesProperty { }
+            interface IntrinsicElements { }
+        }
+        interface Obj2type { new(n: string): { q?: number }; }
+        declare var Obj2: Obj2type;
+        <Obj2 x={10} />;
+        "#,
+    );
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.iter().any(|d| d
+            .message_text
+            .contains("is not assignable to type '{ q?: number | undefined; }'")),
+        "expected TS2322 to compare against the instance type, got: {diagnostics:?}"
+    );
+    assert!(
+        !ts2322
+            .iter()
+            .any(|d| d.message_text.contains("type 'string'")),
+        "TS2322 should not use the constructor's first parameter ('string') as the props type, got: {diagnostics:?}"
+    );
+}
+
+/// Empty EAP with a constructor whose return type already has the attribute
+/// shape (`{ x: number }`) should not emit TS2322.
+#[test]
+fn jsx_empty_element_attributes_property_matches_instance_type_no_error() {
+    let diagnostics = check_jsx_codes(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface ElementAttributesProperty { }
+            interface IntrinsicElements { }
+        }
+        interface Obj3type { new(n: string): { x: number; }; }
+        declare var Obj3: Obj3type;
+        <Obj3 x={10} />;
+        "#,
+    );
+    assert!(
+        !diagnostics.contains(&2322),
+        "Instance type with matching attribute should not emit TS2322, got: {diagnostics:?}"
+    );
+}
+
+/// `JSX.ElementAttributesProperty` with multiple members emits TS2608 and
+/// then routes the attributes type back through the no-EAP branch (first
+/// construct-signature parameter), matching tsc's
+/// `getJsxElementPropertiesName` returning `undefined` in that case.
+#[test]
+fn jsx_multi_member_eap_uses_first_constructor_parameter() {
+    let diagnostics = check_jsx(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface ElementAttributesProperty { pr1: any; pr2: any; }
+            interface IntrinsicElements { }
+        }
+        interface CompType { new(n: string): {}; }
+        declare var Comp: CompType;
+        <Comp x={10} />;
+        "#,
+    );
+    let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2608),
+        "TS2608 expected for multi-member ElementAttributesProperty, got: {codes:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2322
+            && d.message_text
+                .contains("is not assignable to type 'string'")),
+        "TS2322 should compare against the first constructor parameter when EAP has >1 members, got: {diagnostics:?}"
+    );
+}
+
 /// TS2786 should NOT fire for generic class components whose construct
 /// signature return type contains unresolved type parameters.
 /// TSC resolves signatures before checking; we skip the check when


### PR DESCRIPTION
## Summary

`getJsxPropsTypeFromClassType` in `tsc` selects the JSX attributes type from
the construct signature based on `getJsxElementPropertiesName`:

- `undefined` (no `JSX.ElementAttributesProperty`, **or** the EAP has more
  than one property) → first parameter of the constructor.
- `""` (EAP exists but has zero properties) → the constructor's return
  (instance) type.
- a name → that property of the instance type.

`get_class_component_props_type` in `tsz-checker` was using the first
construct-signature parameter for both the empty-EAP case and the
multi-member-EAP case, producing TS2322 messages like
`is not assignable to type 'string'` when checking JSX attributes against the
constructor's parameter type instead of the instance shape.

### Fix

- Empty EAP → return the construct signature's instance type (matches
  `forcedLookupLocation === "" ? getReturnTypeOfSignature(sig) : ...`).
- Multi-member EAP → propagate `None` so the caller routes through the
  no-EAP branch (first parameter), matching tsc's
  `getJsxElementPropertiesName` returning `undefined` when the EAP declares
  more than one property.

### Reproducer

```ts
declare namespace JSX {
    interface Element { }
    interface ElementAttributesProperty { } // empty
    interface IntrinsicElements { }
}

interface Obj1type { new(n: string): any; }
declare var Obj1: Obj1type;
<Obj1 x={10} />; // OK (instance type is `any`)

interface Obj2type { new(n: string): { q?: number }; }
declare var Obj2: Obj2type;
<Obj2 x={10} />;
// expected: TS2322 "Type '{ x: number; }' is not assignable to type
//                   '{ q?: number | undefined; }'."

interface Obj3type { new(n: string): { x: number; }; }
declare var Obj3: Obj3type;
<Obj3 x={10} />; // OK (instance type matches the JSX attributes object)
```

Before the fix, `tsz` reported `is not assignable to type 'string'` (using
the constructor's first parameter `n: string` instead of the instance type)
at the JSX tag for both `Obj2` and `Obj3` — including a false positive for
`Obj3`. After the fix, only the genuine `Obj2` error fires, matching tsc.

### Conformance

- `tsxElementResolution10.tsx`: FAIL → PASS
- `tsxElementResolution11.tsx`: FAIL → PASS
- No JSX regressions across `conformance/jsx/` (211 tests).
- Net +9 conformance tests vs baseline; no PASS → FAIL caused by this change.

### Tests

Three new unit tests in `crates/tsz-checker/src/checkers/jsx/tests.rs`:

- `jsx_empty_element_attributes_property_uses_instance_type` — empty EAP
  reports the assignability mismatch against the instance shape.
- `jsx_empty_element_attributes_property_matches_instance_type_no_error` —
  matching attributes against the instance type emits no TS2322.
- `jsx_multi_member_eap_uses_first_constructor_parameter` — TS2608 for the
  multi-member EAP, plus TS2322 against the first parameter type.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p tsz-checker --lib` (2739 passed)
- [x] `cargo nextest run -p tsz-solver --lib` (5305 passed)
- [x] `cargo nextest run` workspace-wide (21408 passed; the 8 pre-existing
      failures in `tsz-cli`/`tsz-solver` tracing tests reproduce on `main`
      without this change)
- [x] Conformance verified: `tsxElementResolution10`, `tsxElementResolution11`
      pass; no JSX regressions; net +9 vs baseline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lk22J3UZLS5RbLq48QBVy9)_