### PR TITLE
fix(checker): emit TS2353 for empty destructuring-assignment patterns

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -928,6 +928,17 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|n| n.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
                 if is_direct_literal {
                     self.check_object_literal_excess_properties(right_type, left_type, right_idx);
+                    // tsc treats `({ } = { x: 0, y: 0 })` (destructuring assignment
+                    // with an empty pattern) as a strict excess-property check,
+                    // unlike `var { } = …` which silently accepts. The shared
+                    // excess-property helper bails on empty targets because `{}` is
+                    // wide for normal assignability; the destructuring-assignment
+                    // semantic is narrower and every source property is excess.
+                    if is_destructuring && !is_array_destructuring {
+                        self.check_destructuring_assignment_empty_pattern_excess(
+                            left_idx, right_type, right_idx,
+                        );
+                    }
                 } else if crate::query_boundaries::common::is_fresh_object_type(
                     self.ctx.types,
                     right_type,
@@ -946,6 +957,53 @@ impl<'a> CheckerState<'a> {
         }
 
         right_type
+    }
+
+    /// Emit TS2353 for every property on the RHS object literal when the
+    /// destructuring assignment LHS pattern is empty (`({} = …)`). The shared
+    /// excess-property helper bails on empty targets because `{}` is wide for
+    /// normal assignability, but tsc applies a strict check for the empty
+    /// destructuring pattern: every source property is excess. Patterns with
+    /// at least one named binding (or a rest element) flow through the regular
+    /// excess path and this helper is a no-op for them.
+    pub(crate) fn check_destructuring_assignment_empty_pattern_excess(
+        &mut self,
+        left_idx: NodeIndex,
+        right_type: TypeId,
+        right_idx: NodeIndex,
+    ) {
+        let Some(left_node) = self.ctx.arena.get(left_idx) else {
+            return;
+        };
+        if left_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return;
+        }
+        let Some(pattern) = self.ctx.arena.get_literal_expr(left_node) else {
+            return;
+        };
+        // Only the empty-pattern case — non-empty patterns are handled by the
+        // standard excess-property loop against the inferred pattern type.
+        if !pattern.elements.nodes.is_empty() {
+            return;
+        }
+        let Some(source_shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, right_type)
+        else {
+            return;
+        };
+        // Build the empty target type once for diagnostic reuse.
+        let empty_target = self.ctx.types.factory().object(Vec::new());
+        let source_props: Vec<_> = source_shape.properties.to_vec();
+        for source_prop in source_props {
+            let report_idx = self
+                .find_object_literal_property_element(right_idx, source_prop.name)
+                .unwrap_or(right_idx);
+            let prop_name = self.object_literal_property_display_name(
+                report_idx,
+                self.ctx.types.resolve_atom(source_prop.name).as_ref(),
+            );
+            self.error_excess_property_at(&prop_name, empty_target, report_idx);
+        }
     }
 
     /// Walk through the RHS of an assignment to find the underlying object literal.

--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -1395,3 +1395,53 @@ fn import_meta_property_assignment_is_valid() {
         diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }
+
+/// `({ } = { x: 0, y: 0 })` is a destructuring assignment with an empty
+/// pattern. tsc treats every property on the RHS as excess and emits TS2353
+/// for each, even though the empty `{}` target is normally treated as wide
+/// for assignability. The variable-declaration form `var { } = { x: 0, y: 0 };`
+/// stays silent — only the assignment-expression shape gets the strict check.
+#[test]
+fn destructuring_assignment_empty_pattern_emits_ts2353_for_each_excess_property() {
+    let diags = diagnostics_for(
+        r#"
+function f() {
+    ({ } = { x: 0, y: 0 });
+}
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        2,
+        "expected exactly two TS2353 (one per RHS property) for empty destructuring pattern; got: {ts2353:?}"
+    );
+    assert!(
+        ts2353.iter().any(|d| d.message_text.contains("'x'")),
+        "expected TS2353 for property 'x', got: {ts2353:?}"
+    );
+    assert!(
+        ts2353.iter().any(|d| d.message_text.contains("'y'")),
+        "expected TS2353 for property 'y', got: {ts2353:?}"
+    );
+}
+
+/// `var { } = { x: 0, y: 0 };` (declaration form) must NOT emit TS2353 for
+/// excess properties. tsc only applies the strict empty-pattern check to
+/// destructuring assignments, not declarations — verifying the new check is
+/// scoped correctly to the assignment path.
+#[test]
+fn destructuring_declaration_empty_pattern_does_not_emit_ts2353() {
+    let diags = diagnostics_for(
+        r#"
+function f() {
+    var { } = { x: 0, y: 0 };
+}
+"#,
+    );
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+    assert!(
+        ts2353.is_empty(),
+        "destructuring declaration with empty pattern must not emit TS2353; got: {ts2353:?}"
+    );
+}

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1587,7 +1587,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Find the property element node in an object literal by interned property name.
-    fn find_object_literal_property_element(
+    pub(crate) fn find_object_literal_property_element(
         &self,
         obj_literal_idx: NodeIndex,
         prop_name: tsz_common::interner::Atom,
@@ -1618,7 +1618,7 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    fn object_literal_property_display_name(
+    pub(crate) fn object_literal_property_display_name(
         &self,
         elem_idx: NodeIndex,
         fallback_name: &str,


### PR DESCRIPTION
## Summary

Fixes `missingAndExcessProperties.ts` (PASSES after this PR) plus three other tests as net improvements: `isolatedModulesReExportAlias.ts`, `tsxElementResolution11.tsx`, `directDependenceBetweenTypeAliases.ts`.

`tsc` treats `({ } = { x: 0, y: 0 })` as a strict excess-property check: every property on the RHS object literal is excess against the empty pattern, so it emits `TS2353` once per property. The variable-declaration form `var { } = { x: 0, y: 0 };` stays silent — only the assignment-expression shape gets the strict check.

`check_object_literal_excess_properties` bails on empty `{}` targets because the empty object is wide for normal assignability (line 727 of `state_checking/property.rs`), so the existing destructuring-assignment call site never fired for the empty-pattern case.

The fix adds a small helper `check_destructuring_assignment_empty_pattern_excess` that runs after the standard call and emits TS2353 for every source property when the LHS is an empty object pattern. Patterns with at least one binding already flow through the standard excess loop against their inferred target type, so the helper is a no-op for them.

Two private helpers in `state_checking/property.rs` (`find_object_literal_property_element`, `object_literal_property_display_name`) were widened to `pub(crate)` so the new helper can produce the same anchor + display behaviour as the rest of the excess-property pipeline.

```ts
function f4() {
    var x: number, y: number;
    ({ } = { x: 0, y: 0 }); // tsc: TS2353 'x' and TS2353 'y' (column 14, column 20)
}
```

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` (2746 tests pass)
- [x] `cargo nextest run -p tsz-solver --lib` (5307 tests pass)
- [x] New checker tests: `destructuring_assignment_empty_pattern_emits_ts2353_for_each_excess_property` (positive) and `destructuring_declaration_empty_pattern_does_not_emit_ts2353` (negative — confirms the fix is scoped to the assignment expression and doesn't change declaration behaviour)
- [x] `./scripts/conformance/conformance.sh run --filter missingAndExcessProperties --verbose` — PASS 1/1
- [x] `scripts/session/verify-all.sh --quick` — fmt ✓, clippy ✓, unit tests ✓, **conformance +4** (12133 vs 12129 baseline), no regressions

## Improvements (FAIL -> PASS)

- `TypeScript/tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts` (target)
- `TypeScript/tests/cases/compiler/isolatedModulesReExportAlias.ts`
- `TypeScript/tests/cases/conformance/jsx/tsxElementResolution11.tsx`
- `TypeScript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`