### PR TITLE
fix(checker): TS2729 visitor — JSX self-closing, children, dedupe closing tag

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/property_init.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/property_init.rs
@@ -638,16 +638,31 @@ impl<'a> CheckerState<'a> {
                     );
                 }
             }
-            k if k == syntax_kind_ext::JSX_OPENING_ELEMENT
-                || k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT =>
-            {
-                // Check JSX element attributes
+            k if k == syntax_kind_ext::JSX_OPENING_ELEMENT => {
+                // Visited only when JSX_OPENING_ELEMENT is the entry node.
+                // When descending from JSX_ELEMENT below, that branch handles
+                // the opening tag's `tag_name` and attributes directly — do
+                // NOT also handle them here or they fire twice.
                 if let Some(jsx_elem) = self.ctx.arena.get_jsx_opening(node)
                     && let Some(attrs_node) = self.ctx.arena.get(jsx_elem.attributes)
                     && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
                 {
                     for &attr_idx in &attrs.properties.nodes {
                         self.collect_static_accesses_recursive(attr_idx, class_name, accesses);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT => {
+                // A self-closing element (`<C.z/>`) has no JSX_ELEMENT wrapper,
+                // so this branch must walk both the tag name AND attributes.
+                if let Some(jsx_elem) = self.ctx.arena.get_jsx_opening(node) {
+                    self.collect_static_accesses_recursive(jsx_elem.tag_name, class_name, accesses);
+                    if let Some(attrs_node) = self.ctx.arena.get(jsx_elem.attributes)
+                        && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
+                    {
+                        for &attr_idx in &attrs.properties.nodes {
+                            self.collect_static_accesses_recursive(attr_idx, class_name, accesses);
+                        }
                     }
                 }
             }
@@ -678,18 +693,21 @@ impl<'a> CheckerState<'a> {
                 }
             }
             k if k == syntax_kind_ext::JSX_ELEMENT => {
-                // Check JSX element tag name for C.prop references
+                // Walk the opening tag (tag name + attributes) and the element
+                // children. We deliberately do NOT walk the closing element's
+                // tag name: tsc emits TS2729 once per JSX element use, anchored
+                // at the opening tag. The closing tag is markup that must
+                // syntactically match the opening; checking it again would
+                // emit a duplicate diagnostic.
                 if let Some(jsx_elem) = self.ctx.arena.get_jsx_element(node) {
                     if let Some(opening_node) = self.ctx.arena.get(jsx_elem.opening_element)
                         && let Some(opening) = self.ctx.arena.get_jsx_opening(opening_node)
                     {
-                        // Recursively check tag name (might be C.x)
                         self.collect_static_accesses_recursive(
                             opening.tag_name,
                             class_name,
                             accesses,
                         );
-                        // Also check attributes
                         if let Some(attrs_node) = self.ctx.arena.get(opening.attributes)
                             && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
                         {
@@ -700,15 +718,10 @@ impl<'a> CheckerState<'a> {
                             }
                         }
                     }
-                    if let Some(closing_node) = self.ctx.arena.get(jsx_elem.closing_element)
-                        && let Some(closing) = self.ctx.arena.get_jsx_closing(closing_node)
-                    {
-                        // Also check closing tag name
-                        self.collect_static_accesses_recursive(
-                            closing.tag_name,
-                            class_name,
-                            accesses,
-                        );
+                    // Walk JSX element children — `{C.y}` expressions and nested
+                    // elements both reference static members through here.
+                    for &child_idx in &jsx_elem.children.nodes {
+                        self.collect_static_accesses_recursive(child_idx, class_name, accesses);
                     }
                 }
             }

--- a/crates/tsz-checker/src/types/type_checking/property_init.rs
+++ b/crates/tsz-checker/src/types/type_checking/property_init.rs
@@ -594,16 +594,31 @@ impl<'a> CheckerState<'a> {
                     );
                 }
             }
-            k if k == syntax_kind_ext::JSX_OPENING_ELEMENT
-                || k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT =>
-            {
-                // Check JSX element attributes
+            k if k == syntax_kind_ext::JSX_OPENING_ELEMENT => {
+                // Visited only when JSX_OPENING_ELEMENT is the entry node.
+                // When descending from JSX_ELEMENT below, that branch handles
+                // the opening tag's `tag_name` and attributes directly — do
+                // NOT also handle them here or they fire twice.
                 if let Some(jsx_elem) = self.ctx.arena.get_jsx_opening(node)
                     && let Some(attrs_node) = self.ctx.arena.get(jsx_elem.attributes)
                     && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
                 {
                     for &attr_idx in &attrs.properties.nodes {
                         self.collect_static_accesses_recursive(attr_idx, class_name, accesses);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT => {
+                // A self-closing element (`<C.z/>`) has no JSX_ELEMENT wrapper,
+                // so this branch must walk both the tag name AND attributes.
+                if let Some(jsx_elem) = self.ctx.arena.get_jsx_opening(node) {
+                    self.collect_static_accesses_recursive(jsx_elem.tag_name, class_name, accesses);
+                    if let Some(attrs_node) = self.ctx.arena.get(jsx_elem.attributes)
+                        && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
+                    {
+                        for &attr_idx in &attrs.properties.nodes {
+                            self.collect_static_accesses_recursive(attr_idx, class_name, accesses);
+                        }
                     }
                 }
             }
@@ -634,18 +649,21 @@ impl<'a> CheckerState<'a> {
                 }
             }
             k if k == syntax_kind_ext::JSX_ELEMENT => {
-                // Check JSX element tag name for C.prop references
+                // Walk the opening tag (tag name + attributes) and the element
+                // children. We deliberately do NOT walk the closing element's
+                // tag name: tsc emits TS2729 once per JSX element use, anchored
+                // at the opening tag. The closing tag is markup that must
+                // syntactically match the opening; checking it again would
+                // emit a duplicate diagnostic.
                 if let Some(jsx_elem) = self.ctx.arena.get_jsx_element(node) {
                     if let Some(opening_node) = self.ctx.arena.get(jsx_elem.opening_element)
                         && let Some(opening) = self.ctx.arena.get_jsx_opening(opening_node)
                     {
-                        // Recursively check tag name (might be C.x)
                         self.collect_static_accesses_recursive(
                             opening.tag_name,
                             class_name,
                             accesses,
                         );
-                        // Also check attributes
                         if let Some(attrs_node) = self.ctx.arena.get(opening.attributes)
                             && let Some(attrs) = self.ctx.arena.get_jsx_attributes(attrs_node)
                         {
@@ -656,15 +674,10 @@ impl<'a> CheckerState<'a> {
                             }
                         }
                     }
-                    if let Some(closing_node) = self.ctx.arena.get(jsx_elem.closing_element)
-                        && let Some(closing) = self.ctx.arena.get_jsx_closing(closing_node)
-                    {
-                        // Also check closing tag name
-                        self.collect_static_accesses_recursive(
-                            closing.tag_name,
-                            class_name,
-                            accesses,
-                        );
+                    // Walk JSX element children — `{C.y}` expressions and nested
+                    // elements both reference static members through here.
+                    for &child_idx in &jsx_elem.children.nodes {
+                        self.collect_static_accesses_recursive(child_idx, class_name, accesses);
                     }
                 }
             }

--- a/crates/tsz-checker/tests/definite_assignment_tests.rs
+++ b/crates/tsz-checker/tests/definite_assignment_tests.rs
@@ -176,6 +176,72 @@ fn test_ts2564_constructor_assignment_summary_handles_parameter_property_flow() 
     );
 }
 
+/// Helper: parse a `.tsx` source so the parser enables JSX productions, then
+/// run the checker with the supplied options.
+fn diagnostics_for_tsx(source: &str, options: CheckerOptions) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.tsx".to_string(),
+        options,
+    );
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Regression for `useBeforeDeclaration_jsx`: the static-property forward-
+/// reference walker must visit JSX self-closing tag names, JSX element
+/// children (`{C.y}`), and the opening tag exactly once (no duplicate from
+/// the closing tag). This locks in the visitor invariants that produce
+/// tsc's TS2729 fingerprint set for the conformance fixture.
+#[test]
+fn test_ts2729_jsx_static_forward_reference_visits_self_closing_and_children_once() {
+    let source = r"
+namespace JSX {
+    export interface Element {}
+}
+
+class C {
+    static a = <C.z></C.z>;
+    static b = <C.z/>;
+    static c = <span {...C.x}></span>;
+    static d = <span id={C.y}></span>;
+    static e = <span>{C.y}</span>;
+    static x = {};
+    static y = '';
+    static z = () => <b></b>;
+}
+";
+
+    let diags = diagnostics_for_tsx(
+        source,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let count = count_code(
+        &diags,
+        diagnostic_codes::PROPERTY_IS_USED_BEFORE_ITS_INITIALIZATION,
+    );
+    assert_eq!(
+        count, 5,
+        "expected exactly 5 TS2729 (one per JSX use of forward-declared static), got {count}: {diags:?}"
+    );
+}
+
 #[test]
 fn test_ts2729_parameter_property_before_define_field_initialization() {
     let source = r"


### PR DESCRIPTION
## Summary

The static-property forward-reference visitor (TS2729 \"Property is used before its initialization\") was wrong on three JSX shapes:

| Shape | Symptom | Root cause |
| --- | --- | --- |
| `<C.z></C.z>` | Duplicate diagnostic on closing tag | `JSX_ELEMENT` arm walked both opening AND closing element's tag name |
| `<C.z/>` | Missing diagnostic | `JSX_OPENING_ELEMENT \| JSX_SELF_CLOSING_ELEMENT` arm only walked attributes (relying on the absent `JSX_ELEMENT` parent for tag name) |
| `<span>{C.y}</span>` | Missing diagnostic | `JSX_ELEMENT` arm never recursed into `JsxElementData.children` |

Conformance net: **+11 tests** vs origin/main baseline, including
`useBeforeDeclaration_jsx.tsx` flipping `fingerprint-only → PASS`.

## Repro

```tsx
class C {
    static a = <C.z></C.z>;        // TS2729: 'z' used before init (opening only)
    static b = <C.z/>;             // TS2729: 'z' used before init (self-closing)
    static c = <span {...C.x}></span>;  // TS2729: 'x' used before init
    static d = <span id={C.y}></span>;  // TS2729: 'y' used before init
    static e = <span>{C.y}</span>;      // TS2729: 'y' used before init (child expr)
    static x = {};
    static y = '';
    static z = () => <b></b>;
}
```

tsc emits exactly 5 TS2729 (one per JSX use of a forward-declared static).
Before this PR tsz emitted 4 in the wrong positions. After: matches
fingerprints exactly.

## Architecture

The visitor is in `crates/tsz-checker/src/types/type_checking/property_init.rs`.
Splitting the joined opening/self-closing arm makes the invariant explicit:

- `JSX_OPENING_ELEMENT`: only when entered as a top-level node (rare). Walk
  attributes only — the parent `JSX_ELEMENT` arm handles `tag_name`.
- `JSX_SELF_CLOSING_ELEMENT`: always entered as a top-level node (no
  `JSX_ELEMENT` wrapper). Walk both `tag_name` and attributes.
- `JSX_ELEMENT`: walk opening tag (name + attrs) and `children`. Do NOT
  walk the closing tag — tsc anchors TS2729 once at the opening tag.

## Test plan

- [x] New unit test `test_ts2729_jsx_static_forward_reference_visits_self_closing_and_children_once`
      in `crates/tsz-checker/tests/definite_assignment_tests.rs`. Asserts
      count == 5 for the conformance fixture; fails with count == 4 before
      the fix.
- [x] All 73 related tests pass (`definite_assignment_tests`,
      `property_init`, `flow_analyzer`, `ts7041_tests`).
- [x] Targeted conformance: `useBeforeDeclaration_jsx` PASSES.
- [x] Full conformance: +11 tests vs baseline (12129 → 12140).
- [x] Emit: JS +1, DTS +37 vs baseline.
- [x] Fourslash: 50/50.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- --deny warnings`.

Pre-existing test failure on `ts2352_angle_bracket_type_display_no_trailing_gt`
(also fails on origin/main HEAD via `git stash` round-trip) — unrelated
to this diff.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
