### PR TITLE
fix(checker): preserve as-written union origin for diagnostic display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -419,6 +419,10 @@ path = "tests/ts2451_type_only_namespace_merge_tests.rs"
 name = "intersection_primitive_member_assignability_tests"
 path = "tests/intersection_primitive_member_assignability_tests.rs"
 
+[[test]]
+name = "union_origin_display_tests"
+path = "tests/union_origin_display_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -44,7 +44,16 @@ impl<'a> CheckerState<'a> {
                 return member_types[0];
             }
 
-            return factory.union(member_types);
+            let result = factory.union(member_types.clone());
+
+            // Mirror tsc's `UnionType.origin`: record the as-written input
+            // member list so the diagnostic printer can preserve top-level
+            // alias names that union flattening would otherwise dissolve
+            // (e.g., `T | null` should display as `T | null`, not as T's
+            // expanded body). The interner stores at most one origin per
+            // flattened TypeId; first writer wins.
+            self.ctx.types.store_union_origin(result, member_types);
+            return result;
         }
 
         TypeId::ERROR // Missing composite type data - propagate error

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -221,7 +221,17 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // UnionReduction.Literal behavior. This preserves the union structure
             // (e.g., C | D stays as C | D even when D extends C) which is important
             // for TS2403 redeclaration checks and type display in diagnostics.
-            return tsz_solver::utils::union_or_single_literal_reduce(self.ctx.types, member_types);
+            let result = tsz_solver::utils::union_or_single_literal_reduce(
+                self.ctx.types,
+                member_types.clone(),
+            );
+
+            // Mirror tsc's `UnionType.origin`: record the as-written input
+            // member list so the diagnostic printer can preserve top-level
+            // alias names that union flattening would otherwise dissolve
+            // (see `TypeInterner::store_union_origin`).
+            self.ctx.types.store_union_origin(result, member_types);
+            return result;
         }
 
         TypeId::ERROR

--- a/crates/tsz-checker/tests/union_origin_display_tests.rs
+++ b/crates/tsz-checker/tests/union_origin_display_tests.rs
@@ -1,0 +1,53 @@
+//! Regression tests for diagnostic display of unions whose top-level alias
+//! names would be lost during interner flattening.
+//!
+//! When a user writes `T | null` and `T` is itself a union alias (e.g.,
+//! `type T = "a" | "b" | undefined`), the interner flattens the result into
+//! `"a" | "b" | undefined | null` for type-system correctness. tsc preserves
+//! the as-written `T | null` form for diagnostic display via `UnionType.origin`.
+//!
+//! tsz captures the same information through the `display_union_origin` side
+//! table on `TypeInterner`, populated by `get_type_from_union_type` and
+//! consulted by the diagnostic printer. These tests lock the contract via the
+//! highest-fidelity public surface available: full source → diagnostic text.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+/// TS2859 ("Excessive complexity comparing types") must reference the
+/// as-written alias name (`T1 | null`) rather than the flattened union body.
+///
+/// The repro is taken from `relationComplexityError.ts` (TS issue #55630).
+#[test]
+fn ts2859_message_preserves_top_level_alias_in_target_union() {
+    let source = r#"
+type Digits = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7';
+type T1 = `${Digits}${Digits}${Digits}${Digits}` | undefined;
+type T2 = { a: string } | { b: number };
+
+function f2(x: T1 | null, y: T1 & T2) {
+    x = y;
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    let ts2859 = diags
+        .iter()
+        .find(|d| d.code == 2859)
+        .unwrap_or_else(|| panic!("Expected TS2859, got: {diags:?}"));
+
+    assert!(
+        ts2859.message_text.contains("'T1 & T2'"),
+        "Source half of TS2859 must read 'T1 & T2'. Got: {}",
+        ts2859.message_text
+    );
+    assert!(
+        ts2859.message_text.contains("'T1 | null'"),
+        "Target half of TS2859 must read 'T1 | null' (the as-written alias \
+         form), not the flattened union body. Got: {}",
+        ts2859.message_text
+    );
+    assert!(
+        !ts2859.message_text.contains("Digits"),
+        "Target half must not leak T1's expanded body. Got: {}",
+        ts2859.message_text
+    );
+}

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -170,6 +170,18 @@ pub trait TypeDatabase {
         None
     }
 
+    /// Record the as-written origin members for a flattened Union TypeId.
+    ///
+    /// The checker calls this from `get_type_from_union_type` so that the
+    /// printer can recover top-level alias names lost during flattening.
+    /// See `TypeInterner::store_union_origin` for the full contract.
+    fn store_union_origin(&self, _union_type_id: TypeId, _origin_members: Vec<TypeId>) {}
+
+    /// Look up the as-written origin members for a flattened Union TypeId.
+    fn get_union_origin(&self, _type_id: TypeId) -> Option<Arc<Vec<TypeId>>> {
+        None
+    }
+
     /// Atomically read and clear the "union too complex" flag.
     ///
     /// Returns `true` if a union construction was aborted due to complexity
@@ -549,6 +561,14 @@ impl TypeDatabase for TypeInterner {
 
     fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {
         Self::get_display_alias(self, type_id)
+    }
+
+    fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
+        Self::store_union_origin(self, union_type_id, origin_members);
+    }
+
+    fn get_union_origin(&self, type_id: TypeId) -> Option<Arc<Vec<TypeId>>> {
+        Self::get_union_origin(self, type_id)
     }
 
     fn take_union_too_complex(&self) -> bool {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1093,6 +1093,15 @@ impl TypeDatabase for QueryCache<'_> {
         self.interner.get_display_alias(type_id)
     }
 
+    fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
+        self.interner
+            .store_union_origin(union_type_id, origin_members);
+    }
+
+    fn get_union_origin(&self, type_id: TypeId) -> Option<Arc<Vec<TypeId>>> {
+        self.interner.get_union_origin(type_id)
+    }
+
     fn take_union_too_complex(&self) -> bool {
         self.interner.take_union_too_complex()
     }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -938,6 +938,14 @@ impl<'a> TypeFormatter<'a> {
                 self.format_object_with_index(shape.as_ref()).into()
             }
             TypeData::Union(members) => {
+                // tsc preserves top-level alias names that would otherwise be
+                // lost during union flattening (e.g., `T | null` should not
+                // expand to T's body). The checker records the unflattened
+                // input member list as a side-table "origin"; consult it here
+                // before structural display.
+                if let Some(origin) = self.interner.get_union_origin(type_id) {
+                    return self.format_union(origin.as_slice()).into();
+                }
                 let members = self.interner.type_list(*members);
                 self.format_union(members.as_ref()).into()
             }

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -3067,3 +3067,82 @@ fn distributive_conditional_alias_with_non_boolean_singleton_keeps_alias() {
         "Singleton non-distributable args must keep the alias name. Got: {result}"
     );
 }
+
+// =====================================================================
+// Union containing a Lazy alias — TS2859 / general union-display parity
+// =====================================================================
+//
+// When a user writes `T | null` where `T` is a type alias whose body is a
+// union (e.g., `type T = "a" | "b" | undefined`), tsc displays the diagnostic
+// with the alias name preserved at the top level: `T | null`. The flattened
+// member list `"a" | "b" | undefined | null` is the structural form, but the
+// printer is supposed to factor the alias back out for display.
+//
+// These tests lock in two invariants:
+//   1. A union built from `[Lazy(T), null]` *without* prior flattening must
+//      display as `T | null` (the Lazy is preserved).
+//   2. After we add union-origin tracking, a flattened union annotated with
+//      its origin should also display as `T | null`.
+#[test]
+fn union_of_lazy_alias_with_null_preserves_alias_name() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    // type Foo = "a" | "b" | undefined
+    let lit_a = db.literal_string("a");
+    let lit_b = db.literal_string("b");
+    let foo_body = db.union_literal_reduce(vec![lit_a, lit_b, TypeId::UNDEFINED]);
+    let foo_name = db.intern_string("Foo");
+    let foo_def = crate::def::DefinitionInfo::type_alias(foo_name, vec![], foo_body);
+    let foo_def_id = def_store.register(foo_def);
+    def_store.register_type_to_def(foo_body, foo_def_id);
+
+    // Build the union from `[Lazy(Foo), null]`. Since Lazy is not a Union,
+    // collect_union_members must NOT flatten it — the resulting union should
+    // retain Lazy(Foo) as a top-level member.
+    let foo_lazy = db.lazy(foo_def_id);
+    let foo_or_null = db.union_literal_reduce(vec![foo_lazy, TypeId::NULL]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    let rendered = fmt.format(foo_or_null);
+    assert_eq!(rendered, "Foo | null", "got: {rendered}");
+}
+
+// Simulate the realistic case where the alias body has been substituted in
+// place of Lazy(Foo) — i.e., the union members that reach the printer are
+// the *flattened* union body plus `null`. Today we lose the alias name in
+// this scenario; the new union-origin side table should restore it.
+#[test]
+fn union_with_origin_preserves_alias_name_after_flattening() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let lit_a = db.literal_string("a");
+    let lit_b = db.literal_string("b");
+    let foo_body = db.union_literal_reduce(vec![lit_a, lit_b, TypeId::UNDEFINED]);
+    let foo_name = db.intern_string("Foo");
+    let foo_def = crate::def::DefinitionInfo::type_alias(foo_name, vec![], foo_body);
+    let foo_def_id = def_store.register(foo_def);
+    def_store.register_type_to_def(foo_body, foo_def_id);
+
+    // Pre-flattened union: [lit_a, lit_b, undefined, null]
+    let flattened = db.union_literal_reduce(vec![lit_a, lit_b, TypeId::UNDEFINED, TypeId::NULL]);
+
+    // Sanity: without origin, the printer must NOT know the alias.
+    {
+        let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+        let rendered = fmt.format(flattened);
+        assert!(
+            !rendered.contains("Foo"),
+            "Pre-condition: structural form must not mention `Foo`. Got: {rendered}"
+        );
+    }
+
+    // Record the as-written origin members [Lazy(Foo), null].
+    let foo_lazy = db.lazy(foo_def_id);
+    db.store_union_origin(flattened, vec![foo_lazy, TypeId::NULL]);
+
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    let rendered = fmt.format(flattened);
+    assert_eq!(rendered, "Foo | null", "got: {rendered}");
+}

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -578,6 +578,22 @@ pub struct TypeInterner {
     /// The formatter checks this to show `Dictionary<string>` instead
     /// of `{ [index: string]: string; }` in error messages.
     pub(super) display_alias: DashMap<TypeId, TypeId, FxBuildHasher>,
+    /// As-written origin members for a Union TypeId, used to preserve top-level
+    /// alias names that would otherwise be lost during union flattening.
+    ///
+    /// When a user writes `T | null` and `T` is a type alias whose body is itself
+    /// a union (e.g., `type T = "a" | "b" | undefined`), tsc's `getUnionType`
+    /// flattens the inputs into `"a" | "b" | undefined | null`, but the printer
+    /// still displays `T | null` by consulting the union's `origin` field.
+    ///
+    /// tsz captures the equivalent information here: the checker records the
+    /// *unflattened* member list (e.g., `[Lazy(T), null]`) for the resulting
+    /// flattened union. The formatter consults this map before falling through
+    /// to structural display.
+    ///
+    /// Key: the flattened Union `TypeId` returned to the checker.
+    /// Value: the unflattened input member list, in the order the user wrote.
+    pub(super) display_union_origin: DashMap<TypeId, Arc<Vec<TypeId>>, FxBuildHasher>,
     /// Flag set when union normalization detects that a union type is too complex
     /// to represent (would require > 1M pairwise subtype comparisons during
     /// reduction). Mirrors tsc's `removeSubtypes` complexity heuristic that
@@ -643,6 +659,7 @@ impl TypeInterner {
             exact_optional_property_types: AtomicBool::new(false),
             display_properties: DashMap::with_hasher(FxBuildHasher),
             display_alias: DashMap::with_hasher(FxBuildHasher),
+            display_union_origin: DashMap::with_hasher(FxBuildHasher),
             union_too_complex: AtomicBool::new(false),
             evaluation_fuel: AtomicU32::new(0),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
@@ -1325,6 +1342,46 @@ impl TypeInterner {
     /// Returns `None` if this type was not produced from an Application evaluation.
     pub fn get_display_alias(&self, type_id: TypeId) -> Option<TypeId> {
         self.display_alias.get(&type_id).map(|r| *r)
+    }
+
+    /// Record the as-written origin members for a flattened Union TypeId.
+    ///
+    /// Mirrors tsc's `UnionType.origin` mechanism: when `T | null` is built and
+    /// `T` is itself a union alias, normalization flattens the result, but the
+    /// printer needs the unflattened input list to display `T | null` instead
+    /// of the structural expansion.
+    ///
+    /// We only store the origin when normalization *actually flattened* a
+    /// nested union — i.e., the resulting Union has strictly more members than
+    /// the input list. Without this guard, recording the as-written order for
+    /// trivially-different inputs (e.g., user wrote `"foo" | Refrigerator` but
+    /// the interner sorted to `Refrigerator | "foo"`) would override tsc's
+    /// canonical sort and regress the diagnostic display.
+    pub fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
+        if origin_members.len() < 2 {
+            return;
+        }
+        let Some(TypeData::Union(list_id)) = self.lookup(union_type_id) else {
+            // Only store origins for actual Union TypeIds; other shapes have
+            // their own display paths.
+            return;
+        };
+        let current = self.type_list(list_id);
+        if current.len() <= origin_members.len() {
+            // No flattening occurred — same or fewer members. The structural
+            // display already matches what tsc shows after canonical sort.
+            return;
+        }
+        // First writer wins so deterministic display order is preserved when
+        // the same flattened union is reached from multiple annotation sites.
+        self.display_union_origin
+            .entry(union_type_id)
+            .or_insert_with(|| Arc::new(origin_members));
+    }
+
+    /// Look up the as-written origin members for a flattened Union TypeId.
+    pub fn get_union_origin(&self, type_id: TypeId) -> Option<Arc<Vec<TypeId>>> {
+        self.display_union_origin.get(&type_id).map(|r| r.clone())
     }
 
     pub(super) fn intern_function_shape(&self, shape: FunctionShape) -> FunctionShapeId {


### PR DESCRIPTION
## Summary

When a user writes `T | null` and `T` is itself a union alias (e.g.,
`type T = ` + "`" + `${Digits}` + "`" + ` | undefined`), `getUnionType` flattens the inputs into the
structural form. tsc preserves the as-written `T | null` for diagnostic
display via `UnionType.origin`; tsz was losing the alias name and printing
the expanded body instead.

Repro from `relationComplexityError.ts` (TS issue [#55630](https://github.com/microsoft/TypeScript/issues/55630)):

```ts
type Digits = '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7';
type T1 = `${Digits}${Digits}${Digits}${Digits}` | undefined;
type T2 = { a: string } | { b: number };

function f2(x: T1 | null, y: T1 & T2) {
    x = y;  // TS2859
}
```

**Before**

```
Excessive complexity comparing types 'T1 & T2' and
  '`${Digits}${Digits}${Digits}${Digits}` | null | undefined'.
```

**After (matches tsc)**

```
Excessive complexity comparing types 'T1 & T2' and 'T1 | null'.
```

## Implementation

* `TypeInterner` gains a `display_union_origin` side table mapping a
  flattened `Union` `TypeId` to its as-written input member list, plus
  `store_union_origin` / `get_union_origin` accessors. The setter records
  origin **only when normalization actually flattened a nested union**
  (i.e., the resulting `Union` has strictly more members than the input).
  For trivially reordered annotations like `"foo" | Refrigerator` →
  `Refrigerator | "foo"`, no flattening occurred and tsc's canonical sort
  already matches the structural display, so no origin is stored. First
  writer wins so the origin display is deterministic when multiple
  annotations alias the same flattened `TypeId`.

* `TypeDatabase` exposes the same accessors (default no-op for
  non-interner backends; forwarded by `QueryCache`).

* The diagnostic printer's `Union` branch consults `get_union_origin`
  before falling through to structural display.

* Both `get_type_from_union_type` checker entry points (the
  `TypeNodeChecker`/literal-reduce path and the `CheckerState`/typeof
  path) record the unflattened input members on the resulting `Union`.

## Tests

* `tsz-solver`: `union_of_lazy_alias_with_null_preserves_alias_name` and
  `union_with_origin_preserves_alias_name_after_flattening` lock the
  formatter contract at the solver layer.
* `tsz-checker`: `ts2859_message_preserves_top_level_alias_in_target_union`
  exercises the full source → diagnostic path against the repro.
* Conformance: `relationComplexityError.ts` flips PASS. The pre-refinement
  full-suite run flipped 9 PASS↔FAIL improvements with 3 incidental
  regressions on `string-literal | InterfaceLazy` ordering; the
  cardinality-only origin guard added in the final patch fixes those
  three regressions while preserving all 9 improvements (verified
  individually with `--filter`).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --package tsz-solver --lib union_with_origin_preserves_alias_name_after_flattening`
- [x] `cargo test --package tsz-solver --lib union_of_lazy_alias_with_null_preserves_alias_name`
- [x] `cargo test --package tsz-checker --test union_origin_display_tests`
- [x] `./scripts/conformance/conformance.sh run --filter relationComplexityError --verbose` → PASS
- [x] `./scripts/conformance/conformance.sh run --filter stringLiteralsWithEqualityChecks03 --verbose` → PASS
- [x] `./scripts/conformance/conformance.sh run --filter stringLiteralsWithEqualityChecks04 --verbose` → PASS
- [x] `./scripts/conformance/conformance.sh run --filter nonPrimitiveAndTypeVariables --verbose` → PASS

Also adds `scripts/session/random-target.sh`, a small standalone agent-workflow helper that picks one random conformance failure and joins it with `tsc-cache-full.json` so the per-fingerprint expected message text is shown alongside the codes.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TecGN7ZtkQ593ghanh5U)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
