### PR TITLE
fix(solver): exclude homomorphic param from post-reverse template inference

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -247,6 +247,78 @@ oub.b;
 }
 
 #[test]
+fn reverse_mapped_recursive_any_property_does_not_collapse_t_to_any() {
+    // Regression test for mappedTypeRecursiveInference.ts:
+    // when a homomorphic mapped type `Deep<T> = { [K in keyof T]: Deep<T[K]> }`
+    // is inferred against an object source whose property has type `any`,
+    // T must be inferred as the structural reverse-mapped object
+    // (e.g. `{ p: unknown }`), NOT as `T = any`.
+    //
+    // Before the fix, reverse-mapped inference produced the structural
+    // candidate `{ p: unknown }` at HomomorphicMappedType priority, but the
+    // post-reverse `constrain_template_against_properties` then ran
+    // `constrain_types(any, Deep<T[K]>)` which propagated `any` to T via the
+    // `T[K]` placeholder at the OUTER call's higher priority — overriding
+    // the reverse-mapped result and collapsing T to `any`. The downstream
+    // assignability check then failed with the wrong inferred parameter
+    // (`Deep<any>` instead of `Deep<{ p: unknown }>`).
+    //
+    // The fix excludes the homomorphic type parameter from the var map
+    // when running the residual property-template inference: tsc treats
+    // reverse inference as the sole inference path for the homomorphic
+    // parameter, and we now mirror that.
+    let code = r#"
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+declare function foo<T>(deep: Deep<T>): T;
+interface XHR { readonly p: any; }
+declare let xhr: XHR;
+const out = foo(xhr);
+type _Probe = typeof out;
+const probe: { p: unknown } = out;
+"#;
+    // The `probe` annotation forces tsz to compare `T` (typeof out) against
+    // `{ p: unknown }`. If the fix is correct, T resolves to `{ p: unknown }`
+    // and there are no diagnostics. If T collapses to `any`, the structural
+    // check would still permit the assignment (any is assignable everywhere),
+    // so the strongest signal is that `foo(xhr)` does NOT produce a TS2345
+    // about `Deep<any>` and that no `Index signature for type 'string'`
+    // diagnostic is emitted (which is the symptom of T collapsing to any
+    // for sources without a string index).
+    let codes = check_and_get_codes(code);
+    assert!(
+        !codes.contains(&2345),
+        "Expected no TS2345 (T should be structural `{{ p: unknown }}`, not `any` which would force the parameter to `Deep<any>` and break assignability), got: {codes:?}",
+    );
+}
+
+#[test]
+fn reverse_mapped_recursive_any_property_with_extra_props_keeps_structural_t() {
+    // Companion test: even when the source has multiple properties — some
+    // `any`-typed and some not — the homomorphic parameter T must remain a
+    // structural object derived from reverse mapping, not collapse to `any`.
+    //
+    // The inferred `T` should be `{ p: unknown; q: unknown }`. Accessing
+    // `out.q` should therefore produce TS18046 ("of type 'unknown'"), not
+    // be silently typed `any` (which would happen if T collapsed to any).
+    let code = r#"
+type Deep<T> = { [K in keyof T]: Deep<T[K]> }
+declare function foo<T>(deep: Deep<T>): T;
+interface XHR { readonly p: any; readonly q: number; }
+declare let xhr: XHR;
+const out = foo(xhr);
+out.q.toFixed(2);
+"#;
+    let codes = check_and_get_codes(code);
+    // `out.q` should be `unknown`, so calling `.toFixed` on it is an error.
+    // If T had collapsed to `any`, `out.q` would be `any` and the call
+    // would silently succeed.
+    assert!(
+        codes.contains(&18046),
+        "Expected TS18046 on `out.q` (which should be `unknown` after structural reverse-mapped inference); got: {codes:?}",
+    );
+}
+
+#[test]
 fn reverse_mapped_preserves_source_property_declaration_order_in_ts2353() {
     // Regression test for reverseMappedTypeLimitedConstraint.ts:
     // the excess-property (TS2353) diagnostic must render the inferred

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -617,10 +617,22 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             // inference type params (e.g., A in `{ fn: (a: A) => void; val: B[K] }`).
                             // Constrain those by matching source properties against the
                             // instantiated template for each key.
+                            //
+                            // Exclude the homomorphic type parameter from the var map:
+                            // its candidate has already been produced by reverse inference
+                            // (at HomomorphicMappedType priority). Re-running the property
+                            // inference for that var would let `any`-typed source properties
+                            // propagate `any` into T via `T[K]` placeholders — which, at the
+                            // outer call's higher priority (e.g. NakedTypeVariable), would
+                            // override the structural reverse-mapped candidate. tsc handles
+                            // this by treating reverse inference as the sole inference path
+                            // for the homomorphic parameter; we mirror that here.
                             if has_properties {
+                                let mut other_params_var_map = var_map.clone();
+                                other_params_var_map.remove(&keyof_target);
                                 self.constrain_template_against_properties(
                                     ctx,
-                                    var_map,
+                                    &other_params_var_map,
                                     &source_obj.properties,
                                     &mapped,
                                     priority,


### PR DESCRIPTION
## Summary

Fixes a long-standing bug in homomorphic mapped-type inference: when an
object source has an `any`-typed property, the inferred type parameter
collapses to `any` instead of the structural reverse-mapped object that
`tsc` produces.

## Root cause

`constrain_types_impl` runs reverse-mapped inference for homomorphic
mapped types `{ [K in keyof T]: F<T[K]> }` against object sources, then
calls `constrain_template_against_properties` to pick up *other*
inference parameters in the template (e.g. `A` in
`{ fn: (a: A) => void; val: B[K] }`).

The post-reverse pass kept the homomorphic parameter `T` in `var_map`.
For sources with `any`-typed properties, the call

```rust
constrain_types(any, Deep<T["response"]>, priority)
```

entered the `source == ANY` branch and propagated `any` into `T` via the
`T[K]` placeholder at the *outer* call's priority. The outer priority
was typically `NakedTypeVariable` (1), which beats
`HomomorphicMappedType` (2), so `T` collapsed to `any` and the
structural reverse-mapped candidate was discarded.

## Fix

Clone `var_map` and remove the homomorphic target before
`constrain_template_against_properties`. `tsc` treats reverse inference
as the sole inference path for the homomorphic parameter, and we now
mirror that. Other inference parameters in the template still receive
their candidates via the cloned map.

## Behaviour

```ts
type Deep<T> = { [K in keyof T]: Deep<T[K]> }
declare function foo<T>(deep: Deep<T>): T;
interface XHR { readonly response: any; }
declare let xhr: XHR;
const out = foo(xhr);
//                ^? before: T = any (Deep<any> in error message)
//                   after:  T = { response: unknown } (structural)
```

## Tests

Two new unit tests in
`crates/tsz-checker/tests/reverse_mapped_inference_tests.rs`:

- `reverse_mapped_recursive_any_property_does_not_collapse_t_to_any`:
  single `any`-typed property must keep T structural
  (no `Deep<any>` TS2345).
- `reverse_mapped_recursive_any_property_with_extra_props_keeps_structural_t`:
  mixed `any` + concrete properties; asserts `out.q` is `unknown`
  (TS18046) — proving T did **not** collapse to `any` (which would
  silently type `out.q` as `any`).

Both tests fail without the fix.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo nextest run` (18,654 tests across 94 binaries via the
  `precommit` profile) ✓
- Architecture guardrails ✓
- Conformance net **+7** (8 fixed, 1 stale-baseline flake unrelated to
  this change — `reverseMappedTupleContext.ts` fails identically
  with and without the fix; pre-fix snapshot incorrectly recorded it as
  passing).

## Test plan

- [x] `mappedTypeRecursiveInference.ts` no longer produces `Deep<any>`
      in the TS2345 message; `T` is now inferred structurally.
- [x] Existing `reverse_mapped_*` regression tests still pass.
- [x] Other inference parameters in homomorphic mapped templates still
      receive candidates (no regressions in
      `reverse_mapped_reducer_pattern_no_false_ts2322` etc.).

https://claude.ai/code/session_01CKukHZWyrwjdyF69oUxW7F

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKukHZWyrwjdyF69oUxW7F)_