### PR TITLE
perf(cli): skip DefinitionStore.statistics() unless --diagnostics is set

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -276,6 +276,7 @@ pub(super) fn collect_diagnostics(
     typescript_dom_replacement_globals: (bool, bool, bool),
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
     has_deprecation_diagnostics: bool,
+    collect_compile_stats: bool,
 ) -> CollectDiagnosticsResult {
     let _collect_span =
         tracing::info_span!("collect_diagnostics", files = program.files.len()).entered();
@@ -1202,11 +1203,18 @@ pub(super) fn collect_diagnostics(
             }
         }
         aggregated_qc_stats = Some(parallel_qc_stats);
-        aggregated_ds_stats = project_env
-            .shared_definition_store
-            .as_ref()
-            .map(|store| store.statistics())
-            .or(Some(parallel_ds_stats));
+        // PERF: `DefinitionStore::statistics()` walks every entry (and
+        // `estimated_size_bytes()` walks again) — only worth paying for
+        // when --diagnostics or --extendedDiagnostics is requested.
+        aggregated_ds_stats = if collect_compile_stats {
+            project_env
+                .shared_definition_store
+                .as_ref()
+                .map(|store| store.statistics())
+                .or(Some(parallel_ds_stats))
+        } else {
+            None
+        };
     } else {
         // --- SEQUENTIAL PATH: Cached build with dependency cascade ---
         // Fallback used only when no shared_definition_store exists (e.g.,
@@ -1503,14 +1511,18 @@ pub(super) fn collect_diagnostics(
         }
         // Sequential path: single shared QueryCache — capture stats after all files.
         aggregated_qc_stats = Some(query_cache.statistics());
-        // PERF: matching the parallel path, prefer the shared DefinitionStore
-        // (single .statistics() call) over summing per-file/per-lib stats from
-        // checkers that all Arc::clone the same shared store.
-        aggregated_ds_stats = project_env
-            .shared_definition_store
-            .as_ref()
-            .map(|store| store.statistics())
-            .or(Some(sequential_ds_stats));
+        // PERF: skip the shared DefinitionStore stats walk unless --diagnostics
+        // / --extendedDiagnostics actually consumes them. Matches the parallel
+        // path's gating above.
+        aggregated_ds_stats = if collect_compile_stats {
+            project_env
+                .shared_definition_store
+                .as_ref()
+                .map(|store| store.statistics())
+                .or(Some(sequential_ds_stats))
+        } else {
+            None
+        };
     }
 
     // Collect diagnostics from cache for all files
@@ -2869,6 +2881,7 @@ mod tests {
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics
     }
@@ -2895,6 +2908,7 @@ mod tests {
             &CheckerLibSet::default(),
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics
@@ -2974,6 +2988,7 @@ mod tests {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics
@@ -3195,6 +3210,7 @@ const elem = <div className={class1, class2}/>;
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
         let ts18048_count = diagnostics
@@ -3313,6 +3329,7 @@ const q: PromiseLike<number> = p;
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -3391,6 +3408,7 @@ async function f() {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -3473,6 +3491,7 @@ type Recurse2 = {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -3685,6 +3704,7 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
         let direct_ts2322_count = direct_diagnostics
@@ -3704,6 +3724,7 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -3807,6 +3828,7 @@ export const x = foo();
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -3907,6 +3929,7 @@ export type RowToColumns<TColumns> = {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -4449,6 +4472,7 @@ let x2: string = f;
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -4566,6 +4590,7 @@ const onSomeEvent = <T extends keyof TypesMap>(p: P<T>) => typeHandlers[p.t]?.(p
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -4663,6 +4688,7 @@ const nestedTuple = type([["ark", "|>", (x) => x.length]])
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -4750,6 +4776,7 @@ m(item => item.id < 5);
             (false, false, false),
             &type_cache_output,
             false,
+            false,
         )
         .diagnostics;
 
@@ -4830,6 +4857,7 @@ interface Buzz { id: number; buzz: string }
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -4919,6 +4947,7 @@ const obj: {field: Rule} = {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -5039,6 +5068,7 @@ function foo() {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;
@@ -5187,6 +5217,7 @@ interface Node {
             &checker_libs,
             (false, false, false),
             &type_cache_output,
+            false,
             false,
         )
         .diagnostics;

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1557,7 +1557,10 @@ pub(super) fn collect_diagnostics(
     let query_cache_stats = aggregated_qc_stats.or_else(|| Some(query_cache.statistics()));
 
     // Compute module dependency graph statistics for --extendedDiagnostics.
-    let module_dep_stats = {
+    // PERF: Skip the SCC computation entirely when the CLI won't print stats.
+    // tarjan_scc + adjacency dedup is O(V+E) and adj allocates a Vec<Vec<usize>>
+    // of file_count.
+    let module_dep_stats = if collect_compile_stats {
         let file_count = program.files.len();
         // Build a deduplicated adjacency list from resolved_module_paths.
         let mut adj: Vec<Vec<usize>> = vec![Vec::new(); file_count];
@@ -1578,6 +1581,8 @@ pub(super) fn collect_diagnostics(
             import_cycles,
             largest_cycle_size,
         })
+    } else {
+        None
     };
 
     CollectDiagnosticsResult {

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1348,6 +1348,12 @@ fn compile_inner(
 
     let collect_diagnostics_start = Instant::now();
     let parallel_type_caches = std::sync::Mutex::new(FxHashMap::default());
+    // PERF: only walk the DefinitionStore for statistics() when the CLI
+    // will actually print or write them. Saves an O(N) DashMap iteration
+    // (and another in `estimated_size_bytes`) on the hot collect_diagnostics
+    // return path.
+    let collect_compile_stats =
+        args.diagnostics || args.extended_diagnostics || args.generate_trace.is_some();
     let collected = collect_diagnostics(
         &program,
         &resolved,
@@ -1357,6 +1363,7 @@ fn compile_inner(
         typescript_dom_replacement_globals,
         &parallel_type_caches,
         has_deprecation_diagnostics,
+        collect_compile_stats,
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1604,7 +1604,11 @@ fn compile_inner(
             emit_ms: emit_duration.as_secs_f64() * 1000.0,
             total_ms: compile_start.elapsed().as_secs_f64() * 1000.0,
         },
-        residency_stats: Some(program.residency_stats()),
+        // PERF: residency_stats walks every unique arena (estimated_size_bytes
+        // per arena), every bound file, the skeleton index, and the dep graph
+        // — only worth paying for when --extendedDiagnostics actually prints
+        // the numbers. See iter 4's collect_compile_stats gating for parity.
+        residency_stats: collect_compile_stats.then(|| program.residency_stats()),
         module_dep_stats: collected.module_dep_stats,
         invalidation_summaries: Vec::new(),
     })


### PR DESCRIPTION
## Summary

`DefinitionStore::statistics()` walks every entry in the `definitions` DashMap to count by `DefKind`, then `estimated_size_bytes()` walks them again plus iterates `file_to_defs`. For a single-file `--noEmit` of a 2071-line input, the shared DefinitionStore holds ~5000 lib entries, so each `.statistics()` call costs ~2 full DashMap iterations.

After PRs #1271 / #1276 / #1279 trimmed the redundant per-file calls, profiling (samply, deep-50.ts fixture) shows `statistics` + `estimated_size_bytes` still consume **~1.5% of leaf self-time** — invoked once on the shared store at the end of `collect_diagnostics`.

The result is consumed exclusively by the CLI's `print_diagnostics` codepath, gated on `args.diagnostics || args.extended_diagnostics`. Without those flags, the work is wasted.

This change threads a `collect_compile_stats: bool` parameter through `compile_inner -> collect_diagnostics` and skips both shared-store `.statistics()` calls (parallel + sequential paths) when the CLI won't print or write them. Set to `true` for `--diagnostics`, `--extendedDiagnostics`, and `--generateTrace`.

## Bench (full quick suite, dist binary)

```
Score: tsz 14 vs tsgo 2 (maintained)

Hyperfine deep-50.ts (5-7 runs, dist):
  Iter 3: 365.9ms ± 4.5ms
  Iter 4: 356.0ms ± 1.8ms  (-3%)
```

Cumulative since baseline (PRs #1271 + #1276 + #1279 + this one):
- DeepPartial optional-chain N=50: tsz 429ms -> 372ms (**-13%**)
- Shallow optional-chain N=50:     tsz 425ms -> 364ms (**-14%**)

## Test plan

- [x] `cargo check -p tsz-cli --tests` — clean
- [x] `cargo nextest run -p tsz-cli --lib` — only the same pre-existing CLI parity failures (`tsc_parity_help`/`_no_input`/`_ts6046_*`) and the `default_lib_validation_*` 60s timeout, none related to this change
- [x] Pre-commit hook: passed (no test crates affected since change is isolated to `tsz-cli`)
- [x] Full `bench-vs-tsgo --quick`: zero regressions

## Notes

When `--diagnostics`/`--extendedDiagnostics`/`--generateTrace` is set, behavior is unchanged: the shared store walk still happens (with the same fallback to per-path aggregated stats). When neither is set, `aggregated_ds_stats` is `None` and the CLI's stats printout block is bypassed entirely.

The 14 internal test call sites of `collect_diagnostics` were updated to pass `false` since they don't consume the stats.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
