### PR TITLE
ci: dedicated build job + 32 conformance shards for 5-min CI

### DIFF
--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -312,6 +312,7 @@ configure_sccache() {
   else
     echo "warning: sccache server failed to start; unsetting RUSTC_WRAPPER" >&2
     unset RUSTC_WRAPPER
+    export CARGO_INCREMENTAL="1"
   fi
 }
 

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -310,7 +310,7 @@ configure_sccache() {
 
   echo "sccache: GCS bucket=${gcs_bucket} prefix=${gcs_prefix} mode=${SCCACHE_GCS_RW_MODE}"
   sccache --stop-server 2>/dev/null || true
-  if sccache --start-server 2>/dev/null; then
+  if sccache --start-server; then
     echo "sccache server started"
   else
     echo "warning: sccache server failed to start; unsetting RUSTC_WRAPPER" >&2

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -301,6 +301,9 @@ configure_sccache() {
   export SCCACHE_GCS_BUCKET="$gcs_bucket"
   export SCCACHE_GCS_KEY_PREFIX="$gcs_prefix"
   export SCCACHE_GCS_RW_MODE="${SCCACHE_GCS_RW_MODE:-READ_WRITE}"
+  # Use GCE metadata server for OAuth2 tokens (works on Cloud Run workers)
+  export SCCACHE_GCS_CREDENTIALS_URL="${SCCACHE_GCS_CREDENTIALS_URL:-http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token}"
+  export SCCACHE_GCS_CREDENTIALS_URL_HEADERS="${SCCACHE_GCS_CREDENTIALS_URL_HEADERS:-Metadata-Flavor:Google}"
   export RUSTC_WRAPPER="sccache"
   export CARGO_INCREMENTAL="0"  # incompatible with sccache
   export SCCACHE_LOG="${SCCACHE_LOG:-warn}"


### PR DESCRIPTION
## Summary

- **Build-once pattern**: New `build` job compiles dist-fast binaries (tsz, tsz-server, tsz-conformance, generate-tsc-cache) and immediately saves them to GCS by commit SHA. All test jobs restore from GCS and skip recompilation.
- **Conformance shards**: 16 → 32 shards, workers 6 → 8 per shard
- **Emit/fourslash shards**: 8 → 16 shards, workers 6 → 8
- **SHA fallback fix**: `build_test_binaries` now resolves commit SHA via `COMMIT_SHA → REVISION_ID → GITHUB_SHA → git rev-parse HEAD`, matching what `gcp-cache.sh` uses

## How it works

```
gate
 └── build  (compiles once, saves dist-fast binaries to GCS/{sha}.tar.gz)
      ├── lint
      ├── unit
      ├── wasm
      ├── conformance-0..31  (each restores binaries, skips compile)
      ├── emit
      └── fourslash
```

## Test plan

- [ ] CI on this PR shows `build` job runs first
- [ ] Subsequent test jobs log "Using cached dist-fast binaries"
- [ ] Wall time approaches 5 min total
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
