### PR TITLE
fix(parser): route `import defer type *` to import-declaration, not import-equals

### DIFF
--- a/crates/tsz-parser/src/parser/parse_rules/utils.rs
+++ b/crates/tsz-parser/src/parser/parse_rules/utils.rs
@@ -182,6 +182,19 @@ pub fn look_ahead_is_import_equals(
         }
         // `import type/defer <identifier> ...` where identifier is not `from`
         if is_identifier_fn(next2) {
+            // `import defer type ...` is a modifier conflict that tsc parses as
+            // an import-declaration (with `defer` as modifier, `type` as the
+            // default-import name, then expects `from` at the next significant
+            // token). Without this guard, `defer type *` erroneously routes to
+            // the import-equals path and emits `'=' expected` at the `type`
+            // keyword instead of `'from' expected` at the `*`. The reverse
+            // ordering `import type defer *` is intentionally NOT short-
+            // circuited — tsc treats `type` as a modifier and `defer` as the
+            // import name, then routes through the import-equals lookahead.
+            if next1 == SyntaxKind::DeferKeyword && next2 == SyntaxKind::TypeKeyword {
+                scanner.restore_state(snapshot);
+                return false;
+            }
             let next3 = scanner.scan();
             scanner.restore_state(snapshot);
             if next3 == SyntaxKind::EqualsToken {

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -2490,6 +2490,14 @@ impl ParserState {
             {
                 // `import defer * ...` or `import defer { ... }` — defer is modifier
                 is_deferred = true;
+            } else if self.is_token(SyntaxKind::TypeKeyword) {
+                // `import defer type ...` — modifier conflict. tsc treats `defer`
+                // as the deferred modifier and `type` as the default-import name
+                // (a contextual keyword used as an identifier). The cursor stays
+                // at `type` so the existing default-name parser handles it; the
+                // `from` diagnostic then anchors at the next significant token
+                // (e.g. the `*` at column 19) rather than at `type` itself.
+                is_deferred = true;
             } else if self.is_identifier_or_keyword() && !self.is_token(SyntaxKind::TypeKeyword) {
                 // Could be `import defer foo from` (modifier + name)
                 // or `import defer from '...'` (defer is name).

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -2864,6 +2864,41 @@ fn test_import_defer_from_as_name_not_deferred() {
 }
 
 #[test]
+fn test_import_defer_type_modifier_conflict_anchors_from_at_namespace_token() {
+    // `import defer type * as ns from "./a"` is illegal (defer + type modifier
+    // conflict) but tsc still parses it as: `defer` modifier, `type` as the
+    // default-import name (contextual keyword), then expects `from`. The
+    // resulting `'from' expected` diagnostic anchors at the `*` (column 19),
+    // not at the `type` keyword (column 14) or with an incorrect `'='
+    // expected` from the import-equals lookahead path.
+    let source = r#"import defer type * as ns from "./a";"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let ts1005: Vec<_> = diagnostics.iter().filter(|d| d.code == 1005).collect();
+    assert!(
+        !ts1005.is_empty(),
+        "Expected at least one TS1005 for `import defer type *`, got {diagnostics:?}"
+    );
+    // No `'=' expected.` (would be the import-equals lookahead misroute).
+    assert!(
+        !ts1005.iter().any(|d| d.message.contains("'=' expected")),
+        "Should not emit `'=' expected.` for `import defer type *`: {ts1005:?}"
+    );
+    // The `'from' expected.` should anchor at column 19 (the `*`), 0-indexed
+    // start = 18.
+    let from_expected: Vec<_> = ts1005
+        .iter()
+        .filter(|d| d.message.contains("'from' expected"))
+        .collect();
+    assert!(
+        from_expected.iter().any(|d| d.start == 18),
+        "Expected `'from' expected.` anchored at column 19 (start=18), got {from_expected:?}"
+    );
+}
+
+#[test]
 fn test_regex_named_capturing_groups_do_not_emit_unexpected_paren() {
     let source = r#"const re = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u;"#;
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());


### PR DESCRIPTION
## Summary

Fixes `importDeferTypeConflict2.ts` (PASSES after this PR) plus three other tests as net improvements: `isolatedModulesReExportAlias.ts`, `tsxElementResolution11.tsx`, `directDependenceBetweenTypeAliases.ts`.

`tsc` parses `import defer type * as ns from "./a"` as: `defer` modifier, `type` as the default-import name (a contextual keyword used as identifier), then expects `from` at the next token — emitting `'from' expected.` at the `*` (column 19).

`tsz` was routing this through `look_ahead_is_import_equals` because after `defer` and `type`, the third token (`*`) is not `,`/`from`/`=`, which the heuristic interpreted as "this could be an import-equals". The import-equals path then emitted the wrong fingerprint: `'=' expected.` at the `type` keyword (column 14) and a cascading `';' expected.`.

Two coupled fixes:

1. **`look_ahead_is_import_equals`** (`crates/tsz-parser/src/parser/parse_rules/utils.rs`): when the keyword sequence is specifically `defer type`, return false. The reverse `type defer` intentionally still routes to import-equals so the existing `parse_import_type_defer_star_matches_tsc_recovery` test stays green — `tsc` distinguishes the two orderings.
2. **`parse_import_clause`** (`crates/tsz-parser/src/parser/state_declarations.rs`): when `defer` is followed by `type`, set `is_deferred=true` and leave the cursor at `type` so the default-name parser consumes it. The `from` diagnostic then anchors at the next significant token (the `*` at column 19), matching `tsc`.

```ts
import defer type * as ns1 from "./a"; // tsc: TS1005 'from' expected. at col 19
```

## Test plan

- [x] `cargo nextest run -p tsz-parser --lib` (558 tests pass, including the prior `parse_import_type_defer_star_matches_tsc_recovery` reverse-ordering case)
- [x] `cargo nextest run -p tsz-checker --lib` (2744 tests pass)
- [x] `cargo nextest run -p tsz-solver --lib` (5306 tests pass)
- [x] New parser test: `test_import_defer_type_modifier_conflict_anchors_from_at_namespace_token`
- [x] `./scripts/conformance/conformance.sh run --filter importDeferTypeConflict2 --verbose` — PASS 1/1
- [x] `scripts/session/verify-all.sh --quick` — fmt ✓, clippy ✓, unit tests ✓, **conformance +4** (12133 vs 12129 baseline), no regressions

## Improvements (FAIL -> PASS)

- `TypeScript/tests/cases/conformance/importDefer/importDeferTypeConflict2.ts` (target)
- `TypeScript/tests/cases/compiler/isolatedModulesReExportAlias.ts`
- `TypeScript/tests/cases/conformance/jsx/tsxElementResolution11.tsx`
- `TypeScript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`