### PR TITLE
perf(binder,checker,cli,core): Arc-share per-file node_symbols (~38% RSS reduction on large-ts-repo)

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -66,7 +66,7 @@ impl BinderState {
                 }
 
                 let sym_id = self.declare_symbol(arena, name, flags, idx, is_exported);
-                self.node_symbols.insert(decl.name.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(decl.name.0, sym_id);
                 self.record_semantic_def(
                     sym_id,
                     crate::state::SemanticDefKind::Variable,
@@ -224,7 +224,7 @@ impl BinderState {
                     idx,
                     false,
                 );
-                self.node_symbols.insert(param.name.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(param.name.0, sym_id);
                 tracing::debug!(param_name = %name, sym_id = sym_id.0, "Parameter bound");
             } else {
                 let mut names = Vec::new();
@@ -350,7 +350,7 @@ impl BinderState {
                         param_idx,
                         false,
                     );
-                    self.node_symbols.insert(type_param.name.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(type_param.name.0, sym_id);
                 }
             }
         }
@@ -682,7 +682,7 @@ impl BinderState {
                     flags |= symbol_flags::ABSTRACT;
                 }
                 let sym_id = self.declare_symbol(arena, name, flags, idx, false);
-                self.node_symbols.insert(class.name.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(class.name.0, sym_id);
             } else {
                 // Anonymous class expression: create a CLASS symbol so that
                 // the checker can use it as parent_id on instance properties,
@@ -697,7 +697,7 @@ impl BinderState {
                     sym.add_declaration(idx, span);
                     sym.set_value_declaration(idx, span);
                 }
-                self.node_symbols.insert(idx.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(idx.0, sym_id);
             }
 
             self.bind_type_parameters(arena, class.type_parameters.as_ref());
@@ -735,7 +735,7 @@ impl BinderState {
                     let flags = symbol_flags::METHOD
                         | Self::extract_member_modifier_flags(arena, method.modifiers.as_ref());
                     let sym_id = self.declare_symbol(arena, &name, flags, idx, false);
-                    self.node_symbols.insert(method.name.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(method.name.0, sym_id);
                 }
                 self.bind_callable_body_with_type_params(
                     arena,
@@ -760,7 +760,7 @@ impl BinderState {
                     let flags = symbol_flags::PROPERTY
                         | Self::extract_member_modifier_flags(arena, prop.modifiers.as_ref());
                     let sym_id = self.declare_symbol(arena, &name, flags, idx, false);
-                    self.node_symbols.insert(prop.name.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(prop.name.0, sym_id);
                 }
 
                 if prop.initializer.is_some() {
@@ -787,7 +787,7 @@ impl BinderState {
                     let flags = base_flags
                         | Self::extract_member_modifier_flags(arena, accessor.modifiers.as_ref());
                     let sym_id = self.declare_symbol(arena, &name, flags, idx, false);
-                    self.node_symbols.insert(accessor.name.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(accessor.name.0, sym_id);
                 }
                 self.bind_callable_body(arena, &accessor.parameters, accessor.body, idx);
             }
@@ -1011,7 +1011,7 @@ impl BinderState {
                 {
                     self.file_locals.set(name.to_string(), sym_id);
                 }
-                self.node_symbols.insert(idx.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(idx.0, sym_id);
                 self.declare_in_persistent_scope(name.to_string(), sym_id);
                 // Record partnership: TYPE_ALIAS → ALIAS
                 self.alias_partners.insert(sym_id, alias_id);
@@ -1157,7 +1157,7 @@ impl BinderState {
                         sym.parent = enum_sym_id; // Set parent to the enum symbol
                     }
                     self.current_scope.set(member_name.to_string(), sym_id);
-                    self.node_symbols.insert(member_idx.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(member_idx.0, sym_id);
                     // Add to exports for namespace merging
                     exports.set(member_name.to_string(), sym_id);
 

--- a/crates/tsz-binder/src/binding/validation.rs
+++ b/crates/tsz-binder/src/binding/validation.rs
@@ -19,7 +19,7 @@ impl BinderState {
     pub fn validate_symbol_table(&self) -> Vec<ValidationError> {
         let mut errors = Vec::new();
 
-        for (&node_idx, &sym_id) in &self.node_symbols {
+        for (&node_idx, &sym_id) in self.node_symbols.iter() {
             if self.symbols.get(sym_id).is_none() {
                 errors.push(ValidationError::BrokenSymbolLink {
                     node_index: node_idx,

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -66,7 +66,7 @@ impl BinderState {
                     sym.import_name = Some("default".to_string());
                 }
             }
-            self.node_symbols.insert(clause.name.0, sym_id);
+            Arc::make_mut(&mut self.node_symbols).insert(clause.name.0, sym_id);
         }
 
         // Named imports
@@ -89,7 +89,7 @@ impl BinderState {
                             sym.import_module = Some(specifier.clone());
                         }
                     }
-                    self.node_symbols.insert(clause.named_bindings.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(clause.named_bindings.0, sym_id);
                 }
             } else if let Some(named) = arena.get_named_imports(bindings_node) {
                 // Handle namespace import: import * as ns from 'module'
@@ -114,8 +114,8 @@ impl BinderState {
                             sym.import_name = Some("*".to_string());
                         }
                     }
-                    self.node_symbols.insert(named.name.0, sym_id);
-                    self.node_symbols.insert(clause.named_bindings.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(named.name.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(clause.named_bindings.0, sym_id);
                 }
                 // Handle named imports: import { foo, bar } from 'module'
                 for &spec_idx in &named.elements.nodes {
@@ -161,8 +161,8 @@ impl BinderState {
                             }
                         }
                     }
-                    self.node_symbols.insert(spec_idx.0, sym_id);
-                    self.node_symbols.insert(local_ident.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(spec_idx.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(local_ident.0, sym_id);
                 }
             }
         }
@@ -372,7 +372,7 @@ impl BinderState {
                     self.file_locals.set("default".to_string(), default_sym_id);
                 }
 
-                self.node_symbols
+                Arc::make_mut(&mut self.node_symbols)
                     .insert(export.export_clause.0, default_sym_id);
 
                 // Also mark the underlying local symbol as exported if it exists.
@@ -508,7 +508,8 @@ impl BinderState {
                                                 }
                                             }
                                         }
-                                        self.node_symbols.insert(spec_idx.0, export_sym_id);
+                                        Arc::make_mut(&mut self.node_symbols)
+                                            .insert(spec_idx.0, export_sym_id);
 
                                         // Add alias to file_locals so it appears in
                                         // module_exports for cross-file import resolution.
@@ -618,7 +619,7 @@ impl BinderState {
                                             .unwrap_or_else(|| exported.clone()),
                                     );
                                 }
-                                self.node_symbols.insert(spec_idx.0, sym_id);
+                                Arc::make_mut(&mut self.node_symbols).insert(spec_idx.0, sym_id);
                             }
 
                             // Now apply the mutable borrow to insert the mappings
@@ -696,7 +697,7 @@ impl BinderState {
                     } else if is_umd {
                         self.current_scope.set(name.to_string(), sym_id);
                     }
-                    self.node_symbols.insert(export.export_clause.0, sym_id);
+                    Arc::make_mut(&mut self.node_symbols).insert(export.export_clause.0, sym_id);
 
                     if is_umd {
                         // UMD namespace exports register a global name.

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1,5 +1,7 @@
 //! AST node binding, hoisting, and scope management.
 
+use std::sync::Arc;
+
 use crate::{ContainerKind, ScopeContext, SymbolId, SymbolTable, flow_flags, symbol_flags};
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
@@ -1365,7 +1367,7 @@ impl BinderState {
                 // CRITICAL: Also update file_locals to shadow lib symbol in file-level scope
                 // This ensures symbol resolution finds the local symbol instead of the lib one
                 self.file_locals.set(owned_name.clone(), sym_id);
-                self.node_symbols.insert(declaration.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
                 self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
@@ -1438,7 +1440,7 @@ impl BinderState {
                 }
                 self.current_scope.set(owned_name.clone(), sym_id);
                 self.file_locals.set(owned_name.clone(), sym_id);
-                self.node_symbols.insert(declaration.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
                 self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
@@ -1476,7 +1478,7 @@ impl BinderState {
                     }
                 }
                 self.current_scope.set(owned_name.clone(), sym_id);
-                self.node_symbols.insert(declaration.0, sym_id);
+                Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
                 self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
@@ -1527,7 +1529,7 @@ impl BinderState {
                 );
             }
 
-            self.node_symbols.insert(declaration.0, existing_id);
+            Arc::make_mut(&mut self.node_symbols).insert(declaration.0, existing_id);
             self.declare_in_persistent_scope(name.to_string(), existing_id);
             return existing_id;
         }
@@ -1603,7 +1605,7 @@ impl BinderState {
             self.file_locals.set(owned_name.clone(), sym_id);
         }
 
-        self.node_symbols.insert(declaration.0, sym_id);
+        Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
         self.declare_in_persistent_scope(owned_name, sym_id);
 
         // Record declaration event (new symbol)

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -182,7 +182,7 @@ impl BinderState {
             unreachable_flow,
             scope_chain: Vec::with_capacity(32),
             current_scope_idx: 0,
-            node_symbols: FxHashMap::with_capacity_and_hasher(256, Default::default()),
+            node_symbols: Arc::new(FxHashMap::with_capacity_and_hasher(256, Default::default())),
             module_declaration_exports_publicly: FxHashMap::default(),
             symbol_arenas: Arc::new(FxHashMap::default()),
             declaration_arenas: Arc::new(FxHashMap::default()),
@@ -252,7 +252,7 @@ impl BinderState {
         self.current_flow = FlowNodeId::NONE;
         self.scope_chain.clear();
         self.current_scope_idx = 0;
-        self.node_symbols.clear();
+        Arc::make_mut(&mut self.node_symbols).clear();
         self.module_declaration_exports_publicly.clear();
         Arc::make_mut(&mut self.symbol_arenas).clear();
         Arc::make_mut(&mut self.declaration_arenas).clear();
@@ -377,7 +377,7 @@ impl BinderState {
     /// symbols and `file_locals` (no `node_symbols` or other binding state).
     #[must_use]
     pub fn from_preparsed(symbols: SymbolArena, file_locals: SymbolTable) -> Self {
-        Self::from_bound_state(symbols, file_locals, FxHashMap::default())
+        Self::from_bound_state(symbols, file_locals, Arc::new(FxHashMap::default()))
     }
 
     /// Create a `BinderState` from existing bound state.
@@ -388,7 +388,7 @@ impl BinderState {
     pub fn from_bound_state(
         symbols: SymbolArena,
         file_locals: SymbolTable,
-        node_symbols: FxHashMap<u32, SymbolId>,
+        node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     ) -> Self {
         Self::from_bound_state_with_options(
             BinderOptions::default(),
@@ -404,7 +404,7 @@ impl BinderState {
         options: BinderOptions,
         symbols: SymbolArena,
         file_locals: SymbolTable,
-        node_symbols: FxHashMap<u32, SymbolId>,
+        node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     ) -> Self {
         let mut flow_nodes = FlowNodeArena::new();
         let unreachable_flow = flow_nodes.alloc(flow_flags::UNREACHABLE);
@@ -476,7 +476,7 @@ impl BinderState {
     pub fn from_bound_state_with_scopes(
         symbols: SymbolArena,
         file_locals: SymbolTable,
-        node_symbols: FxHashMap<u32, SymbolId>,
+        node_symbols: Arc<FxHashMap<u32, SymbolId>>,
         scopes: Vec<Scope>,
         node_scope_ids: FxHashMap<u32, ScopeId>,
     ) -> Self {
@@ -501,7 +501,7 @@ impl BinderState {
         options: BinderOptions,
         symbols: SymbolArena,
         file_locals: SymbolTable,
-        node_symbols: FxHashMap<u32, SymbolId>,
+        node_symbols: Arc<FxHashMap<u32, SymbolId>>,
         inputs: BinderStateScopeInputs,
     ) -> Self {
         let BinderStateScopeInputs {
@@ -988,8 +988,11 @@ impl BinderState {
         // A rough estimate: ~3-5 nodes per top-level statement.
         if estimated_decl_count > 16 {
             let estimated_nodes = estimated_decl_count * 4;
-            self.node_symbols.clear();
-            self.node_symbols.reserve(estimated_nodes);
+            {
+                let node_symbols = Arc::make_mut(&mut self.node_symbols);
+                node_symbols.clear();
+                node_symbols.reserve(estimated_nodes);
+            }
             self.node_flow.clear();
             self.node_flow.reserve(estimated_nodes);
         }
@@ -1705,7 +1708,7 @@ impl BinderState {
         let mut symbol_nodes = Vec::new();
         self.collect_statement_symbol_nodes(arena, old_suffix_statements, &mut symbol_nodes);
         for node in symbol_nodes {
-            if let Some(sym_id) = self.node_symbols.remove(&node.0)
+            if let Some(sym_id) = Arc::make_mut(&mut self.node_symbols).remove(&node.0)
                 && let Some(sym) = self.symbols.get_mut(sym_id)
             {
                 // Keep `declarations` and `stable_declarations` in lockstep —

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -274,8 +274,17 @@ pub struct BinderState {
     pub(crate) scope_chain: Vec<crate::ScopeContext>,
     /// Current scope index in `scope_chain`
     pub(crate) current_scope_idx: usize,
-    /// Node-to-symbol mapping
-    pub node_symbols: FxHashMap<u32, SymbolId>,
+    /// Node-to-symbol mapping.
+    ///
+    /// Stored behind `Arc` so cross-file lookup binders (one per file in the
+    /// parallel CLI pipeline) can share each file's per-file map by reference
+    /// instead of deep-cloning the underlying `FxHashMap` on every binder
+    /// reconstruction. On large repos (6086 files), the previous deep clone
+    /// of `node_symbols` was one of the largest per-binder allocations
+    /// (#1202 covered `semantic_defs`; this is the same template applied to
+    /// `node_symbols`). Mutations during binding use `Arc::make_mut` (free
+    /// when refcount=1, the case during a single binder's construction).
+    pub node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     /// Symbol-to-arena mapping for cross-file declaration lookup (legacy, stores last arena).

--- a/crates/tsz-binder/tests/lib_loader.rs
+++ b/crates/tsz-binder/tests/lib_loader.rs
@@ -24,8 +24,11 @@ fn test_merge_lib_symbols() {
     lib_file_locals.set("Function".to_string(), function_id);
     lib_file_locals.set("console".to_string(), console_id);
 
-    let lib_binder =
-        BinderState::from_bound_state(arena, lib_file_locals, rustc_hash::FxHashMap::default());
+    let lib_binder = BinderState::from_bound_state(
+        arena,
+        lib_file_locals,
+        Arc::new(rustc_hash::FxHashMap::default()),
+    );
     let lib = Arc::new(LibFile::new(
         "lib.d.ts".to_string(),
         Arc::new(NodeArena::new()),
@@ -40,7 +43,7 @@ fn test_merge_lib_symbols() {
     let mut user_binder = BinderState::from_bound_state(
         user_arena,
         user_file_locals,
-        rustc_hash::FxHashMap::default(),
+        Arc::new(rustc_hash::FxHashMap::default()),
     );
 
     user_binder.merge_lib_symbols(&[lib]);

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -693,7 +693,7 @@ impl<'a> FlowAnalyzer<'a> {
 
     fn symbol_identifier_ref(&self, sym: SymbolId) -> Option<NodeIndex> {
         let mut declaration_ident = None;
-        for (&node_id, &node_sym) in &self.binder.node_symbols {
+        for (&node_id, &node_sym) in self.binder.node_symbols.iter() {
             if node_sym != sym {
                 continue;
             }

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -667,7 +667,7 @@ impl<'a> CheckerState<'a> {
         };
         let symbol_identifier_ref = |sym: SymbolId| -> Option<NodeIndex> {
             let mut declaration_ident: Option<NodeIndex> = None;
-            for (&node_id, &node_sym) in &self.ctx.binder.node_symbols {
+            for (&node_id, &node_sym) in self.ctx.binder.node_symbols.iter() {
                 if node_sym != sym {
                     continue;
                 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2756,7 +2756,7 @@ fn build_lib_bound_file_for_interface_checks(
         file_name: lib_file.file_name.clone(),
         source_file: lib_file.root_index,
         arena: Arc::clone(&lib_file.arena),
-        node_symbols,
+        node_symbols: std::sync::Arc::new(node_symbols),
         symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1589,7 +1589,12 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
         BinderOptions::default(),
         program.symbols.clone(),
         file_locals,
-        file.node_symbols.clone(),
+        // Arc::clone is O(1) (atomic refcount bump) instead of deep-cloning the
+        // underlying `FxHashMap<u32, SymbolId>`. Per-file binders consume this
+        // map read-only after construction (binder mutations during checking
+        // are gated by `Arc::make_mut`, which copy-on-writes safely if a
+        // mutation ever does fire); sharing is safe.
+        Arc::clone(&file.node_symbols),
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
@@ -1711,7 +1716,12 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
         BinderOptions::default(),
         program.symbols.clone(),
         file_locals,
-        file.node_symbols.clone(),
+        // Arc::clone is O(1) (atomic refcount bump) instead of deep-cloning the
+        // underlying `FxHashMap<u32, SymbolId>`. Per-file binders consume this
+        // map read-only after construction (binder mutations during checking
+        // are gated by `Arc::make_mut`, which copy-on-writes safely if a
+        // mutation ever does fire); sharing is safe.
+        Arc::clone(&file.node_symbols),
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),

--- a/crates/tsz-cli/tests/driver_tests.rs
+++ b/crates/tsz-cli/tests/driver_tests.rs
@@ -2954,7 +2954,7 @@ const onSomeEvent = <T extends keyof TypesMap>(p: P<T>) =>
     let merged_binder =
         tsz::parallel::create_binder_from_bound_file(&program.files[0], &program, 0);
 
-    for (&node_idx, &original_sym_id) in &original_binder.node_symbols {
+    for (&node_idx, &original_sym_id) in original_binder.node_symbols.iter() {
         let Some(&merged_sym_id) = merged_binder.node_symbols.get(&node_idx) else {
             panic!("missing merged node symbol for node {node_idx}");
         };
@@ -3040,7 +3040,7 @@ const onSomeEvent = <T extends keyof TypesMap>(p: P<T>) =>
     let merged_binder =
         tsz::parallel::create_binder_from_bound_file(&program.files[0], &program, 0);
 
-    for (&node_idx, &original_sym_id) in &original_binder.node_symbols {
+    for (&node_idx, &original_sym_id) in original_binder.node_symbols.iter() {
         let Some(&merged_sym_id) = merged_binder.node_symbols.get(&node_idx) else {
             panic!("missing merged node symbol for node {node_idx}");
         };

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -481,8 +481,14 @@ pub struct BindResult {
     pub declared_modules: FxHashSet<String>,
     /// Module exports keyed by specifier or file name
     pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
-    /// Node-to-symbol mapping
-    pub node_symbols: FxHashMap<u32, SymbolId>,
+    /// Node-to-symbol mapping.
+    ///
+    /// Shared via `Arc` because the binder owns it as `Arc<FxHashMap<...>>`
+    /// to avoid deep clones when reconstructing per-file binders for the
+    /// cross-file lookup pipeline. The Arc is moved out of the binder when
+    /// finalizing the bind result. See PR #1202 for the equivalent fix to
+    /// `semantic_defs`; this is the same template applied to `node_symbols`.
+    pub node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     /// Symbol-to-arena mapping for cross-file declaration lookup (including lib symbols)
@@ -1401,8 +1407,15 @@ pub struct BoundFile {
     pub source_file: NodeIndex,
     /// The arena containing all nodes (owned by this file)
     pub arena: Arc<NodeArena>,
-    /// Node-to-symbol mapping (symbol IDs are global after merge)
-    pub node_symbols: FxHashMap<u32, SymbolId>,
+    /// Node-to-symbol mapping (symbol IDs are global after merge).
+    ///
+    /// Shared via `Arc` so cross-file lookup binders (one per file in the
+    /// parallel CLI pipeline) can take an O(1) reference to this file's
+    /// per-file map instead of deep-cloning the underlying `FxHashMap`. On
+    /// large repos (6086 files), the deep clone of `node_symbols` was one
+    /// of the largest per-binder allocations. PR #1202 applied the same
+    /// template to `semantic_defs`; this extends it to `node_symbols`.
+    pub node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     /// Per-file symbol-to-arena mapping captured during binding.
     pub symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
     /// Per-file declaration-to-arena mapping captured during binding.
@@ -3131,7 +3144,7 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
         // Note: node_symbols primarily maps user file nodes to user symbols,
         // but lib symbols referenced in user code need remapping too
         let mut remapped_node_symbols = FxHashMap::default();
-        for (node_idx, old_sym_id) in &result.node_symbols {
+        for (node_idx, old_sym_id) in result.node_symbols.iter() {
             if let Some(&new_sym_id) = id_remap.get(old_sym_id) {
                 remapped_node_symbols.insert(*node_idx, new_sym_id);
             }
@@ -3291,7 +3304,11 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
             file_name: result.file_name.clone(),
             source_file: result.source_file,
             arena: Arc::clone(&result.arena),
-            node_symbols: remapped_node_symbols,
+            // Wrap once here. `cross_file_node_symbols` (built later) takes
+            // an Arc::clone of `file.node_symbols`, so the underlying
+            // `FxHashMap<u32, SymbolId>` is shared via refcount instead of
+            // deep-cloned per consumer.
+            node_symbols: Arc::new(remapped_node_symbols),
             symbol_arenas: remapped_symbol_arenas,
             declaration_arenas: remapped_declaration_arenas,
             module_declaration_exports_publicly: result.module_declaration_exports_publicly.clone(),
@@ -3330,9 +3347,12 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
 
     // Build cross_file_node_symbols: map each arena pointer to its remapped node_symbols.
     // This enables the checker to resolve type references in cross-file interface declarations.
+    // `file.node_symbols` is now `Arc<FxHashMap<...>>`, so cloning the Arc is an
+    // O(1) refcount bump that shares the underlying map with the per-file
+    // `BoundFile` instead of deep-cloning it.
     for file in &files {
         let arena_ptr = Arc::as_ptr(&file.arena) as usize;
-        cross_file_node_symbols.insert(arena_ptr, Arc::new(file.node_symbols.clone()));
+        cross_file_node_symbols.insert(arena_ptr, Arc::clone(&file.node_symbols));
     }
 
     // Validate skeleton data against legacy merge state before construction.
@@ -4057,7 +4077,7 @@ fn build_lib_bound_file_for_interface_checks(
         file_name: lib_file.file_name.clone(),
         source_file: lib_file.root_index,
         arena: Arc::clone(&lib_file.arena),
-        node_symbols,
+        node_symbols: Arc::new(node_symbols),
         symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),
@@ -4870,7 +4890,9 @@ pub fn create_binder_from_bound_file(
         BinderOptions::default(),
         program.symbols.clone(),
         file_locals,
-        file.node_symbols.clone(),
+        // Arc::clone is O(1); cross-file lookup binders share the per-file
+        // map by reference instead of deep-cloning it.
+        Arc::clone(&file.node_symbols),
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),
@@ -4973,7 +4995,9 @@ pub fn create_binder_from_bound_file_with_shared(
         BinderOptions::default(),
         program.symbols.clone(),
         file_locals,
-        file.node_symbols.clone(),
+        // Arc::clone is O(1); cross-file lookup binders share the per-file
+        // map by reference instead of deep-cloning it.
+        Arc::clone(&file.node_symbols),
         BinderStateScopeInputs {
             scopes: file.scopes.clone(),
             node_scope_ids: file.node_scope_ids.clone(),

--- a/crates/tsz-core/tests/binder_state_tests.rs
+++ b/crates/tsz-core/tests/binder_state_tests.rs
@@ -2446,7 +2446,7 @@ fn test_symbol_table_validation_broken_links() {
     binder.bind_source_file(arena, root);
 
     let fake_sym_id = crate::binder::SymbolId(99999);
-    binder.node_symbols.insert(100, fake_sym_id);
+    std::sync::Arc::make_mut(&mut binder.node_symbols).insert(100, fake_sym_id);
 
     let errors = binder.validate_symbol_table();
     assert!(!errors.is_empty());

--- a/crates/tsz-lsp/tests/resolver_tests.rs
+++ b/crates/tsz-lsp/tests/resolver_tests.rs
@@ -72,7 +72,7 @@ bar;
                 || parent_node.kind == tsz_parser::syntax_kind_ext::EXPORT_SPECIFIER,
             "expected quoted namespace literal to be under import/export specifier"
         );
-        binder.node_symbols.insert(parent_idx.0, symbol_id);
+        std::sync::Arc::make_mut(&mut binder.node_symbols).insert(parent_idx.0, symbol_id);
     }
 
     let mut ref_walker = ScopeWalker::new(arena, &binder);

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -362,8 +362,9 @@ Status snapshot 2026-04-25 (large-ts-repo, 6086 files, 39MB):
 
 1. Pre-#1202 baseline: peak RSS ~67 GB virtual, exit 137 (SIGKILL by macOS jetsam) at ~75s. Bench reports as TIMEOUT.
 2. Post-#1202 (`perf(binder,checker,cli,core): Arc-share per-file semantic_defs`): peak RSS dropped to ~10 GB resident, exit 137 still hits at ~47s. **6.7× memory reduction**, but system memory ceiling still exceeded on this 32 GB host.
-3. Implication: #1202 worked but is not sufficient alone. Continue Arc-sharing the next-largest per-binder maps: `node_symbols`, `node_flow`, `node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`. Each is a per-file `FxHashMap` cloned at `crates/tsz-cli/src/driver/check_utils.rs` cross-file binder construction.
-4. Bench harness caveat: `tsz: TIMEOUT` in the table can mean either timer-kill (124) or OS-kill (137). The 137 case ("OOM-by-paging") is the dominant failure mode here. Inspect exit codes when investigating.
+3. Post-Arc-share-`node_symbols` (this PR): peak RSS dropped further to **~6.2 GB** resident, exit 137 still hits at ~45s. Additional **~38% reduction** on top of #1202. Cumulative: 67 GB virtual → 6.2 GB resident (~10× from baseline).
+4. Implication: #1202 + node_symbols Arc-share got us most of the way; continue Arc-sharing the remaining per-binder maps (`node_flow`, `node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`) to push further toward stable completion.
+5. Bench harness caveat: `tsz: TIMEOUT` in the table can mean either timer-kill (124) or OS-kill (137). The 137 case ("OOM-by-paging") is the dominant failure mode here. Inspect exit codes when investigating.
 
 Exit criteria:
 


### PR DESCRIPTION
## Summary

Apply the [#1202](https://github.com/mohsen1/tsz/pull/1202) template (Arc-share `semantic_defs`) to the next-largest per-binder field cloned at cross-file binder construction: `BinderState::node_symbols` (and its mirrors on `BindResult` / `BoundFile`) now live behind `Arc<FxHashMap<u32, SymbolId>>`.

ROADMAP §5 large-ts-repo (6086 files):
- Pre-#1202: peak RSS ~67 GB virtual / TIMEOUT.
- Post-#1202 (`semantic_defs`): peak RSS ~10 GB / exit 137 at ~47s. (6.7×)
- **This PR (`node_symbols`): peak RSS ~6.2 GB / exit 137 at ~45s. (additional ~38% reduction; ~10× cumulative)**

Process still OOM-kills on this 32 GB host but each Arc-share migration brings residency closer to the system memory ceiling. Remaining migrations on this template: `node_flow`, `node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`.

## What changed

- `BinderState.node_symbols`: `FxHashMap<u32, SymbolId>` → `Arc<FxHashMap<u32, SymbolId>>`. Same on `BindResult` and `BoundFile`.
- All 28 binder mutation sites use `Arc::make_mut` (zero-cost when refcount=1, the case during a single binder's construction).
- `from_bound_state*` / `from_bound_state_with_scopes*` constructor params switch to `Arc<...>`; callers pass `Arc::clone(&file.node_symbols)`.
- `cross_file_node_symbols.insert(arena_ptr, Arc::new(file.node_symbols.clone()))` becomes `Arc::clone(&file.node_symbols)` — same Arc shared with the per-file `BoundFile` and the program-wide cross-file map.
- Test paths and helper builders use `Arc::new(...)` / `Arc::make_mut(...)` as appropriate.
- ROADMAP §5 updated.

## Audit (mutation safety)

Every consumer that mutates `node_symbols` is in the binder's own construction code (28 sites in `binding/declaration.rs`, `nodes/binding.rs`, `modules/import_export.rs`, `state/core.rs`). Two test sites mutate post-construction and use `Arc::make_mut`. All checker / emitter / LSP / CLI read paths go through `Deref` (`.get`, `.iter`, `.contains_key`, `.values`, `.is_empty`, `.len`) — no missed mutation sites.

## Test plan

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo nextest run -p tsz-binder` — 372/372 passing
- [x] `cargo nextest run -p tsz-checker --lib` — 2765/2765 passing
- [x] `cargo nextest run -p tsz-core` — 2964/2964 passing
- [x] Pre-commit hook full profile — 19127/19127 tests passed, clippy/fmt/wasm32/architecture-guardrails clean
- [x] Bench on `large-ts-repo` (`tsconfig.flat.json`, 6086 files): peak RSS ~6.2 GB (down from 10 GB post-#1202)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
