### PR TITLE
chore(parser): replace hardcoded keyword lengths with scanner-metadata helper

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -17,6 +17,7 @@ use crate::parser::{
     syntax_kind_ext,
 };
 use tsz_scanner::SyntaxKind;
+use tsz_scanner::keyword_text_len;
 use tsz_scanner::scanner_impl::TokenFlags;
 
 impl ParserState {
@@ -73,7 +74,7 @@ impl ParserState {
             // (tsc points the error at the modifier, not the `import` keyword)
             self.parse_error_at(
                 start_pos,
-                6, // length of "export"
+                keyword_text_len(SyntaxKind::ExportKeyword),
                 "An import declaration cannot have modifiers.",
                 diagnostic_codes::AN_IMPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
             );
@@ -695,14 +696,14 @@ impl ParserState {
                 }) {
                     self.parse_error_at(
                         start_pos,
-                        6, // length of "export"
+                        keyword_text_len(SyntaxKind::ExportKeyword),
                         "Declaration or statement expected.",
                         diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
                     );
                     let abstract_pos = self.token_pos();
                     self.parse_error_at(
                         abstract_pos,
-                        8, // length of "abstract"
+                        keyword_text_len(SyntaxKind::AbstractKeyword),
                         "Unexpected keyword or identifier.",
                         diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
                     );
@@ -814,7 +815,7 @@ impl ParserState {
                     // Genuine duplicate export modifier
                     self.parse_error_at(
                         second_export_pos,
-                        6, // length of "export"
+                        keyword_text_len(SyntaxKind::ExportKeyword),
                         &format!("'{}' modifier already seen.", "export"),
                         diagnostic_codes::MODIFIER_ALREADY_SEEN,
                     );
@@ -1020,9 +1021,11 @@ impl ParserState {
         // Create an export modifier to pass to the ambient declaration
         // The export keyword was already consumed in parse_export_declaration
         // We need to create a token for it at the start_pos
-        let export_modifier =
-            self.arena
-                .add_token(SyntaxKind::ExportKeyword as u16, start_pos, start_pos + 6); // "export" is 6 chars
+        let export_modifier = self.arena.add_token(
+            SyntaxKind::ExportKeyword as u16,
+            start_pos,
+            start_pos + keyword_text_len(SyntaxKind::ExportKeyword),
+        );
         self.parse_ambient_declaration_with_modifiers(vec![export_modifier])
     }
 
@@ -1966,7 +1969,7 @@ impl ParserState {
         {
             // Line break after throw - TS1142: Line break not permitted here
             // The error position should be at the end of the `throw` keyword
-            let throw_end = start_pos + 5; // "throw" is 5 chars
+            let throw_end = start_pos + keyword_text_len(SyntaxKind::ThrowKeyword);
             self.parse_error_at(
                 throw_end,
                 0,

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -16,6 +16,7 @@ use crate::parser::{
 };
 use tsz_common::interner::Atom;
 use tsz_scanner::SyntaxKind;
+use tsz_scanner::keyword_text_len;
 use tsz_scanner::scanner_impl::TokenFlags;
 
 impl ParserState {
@@ -1794,7 +1795,7 @@ impl ParserState {
                         // position-based dedup with the TS1005 from parameter list.
                         self.parse_error_at(
                             start_pos,
-                            5, // length of "await"
+                            keyword_text_len(SyntaxKind::AwaitKeyword),
                             "Expression expected.",
                             diagnostic_codes::EXPRESSION_EXPECTED,
                         );

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -14,6 +14,7 @@ use crate::parser::{
 };
 use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use tsz_scanner::SyntaxKind;
+use tsz_scanner::keyword_text_len;
 use tsz_scanner::scanner_impl::TokenFlags;
 
 impl ParserState {
@@ -2099,9 +2100,11 @@ impl ParserState {
     pub(crate) fn parse_import_expression(&mut self) -> NodeIndex {
         let start_pos = self.token_pos();
         self.parse_expected(SyntaxKind::ImportKeyword);
-        let import_node =
-            self.arena
-                .add_token(SyntaxKind::ImportKeyword as u16, start_pos, start_pos + 6);
+        let import_node = self.arena.add_token(
+            SyntaxKind::ImportKeyword as u16,
+            start_pos,
+            start_pos + keyword_text_len(SyntaxKind::ImportKeyword),
+        );
         let mut import_call_type_arguments: Option<NodeList> = None;
 
         // Check for import.meta / import.defer(...)
@@ -2186,7 +2189,7 @@ impl ParserState {
             // import<T>(...) — type arguments not allowed on import calls (TS1326)
             self.parse_error_at(
                 start_pos,
-                6, // length of "import"
+                keyword_text_len(SyntaxKind::ImportKeyword),
                 diagnostic_messages::THIS_USE_OF_IMPORT_IS_INVALID_IMPORT_CALLS_CAN_BE_WRITTEN_BUT_THEY_MUST_HAVE_PAR,
                 diagnostic_codes::THIS_USE_OF_IMPORT_IS_INVALID_IMPORT_CALLS_CAN_BE_WRITTEN_BUT_THEY_MUST_HAVE_PAR,
             );
@@ -2227,7 +2230,7 @@ impl ParserState {
             // Emit TS1109 "Expression expected" (matches tsc behavior for e.g. `import { ... } from`)
             self.parse_error_at(
                 start_pos,
-                6, // length of "import"
+                keyword_text_len(SyntaxKind::ImportKeyword),
                 diagnostic_messages::EXPRESSION_EXPECTED,
                 diagnostic_codes::EXPRESSION_EXPECTED,
             );

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -20,7 +20,7 @@ use crate::parser::{
 };
 use tsz_common::diagnostics::diagnostic_codes;
 use tsz_common::interner::Atom;
-use tsz_scanner::{SyntaxKind, token_is_keyword};
+use tsz_scanner::{SyntaxKind, keyword_text_len, token_is_keyword};
 
 impl ParserState {
     fn look_ahead_is_invalid_shebang(&mut self) -> bool {
@@ -945,7 +945,7 @@ impl ParserState {
             let start_pos = self.token_pos();
             self.parse_error_at(
                 start_pos,
-                6, // length of "import"
+                keyword_text_len(SyntaxKind::ImportKeyword),
                 "Declaration or statement expected.",
                 diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
             );

--- a/crates/tsz-scanner/src/lib.rs
+++ b/crates/tsz-scanner/src/lib.rs
@@ -689,6 +689,20 @@ pub fn keyword_to_text(token: SyntaxKind) -> Option<String> {
     keyword_to_text_static(token).map(std::convert::Into::into)
 }
 
+/// Byte length of a keyword's source text, as a `u32` for `parse_error_at`
+/// span arguments. Returns `0` for non-keyword tokens.
+///
+/// All keyword texts in `keyword_to_text_static` are pure ASCII, so byte length
+/// equals character length. Using this avoids hardcoding `6 // length of "export"`
+/// at every parser-recovery diagnostic site.
+#[must_use]
+pub const fn keyword_text_len(token: SyntaxKind) -> u32 {
+    match keyword_to_text_static(token) {
+        Some(text) => text.len() as u32,
+        None => 0,
+    }
+}
+
 /// Internal non-allocating version - returns static str reference.
 /// Use this for Rust-internal code to avoid allocations.
 #[must_use]

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -50,7 +50,7 @@ Rules:
 Add new roadmap and DRY claims here before implementation begins.
 
 - **2026-04-25** · branch `claude/modest-archimedes-QBaXl` · **DRY active claim** · P0 Test-Harness Consolidation: replace local `check_with_options` helpers with `tsz_checker::test_utils::check_source` in `crates/tsz-checker/tests/class_member_closure_tests.rs`, `contextual_tuple_tests.rs`, `contextual_typing_tests.rs`, and `never_returning_narrowing_tests.rs`. Legacy draft title: `[do not merge] chore(checker-tests): replace local check_with_options helpers with test_utils::check_source`; treat as WIP until ready.
-- **2026-04-25** · branch `chore/parser-keyword-token-length-helper` · **DRY workstream-8 claim** · workstream 8.9 ("Move hardcoded modifier/keyword token lengths into scanner/parser metadata"): ~10 sites in `crates/tsz-parser/src/parser/state_*.rs` hardcode `6 // length of "export"`, `8 // length of "abstract"`, `5 // length of "throw"`, etc. for `parse_error_at` spans. Add `pub const fn keyword_text_len(SyntaxKind) -> u32` (or use existing `keyword_to_text_static().len()`) and migrate the call sites. Pure refactor — preserve byte-for-byte spans. Draft PR: `[WIP] chore(parser): replace hardcoded keyword lengths with scanner-metadata helper`.
+- **2026-04-25** · branch `chore/parser-keyword-token-length-helper` · **DRY workstream-8 ready** · workstream 8.9 ("Move hardcoded modifier/keyword token lengths into scanner/parser metadata"): added `pub const fn keyword_text_len(SyntaxKind) -> u32` in `tsz-scanner` and migrated 8 hardcoded sites across `state_declarations_exports.rs`, `state_expressions_literals.rs`, `state_expressions.rs`, `state_statements.rs`. Net-zero conformance. PR #1203.
 
 ## How To Keep This Current
 

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -50,6 +50,7 @@ Rules:
 Add new roadmap and DRY claims here before implementation begins.
 
 - **2026-04-25** · branch `claude/modest-archimedes-QBaXl` · **DRY active claim** · P0 Test-Harness Consolidation: replace local `check_with_options` helpers with `tsz_checker::test_utils::check_source` in `crates/tsz-checker/tests/class_member_closure_tests.rs`, `contextual_tuple_tests.rs`, `contextual_typing_tests.rs`, and `never_returning_narrowing_tests.rs`. Legacy draft title: `[do not merge] chore(checker-tests): replace local check_with_options helpers with test_utils::check_source`; treat as WIP until ready.
+- **2026-04-25** · branch `chore/parser-keyword-token-length-helper` · **DRY workstream-8 claim** · workstream 8.9 ("Move hardcoded modifier/keyword token lengths into scanner/parser metadata"): ~10 sites in `crates/tsz-parser/src/parser/state_*.rs` hardcode `6 // length of "export"`, `8 // length of "abstract"`, `5 // length of "throw"`, etc. for `parse_error_at` spans. Add `pub const fn keyword_text_len(SyntaxKind) -> u32` (or use existing `keyword_to_text_static().len()`) and migrate the call sites. Pure refactor — preserve byte-for-byte spans. Draft PR: `[WIP] chore(parser): replace hardcoded keyword lengths with scanner-metadata helper`.
 
 ## How To Keep This Current
 


### PR DESCRIPTION
## Intent

Replace ~10 hardcoded keyword-length constants in `crates/tsz-parser/src/parser/state_*.rs` with calls to a scanner-side helper. Pattern looks like:

```rust
self.parse_error_at(
    start_pos,
    8, // length of "abstract"
    "Unexpected keyword or identifier.",
    diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
);
```

Plan: add `pub const fn keyword_text_len(SyntaxKind) -> u32` next to `keyword_to_text_static` in `tsz-scanner`. Migrate the call sites. Behavior must stay byte-identical.

## Roadmap Claim

- Updated `docs/plan/ROADMAP.md` Active Implementation Claims for workstream 8 item 9 (Parser/scanner residuals).

## Planned Scope

- `crates/tsz-scanner/src/lib.rs` — add `keyword_text_len` const fn
- `crates/tsz-parser/src/parser/state_declarations_exports.rs` — 4 sites
- `crates/tsz-parser/src/parser/state_expressions_literals.rs` — 3 sites
- `crates/tsz-parser/src/parser/state_statements.rs` — 1 site
- `crates/tsz-parser/src/parser/state_expressions.rs` — 1 site

## Verification Plan

- `cargo nextest run -p tsz-scanner -p tsz-parser`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — must be net-zero
- `scripts/session/verify-all.sh` before marking ready