### PR TITLE
fix(checker): TS2339 displays underlying enum name for type alias of enum

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -120,6 +120,10 @@ name = "ts2540_readonly_tests"
 path = "tests/ts2540_readonly_tests.rs"
 
 [[test]]
+name = "tuple_index_access_tests"
+path = "tests/tuple_index_access_tests.rs"
+
+[[test]]
 name = "control_flow_type_guard_tests"
 path = "tests/control_flow_type_guard_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -321,10 +321,34 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// When `type_id` is a `Lazy(DefId)` for a `TypeAlias` whose evaluated body
+    /// is an `Enum`, return the enum's nominal name. Returns `None` when the
+    /// receiver is not such an alias.
+    fn alias_to_enum_display_name(&mut self, type_id: TypeId) -> Option<String> {
+        let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id)?;
+        let def = self.ctx.definition_store.get(def_id)?;
+        if def.kind != tsz_solver::def::DefKind::TypeAlias {
+            return None;
+        }
+        let evaluated = self.evaluate_type_for_assignability(type_id);
+        let enum_def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, evaluated)?;
+        let sym_id = self.ctx.def_to_symbol_id(enum_def_id)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        Some(symbol.escaped_name.to_string())
+    }
+
     fn property_receiver_display_for_node(&mut self, type_id: TypeId, idx: NodeIndex) -> String {
         let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
         if let Some(name) = self.js_constructor_receiver_display_for_node(idx) {
             return name;
+        }
+        // When the receiver is a type alias whose body resolves to an Enum
+        // (e.g. `type C1 = Color` where `Color` is an enum), tsc displays the
+        // underlying enum's nominal name in TS2339 messages, not the alias.
+        // The default type formatter follows the Lazy(DefId) directly to the
+        // alias name, producing `'C1'` instead of `'Color'`.
+        if let Some(enum_name) = self.alias_to_enum_display_name(type_id) {
+            return enum_name;
         }
         if crate::query_boundaries::state::checking::is_type_parameter_like(self.ctx.types, type_id)
             && let Some(constraint) =

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -388,18 +388,40 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         if !has_index_sig
                             && let Some(idx_node) = self.ctx.arena.get(indexed_access.index_type)
                         {
-                            let mut formatter = self.ctx.create_type_formatter();
-                            let type_str = formatter.format(object_type);
+                            // When the receiver is a type alias whose body resolves
+                            // to an Enum (e.g. `type C1 = Color`), tsc displays the
+                            // underlying enum's nominal name in TS2339 messages.
+                            // The default formatter would follow the Lazy(DefId) to
+                            // the alias name, producing `'C1'` instead of `'Color'`.
+                            let alias_enum_name = crate::query_boundaries::common::lazy_def_id(
+                                self.ctx.types,
+                                object_type,
+                            )
+                            .and_then(|def_id| self.ctx.definition_store.get(def_id))
+                            .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
+                            .and_then(|_| {
+                                crate::query_boundaries::common::enum_def_id(
+                                    self.ctx.types,
+                                    resolved_object,
+                                )
+                            })
+                            .and_then(|enum_def_id| self.ctx.def_to_symbol_id(enum_def_id))
+                            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+                            .map(|symbol| symbol.escaped_name.to_string());
+                            let type_str = alias_enum_name.unwrap_or_else(|| {
+                                let mut formatter = self.ctx.create_type_formatter();
+                                formatter.format(object_type).into_owned()
+                            });
                             let message = crate::diagnostics::format_message(
-                                    crate::diagnostics::diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
-                                    &[&key, &type_str],
-                                );
+                                crate::diagnostics::diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+                                &[&key, &type_str],
+                            );
                             self.ctx.error(
-                                    idx_node.pos,
-                                    idx_node.end - idx_node.pos,
-                                    message,
-                                    crate::diagnostics::diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
-                                );
+                                idx_node.pos,
+                                idx_node.end - idx_node.pos,
+                                message,
+                                crate::diagnostics::diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+                            );
                         }
                     }
                 }

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -2,7 +2,7 @@
 //! - TS2493: Tuple out-of-bounds on single tuple types
 //! - TS2339: Property does not exist on union-of-tuple types
 
-use crate::test_utils::check_source_diagnostics;
+use tsz_checker::test_utils::check_source_diagnostics;
 
 #[test]
 fn test_type_level_tuple_out_of_bounds_ts2493() {
@@ -78,5 +78,37 @@ type T21 = T2[1];
         diagnostics.iter().all(|d| d.code != 2339 && d.code != 2493),
         "Expected no TS2339/TS2493 for valid union tuple index, got: {:?}",
         diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// Regression: errorForUsingPropertyOfTypeAsType03.ts
+/// `type C1 = Color` is a type alias for an enum.  Accessing a non-existent
+/// property on `C1` (e.g. `C1["Red"]`) should report the error against the
+/// underlying enum's nominal name (`'Color'`), not the alias (`'C1'`).
+/// tsc treats type aliases for enums transparently in TS2339 messages.
+#[test]
+fn test_ts2339_type_alias_for_enum_displays_underlying_enum_name() {
+    let diagnostics = check_source_diagnostics(
+        r"
+namespace Test1 {
+    enum Color { Red, Green, Blue }
+    type C1 = Color;
+    let c3: C1['Red']['toString'];
+}
+",
+    );
+    let ts2339 = diagnostics
+        .iter()
+        .find(|d| d.code == 2339)
+        .expect("expected TS2339 for non-existent property on alias-of-enum");
+    assert!(
+        ts2339.message_text.contains("on type 'Color'"),
+        "TS2339 should display underlying enum name `Color`, got: {}",
+        ts2339.message_text
+    );
+    assert!(
+        !ts2339.message_text.contains("on type 'C1'"),
+        "TS2339 must not display alias name `C1`, got: {}",
+        ts2339.message_text
     );
 }


### PR DESCRIPTION
## Summary

When a type alias resolves to an enum (e.g. `type C1 = Color`), tsc displays the underlying enum's nominal name in TS2339 property-not-exist messages, not the alias name. tsz's default type formatter follows `Lazy(DefId)` directly to the alias name, producing `'C1'` where tsc says `'Color'`.

```ts
namespace Test1 {
    enum Color { Red, Green, Blue }
    type C1 = Color;
    let c3: C1["Red"]["toString"];
//          ~~~~~ tsc: Property 'Red' does not exist on type 'Color'.
//                tsz: Property 'Red' does not exist on type 'C1'.   ← was wrong
}
```

The fix adds an alias-to-enum check in two display paths:
- `property_receiver_display_for_node` (value-position property access — `let x: C1; x.Red`)
- `get_type_from_indexed_access_type` (type-position element access in `type_node_advanced.rs` — `let c3: C1["Red"]`)

Conformance: +1 net (`errorForUsingPropertyOfTypeAsType03.ts` flips FAIL → PASS).

## Test plan

- [x] New unit test `test_ts2339_type_alias_for_enum_displays_underlying_enum_name`
- [x] All 6 `tuple_index_access_tests` pass
- [x] No regressions (rebased onto current main after PR #1196 reverted #1189)