### PR TITLE
fix(resolver): suppress TS2877 when exports/imports key consumed .ts

### DIFF
--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -54,6 +54,14 @@ pub type ResolvedModuleRequestPathMap =
 pub type ResolvedModuleRequestErrorMap =
     FxHashMap<(usize, String, Option<ResolutionModeOverride>), ResolutionError>;
 
+/// Per-`(source_file_idx, specifier)` flag mirroring tsc's
+/// `resolvedUsingTsExtension`: `true` when the resolver consumed a TS source
+/// extension from the specifier via a literal package.json `exports`/`imports`
+/// key (e.g. `"./*.ts"` or `"#foo.ts"`). Used by the import-extension gate
+/// (TS2877) to suppress the warning when the package author opted into the
+/// `.ts` mapping.
+pub type ResolvedModuleTsExtensionMap = FxHashMap<(usize, String), bool>;
+
 /// Program-wide type-only wildcard re-exports map: module specifier → entries of
 /// (re-exported module specifier, is-type-only flag). Mirrors
 /// `tsz_binder::Binder::wildcard_reexports_type_only` but wrapped in `Arc` so

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -246,6 +246,7 @@ impl<'a> CheckerContext<'a> {
             program_alias_partners: None,
             resolved_module_paths: None,
             resolved_module_request_paths: None,
+            resolved_module_ts_extension_flags: None,
             current_file_idx: 0,
             resolved_modules: None,
             module_augmentation_value_decls: FxHashMap::default(),

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -447,6 +447,7 @@ impl<'a> CheckerContext<'a> {
         self.program_alias_partners = parent.program_alias_partners.clone();
         self.global_symbol_file_index = parent.global_symbol_file_index.clone();
         self.resolved_module_paths = parent.resolved_module_paths.clone();
+        self.resolved_module_ts_extension_flags = parent.resolved_module_ts_extension_flags.clone();
         self.resolved_module_errors = parent.resolved_module_errors.clone();
         self.module_specifiers = parent.module_specifiers.clone();
         self.module_path_specifiers = parent.module_path_specifiers.clone();

--- a/crates/tsz-checker/src/context/import_extension_flags.rs
+++ b/crates/tsz-checker/src/context/import_extension_flags.rs
@@ -1,0 +1,42 @@
+//! TS2877 helpers — the `resolvedUsingTsExtension` flag map.
+//!
+//! Extracted from `context/core.rs` to keep the core file under the per-file
+//! LOC ceiling. The accessors here are consulted by the import-extension
+//! emission gate in `declarations/import/declaration.rs`.
+
+use std::sync::Arc;
+
+use super::CheckerContext;
+use super::aliases::ResolvedModuleTsExtensionMap;
+use crate::module_resolution::module_specifier_candidates;
+
+impl CheckerContext<'_> {
+    /// Set the per-`(source_file_idx, specifier)` `resolvedUsingTsExtension`
+    /// flag map. See [`ResolvedModuleTsExtensionMap`].
+    pub fn set_resolved_module_ts_extension_flags(
+        &mut self,
+        flags: Arc<ResolvedModuleTsExtensionMap>,
+    ) {
+        self.resolved_module_ts_extension_flags = Some(flags);
+    }
+
+    /// Returns true when the resolver consumed a TypeScript source extension
+    /// from the specifier via a literal package.json `exports`/`imports` key.
+    /// Used by the TS2877 gate to suppress the import-extension warning when
+    /// the package author opted into the `.ts` mapping (e.g. `"./*.ts": ...`).
+    ///
+    /// Returns false when the flag is unknown — callers should treat unknown
+    /// as "extension preserved through wildcard substitution", which is the
+    /// situation TS2877 warns about.
+    pub fn import_resolved_using_ts_extension(&self, specifier: &str) -> bool {
+        let Some(flags) = self.resolved_module_ts_extension_flags.as_ref() else {
+            return false;
+        };
+        for candidate in module_specifier_candidates(specifier) {
+            if let Some(&flag) = flags.get(&(self.current_file_idx, candidate)) {
+                return flag;
+            }
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use compiler_options::should_resolve_jsdoc_for_file;
 mod constructors;
 mod core;
 mod def_mapping;
+mod import_extension_flags;
 mod lib_queries;
 mod module_entity;
 mod request_cache;
@@ -1060,6 +1061,11 @@ pub struct CheckerContext<'a> {
     /// Resolved module paths keyed by the full driver request, including any
     /// explicit `resolution-mode` override from import attributes / import types.
     pub resolved_module_request_paths: Option<Arc<ResolvedModuleRequestPathMap>>,
+    /// `resolvedUsingTsExtension` flag per resolved import. See
+    /// [`ResolvedModuleTsExtensionMap`] — consulted by the TS2877 emission gate
+    /// to suppress the diagnostic when the package author's `exports`/`imports`
+    /// entry literally consumes the `.ts` extension.
+    pub resolved_module_ts_extension_flags: Option<Arc<ResolvedModuleTsExtensionMap>>,
 
     /// Current file index in multi-file mode (index into `all_arenas/all_binders`).
     /// Used with `resolved_module_paths` to look up cross-file imports.
@@ -1386,6 +1392,10 @@ pub struct ProjectEnv {
     pub resolved_module_paths: Arc<ResolvedModulePathMap>,
     /// Resolved module paths keyed by (`source_file_idx`, specifier, resolution-mode override).
     pub resolved_module_request_paths: Arc<ResolvedModuleRequestPathMap>,
+    /// `resolvedUsingTsExtension` flag per resolved import, mirroring tsc.
+    /// Populated by the driver from `ModuleLookupResult.resolved_using_ts_extension`
+    /// and consulted by the TS2877 emission gate.
+    pub resolved_module_ts_extension_flags: Arc<ResolvedModuleTsExtensionMap>,
     /// Resolved module errors: (`source_file_idx`, specifier) -> error details.
     pub resolved_module_errors: Arc<ResolvedModuleErrorMap>,
     /// Resolved module errors keyed by (`source_file_idx`, specifier, resolution-mode override).
@@ -1438,6 +1448,7 @@ impl Default for ProjectEnv {
             program_alias_partners: None,
             resolved_module_paths: Arc::new(FxHashMap::default()),
             resolved_module_request_paths: Arc::new(FxHashMap::default()),
+            resolved_module_ts_extension_flags: Arc::new(FxHashMap::default()),
             resolved_module_errors: Arc::new(FxHashMap::default()),
             resolved_module_request_errors: Arc::new(FxHashMap::default()),
             is_external_module_by_file: Arc::new(FxHashMap::default()),
@@ -1552,6 +1563,9 @@ impl ProjectEnv {
         }
         ctx.set_resolved_module_paths(Arc::clone(&self.resolved_module_paths));
         ctx.set_resolved_module_request_paths(Arc::clone(&self.resolved_module_request_paths));
+        ctx.set_resolved_module_ts_extension_flags(Arc::clone(
+            &self.resolved_module_ts_extension_flags,
+        ));
         ctx.set_resolved_module_errors(Arc::clone(&self.resolved_module_errors));
         ctx.set_resolved_module_request_errors(Arc::clone(&self.resolved_module_request_errors));
         ctx.is_external_module_by_file = Some(Arc::clone(&self.is_external_module_by_file));

--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -977,6 +977,13 @@ impl<'a> CheckerState<'a> {
         // TS2877: rewriteRelativeImportExtensions — non-relative imports with
         // a TypeScript extension that resolve to an input TypeScript file are not
         // rewritten during emit.
+        //
+        // Suppress when the resolver consumed the `.ts` via a literal
+        // package.json `exports`/`imports` key (e.g. `"./*.ts": "./*.js"` or
+        // `"#foo.ts": ...`). In those cases the package author has explicitly
+        // opted into the `.ts`→`.js` mapping at runtime, so the import will
+        // resolve correctly without rewriting. This mirrors tsc's
+        // `resolvedUsingTsExtension` gate.
         if !emitted_extension_diagnostic
             && self.ctx.compiler_options.rewrite_relative_import_extensions
             && !is_type_only_import
@@ -985,6 +992,7 @@ impl<'a> CheckerState<'a> {
             && !self.resolved_via_directory_index(module_name)
             && self.module_target_is_typescript_input_file(module_name)
             && !self.resolved_module_is_from_node_modules(module_name)
+            && !self.ctx.import_resolved_using_ts_extension(module_name)
             && let Some(ext) = ts_extension_suffix(module_name)
         {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};

--- a/crates/tsz-checker/tests/project_env_tests.rs
+++ b/crates/tsz-checker/tests/project_env_tests.rs
@@ -41,6 +41,7 @@ fn empty_project_env() -> ProjectEnv {
         program_alias_partners: None,
         resolved_module_paths: Arc::new(FxHashMap::default()),
         resolved_module_request_paths: Arc::new(FxHashMap::default()),
+        resolved_module_ts_extension_flags: Arc::new(FxHashMap::default()),
         resolved_module_errors: Arc::new(FxHashMap::default()),
         resolved_module_request_errors: Arc::new(FxHashMap::default()),
         is_external_module_by_file: Arc::new(FxHashMap::default()),

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -390,6 +390,11 @@ pub(super) fn collect_diagnostics(
     // Build resolved_module_paths map: (source_file_idx, specifier) -> target_file_idx
     // Also build resolved_module_errors map for specific error codes
     let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
+    // Per-resolution `resolvedUsingTsExtension` flag — populated when the
+    // resolver consumed a `.ts` extension via a literal package.json
+    // exports/imports key. Consumed by the checker's TS2877 gate.
+    let mut resolved_module_ts_extension_flags: FxHashMap<(usize, String), bool> =
+        FxHashMap::default();
     let mut resolved_module_request_paths: FxHashMap<
         (
             usize,
@@ -546,6 +551,10 @@ pub(super) fn collect_diagnostics(
                                 (file_idx, specifier.clone(), request_mode_key),
                                 target_idx,
                             );
+                            if outcome.resolved_using_ts_extension {
+                                resolved_module_ts_extension_flags
+                                    .insert((file_idx, specifier.clone()), true);
+                            }
                         }
                     } else if outcome.is_resolved {
                         resolved_module_specifiers.insert((file_idx, specifier.clone()));
@@ -575,6 +584,7 @@ pub(super) fn collect_diagnostics(
 
     let resolved_module_paths = Arc::new(resolved_module_paths);
     let resolved_module_request_paths = Arc::new(resolved_module_request_paths);
+    let resolved_module_ts_extension_flags = Arc::new(resolved_module_ts_extension_flags);
     let resolved_module_specifiers = Arc::new(resolved_module_specifiers);
     let resolved_module_errors = Arc::new(resolved_module_errors);
     let resolved_module_request_errors = Arc::new(resolved_module_request_errors);
@@ -859,6 +869,7 @@ pub(super) fn collect_diagnostics(
         symbol_file_targets: Arc::clone(&symbol_file_targets),
         resolved_module_paths: Arc::clone(&resolved_module_paths),
         resolved_module_request_paths: Arc::clone(&resolved_module_request_paths),
+        resolved_module_ts_extension_flags: Arc::clone(&resolved_module_ts_extension_flags),
         resolved_module_errors: Arc::clone(&resolved_module_errors),
         resolved_module_request_errors: Arc::clone(&resolved_module_request_errors),
         is_external_module_by_file: Arc::clone(&is_external_module_by_file),

--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -12,6 +12,17 @@ use crate::module_resolver_helpers::*;
 use crate::span::Span;
 use std::path::{Path, PathBuf};
 
+/// Returns true when an exports/imports pattern key literally ends with a
+/// TypeScript source extension. This mirrors tsc's `resolvedUsingTsExtension`
+/// signal: the package author opted into the `.ts` mapping by writing it in
+/// the key (e.g. `"./*.ts": ...` or `"#foo.ts": ...`). Wildcard substitutions
+/// that happen to capture a `.ts` extension do NOT count — those preserve the
+/// user's `.ts` extension through to the resolved target, which is exactly the
+/// situation TS2877 warns about.
+pub(super) fn key_ends_with_ts_extension(key: &str) -> bool {
+    key.ends_with(".ts") || key.ends_with(".tsx") || key.ends_with(".mts") || key.ends_with(".cts")
+}
+
 impl ModuleResolver {
     /// Resolve package.json imports field (#-prefixed specifiers)
     pub(super) fn resolve_package_imports(
@@ -94,7 +105,16 @@ impl ModuleResolver {
         })
     }
 
-    /// Resolve imports field subpath (similar to exports but with # prefix)
+    /// Resolve imports field subpath (similar to exports but with # prefix).
+    ///
+    /// Returns `(resolved_target, resolved_using_ts_extension)`.
+    ///
+    /// `resolved_using_ts_extension` mirrors tsc's behavior: it is `true` when
+    /// the literal pattern key (the package author's declared mapping) ends in
+    /// a TypeScript source extension. It is **not** sufficient for the wildcard
+    /// substitution to end in `.ts` — that just preserves the user's `.ts`
+    /// through the substitution, which means Node would try to load a `.ts`
+    /// file at runtime (the situation TS2877 warns about).
     pub(super) fn resolve_imports_subpath(
         &self,
         imports: &rustc_hash::FxHashMap<String, PackageExports>,
@@ -106,33 +126,31 @@ impl ModuleResolver {
         if let Some((key, value)) = imports.get_key_value(specifier)
             && !key.contains('*')
         {
+            let resolved_using_ts_extension = key_ends_with_ts_extension(key);
             return Self::resolve_export_target_to_string(value, conditions)
-                .map(|target| (target, false));
+                .map(|target| (target, resolved_using_ts_extension));
         }
 
         // Try pattern matching (e.g., "#utils/*")
-        let mut best_match: Option<(usize, String, &PackageExports)> = None;
+        let mut best_match: Option<(usize, &str, String, &PackageExports)> = None;
 
         for (pattern, value) in imports {
             if let Some(wildcard) = match_imports_pattern(pattern, specifier) {
                 let specificity = pattern.len();
                 let is_better = match &best_match {
                     None => true,
-                    Some((best_len, _, _)) => specificity > *best_len,
+                    Some((best_len, _, _, _)) => specificity > *best_len,
                 };
                 if is_better {
-                    best_match = Some((specificity, wildcard, value));
+                    best_match = Some((specificity, pattern.as_str(), wildcard, value));
                 }
             }
         }
 
-        if let Some((_, wildcard, value)) = best_match
+        if let Some((_, pattern, wildcard, value)) = best_match
             && let Some(target) = Self::resolve_export_target_to_string(value, conditions)
         {
-            let resolved_using_ts_extension = wildcard.ends_with(".ts")
-                || wildcard.ends_with(".tsx")
-                || wildcard.ends_with(".mts")
-                || wildcard.ends_with(".cts");
+            let resolved_using_ts_extension = key_ends_with_ts_extension(pattern);
             return Some((
                 apply_wildcard_substitution(&target, &wildcard),
                 resolved_using_ts_extension,
@@ -258,20 +276,25 @@ impl ModuleResolver {
         match_types_versions_range(version_range, compiler_version).is_some()
     }
 
-    /// Resolve package exports with explicit conditions
+    /// Resolve package exports with explicit conditions.
+    ///
+    /// Returns `(resolved_path, resolved_using_ts_extension)`. The bool is `true`
+    /// when the matched subpath KEY ends in a TS source extension (e.g. the
+    /// author wrote `"./*.ts": "./*.js"`), mirroring tsc's
+    /// `resolvedUsingTsExtension` semantics.
     pub(super) fn resolve_package_exports_with_conditions(
         &self,
         package_dir: &Path,
         exports: &PackageExports,
         subpath: &str,
         conditions: &[String],
-    ) -> Option<PathBuf> {
+    ) -> Option<(PathBuf, bool)> {
         match exports {
             PackageExports::String(s) => {
                 if subpath == "." {
                     let resolved = package_dir.join(s.trim_start_matches("./"));
                     if let Some(r) = self.try_export_target(&resolved) {
-                        return Some(r);
+                        return Some((r, false));
                     }
                 }
                 None
@@ -282,40 +305,40 @@ impl ModuleResolver {
                 if let Some((key, value)) = map.get_key_value(subpath)
                     && !key.contains('*')
                 {
-                    return self.resolve_export_value_with_conditions(
-                        package_dir,
-                        value,
-                        conditions,
-                    );
+                    let key_uses_ts = key_ends_with_ts_extension(key);
+                    return self
+                        .resolve_export_value_with_conditions(package_dir, value, conditions)
+                        .map(|p| (p, key_uses_ts));
                 }
 
                 // Try pattern matching (e.g., "./*" or "./lib/*")
-                let mut best_match: Option<(usize, String, &PackageExports)> = None;
+                let mut best_match: Option<(usize, &str, String, &PackageExports)> = None;
 
                 for (pattern, value) in map {
                     if let Some(matched) = match_export_pattern(pattern, subpath) {
                         let specificity = pattern.len();
                         let is_better = match &best_match {
                             None => true,
-                            Some((best_len, _, _)) => specificity > *best_len,
+                            Some((best_len, _, _, _)) => specificity > *best_len,
                         };
                         if is_better {
-                            best_match = Some((specificity, matched, value));
+                            best_match = Some((specificity, pattern.as_str(), matched, value));
                         }
                     }
                 }
 
-                if let Some((_, wildcard, value)) = best_match {
+                if let Some((_, pattern, wildcard, value)) = best_match {
                     // Per Node.js PACKAGE_TARGET_RESOLVE spec, substitute * with the
                     // matched wildcard portion BEFORE resolving the target path.
                     // Without this, try_export_target would look for literal "*.cjs" files.
                     let substituted_value = substitute_wildcard_in_exports(value, &wildcard);
+                    let key_uses_ts = key_ends_with_ts_extension(pattern);
                     if let Some(resolved) = self.resolve_export_value_with_conditions(
                         package_dir,
                         &substituted_value,
                         conditions,
                     ) {
-                        return Some(resolved);
+                        return Some((resolved, key_uses_ts));
                     }
                 }
 
@@ -359,7 +382,10 @@ impl ModuleResolver {
         }
     }
 
-    /// Resolve a single export value with conditions
+    /// Resolve a single export value with conditions.
+    ///
+    /// This walks the value side of an exports entry only — it does not touch
+    /// subpath keys, so it does not contribute to `resolved_using_ts_extension`.
     pub(super) fn resolve_export_value_with_conditions(
         &self,
         package_dir: &Path,

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -441,15 +441,17 @@ impl ModuleResolver {
             if self.resolve_package_json_exports
                 && let Some(exports) = &package_json.exports
             {
-                if let Some(resolved) = self.resolve_package_exports_with_conditions(
-                    package_dir,
-                    exports,
-                    &subpath_key,
-                    conditions,
-                ) {
+                if let Some((resolved, resolved_using_ts_extension)) = self
+                    .resolve_package_exports_with_conditions(
+                        package_dir,
+                        exports,
+                        &subpath_key,
+                        conditions,
+                    )
+                {
                     return Ok(ResolvedModule {
                         resolved_path: resolved.clone(),
-                        resolved_using_ts_extension: false,
+                        resolved_using_ts_extension,
                         is_external: true,
                         package_name: Some(package_json.name.clone().unwrap_or_default()),
                         original_specifier: original_specifier.to_string(),
@@ -556,12 +558,12 @@ impl ModuleResolver {
         if self.resolve_package_json_exports
             && let Some(exports) = &package_json.exports
         {
-            if let Some(resolved) =
+            if let Some((resolved, resolved_using_ts_extension)) =
                 self.resolve_package_exports_with_conditions(package_dir, exports, ".", conditions)
             {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
-                    resolved_using_ts_extension: false,
+                    resolved_using_ts_extension,
                     is_external: true,
                     package_name: Some(package_json.name.clone().unwrap_or_default()),
                     original_specifier: original_specifier.to_string(),

--- a/crates/tsz-core/src/module_resolver/self_reference.rs
+++ b/crates/tsz-core/src/module_resolver/self_reference.rs
@@ -72,19 +72,28 @@ impl ModuleResolver {
                             None => ".".to_string(),
                         };
 
-                        if let Some(resolved) = self.resolve_package_exports_with_conditions(
-                            &current,
-                            exports,
-                            &subpath_key,
-                            conditions,
-                        ) {
+                        if let Some((resolved, resolved_using_ts_extension)) = self
+                            .resolve_package_exports_with_conditions(
+                                &current,
+                                exports,
+                                &subpath_key,
+                                conditions,
+                            )
+                        {
                             // Self-reference resolved successfully via exports.
                             // This includes .ts files found via .js -> .ts extension
                             // substitution, which is the standard Node16/NodeNext
                             // behavior for source-to-output mapping.
+                            //
+                            // `resolved_using_ts_extension` is propagated from the
+                            // matched export pattern key: when the package author
+                            // wrote `"./*.ts": ...` in exports, the import path's
+                            // `.ts` was consumed by the exports map (rather than
+                            // preserved through to the resolved file), suppressing
+                            // TS2877 in the checker's import-extension gate.
                             return SelfReferenceResultV2::Resolved(ResolvedModule {
                                 resolved_path: resolved.clone(),
-                                resolved_using_ts_extension: false,
+                                resolved_using_ts_extension,
                                 is_external: false,
                                 package_name: Some(package_name.to_string()),
                                 original_specifier: original_specifier.to_string(),

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -3130,7 +3130,7 @@ fn test_classify_resolved_path() {
 }
 
 #[test]
-fn test_package_imports_exact_mapping_does_not_mark_ts_extension_usage() {
+fn test_package_imports_exact_mapping_marks_ts_extension_usage_when_key_ends_with_ts() {
     use std::fs;
 
     let dir = std::env::temp_dir().join("tsz_test_package_imports_exact_ts_usage");
@@ -3171,16 +3171,19 @@ fn test_package_imports_exact_mapping_does_not_mark_ts_extension_usage() {
         .lookup(&request, |_, _| None, |_| false, None)
         .classify();
     assert!(outcome.resolved_path.is_some());
+    // The exact key `#foo.ts` literally ends in `.ts`, so the package author
+    // opted into the `.ts` mapping. Mirrors tsc's `resolvedUsingTsExtension`
+    // and lets the checker's TS2877 gate suppress the rewrite warning.
     assert!(
-        !outcome.resolved_using_ts_extension,
-        "exact package imports entry should suppress ts-extension rewrite diagnostics"
+        outcome.resolved_using_ts_extension,
+        "exact package imports key ending in .ts should mark resolvedUsingTsExtension"
     );
 
     let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
-fn test_package_imports_pattern_marks_ts_extension_usage() {
+fn test_package_imports_pattern_does_not_mark_ts_extension_when_key_lacks_ts_suffix() {
     use std::fs;
 
     let dir = std::env::temp_dir().join("tsz_test_package_imports_pattern_ts_usage");
@@ -3221,9 +3224,70 @@ fn test_package_imports_pattern_marks_ts_extension_usage() {
         .lookup(&request, |_, _| None, |_| false, None)
         .classify();
     assert!(outcome.resolved_path.is_some());
+    // Pattern key `#internal/*` does NOT end in `.ts`. The wildcard captured
+    // `foo.ts` and substituted it into the target — the `.ts` was preserved
+    // through to the resolved file rather than consumed by the package
+    // author's mapping. That's exactly the situation TS2877 warns about, so
+    // `resolvedUsingTsExtension` must be `false`.
+    assert!(
+        !outcome.resolved_using_ts_extension,
+        "pattern imports key without .ts suffix must not mark resolvedUsingTsExtension"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_self_reference_exports_pattern_with_ts_key_marks_ts_extension_usage() {
+    use std::fs;
+
+    let dir = std::env::temp_dir().join("tsz_test_self_reference_exports_ts_pattern");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r##"{
+            "name": "pkg",
+            "type": "module",
+            "exports": {
+                "./*.ts": { "source": "./*.ts", "default": "./*.js" }
+            }
+        }"##,
+    )
+    .unwrap();
+    fs::write(dir.join("foo.ts"), "export {};").unwrap();
+    fs::write(dir.join("index.ts"), "import {} from \"pkg/foo.ts\";").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::NodeNext),
+        resolve_package_json_exports: true,
+        rewrite_relative_import_extensions: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let request = ModuleLookupRequest {
+        specifier: "pkg/foo.ts",
+        containing_file: &dir.join("index.ts"),
+        specifier_span: Span::new(0, 12),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    };
+
+    let outcome = resolver
+        .lookup(&request, |_, _| None, |_| false, None)
+        .classify();
+    assert!(
+        outcome.resolved_path.is_some(),
+        "self-reference via exports must resolve, got {outcome:?}"
+    );
+    // Exports key `./*.ts` literally ends in `.ts` and the matching default
+    // condition rewrites it to `.js` at runtime — the package author opted
+    // into the `.ts` → `.js` mapping. TS2877 must be suppressed.
     assert!(
         outcome.resolved_using_ts_extension,
-        "pattern package imports entry should preserve ts-extension usage for TS2877"
+        "self-reference via `./*.ts` exports key must mark resolvedUsingTsExtension"
     );
 
     let _ = fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary

- Track tsc's `resolvedUsingTsExtension` semantics through package.json
  `exports`/`imports` resolution: the flag is `true` only when the literal
  pattern key (e.g. `"./*.ts"`, `"#foo.ts"`) consumed the `.ts` extension,
  not when a wildcard captured `.ts` and substituted it back into the
  resolved target.
- Plumb the flag from resolver → driver → checker via a new
  `resolved_module_ts_extension_flags: HashMap<(file_idx, specifier), bool>`
  map.
- Consult the flag in the TS2877 emission gate to suppress the warning
  when the package author opted into the `.ts` mapping (e.g. exports
  `"./*.ts": { "default": "./*.js" }`).

## Failing test that motivated this

`TypeScript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/packageJsonImportsErrors.ts`

```ts
import {} from "#foo.ts";          // OK — exact imports key with .ts
import {} from "#internal/foo.ts"; // ERROR — pattern key #internal/* lacks .ts
import {} from "pkg/foo.ts";       // OK — exports key ./*.ts consumes .ts
```

Before this PR: tsz emitted TS2877 on `pkg/foo.ts` (wrong) and missed it on
`#internal/foo.ts` (also wrong). After: matches tsc fingerprint exactly.

Conformance net: **+10 tests** vs origin/main baseline.

## Architectural notes

- The new helpers live in `crates/tsz-checker/src/context/import_extension_flags.rs`
  to keep `context/core.rs` under the 2000 LOC ceiling.
- `resolve_package_exports_with_conditions` signature widens from
  `Option<PathBuf>` to `Option<(PathBuf, bool)>`. All 6 callers updated;
  node_modules-resolved packages now also benefit (same bug class).
- Two existing resolver tests had assertions reflecting the previous
  (inverted) behavior and are corrected with rationale comments. A new
  self-reference test covers the exports `./*.ts` → `./*.js` case.

## Test plan

- [x] `cargo nextest run --package tsz-core --lib` — 2964/2964
- [x] `cargo nextest run --package tsz-checker --lib` — 2749/2750 (1 pre-existing
      failure on `ts2352_angle_bracket_type_display_no_trailing_gt` confirmed
      identical on origin/main — unrelated to this PR)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- --deny warnings`
- [x] Conformance: +10 vs baseline (12129 → 12139)
- [x] Emit: JS +1, DTS +37 vs baseline
- [x] Fourslash: 50/50

CI will exercise the same gates on the merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
