### PR TITLE
fix(checker): anchor TS2589 at last self-reference in recursive type aliases

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -247,8 +247,16 @@ impl<'a> CheckerState<'a> {
                 let depth_exceeded = self.evaluate_type_for_ts2589_check(body_type, def_id);
                 if depth_exceeded {
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                    // tsc anchors TS2589 at `currentNode` (the inner self-reference
+                    // being instantiated when `instantiationDepth === 100` fires).
+                    // Conditional-type children are visited in
+                    // check→extends→true→false order, so the last self-referential
+                    // type reference in source order matches tsc's anchor.
+                    let anchor = self
+                        .find_last_recursive_alias_ref(alias.type_node, alias_sid)
+                        .unwrap_or(alias.type_node);
                     self.error_at_node(
-                        alias.type_node,
+                        anchor,
                         diagnostic_messages::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
                         diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE,
                     );
@@ -370,6 +378,55 @@ impl<'a> CheckerState<'a> {
             crate::diagnostics::diagnostic_messages::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
             crate::diagnostics::diagnostic_codes::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
         );
+    }
+
+    /// Walk the alias body AST and return the AST node of the last
+    /// `TypeReference` (in source order) whose name resolves to `alias_sid`.
+    ///
+    /// Used as the anchor for TS2589 at type-alias definition sites: tsc emits
+    /// at `currentNode`, which is the inner self-reference being instantiated
+    /// at the time the depth limit fires. `forEachChild` visits conditional
+    /// children in check→extends→true→false order, so the last self-reference
+    /// in source order is the one tsc reports against.
+    fn find_last_recursive_alias_ref(
+        &self,
+        body_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> Option<NodeIndex> {
+        let mut best: Option<(u32, NodeIndex)> = None;
+        self.collect_recursive_alias_refs(body_idx, alias_sid, &mut best);
+        best.map(|(_, idx)| idx)
+    }
+
+    fn collect_recursive_alias_refs(
+        &self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+        best: &mut Option<(u32, NodeIndex)>,
+    ) {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(tr) = self.ctx.arena.get_type_ref(node)
+        {
+            let resolved = self
+                .resolve_type_symbol_for_lowering(tr.type_name)
+                .map(tsz_binder::SymbolId);
+            if resolved == Some(alias_sid) {
+                let pos = node.pos;
+                if best.map_or(true, |(p, _)| pos >= p) {
+                    *best = Some((pos, node_idx));
+                }
+            }
+        }
+
+        for child_idx in self.ctx.arena.get_children(node_idx) {
+            self.collect_recursive_alias_refs(child_idx, alias_sid, best);
+        }
     }
 
     /// Walk a type argument AST node and return true if it contains a reference

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for TS2589: Type instantiation is excessively deep and possibly infinite.
 
-use crate::test_utils::check_source_code_messages;
+use crate::test_utils::{check_source_code_messages, check_source_diagnostics};
 
 fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
     check_source_code_messages(source)
@@ -231,6 +231,52 @@ type Foo<T> = T extends unknown
     assert!(
         diags.iter().any(|d| d.0 == 2589),
         "Should emit TS2589 for recursive conditional type alias at definition site. Got: {diags:?}"
+    );
+}
+
+/// TS2589 at a type alias definition is anchored at the LAST recursive
+/// self-reference in source order — the same node `tsc` reports against
+/// (its `currentNode` when `instantiationDepth === 100` fires while
+/// instantiating the alias body).
+///
+/// `forEachChild` visits conditional-type children in
+/// check→extends→true→false order, so for `type Foo<T> = T extends U ?
+/// Foo<T> : Foo<unknown>;` the anchor lands on `Foo<unknown>` (false
+/// branch) rather than the body's first token or the alias name.
+///
+/// This locks in the anchor used by the
+/// `compiler/recursiveConditionalCrash4.ts` conformance fixture.
+#[test]
+fn recursive_conditional_type_alias_anchors_ts2589_at_last_self_reference() {
+    let source = r#"type Foo<T> = T extends unknown
+  ? unknown extends `${infer $Rest}`
+    ? Foo<T>
+    : Foo<unknown>
+  : unknown;
+"#;
+    let diags = check_source_diagnostics(source);
+    let ts2589 = diags
+        .iter()
+        .find(|d| d.code == 2589)
+        .expect("TS2589 should be emitted for recursive conditional alias");
+
+    // The anchor must point at the start of `Foo<unknown>` — the last
+    // self-reference in source order, matching tsc's currentNode.
+    let start = ts2589.start as usize;
+    let snippet = &source[start..(start + "Foo<unknown>".len()).min(source.len())];
+    assert_eq!(
+        snippet,
+        "Foo<unknown>",
+        "TS2589 should anchor at the last recursive self-reference (`Foo<unknown>`). \
+         Anchor was at byte {start}: {:?}, full diag: {ts2589:?}",
+        &source[start..(start + 20).min(source.len())]
+    );
+    // Length should cover only the type reference, not the entire body.
+    assert_eq!(
+        ts2589.length as usize,
+        "Foo<unknown>".len(),
+        "TS2589 span should cover only the type reference, got {}",
+        ts2589.length
     );
 }
 

--- a/scripts/session/roll.sh
+++ b/scripts/session/roll.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# =============================================================================
+# roll.sh — One-line "roll the dice" random conformance failure picker
+# =============================================================================
+#
+# The most compact picker in scripts/session. Prints exactly one line:
+#
+#   <category>  <filter-name>  <expected>  <actual>  <missing>  <extra>
+#
+# Plus, when stdout is a TTY, a second line with the verbose-run command.
+# Designed for grep/awk pipelines and quick "what should I work on" prompts.
+#
+# Usage:
+#   scripts/session/roll.sh
+#   scripts/session/roll.sh --code TS2322
+#   scripts/session/roll.sh --category fingerprint-only
+#   scripts/session/roll.sh --seed 13
+#
+# Reads scripts/conformance/conformance-detail.json. Auto-initialises the
+# TypeScript submodule when missing so the verbose run command actually works.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+CATEGORY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="${2:-}"; shift 2 ;;
+        --code) CODE="${2:-}"; shift 2 ;;
+        --category) CATEGORY="${2:-}"; shift 2 ;;
+        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL not found." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initialising..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+
+TTY=0
+[[ -t 1 ]] && TTY=1
+
+exec python3 - "$DETAIL" "$SEED" "$CODE" "$CATEGORY" "$TTY" <<'PY'
+import json, random, sys
+from pathlib import Path
+
+detail_path, seed, code, category, tty = sys.argv[1:6]
+
+with open(detail_path, encoding="utf-8") as f:
+    failures = json.load(f).get("failures", {})
+
+def classify(entry):
+    e, a, m, x = entry.get("e", []), entry.get("a", []), entry.get("m", []), entry.get("x", [])
+    if not e and a:
+        return "false-positive"
+    if e and not a:
+        return "all-missing"
+    if set(e) == set(a):
+        return "fingerprint-only"
+    if m and not x:
+        return "only-missing"
+    if x and not m:
+        return "only-extra"
+    return "wrong-code"
+
+picks = []
+for path, entry in failures.items():
+    if not entry:
+        continue
+    codes = set(entry.get("e", [])) | set(entry.get("a", [])) \
+          | set(entry.get("m", [])) | set(entry.get("x", []))
+    if code and code not in codes:
+        continue
+    cat = classify(entry)
+    if category and category != cat:
+        continue
+    picks.append((path, entry, cat))
+
+if not picks:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry, cat = rng.choice(picks)
+filter_name = Path(path).stem
+
+def fmt(xs): return ",".join(xs) or "-"
+
+print(
+    f"{cat}\t{filter_name}"
+    f"\texpected={fmt(entry.get('e', []))}"
+    f"\tactual={fmt(entry.get('a', []))}"
+    f"\tmissing={fmt(entry.get('m', []))}"
+    f"\textra={fmt(entry.get('x', []))}"
+)
+
+if tty == "1":
+    print(
+        f'verbose: ./scripts/conformance/conformance.sh run --filter "{filter_name}" --verbose'
+    )
+PY


### PR DESCRIPTION
## Summary

Fixes the TS2589 ("Type instantiation is excessively deep and possibly infinite") **anchor position** for recursive conditional type aliases so it matches `tsc` byte-for-byte.

`tsc` calls `error(currentNode, ...)` from `getConditionalType` and `instantiateTypeWithAlias` when the depth limit fires. By the time the limit fires while resolving a type alias body, `currentNode` is the inner self-reference being instantiated. `forEachChild` visits conditional-type children in **check → extends → true → false** order, so the **last** self-referential `TypeReference` in source order is the one `tsc` reports against.

Previously, our checker anchored at `alias.type_node` (the start of the body), producing fingerprints like `test.ts:8:5` instead of the expected `test.ts:11:7`. After this change the anchor lands on the actual recursive use, matching `tsc`.

```ts
type Foo<T> = T extends unknown
  ? unknown extends `${infer $Rest}`
    ? Foo<T>
    : Foo<unknown>   // ← TS2589 now anchored here, matching tsc
  : unknown;
```

This was the picked failure from `scripts/session/quick-pick.sh` (`compiler/recursiveConditionalCrash4.ts`).

## Changes

- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs` — adds `find_last_recursive_alias_ref` helper that walks the body AST for `TypeReference` nodes resolving to the alias's own symbol and returns the last in source order; uses it as the TS2589 anchor (falls back to `alias.type_node` if the walker finds none).
- `crates/tsz-checker/tests/ts2589_tests.rs` — locks in the new anchor with a unit test that verifies both the byte offset (must point at `Foo<unknown>`) and the span length (must match the type-reference text, not the whole body).
- `scripts/session/roll.sh` — new tiny "roll the dice" random conformance failure picker that prints a single tab-separated line (category, filter name, expected/actual/missing/extra). Complementary to the existing `quick-pick.sh` for grep/awk pipelines.

## Architecture notes

- The fix lives squarely in the **checker** (`WHERE`/diagnostic location), not the solver — it changes only which AST node the diagnostic anchors at, not any type semantics.
- Detection of `body_refs.contains(&def_id)` already runs through the solver via `query_boundaries::common::collect_lazy_def_ids`, so the new walker only handles the AST-level "which `TypeReference` to anchor at" question.
- No new boundary helper or solver query was needed since `currentNode`-style tracking would be a much larger architectural change.

## Test plan

- [x] Targeted conformance: `compiler/recursiveConditionalCrash4.ts` → **PASS** (was fingerprint-only FAIL).
- [x] Full conformance: **12144 → 12149 (+5 net)**, zero `PASS → FAIL` regressions.
- [x] Unit tests: `ts2589_tests` 11/11 (incl. new `recursive_conditional_type_alias_anchors_ts2589_at_last_self_reference`); `cargo nextest run -p tsz-checker -p tsz-solver --lib` → 8094/8094.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] Pre-commit hook (clippy, wasm32 lint gate, architecture guardrails) — passed.

Pre-commit test compilation was skipped via `TSZ_SKIP_TESTS=1` (which the hook documents for disk-constrained envs that can't link the full ~25GB of dev-profile test binaries); the same tests were verified separately via `cargo nextest run -p tsz-checker -p tsz-solver --lib` before pushing.

https://claude.ai/code/session_01Hw513UCKzGw7TP9ZceDw7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw513UCKzGw7TP9ZceDw7G)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
