### PR TITLE
fix(checker): select tagged template overload by arity for contextual typing

### DIFF
--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -82,9 +82,21 @@ impl<'a> CheckerState<'a> {
         let resolved_tag_type = self.resolve_ref_type(tag_type);
         let resolved_tag_type = self.resolve_lazy_type(resolved_tag_type);
 
-        // Extract function shape from the tag function type
-        let callee_shape =
-            call_checker::get_contextual_signature(self.ctx.types, resolved_tag_type);
+        // Extract function shape from the tag function type. Tagged templates
+        // pass `TemplateStringsArray` as the first argument followed by the
+        // substitution expressions, so the effective arg count is
+        // `1 + substitution_exprs.len()`. Threading this arity into signature
+        // selection lets overload-aware contextual typing pick the matching
+        // overload (mirrors the regular call expression path) instead of
+        // returning `None` for mixed-arity overload sets and falling back to a
+        // signature-less single pass.
+        let total_arg_count = 1 + substitution_exprs.len();
+        let callee_shape = call_checker::get_contextual_signature_for_arity(
+            self.ctx.types,
+            resolved_tag_type,
+            total_arg_count,
+        )
+        .or_else(|| call_checker::get_contextual_signature(self.ctx.types, resolved_tag_type));
 
         // Detect constructor-only callable types (classes, interfaces with only `new` sigs).
         // `get_contextual_signature` falls back to construct signatures when call

--- a/crates/tsz-checker/tests/conformance_issues/features/templates.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/templates.rs
@@ -1030,6 +1030,49 @@ var a9e: {};
     );
 }
 
+/// Mixed-arity generic overloads on a tagged template tag must select the
+/// matching overload by arity for contextual typing of substitution
+/// expressions, the same way regular call expressions do. Previously the
+/// tagged-template path called `get_contextual_signature` without an arity,
+/// which returned `None` for mixed-arity overload sets and forced a
+/// signature-less single-pass that left the type parameter `T` un-inferred,
+/// producing a spurious TS2345 on later substitutions.
+///
+/// From: parenthesizedContexualTyping3.ts
+#[test]
+fn test_tagged_template_overload_arity_selects_signature_for_inference() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, h: (y: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T {
+    return g(x);
+}
+
+var a = tempFun `${ x => x }  ${ 10 }`;
+var b = tempFun `${ (x => x) }  ${ 10 }`;
+var c = tempFun `${ ((x => x)) } ${ 10 }`;
+var d = tempFun `${ x => x } ${ x => x } ${ 10 }`;
+var e = tempFun `${ x => x } ${ (x => x) } ${ 10 }`;
+var f = tempFun `${ x => x } ${ ((x => x)) } ${ 10 }`;
+var g = tempFun `${ (x => x) } ${ (((x => x))) } ${ 10 }`;
+var h = tempFun `${ (x => x) } ${ (((x => x))) } ${ undefined }`;
+        "#,
+    );
+
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "Tagged template against mixed-arity generic overloads should select \
+         the correct overload by arity and infer T from later substitutions, \
+         producing no TS2345.\nActual errors: {diagnostics:#?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 7006),
+        "Substitution arrow parameters should be contextually typed from the \
+         arity-matched overload, so no TS7006 should fire.\nActual errors: {diagnostics:#?}"
+    );
+}
+
 #[test]
 fn test_tagged_template_generic_unresolved_type_params_display_as_unknown() {
     let diagnostics = compile_and_get_diagnostics_with_lib(

--- a/docs/plan/claims/fix-checker-tagged-template-overload-arity-contextual.md
+++ b/docs/plan/claims/fix-checker-tagged-template-overload-arity-contextual.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-tagged-template-overload-arity-contextual`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1326
+- **Status**: ready
 - **Workstream**: Conformance / TS2345 false positive
 
 ## Intent

--- a/docs/plan/claims/fix-checker-tagged-template-overload-arity-contextual.md
+++ b/docs/plan/claims/fix-checker-tagged-template-overload-arity-contextual.md
@@ -1,0 +1,33 @@
+# fix(checker): select tagged template overload by arity for contextual typing
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-tagged-template-overload-arity-contextual`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance / TS2345 false positive
+
+## Intent
+
+Tagged template type computation called `get_contextual_signature` without
+threading the effective argument count, so mixed-arity overload sets returned
+`None` from `combine_contextual_signatures` and the path fell through to a
+signature-less single pass. The single pass left the type parameter `T`
+un-inferred, so later concrete substitutions (e.g. `${ 10 }`) tripped a
+spurious `TS2345 'number' is not assignable to 'T'`. This change threads the
+tagged template's effective arg count (`1 + substitution_count`) into
+contextual signature selection, mirroring the regular call expression path
+in `call/inner.rs`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/computation/tagged_template.rs` (~12 LOC)
+- `crates/tsz-checker/tests/conformance_issues/features/templates.rs` (regression test, ~38 LOC)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (2793 tests pass)
+- `cargo nextest run -p tsz-checker -- test_tagged_template` (6/6 pass, including new regression test)
+- `./scripts/conformance/conformance.sh run --filter "parenthesizedContexualTyping"` — `parenthesizedContexualTyping3.ts` now PASSES (was: `expected []` vs `actual [TS2345]`)
+- `./scripts/conformance/conformance.sh run --filter "templateString"` — 151/151 pass
+- `./scripts/conformance/conformance.sh run --filter "overload"` — 62/62 pass
+- `./scripts/conformance/conformance.sh run --filter "tag"` — no new error-code-level failures (pre-existing fingerprint-only and wrong-code failures unchanged)


### PR DESCRIPTION
## Summary

- Tagged template type computation in `tagged_template.rs` called `get_contextual_signature` without an arity, so mixed-arity overload sets returned `None` and fell through to a signature-less single pass that left the type parameter `T` un-inferred.
- Symptom: spurious `TS2345 'number' is not assignable to 'T'` on `parenthesizedContexualTyping3.ts` (and any tagged template against a generic mixed-arity overload set).
- Fix: thread the effective arg count (`1 + substitution_count`) into contextual signature selection, mirroring `call/inner.rs`. The arity-aware path (`get_contextual_signature_for_arity`) picks the matching overload, and we fall back to the original arity-less call when no overload matches.

## Root cause

In `combine_contextual_signatures` (solver), mixed-arity overload sets bail with `None`:

```rust
if signatures.iter().any(|sig| sig.params.len() != first.params.len()) {
    return None;
}
```

The regular call expression path passes `args.len()` to `get_contextual_signature_for_arity`, which filters overloads to those whose arity matches before combining. Tagged templates were not threading that arity, so for mixed-arity overloads they got `None` and lost both `is_generic_call=true` and the shape needed to drive two-pass inference for contextually-sensitive arrows.

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib` (2793 tests pass)
- [x] `cargo nextest run -p tsz-checker -- test_tagged_template` — 6/6 pass, including new `test_tagged_template_overload_arity_selects_signature_for_inference` regression test
- [x] `./scripts/conformance/conformance.sh run --filter "parenthesizedContexualTyping"` — `parenthesizedContexualTyping3.ts` now PASSES (was: `expected []` vs `actual [TS2345]`)
- [x] `./scripts/conformance/conformance.sh run --filter "templateString"` — 151/151 pass
- [x] `./scripts/conformance/conformance.sh run --filter "overload"` — 62/62 pass
- [x] `./scripts/conformance/conformance.sh run --filter "tag"` — no new error-code-level failures
- [x] `./scripts/conformance/conformance.sh run --filter "Contextual"` — no new regressions (9 pre-existing failures unchanged)

## Conformance impact

`parenthesizedContexualTyping3.ts`: `[TS2345]` → `[]` (false-positive removed; +1 test)