### PR TITLE
perf(binder,checker,cli,core): Arc-share per-file semantic_defs to reduce large-repo memory

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -2675,7 +2675,7 @@ impl BinderState {
         // from later declarations.  This ensures the pre-populated DefinitionInfo
         // has complete heritage information (e.g., `interface A extends B {}` +
         // `interface A extends C {}` yields extends_names = ["B", "C"]).
-        if let Some(existing) = self.semantic_defs.get_mut(&sym_id) {
+        if let Some(existing) = std::sync::Arc::make_mut(&mut self.semantic_defs).get_mut(&sym_id) {
             // Accumulate new extends_names that aren't already present.
             for h in &extends_names {
                 if !existing.extends_names.contains(h) {
@@ -2762,7 +2762,7 @@ impl BinderState {
             None
         };
 
-        self.semantic_defs.insert(
+        std::sync::Arc::make_mut(&mut self.semantic_defs).insert(
             sym_id,
             crate::state::SemanticDefEntry {
                 kind,

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -261,7 +261,8 @@ impl BinderState {
             }
             // Propagate to semantic_defs (record_semantic_def was called before
             // the ExportDeclaration wrapper set is_exported on the symbol).
-            if let Some(entry) = self.semantic_defs.get_mut(&sym_id) {
+            if let Some(entry) = std::sync::Arc::make_mut(&mut self.semantic_defs).get_mut(&sym_id)
+            {
                 entry.is_exported = true;
             }
             return;
@@ -282,7 +283,9 @@ impl BinderState {
                             if let Some(sym) = self.symbols.get_mut(sym_id) {
                                 sym.is_exported = true;
                             }
-                            if let Some(entry) = self.semantic_defs.get_mut(&sym_id) {
+                            if let Some(entry) =
+                                std::sync::Arc::make_mut(&mut self.semantic_defs).get_mut(&sym_id)
+                            {
                                 entry.is_exported = true;
                             }
                         }

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -221,7 +221,7 @@ impl BinderState {
             return_targets: Vec::new(),
             file_features: FileFeatures::NONE,
             alias_partners: FxHashMap::default(),
-            semantic_defs: FxHashMap::default(),
+            semantic_defs: Arc::new(FxHashMap::default()),
             file_import_sources: Vec::new(),
             file_idx: u32::MAX,
         };
@@ -293,7 +293,7 @@ impl BinderState {
         self.break_targets.clear();
         self.continue_targets.clear();
         self.return_targets.clear();
-        self.semantic_defs.clear();
+        Arc::make_mut(&mut self.semantic_defs).clear();
         self.file_import_sources.clear();
         // Note: file_idx is NOT reset here. It is set by the driver (LSP/CLI)
         // and should persist across re-binds of the same file.
@@ -463,7 +463,7 @@ impl BinderState {
             return_targets: Vec::new(),
             file_features: FileFeatures::NONE,
             alias_partners: FxHashMap::default(),
-            semantic_defs: FxHashMap::default(),
+            semantic_defs: Arc::new(FxHashMap::default()),
             file_import_sources: Vec::new(),
             file_idx: u32::MAX,
         };
@@ -588,7 +588,7 @@ impl BinderState {
             return_targets: Vec::new(),
             file_features: FileFeatures::NONE,
             alias_partners,
-            semantic_defs: FxHashMap::default(),
+            semantic_defs: Arc::new(FxHashMap::default()),
             file_import_sources: Vec::new(),
             file_idx: u32::MAX,
         };
@@ -1178,7 +1178,7 @@ impl BinderState {
         }
 
         // Stamp semantic_defs
-        for entry in self.semantic_defs.values_mut() {
+        for entry in Arc::make_mut(&mut self.semantic_defs).values_mut() {
             if entry.file_id == u32::MAX {
                 entry.file_id = idx;
             }

--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -445,7 +445,7 @@ impl BinderState {
         for lib_ctx in lib_contexts {
             let lib_binder_ptr = Arc::as_ptr(&lib_ctx.binder) as usize;
 
-            for (&old_sym_id, entry) in &lib_ctx.binder.semantic_defs {
+            for (&old_sym_id, entry) in lib_ctx.binder.semantic_defs.iter() {
                 if let Some(&new_id) = lib_symbol_remap.get(&(lib_binder_ptr, old_sym_id)) {
                     // Update file_id to match the remapped symbol's decl_file_idx
                     // so that DefinitionStore composite key lookups stay consistent.
@@ -474,12 +474,13 @@ impl BinderState {
                         is_global_augmentation: entry.is_global_augmentation,
                         is_declare: entry.is_declare,
                     };
-                    if let Some(existing) = self.semantic_defs.get_mut(&new_id) {
+                    let semantic_defs_mut = Arc::make_mut(&mut self.semantic_defs);
+                    if let Some(existing) = semantic_defs_mut.get_mut(&new_id) {
                         // User-declared entries take precedence for core identity,
                         // but accumulate heritage/members/exports from lib declarations.
                         existing.merge_cross_file(&remapped);
                     } else {
-                        self.semantic_defs.insert(new_id, remapped);
+                        semantic_defs_mut.insert(new_id, remapped);
                     }
                 }
             }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -496,7 +496,14 @@ pub struct BinderState {
     ///
     /// This is the binder's contribution to stable semantic identity (Phase 1).
     /// The checker converts these entries to solver `DefId`s during construction.
-    pub semantic_defs: FxHashMap<SymbolId, SemanticDefEntry>,
+    ///
+    /// Stored behind `Arc` so cross-file lookup binders (one per file in the
+    /// parallel CLI pipeline) can share the per-file map by reference instead
+    /// of deep-cloning the underlying `FxHashMap` on every reconstruction.
+    /// On large repos (6086 files), the previous deep clone was the largest
+    /// single source of memory pressure during cross-file binder build.
+    /// Mutations during binding use `Arc::make_mut` (free when refcount=1).
+    pub semantic_defs: Arc<FxHashMap<SymbolId, SemanticDefEntry>>,
 
     /// Stable file index assigned by the driver (LSP `Project` or CLI).
     ///

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -3502,7 +3502,7 @@ const G = 42;
     assert_eq!(binder1.semantic_defs.len(), binder2.semantic_defs.len());
 
     // Same names and kinds
-    for (sym_id, entry1) in &binder1.semantic_defs {
+    for (sym_id, entry1) in binder1.semantic_defs.iter() {
         let entry2 = binder2
             .semantic_defs
             .get(sym_id)
@@ -3720,7 +3720,7 @@ enum D { X }
 namespace E {}
 ",
     );
-    for (&sym_id, entry) in &binder.semantic_defs {
+    for (&sym_id, entry) in binder.semantic_defs.iter() {
         let symbol = binder
             .symbols
             .get(sym_id)
@@ -3784,7 +3784,7 @@ enum Direction { Up, Down }
 
     // Each lib semantic_def should use a remapped SymbolId that exists in the
     // main binder's symbol arena (not the lib binder's original IDs).
-    for (&sym_id, entry) in &main_binder.semantic_defs {
+    for (&sym_id, entry) in main_binder.semantic_defs.iter() {
         assert!(
             main_binder.symbols.get(sym_id).is_some(),
             "semantic_def for '{}' (SymbolId {}) should reference a symbol in the main arena",
@@ -4491,7 +4491,7 @@ const LOCAL = 42;
 
     assert_eq!(binder1.semantic_defs.len(), binder2.semantic_defs.len());
 
-    for (sym_id, entry1) in &binder1.semantic_defs {
+    for (sym_id, entry1) in binder1.semantic_defs.iter() {
         let entry2 = binder2
             .semantic_defs
             .get(sym_id)
@@ -4627,7 +4627,7 @@ class Concrete {}
     let binder1 = bind_source(source);
     let binder2 = bind_source(source);
 
-    for (sym_id, e1) in &binder1.semantic_defs {
+    for (sym_id, e1) in binder1.semantic_defs.iter() {
         let e2 = binder2
             .semantic_defs
             .get(sym_id)

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1292,13 +1292,16 @@ impl<'a> CheckerContext<'a> {
         let sources: Vec<
             &rustc_hash::FxHashMap<tsz_binder::SymbolId, tsz_binder::SemanticDefEntry>,
         > = {
-            let mut v = vec![&self.binder.semantic_defs];
+            // `&*x.semantic_defs` dereferences the `Arc<FxHashMap<...>>` so the
+            // resulting reference targets the underlying map (the type the Vec
+            // expects), not the Arc wrapper.
+            let mut v = vec![&*self.binder.semantic_defs];
             for lib_ctx in self.lib_contexts.iter() {
-                v.push(&lib_ctx.binder.semantic_defs);
+                v.push(&*lib_ctx.binder.semantic_defs);
             }
             if let Some(ref binders) = self.all_binders {
                 for binder in binders.iter() {
-                    v.push(&binder.semantic_defs);
+                    v.push(&*binder.semantic_defs);
                 }
             }
             v

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -891,7 +891,7 @@ pub(super) fn collect_diagnostics(
     {
         let mut all_semantic_defs = program.semantic_defs.clone();
         for file in &program.files {
-            for (sym_id, entry) in &file.semantic_defs {
+            for (sym_id, entry) in file.semantic_defs.iter() {
                 all_semantic_defs.insert(*sym_id, entry.clone());
             }
         }
@@ -2762,7 +2762,7 @@ fn build_lib_bound_file_for_interface_checks(
         expando_properties: FxHashMap::default(),
         file_features: tsz::binder::FileFeatures::NONE,
         lib_symbol_reverse_remap: FxHashMap::default(),
-        semantic_defs: FxHashMap::default(),
+        semantic_defs: std::sync::Arc::new(FxHashMap::default()),
     }
 }
 

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1648,7 +1648,13 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
     // read the binder's map — copying `program.semantic_defs` into each
     // per-file binder was pure O(N · program_defs) waste (6%+ of total
     // CPU on ts-toolbelt subsets, all of it in `SemanticDefEntry::drop`).
-    binder.semantic_defs = file.semantic_defs.clone();
+    // Arc::clone is O(1) (atomic refcount bump) instead of deep-cloning the
+    // underlying `FxHashMap<SymbolId, SemanticDefEntry>`. The previous deep
+    // clone was the largest single source of memory pressure on multi-file
+    // builds (e.g., 50-70 GB total virtual on the 6086-file large-ts-repo
+    // benchmark, multiplied across rayon worker threads). Cross-file lookup
+    // binders only read this map (post-construction), so sharing is safe.
+    binder.semantic_defs = Arc::clone(&file.semantic_defs);
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();
         binder.current_scope_id = tsz::binder::ScopeId(0);
@@ -1763,7 +1769,13 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
     // See `create_binder_from_bound_file_with_augmentations` for the
     // rationale: the cross-file semantic_defs live in the shared
     // `DefinitionStore`, not here.
-    binder.semantic_defs = file.semantic_defs.clone();
+    // Arc::clone is O(1) (atomic refcount bump) instead of deep-cloning the
+    // underlying `FxHashMap<SymbolId, SemanticDefEntry>`. The previous deep
+    // clone was the largest single source of memory pressure on multi-file
+    // builds (e.g., 50-70 GB total virtual on the 6086-file large-ts-repo
+    // benchmark, multiplied across rayon worker threads). Cross-file lookup
+    // binders only read this map (post-construction), so sharing is safe.
+    binder.semantic_defs = Arc::clone(&file.semantic_defs);
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();
         binder.current_scope_id = tsz::binder::ScopeId(0);

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -551,7 +551,11 @@ pub struct BindResult {
     pub file_features: crate::binder::FileFeatures,
     /// Binder-captured semantic definitions for top-level declarations (Phase 1 DefId-first).
     /// Maps pre-remap `SymbolId` → `SemanticDefEntry`.
-    pub semantic_defs: FxHashMap<SymbolId, crate::binder::SemanticDefEntry>,
+    ///
+    /// Shared via `Arc` because the binder owns it as `Arc<FxHashMap<...>>` to
+    /// avoid deep clones in cross-file binder reconstruction. The Arc is moved
+    /// out of the binder when finalizing the bind result.
+    pub semantic_defs: Arc<FxHashMap<SymbolId, crate::binder::SemanticDefEntry>>,
     /// Static import/export-from module specifiers collected during binding.
     pub file_import_sources: Vec<String>,
 }
@@ -1445,7 +1449,11 @@ pub struct BoundFile {
     /// Per-file semantic definitions for top-level declarations (Phase 1 DefId-first).
     /// Contains only entries that originated in this file (post-remap `SymbolIds`).
     /// This enables file-scoped identity without cloning the entire global map.
-    pub semantic_defs: FxHashMap<SymbolId, crate::binder::SemanticDefEntry>,
+    ///
+    /// Shared via `Arc` so cross-file lookup binders can take an O(1) reference
+    /// instead of deep-cloning the underlying map per file. See
+    /// `tsz_cli::driver::check_utils::create_cross_file_lookup_binder_with_augmentations`.
+    pub semantic_defs: Arc<FxHashMap<SymbolId, crate::binder::SemanticDefEntry>>,
 }
 
 impl BoundFile {
@@ -2445,7 +2453,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
     // self-contained and deterministic.
     for lib_binder in &lib_binders {
         let lib_binder_ptr = Arc::as_ptr(lib_binder) as usize;
-        for (&old_sym_id, entry) in &lib_binder.semantic_defs {
+        for (&old_sym_id, entry) in lib_binder.semantic_defs.iter() {
             if let Some(&global_id) = lib_symbol_remap.get(&(lib_binder_ptr, old_sym_id)) {
                 // Keep first occurrence (declaration merging keeps first identity).
                 semantic_defs.entry(global_id).or_insert_with(|| {
@@ -2849,7 +2857,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         // Also collect per-file entries for BoundFile.semantic_defs (file-scoped identity).
         let mut file_semantic_defs: FxHashMap<SymbolId, crate::binder::SemanticDefEntry> =
             FxHashMap::default();
-        for (old_sym_id, entry) in &result.semantic_defs {
+        for (old_sym_id, entry) in result.semantic_defs.iter() {
             if result.lib_symbol_ids.contains(old_sym_id) {
                 continue;
             }
@@ -3316,7 +3324,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
                         .map(|new_sym| (new_sym, (lib_idx, lib_local_sym)))
                 })
                 .collect(),
-            semantic_defs: file_semantic_defs,
+            semantic_defs: Arc::new(file_semantic_defs),
         });
     }
 
@@ -4066,7 +4074,7 @@ fn build_lib_bound_file_for_interface_checks(
         expando_properties: FxHashMap::default(),
         file_features: crate::binder::FileFeatures::NONE,
         lib_symbol_reverse_remap: FxHashMap::default(),
-        semantic_defs: FxHashMap::default(),
+        semantic_defs: Arc::new(FxHashMap::default()),
     }
 }
 
@@ -4602,10 +4610,10 @@ pub fn check_files_parallel(
         let mut binder =
             create_binder_from_bound_file(&lib_bound_file, program, program.files.len());
         let mut composed_semantic_defs = program.semantic_defs.clone();
-        for (sym_id, entry) in &lib_bound_file.semantic_defs {
+        for (sym_id, entry) in lib_bound_file.semantic_defs.iter() {
             composed_semantic_defs.insert(*sym_id, entry.clone());
         }
-        binder.semantic_defs = composed_semantic_defs;
+        binder.semantic_defs = Arc::new(composed_semantic_defs);
 
         let mut checker = CheckerState::with_options(
             &lib_bound_file.arena,
@@ -4904,10 +4912,10 @@ pub fn create_binder_from_bound_file(
     // Skip the expensive clone+overlay to avoid O(files * total_defs) work.
     if !program.definition_store.is_fully_populated() {
         let mut composed_semantic_defs = program.semantic_defs.clone();
-        for (sym_id, entry) in &file.semantic_defs {
+        for (sym_id, entry) in file.semantic_defs.iter() {
             composed_semantic_defs.insert(*sym_id, entry.clone());
         }
-        binder.semantic_defs = composed_semantic_defs;
+        binder.semantic_defs = Arc::new(composed_semantic_defs);
     }
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();
@@ -4999,10 +5007,10 @@ pub fn create_binder_from_bound_file_with_shared(
 
     if !program.definition_store.is_fully_populated() {
         let mut composed_semantic_defs = program.semantic_defs.clone();
-        for (sym_id, entry) in &file.semantic_defs {
+        for (sym_id, entry) in file.semantic_defs.iter() {
             composed_semantic_defs.insert(*sym_id, entry.clone());
         }
-        binder.semantic_defs = composed_semantic_defs;
+        binder.semantic_defs = Arc::new(composed_semantic_defs);
     }
     if let Some(root_scope) = binder.scopes.first() {
         binder.current_scope = root_scope.table.clone();


### PR DESCRIPTION
## Summary

Eliminates the largest single source of memory pressure on large-ts-repo (6086 files): per-file deep clones of \`semantic_defs: FxHashMap<SymbolId, SemanticDefEntry>\` when constructing cross-file lookup binders.

Investigation report (attached as commit message context): tsz allocates **67 GB virtual on 32 GB RAM** when checking large-ts-repo. macOS \`sample\` identified \`RawTable<(SymbolId, SemanticDefEntry)>::clone\` and \`Vec<String>::clone\` as the dominant allocator hot frames in the cross-file lookup binder construction (\`check_utils.rs:1651\` and \`:1766\`).

The original "Arc-share \`module_export_equals_non_module\`" hypothesis (PR #1174 doc) was DISCARDED — that map is empty on cross-file lookup binders. The real hotspot is \`semantic_defs.clone()\`. This PR addresses the real hotspot.

## What changes

- \`BoundFile.semantic_defs\` and \`BinderState.semantic_defs\` move to \`Arc<FxHashMap<SymbolId, SemanticDefEntry>>\`.
- The two clone sites in \`check_utils.rs\` change from element-wise deep-clone to \`Arc::clone\`.
- Mutation paths use \`Arc::make_mut\` for copy-on-write — zero-cost when refcount=1 (the common case during binding).

## Validation

- \`cargo check --workspace\` clean.
- \`cargo nextest run -p tsz-binder --lib\` — **245 tests pass**.
- \`cargo nextest run -p tsz-checker --lib\` — **2,744 tests pass**.
- Pre-commit hook full profile run: **19,055 tests pass** in 62s.

## Salvage note

This PR is salvaged from \`arc-share-semantic-defs\` agent. The agent implemented the change (10 files, +71/-37) but its bench-on-large-ts-repo verification exceeded the watchdog timeout (the bench is the slow part — 5+ min per run). Salvaged after verifying build + tsz-binder + tsz-checker unit tests + pre-commit hook all pass.

**Bench-vs-tsgo measurement on large-ts-repo deferred to follow-up** — confirming the RSS reduction from baseline 67 GB requires a fresh measurement run that didn't fit in the agent's session.

## References

- Investigation #1 (closed) — \`recompute_module_export_equals_non_module\` was the misattributed hypothesis (#1174 doc PR).
- Investigation #2 — \`semantic_defs.clone()\` is the real hotspot.
- \`docs/plan/perf-loop-prompt.md\` — full investigation history.
- \`docs/plan/perf-large-repo-followup.md\` §4 step 2 — \"land the highest-impact remaining file.* clone Arc migration\".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
