### PR TITLE
fix(checker): narrow union via absent-required discriminator inference

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1312,8 +1312,14 @@ impl<'a> CheckerState<'a> {
         // Pre-scan: collect discriminant info from the object literal.
         // - `unit_discriminants`: properties with unit-type literal values (e.g. `kind: "a"`)
         // - `present_property_names`: all explicitly named properties (for never-elimination)
+        // - `non_unit_named_properties`: present properties whose initializer is NOT a
+        //   unit literal (e.g. `type: foo1` where `foo1: string`). When such a property
+        //   names a discriminator slot in the union, narrowing must bail entirely so
+        //   the diagnostic reports the full union (`"foo" | "bar"`) rather than a
+        //   single arm — matches tsc's `indirectDiscriminantAndExcessProperty` shape.
         let mut unit_discriminants: Vec<(String, TypeId)> = Vec::new();
         let mut present_property_names: Vec<String> = Vec::new();
+        let mut non_unit_named_properties: Vec<String> = Vec::new();
         for &elem_idx in elements {
             let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
                 continue;
@@ -1324,10 +1330,15 @@ impl<'a> CheckerState<'a> {
                 };
                 present_property_names.push(name.clone());
                 // Get the literal type of the initializer without full type computation.
-                if let Some(lit_type) = self.literal_type_from_initializer(prop.initializer)
-                    && crate::query_boundaries::common::is_unit_type(self.ctx.types, lit_type)
-                {
+                let unit_lit =
+                    self.literal_type_from_initializer(prop.initializer)
+                        .filter(|&lit_type| {
+                            crate::query_boundaries::common::is_unit_type(self.ctx.types, lit_type)
+                        });
+                if let Some(lit_type) = unit_lit {
                     unit_discriminants.push((name, lit_type));
+                } else {
+                    non_unit_named_properties.push(name);
                 }
             } else if let Some(shorthand) = self.ctx.arena.get_shorthand_property(elem_node)
                 && let Some(name) = self.get_property_name_resolved(shorthand.name)
@@ -1337,12 +1348,16 @@ impl<'a> CheckerState<'a> {
                 // resolve the identifier to its const declaration and extract the literal
                 // type from the initializer. This enables discriminant narrowing for
                 // shorthand properties, matching tsc behavior.
-                if let Some(lit_type) = self
+                let unit_lit = self
                     .shorthand_const_literal_type(shorthand.name)
                     .or_else(|| self.literal_type_from_initializer(shorthand.name))
-                    && crate::query_boundaries::common::is_unit_type(self.ctx.types, lit_type)
-                {
+                    .filter(|&lit_type| {
+                        crate::query_boundaries::common::is_unit_type(self.ctx.types, lit_type)
+                    });
+                if let Some(lit_type) = unit_lit {
                     unit_discriminants.push((name, lit_type));
+                } else {
+                    non_unit_named_properties.push(name);
                 }
             }
         }
@@ -1351,7 +1366,7 @@ impl<'a> CheckerState<'a> {
             return ctx_type;
         }
 
-        unit_discriminants.retain(|(prop_name, _)| {
+        let mut is_discriminator_slot = |prop_name: &str| -> bool {
             let mut unit_member_count = 0;
             for &member in &members {
                 let lazy_member = self.resolve_lazy_type(member);
@@ -1373,7 +1388,21 @@ impl<'a> CheckerState<'a> {
                 unit_member_count += 1;
             }
             unit_member_count >= 2
-        });
+        };
+
+        unit_discriminants.retain(|(prop_name, _)| is_discriminator_slot(prop_name));
+
+        // If the literal supplies a discriminator slot with a non-unit value
+        // (e.g. `type: foo1` where `foo1: string`), the user is attempting a
+        // dynamic discriminator. tsc reports the assignability error against
+        // the FULL union (`"foo" | "bar"`); narrowing here would collapse the
+        // diagnostic to a single arm. Bail entirely in that case.
+        let literal_has_dynamic_discriminator = non_unit_named_properties
+            .iter()
+            .any(|name| is_discriminator_slot(name));
+        if literal_has_dynamic_discriminator {
+            return ctx_type;
+        }
 
         // For each union member, check if all discriminant values are compatible
         // AND no present property maps to `never` in that member.
@@ -1453,9 +1482,12 @@ impl<'a> CheckerState<'a> {
             //   type A = { disc: true; cb: (x: string) => void }
             //   type B = { disc?: false; cb: (x: number) => void }
             //   f({ cb: n => ... })  // disc is required in A but optional in B
-            let absent_required_match = if unit_discriminants.is_empty() {
-                true
-            } else {
+            //
+            // Run this check even when there are no unit-typed discriminant
+            // properties present in the literal — the inference is purely
+            // structural (required-vs-optional) and a missing discriminator
+            // is itself a signal in tsc's discriminantPropertyInference.
+            let absent_required_match = {
                 let mut ok = true;
                 if let Some(shape) = member_candidates.iter().find_map(|&candidate| {
                     crate::query_boundaries::common::object_shape_for_type(

--- a/crates/tsz-checker/tests/contextual_typing_tests.rs
+++ b/crates/tsz-checker/tests/contextual_typing_tests.rs
@@ -1752,3 +1752,83 @@ var k = fun((coin < 0.5 ? (x => { x<number>(undefined); return x; }) : (x => und
         "Conditional callback retry should not degrade into outer TS2769, got diagnostics={diagnostics:?}"
     );
 }
+
+/// Mirrors `compiler/discriminantPropertyInference.ts`: when an object literal
+/// completely OMITS a discriminator property, narrowing must eliminate union
+/// members that *require* the property, leaving only members where the
+/// property is optional. Without this, the callback `n` falls back to implicit
+/// any (TS7006) under `noImplicitAny`.
+#[test]
+fn test_discriminant_property_inference_omitted_discriminator_narrows_to_optional_arm() {
+    let source = r#"
+type DiscriminatorTrue = {
+    disc: true;
+    cb: (x: string) => void;
+};
+
+type DiscriminatorFalse = {
+    disc?: false;
+    cb: (x: number) => void;
+};
+
+declare function f(options: DiscriminatorTrue | DiscriminatorFalse): any;
+
+f({
+    cb: n => n.toFixed()
+});
+"#;
+    let diagnostics = check_with_options(
+        source,
+        CheckerOptions {
+            no_implicit_any: true,
+            strict_null_checks: true,
+            ..Default::default()
+        },
+    );
+    let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&7006),
+        "Omitted-discriminator narrowing should give `n` a contextual `number` type \
+         from DiscriminatorFalse; got TS7006: {diagnostics:?}"
+    );
+}
+
+/// Mirrors `compiler/indirectDiscriminantAndExcessProperty.ts`: when the literal
+/// supplies a discriminator slot with a NON-unit value (e.g. `type: foo1` where
+/// `foo1: string`), narrowing must NOT collapse to a single arm. The TS2322
+/// diagnostic must still report the full union (`"foo" | "bar"`) rather than
+/// an arbitrarily-picked arm.
+#[test]
+fn test_dynamic_discriminator_value_does_not_narrow_union() {
+    let source = r#"
+type Blah =
+    | { type: "foo", abc: string }
+    | { type: "bar", xyz: number, extra: any };
+
+declare function thing(blah: Blah): void;
+
+let foo1 = "foo";
+thing({
+    type: foo1,
+    abc: "hello!"
+});
+"#;
+    let diagnostics = check_with_options(
+        source,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..Default::default()
+        },
+    );
+    // The diagnostic should mention the full union target type, not the
+    // single narrowed arm. We don't depend on exact code (TS2322 vs TS2353):
+    // we only require that no diagnostic mentions a single narrowed arm.
+    for d in &diagnostics {
+        assert!(
+            !d.message_text.contains("type '\"foo\"'")
+                && !d.message_text.contains("type '\"bar\"'"),
+            "Dynamic discriminator (`type: foo1`) must not collapse the union to a \
+             single arm in diagnostics; got: {d:?}"
+        );
+    }
+}

--- a/docs/plan/claims/fix-checker-discriminant-omitted-narrowing.md
+++ b/docs/plan/claims/fix-checker-discriminant-omitted-narrowing.md
@@ -1,0 +1,50 @@
+# fix(checker): narrow union via absent-required discriminator inference
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-tracked-symbols-helper`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the false-positive TS7006 on `discriminantPropertyInference.ts`:
+when an object-literal argument completely OMITS a discriminator
+property, the contextual narrowing must eliminate union members that
+*require* the discriminator and pick the arm where it is optional.
+This is what gives the callback parameter `n` its contextual type.
+
+`narrow_contextual_union_via_object_literal_discriminants` already had
+the absent-required-property logic (with the comment explicitly
+describing the `disc?: false` case), but PR #753 had wrapped it in a
+`if unit_discriminants.is_empty() { true } else { ... }` guard that
+disabled the check whenever the literal had no unit-typed discriminator
+— which is *exactly* the omitted-discriminator case the comment
+described.
+
+The naïve un-guarding regressed `indirectDiscriminantAndExcessProperty.ts`,
+where `type: foo1` (with `foo1: string`) supplies a discriminator slot
+with a non-unit value. There the user is attempting a dynamic
+discriminator and tsc keeps the diagnostic against the full union.
+
+The fix narrows the guard: bail entirely when the literal supplies a
+discriminator slot with a non-unit value. Otherwise run the
+absent-required check unconditionally.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/computation/object_literal_context.rs`
+  (~30 LOC: extract `is_discriminator_slot` closure, add
+   `non_unit_named_properties` collection, add early-return when a
+   discriminator slot is supplied with a non-unit value, drop the
+   `unit_discriminants.is_empty()` guard on `absent_required_match`)
+- `crates/tsz-checker/tests/contextual_typing_tests.rs`
+  (+85 LOC, 2 new tests locking both halves)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test contextual_typing_tests`
+- `cargo nextest run -p tsz-checker --lib -E 'test(discriminat)'` (14 PASS, no regressions)
+- Full conformance: net +1 from this fix (`discriminantPropertyInference.ts`
+  flips PASS, `indirectDiscriminantAndExcessProperty.ts` stays PASS).
+  Other listed improvements are stale-snapshot drift from already-merged PRs.


### PR DESCRIPTION
## Summary

Fixes false-positive TS7006 on `discriminantPropertyInference.ts`: when an
object-literal argument completely **omits** a discriminator property,
contextual narrowing must eliminate union members that *require* the property
and pick the arm where it is optional. This gives the callback parameter `n`
its contextual type:

```ts
type DiscriminatorTrue  = { disc: true;   cb: (x: string) => void };
type DiscriminatorFalse = { disc?: false; cb: (x: number) => void };
declare function f(o: DiscriminatorTrue | DiscriminatorFalse): any;
f({ cb: n => n.toFixed() });   // n must be number, not implicit any
```

## Root cause

`narrow_contextual_union_via_object_literal_discriminants` already had the
absent-required-property logic (with a comment explicitly describing the
`disc?: false` case), but PR #753 wrapped it in
`if unit_discriminants.is_empty() { true } else { … }`. That guard disabled
the check whenever the literal had no unit-typed discriminator — which is
exactly the omitted-discriminator case the comment described.

## Why a naive un-guarding regresses

`indirectDiscriminantAndExcessProperty.ts` writes `type: foo1` where
`foo1: string`, supplying a discriminator slot with a non-unit value. tsc
keeps the diagnostic against the full union (`"foo" | "bar"`); collapsing to
a single arm changes the message text and breaks the conformance fingerprint.

## Fix

- Extract `is_discriminator_slot` closure (was the body of `unit_discriminants.retain`).
- Pre-collect `non_unit_named_properties` during the scan.
- Bail entirely when the literal supplies a discriminator slot with a non-unit value.
- Otherwise drop the `unit_discriminants.is_empty()` guard and run the
  absent-required check unconditionally.

## Test plan

- [x] `cargo nextest run -p tsz-checker --test contextual_typing_tests -E 'test(discriminant_property_inference) or test(dynamic_discriminator)'` (2/2 PASS, both new)
- [x] `cargo nextest run -p tsz-checker --lib -E 'test(discriminat) or test(narrow_contextual)'` (14/14 PASS, no existing-test regressions)
- [x] `./scripts/conformance/conformance.sh run --filter "discriminantPropertyInference"` (PASS)
- [x] `./scripts/conformance/conformance.sh run --filter "indirectDiscriminantAndExcessProperty"` (PASS — guard preserved)
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — net +1 (12144 → 12155, +11 are stale-snapshot drift unrelated to this change), 0 regressions