### PR TITLE
fix(checker): suppress TS2303 for cross-module require() in ambient modules

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -108,6 +108,10 @@ name = "type_alias_typeof_circular_tests"
 path = "tests/type_alias_typeof_circular_tests.rs"
 
 [[test]]
+name = "ts2303_tests"
+path = "tests/ts2303_tests.rs"
+
+[[test]]
 name = "namespace_qualified_diagnostic_tests"
 path = "tests/namespace_qualified_diagnostic_tests.rs"
 

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1132,6 +1132,32 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Walk up from `node_idx` looking for a `MODULE_DECLARATION` whose name is
+    /// a string literal (i.e., `declare module "<specifier>"`). Returns the
+    /// specifier text. Used by TS2303 cycle suppression to compare a
+    /// `require()` target against the enclosing ambient module's name.
+    fn enclosing_ambient_module_specifier(&self, node_idx: NodeIndex) -> Option<String> {
+        use tsz_parser::parser::syntax_kind_ext;
+        let mut current = node_idx;
+        for _ in 0..64 {
+            let ext = self.ctx.arena.get_extended(current)?;
+            let parent = ext.parent;
+            if parent == NodeIndex::NONE || parent == current {
+                return None;
+            }
+            let parent_node = self.ctx.arena.get(parent)?;
+            if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                && let Some(module) = self.ctx.arena.get_module(parent_node)
+                && let Some(name_node) = self.ctx.arena.get(module.name)
+                && let Some(lit) = self.ctx.arena.get_literal(name_node)
+            {
+                return Some(lit.text.to_string());
+            }
+            current = parent;
+        }
+        None
+    }
+
     /// Eagerly checks all alias symbols in the current file for circular definitions.
     /// Emits TS2303 for any alias that circularly references itself.
     pub(crate) fn check_circular_import_aliases(&mut self) {
@@ -1232,7 +1258,43 @@ impl<'a> CheckerState<'a> {
                                     false
                                 }
                             });
-                            if !has_reexport_from {
+                            // `import X = require("m")` inside a different
+                            // ambient module declaration (e.g.
+                            //   declare module "m"      { export = T; }
+                            //   declare module "node:m" { import m = require("m"); export = m; }
+                            // ) names an external module — the alias resolves
+                            // through `m`'s `export = ...`, not back to itself.
+                            // Our binder can spuriously map the alias to itself
+                            // because `m` is both a sibling declared-module
+                            // specifier and an alias name in the same file.
+                            // Suppress only for the cross-module-name case;
+                            // genuine self-imports
+                            //   declare module "moduleC" { import self = require("moduleC"); }
+                            // remain TS2303.
+                            let require_target_differs_from_enclosing_module =
+                                sym.declarations.iter().any(|&decl_idx| {
+                                    let Some(n) = self.ctx.arena.get(decl_idx) else {
+                                        return false;
+                                    };
+                                    if n.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+                                        return false;
+                                    }
+                                    let Some(imp) = self.ctx.arena.get_import_decl(n) else {
+                                        return false;
+                                    };
+                                    let Some(target) =
+                                        self.get_require_module_specifier(imp.module_specifier)
+                                    else {
+                                        return false;
+                                    };
+                                    let Some(enclosing) =
+                                        self.enclosing_ambient_module_specifier(decl_idx)
+                                    else {
+                                        return false;
+                                    };
+                                    target != enclosing
+                                });
+                            if !has_reexport_from && !require_target_differs_from_enclosing_module {
                                 cycle_detected = true;
                             }
                         } else {

--- a/crates/tsz-checker/tests/ts2303_tests.rs
+++ b/crates/tsz-checker/tests/ts2303_tests.rs
@@ -84,6 +84,24 @@ declare module "node:events" {
 }
 
 #[test]
+fn ambient_require_alias_self_import_still_reports_ts2303() {
+    // `declare module "moduleC" { import self = require("moduleC"); ... }` —
+    // the require target equals the enclosing ambient module's specifier, so
+    // the alias really is self-referential. tsc emits TS2303; we must too.
+    let source = r#"
+declare module "moduleC" {
+    import self = require("moduleC");
+    export = self;
+}
+"#;
+    let diagnostics = get_diagnostics(source, "self.d.ts");
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2303),
+        "Expected TS2303 for `import self = require(\"moduleC\")` inside `declare module \"moduleC\"`. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn export_equals_global_augmentation_namespace_cycle_reports_ts2303_not_ts2686() {
     let source = r#"
 declare global { namespace N {} }


### PR DESCRIPTION
## Summary

`declare module "node:events" { import events = require("events"); ... }` is a common pattern in lib type definitions: the inner ambient module re-exports an external module (`"events"`) by aliasing its `export = ...` value. tsc accepts this without diagnostics; tsz emitted **TS2303 "Circular definition of import alias"** because the binder's resolution for `events` returned the alias to itself when the alias name happened to match a sibling declared-module specifier in the same file.

## Root cause

`check_circular_import_aliases` walks alias targets and flags one-step self-cycles as TS2303. For cross-file re-export specifiers it has an existing carve-out (the `EXPORT_SPECIFIER from "..."` check). But for `import X = require("m")` aliases inside ambient module bodies, the binder spuriously produces an immediate self-resolution because the alias name and a sibling declared-module specifier collide in the same file's symbol table — and there was no carve-out for require-form aliases.

## Fix

When a one-step self-cycle is detected on a `import X = require("m")` declaration, compare the require target against the enclosing `declare module "..."` specifier (via a small AST walk to the enclosing `MODULE_DECLARATION`). If they differ, the alias targets a real external module and is not circular — suppress the report. Genuine self-imports (`declare module "moduleC" { import self = require("moduleC"); ... }`) keep emitting TS2303 because target == enclosing.

```ts
declare module "events" {
    class EventEmitter { ... }
    export = EventEmitter;
}
declare module "node:events" {
    import events = require("events");   // not circular — different module
    export = events;
}

declare module "moduleC" {
    import self = require("moduleC");    // still TS2303
    export = self;
}
```

## Test plan

- [x] New helper `enclosing_ambient_module_specifier` walks `MODULE_DECLARATION` parents and returns the string-literal specifier text.
- [x] `ts2303_tests` already had the negative case; added a positive case (`ambient_require_alias_self_import_still_reports_ts2303`) so we lock both directions.
- [x] Targeted conformance: `isolatedModulesReExportAlias.ts` now passes; `recursiveExportAssignmentAndFindAliasedType{1,4}.ts` continue to pass.
- [x] Full conformance: 12129 → 12132 (+3, no regressions).
- [x] Pre-commit: 20245 unit tests pass.