### PR TITLE
[WIP] fix(parser): keep arena interner coherent after incremental parse

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -200,6 +200,13 @@ impl ParserState {
             .arena
             .add_token(SyntaxKind::EndOfFileToken as u16, end_pos, end_pos);
 
+        // Refresh the arena's interner so atoms produced during this suffix
+        // parse remain resolvable. Without this, identifiers introduced by
+        // the incremental parse are absent from the arena's clone and
+        // `resolve_identifier_text` returns the empty string, silently
+        // corrupting binder, LSP, and incremental diagnostic results.
+        self.arena.set_interner(self.scanner.interner().clone());
+
         IncrementalParseResult {
             statements,
             end_pos,

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -1427,6 +1427,49 @@ fn test_incremental_parse_records_reparse_start() {
 }
 
 #[test]
+fn test_incremental_parse_keeps_arena_interner_coherent() {
+    // Regression test for the incremental parser interner coherence bug.
+    //
+    // After a full parse, the arena's interner is a clone of the scanner's.
+    // If we then incrementally parse a suffix that introduces an identifier
+    // not present in the initial source, the scanner adds an atom but the
+    // arena's clone is stale — `arena.resolve_identifier_text` then returns
+    // the empty string for that identifier (silent corruption of binder /
+    // LSP-visible names). The fix updates the arena's interner at the end
+    // of the incremental parse, mirroring the full-parse path.
+    let initial_source = "const a = 1;\n";
+    let updated_source = "const a = 1;\nconst zyxw_uniq_ident = 2;\n";
+
+    let mut parser = ParserState::new("test.ts".to_string(), initial_source.to_string());
+    let _root = parser.parse_source_file();
+
+    let offset = u32::try_from(initial_source.len()).expect("offset fits in u32");
+    let _result = parser.parse_source_file_statements_from_offset(
+        "test.ts".to_string(),
+        updated_source.to_string(),
+        offset,
+    );
+
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "expected clean parse, got {:?}",
+        parser.get_diagnostics()
+    );
+
+    let arena = parser.get_arena();
+    let new_ident_resolves = arena
+        .identifiers
+        .iter()
+        .any(|id| arena.resolve_identifier_text(id) == "zyxw_uniq_ident");
+    assert!(
+        new_ident_resolves,
+        "arena.resolve_identifier_text must resolve identifiers introduced \
+         by an incremental parse; the arena's interner appears stale relative \
+         to the scanner's (no identifier resolves to \"zyxw_uniq_ident\")"
+    );
+}
+
+#[test]
 fn test_incremental_parse_with_syntax_error() {
     // Test incremental parsing recovers from syntax errors
     let source = r"const a = 1;

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -50,6 +50,7 @@ Rules:
 Add new roadmap and DRY claims here before implementation begins.
 
 - **2026-04-25** · branch `claude/modest-archimedes-QBaXl` · **DRY active claim** · P0 Test-Harness Consolidation: replace local `check_with_options` helpers with `tsz_checker::test_utils::check_source` in `crates/tsz-checker/tests/class_member_closure_tests.rs`, `contextual_tuple_tests.rs`, `contextual_typing_tests.rs`, and `never_returning_narrowing_tests.rs`. Legacy draft title: `[do not merge] chore(checker-tests): replace local check_with_options helpers with test_utils::check_source`; treat as WIP until ready.
+- **2026-04-25** · branch `fix/incremental-parse-interner-coherence` · **Workstream 7 active claim** · Fix incremental parser/interner coherence: `parse_source_file_statements_from_offset` does not update `NodeArena`'s interner after a suffix re-parse, so identifiers introduced by the suffix are absent from the arena's clone and `resolve_identifier_text` returns `""`. Adds a regression test in `crates/tsz-parser/tests/parser_improvement_tests.rs` and refreshes `arena.set_interner(scanner.interner().clone())` at the end of the incremental path, mirroring the full-parse transfer. Draft PR title: `[WIP] fix(parser): keep arena interner coherent after incremental parse`.
 
 ## How To Keep This Current
 


### PR DESCRIPTION
## Intent

Fix a silent identity-corruption bug in the incremental parser path
called out as the **Workstream 7** deliverable in
[`docs/plan/ROADMAP.md`](docs/plan/ROADMAP.md).

`ParserState::parse_source_file_statements_from_offset` mutates the
scanner's interner during a suffix re-parse but never refreshes the
clone stored on `NodeArena::interner`. Identifiers introduced for the
first time by the incremental parse end up only in the scanner's
interner; the arena's clone is missing them, so:

- `Interner::resolve(atom)` falls into the silent out-of-bounds branch
  and returns `""`,
- `NodeArena::resolve_identifier_text` (and the `NodeAccess`
  `get_identifier_text` view) return that empty string,
- binder symbol naming, LSP hover/quickInfo/completion/references, and
  any incremental diagnostic that routes identifier text through the
  arena silently degrade.

## Fix

Refresh the arena's interner at the end of the incremental path,
mirroring the transfer that the full-parse path
([`state_statements.rs:156`](crates/tsz-parser/src/parser/state_statements.rs))
already performs:

```rust
self.arena.set_interner(self.scanner.interner().clone());
```

The new interner is a strict superset of the previous arena clone
because incremental parsing only ever **adds** atoms — existing atoms
remain resolvable; new atoms now resolve correctly too.

## Roadmap Claim

- Updated `docs/plan/ROADMAP.md` (Active Implementation Claims) before
  pushing the implementation commit.
- Workstream: §7 *Incremental Parser And Interner Coherence*.

## Planned Scope

- `crates/tsz-parser/src/parser/state_statements.rs` — interner
  refresh at end of `parse_source_file_statements_from_offset`.
- `crates/tsz-parser/tests/parser_improvement_tests.rs` — regression
  test `test_incremental_parse_keeps_arena_interner_coherent`.
- `docs/plan/ROADMAP.md` — claim entry.

## Verification Plan

- [x] Regression test fails on prior `main`, passes with the fix.
- [x] `cargo nextest run -p tsz-parser` (559/559 pass).
- [x] `cargo nextest run -p tsz-lsp` (3713/3713 pass — exercises the
      live incremental-parse path through `LspProject`).
- [x] `cargo nextest run -p tsz-parser -p tsz-scanner -p tsz-lsp -p tsz-binder -p tsz-checker`
      (10169/10169 pass, parser-adjacent crates).
- [x] Pre-commit hook full nextest profile (19658/19658 pass on the
      seven affected crates).
- [ ] Optional: full `scripts/session/verify-all.sh` (conformance +
      emit + fourslash). Adds confidence but pre-commit already covered
      the critical surface; will run before marking the PR ready.

## Why This Belongs in the First Stable Roadmap Slice for §7

The roadmap exit criterion for §7 is:

> Incremental parse, binder-visible identifier text, and LSP-visible
> names remain coherent after suffix edits.

This PR is the smallest behavior-preserving change that satisfies the
exit criterion plus the "regression test introducing a new identifier"
deliverable. The roadmap also flags an alternative: move scanner and
arena to a shared coherent interner handle (e.g. `Arc<RwLock<Interner>>`).
That is a larger architectural change and is intentionally **not** in
scope here — it would be a follow-up slice.