### PR TITLE
fix(solver): preserve nullable-stripped union from object-property inference

### DIFF
--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -711,9 +711,26 @@ impl<'a> InferenceContext<'a> {
         } else {
             resolved
         };
+        // First-property-wins fallback: when BCT/getCommonSupertype produced a
+        // union from object-property candidates that don't share a subtype
+        // relationship (e.g., `{x: 3, y: ""}` → `number | string`), tsc actually
+        // picks the first candidate (number). We replicate that here.
+        //
+        // EXCEPTION: when any candidate is a nullable type (undefined/null/void),
+        // the union is the *correct* result of tsc's getCommonSupertype, which
+        // strips nullables, runs the tournament on what remains, and then
+        // re-attaches the nullable members via getNullableType. For example,
+        // `foo<T>(f1: { x: T; y: T })` called with `{ x: undefined, y: "def" }`
+        // strips `undefined`, sees a single non-nullable candidate `string`
+        // (after widening), and returns `string | undefined`. Applying first-
+        // wins here would collapse that back to `undefined`, which is wrong:
+        // tsc emits `Type 'string | undefined' is not assignable to type 'number'`,
+        // not `Type 'undefined' is not assignable to type 'number'`.
+        let any_candidate_is_nullable = filtered_no_never.iter().any(|c| c.type_id.is_nullable());
         if all_from_object_properties
             && !has_index_signature_candidates
             && !is_const
+            && !any_candidate_is_nullable
             && let Some(TypeData::Union(member_list_id)) = self.interner.lookup(resolved)
         {
             let member_count = self.interner.type_list(member_list_id).len();

--- a/crates/tsz-solver/tests/infer_tests.rs
+++ b/crates/tsz-solver/tests/infer_tests.rs
@@ -345,6 +345,104 @@ fn test_resolve_from_property_candidates_prefers_source_order_on_union() {
 }
 
 #[test]
+fn test_resolve_from_property_candidates_preserves_nullable_strip_union() {
+    // Regression for `widenToAny1.ts`:
+    //
+    //   function foo1<T>(f1: { x: T; y: T }): T { return undefined; }
+    //   var z1: number = foo1({ x: undefined, y: "def" });
+    //
+    // tsc's getCommonSupertype strips `undefined` from the candidate set,
+    // unifies the remaining `string` candidate, then re-attaches `undefined`
+    // via getNullableType, producing `T = string | undefined`. The first-
+    // property-wins fallback used for non-nullable mismatches (e.g., `{x:3,y:""}`
+    // → number) must NOT collapse this nullable-stripped union back to a
+    // single member, otherwise we'd infer `T = undefined` and emit
+    // `Type 'undefined' is not assignable to type 'number'` instead of tsc's
+    // `Type 'string | undefined' is not assignable to type 'number'`.
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+
+    let var = ctx.fresh_type_param(interner.intern_string("T"), false);
+    let x_name = interner.intern_string("x");
+    let y_name = interner.intern_string("y");
+
+    // Candidate from property `x: T` ← undefined.
+    // Object-literal source widening (widen_object_literal_properties) happens
+    // BEFORE constraint collection in the call resolver, so by the time we
+    // reach inference resolution the candidates are already primitive types
+    // (`string`, not the fresh `"def"` literal).
+    ctx.add_property_candidate_with_index(
+        var,
+        TypeId::UNDEFINED,
+        crate::types::InferencePriority::NakedTypeVariable,
+        0,
+        Some(x_name),
+        false,
+    );
+    // Candidate from property `y: T` ← string (already widened from "def").
+    ctx.add_property_candidate_with_index(
+        var,
+        TypeId::STRING,
+        crate::types::InferencePriority::NakedTypeVariable,
+        1,
+        Some(y_name),
+        false,
+    );
+
+    let result = ctx.resolve_with_constraints(var).unwrap();
+    let expected = interner.union(vec![TypeId::STRING, TypeId::UNDEFINED]);
+    assert_eq!(
+        result, expected,
+        "T should be inferred as `string | undefined` (nullable preserved \
+         after stripping during getCommonSupertype), not collapsed to a \
+         single candidate via the first-property-wins fallback"
+    );
+}
+
+#[test]
+fn test_resolve_from_property_candidates_first_wins_for_non_nullable_mismatch() {
+    // Companion to `_preserves_nullable_strip_union`. When neither candidate
+    // is nullable, the first-property-wins fallback must still apply: tsc
+    // infers `T = number` for `foo<T>(n: {x: T, y: T})` called with
+    // a primitive `{x: number, y: string}` source, NOT `T = number | string`.
+    //
+    // Using non-fresh primitive types (NUMBER/STRING) here mirrors the
+    // existing `_prefers_source_order_on_union` test fixture so the fallback
+    // returns the candidate's stored type directly (without re-widening).
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+
+    let var = ctx.fresh_type_param(interner.intern_string("T"), false);
+    let x_name = interner.intern_string("x");
+    let y_name = interner.intern_string("y");
+
+    ctx.add_property_candidate_with_index(
+        var,
+        TypeId::NUMBER,
+        crate::types::InferencePriority::NakedTypeVariable,
+        0,
+        Some(x_name),
+        false,
+    );
+    ctx.add_property_candidate_with_index(
+        var,
+        TypeId::STRING,
+        crate::types::InferencePriority::NakedTypeVariable,
+        1,
+        Some(y_name),
+        false,
+    );
+
+    let result = ctx.resolve_with_constraints(var).unwrap();
+    assert_eq!(
+        result,
+        TypeId::NUMBER,
+        "T should be inferred as `number` (first-property-wins) for \
+         non-nullable mismatched candidates, not a `number | string` union"
+    );
+}
+
+#[test]
 fn test_fresh_object_property_literal_is_widened() {
     // When a literal type is inferred from a fresh object literal property,
     // it should be widened (e.g., "hello" → string). This matches TSC's

--- a/docs/plan/claims/fix-inference-nullable-strip-preserve-union.md
+++ b/docs/plan/claims/fix-inference-nullable-strip-preserve-union.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/inference-nullable-strip-preserve-union`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1341
+- **Status**: ready
 - **Workstream**: 1 (Conformance fixes)
 
 ## Intent
@@ -29,8 +29,14 @@ not a fallback union from incompatible candidates.
 
 ## Verification
 
-- `cargo nextest run -p tsz-solver --lib` — 5451 tests pass
+- `cargo nextest run -p tsz-solver --lib` — 5451 tests pass (incl. 2 new regression tests)
 - `./scripts/conformance/conformance.sh run --filter widenToAny1` — 1/1 pass
 - `./scripts/conformance/conformance.sh run --filter undefinedArgumentInference` — 1/1 pass
 - `./scripts/conformance/conformance.sh run --filter genericCallWithObjectLiteral` — 2/2 pass
 - `./scripts/conformance/conformance.sh run --filter widenedTypes` — 6/6 pass
+- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — Net 12144 → 12156 (**+12** tests, 0 regressions)
+  - widenToAny1.ts (target), booleanAssignment.ts, contravariantOnlyInferenceFromAnnotatedFunctionJs.ts,
+    mappedTypeIndexedAccessConstraint.ts, recursiveConditionalCrash4.ts, typePredicateInherit.ts,
+    parenthesizedContexualTyping3.ts, jsdocTemplateConstructorFunction.ts,
+    propertiesOfGenericConstructorFunctions.ts, intersectionReductionStrict.ts,
+    numericStringLiteralTypes.ts, stringLiteralsWithSwitchStatements03.ts

--- a/docs/plan/claims/fix-inference-nullable-strip-preserve-union.md
+++ b/docs/plan/claims/fix-inference-nullable-strip-preserve-union.md
@@ -1,0 +1,36 @@
+# fix(solver): preserve nullable-stripped union from object-property inference
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/inference-nullable-strip-preserve-union`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Conformance fixes)
+
+## Intent
+
+`widenToAny1.ts` (and similar `{ x: T; y: T }` calls where one property is
+nullable and another is a literal) was inferring `T = undefined` instead of
+TSC's `T = string | undefined`. The "first-property-wins" fallback in
+`resolve_from_candidates` was collapsing the union returned from
+`get_common_supertype_for_inference` (which strips nullables, runs the
+tournament, and re-attaches nullable members) back to a single member,
+producing the wrong inferred type and the wrong TS2322 message.
+
+This PR teaches the fallback to skip when any candidate is a nullable type
+(`UNDEFINED`, `NULL`, or `VOID`). In that case the resulting union is the
+correct output of TSC's `getCommonSupertype` + `getNullableType` pipeline,
+not a fallback union from incompatible candidates.
+
+## Files Touched
+
+- `crates/tsz-solver/src/inference/infer_resolve.rs` (~17 LOC change in
+  `resolve_from_candidates`)
+- `crates/tsz-solver/tests/infer_tests.rs` (+90 LOC, two regression tests)
+
+## Verification
+
+- `cargo nextest run -p tsz-solver --lib` — 5451 tests pass
+- `./scripts/conformance/conformance.sh run --filter widenToAny1` — 1/1 pass
+- `./scripts/conformance/conformance.sh run --filter undefinedArgumentInference` — 1/1 pass
+- `./scripts/conformance/conformance.sh run --filter genericCallWithObjectLiteral` — 2/2 pass
+- `./scripts/conformance/conformance.sh run --filter widenedTypes` — 6/6 pass


### PR DESCRIPTION
## Summary

- Fix `widenToAny1.ts` (and similar nullable-+-literal object-property inferences) by skipping the first-property-wins fallback in `resolve_from_candidates` when any candidate is a nullable type (UNDEFINED/NULL/VOID).
- For `foo<T>(f1: { x: T; y: T }): T` called with `{ x: undefined, y: "def" }`, tsc strips `undefined` from the candidate set, runs `getCommonSupertype` on what remains, and re-attaches nullable members via `getNullableType`, producing `T = string | undefined`. Our existing fallback was collapsing that legitimate union back to a single member, producing `T = undefined` and the wrong TS2322 message at the assignment to `var z1: number`.
- Two regression tests pin the new behavior plus the existing first-wins behavior for non-nullable mismatches.

## Diagnostics before vs. after

`var z1: number = foo1({ x: undefined, y: "def" });` (target source)

| | TSC | TSZ before | TSZ after |
|---|---|---|---|
| line 5:5 | `Type 'string \| undefined' is not assignable to type 'number'.` | `Type 'undefined' is not assignable to type 'number'.` | matches tsc |
| line 5:39 | (no diagnostic) | `Type '"def"' is not assignable to type 'undefined'.` (extra) | (no diagnostic) |

## Conformance impact

**Net: 12144 → 12156 (+12 tests, 0 regressions)**

12 FAIL → PASS:
- widenToAny1.ts (target)
- booleanAssignment.ts
- contravariantOnlyInferenceFromAnnotatedFunctionJs.ts
- mappedTypeIndexedAccessConstraint.ts
- recursiveConditionalCrash4.ts
- typePredicateInherit.ts
- parenthesizedContexualTyping3.ts
- jsdocTemplateConstructorFunction.ts
- propertiesOfGenericConstructorFunctions.ts
- intersectionReductionStrict.ts
- numericStringLiteralTypes.ts
- stringLiteralsWithSwitchStatements03.ts

## Test plan
- [x] `cargo nextest run -p tsz-solver --lib` (5451 tests pass, including 2 new regression tests)
- [x] `./scripts/conformance/conformance.sh run --filter widenToAny1` → 1/1 pass (was fingerprint-only failure)
- [x] `./scripts/conformance/conformance.sh run --filter undefinedArgumentInference` → 1/1 pass (no regression)
- [x] `./scripts/conformance/conformance.sh run --filter genericCallWithObjectLiteral` → 2/2 pass (no regression — fallback still applies for non-nullable mismatches)
- [x] `./scripts/conformance/conformance.sh run --filter widenedTypes` → 6/6 pass
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` → +12 tests, 0 regressions