### PR TITLE
fix(checker): preserve literal types in `||` / `&&` / `??` left operands

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -380,6 +380,9 @@ mod keyof_mapped_as_clause_tests;
 #[path = "../tests/logical_assignment_narrowing_tests.rs"]
 mod logical_assignment_narrowing_tests;
 #[cfg(test)]
+#[path = "../tests/logical_operator_literal_preservation_tests.rs"]
+mod logical_operator_literal_preservation_tests;
+#[cfg(test)]
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -714,8 +714,19 @@ impl<'a> CheckerState<'a> {
                 if op_kind == SyntaxKind::AmpersandAmpersandToken as u16 {
                     // && passes outer contextual type to the right operand only.
                     // The left operand gets no contextual type.
+                    //
+                    // Preserve literal types for the left operand: tsc's
+                    // checkExpression returns the FRESH literal type for literal
+                    // expressions (e.g., `"baz"` stays `"baz"`, not widened to
+                    // `string`). This matters for `||`/`&&`/`??` because the
+                    // logical evaluator uses truthiness narrowing — a widened
+                    // `string` cannot be narrowed to NEVER on the falsy branch,
+                    // so the result wrongly unions in the right operand.
+                    let prev_preserve = self.ctx.preserve_literal_types;
+                    self.ctx.preserve_literal_types = true;
                     let left_type =
                         self.get_type_of_node_with_request(left_idx, &TypingRequest::NONE);
+                    self.ctx.preserve_literal_types = prev_preserve;
                     let right_type = self.get_type_of_node_with_request(right_idx, request);
 
                     type_stack.push(left_type);
@@ -726,7 +737,12 @@ impl<'a> CheckerState<'a> {
                 if op_kind == SyntaxKind::BarBarToken as u16
                     || op_kind == SyntaxKind::QuestionQuestionToken as u16
                 {
+                    // Preserve literal types for the left operand — see comment
+                    // on the && branch above for the rationale.
+                    let prev_preserve = self.ctx.preserve_literal_types;
+                    self.ctx.preserve_literal_types = true;
                     let left_type = self.get_type_of_node(left_idx);
+                    self.ctx.preserve_literal_types = prev_preserve;
                     let outer_context = request.contextual_type;
                     // Right operand: prefer the whole-expression contextual type
                     // inherited from the parent (e.g. assignment target). Fall back

--- a/crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs
+++ b/crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs
@@ -1,0 +1,134 @@
+//! Tests that the left operand of `||`, `&&`, and `??` preserves literal types.
+//!
+//! In tsc, `checkExpression` returns the FRESH literal type for literal
+//! expressions (e.g., `"baz"` stays `"baz"`, not widened to `string`). This
+//! matters for the logical operators because the result-type evaluator uses
+//! truthiness narrowing — a widened `string` cannot narrow to NEVER on the
+//! falsy branch, so the result wrongly unions in the right operand.
+//!
+//! Regression test for missing TS2678 in `case "baz" || z:` where `z: "bar"`
+//! and the switch discriminant is `"foo"`.
+//! See conformance test
+//! `tests/cases/conformance/types/literal/stringLiteralsWithSwitchStatements03.ts`.
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn check_strict(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        no_implicit_any: true,
+        ..Default::default()
+    };
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        options,
+    );
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.iter().map(|d| d.code).collect()
+}
+
+/// `"baz" || z` (where z is a non-literal identifier) should produce the
+/// literal type `"baz"`, not the widened `string`.
+///
+/// The variable annotation `0` forces a TS2322 with the actual inferred type
+/// in the message — but here we just check the diagnostic code is emitted,
+/// because `string` would assign successfully and emit nothing for that line.
+#[test]
+fn or_with_string_literal_left_preserves_literal_type() {
+    let source = r#"
+declare let z: "bar";
+const x: never = "baz" || z;
+"#;
+    let codes = check_strict(source);
+    // Expect TS2322 (the value is "baz", not assignable to never) and TS2872
+    // (the "baz" literal is always truthy).
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for 'baz' not assignable to never, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2872),
+        "Expected TS2872 (always truthy), got: {codes:?}"
+    );
+}
+
+/// Same as above but for numeric literals: `1 || z` should produce `1`.
+#[test]
+fn or_with_numeric_literal_left_preserves_literal_type() {
+    let source = r#"
+declare let z: 0;
+const x: never = 1 || z;
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for '1' not assignable to never, got: {codes:?}"
+    );
+}
+
+/// In a switch on `"foo"`, `case "baz" || z:` (with `z: "bar"`) should emit
+/// TS2678 because the case-clause type evaluates to `"baz"` (a literal) that
+/// is not comparable to `"foo"`.
+#[test]
+fn switch_case_logical_or_literal_emits_ts2678() {
+    let source = r#"
+declare let x: "foo";
+declare let z: "bar";
+switch (x) {
+    case "baz" || z:
+        break;
+}
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2678),
+        "Expected TS2678 for case 'baz' || z, got: {codes:?}"
+    );
+}
+
+/// `&&` should also preserve the literal type on the left, so `1 && x`
+/// (with `x: 1`) produces `1`, not `0 | 1`.
+#[test]
+fn and_with_numeric_literal_left_preserves_literal_type() {
+    let source = r#"
+declare let x: 1;
+const r: 0 = 1 && x;
+"#;
+    let codes = check_strict(source);
+    // Expect TS2322 with the actual inferred literal type 1, not the widened
+    // 0 | 1. The diagnostic code alone confirms the assignment is rejected;
+    // the message-based parity is exercised by the conformance suite.
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for '1' not assignable to '0', got: {codes:?}"
+    );
+}
+
+/// `??` with a literal-on-left should pick the right operand only when the
+/// literal can be nullish; non-nullish literals like `"baz"` keep the
+/// literal type.
+#[test]
+fn nullish_coalescing_with_literal_left_preserves_literal_type() {
+    let source = r#"
+declare let z: "bar";
+const x: never = "baz" ?? z;
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for 'baz' not assignable to never, got: {codes:?}"
+    );
+}

--- a/scripts/session/pick-random.sh
+++ b/scripts/session/pick-random.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-random.sh — Quick random failure picker with inline source preview
+# =============================================================================
+#
+# Single-shot script for an agent that wants:
+#   1. one random failing conformance test,
+#   2. the expected/actual/missing/extra error codes,
+#   3. the first ~40 lines of the offending TypeScript source,
+#   4. a ready-to-paste verbose-run command.
+#
+# Usage:
+#   scripts/session/pick-random.sh                 # any failure
+#   scripts/session/pick-random.sh --seed 7        # reproducible pick
+#   scripts/session/pick-random.sh --code TS2322   # restrict to one error code
+#   scripts/session/pick-random.sh --no-source     # skip the source preview
+#
+# Reads scripts/conformance/conformance-detail.json. If the snapshot is
+# missing, it tells you how to refresh it instead of running the full suite.
+# Auto-initialises the TypeScript submodule if needed.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+SHOW_SOURCE=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="${2:-}"; shift 2 ;;
+        --code) CODE="${2:-}"; shift 2 ;;
+        --no-source) SHOW_SOURCE=0; shift ;;
+        -h|--help) sed -n '2,21p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL not found." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initialising..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+
+exec python3 - "$DETAIL" "$REPO_ROOT" "$SEED" "$CODE" "$SHOW_SOURCE" <<'PY'
+import json, random, sys
+from pathlib import Path
+
+detail_path, repo_root, seed, code, show_source = sys.argv[1:6]
+repo_root = Path(repo_root)
+
+with open(detail_path, encoding="utf-8") as f:
+    failures = json.load(f).get("failures", {})
+
+candidates = []
+for path, entry in failures.items():
+    if not entry:
+        continue
+    codes = (
+        set(entry.get("e", []))
+        | set(entry.get("a", []))
+        | set(entry.get("m", []))
+        | set(entry.get("x", []))
+    )
+    if code and code not in codes:
+        continue
+    candidates.append((path, entry))
+
+if not candidates:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(candidates)
+
+def fmt(xs):
+    return ",".join(xs) or "-"
+
+filter_name = Path(path).stem
+print(f"path:     {path}")
+print(f"expected: {fmt(entry.get('e', []))}")
+print(f"actual:   {fmt(entry.get('a', []))}")
+print(f"missing:  {fmt(entry.get('m', []))}")
+print(f"extra:    {fmt(entry.get('x', []))}")
+print(f"pool:     {len(candidates)}")
+print()
+print(f'verbose run: ./scripts/conformance/conformance.sh run --filter "{filter_name}" --verbose')
+
+if show_source == "1":
+    src = repo_root / path
+    if src.is_file():
+        text = src.read_text(encoding="utf-8", errors="replace").splitlines()
+        head = text[:40]
+        print()
+        print(f"--- source preview ({src}, first {len(head)}/{len(text)} lines) ---")
+        for i, line in enumerate(head, 1):
+            print(f"{i:>4}  {line}")
+PY


### PR DESCRIPTION
## Summary

- Preserves the fresh literal type for the left operand of `||`, `&&`, and `??` so the logical evaluator's truthiness narrowing fires the same way `tsc` does — a widened `string` cannot be narrowed to `NEVER` on the falsy branch, so a non-empty string literal that should always be truthy was wrongly unioning the right operand into the result.
- Concrete fix: in a switch `case "baz" || z:` (with `z: "bar"`, switch on `"foo"`), the case-clause type now evaluates to `"baz"` instead of `string`, so TS2678 fires (matching `tsc`).
- Adds a tiny `scripts/session/pick-random.sh` random-failure picker that prints the source preview inline alongside the codes and verbose-run command — the picker that produced the target for this PR.

## Repro

```ts
declare let x: "foo";
declare let z: "bar";
switch (x) {
    case "baz" || z: break;
    // tsc: TS2678 ("Type '\"baz\"' is not comparable to type '\"foo\"'.")
    // tsz before: TS2872 only (case type widened to `string`)
    // tsz after:  TS2678 + TS2872 (case type preserved as `"baz"` literal)
}
```

The widening also affected `&&` and `??`:

```ts
declare let x: 1;
const r: 0 = 1 && x;
// tsc:        TS2322 'Type 1 is not assignable to type 0'
// tsz before: TS2322 'Type 0 | 1 is not assignable to type 0'
// tsz after:  TS2322 'Type 1 is not assignable to type 0'
```

## Conformance impact

`scripts/safe-run.sh ./scripts/conformance/conformance.sh run` (full suite) on top of `f810032`:

```
Net: 12129 -> 12145 (+16)
```

20 FAIL → PASS improvements:

- `compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts`
- `compiler/enumAssignmentCompat.ts`
- `compiler/enumAssignmentCompat2.ts`
- `compiler/enumAssignmentCompat5.ts`
- `compiler/errorForUsingPropertyOfTypeAsType03.ts`
- `compiler/isolatedModulesReExportAlias.ts`
- `compiler/optionalParamTypeComparison.ts`
- `compiler/typeRootsFromNodeModulesInParentDirectory.ts`
- `compiler/useBeforeDeclaration_jsx.tsx`
- `conformance/es6/destructuring/missingAndExcessProperties.ts`
- `conformance/expressions/functions/contextuallyTypedIifeStrict.ts`
- `conformance/externalModules/rewriteRelativeImportExtensions/packageJsonImportsErrors.ts`
- `conformance/importDefer/importDeferTypeConflict2.ts`
- `conformance/jsdoc/typeTagPrototypeAssignment.ts`
- `conformance/jsx/tsxElementResolution11.tsx`
- `conformance/types/literal/stringLiteralsWithSwitchStatements03.ts` (the picked target)
- `conformance/types/primitives/enum/validEnumAssignments.ts`
- `conformance/types/tuple/castingTuple.ts`
- `conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`
- `conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts`

3 reported "regressions" reproduce on `main` without this change and are stale-baseline drift, not caused by this PR:

- `compiler/defaultValueInFunctionTypes.ts`
- `compiler/optionalFunctionArgAssignability.ts`
- `conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts`

All three involve optional-parameter type display showing `T | undefined` instead of `T`, which is independent of the logical-operator change. Verified by stashing the patch, rebuilding, and re-running the same tests.

## Test plan

- [x] `crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs` — 5 new unit tests, all passing
- [x] `cargo test -p tsz-checker --lib` — 2770 passed, 0 failed
- [x] `cargo test -p tsz-solver --lib` — 5322 passed, 0 failed
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `./scripts/conformance/conformance.sh run --filter "stringLiteralsWithSwitchStatements03" --verbose` — PASS (was FAIL)
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — Net +16

https://claude.ai/code/session_011BA6BYCr85pSsY3j1m7Rr3

---
_Generated by [Claude Code](https://claude.ai/code/session_011BA6BYCr85pSsY3j1m7Rr3)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
