### PR TITLE
chore(checker): remove duplicate tuple comparability comment

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1340,12 +1340,6 @@ impl<'a> CheckerState<'a> {
         let target_is_tuple =
             crate::query_boundaries::common::tuple_elements(self.ctx.types, target_resolved)
                 .is_some();
-        // Tuples are already handled element-wise by the solver's
-        // `types_are_comparable_for_assertion` (see flow.rs); the property-bag
-        // view here would treat the implicit `length` literal as a shared
-        // comparable property and falsely report overlap for casts like
-        // `[C, D] as [A, I]` where the elements don't overlap. Defer to the
-        // solver's tuple logic.
         if source_is_tuple && target_is_tuple {
             return false;
         }


### PR DESCRIPTION
## Summary
- Removes a duplicated tuple-comparability comment block left in the merged tuple assertion fix.

## Review Comment
- Addresses Devin review feedback from #1204 after that PR was already merged.

## Test plan
- Comment-only change; pre-commit hook passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
