### PR TITLE
fix(checker): preserve enum-member widening in pair disambiguation

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -136,6 +136,10 @@ name = "ts2322_literal_source_display_tests"
 path = "tests/ts2322_literal_source_display_tests.rs"
 
 [[test]]
+name = "ts2322_pair_disambiguation_widening_tests"
+path = "tests/ts2322_pair_disambiguation_widening_tests.rs"
+
+[[test]]
 name = "spread_rest_tests"
 path = "tests/spread_rest_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -774,6 +774,20 @@ impl<'a> CheckerState<'a> {
             return (source_candidate, target_candidate);
         }
 
+        // Enum-member → enum-type widening: upstream produces `W` while the
+        // disambiguator regenerates `W.a`.  When the upstream `source_display`
+        // is exactly the dotted *parent* of `pair_source` (i.e. `pair_source`
+        // is `<source_display>.<member>`), the disambiguator is undoing
+        // upstream's deliberate widening.  Cross-package symlink
+        // disambiguation is unaffected because there `pair_source` matches
+        // `source_display` (no parent-of relationship triggered).
+        let pair_source_parent = pair_source
+            .rsplit_once('.')
+            .map(|(parent, _)| parent.trim_end());
+        if pair_source_parent == Some(source_display.as_str()) && source_display != target_display {
+            return (source_display, target_display);
+        }
+
         (pair_source, pair_target)
     }
 

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -5,4 +5,5 @@
 //! over direct `TypeInterner` access. Test code may use the re-exported
 //! `TypeInterner` type for scaffolding.
 
+#[cfg(test)]
 pub(crate) use tsz_solver::TypeInterner;

--- a/crates/tsz-checker/tests/ts2322_pair_disambiguation_widening_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_pair_disambiguation_widening_tests.rs
@@ -1,0 +1,85 @@
+//! Lock in `finalize_pair_display_for_diagnostic` preserving upstream-widened
+//! source displays when the pair is already distinguishable.
+//!
+//! Regression: assigning `W.a` to `typeof W` reported
+//! `Type 'W.a' is not assignable to type 'typeof W'.` even though
+//! `format_assignment_source_type_for_diagnostic` correctly widened the
+//! enum-member source to the enum type `W`. The disambiguator unconditionally
+//! re-formatted from the raw `W.a` TypeId and clobbered the widened display.
+
+use tsz_binder::BinderState;
+use tsz_checker::CheckerState;
+use tsz_checker::context::CheckerOptions;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn diagnostic_messages(source: &str) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+#[test]
+fn ts2322_enum_member_to_typeof_enum_keeps_widened_source_display() {
+    let src = r#"
+enum W { a, b, c }
+declare var b: typeof W;
+b = W.a;
+"#;
+    let diagnostics = diagnostic_messages(src);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .expect("expected TS2322 for `b = W.a`");
+    assert!(
+        ts2322.1.contains("Type 'W'"),
+        "TS2322 should display the widened enum source `W`, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322.1.contains("Type 'W.a'"),
+        "TS2322 must not re-qualify the widened source back to `W.a`, got: {ts2322:?}"
+    );
+}
+
+#[test]
+fn ts2322_enum_member_to_wstatic_keeps_widened_source_display() {
+    let src = r#"
+enum W { a, b, c }
+namespace W { export class D {} }
+interface WStatic { a: W; b: W; c: W }
+declare var f: WStatic;
+f = W.a;
+"#;
+    let diagnostics = diagnostic_messages(src);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .expect("expected TS2322 for `f = W.a`");
+    assert!(
+        ts2322.1.contains("Type 'W'"),
+        "TS2322 should display source as widened `W`, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322.1.contains("Type 'W.a'"),
+        "TS2322 must not re-qualify the widened source, got: {ts2322:?}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -440,7 +440,9 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         match name_node.kind {
-            k if k == SyntaxKind::Identifier as u16 => self.should_emit_public_api_dependency(name_idx),
+            k if k == SyntaxKind::Identifier as u16 => {
+                self.should_emit_public_api_dependency(name_idx)
+            }
             k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
                 || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
             {


### PR DESCRIPTION
## Summary

`finalize_pair_display_for_diagnostic` was clobbering upstream enum-member→enum-type widening. When `format_assignment_source_type_for_diagnostic` correctly widened a source like `W.a` to `W` for a TS2322 diagnostic, the disambiguator unconditionally re-formatted from the raw `W.a` TypeId, producing `Type 'W.a' is not assignable to type 'typeof W'.` instead of `Type 'W' is not assignable to type 'typeof W'.`.

The fix detects when `pair_source` is exactly `<source_display>.<member>` (i.e. the parent of the dotted form matches the upstream-widened display). In that case the disambiguator is reversing deliberate widening, so we preserve the upstream displays.

Cross-package symlink disambiguation is unaffected: in those cases `pair_source` already matches `source_display`, so the parent-of relationship doesn't trigger.

## Test plan

- [x] New unit tests `ts2322_pair_disambiguation_widening_tests` cover both `typeof W` and `WStatic`-shaped targets
- [x] Existing 140 TS2322 tests still pass
- [x] No regressions on cross-package symlink disambiguation tests