### PR TITLE
fix(checker): emit TS2344 for failed typeof-instantiation expressions

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -76,6 +76,27 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
+                // Failed instantiation expressions (`typeof fn<TArgs>` where `TArgs`
+                // do not match any signature's type-parameter arity) are treated by
+                // tsc as `errorType`, which then fails the surrounding type-parameter
+                // constraint check and triggers TS2344 — in addition to the TS2635
+                // emitted at the instantiation site. Match that behavior.
+                //
+                // The Application path further down would otherwise defer constraint
+                // checking for any `Application(TypeQuery, args)` whose constraint is
+                // not generic-indexed-access shaped, dropping TS2344 in this case.
+                if self.is_failed_typeof_instantiation_arg(type_arg) {
+                    let constraint_resolved = self.resolve_lazy_type(constraint);
+                    if let Some(&arg_idx) = type_args_list.nodes.get(i) {
+                        self.error_type_constraint_not_satisfied(
+                            type_arg,
+                            constraint_resolved,
+                            arg_idx,
+                        );
+                    }
+                    continue;
+                }
+
                 // When the type argument contains type parameters, we generally skip
                 // constraint checking (deferred to instantiation time). However, when
                 // the type arg IS a bare type parameter, check its base constraint
@@ -1722,5 +1743,58 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Return `true` when `type_arg` is the type of an instantiation expression
+    /// `typeof fn<TArgs>` whose `TArgs` do not match the type-parameter arity
+    /// of any call/construct signature on the underlying function. Such
+    /// expressions also raise TS2635 at the instantiation site; tsc treats the
+    /// resulting type as `errorType`, which then fails any non-trivial
+    /// type-parameter constraint check (TS2344).
+    ///
+    /// Implementation note: the Application produced by the typeof-instantiation
+    /// path (`type_node_advanced.rs`) wraps a `TypeQuery(SymbolRef)` as the
+    /// base, which only yields callable signatures after evaluation through
+    /// `TypeEnvironment`. Generic-type-alias / class / interface references use
+    /// a `Lazy(DefId)` base instead, so we filter those out before evaluating.
+    fn is_failed_typeof_instantiation_arg(&mut self, type_arg: TypeId) -> bool {
+        let db = self.ctx.types.as_type_database();
+        let Some((base, args)) = query::application_base_and_args(db, type_arg) else {
+            return false;
+        };
+
+        // Generic-type-reference Applications (`Foo<X>` for a type alias /
+        // class / interface) use a `Lazy(DefId)` / `Recursive` / `BoundParameter`
+        // base. Their arity mismatches are reported elsewhere (TS2305 / TS2558)
+        // — not the typeof-instantiation flow.
+        if query::is_named_type_reference(db, base) {
+            return false;
+        }
+
+        let num_args = args.len();
+        // Evaluate the base through the type environment so `TypeQuery(sym)`
+        // resolves to the underlying function/constructor type. The evaluation
+        // path is necessary — `get_callable_shape_for_type` does not look
+        // through `TypeQuery` itself — but we limit it to typeof-instantiation
+        // shapes (filtered above) so unrelated assignability checks are not
+        // disturbed.
+        let resolved = self.resolve_lazy_type(base);
+        let resolved = self.evaluate_type_for_assignability(resolved);
+        let db = self.ctx.types.as_type_database();
+        let Some(shape) =
+            crate::query_boundaries::common::get_callable_shape_for_type(db, resolved)
+        else {
+            return false;
+        };
+
+        let call_match = shape
+            .call_signatures
+            .iter()
+            .any(|s| s.type_params.len() == num_args);
+        let construct_match = shape
+            .construct_signatures
+            .iter()
+            .any(|s| s.type_params.len() == num_args);
+        !(call_match || construct_match)
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -348,3 +348,20 @@ pub(crate) fn typeof_instantiation_arg_count(
     tsz_solver::visitor::type_query_symbol(db, base)?;
     Some(args.len())
 }
+
+/// Get `(base, args)` for a generic-type application, or `None` if `type_id`
+/// is not an `Application` type.
+pub(crate) fn application_base_and_args(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<(TypeId, Vec<TypeId>)> {
+    tsz_solver::type_queries::extended::get_application_info(db, type_id)
+}
+
+/// Returns `true` for named-type references (`Lazy(DefId)`, `Recursive`, or
+/// `BoundParameter`). These appear as the base of `Application` types when the
+/// application is a generic-type instantiation (`Foo<X>`) rather than an
+/// instantiation expression (`typeof fn<X>`).
+pub(crate) fn is_named_type_reference(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::is_type_reference(db, type_id)
+}

--- a/crates/tsz-checker/src/tests/dispatch_tests.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests.rs
@@ -154,6 +154,60 @@ e as ErrAlias<string>;
 }
 
 #[test]
+fn ts2344_failed_typeof_instantiation_emits_constraint_diagnostic() {
+    // `typeof fn<TArgs>` is an instantiation expression. When TArgs do not
+    // match any signature's type-parameter arity, tsc emits TS2635 at the
+    // instantiation site AND TS2344 at the surrounding type-argument position
+    // because the instantiation result is treated as errorType which does
+    // not satisfy the declared type-parameter constraint.
+    //
+    // Mirrors `compiler/instantiationExpressionErrorNoCrash.ts` without
+    // depending on lib.d.ts (which the unit-test pipeline disables).
+    let diags = check_source_diagnostics(
+        r#"
+type RT<T extends (...args: any) => any> = T;
+declare const createCacheReducer: <N extends string, QR>(q: QR) => QR;
+type Cache<QR> = {
+    queries: {
+        [QK in keyof QR]: RT<typeof createCacheReducer<QR>>;
+    };
+};
+"#,
+    );
+
+    let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    let ts2635 = codes.iter().filter(|&&c| c == 2635).count();
+    let ts2344 = codes.iter().filter(|&&c| c == 2344).count();
+    assert_eq!(
+        ts2635, 1,
+        "Expected one TS2635 at the instantiation expression, got diags: {diags:?}"
+    );
+    assert_eq!(
+        ts2344, 1,
+        "Expected one TS2344 against the callable type-parameter constraint, got diags: {diags:?}"
+    );
+}
+
+#[test]
+fn ts2344_valid_typeof_instantiation_does_not_emit_constraint_diagnostic() {
+    // Sanity check: a *successful* typeof-instantiation expression must not
+    // trigger TS2344 against a callable constraint. Use a concrete type arg
+    // to keep the assertion focused on the new arity check.
+    let diags = check_source_diagnostics(
+        r#"
+type RT<T extends (...args: any) => any> = T;
+declare const createReducer: <S>(s: S) => S;
+type R = RT<typeof createReducer<string>>;
+"#,
+    );
+    let ts2344 = diags.iter().filter(|d| d.code == 2344).count();
+    assert_eq!(
+        ts2344, 0,
+        "Successful typeof-instantiation must not emit TS2344, got diags: {diags:?}"
+    );
+}
+
+#[test]
 fn ts2352_array_assertion_anchors_first_excess_property() {
     let source = r#"
 <{ id: number; }[]>[{ foo: "s" }];


### PR DESCRIPTION
## Summary

When `typeof fn<TArgs>` is used as a type argument to a parameter with a non-trivial constraint (e.g. `T extends (...args: any) => any` for `ReturnType<T>`) and `TArgs` does not match any signature's type-parameter arity, `tsc` emits **TS2344** against the constraint *in addition* to the **TS2635** fired at the instantiation site. `tsz` only emitted TS2635, missing TS2344.

This PR detects failed `typeof`-instantiation `Application` types eagerly inside `validate_type_args_against_params` and emits TS2344 through the existing reporter, matching `tsc` behavior for `compiler/instantiationExpressionErrorNoCrash.ts` and similar cases.

```ts
type RT<T extends (...args: any) => any> = T;
declare const fn: <N extends string, QR>(q: QR) => QR;
type Cache<QR> = {
    queries: {
        [QK in keyof QR]: RT<typeof fn<QR>>; // TS2344 + TS2635
    };
};
```

The arity check runs against the underlying TypeQuery target, so a valid `typeof fn<X>` (where the argument count matches) does not trigger the new path. Generic-type-reference Applications (`Foo<X>` for a type alias / class / interface) are filtered out via `is_named_type_reference` so they keep their existing TS2305 / TS2558 paths.

## Conformance

- `compiler/instantiationExpressionErrorNoCrash.ts`: now emits both TS2344 + TS2635 (matches expected error codes; remaining diff is a separate type-printer fingerprint issue).
- Full conformance: **+17 net** (12146 vs 12129 baseline). The 3 reported "PASS → FAIL" flips reproduce on `main` without this change — they're stale-snapshot fingerprint flakiness in optional-parameter display (`?: T` vs `?: T | undefined`), not introduced here.

## Files

- `crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs` — early failed-typeof-instantiation detection in the constraint-check loop, plus the `is_failed_typeof_instantiation_arg` helper.
- `crates/tsz-checker/src/query_boundaries/checkers/generic.rs` — two new boundary helpers (`application_base_and_args`, `is_named_type_reference`) so the checker doesn't pattern-match solver internals.
- `crates/tsz-checker/src/tests/dispatch_tests.rs` — two unit tests locking the invariant: failed instantiation emits TS2344, valid instantiation does not.
- `crates/tsz-solver/tests/def_tests.rs` — small `clippy::doc_markdown` cleanup that was blocking the workspace clippy gate.
- `scripts/session/pick-random.sh` — single-file conformance failure picker (sibling to `quick-pick.sh` / `random-failure.sh`).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p tsz-checker --lib` (5211 / 5211 pass)
- [x] `cargo nextest run -p tsz-solver --lib` (5323 / 5323 pass)
- [x] `cargo nextest run -p tsz-checker -p tsz-solver -p tsz-binder -p tsz-parser -p tsz-scanner -p tsz-common -p tsz-lowering -p tsz-emitter -p tsz-cli -p tsz-core -p tsz-lsp -p tsz-conformance` (all green except 2 environmental failures in `tsz-cli` — `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable` and `test_format_document_does_not_invalidate_fourslash_markers` — that reproduce on clean `main`).
- [x] Full conformance suite: net **+17** vs snapshot, target test now matches expected codes.
- [x] Architecture contract test (`test_no_inline_type_queries_in_cleaned_modules`) passes — solver queries are wrapped in boundary helpers.

> Note: `verify-all.sh --quick` could not complete in this environment due to disk space limits during simultaneous test-profile compilation of all workspace crates. Each suite was verified individually instead. The pre-commit hook ran with `TSZ_SKIP_TESTS=1` for the same reason (with tests verified separately, as the hook documentation explicitly suggests for disk-constrained environments).

https://claude.ai/code/session_016dR2vU4Dnd7MikQWLnFPff

---
_Generated by [Claude Code](https://claude.ai/code/session_016dR2vU4Dnd7MikQWLnFPff)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
