### PR TITLE
fix(emitter,dts): widen empty array-binding-pattern param to Iterable

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -767,8 +767,22 @@ impl<'a> DeclarationEmitter<'a> {
                                 .get_binding_pattern(n)
                                 .is_none_or(|bp| bp.elements.nodes.is_empty())
                     });
+                    let is_empty_array_binding = self.arena.get(param.name).is_some_and(|n| {
+                        n.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+                            && self
+                                .arena
+                                .get_binding_pattern(n)
+                                .is_none_or(|bp| bp.elements.nodes.is_empty())
+                    });
                     if is_empty_object_binding {
                         self.write(": {}");
+                    } else if is_empty_array_binding {
+                        // Empty array binding pattern `[]` desugars to an
+                        // iterator-protocol consumption; tsc widens to
+                        // `Iterable<any, void, undefined>` (the 3-arg shape
+                        // matches the lib `Iterable<T, TReturn, TNext>`).
+                        // Matches emptyArrayBindingPatternParameter02.
+                        self.write(": Iterable<any, void, undefined>");
                     } else {
                         // In declaration emit from source, parameters without
                         // explicit type annotations default to `any` (matching tsc)


### PR DESCRIPTION
## Summary
- For `function f([]) {}` (no annotation, no init), emit `: Iterable<any, void, undefined>` instead of `: any`.
- Mirrors the existing empty-object-binding special case (`{}` → `: {}`).

## Why
Empty array-binding-pattern parameter iterates the argument via the iterator protocol. tsc widens to `Iterable<any, void, undefined>` (the 3-arg shape matches the lib `Iterable<T, TReturn, TNext>`).

## Delta
- DTS: +3 / 0 regressions (full suite, fixes emptyArrayBindingPatternParameter01/02/03).

## Test plan
- [x] Full DTS run shows +3 with no regressions.
- [ ] CI passes.