### PR TITLE
chore(emitter/tests): add parse helpers in module_commonjs_tests; remove boilerplate

### DIFF
--- a/crates/tsz-emitter/tests/module_commonjs_tests.rs
+++ b/crates/tsz-emitter/tests/module_commonjs_tests.rs
@@ -4,6 +4,28 @@ use crate::transforms::module_commonjs::*;
 use crate::transforms::module_commonjs_ir::CommonJsTransformContext;
 use tsz_parser::parser::ParserState;
 
+fn parse_collect_exports(source: &str) -> Vec<String> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let source_file = parser
+        .arena
+        .get_source_file(parser.arena.get(root).expect("root node must exist"))
+        .expect("source file must exist");
+    collect_export_names(&parser.arena, &source_file.statements.nodes)
+}
+
+fn parse_transform_cjs(source: &str) -> Vec<IRNode> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let root_node = parser.arena.get(root).expect("root node must exist");
+    let source_file = parser
+        .arena
+        .get_source_file(root_node)
+        .expect("source file must exist");
+    let mut transform = CommonJsTransformContext::new(&parser.arena);
+    transform.transform_source_file(&source_file.statements.nodes)
+}
+
 #[test]
 fn test_sanitize_module_name() {
     // tsc uses the last path segment of the module specifier
@@ -68,7 +90,6 @@ fn test_emit_reexport_property_alias() {
 
 #[test]
 fn test_get_import_bindings_default_import_uses_default_property() {
-    use tsz_parser::parser::ParserState;
     use tsz_parser::parser::syntax_kind_ext;
 
     let source = "import foo from \"./module\";";
@@ -100,7 +121,6 @@ fn test_get_import_bindings_default_import_uses_default_property() {
 
 #[test]
 fn test_namespace_import_without_es_module_interop() {
-    use tsz_parser::parser::ParserState;
     use tsz_parser::parser::syntax_kind_ext;
 
     let source = r#"import * as ns from "./module";"#;
@@ -139,23 +159,7 @@ fn test_namespace_import_without_es_module_interop() {
 
 #[test]
 fn test_collect_export_names_with_parsed_ast() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export class C {}";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export class C {}");
     assert!(
         !export_names.is_empty(),
         "Expected to find exported class name"
@@ -169,23 +173,7 @@ fn test_collect_export_names_with_parsed_ast() {
 
 #[test]
 fn test_collect_export_names_with_destructuring() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export const { a, b: c } = obj;";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export const { a, b: c } = obj;");
     assert_eq!(
         export_names,
         vec!["a", "c"],
@@ -195,23 +183,7 @@ fn test_collect_export_names_with_destructuring() {
 
 #[test]
 fn test_collect_export_names_with_default_export() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export default function () {}";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export default function () {}");
     assert!(
         export_names.is_empty(),
         "Default exports should not be in void 0 initialization list"
@@ -220,23 +192,7 @@ fn test_collect_export_names_with_default_export() {
 
 #[test]
 fn test_collect_export_names_with_default_class_export() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export default class Foo {}";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export default class Foo {}");
     assert!(
         export_names.is_empty(),
         "Default class exports should not be in void 0 initialization list"
@@ -245,23 +201,7 @@ fn test_collect_export_names_with_default_class_export() {
 
 #[test]
 fn test_collect_export_names_with_named_exports() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "const foo = 1; export { foo as bar };";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("const foo = 1; export { foo as bar };");
     assert_eq!(
         export_names,
         vec!["bar"],
@@ -271,23 +211,8 @@ fn test_collect_export_names_with_named_exports() {
 
 #[test]
 fn test_collect_export_names_ignores_type_only_specifiers() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "type Foo = number; const foo = 1; export { foo, type Foo };";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names =
+        parse_collect_exports("type Foo = number; const foo = 1; export { foo, type Foo };");
     assert_eq!(
         export_names,
         vec!["foo"],
@@ -297,23 +222,7 @@ fn test_collect_export_names_ignores_type_only_specifiers() {
 
 #[test]
 fn test_collect_export_names_ignores_type_only_named_exports() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "type Foo = number; export type { Foo };";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("type Foo = number; export type { Foo };");
     assert!(
         export_names.is_empty(),
         "Expected type-only named exports to be ignored"
@@ -322,23 +231,8 @@ fn test_collect_export_names_ignores_type_only_named_exports() {
 
 #[test]
 fn test_collect_export_names_with_multiple_named_exports() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "const foo = 1; const bar = 2; export { foo, bar as baz };";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names =
+        parse_collect_exports("const foo = 1; const bar = 2; export { foo, bar as baz };");
     assert_eq!(
         export_names,
         vec!["foo", "baz"],
@@ -348,23 +242,7 @@ fn test_collect_export_names_with_multiple_named_exports() {
 
 #[test]
 fn test_collect_export_names_with_export_import_equals() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export import Foo = require(\"./bar\");";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export import Foo = require(\"./bar\");");
     assert_eq!(
         export_names,
         vec!["Foo"],
@@ -374,23 +252,8 @@ fn test_collect_export_names_with_export_import_equals() {
 
 #[test]
 fn test_collect_export_names_ignores_type_only_declarations() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export type Foo = number; export interface Bar { x: number; }";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names =
+        parse_collect_exports("export type Foo = number; export interface Bar { x: number; }");
     assert!(
         export_names.is_empty(),
         "Expected no runtime exports for type-only declarations"
@@ -399,23 +262,9 @@ fn test_collect_export_names_ignores_type_only_declarations() {
 
 #[test]
 fn test_collect_export_names_ignores_declare_exports() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export declare const foo: number; export declare function bar(): void;";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports(
+        "export declare const foo: number; export declare function bar(): void;",
+    );
     assert!(
         export_names.is_empty(),
         "Expected no runtime exports for declare-only exports"
@@ -424,25 +273,10 @@ fn test_collect_export_names_ignores_declare_exports() {
 
 #[test]
 fn test_collect_export_names_includes_named_reexports() {
-    use tsz_parser::parser::ParserState;
-
     // `export * from "x"` does NOT produce void 0 exports (no named specifiers).
     // `export { bar } from "x"` DOES produce void 0 exports (tsc emits exports.bar = void 0;).
-    let source = "export * from \"./foo\"; export { bar } from \"./bar\";";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names =
+        parse_collect_exports("export * from \"./foo\"; export { bar } from \"./bar\";");
     assert_eq!(
         export_names,
         vec!["bar".to_string()],
@@ -452,24 +286,8 @@ fn test_collect_export_names_includes_named_reexports() {
 
 #[test]
 fn test_collect_export_names_includes_default_reexport() {
-    use tsz_parser::parser::ParserState;
-
     // tsc emits `exports.default = void 0;` for `export { default } from "x"`.
-    let source = "export { default } from \"./foo\";";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export { default } from \"./foo\";");
     assert_eq!(
         export_names,
         vec!["default".to_string()],
@@ -479,23 +297,7 @@ fn test_collect_export_names_includes_default_reexport() {
 
 #[test]
 fn test_collect_export_names_ignores_const_enum() {
-    use tsz_parser::parser::ParserState;
-
-    let source = "export const enum Foo { A }";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
-
+    let export_names = parse_collect_exports("export const enum Foo { A }");
     assert!(
         export_names.is_empty(),
         "Expected no runtime exports for const enums"
@@ -504,16 +306,7 @@ fn test_collect_export_names_ignores_const_enum() {
 
 #[test]
 fn side_effect_import_emits_bare_require() {
-    let source = "import \"./side\";";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-    let root_node = parser.arena.get(root).expect("root node must exist");
-    let source_file = parser
-        .arena
-        .get_source_file(root_node)
-        .expect("source file must exist");
-    let mut transform = CommonJsTransformContext::new(&parser.arena);
-    let nodes = transform.transform_source_file(&source_file.statements.nodes);
+    let nodes = parse_transform_cjs("import \"./side\";");
     assert!(
         nodes
             .iter()
@@ -524,17 +317,7 @@ fn side_effect_import_emits_bare_require() {
 
 #[test]
 fn empty_named_import_emits_bare_require() {
-    let source = "import {} from \"./side\";";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-    let root_node = parser.arena.get(root).expect("root node must exist");
-    let source_file = parser
-        .arena
-        .get_source_file(root_node)
-        .expect("source file must exist");
-    let mut transform = CommonJsTransformContext::new(&parser.arena);
-    let nodes = transform.transform_source_file(&source_file.statements.nodes);
-
+    let nodes = parse_transform_cjs("import {} from \"./side\";");
     assert!(
         nodes
             .iter()
@@ -551,16 +334,7 @@ fn empty_named_import_emits_bare_require() {
 
 #[test]
 fn type_only_named_import_is_elided_in_ir_commonjs_transform() {
-    let source = "import { type Foo } from \"./types\";";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-    let root_node = parser.arena.get(root).expect("root node must exist");
-    let source_file = parser
-        .arena
-        .get_source_file(root_node)
-        .expect("source file must exist");
-    let mut transform = CommonJsTransformContext::new(&parser.arena);
-    let nodes = transform.transform_source_file(&source_file.statements.nodes);
+    let nodes = parse_transform_cjs("import { type Foo } from \"./types\";");
     assert!(
         nodes.is_empty(),
         "type-only named imports should be erased in CommonJS IR transform"
@@ -569,8 +343,6 @@ fn type_only_named_import_is_elided_in_ir_commonjs_transform() {
 
 #[test]
 fn test_collect_export_names_deduplicates_overloaded_functions() {
-    use tsz_parser::parser::ParserState;
-
     // Overloaded functions produce multiple FUNCTION_DECLARATION nodes with the same name.
     // The collector must deduplicate to avoid repeated `exports.X = X;` lines.
     let source = r#"
@@ -578,19 +350,7 @@ export function foo(a: string): string;
 export function foo(a: number): number;
 export function foo(a: any): any { return a; }
 "#;
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-
-    let Some(source_file) = parser.arena.get_source_file(
-        parser
-            .arena
-            .get(root)
-            .expect("root node must exist in arena"),
-    ) else {
-        panic!("Failed to get source file");
-    };
-
-    let export_names = collect_export_names(&parser.arena, &source_file.statements.nodes);
+    let export_names = parse_collect_exports(source);
     assert_eq!(
         export_names,
         vec!["foo"],
@@ -600,8 +360,6 @@ export function foo(a: any): any { return a; }
 
 #[test]
 fn test_collect_export_names_categorized_deduplicates_overloaded_functions() {
-    use tsz_parser::parser::ParserState;
-
     let source = r#"
 export function foo(a: string): string;
 export function foo(a: number): number;
@@ -637,17 +395,7 @@ export const bar = 42;
 
 #[test]
 fn ir_commonjs_does_not_preinit_function_exports_with_void_zero() {
-    let source = "export function f() {}";
-    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-    let root = parser.parse_source_file();
-    let root_node = parser.arena.get(root).expect("root node must exist");
-    let source_file = parser
-        .arena
-        .get_source_file(root_node)
-        .expect("source file must exist");
-    let mut transform = CommonJsTransformContext::new(&parser.arena);
-    let nodes = transform.transform_source_file(&source_file.statements.nodes);
-
+    let nodes = parse_transform_cjs("export function f() {}");
     assert!(
         !nodes
             .iter()


### PR DESCRIPTION
## Summary

- Adds two test-local helper functions in `crates/tsz-emitter/tests/module_commonjs_tests.rs`:
  - `parse_collect_exports(source)` — parse source + call `collect_export_names` in one line
  - `parse_transform_cjs(source)` — parse source + run `CommonJsTransformContext::transform_source_file` in one line
- Migrates 15 `collect_export_names` test bodies and 4 `CommonJsTransformContext` test bodies to the helpers
- Removes redundant inline `use tsz_parser::parser::ParserState` inside test bodies (already imported at the top of the file)
- File: 657 → 405 lines (−252 lines). All 29 tests preserved, behavior unchanged.

## Verification

- `cargo fmt --all --check`: ✓ PASSED
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: ✓ PASSED
- `cargo test -p tsz-emitter --tests`: ✓ 1405 lib tests + 31 integration tests passed, 0 failures
- Pre-commit hook (`TSZ_SKIP_WASM_LINT=1`): formatting ✓, clippy ✓, architecture guardrails ✓, tests ✓
- `scripts/session/verify-all.sh`: formatting PASSED, clippy PASSED;
  unit tests FAILED (pre-existing: `cargo nextest` not installed — same environment issue as #1169);
  conformance: npm install step running (pre-existing env issue; change is test-only, no production code affected)

## Audit Notes

- Source: `docs/DRY_AUDIT_2026-04-21.md`
- Item: §tsz-emitter test fixtures — "Emitter tests repeat parser/print harness setup"
- Duplicate-work check: reviewed open and recently merged PRs before starting — no overlap found (#1181/printer.rs, #1169/statements.rs+declarations_class.rs cover different test files)