### PR TITLE
fix(checker): preserve instance type after `new` arg mismatch + run binding-pattern check for constructors

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1451,6 +1451,29 @@ mod binding_pattern_defaults_tests {
             "JSDoc-optional binding-pattern parameter should not cascade into TS2339: {codes:?}"
         );
     }
+
+    /// Regression: nested binding-pattern check must run for class
+    /// constructors too. Previously, `check_parameter_binding_pattern_defaults`
+    /// was only invoked for function declarations, so missing properties
+    /// inside a constructor's binding-pattern parameter (e.g., `{ x1, x2 }`
+    /// extracted from `ObjType1` which has `{ x; y; z }`) silently passed.
+    /// tsc emits TS2339 in this position.
+    #[test]
+    fn constructor_binding_pattern_emits_ts2339_for_missing_properties() {
+        let codes = check_source_codes(
+            "type ObjType1 = { x: number; y: string; z: boolean }
+             type TupleType1 = [ObjType1, number, string]
+             class C1 {
+                 constructor([{ x1, x2, x3 }, y, z]: TupleType1) {}
+             }",
+        );
+        let ts2339_count = codes.iter().filter(|&&c| c == 2339).count();
+        assert!(
+            ts2339_count >= 3,
+            "Constructor binding pattern with missing properties should \
+             emit TS2339 for x1, x2, x3 (>=3 occurrences). Got codes: {codes:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1277,6 +1277,13 @@ impl<'a> CheckerState<'a> {
             ctor.body.is_some(),
         );
 
+        // Check binding-element property/index lookups in destructuring parameters
+        // (e.g., `constructor([{ x1, x2 }, y]: [ObjType1, number])` emits TS2339 for
+        // properties not on `ObjType1`). Mirrors the call in `check_function_decl`.
+        // This must run for constructors too — otherwise destructuring parameter
+        // patterns silently skip nested property-existence checks.
+        self.check_parameter_binding_pattern_defaults(&ctor.parameters.nodes);
+
         // Set in_constructor flag for abstract property checks (error 2715)
         if let Some(ref mut class_info) = self.ctx.enclosing_class {
             class_info.in_constructor = true;

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1376,6 +1376,18 @@ impl<'a> CheckerState<'a> {
                 }
                 if fallback_return != TypeId::ERROR {
                     fallback_return
+                } else if let Some(instance_type) =
+                    crate::query_boundaries::common::construct_return_type_for_type(
+                        self.ctx.types,
+                        constructor_type,
+                    )
+                {
+                    // When the solver's `ArgumentTypeMismatch` carries no
+                    // explicit fallback, recover the constructor's instance
+                    // type so `var a = new C(<bad-args>)` still types `a` as
+                    // the instance and subsequent property accesses can emit
+                    // TS2339 (matching tsc).
+                    instance_type
                 } else {
                     TypeId::ERROR
                 }
@@ -1474,5 +1486,35 @@ new A?.b();
             "TS1209 should anchor at `?.`, got: {diag:?}"
         );
         assert_eq!(diag.length, 2, "TS1209 should cover only `?.`");
+    }
+
+    /// Regression: `var a = new C(<bad-args>)` must keep `a` typed as the
+    /// constructor's instance type so subsequent property accesses still
+    /// emit TS2339 when the property doesn't exist. Previously, the solver
+    /// returned `TypeId::ERROR` on argument mismatch, which silenced TS2339
+    /// on `a.foo`.
+    #[test]
+    fn new_with_bad_arg_still_emits_ts2339_on_subsequent_member_access() {
+        let source = r#"
+class C1 {
+    constructor(n: number) {}
+}
+var a = new C1("bad");
+a.foo;
+"#;
+        let codes: Vec<u32> = crate::test_utils::check_source_diagnostics(source)
+            .iter()
+            .map(|d| d.code)
+            .collect();
+        assert!(
+            codes.contains(
+                &diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+            ),
+            "Expected TS2345 for bad constructor arg: {codes:?}"
+        );
+        assert!(
+            codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+            "Expected TS2339 on `a.foo` even when `new C1` had bad args: {codes:?}"
+        );
     }
 }

--- a/docs/plan/claims/fix-solver-new-arg-mismatch-preserves-instance-type.md
+++ b/docs/plan/claims/fix-solver-new-arg-mismatch-preserves-instance-type.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/solver-new-arg-mismatch-preserves-instance-type`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1345
+- **Status**: ready
 - **Workstream**: 1 (Conformance fixes)
 
 ## Intent

--- a/docs/plan/claims/fix-solver-new-arg-mismatch-preserves-instance-type.md
+++ b/docs/plan/claims/fix-solver-new-arg-mismatch-preserves-instance-type.md
@@ -1,0 +1,54 @@
+# fix(checker): preserve instance type after `new` arg mismatch and emit TS2339 in constructor binding patterns
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/solver-new-arg-mismatch-preserves-instance-type`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Conformance fixes)
+
+## Intent
+
+Two coupled checker-side fixes that flip `destructuringParameterProperties5`
+plus a broader cluster of property-after-mismatched-call scenarios:
+
+1. **`new`-expression `ArgumentTypeMismatch` recovery**: when the solver
+   returns `ArgumentTypeMismatch { fallback_return: TypeId::ERROR }` for a
+   `new C(<bad-args>)` call, recover the constructor's instance type via
+   `construct_return_type_for_type` instead of decaying to `TypeId::ERROR`.
+   This mirrors the existing call-expression fallback in `handle_call_result`
+   (which uses `get_function_return_type`). Without this, `var a = new C(<bad>)`
+   left `a` typed as `error`, silencing every TS2339 on subsequent
+   `a.<missing-prop>` access.
+2. **Constructor binding-pattern checks**: `check_constructor_declaration_with_request`
+   now invokes `check_parameter_binding_pattern_defaults`, mirroring the
+   call already present for regular function declarations. This descends
+   into nested binding patterns on constructor parameters (e.g.
+   `constructor([{ x1, x2 }, y]: [ObjType1, number])`) and emits TS2339
+   for properties that don't exist on the source type.
+
+```ts
+// Bug 1: silenced TS2339 after `new` with bad args
+class C { constructor(n: number) {} }
+var a = new C("bad");  // tsz emitted only TS2345
+a.foo;                 // tsc emits TS2339; tsz had nothing
+
+// Bug 2: silenced TS2339 inside constructor binding pattern
+type T = [{ x: number }, number]
+class C2 {
+  constructor([{ a, b }, n]: T) {}  // tsc TS2339 on a, b; tsz had nothing
+}
+```
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs` (~7 LOC)
+- `crates/tsz-checker/src/types/computation/complex.rs` (~14 LOC + ~28 LOC unit test)
+- `crates/tsz-checker/src/checkers/parameter_checker.rs` (~22 LOC unit test)
+
+## Verification
+
+- `cargo nextest run --package tsz-solver --lib` (5449 tests pass)
+- `cargo nextest run --package tsz-checker --lib` (2823 tests pass + 2 new)
+- `./scripts/conformance/conformance.sh run --filter "destructuringParameterProperties5" --verbose` — passes
+- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` —
+  conformance Net: 12144 → 12156 (+12), zero regressions


### PR DESCRIPTION
## Summary

Two coupled checker-side fixes that flip
`destructuringParameterProperties5.ts` plus 11 sibling failures
(+12 conformance tests, 12144 → 12156, zero regressions):

1. **`new`-expression `ArgumentTypeMismatch` recovery**: when the solver
   returns `ArgumentTypeMismatch { fallback_return: TypeId::ERROR }` for a
   `new C(<bad-args>)` call, recover the constructor's instance type via
   `construct_return_type_for_type` instead of decaying to `TypeId::ERROR`.
   This mirrors the existing call-expression fallback in
   `handle_call_result` (which uses `get_function_return_type`). Without
   this, `var a = new C(<bad>)` left `a` typed as `error`, silencing every
   subsequent TS2339 on `a.<missing-prop>`.
2. **Constructor binding-pattern checks**: `check_constructor_declaration_with_request`
   now invokes `check_parameter_binding_pattern_defaults`, mirroring the
   call already present for regular function declarations. This descends
   into nested binding patterns on constructor parameters and emits
   TS2339 for properties not on the source type.

## Repro

```ts
// Bug 1: silenced TS2339 after `new` with bad args
class C { constructor(n: number) {} }
var a = new C("bad");  // tsz emitted only TS2345
a.foo;                 // tsc emits TS2339; tsz had nothing

// Bug 2: silenced TS2339 inside constructor binding pattern
type T = [{ x: number }, number]
class C2 {
  constructor([{ a, b }, n]: T) {}  // tsc TS2339 on a, b; tsz had nothing
}
```

## Test plan

- [x] `cargo nextest run --package tsz-solver --lib` (5449 passed)
- [x] `cargo nextest run --package tsz-checker --lib` (2823 passed + 2 new)
- [x] `./scripts/conformance/conformance.sh run --filter "destructuringParameterProperties5" --verbose` — passes
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — Net +12, 0 regressions
- [x] Pre-commit hook passed (13565/13565 tests)