### PR TITLE
fix(emitter): drop double parens around IIFE / type-cast object literal at statement position

### DIFF
--- a/crates/tsz-binder/tests/lib_loader.rs
+++ b/crates/tsz-binder/tests/lib_loader.rs
@@ -239,7 +239,7 @@ fn get_suggested_lib_default_es2015() {
     assert_eq!(get_suggested_lib_for_type(""), "es2015");
 }
 
-/// SharedArrayBuffer family is es2017.
+/// `SharedArrayBuffer` family is es2017.
 #[test]
 fn get_suggested_lib_shared_array_buffer_is_es2017() {
     assert_eq!(get_suggested_lib_for_type("SharedArrayBuffer"), "es2017");
@@ -250,7 +250,7 @@ fn get_suggested_lib_shared_array_buffer_is_es2017() {
     assert_eq!(get_suggested_lib_for_type("Atomics"), "es2017");
 }
 
-/// AsyncGenerator family is es2018.
+/// `AsyncGenerator` family is es2018.
 #[test]
 fn get_suggested_lib_async_generator_is_es2018() {
     assert_eq!(get_suggested_lib_for_type("AsyncGenerator"), "es2018");
@@ -264,7 +264,7 @@ fn get_suggested_lib_async_generator_is_es2018() {
     );
 }
 
-/// BigInt family is es2020.
+/// `BigInt` family is es2020.
 #[test]
 fn get_suggested_lib_bigint_is_es2020() {
     assert_eq!(get_suggested_lib_for_type("BigInt"), "es2020");
@@ -281,7 +281,7 @@ fn get_suggested_lib_bigint_is_es2020() {
     );
 }
 
-/// FinalizationRegistry / WeakRef / AggregateError / ErrorOptions are es2021.
+/// `FinalizationRegistry` / `WeakRef` / `AggregateError` / `ErrorOptions` are es2021.
 #[test]
 fn get_suggested_lib_finalization_family_is_es2021() {
     assert_eq!(get_suggested_lib_for_type("FinalizationRegistry"), "es2021");
@@ -299,7 +299,7 @@ fn get_suggested_lib_finalization_family_is_es2021() {
     assert_eq!(get_suggested_lib_for_type("ErrorOptions"), "es2021");
 }
 
-/// Disposable / AsyncDisposable suggest `esnext`.
+/// Disposable / `AsyncDisposable` suggest `esnext`.
 #[test]
 fn get_suggested_lib_disposable_is_esnext() {
     assert_eq!(get_suggested_lib_for_type("Disposable"), "esnext");

--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -44,5 +44,9 @@ path = "tests/computed_property_es5_tests.rs"
 name = "jsx_spread_tests"
 path = "tests/jsx_spread_tests.rs"
 
+[[test]]
+name = "parenthesized_iife_tests"
+path = "tests/parenthesized_iife_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
@@ -274,13 +274,22 @@ impl<'a> Printer<'a> {
         let prev_optional = self.ctx.flags.optional_chain_needs_parens;
         let prev_nullish = self.ctx.flags.nullish_coalescing_needs_parens;
         let prev_in_binary = self.ctx.flags.in_binary_operand;
+        // Likewise, clear the "self-parenthesize Function/Object literal"
+        // flag: the explicit source paren already disambiguates the IIFE
+        // (`(function(){})()`), so the inner FunctionExpression /
+        // ObjectLiteralExpression must not add another wrapping pair.
+        // Without this, `(<any>function foo() {})()` emits as
+        // `((function foo() {}))()` instead of `(function foo() {})()`.
+        let prev_paren_leftmost = self.ctx.flags.paren_leftmost_function_or_object;
         self.ctx.flags.optional_chain_needs_parens = false;
         self.ctx.flags.nullish_coalescing_needs_parens = false;
         self.ctx.flags.in_binary_operand = false;
+        self.ctx.flags.paren_leftmost_function_or_object = false;
         self.emit(paren.expression);
         self.ctx.flags.in_binary_operand = prev_in_binary;
         self.ctx.flags.optional_chain_needs_parens = prev_optional;
         self.ctx.flags.nullish_coalescing_needs_parens = prev_nullish;
+        self.ctx.flags.paren_leftmost_function_or_object = prev_paren_leftmost;
         self.write(")");
     }
 

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -1181,13 +1181,20 @@ impl<'a> Printer<'a> {
         // in JS output) to find the actual leading token.
         // e.g., `<unknown>function() {}();` → `(function () { })();`
         // e.g., `<unknown>{foo() {}}.foo();` → `({ foo() { } }.foo());`
+        //
+        // EXCEPTION: when the outer expression is itself a ParenthesizedExpression that
+        // will survive emit (e.g., `(<any>{a:0})`), its own surviving parens already
+        // disambiguate the leading `{`/`function` token. Adding another pair here would
+        // produce double parens like `(({a:0}))`. Skip the wrapping in that case —
+        // `emit_parenthesized` will print `({a:0})`.
         let needs_parens = if let Some(expr_node) = self.arena.get(expr_stmt.expression) {
             let leftmost = self
                 .leftmost_expression_kind_after_erasure(expr_stmt.expression)
                 .unwrap_or(expr_node.kind);
-            leftmost == syntax_kind_ext::FUNCTION_EXPRESSION
+            let leftmost_needs_parens = leftmost == syntax_kind_ext::FUNCTION_EXPRESSION
                 || leftmost == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-                || (self.ctx.target_es5 && expr_node.kind == syntax_kind_ext::ARROW_FUNCTION)
+                || (self.ctx.target_es5 && expr_node.kind == syntax_kind_ext::ARROW_FUNCTION);
+            leftmost_needs_parens && !self.outer_paren_will_survive_emit(expr_stmt.expression)
         } else {
             false
         };
@@ -1297,6 +1304,75 @@ impl<'a> Printer<'a> {
         };
         callee_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
             || callee_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+    }
+
+    /// Returns `true` when the given expression node is a `ParenthesizedExpression`
+    /// whose outer `(...)` will survive emit — that is, the inner expression is a
+    /// type assertion whose unwrapped target is *not* in the can-strip set used by
+    /// `emit_parenthesized`.
+    ///
+    /// Used by `emit_expression_statement` to avoid double-wrapping when the source
+    /// already has parens that disambiguate the leading `{` / `function` token:
+    /// `(<any>{a:0});` should emit `({ a: 0 });`, not `(({ a: 0 }));`.
+    ///
+    /// The check is intentionally conservative: it only returns `true` for the
+    /// specific shape `(<TypeAssertion or as/satisfies>{ObjectLiteral|FunctionExpression|...})`
+    /// where the surviving paren wraps a leading-token-ambiguous primary. Other
+    /// `ParenthesizedExpression`s (e.g., wrapping an assignment, comma, or arrow)
+    /// are not considered, because their wrapping behavior is different and
+    /// already covered by other rules.
+    fn outer_paren_will_survive_emit(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+            return false;
+        }
+        let Some(paren) = self.arena.get_parenthesized(node) else {
+            return false;
+        };
+        let Some(inner) = self.arena.get(paren.expression) else {
+            return false;
+        };
+        // Only handle the type-assertion-erasure shape: `(<T>x)` / `(x as T)` /
+        // `(x satisfies T)`. Without an erased assertion, the outer paren is
+        // either redundant in source or already handled by other rules.
+        let is_type_erasure = inner.kind == syntax_kind_ext::TYPE_ASSERTION
+            || inner.kind == syntax_kind_ext::AS_EXPRESSION
+            || inner.kind == syntax_kind_ext::SATISFIES_EXPRESSION
+            || inner.kind == syntax_kind_ext::EXPRESSION_WITH_TYPE_ARGUMENTS;
+        if !is_type_erasure {
+            return false;
+        }
+        let unwrapped = self.unwrap_type_assertion_kind(paren.expression);
+        // Mirror the `can_strip` set in `emit_parenthesized`. If the unwrapped kind
+        // is NOT strippable, the outer paren survives emit and provides leading-
+        // token disambiguation, so the statement-level wrap is redundant.
+        let can_strip = matches!(
+            unwrapped,
+            Some(k) if k == SyntaxKind::Identifier as u16
+                || k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+                || k == SyntaxKind::ThisKeyword as u16
+                || k == SyntaxKind::SuperKeyword as u16
+                || k == SyntaxKind::NullKeyword as u16
+                || k == SyntaxKind::TrueKeyword as u16
+                || k == SyntaxKind::FalseKeyword as u16
+                || k == SyntaxKind::NumericLiteral as u16
+                || k == SyntaxKind::BigIntLiteral as u16
+                || k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::RegularExpressionLiteral as u16
+                || k == syntax_kind_ext::TEMPLATE_EXPRESSION
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::NON_NULL_EXPRESSION
+                || k == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                || k == syntax_kind_ext::CALL_EXPRESSION
+                || k == syntax_kind_ext::NEW_EXPRESSION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::CLASS_EXPRESSION
+        );
+        !can_strip
     }
 
     /// Emit trailing comments after a semicolon. Scans backward through the

--- a/crates/tsz-emitter/tests/parenthesized_iife_tests.rs
+++ b/crates/tsz-emitter/tests/parenthesized_iife_tests.rs
@@ -1,0 +1,126 @@
+//! Integration tests for `ParenthesizedExpression` emit interactions with
+//! IIFE-style call expressions and statement-level wrapping.
+//!
+//! These tests guard against double-wrapping bugs where the source already
+//! has explicit parens around a type-asserted Function/Object/Class
+//! expression and the emitter accidentally adds a second pair when erasing
+//! the type annotation.
+//!
+//! See `crates/tsz-emitter/src/emitter/expressions/core/helpers.rs`
+//! (`emit_parenthesized`) and
+//! `crates/tsz-emitter/src/emitter/statements/core.rs`
+//! (`emit_expression_statement`, `outer_paren_will_survive_emit`).
+
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn print_es2015(source: &str) -> String {
+    parse_and_print_with_opts(source, PrintOptions::es6())
+}
+
+/// `(<any>function foo() { })()` is an IIFE: the source paren around
+/// `<any>function foo() { }` survives emit (it disambiguates the leading
+/// `function` keyword from a function declaration). After type erasure we
+/// must emit `(function foo() { })();`, NOT `((function foo() { }))();`.
+///
+/// Before the fix, `paren_leftmost_function_or_object` was set by the
+/// expression-statement and consumed by the inner `FunctionExpression`,
+/// causing it to self-parenthesize on top of the surviving source paren.
+#[test]
+fn iife_typeassertion_function_expression_no_double_parens() {
+    let source = "(<any>function foo() { })();\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("(function foo() { })();"),
+        "IIFE should keep one pair of parens; output:\n{output}"
+    );
+    assert!(
+        !output.contains("((function foo()"),
+        "IIFE must not double-parenthesize the callee; output:\n{output}"
+    );
+}
+
+/// Same shape with `as` instead of `<T>` syntax — both are type erasures and
+/// should hit the same `emit_parenthesized` path.
+#[test]
+fn iife_as_expression_function_no_double_parens() {
+    let source = "(function foo() { } as any)();\n";
+    let output = print_es2015(source);
+    assert!(
+        !output.contains("((function"),
+        "IIFE with `as` cast must not double-parenthesize; output:\n{output}"
+    );
+}
+
+/// `(<any>{a:0});` at statement position: the source paren around the type-
+/// asserted object literal survives emit (object literals are NOT in
+/// `can_strip`). The expression statement must NOT add another wrapping
+/// pair, which would produce `(({ a: 0 }));`.
+#[test]
+fn statement_object_literal_typeassertion_no_double_parens() {
+    let source = "(<any>{a:0});\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("({ a: 0 });"),
+        "Object literal cast at statement position should keep one pair of parens; output:\n{output}"
+    );
+    assert!(
+        !output.contains("(({ a:"),
+        "Object literal cast must not double-parenthesize at statement position; output:\n{output}"
+    );
+}
+
+/// `({ a: 0 } as any);` at statement position — same shape via `as` syntax.
+#[test]
+fn statement_object_literal_as_no_double_parens() {
+    let source = "({ a: 0 } as any);\n";
+    let output = print_es2015(source);
+    assert!(
+        !output.contains("(({"),
+        "Object literal `as` cast must not double-parenthesize at statement position; output:\n{output}"
+    );
+}
+
+/// Naked `(<any>function () { })` (no call) is still an expression statement
+/// whose leftmost token is `function`. Here the type-asserted `FunctionExpression`
+/// IS in `can_strip` (no enclosing call → both `paren_in_access_position` and
+/// `paren_is_direct_call_callee` are false), so the source paren strips. The
+/// expression-statement wrap must add its own pair to disambiguate, producing
+/// exactly `(function () { });`.
+#[test]
+fn statement_function_expression_typeassertion_keeps_one_pair() {
+    let source = "(<any>function () { });\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("(function () { });"),
+        "Bare function-expression cast at statement position should keep one pair of parens; output:\n{output}"
+    );
+    assert!(
+        !output.contains("((function"),
+        "Bare function-expression cast must not double-parenthesize; output:\n{output}"
+    );
+}
+
+/// `(<any>(1.0));` is the "nested parenthesized expression, should keep one
+/// pair of parenthese" case from
+/// `tests/cases/compiler/castExpressionParentheses.ts`. The outer paren
+/// survives because the inner expression after type erasure is itself a
+/// `ParenthesizedExpression` (so the type-erasure path reuses it). The
+/// expression statement must NOT add another wrap.
+#[test]
+fn statement_nested_paren_typeassertion_keeps_one_pair() {
+    let source = "declare var A;\n(<any>(A));\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("(A);"),
+        "Nested paren cast should keep one pair of parens at statement position; output:\n{output}"
+    );
+    assert!(
+        !output.contains("((A))"),
+        "Nested paren cast must not double-parenthesize; output:\n{output}"
+    );
+}

--- a/docs/plan/claims/fix-emitter-paren-iife-double-paren.md
+++ b/docs/plan/claims/fix-emitter-paren-iife-double-paren.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/emitter-paren-iife-double-paren`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1342
+- **Status**: ready
 - **Workstream**: 2 (JS emit pass-rate)
 
 ## Intent

--- a/docs/plan/claims/fix-emitter-paren-iife-double-paren.md
+++ b/docs/plan/claims/fix-emitter-paren-iife-double-paren.md
@@ -1,0 +1,55 @@
+# fix(emitter): drop double parens around IIFE / type-cast object literal at statement position
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/emitter-paren-iife-double-paren`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (JS emit pass-rate)
+
+## Intent
+
+The JS emitter produced double parens for two related shapes:
+
+1. `(<any>function foo() { })()` → `((function foo() { }))()` (expected
+   `(function foo() { })();`).
+2. `(<any>{ a: 0 });` at statement position → `(({ a: 0 }));` (expected
+   `({ a: 0 });`).
+
+Root cause: the surviving source `ParenthesizedExpression` already provides
+leading-token disambiguation, but the printer still applied either
+`paren_leftmost_function_or_object` (for the IIFE callee) or the
+expression-statement wrap on top of it. This PR clears the
+self-parenthesize flag inside `emit_parenthesized` and adds a
+`outer_paren_will_survive_emit` short-circuit in
+`emit_expression_statement` so the source paren is reused exactly once.
+
+Fixes the `castExpressionParentheses` and `noImplicitAnyInCastExpression`
+emit baselines (JS pass count: 12327 → 12329 net delta on the local
+worktree). No declaration emit movement; no JS regressions.
+
+## Files Touched
+
+- `crates/tsz-emitter/src/emitter/expressions/core/helpers.rs` (~10 LOC)
+  — clear `paren_leftmost_function_or_object` inside the surviving-paren
+  emit branch.
+- `crates/tsz-emitter/src/emitter/statements/core.rs` (~75 LOC)
+  — add `outer_paren_will_survive_emit` and short-circuit
+  `needs_parens` when the source paren survives.
+- `crates/tsz-emitter/Cargo.toml` (+4 LOC) — register new test target.
+- `crates/tsz-emitter/tests/parenthesized_iife_tests.rs` (new, ~115 LOC)
+  — six regression tests using the `test_support` fixture from PR #1238.
+
+Net LOC: about +130 lines (mostly comments + tests).
+
+## Verification
+
+- `cargo nextest run -p tsz-emitter` (1616 tests pass, 2 skipped — six
+  new tests in `parenthesized_iife_tests`).
+- `cargo nextest run -p tsz-checker --lib` (2821 tests pass, 9 skipped —
+  no behavioral coupling).
+- `cargo clippy -p tsz-emitter --tests --no-deps -- -D warnings`: clean.
+- `python3 scripts/arch/arch_guard.py`: passes.
+- `scripts/emit/run.sh --js-only`: 12327 → 12329 (+2 tests:
+  `castExpressionParentheses`, `noImplicitAnyInCastExpression`); 0
+  regressions.
+- `scripts/emit/run.sh --dts-only`: 1284 (no change).


### PR DESCRIPTION
## Summary

The JS emitter produced double parens for two related shapes:

- `(<any>function foo() { })()` → `((function foo() { }))()` (expected `(function foo() { })();`).
- `(<any>{ a: 0 });` at statement position → `(({ a: 0 }));` (expected `({ a: 0 });`).

Root cause: the surviving source `ParenthesizedExpression` already provides leading-token disambiguation, but the printer still applied either `paren_leftmost_function_or_object` (for the IIFE callee) or the expression-statement wrap on top of it.

## Changes

- `emit_parenthesized` now clears `paren_leftmost_function_or_object` inside the source-paren branch so the inner `FunctionExpression` / `ObjectLiteralExpression` does not self-parenthesize when the surviving outer paren already disambiguates.
- `emit_expression_statement` consults a new `outer_paren_will_survive_emit` helper to skip the statement-level wrap when the expression itself is a `ParenthesizedExpression` whose paren is guaranteed to survive emit.
- Six regression tests live in `crates/tsz-emitter/tests/parenthesized_iife_tests.rs` (new), built on the `test_support` fixture from #1238.

## Test plan

- [x] `cargo nextest run -p tsz-emitter` — 1616 pass / 2 skipped (six new tests).
- [x] `cargo nextest run -p tsz-checker --lib` — 2821 pass / 9 skipped.
- [x] `cargo clippy -p tsz-emitter --tests --no-deps -- -D warnings` clean.
- [x] `python3 scripts/arch/arch_guard.py` passes.
- [x] `scripts/emit/run.sh --js-only`: 12327 → 12329 (+2 tests: `castExpressionParentheses`, `noImplicitAnyInCastExpression`); 0 regressions.
- [x] `scripts/emit/run.sh --dts-only`: 1284 (no change).

## Roadmap

Per-PR claim file at `docs/plan/claims/fix-emitter-paren-iife-double-paren.md` (status `claim`, will flip to `ready` once review-ready).