### PR TITLE
[WIP] fix(lsp): purge sub_to_bases edges on file removal

### DIFF
--- a/crates/tsz-lsp/src/symbols/symbol_index.rs
+++ b/crates/tsz-lsp/src/symbols/symbol_index.rs
@@ -106,6 +106,18 @@ pub struct SymbolIndex {
     /// For example, if "class B extends A, implements I",
     /// then `sub_to_bases`["B"] = {"A", "I"}
     sub_to_bases: FxHashMap<String, FxHashSet<String>>,
+
+    /// Per-file edge log for `sub_to_bases`: file path -> set of
+    /// `(class_name, base_name)` edges that file contributed.
+    ///
+    /// Enables correct removal of stale heritage entries when a file is
+    /// removed or re-indexed. Without this, `remove_file` cannot undo a
+    /// file's contribution to `sub_to_bases` because the public map only
+    /// stores `class -> {bases}` — there is no way to know which file
+    /// originally added each base. Edges are reference-counted across
+    /// files via this map, so a class declared in two files keeps its
+    /// edges until both files are removed.
+    sub_to_bases_by_file: FxHashMap<String, FxHashSet<(String, String)>>,
 }
 
 impl SymbolIndex {
@@ -298,11 +310,31 @@ impl SymbolIndex {
         }
         self.heritage_clauses.retain(|_, files| !files.is_empty());
 
-        // Remove sub_to_bases entries for this file
-        for bases in self.sub_to_bases.values_mut() {
-            bases.remove(file_name);
+        // Remove this file's contributions to sub_to_bases.
+        //
+        // The public `sub_to_bases` map only stores `class -> {bases}`, so it
+        // alone cannot distinguish which file added which base. We use the
+        // per-file edge log (`sub_to_bases_by_file`) for refcount-style
+        // cleanup: each (class, base) edge is dropped from `sub_to_bases`
+        // only when no other indexed file still contributes it. Classes
+        // declared exclusively in this file lose their entries entirely.
+        if let Some(edges) = self.sub_to_bases_by_file.remove(file_name) {
+            for (class, base) in edges {
+                let still_contributed = self
+                    .sub_to_bases_by_file
+                    .values()
+                    .any(|other| other.contains(&(class.clone(), base.clone())));
+                if still_contributed {
+                    continue;
+                }
+                if let Some(bases) = self.sub_to_bases.get_mut(&class) {
+                    bases.remove(&base);
+                    if bases.is_empty() {
+                        self.sub_to_bases.remove(&class);
+                    }
+                }
+            }
         }
-        self.sub_to_bases.retain(|_, bases| !bases.is_empty());
     }
 
     /// Index a file during binding.
@@ -604,7 +636,11 @@ impl SymbolIndex {
                         self.sub_to_bases
                             .entry(class_name.clone())
                             .or_default()
-                            .insert(base_name);
+                            .insert(base_name.clone());
+                        self.sub_to_bases_by_file
+                            .entry(file_name_owned.clone())
+                            .or_default()
+                            .insert((class_name.clone(), base_name));
                     }
                 }
             }
@@ -777,6 +813,7 @@ impl SymbolIndex {
         // root change).
         self.heritage_clauses.clear();
         self.sub_to_bases.clear();
+        self.sub_to_bases_by_file.clear();
     }
 
     /// Get all symbols that start with the given prefix.

--- a/crates/tsz-lsp/tests/symbol_index_tests.rs
+++ b/crates/tsz-lsp/tests/symbol_index_tests.rs
@@ -1738,6 +1738,72 @@ fn test_index_file_sub_to_bases_survives_large_class_body() {
 }
 
 #[test]
+fn test_remove_file_clears_sub_to_bases_for_classes_in_that_file() {
+    // Regression: remove_file() iterated `sub_to_bases.values_mut()` and
+    // tried to remove `file_name` from each value set — but the values are
+    // base symbol names (not file paths), so the loop did nothing in
+    // practice. After the fix, removing a file drops `sub_to_bases` entries
+    // for classes that were declared in that file, so go-to-implementation
+    // and upward-rename do not return ghost edges to deleted classes.
+    let source = r"class Base {} class Sub extends Base {}";
+    let (binder, parser) = parse_and_bind("file.ts", source);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("file.ts", &binder, parser.get_arena(), source);
+
+    assert!(
+        !index.get_bases_for_class("Sub").is_empty(),
+        "precondition: sub_to_bases should be populated after indexing"
+    );
+
+    index.remove_file("file.ts");
+
+    assert!(
+        index.get_bases_for_class("Sub").is_empty(),
+        "remove_file should drop sub_to_bases entries for classes declared \
+         in the removed file; got stale entry {:?}",
+        index.get_bases_for_class("Sub")
+    );
+}
+
+#[test]
+fn test_remove_file_keeps_sub_to_bases_for_classes_in_other_files() {
+    // Cleanup must not over-purge: classes declared in OTHER files keep
+    // their heritage edges. Removing `a.ts` (which declares `Sub extends
+    // Base`) must not affect `Other` declared in `b.ts`.
+    let source_a = r"class Base {} class Sub extends Base {}";
+    let source_b = r"interface Mixin {} class Other extends Sub implements Mixin {}";
+    let (binder_a, parser_a) = parse_and_bind("a.ts", source_a);
+    let (binder_b, parser_b) = parse_and_bind("b.ts", source_b);
+
+    let mut index = SymbolIndex::new();
+    index.index_file("a.ts", &binder_a, parser_a.get_arena(), source_a);
+    index.index_file("b.ts", &binder_b, parser_b.get_arena(), source_b);
+
+    let other_bases_before = index.get_bases_for_class("Other");
+    assert!(
+        other_bases_before.contains(&"Sub".to_string())
+            && other_bases_before.contains(&"Mixin".to_string()),
+        "precondition: Other should extend Sub and implement Mixin; got {other_bases_before:?}",
+    );
+
+    index.remove_file("a.ts");
+
+    assert!(
+        index.get_bases_for_class("Sub").is_empty(),
+        "Sub was declared only in a.ts; its sub_to_bases entry should be gone"
+    );
+
+    let other_bases_after = index.get_bases_for_class("Other");
+    assert!(
+        other_bases_after.contains(&"Sub".to_string())
+            && other_bases_after.contains(&"Mixin".to_string()),
+        "Other was declared in b.ts; its sub_to_bases entry must survive \
+         removal of unrelated file a.ts; got {other_bases_after:?}",
+    );
+}
+
+#[test]
 fn test_clear_resets_heritage_and_sub_to_bases() {
     // Regression: clear() used to leave heritage_clauses and sub_to_bases
     // populated, so a fully-rebuilt index would see stale class edges.

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -50,6 +50,7 @@ Rules:
 Add new roadmap and DRY claims here before implementation begins.
 
 - **2026-04-25** · branch `claude/modest-archimedes-QBaXl` · **DRY active claim** · P0 Test-Harness Consolidation: replace local `check_with_options` helpers with `tsz_checker::test_utils::check_source` in `crates/tsz-checker/tests/class_member_closure_tests.rs`, `contextual_tuple_tests.rs`, `contextual_typing_tests.rs`, and `never_returning_narrowing_tests.rs`. Legacy draft title: `[do not merge] chore(checker-tests): replace local check_with_options helpers with test_utils::check_source`; treat as WIP until ready.
+- **2026-04-25** · branch `fix/lsp-heritage-cleanup-sub-to-bases` · **DRY §8 bug-shaped finding active claim** · Fix `tsz-lsp` `SymbolIndex::remove_file` so it correctly purges `sub_to_bases` entries for classes declared in the removed file. The current cleanup iterates `sub_to_bases.values_mut()` and removes `file_name` from each value set, but the values are base symbol names (not file paths), so the loop was a no-op and stale upward-heritage edges leaked into go-to-implementation / rename. Adds a per-file `(class, base)` edge log so the public `class -> {bases}` view stays correct under multi-file class merging. Two regression tests in `crates/tsz-lsp/tests/symbol_index_tests.rs` cover both the single-file and cross-file cases. Draft PR title: `[WIP] fix(lsp): purge sub_to_bases edges on file removal`.
 
 ## How To Keep This Current
 


### PR DESCRIPTION
## Intent

Fix the `tsz-lsp` heritage-index cleanup bug called out in
[`docs/plan/ROADMAP.md`](docs/plan/ROADMAP.md) §8 *DRY Cleanup —
Bug-shaped findings still worth triage*:

> `tsz-lsp` heritage index cleanup may still leave stale
> `sub_to_bases` relationships on file removal.

`SymbolIndex::sub_to_bases` is `class_name -> {base_name, …}` — the
values are base symbol names. The previous `remove_file` code
attempted to clean up by iterating `values_mut()` and removing
`file_name` from each value set:

```rust
for bases in self.sub_to_bases.values_mut() {
    bases.remove(file_name);                 // <-- looking up a file path in a set of CLASS names
}
self.sub_to_bases.retain(|_, bases| !bases.is_empty());
```

That loop was a no-op in practice, because file paths never collide
with base symbol names. So once a file added an entry, it stayed
there forever — Go to Implementation, upward-rename across
hierarchies, and any other consumer of `get_bases_for_class` would
keep returning ghost edges pointing at removed classes.

## Fix

Add an explicit per-file `(class, base)` edge log so the public
`class -> {bases}` view can be cleaned up correctly:

- New field `sub_to_bases_by_file: FxHashMap<String, FxHashSet<(String, String)>>`.
- `index_file` records every `(class, base)` edge under the current
  file alongside the existing `sub_to_bases.insert`.
- `remove_file` removes the file's edges and drops each edge from
  `sub_to_bases` only when no other indexed file still contributes
  it (refcount semantics, so classes declared in two files keep
  their edges until *both* contributors are gone).
- `clear()` also clears the new map.

The read paths (`get_bases_for_class`, etc.) stay unchanged.

## Roadmap Claim

- Updated `docs/plan/ROADMAP.md` Active Implementation Claims before
  pushing the implementation commit.
- Workstream §8 bug-shaped finding.

## Planned Scope

- `crates/tsz-lsp/src/symbols/symbol_index.rs` — new field, edge log
  population, refcount-aware `remove_file`, `clear()`.
- `crates/tsz-lsp/tests/symbol_index_tests.rs` — two regression
  tests:
  1. `test_remove_file_clears_sub_to_bases_for_classes_in_that_file`
  2. `test_remove_file_keeps_sub_to_bases_for_classes_in_other_files`
- `docs/plan/ROADMAP.md` — claim entry.

## Verification Plan

- [x] Both regression tests fail on prior `main`, pass with the fix.
- [x] All previously-passing heritage tests still pass
      (`test_index_file_populates_sub_to_bases_for_class`,
      `_for_interface`, `_survives_large_class_body`,
      `test_clear_resets_heritage_and_sub_to_bases`).
- [x] `cargo nextest run -p tsz-lsp` (3715/3715 pass — 2 new tests
      added).
- [x] `cargo fmt --check -p tsz-lsp` clean.
- [x] `cargo clippy -p tsz-lsp --all-targets -- -D warnings` clean.
- [x] Repo pre-commit hook (clippy + boundary guardrail + 7-crate
      nextest profile + wasm32 rustc gate) passed.
- [ ] Optional: full `scripts/session/verify-all.sh` before marking
      ready.

## Why This Is Bounded

- Only LSP semantic symbol-index code is touched; no checker, solver,
  parser, or emitter behavior changes.
- The data-structure addition is internal to `SymbolIndex`; the public
  API surface (`get_bases_for_class`, `get_files_with_heritage`, etc.)
  is unchanged.
- The fix preserves the existing `heritage_clauses` cleanup, which is
  symmetric on a different shape (`base -> {files}`) where
  `values_mut().remove(file_name)` is correct.