### PR TITLE
perf(cli): match parallel path — skip per-file definition_store stats

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1209,7 +1209,9 @@ pub(super) fn collect_diagnostics(
             .or(Some(parallel_ds_stats));
     } else {
         // --- SEQUENTIAL PATH: Cached build with dependency cascade ---
-        let mut sequential_ds_stats = tsz_solver::StoreStatistics::default();
+        // Fallback used only when no shared_definition_store exists (e.g.,
+        // tests). Production paths set the shared store unconditionally.
+        let sequential_ds_stats = tsz_solver::StoreStatistics::default();
 
         // Reorder work queue in topological (dependency-first) order so that
         // dependencies are checked before their dependents. This ensures that
@@ -1451,7 +1453,14 @@ pub(super) fn collect_diagnostics(
             // so body-only/comment-only/private-symbol edits produce the same
             // invalidation decisions in both CLI and LSP.
             let checker_counters = checker.ctx.request_cache_counters;
-            sequential_ds_stats.merge(&checker.ctx.definition_store.statistics());
+            // PERF: Skip per-file `definition_store.statistics()`. When
+            // `project_env.shared_definition_store` is set, every per-file
+            // checker.ctx.definition_store is `Arc::clone` of the SAME shared
+            // store — calling .statistics() per file iterates that shared
+            // store N times and produces N× inflated counts. The parallel
+            // path already documents this same issue at line ~1159 ("summing
+            // per-file was both wasted work and N× inflated"). Compute once
+            // after the loop instead.
 
             if let Some(c) = cache.as_deref_mut() {
                 let new_sig = compute_export_signature(program, file, file_idx);
@@ -1484,18 +1493,24 @@ pub(super) fn collect_diagnostics(
         }
         if !options.no_check {
             for lib_idx in 0..checker_libs.files.len() {
-                let (lib_diags, lib_counters, lib_ds_stats) =
+                let (lib_diags, lib_counters, _lib_ds_stats) =
                     check_checker_lib_file(&checker_lib_file_env, lib_idx, &query_cache, None);
                 let mut lib_diags = lib_diags;
                 retain_program_induced_lib_diagnostics(&mut lib_diags, &baseline_lib_diagnostics);
                 diagnostics.extend(lib_diags);
                 request_cache_counters.merge(lib_counters);
-                sequential_ds_stats.merge(&lib_ds_stats);
             }
         }
         // Sequential path: single shared QueryCache — capture stats after all files.
         aggregated_qc_stats = Some(query_cache.statistics());
-        aggregated_ds_stats = Some(sequential_ds_stats);
+        // PERF: matching the parallel path, prefer the shared DefinitionStore
+        // (single .statistics() call) over summing per-file/per-lib stats from
+        // checkers that all Arc::clone the same shared store.
+        aggregated_ds_stats = project_env
+            .shared_definition_store
+            .as_ref()
+            .map(|store| store.statistics())
+            .or(Some(sequential_ds_stats));
     }
 
     // Collect diagnostics from cache for all files
@@ -2138,10 +2153,13 @@ fn check_checker_lib_file(
     diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
     diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
+    // PERF: All callers Arc::clone the same shared DefinitionStore; the
+    // aggregator computes stats once on the shared store after the loop.
+    // See `check_file_for_parallel` for the same rationale.
     (
         diagnostics,
         checker.ctx.request_cache_counters,
-        checker.ctx.definition_store.statistics(),
+        tsz_solver::StoreStatistics::default(),
     )
 }
 
@@ -2198,10 +2216,12 @@ fn check_checker_lib_file_baseline(
     diagnostics.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.code.cmp(&b.code)));
     diagnostics.dedup_by(|a, b| a.start == b.start && a.code == b.code);
 
+    // PERF: Same as `check_checker_lib_file` — callers ignore stats and the
+    // aggregator computes them once on the shared store.
     (
         diagnostics,
         checker.ctx.request_cache_counters,
-        checker.ctx.definition_store.statistics(),
+        tsz_solver::StoreStatistics::default(),
     )
 }
 


### PR DESCRIPTION
## Summary

The sequential and lib check-file paths called `checker.ctx.definition_store.statistics()` per file/lib and merged the result into a `sequential_ds_stats` aggregate. Each call iterates the entire DashMap of definitions plus `estimated_size_bytes()` which iterates again — for a 1 user file + ~10 lib file run, that's ~22-33 DashMap iterations per check.

The parallel path already documents (line ~1159) why this is wasted work:

> "DefinitionStore stats come from the shared store computed once after the loop (workers all see the same shared store, so summing per-file was both wasted work and N× inflated)."

Every per-file `checker.ctx.definition_store` is `Arc::clone` of the same project-shared `DefinitionStore` (set by `project_env.apply_to`). Summing per-file statistics produces N× inflated counts and repeats identical iterations N times. The parallel path's `check_file_for_parallel` already returns `StoreStatistics::default()`; the aggregator computes stats once on the shared store after the loop completes.

This change applies the same fix to the **sequential** paths:

1. The sequential per-file loop no longer calls `.statistics()` per iteration
2. `check_checker_lib_file` and `check_checker_lib_file_baseline` now return `StoreStatistics::default()` instead of computing per-call
3. `aggregated_ds_stats` for the sequential path now prefers the shared store (matching the parallel path)

## Bench (full quick suite, dist binary)

```
Score: tsz 14 vs tsgo 2  (was 13 vs 3 baseline)

Test                              Before (tsgo factor)   After (tsgo factor)
DeepPartial optional-chain N=50   tsgo 1.26x             tsgo 1.16x
manyConstExports.ts               tsgo 1.03x             tsz  1.27x  ← flipped
Recursive generic depth=25        tsz  1.20x             tsz  1.43x
Constraint conflicts N=30         tsz  1.21x             tsz  1.34x
ts-toolbelt/Iteration             tsz  1.28x             tsz  1.50x
utility-types/index.ts            tsz  1.81x             tsz  1.95x
Mapped complex template keys=50   tsz  1.23x             tsz  1.34x
```

Results stack with #1271 (the `register_boxed_types` arena scan fix). Both branches forked off origin/main HEAD.

## Test plan

- [x] `cargo check -p tsz-cli` — clean
- [x] `cargo nextest run -p tsz-cli --lib` — only pre-existing CLI parity failures (`tsc_parity_help`, `tsc_parity_no_input`, `tsc_parity_ts6046_*`, `default_lib_validation_*` timeout) — none touch this code
- [x] Full `bench-vs-tsgo --quick`: zero regressions, broad improvements

## Notes

The output of `--diagnostics` / `--extendedDiagnostics` is unchanged — `aggregated_ds_stats` still reflects the full project state, just sourced from the shared store directly (one `.statistics()` call) instead of summed per file (N× inflated).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
