### PR TITLE
fix(checker): emit TS2416 for `this is T` predicate inheritance mismatch

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -256,9 +256,16 @@ pub(crate) fn should_report_own_member_type_mismatch(
 /// Check if a TS2416 incompatibility is caused solely by a missing type predicate
 /// that tsc would infer from the method body.
 ///
-/// tsc infers type predicates for methods without explicit return type annotations.
-/// Since we don't support type predicate inference, suppress the diagnostic when the
-/// only difference between the source and target signatures is the type predicate.
+/// tsc infers type predicates for methods without explicit return type annotations
+/// (TS 5.5+ inferred type predicates). That inference only ever produces a
+/// parameter predicate (`x is T`) — `this is T` predicates are never inferred
+/// from a method body. So the suppression below is restricted to parameter
+/// predicates: a `this is T` mismatch must always be reported as TS2416 because
+/// tsc would also report it.
+///
+/// Since we don't implement type predicate inference, suppress the diagnostic
+/// when the only difference between the source and target signatures is a
+/// parameter type predicate that tsc would have inferred.
 fn is_type_predicate_inference_suppressed(
     checker: &CheckerState<'_>,
     source: TypeId,
@@ -266,8 +273,16 @@ fn is_type_predicate_inference_suppressed(
     node_idx: NodeIndex,
 ) -> bool {
     // Get target function shape and check for type predicate
-    let target_has_predicate = get_type_predicate_from_signature(checker, target).is_some();
-    if !target_has_predicate {
+    let Some(target_predicate) = get_type_predicate_from_signature(checker, target) else {
+        return false;
+    };
+
+    // tsc never infers `this is T` predicates from method bodies, so a `this`
+    // predicate target must always emit TS2416.
+    if matches!(
+        target_predicate.target,
+        tsz_solver::types::TypePredicateTarget::This
+    ) {
         return false;
     }
 

--- a/crates/tsz-checker/src/tests/dispatch_tests.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests.rs
@@ -1698,6 +1698,52 @@ class Bar extends Foo {
 }
 
 #[test]
+fn ts2416_this_predicate_inheritance_not_suppressed() {
+    // Regression for typePredicateInherit.ts: tsc never infers `this is T`
+    // predicates from a method body, so a class method without an explicit
+    // return type annotation that happens to return `boolean` must NOT be
+    // suppressed when the interface (or base class) it satisfies declares a
+    // `this is X` predicate. tsc reports TS2416 for each such mismatch.
+    let diags = check_source_diagnostics(
+        r#"
+interface A {
+  method1(): this is { a: 1 };
+  method2(): boolean;
+  method3(): this is { a: 1 };
+}
+class B implements A {
+  method1() { }
+  method2() { }
+  method3() { return true; }
+}
+class C {
+  method1(): this is { a: 1 } { return true; }
+  method3(): this is { a: 1 } { return true; }
+}
+class D extends C {
+  method1(): void { }
+  method3(): boolean { return true; }
+}
+"#,
+    );
+    let ts2416: Vec<_> = diags.iter().filter(|d| d.code == 2416).collect();
+    let messages: Vec<_> = ts2416.iter().map(|d| &d.message_text).collect();
+    assert_eq!(
+        ts2416.len(),
+        5,
+        "Expected 5 TS2416 (B.method1/2/3 + D.method1/3), got: {messages:?}"
+    );
+    for name in ["method1", "method2", "method3"] {
+        assert!(
+            ts2416
+                .iter()
+                .any(|d| d.message_text.contains(&format!("Property '{name}'"))),
+            "Expected TS2416 mentioning Property '{name}', got: {messages:?}"
+        );
+    }
+}
+
+#[test]
 fn ts2352_string_enum_comparable_in_nested_assertion() {
     // Repro from comparableRelationBidirectional.ts:
     // When asserting an object literal `as UserSettings` where a nested property


### PR DESCRIPTION
## Summary

Picked one random conformance failure (`compiler/typePredicateInherit.ts`) with the new `scripts/session/pick-random.sh` helper and chased the root cause.

`is_type_predicate_inference_suppressed` in `crates/tsz-checker/src/query_boundaries/class.rs` was suppressing TS2416 whenever the source class method had no return-type annotation, the source returned `boolean`, and the target signature carried *any* type predicate. That is correct for the TS 5.5+ inferred-predicate case on **parameter** predicates (`x is T`), but `this is T` predicates are *never* inferred from a method body — so a `() => boolean` vs `() => this is X` mismatch must always be reported as TS2416, exactly as `tsc` does.

The fix narrows the suppression to `TypePredicateTarget::Identifier`. `this` predicates fall through and produce the diagnostic.

```ts
interface A {
  method3(): this is { a: 1 };
}
class B implements A {
  method3() { return true; }   // TS2416 — must report
}
```

Before: tsz emitted 4/5 expected TS2416 for `typePredicateInherit.ts` (missed `B.method3` at line 15:3). After: all 5 expected fingerprints match — test passes.

## What's in this branch

1. **`fix(checker): emit TS2416 for \`this is T\` predicate inheritance mismatch`** — the suppression narrowing + a regression unit test (`ts2416_this_predicate_inheritance_not_suppressed` in `dispatch_tests.rs`) that locks the 5-error expectation and would fail before the change.
2. **`chore(solver/tests): backtick TypeIds and TypeFormatter in doc comments`** — fixes a pre-existing `clippy::doc_markdown` failure under rust 1.94 in `tsz-solver/tests/def_tests.rs::test_register_type_to_def_rejects_intrinsic_type_ids` (added by #1240) so workspace clippy is green.
3. **`chore(scripts/session): add pick-random.sh one-shot conformance picker`** — small self-contained picker that prints path/codes/diff + the first 60 lines of the test source + the verbose-run command, complementing `quick-pick.sh` and `random-failure.sh`.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓ (after commit 2)
- `cargo nextest run -p tsz-checker -p tsz-solver` ✓ (10535 passed, 39 skipped) — includes the new unit test
- `./scripts/conformance/conformance.sh run --filter typePredicateInherit --verbose` ✓ (1/1 pass)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — **net +18 (12129 → 12147)**, 21 improvements (incl. `typePredicateInherit.ts`) and 3 fingerprint regressions

The 3 listed PASS→FAIL regressions are **pre-existing on `main` HEAD**, not caused by this PR. They all surface the same printer divergence (`(x?: T)` vs `(x?: T | undefined)` for optional parameters) and reproduce on a clean rebuild after `git stash` of these changes:

- `compiler/defaultValueInFunctionTypes.ts`
- `compiler/optionalFunctionArgAssignability.ts`
- `conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts`

The conformance baseline file (`scripts/conformance/conformance-baseline.txt`) was last regenerated on Apr 25, before recent printer/lowering refactors landed on `main`. None of those tests use `class implements`, type predicates, or anything this PR touches.

The full `verify-all.sh` workspace test build does not fit on the available disk in this sandbox (the workspace test artifacts exceed ~38 GB), so the unit-test step was run for the touched crates (`tsz-checker`, `tsz-solver`) instead. Pre-commit hooks were skipped via the documented `TSZ_SKIP_HOOKS=1` env var after fmt/clippy/nextest were verified externally.

## Test plan
- [ ] CI runs full `cargo nextest run` cleanly
- [ ] CI conformance shows `typePredicateInherit.ts` PASS and no new regressions attributable to this PR
- [ ] Reviewer sanity-checks the suppression invariant against any tests that intentionally rely on parameter-predicate suppression

https://claude.ai/code/session_01GYumnY1zAWN4qyuJUGdZjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYumnY1zAWN4qyuJUGdZjU)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
