### PR TITLE
fix(checker): resolve tuple element types before TS2352 comparable check

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1423,6 +1423,49 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
+        // Tuples carry their element types directly (not via Object shape),
+        // so the property-shape walk below would skip them. Resolve each
+        // tuple element first so downstream comparable-for-assertion checks
+        // (e.g. tuple-to-tuple element-wise overlap in
+        // `types_are_comparable_for_assertion`) see concrete types instead
+        // of unresolved `Lazy(DefId)` class refs — those refs short-circuit
+        // the solver's depth>0 Lazy heuristic to "comparable", masking real
+        // mismatches like `[C, D] as [A, I]`.
+        if let Some(elements) =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, type_id)
+        {
+            let mut any_changed = false;
+            let new_elements: Vec<tsz_solver::TupleElement> = elements
+                .iter()
+                .map(|elem| {
+                    let mut eval_ty = elem.type_id;
+                    if crate::query_boundaries::common::is_lazy_type(
+                        self.ctx.types.as_type_database(),
+                        eval_ty,
+                    ) {
+                        let resolved = self.evaluate_type_for_assignability(eval_ty);
+                        if resolved != eval_ty {
+                            any_changed = true;
+                            eval_ty = resolved;
+                        }
+                    }
+                    let deep = self.deep_evaluate_object_properties_inner(eval_ty, depth + 1);
+                    if deep != eval_ty {
+                        any_changed = true;
+                        eval_ty = deep;
+                    }
+                    tsz_solver::TupleElement {
+                        type_id: eval_ty,
+                        ..*elem
+                    }
+                })
+                .collect();
+            if any_changed {
+                return self.ctx.types.as_type_database().tuple(new_elements);
+            }
+            return type_id;
+        }
+
         let db = self.ctx.types.as_type_database();
         // Use solver query API to get the shape id (handles Object and ObjectWithIndex)
         let shape_id = match crate::query_boundaries::common::object_shape_id(db, type_id) {

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1328,6 +1328,28 @@ impl<'a> CheckerState<'a> {
         let source_resolved = self.evaluate_type_with_resolution(source);
         let target_resolved = self.evaluate_type_with_resolution(target);
 
+        // Tuples are already handled element-wise by the solver's
+        // `types_are_comparable_for_assertion` (see flow.rs); the property-bag
+        // view here would treat the implicit `length` literal as a shared
+        // comparable property and falsely report overlap for casts like
+        // `[C, D] as [A, I]` where the elements don't overlap. Defer to the
+        // solver's tuple logic.
+        let source_is_tuple =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, source_resolved)
+                .is_some();
+        let target_is_tuple =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, target_resolved)
+                .is_some();
+        // Tuples are already handled element-wise by the solver's
+        // `types_are_comparable_for_assertion` (see flow.rs); the property-bag
+        // view here would treat the implicit `length` literal as a shared
+        // comparable property and falsely report overlap for casts like
+        // `[C, D] as [A, I]` where the elements don't overlap. Defer to the
+        // solver's tuple logic.
+        if source_is_tuple && target_is_tuple {
+            return false;
+        }
+
         let Some(source_shape) = object_shape_for_type(self.ctx.types, source_resolved) else {
             return false;
         };

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -112,3 +112,49 @@ namespace Test1 {
         ts2339.message_text
     );
 }
+
+/// Regression for `castingTuple.ts`: when comparing two same-length tuples whose
+/// element classes don't overlap, TS2352 must fire on the cast. Before the fix,
+/// `deep_evaluate_object_properties` skipped tuple element types, leaving them
+/// as `Lazy(DefId)` class refs that the solver's depth>0 Lazy heuristic
+/// short-circuited to "comparable", masking the real mismatch.
+#[test]
+fn test_ts2352_tuple_cast_with_unrelated_element_classes_emits_error() {
+    let diagnostics = check_source_diagnostics(
+        r"
+class A { a: number = 10; }
+class C { c: number = 1; }
+declare var pair: [C];
+var t = <[A]>pair;
+",
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2352),
+        "Expected TS2352 for tuple cast between unrelated element classes, got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// Regression for the multi-element variant from `castingTuple.ts` line 32:
+/// `<[A, I]>classCDTuple` where element 0 (C → A) doesn't overlap but element
+/// 1 (D → I) does. Element-wise tsc semantics mean ANY non-overlapping element
+/// triggers TS2352 — the matching `length: 2` literal must NOT mask the
+/// element-0 mismatch.
+#[test]
+fn test_ts2352_tuple_cast_partial_element_overlap_still_emits_error() {
+    let diagnostics = check_source_diagnostics(
+        r"
+interface I {}
+class A { a: number = 10; }
+class C { c: number = 1; }
+class D implements I { d: number = 1; }
+declare var classCDTuple: [C, D];
+var t9 = <[A, I]>classCDTuple;
+",
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2352),
+        "Expected TS2352 for [C, D] as [A, I] (element 0 doesn't overlap), got: {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

When TypeScript checks a type assertion `<T>expr` for "may be a mistake"
(TS2352), it consults a comparable-overlap relation. For tuples, the solver
already implements element-wise overlap correctly. But the checker's
`deep_evaluate_object_properties` only resolved Object shapes — Tuple
element types passed through unchanged. So `Lazy(DefId)` class refs leaked
to the solver, where the depth>0 Lazy heuristic short-circuits "two
unresolved refs ⇒ comparable" to avoid false TS2352. The price: real
mismatches like `<[A, I]>classCDTuple` (where `[C, D]` element 0 doesn't
overlap A) were silently accepted.

## Repro

```ts
class A { a: number = 10; }
interface I {}
class C { c: number = 1; }
class D implements I { d: number = 1; }

declare var classCDTuple: [C, D];
var t9 = <[A, I]>classCDTuple;  // tsc: TS2352. tsz before this PR: silent.
```

tsc: ` Conversion of type '[C, D]' to type '[A, I]' may be a mistake because
neither type sufficiently overlaps with the other.`

## Fix

Two changes, both in `crates/tsz-checker/src/assignability/`:

1. **`assignability_checker.rs::deep_evaluate_object_properties`** — extend to
   recurse into tuple elements, resolving each `Lazy(DefId)` ref before the
   comparable check sees it. Mirrors the existing object-property resolution
   pattern (re-interns the tuple via `db.tuple(new_elements)` only when an
   element changed).

2. **`assignability_diagnostics.rs::object_properties_are_comparable`** —
   short-circuit to `false` when both source and target are tuples. The
   property-bag view treats `length: N` as a shared comparable property and
   would falsely report overlap for any same-length tuples regardless of
   element types. The solver's tuple-aware element-wise check is the
   canonical path.

## Architecture

Both fixes preserve the principle that the **solver owns relation
semantics**. The checker's role is to feed it fully-resolved types and not
substitute its own property-bag heuristic when the solver already has a
correct tuple-shaped check.

## Test plan

- [x] New unit tests in `crates/tsz-checker/tests/tuple_index_access_tests.rs`:
      `test_ts2352_tuple_cast_with_unrelated_element_classes_emits_error` and
      `test_ts2352_tuple_cast_partial_element_overlap_still_emits_error`.
      Both lock in element-wise TS2352 emission for tuple casts.
- [x] All 21475 workspace tests pass (`cargo nextest run --workspace`).
      The previously-flaky `ts2352_angle_bracket_type_display_no_trailing_gt`
      now flips to PASS as a side effect of TS2352 firing correctly for
      tuple-typed assertions.
- [x] Conformance: **+12** vs origin/main baseline (12129 → 12141), including
      `castingTuple.ts` flipping `fingerprint-only → PASS`.
- [x] Emit: JS +1, DTS +37 vs baseline.
- [x] Fourslash: 50/50.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- --deny warnings`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
