### PR TITLE
ci: use SA key for sccache GCS auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
     timeout-minutes: 30
     env:
       GITHUB_SHA: ${{ github.sha }}
+      SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -301,12 +301,21 @@ configure_sccache() {
   export SCCACHE_GCS_BUCKET="$gcs_bucket"
   export SCCACHE_GCS_KEY_PREFIX="$gcs_prefix"
   export SCCACHE_GCS_RW_MODE="${SCCACHE_GCS_RW_MODE:-READ_WRITE}"
-  # Use GCE metadata server for OAuth2 tokens (works on Cloud Run workers)
-  export SCCACHE_GCS_CREDENTIALS_URL="${SCCACHE_GCS_CREDENTIALS_URL:-http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token}"
-  export SCCACHE_GCS_CREDENTIALS_URL_HEADERS="${SCCACHE_GCS_CREDENTIALS_URL_HEADERS:-Metadata-Flavor:Google}"
   export RUSTC_WRAPPER="sccache"
   export CARGO_INCREMENTAL="0"  # incompatible with sccache
   export SCCACHE_LOG="${SCCACHE_LOG:-warn}"
+
+  # Write SA key to disk if injected via secret; otherwise fall back to ADC metadata URL
+  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+    local key_file="/tmp/sccache-gcs-key.json"
+    printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
+    chmod 600 "$key_file"
+    export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
+    echo "sccache: using service account key from SCCACHE_GCS_KEY_JSON"
+  else
+    export SCCACHE_GCS_CREDENTIALS_URL="${SCCACHE_GCS_CREDENTIALS_URL:-http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token}"
+    echo "sccache: using metadata server credentials"
+  fi
 
   echo "sccache: GCS bucket=${gcs_bucket} prefix=${gcs_prefix} mode=${SCCACHE_GCS_RW_MODE}"
   sccache --stop-server 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Grants `tsz-gh-runners@tsz-ci.iam.gserviceaccount.com` objectAdmin on the GCS cache bucket
- Stores its key as `SCCACHE_GCS_KEY_JSON` GitHub secret  
- `configure_sccache()` writes key to `/tmp/sccache-gcs-key.json` and sets `GOOGLE_APPLICATION_CREDENTIALS`
- Falls back to `SCCACHE_GCS_CREDENTIALS_URL` (metadata server) when secret absent

The previous metadata URL approach required a `Metadata-Flavor: Google` header that sccache doesn't send, causing auth to silently fail and leaving sccache in local-only mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
