### PR TITLE
fix(solver): report union overload this mismatches

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -745,7 +745,11 @@ impl<'a> CheckerState<'a> {
             CallResult::ThisTypeMismatch {
                 expected_this,
                 actual_this,
+                emit_not_callable,
             } => {
+                if emit_not_callable {
+                    self.error_not_callable_at(callee_type, callee_expr);
+                }
                 self.error_this_type_mismatch_at(expected_this, actual_this, callee_expr);
                 TypeId::ERROR
             }

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1408,6 +1408,7 @@ impl<'a> CheckerState<'a> {
             CallResult::ThisTypeMismatch {
                 expected_this,
                 actual_this,
+                ..
             } => {
                 self.error_this_type_mismatch_at(expected_this, actual_this, idx);
                 TypeId::ERROR

--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -1975,10 +1975,10 @@ declare var x1: A & C & {
     f3: F3 | F4;
 };
 x1.f3();
-"#;
+    "#;
     assert!(
-        has_error(source, 2349),
-        "Union of multi-overload interfaces with no compatible this-pairs should emit TS2349"
+        has_error(source, 2684),
+        "Union of multi-overload interfaces with no compatible this-pairs should emit TS2684"
     );
 }
 

--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -1983,6 +1983,26 @@ x1.f3();
 }
 
 #[test]
+fn union_multi_overload_incompatible_without_this_emits_ts2349() {
+    let source = r#"
+interface F1 {
+    (x: string): void;
+    (x: number): void;
+}
+interface F2 {
+    (x: boolean): void;
+    (x: undefined): void;
+}
+declare let f: F1 | F2;
+f("hello");
+"#;
+    assert!(
+        has_error(source, 2349),
+        "Union of incompatible non-this multi-overload interfaces should remain not callable"
+    );
+}
+
+#[test]
 fn union_multi_overload_compatible_this_no_ts2349() {
     // When multi-overload union members DO have a compatible signature pair,
     // the union IS callable (no TS2349). The this-type is intersected.

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -221,6 +221,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 CallResult::ThisTypeMismatch {
                     expected_this,
                     actual_this,
+                    ..
                 } => {
                     all_arg_count_mismatches = false;
                     this_mismatch_count += 1;

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -113,6 +113,7 @@ pub enum CallResult {
     ThisTypeMismatch {
         expected_this: TypeId,
         actual_this: TypeId,
+        emit_not_callable: bool,
     },
 
     /// Argument count mismatch

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -716,13 +716,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             }
                         }
                     }
-                    if !this_types.is_empty() {
-                        let mut combined_this = this_types[0];
-                        for &this_type in &this_types[1..] {
-                            combined_this = self.interner.intersection2(combined_this, this_type);
-                        }
-                        force_union_this_type = Some(combined_this);
+                    if this_types.is_empty() {
+                        return CallResult::NotCallable {
+                            type_id: union_type,
+                        };
                     }
+
+                    let mut combined_this = this_types[0];
+                    for &this_type in &this_types[1..] {
+                        combined_this = self.interner.intersection2(combined_this, this_type);
+                    }
+                    force_union_this_type = Some(combined_this);
 
                     force_not_callable_with_this_mismatch = true;
                 }

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -524,6 +524,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         failures: &mut Vec<CallResult>,
         return_types: Vec<TypeId>,
         combined_return_override: Option<TypeId>,
+        force_not_callable_with_this_mismatch: bool,
     ) -> CallResult {
         if return_types.is_empty() {
             if failures.is_empty() {
@@ -593,6 +594,27 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 };
             }
 
+            if force_not_callable_with_this_mismatch
+                && failures
+                    .iter()
+                    .all(|f| matches!(f, CallResult::ThisTypeMismatch { .. }))
+            {
+                return match failures.first() {
+                    Some(CallResult::ThisTypeMismatch {
+                        expected_this,
+                        actual_this,
+                        ..
+                    }) => CallResult::ThisTypeMismatch {
+                        expected_this: *expected_this,
+                        actual_this: *actual_this,
+                        emit_not_callable: true,
+                    },
+                    _ => CallResult::NotCallable {
+                        type_id: union_type,
+                    },
+                };
+            }
+
             // Not all argument type mismatches, return the first failure
             return failures
                 .drain(..)
@@ -624,13 +646,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // doesn't satisfy ALL members' `this` requirements.
         // IMPORTANT: Defer `this` errors to after argument checking — TSC reports
         // argument errors (TS2345) before `this` context errors (TS2684).
-        let deferred_this_error =
+        let mut deferred_this_error =
             if let Some(combined_this) = self.compute_union_this_type(&members) {
                 let actual_this = self.actual_this_type.unwrap_or(TypeId::VOID);
                 if !self.checker.is_assignable_to(actual_this, combined_this) {
                     Some(CallResult::ThisTypeMismatch {
                         expected_this: combined_this,
                         actual_this,
+                        emit_not_callable: false,
                     })
                 } else {
                     None
@@ -649,6 +672,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let sig_lists = self.collect_union_call_signature_lists(&members);
         let has_multi_overload_members =
             sig_lists.iter().filter(|(_, sigs)| sigs.len() > 1).count();
+        let mut force_not_callable_with_this_mismatch = false;
+        let mut force_union_this_type = None;
 
         if has_multi_overload_members >= 2 {
             if let Some(unified_sigs) = self.find_union_compatible_signatures(&sig_lists) {
@@ -666,6 +691,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         return CallResult::ThisTypeMismatch {
                             expected_this: combined_this,
                             actual_this,
+                            emit_not_callable: false,
                         };
                     }
                 }
@@ -682,9 +708,23 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     .filter(|(_, sigs)| sigs.len() > 1)
                     .all(|(_, sigs)| sigs.iter().all(|s| s.type_params.is_empty()));
                 if all_non_generic {
-                    return CallResult::NotCallable {
-                        type_id: union_type,
-                    };
+                    let mut this_types = Vec::new();
+                    for (_, sigs) in &sig_lists {
+                        for sig in sigs {
+                            if let Some(this_type) = sig.this_type {
+                                this_types.push(this_type);
+                            }
+                        }
+                    }
+                    if !this_types.is_empty() {
+                        let mut combined_this = this_types[0];
+                        for &this_type in &this_types[1..] {
+                            combined_this = self.interner.intersection2(combined_this, this_type);
+                        }
+                        force_union_this_type = Some(combined_this);
+                    }
+
+                    force_not_callable_with_this_mismatch = true;
                 }
             }
         } else if has_multi_overload_members == 1 {
@@ -751,6 +791,20 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         };
                     }
                 }
+            }
+        }
+
+        if deferred_this_error.is_none()
+            && force_not_callable_with_this_mismatch
+            && let Some(expected_this) = force_union_this_type
+        {
+            let actual_this = self.actual_this_type.unwrap_or(TypeId::VOID);
+            if !self.checker.is_assignable_to(actual_this, expected_this) {
+                deferred_this_error = Some(CallResult::ThisTypeMismatch {
+                    expected_this,
+                    actual_this,
+                    emit_not_callable: false,
+                });
             }
         }
 
@@ -1001,6 +1055,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             &mut failures,
                             return_types,
                             combined.as_ref().map(|c| c.return_type),
+                            false,
                         );
                     }
                 }
@@ -1024,6 +1079,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 &mut failures,
                 return_types,
                 combined.as_ref().map(|c| c.return_type),
+                force_not_callable_with_this_mismatch,
             )
         } else if let Some(this_error) = deferred_this_error {
             this_error
@@ -1098,6 +1154,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     Some(CallResult::ThisTypeMismatch {
                         expected_this,
                         actual_this,
+                        emit_not_callable: false,
                     })
                 } else {
                     None
@@ -1106,6 +1163,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 Some(CallResult::ThisTypeMismatch {
                     expected_this,
                     actual_this: TypeId::VOID,
+                    emit_not_callable: false,
                 })
             } else {
                 None
@@ -1325,6 +1383,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 CallResult::ThisTypeMismatch {
                     expected_this,
                     actual_this,
+                    ..
                 } => {
                     all_arg_count_mismatches = false;
                     this_mismatch_count += 1;

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1932,6 +1932,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 return CallResult::ThisTypeMismatch {
                     expected_this,
                     actual_this,
+                    emit_not_callable: false,
                 };
             }
         }


### PR DESCRIPTION
## Summary
- Carries a union-call resolution fix so incompatible multi-overload `this` pairs report TS2684 while still surfacing not-callable context where needed.
- Keeps the TS2352 angle-bracket display regression meaningful on current main by using a truly non-overlapping cast source.

## Roadmap
- No roadmap edit: this wraps an already-existing diagnostic conformance worktree rather than starting a new roadmap/DRY claim.

## Test plan
- `cargo nextest run -p tsz-checker dispatch_tests::ts2352_angle_bracket_type_display_no_trailing_gt`
- Pre-commit hook passed for affected crates.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
