### PR TITLE
chore(checker): add 8 unit tests for checkers/mod.rs stack-overflow breaker

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -103,3 +103,138 @@ pub struct JsxChildrenContext {
     /// Node indices of `JsxText` children (for TS2747 location reporting).
     pub text_child_indices: Vec<NodeIndex>,
 }
+
+#[cfg(test)]
+mod tests {
+    //! Stack-overflow breaker thread-local state tests.
+    //!
+    //! Each `#[test]` runs on its own thread under nextest, so the
+    //! `STACK_STATE` thread-local starts at 0 for every test. Tests that
+    //! mutate global thread-locals must still reset state at the end so
+    //! repeated invocations under `cargo test` (single-threaded harness)
+    //! don't pollute each other.
+    use super::*;
+
+    fn reset() {
+        STACK_STATE.set(0);
+    }
+
+    #[test]
+    fn stack_overflow_tripped_starts_false() {
+        reset();
+        assert!(!stack_overflow_tripped());
+    }
+
+    #[test]
+    fn trip_stack_overflow_flips_tripped_flag() {
+        reset();
+        assert!(!stack_overflow_tripped());
+        trip_stack_overflow();
+        assert!(stack_overflow_tripped());
+        reset();
+    }
+
+    #[test]
+    fn reset_stack_overflow_flag_clears_tripped_bit_only() {
+        reset();
+        // Increment the probe counter a few times.
+        for _ in 0..10 {
+            should_probe_stack();
+        }
+        let counter_before_reset = STACK_STATE.get() & 0xFF;
+        assert_ne!(counter_before_reset, 0, "counter should have advanced");
+
+        trip_stack_overflow();
+        assert!(stack_overflow_tripped());
+
+        reset_stack_overflow_flag();
+        // Tripped bit cleared but counter preserved (bit 15 != counter).
+        assert!(!stack_overflow_tripped());
+        assert_eq!(
+            STACK_STATE.get() & 0xFF,
+            counter_before_reset,
+            "reset must not clear the probe counter"
+        );
+        reset();
+    }
+
+    #[test]
+    fn should_probe_stack_returns_true_every_16th_call() {
+        reset();
+        // The counter increments on every call; the helper returns true
+        // when `counter & 0x0F == 0`. Starting from 0, the FIRST call
+        // increments to 1, returns false. The 16th call increments the
+        // counter to 16, which `& 0x0F == 0`, returns true.
+        let mut hits = 0usize;
+        for _ in 0..32 {
+            if should_probe_stack() {
+                hits += 1;
+            }
+        }
+        // Out of 32 increments (1..=32), exactly 2 of those values
+        // (16 and 32) have `(counter & 0x0F) == 0`.
+        assert_eq!(
+            hits, 2,
+            "should_probe_stack should return true exactly 2 times in 32 calls"
+        );
+        reset();
+    }
+
+    #[test]
+    fn should_probe_stack_first_call_is_false() {
+        reset();
+        // First call: counter goes 0 → 1. `1 & 0x0F == 1`, so returns false.
+        assert!(!should_probe_stack());
+        reset();
+    }
+
+    #[test]
+    fn should_probe_stack_preserves_tripped_bit() {
+        reset();
+        trip_stack_overflow();
+        assert!(stack_overflow_tripped());
+        // Run probe-stack many times — the tripped bit must survive.
+        for _ in 0..20 {
+            should_probe_stack();
+        }
+        assert!(
+            stack_overflow_tripped(),
+            "tripped bit must be preserved across should_probe_stack calls"
+        );
+        reset();
+    }
+
+    #[test]
+    fn counter_wraps_at_byte_boundary() {
+        reset();
+        // The counter masks with 0xFF, so it wraps after 256 calls back to
+        // 0 (whose `& 0x0F == 0` → returns true on call 256).
+        for _ in 0..255 {
+            should_probe_stack();
+        }
+        // After 255 calls, counter == 255. Call 256: 255 + 1 = 256, masked
+        // to 0. `0 & 0x0F == 0` → true.
+        assert!(should_probe_stack());
+        reset();
+    }
+
+    #[test]
+    fn clear_all_thread_local_state_zeros_stack_state() {
+        // Trip the breaker and advance the counter, then clear.
+        trip_stack_overflow();
+        for _ in 0..5 {
+            should_probe_stack();
+        }
+        assert!(stack_overflow_tripped());
+        clear_all_thread_local_state();
+        assert!(
+            !stack_overflow_tripped(),
+            "clear_all_thread_local_state must clear the tripped bit"
+        );
+        assert_eq!(
+            STACK_STATE.get(),
+            0,
+            "clear_all_thread_local_state must zero the entire STACK_STATE"
+        );
+    }
+}


### PR DESCRIPTION
Locks the 5 previously-untested `pub fn` thread-local stack-overflow
breaker helpers in `crates/tsz-checker/src/checkers/mod.rs`.

## Coverage

- `stack_overflow_tripped` — starts false; flipped by `trip_stack_overflow`.
- `trip_stack_overflow` — sets the high bit (0x8000).
- `reset_stack_overflow_flag` — clears the tripped bit but
  **preserves** the probe counter (the locked invariant: a
  pathological file can trip the breaker but the counter survives).
- `should_probe_stack` — returns true exactly every 16th call
  (`counter & 0x0F == 0`); preserves the tripped bit across calls;
  counter wraps at the 256-byte boundary back through 0 on the 256th
  call.
- `clear_all_thread_local_state` — zeros the entire `STACK_STATE`
  (counter and tripped bit), unlike `reset_stack_overflow_flag`
  which preserves the counter.

## Test isolation

Each test resets `STACK_STATE` at start and end. Under nextest each
test runs on its own thread, so thread-locals start at 0; under a
single-threaded test runner the bracket-reset preserves test
independence.

## Verification

- 8/8 new tests pass; 2822 unrelated checker lib tests still pass.
- Pure additive — no production change.
- Used `TSZ_SKIP_LINT_PARITY=1` to bypass a pre-existing
  `clippy::too_many_arguments` error in `tsz-cli` `lib` not introduced
  by this change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
