### PR TITLE
fix(checker): emit only one TS2353 per object literal in source order

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -99,6 +99,38 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Track the earliest source-order candidate; pair with
+    /// [`emit_tracked_excess_property`] to emit one TS2353 per literal.
+    fn track_earliest_excess(
+        &self,
+        current: &mut Option<(Atom, NodeIndex, u32)>,
+        name: Atom,
+        report_idx: NodeIndex,
+    ) {
+        let pos = self.ctx.arena.get(report_idx).map_or(u32::MAX, |n| n.pos);
+        if current.is_none_or(|(_, _, best)| pos < best) {
+            *current = Some((name, report_idx, pos));
+        }
+    }
+
+    /// Emit the single TS2353 + implicit-any check for the earliest excess
+    /// property recorded by [`track_earliest_excess`]. No-op when no excess
+    /// was recorded.
+    fn emit_tracked_excess_property(
+        &mut self,
+        tracked: Option<(Atom, NodeIndex, u32)>,
+        target: TypeId,
+    ) {
+        if let Some((prop_atom, report_idx, _)) = tracked {
+            let prop_name = self.object_literal_property_display_name(
+                report_idx,
+                self.ctx.types.resolve_atom(prop_atom).as_ref(),
+            );
+            self.error_excess_property_at(&prop_name, target, report_idx);
+            self.check_excess_property_initializer_implicit_any(report_idx, target);
+        }
+    }
+
     fn nested_property_target_type(
         &mut self,
         owner_type: TypeId,
@@ -208,23 +240,15 @@ impl<'a> CheckerState<'a> {
                 let report_idx = self
                     .find_object_literal_property_element(idx, source_prop.name)
                     .unwrap_or(idx);
-                let pos = self
-                    .ctx
-                    .arena
-                    .get(report_idx)
-                    .map_or(u32::MAX, |node| node.pos);
-                if generic_mapped_excess.is_none_or(|(_, _, best_pos)| pos < best_pos) {
-                    generic_mapped_excess = Some((source_prop.name, report_idx, pos));
-                }
+                self.track_earliest_excess(
+                    &mut generic_mapped_excess,
+                    source_prop.name,
+                    report_idx,
+                );
             }
         }
-        if let Some((prop_name_atom, report_idx, _)) = generic_mapped_excess {
-            let prop_name = self.object_literal_property_display_name(
-                report_idx,
-                self.ctx.types.resolve_atom(prop_name_atom).as_ref(),
-            );
-            self.error_excess_property_at(&prop_name, target, report_idx);
-            self.check_excess_property_initializer_implicit_any(report_idx, target);
+        if generic_mapped_excess.is_some() {
+            self.emit_tracked_excess_property(generic_mapped_excess, target);
             return;
         }
 
@@ -375,6 +399,8 @@ impl<'a> CheckerState<'a> {
                 discriminant_shapes
             };
 
+            // First excess by source order (see `track_earliest_excess`).
+            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
             for source_prop in source_props {
                 if explicit_property_names.is_some()
                     && !explicit_property_names
@@ -407,12 +433,7 @@ impl<'a> CheckerState<'a> {
                     let report_idx = self
                         .find_object_literal_property_element(idx, source_prop.name)
                         .unwrap_or(idx);
-                    let prop_name = self.object_literal_property_display_name(
-                        report_idx,
-                        self.ctx.types.resolve_atom(source_prop.name).as_ref(),
-                    );
-                    self.error_excess_property_at(&prop_name, target, report_idx);
-                    self.check_excess_property_initializer_implicit_any(report_idx, target);
+                    self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
                 } else {
                     // =============================================================
                     // NESTED OBJECT LITERAL EXCESS PROPERTY CHECKING
@@ -459,6 +480,7 @@ impl<'a> CheckerState<'a> {
                     );
                 }
             }
+            self.emit_tracked_excess_property(first_excess, target);
             return;
         }
 
@@ -523,6 +545,8 @@ impl<'a> CheckerState<'a> {
                 return;
             }
 
+            // First excess by source order (see `track_earliest_excess`).
+            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
             for source_prop in source_props {
                 if explicit_property_names.is_some()
                     && !explicit_property_names
@@ -572,12 +596,7 @@ impl<'a> CheckerState<'a> {
                     let report_idx = self
                         .find_object_literal_property_element(idx, source_prop.name)
                         .unwrap_or(idx);
-                    let prop_name = self.object_literal_property_display_name(
-                        report_idx,
-                        self.ctx.types.resolve_atom(source_prop.name).as_ref(),
-                    );
-                    self.error_excess_property_at(&prop_name, target, report_idx);
-                    self.check_excess_property_initializer_implicit_any(report_idx, target);
+                    self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
                 } else {
                     // Combine named property types with index signature value types
                     // for the nested excess check. This ensures that for intersections
@@ -604,10 +623,13 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+            self.emit_tracked_excess_property(first_excess, target);
             return;
         }
 
         if crate::query_boundaries::common::is_mapped_type(self.ctx.types, effective_target) {
+            // First excess by source order (see `track_earliest_excess`).
+            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
             for source_prop in source_props {
                 if explicit_property_names.is_some()
                     && !explicit_property_names
@@ -640,16 +662,12 @@ impl<'a> CheckerState<'a> {
                         let report_idx = self
                             .find_object_literal_property_element(idx, source_prop.name)
                             .unwrap_or(idx);
-                        let prop_name = self.object_literal_property_display_name(
-                            report_idx,
-                            self.ctx.types.resolve_atom(source_prop.name).as_ref(),
-                        );
-                        self.error_excess_property_at(&prop_name, target, report_idx);
-                        self.check_excess_property_initializer_implicit_any(report_idx, target);
+                        self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
                     }
                     _ => return,
                 }
             }
+            self.emit_tracked_excess_property(first_excess, target);
             return;
         }
 
@@ -726,7 +744,8 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // Report excess properties identified by the boundary, then check nested.
+            // First excess by source order (see `track_earliest_excess`).
+            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
             for source_prop in source_props {
                 if explicit_property_names.is_some()
                     && !explicit_property_names
@@ -782,12 +801,7 @@ impl<'a> CheckerState<'a> {
                     let report_idx = self
                         .find_object_literal_property_element(idx, source_prop.name)
                         .unwrap_or(idx);
-                    let prop_name = self.object_literal_property_display_name(
-                        report_idx,
-                        self.ctx.types.resolve_atom(source_prop.name).as_ref(),
-                    );
-                    self.error_excess_property_at(&prop_name, target, report_idx);
-                    self.check_excess_property_initializer_implicit_any(report_idx, target);
+                    self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
                 } else {
                     // Property exists in target — check nested object literals.
                     let target_prop_type = target_props
@@ -808,6 +822,14 @@ impl<'a> CheckerState<'a> {
                         );
                     }
                 }
+            }
+            if let Some((prop_name_atom, report_idx, _)) = first_excess {
+                let prop_name = self.object_literal_property_display_name(
+                    report_idx,
+                    self.ctx.types.resolve_atom(prop_name_atom).as_ref(),
+                );
+                self.error_excess_property_at(&prop_name, target, report_idx);
+                self.check_excess_property_initializer_implicit_any(report_idx, target);
             }
         }
         // Note: Missing property checks are handled by solver's explain_failure

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -783,3 +783,81 @@ x = { y: { a: 0, b: 0, c: 0 } };
         "Expected TS2353 for excess property 'c' against {{a: 0}} & {{b: 0}}, got: {relevant:?}"
     );
 }
+
+#[test]
+fn simple_object_literal_with_three_excess_properties_reports_only_first() {
+    // tsc reports only the first excess property in source order per object
+    // literal — even when several properties are excess. Repro from
+    // conformance test destructuringParameterProperties5.ts:
+    // `{ x1: 10, x2: "", x3: true }` against `{ x: number; y: string; z: boolean }`
+    // should produce exactly one TS2353 (for 'x1'), not three.
+    let source = r#"
+type ObjType1 = { x: number; y: string; z: boolean };
+let v: ObjType1 = { x1: 10, x2: "", x3: true };
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 for the first excess property, got {} ({:?})",
+        ts2353.len(),
+        diags
+    );
+    let msg = &ts2353[0].1;
+    assert!(
+        msg.contains("'x1'"),
+        "Expected the first excess property 'x1' to be reported, got: {msg}"
+    );
+}
+
+#[test]
+fn union_target_multiple_excess_properties_reports_only_first() {
+    // For a non-discriminated union target where multiple source properties
+    // are missing from every union member, tsc still reports only the first.
+    let source = r#"
+type A = { x: number; y: number };
+type B = { x: number; z: string };
+type AB = A | B;
+let v: AB = { x: 1, foo: 1, bar: 2, baz: 3 };
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 across union excess checks, got {} ({:?})",
+        ts2353.len(),
+        diags
+    );
+    let msg = &ts2353[0].1;
+    assert!(
+        msg.contains("'foo'"),
+        "Expected the first excess property 'foo' (earliest in source) to be reported, got: {msg}"
+    );
+}
+
+#[test]
+fn intersection_target_multiple_excess_properties_reports_only_first() {
+    // tsc emits a single TS2353 for the first excess property when several
+    // properties miss every member of an intersection target.
+    let source = r#"
+interface A { a: number }
+interface B { b: number }
+let v: A & B = { a: 1, b: 2, foo: 1, bar: 2 };
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353: Vec<_> = diags.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 for intersection excess, got {} ({:?})",
+        ts2353.len(),
+        diags
+    );
+    let msg = &ts2353[0].1;
+    assert!(
+        msg.contains("'foo'"),
+        "Expected the first excess property 'foo' to be reported, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

`tsc` reports a **single** TS2353 (excess property) error per object literal — anchored at the first excess property in source order. `tsz` was emitting **one TS2353 per excess property** in four checker paths (union, intersection, mapped, simple object targets), even though the discriminated-union and generic-mapped paths already followed the "track earliest, emit once after the loop" pattern.

This caused fingerprint-only failures on conformance tests where a single object literal has multiple excess properties — e.g. `destructuringParameterProperties5.ts` produced 3 TS2353s where `tsc` produces 1.

## Root cause and fix

In `crates/tsz-checker/src/state/state_checking/property.rs`, the four offending paths emitted `error_excess_property_at` *inside* the iteration over source properties. They now follow the same "track earliest by source position, emit once after the loop" pattern that already existed at the generic-mapped and discriminated-union paths.

Two small helpers were extracted (`track_earliest_excess` and `emit_tracked_excess_property`); the generic-mapped path now also reuses them so the fix doesn't duplicate logic. Non-excess branches still recurse into nested object literals so nested-literal excess checks remain intact.

## Repro

```ts
type ObjType1 = { x: number; y: string; z: boolean };
let v: ObjType1 = { x1: 10, x2: "", x3: true };
//                  ~~ TS2353 ('x1' does not exist in 'ObjType1')
//                          ^^ ^^ no longer reported (matches tsc)
```

`tsc` baseline: 1 TS2353 (for `x1`).
`tsz` before: 3 TS2353s (`x1`, `x2`, `x3`).
`tsz` after: 1 TS2353 (`x1`) — matches tsc.

## Conformance impact

| | baseline | after |
|---|---:|---:|
| passing | 12 129 | **12 140 (+11)** |

11 tests flipped FAIL → PASS (full breakdown in `verify-all.sh` output):
- `enumAssignmentCompat.ts`, `enumAssignmentCompat2.ts`, `enumAssignmentCompat5.ts`
- `isolatedModulesReExportAlias.ts`
- `typeRootsFromNodeModulesInParentDirectory.ts`
- `missingAndExcessProperties.ts`
- `importDeferTypeConflict2.ts`
- `tsxElementResolution11.tsx`
- `validEnumAssignments.ts`
- `directDependenceBetweenTypeAliases.ts`
- `enumAssignability.ts`

The picked target `destructuringParameterProperties5.ts` still fails because of an unrelated parameter-property-with-binding-pattern issue (8 missing TS2339 fingerprints) — the TS2353 over-reporting is fully resolved on this test, and `extra-fingerprints` for that test went from 2 to 0.

## Test plan
- [x] `cargo test --package tsz-checker --test ts2353_tests` (28 existing + 3 new tests → 31 / 31 pass)
- [x] `cargo test --package tsz-checker` (full crate)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Architecture guardrail (`property.rs` 1998 LOC, under the 2000 limit)
- [x] `verify-all.sh`: formatting ✓, clippy ✓, conformance ✓ (+11)
- [x] Targeted: `./scripts/conformance/conformance.sh run --filter destructuringParameterProperties5 --verbose` shows extra TS2353 fingerprints went from 2 to 0
- [x] `./scripts/conformance/conformance.sh run --filter excessProperty` shows 9/11 unchanged (2 pre-existing failures unrelated to this change)

https://claude.ai/code/session_01VX5iZwusnkYWpMfx3w7F57

---
_Generated by [Claude Code](https://claude.ai/code/session_01VX5iZwusnkYWpMfx3w7F57)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
