### PR TITLE
revert: 'fix(checker): respect constrained type parameter overlap' (#1189)

### DIFF
--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1177,12 +1177,13 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                             ) && constraint != TypeId::UNKNOWN
                                                 && constraint != TypeId::ANY
                                             {
-                                                // Use the constraint as the effective asserted type
-                                                // so overlap checks match TSC's `isTypeComparableTo`
-                                                // behavior. Otherwise `x as T` with `T extends object | undefined`
-                                                // can silently skip TS2352 when `x` only satisfies the
-                                                // constraint but not the actual type argument.
-                                                (true, constraint)
+                                                // Use the ORIGINAL asserted type (not constraint)
+                                                // for overlap checking. tsc's isTypeComparableTo
+                                                // checks against the type parameter itself, not its
+                                                // constraint. Using the constraint is too permissive
+                                                // and prevents TS2352 from firing when the expression
+                                                // type satisfies the constraint but not the type param.
+                                                (true, asserted_type)
                                             } else {
                                                 (false, asserted_type)
                                             }

--- a/crates/tsz-checker/src/tests/dispatch_tests.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests.rs
@@ -1493,36 +1493,6 @@ fn ts2352_tuple_different_length_assertion() {
     );
 }
 
-#[test]
-fn ts2352_generic_assertion_uses_type_parameter_constraint() {
-    // Repro for `genericWithNoConstraintComparableWithCurlyCurly` behavior: an assertion to a
-    // constrained type parameter should be checked against the constraint for TS2352 overlap. The
-    // `no` case should report TS2352 (null doesn't satisfy `object | null | undefined`), while
-    // `yes` should not because `object | null | undefined` is the constrained target.
-    let diags = check_source_diagnostics(
-        r#"
-function no<T extends {}>(x: null): T {
-    return x as T;
-}
-
-function yes<T extends object | null | undefined>(x: null): T {
-    return x as T;
-}
-"#,
-    );
-
-    let ts2352: Vec<_> = diags.iter().filter(|d| d.code == 2352).collect();
-    assert_eq!(
-        ts2352.len(),
-        1,
-        "Expected exactly one TS2352 diagnostic (from `no`), got: {:?}",
-        diags
-            .iter()
-            .map(|d| (d.code, d.message_text.as_str()))
-            .collect::<Vec<_>>()
-    );
-}
-
 // =============================================================================
 // Property access narrowing (this.X after equality checks)
 // =============================================================================


### PR DESCRIPTION
## Summary
- Reverts #1189. The change introduced a regression in the conformance-7 lane (failing on every commit since #1189 landed).

## Why
The reverted commit flipped the `as`-cast overlap check to use the type parameter's *constraint* instead of the original asserted type. The pre-revert comment explicitly noted that using the constraint is "too permissive and prevents TS2352 from firing when the expression type satisfies the constraint but not the type param." Reintroducing that path is what's regressing conformance lane 7 — and it's blocking merges of every PR opened since.

## Test plan
- [x] Reverts cleanly off `df9133af`.
- [ ] CI passes on conformance-7 (the failing lane).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
