### PR TITLE
perf(binder,checker,cli,core): Arc-share per-file node_flow to reduce large-repo memory

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -1553,7 +1553,7 @@ impl BinderState {
                     "record_flow: associating node with flow"
                 );
             }
-            self.node_flow.insert(node.0, self.current_flow);
+            Arc::make_mut(&mut self.node_flow).insert(node.0, self.current_flow);
         }
     }
 

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -188,7 +188,7 @@ impl BinderState {
             declaration_arenas: Arc::new(FxHashMap::default()),
             sym_to_decl_indices: Arc::new(FxHashMap::default()),
             cross_file_node_symbols: FxHashMap::default(),
-            node_flow: FxHashMap::with_capacity_and_hasher(128, Default::default()),
+            node_flow: Arc::new(FxHashMap::with_capacity_and_hasher(128, Default::default())),
             top_level_flow: FxHashMap::default(),
             switch_clause_to_switch: FxHashMap::default(),
             hoisted_vars: Vec::new(),
@@ -258,7 +258,7 @@ impl BinderState {
         Arc::make_mut(&mut self.declaration_arenas).clear();
         Arc::make_mut(&mut self.sym_to_decl_indices).clear();
         self.cross_file_node_symbols.clear();
-        self.node_flow.clear();
+        Arc::make_mut(&mut self.node_flow).clear();
         self.top_level_flow.clear();
         self.switch_clause_to_switch.clear();
         self.hoisted_vars.clear();
@@ -430,7 +430,7 @@ impl BinderState {
             declaration_arenas: Arc::new(FxHashMap::default()),
             sym_to_decl_indices: Arc::new(FxHashMap::default()),
             cross_file_node_symbols: FxHashMap::default(),
-            node_flow: FxHashMap::default(),
+            node_flow: Arc::new(FxHashMap::default()),
             top_level_flow: FxHashMap::default(),
             switch_clause_to_switch: FxHashMap::default(),
             hoisted_vars: Vec::new(),
@@ -993,8 +993,11 @@ impl BinderState {
                 node_symbols.clear();
                 node_symbols.reserve(estimated_nodes);
             }
-            self.node_flow.clear();
-            self.node_flow.reserve(estimated_nodes);
+            {
+                let node_flow = Arc::make_mut(&mut self.node_flow);
+                node_flow.clear();
+                node_flow.reserve(estimated_nodes);
+            }
         }
 
         // Initialize scope chain with source file scope (legacy)
@@ -1809,7 +1812,7 @@ impl BinderState {
                 .is_some_and(|node| node.pos < reparse_start)
         };
 
-        self.node_flow.retain(|node_id, _| keep_node(node_id));
+        Arc::make_mut(&mut self.node_flow).retain(|node_id, _| keep_node(node_id));
         self.node_scope_ids.retain(|node_id, _| keep_node(node_id));
         self.switch_clause_to_switch
             .retain(|node_id, _| keep_node(node_id));

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -314,9 +314,18 @@ pub struct BinderState {
     /// Cross-file `node_symbols`: maps arena pointer → `node_symbols` for that arena.
     /// Enables resolving type references in cross-file interface declarations.
     pub cross_file_node_symbols: CrossFileNodeSymbols,
-    /// Node-to-flow mapping: tracks which flow node was active at each AST node
-    /// Used by the checker for control flow analysis (type narrowing)
-    pub node_flow: FxHashMap<u32, FlowNodeId>,
+    /// Node-to-flow mapping: tracks which flow node was active at each AST node.
+    /// Used by the checker for control flow analysis (type narrowing).
+    ///
+    /// Stored behind `Arc` so cross-file lookup binders (one per file in the
+    /// parallel CLI pipeline) can share each file's per-file map by reference
+    /// instead of deep-cloning the underlying `FxHashMap` on every binder
+    /// reconstruction. On large repos (6086 files), the deep clone of
+    /// `node_flow` was one of the largest per-binder allocations after the
+    /// `semantic_defs` (#1202) and `node_symbols` (#1227) Arc migrations.
+    /// Mutations during binding use `Arc::make_mut` (free when refcount=1,
+    /// the case during a single binder's construction).
+    pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     /// Flow node after each top-level statement (for incremental binding).
     pub(crate) top_level_flow: FxHashMap<u32, FlowNodeId>,
     /// Map case/default clause nodes to their containing switch statement.
@@ -904,7 +913,7 @@ pub struct BinderStateScopeInputs {
     pub shorthand_ambient_modules: Arc<FxHashSet<String>>,
     pub modules_with_export_equals: FxHashSet<String>,
     pub flow_nodes: Arc<FlowNodeArena>,
-    pub node_flow: FxHashMap<u32, FlowNodeId>,
+    pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
     pub expando_properties: FxHashMap<String, FxHashSet<String>>,
     pub alias_partners: FxHashMap<SymbolId, SymbolId>,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2767,7 +2767,7 @@ fn build_lib_bound_file_for_interface_checks(
         module_augmentations: FxHashMap::default(),
         augmentation_target_modules: FxHashMap::default(),
         flow_nodes: std::sync::Arc::new(tsz::binder::FlowNodeArena::default()),
-        node_flow: FxHashMap::default(),
+        node_flow: std::sync::Arc::new(FxHashMap::default()),
         switch_clause_to_switch: FxHashMap::default(),
         is_external_module: lib_file.binder.is_external_module,
         expando_properties: FxHashMap::default(),

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1624,7 +1624,13 @@ pub(super) fn create_binder_from_bound_file_with_augmentations(
             // repos it was paid ~2× per file (cross-file lookup +
             // per-file checking binder).
             flow_nodes: Arc::clone(&file.flow_nodes),
-            node_flow: file.node_flow.clone(),
+            // Arc::clone is O(1); per-file binders share the same `node_flow`
+            // map as the `BoundFile` instead of deep-cloning the underlying
+            // `FxHashMap<u32, FlowNodeId>`. Per-file binders consume this map
+            // read-only after construction (binder mutations during checking
+            // are gated by `Arc::make_mut`, which copy-on-writes safely if a
+            // mutation ever does fire); sharing is safe.
+            node_flow: Arc::clone(&file.node_flow),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),
             // Per-binder alias_partners left empty: every checker consumer
@@ -1762,7 +1768,13 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
             // `create_binder_from_bound_file_with_augmentations` for
             // the rationale.
             flow_nodes: Arc::clone(&file.flow_nodes),
-            node_flow: file.node_flow.clone(),
+            // Arc::clone is O(1); cross-file lookup binders share the per-file
+            // `node_flow` map instead of deep-cloning the underlying
+            // `FxHashMap<u32, FlowNodeId>`. Per-file binders consume this map
+            // read-only after construction (binder mutations during checking
+            // are gated by `Arc::make_mut`, which copy-on-writes safely if a
+            // mutation ever does fire); sharing is safe.
+            node_flow: Arc::clone(&file.node_flow),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),
             // See `create_binder_from_bound_file_with_augmentations`:

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -543,8 +543,15 @@ pub struct BindResult {
     /// go through `Arc::make_mut` (free when refcount=1, the case during
     /// a single file's binding).
     pub flow_nodes: Arc<FlowNodeArena>,
-    /// Node-to-flow mapping: tracks which flow node was active at each AST node
-    pub node_flow: FxHashMap<u32, FlowNodeId>,
+    /// Node-to-flow mapping: tracks which flow node was active at each AST node.
+    ///
+    /// Shared via `Arc` because the binder owns it as `Arc<FxHashMap<...>>`
+    /// to avoid deep clones when reconstructing per-file binders for the
+    /// cross-file lookup pipeline. The Arc is moved out of the binder when
+    /// finalizing the bind result. See PR #1202 (`semantic_defs`) and
+    /// PR #1227 (`node_symbols`); this is the same template applied to
+    /// `node_flow`.
+    pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
     /// Used by control flow analysis for switch exhaustiveness checking
     pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
@@ -1444,8 +1451,15 @@ pub struct BoundFile {
     /// on N-file projects this previously cost 2N deep clones of the
     /// per-file flow graph.
     pub flow_nodes: Arc<FlowNodeArena>,
-    /// Node-to-flow mapping: tracks which flow node was active at each AST node
-    pub node_flow: FxHashMap<u32, FlowNodeId>,
+    /// Node-to-flow mapping: tracks which flow node was active at each AST node.
+    ///
+    /// Shared via `Arc` so cross-file lookup binders (one per file in the
+    /// parallel CLI pipeline) can take an O(1) reference to this file's
+    /// per-file map instead of deep-cloning the underlying `FxHashMap`. On
+    /// large repos (6086 files), the deep clone of `node_flow` was one of
+    /// the largest per-binder allocations after the `semantic_defs` (#1202)
+    /// and `node_symbols` (#1227) Arc migrations.
+    pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
     /// Used by control flow analysis for switch exhaustiveness checking
     pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
@@ -3326,7 +3340,9 @@ pub fn merge_bind_results_ref(results: &[&BindResult]) -> MergedProgram {
                 })
                 .collect(),
             flow_nodes: result.flow_nodes.clone(),
-            node_flow: result.node_flow.clone(),
+            // Arc::clone is O(1); per-file `BoundFile` shares the same
+            // `node_flow` map as later `cross_file_*` binder constructions.
+            node_flow: Arc::clone(&result.node_flow),
             switch_clause_to_switch: result.switch_clause_to_switch.clone(),
             is_external_module: result.is_external_module,
             expando_properties: remap_expando_properties(&result.expando_properties, &id_remap),
@@ -4088,7 +4104,7 @@ fn build_lib_bound_file_for_interface_checks(
         module_augmentations: FxHashMap::default(),
         augmentation_target_modules: FxHashMap::default(),
         flow_nodes: Arc::new(FlowNodeArena::default()),
-        node_flow: FxHashMap::default(),
+        node_flow: Arc::new(FxHashMap::default()),
         switch_clause_to_switch: FxHashMap::default(),
         is_external_module: lib_file.binder.is_external_module,
         expando_properties: FxHashMap::default(),
@@ -4911,7 +4927,9 @@ pub fn create_binder_from_bound_file(
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: FxHashSet::default(),
             flow_nodes: file.flow_nodes.clone(),
-            node_flow: file.node_flow.clone(),
+            // Arc::clone is O(1); cross-file lookup binders share the per-file
+            // node_flow map by reference instead of deep-cloning it.
+            node_flow: Arc::clone(&file.node_flow),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),
             alias_partners: program.alias_partners.clone(),
@@ -5016,7 +5034,9 @@ pub fn create_binder_from_bound_file_with_shared(
             shorthand_ambient_modules: program.shorthand_ambient_modules.clone(),
             modules_with_export_equals: FxHashSet::default(),
             flow_nodes: file.flow_nodes.clone(),
-            node_flow: file.node_flow.clone(),
+            // Arc::clone is O(1); cross-file lookup binders share the per-file
+            // node_flow map by reference instead of deep-cloning it.
+            node_flow: Arc::clone(&file.node_flow),
             switch_clause_to_switch: file.switch_clause_to_switch.clone(),
             expando_properties: file.expando_properties.clone(),
             alias_partners: program.alias_partners.clone(),

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -367,9 +367,10 @@ Status snapshot 2026-04-25 (large-ts-repo, 6086 files, 39MB):
 
 1. Pre-#1202 baseline: peak RSS ~67 GB virtual, exit 137 (SIGKILL by macOS jetsam) at ~75s. Bench reports as TIMEOUT.
 2. Post-#1202 (`perf(binder,checker,cli,core): Arc-share per-file semantic_defs`): peak RSS dropped to ~10 GB resident, exit 137 still hits at ~47s. **6.7× memory reduction**, but system memory ceiling still exceeded on this 32 GB host.
-3. Post-Arc-share-`node_symbols` (this PR): peak RSS dropped further to **~6.2 GB** resident, exit 137 still hits at ~45s. Additional **~38% reduction** on top of #1202. Cumulative: 67 GB virtual → 6.2 GB resident (~10× from baseline).
-4. Implication: #1202 + node_symbols Arc-share got us most of the way; continue Arc-sharing the remaining per-binder maps (`node_flow`, `node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`) to push further toward stable completion.
-5. Bench harness caveat: `tsz: TIMEOUT` in the table can mean either timer-kill (124) or OS-kill (137). The 137 case ("OOM-by-paging") is the dominant failure mode here. Inspect exit codes when investigating.
+3. Post-Arc-share-`node_symbols` (#1227): peak RSS dropped further to **~6.2 GB** resident, exit 137 still hits at ~45s. Additional **~38% reduction** on top of #1202. Cumulative: 67 GB virtual → 6.2 GB resident (~10× from baseline).
+4. Post-Arc-share-`node_flow` (this PR): peak RSS measured at ~7.0 GB resident, still exit 137 at ~50s. Same-machine before/after (sampled at 2s intervals on a busy 32 GB host) showed run-to-run variation in the noise band (~6.9-7.5 GB), so the direct measurable savings are within noise. The change is structurally correct (same template as #1202/#1227, no `Arc::make_mut` post-binding hot path) and unblocks the remaining template migrations.
+5. Implication: continue Arc-sharing the remaining per-binder maps (`node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`) to push further toward stable completion. The next likely high-leverage target is `node_scope_ids` (parallels `node_symbols` shape).
+6. Bench harness caveat: `tsz: TIMEOUT` in the table can mean either timer-kill (124) or OS-kill (137). The 137 case ("OOM-by-paging") is the dominant failure mode here. Inspect exit codes when investigating.
 
 Exit criteria:
 


### PR DESCRIPTION
## Summary

Continues the per-binder Arc-share migration started by #1202 (`semantic_defs`) and #1227 (`node_symbols`). Applies the same template to **`node_flow`** — the next per-file `FxHashMap` cloned at cross-file binder construction.

Per ROADMAP §5 (Stable Identity / Large-Repo Residency).

## Honest measurement

**Bench on large-ts-repo (6086 files, 32 GB host) is WITHIN NOISE for this PR alone.** The agent measured:
- Baseline (origin/main, post-#1227): peak RSS ~6.94 GB, exit 137 at ~50s.
- After (this PR): peak RSS ~7.0-7.5 GB (run-to-run variance), exit 137 at ~50s.

The Arc-share for `node_flow` does not visibly move the needle on this fixture. The change is **structurally correct** (same template; `Arc::make_mut` only fires inside the binder pass when refcount=1) and unblocks the remaining template migrations (`node_scope_ids`, `top_level_flow`, `switch_clause_to_switch`).

## What changed

- `BinderState.node_flow` and `BinderStateScopeInputs.node_flow` → `Arc<FxHashMap<u32, FlowNodeId>>`.
- `BindResult.node_flow` and `BoundFile.node_flow` → `Arc<FxHashMap<...>>`.
- 4 binder mutation sites (`record_flow`, `reset`, `pre-size`, `prune_incremental_maps`) wrap with `Arc::make_mut`.
- `merge_bind_results_ref` and `create_binder_from_bound_file*` use `Arc::clone` instead of element-wise deep-clone.
- Both `create_binder_from_bound_file_with_augmentations` and `create_cross_file_lookup_binder_with_augmentations` use `Arc::clone(&file.node_flow)`.
- `FlowGraph.node_flow` in `flow_graph_builder/core.rs` is a separate struct — left untouched.

## Tests

- `cargo check --workspace` clean.
- Pre-commit hook full profile: **19,129 tests pass**, 63 skipped (binder, checker, core, LSP).

## Decision

Open for review with the within-noise caveat. The structural change is the right direction per ROADMAP §5; perf wins from the next migrations may be larger.