### PR TITLE
ci: reduce fourslash internal shards from 16 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 90
     env:
-      TSZ_CI_SHARDS: 16
+      TSZ_CI_SHARDS: 4
       TSZ_CI_FOURSLASH_WORKERS: 8
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Reduce `TSZ_CI_SHARDS` for the fourslash job from 16 → 4 (workers per shard stays at 8)

## Why this doesn't slow CI down

The fourslash job runs all shards simultaneously via `& wait`. SHARD_COUNT directly multiplies peak concurrency:

| Config | Concurrent processes | CPU ratio (8 vCPU runner) |
|--------|---------------------|--------------------------|
| 16 shards × 8 workers (before) | 128 | 16× oversubscribed |
| 4 shards × 8 workers (after) | 32 | 4× oversubscribed |

The memory-cap fix in #1343 already reduces effective concurrency to 16 × 2 = 32 workers. This PR achieves the same 32 concurrent workers but with better per-shard efficiency: each shard processes 6325÷4 ≈ 1581 tests with 8 parallel workers instead of 395 tests with 2 workers.

Emit stays at 16 shards — it completes in ~4 min and is I/O-bound, so the oversubscription there is acceptable.

## Test plan
- [ ] Fourslash job completes in ≤ 9 min (no regression vs current 8.8 min)
- [ ] No "Worker crashed (watchdog killed)" lines
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
