### PR TITLE
fix(emitter): erase `export = X` when X is a type-only namespace

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -48,5 +48,9 @@ path = "tests/jsx_spread_tests.rs"
 name = "parenthesized_iife_tests"
 path = "tests/parenthesized_iife_tests.rs"
 
+[[test]]
+name = "export_equals_type_only_namespace"
+path = "tests/export_equals_type_only_namespace.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1352,15 +1352,23 @@ impl<'a> Printer<'a> {
                 k if k == syntax_kind_ext::MODULE_DECLARATION
                     && self.arena.get_module(stmt_node).is_some_and(|module_decl| {
                         self.get_identifier_text_idx(module_decl.name) == assigned_name
-                    })
-                    && self.arena.get_module(stmt_node).is_some_and(|module_decl| {
-                        !self
-                            .arena
-                            .has_modifier(&module_decl.modifiers, SyntaxKind::DeclareKeyword)
-                            && self.is_instantiated_module(module_decl.body)
                     }) =>
                 {
-                    matched_runtime = true;
+                    // Namespace `X` matches the export-equals identifier.
+                    // Distinguish runtime vs type-only:
+                    // - `declare namespace X` is always type-only at JS emit (ambient).
+                    // - `namespace X { ...types only... }` is type-only (non-instantiated).
+                    // - `namespace X { ...values... }` is runtime (instantiated IIFE).
+                    if let Some(module_decl) = self.arena.get_module(stmt_node) {
+                        let is_declare = self
+                            .arena
+                            .has_modifier(&module_decl.modifiers, SyntaxKind::DeclareKeyword);
+                        if !is_declare && self.is_instantiated_module(module_decl.body) {
+                            matched_runtime = true;
+                        } else {
+                            matched_type = true;
+                        }
+                    }
                 }
                 k if k == syntax_kind_ext::VARIABLE_STATEMENT
                     && self

--- a/crates/tsz-emitter/tests/export_equals_type_only_namespace.rs
+++ b/crates/tsz-emitter/tests/export_equals_type_only_namespace.rs
@@ -1,0 +1,117 @@
+//! Regression tests for `export = X` where `X` is a type-only namespace.
+//!
+//! TypeScript erases `export = X;` when `X` is a non-instantiated namespace
+//! (containing only `interface`, `type`, etc.). For CommonJS output, tsc
+//! emits the `__esModule` marker but no `module.exports = X;` line because
+//! there is no JS binding for `X` at runtime.
+//!
+//! Before the fix in `export_assignment_identifier_is_type_only`, the
+//! emitter only set `matched_runtime` for instantiated namespaces and never
+//! set `matched_type` for type-only ones. The function returned
+//! `matched_type && !matched_runtime = false && true = false`, so the
+//! caller treated `export = X` as a runtime export and emitted
+//! `module.exports = X;`.
+//!
+//! Mirrors the conformance test
+//! `tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts`.
+
+use tsz_common::common::ModuleKind;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn cjs_opts() -> PrintOptions {
+    PrintOptions {
+        module: ModuleKind::CommonJS,
+        ..PrintOptions::default()
+    }
+}
+
+#[test]
+fn export_equals_type_only_namespace_emits_only_es_module_marker() {
+    let source = r#"namespace X {
+    interface A {
+        kind: 'a';
+    }
+
+    interface B {
+        kind: 'b';
+    }
+
+    export type C = A | B;
+}
+
+export = X;
+"#;
+
+    let output = parse_and_print_with_opts(source, cjs_opts());
+
+    assert!(
+        output.contains("Object.defineProperty(exports, \"__esModule\""),
+        "expected __esModule marker for CJS file with type-only export=, got:\n{output}"
+    );
+    assert!(
+        !output.contains("module.exports = X"),
+        "type-only namespace must not be assigned to module.exports, got:\n{output}"
+    );
+}
+
+#[test]
+fn export_equals_instantiated_namespace_still_emits_module_exports() {
+    // Sanity: namespaces with values still produce module.exports = X.
+    let source = r#"namespace X {
+    export const value = 1;
+}
+
+export = X;
+"#;
+
+    let output = parse_and_print_with_opts(source, cjs_opts());
+
+    assert!(
+        output.contains("module.exports = X"),
+        "instantiated namespace must still be exported, got:\n{output}"
+    );
+}
+
+#[test]
+fn export_equals_declare_namespace_does_not_emit_module_exports() {
+    // `declare namespace X { ... }` is ambient and produces no JS even when
+    // it contains "values" (declared variables). `export = X;` must be erased.
+    let source = r#"declare namespace X {
+    const value: number;
+}
+
+export = X;
+"#;
+
+    let output = parse_and_print_with_opts(source, cjs_opts());
+
+    assert!(
+        !output.contains("module.exports = X"),
+        "declare namespace must not appear in module.exports, got:\n{output}"
+    );
+}
+
+#[test]
+fn export_equals_namespace_with_only_interfaces_is_type_only() {
+    // Pure interface-only namespace.
+    let source = r#"namespace X {
+    export interface I {
+        x: number;
+    }
+}
+
+export = X;
+"#;
+
+    let output = parse_and_print_with_opts(source, cjs_opts());
+
+    assert!(
+        !output.contains("module.exports = X"),
+        "interface-only namespace must not be runtime-exported, got:\n{output}"
+    );
+}

--- a/docs/plan/claims/fix-emitter-export-equals-type-only-namespace.md
+++ b/docs/plan/claims/fix-emitter-export-equals-type-only-namespace.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/emitter-export-equals-type-only-namespace`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1346
+- **Status**: ready
 - **Workstream**: 2 (JS Emit pass rate)
 
 ## Intent

--- a/docs/plan/claims/fix-emitter-export-equals-type-only-namespace.md
+++ b/docs/plan/claims/fix-emitter-export-equals-type-only-namespace.md
@@ -1,0 +1,51 @@
+# fix(emitter): erase `export = X` when X is a type-only namespace
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/emitter-export-equals-type-only-namespace`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (JS Emit pass rate)
+
+## Intent
+
+`export_assignment_identifier_is_type_only` in
+`crates/tsz-emitter/src/emitter/module_emission/core/mod.rs` only set
+`matched_runtime` for *instantiated* `MODULE_DECLARATION`s and did
+nothing in the type-only or `declare` cases. Combined with the
+`matched_type && !matched_runtime` return clause, the function returned
+`false` for `export = X` where `X` is a non-instantiated namespace,
+so the source-file emit loop treated `export = X;` as a runtime export
+and emitted `module.exports = X;` even though `X` had no JS binding.
+
+After the fix, the namespace-name match flips into `matched_type` when
+the module is `declare` or non-instantiated, mirroring the existing
+treatment of interfaces, type aliases, and ambient classes/functions.
+The CommonJS emit now correctly produces just the `__esModule` marker
+for these files (matches tsc baseline for
+`exportNamespaceDeclarationRetainsVisibility`).
+
+This unblocks the conformance test
+`tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts`
+and any future test that exports a type-only namespace via
+`export = X;`.
+
+## Files Touched
+
+- `crates/tsz-emitter/src/emitter/module_emission/core/mod.rs`
+  (~12 LOC: split single MODULE_DECLARATION arm into runtime/type-only
+  branches).
+- `crates/tsz-emitter/tests/export_equals_type_only_namespace.rs`
+  (new file, 4 regression tests).
+- `crates/tsz-emitter/Cargo.toml` (+1 `[[test]]` entry).
+
+## Verification
+
+- `cargo nextest run -p tsz-emitter` — 1640 tests pass, 2 skipped.
+- `scripts/emit/run.sh --filter='exportNamespaceDeclarationRetainsVisibility' --js-only`
+  — was failing (+1/-1), now passes.
+- `scripts/emit/run.sh --filter='export' --max=200 --js-only` — 191/200
+  pass; the 9 failing tests are unrelated (module-system / decorator
+  emission issues).
+- `scripts/emit/run.sh --filter='namespace' --max=200 --js-only` — 186/200
+  pass; the 14 failing tests are unrelated (AMD/UMD wrapper issues, JSX
+  namespace handling).


### PR DESCRIPTION
## Summary

`export_assignment_identifier_is_type_only` in `crates/tsz-emitter/src/emitter/module_emission/core/mod.rs` only set `matched_runtime` for *instantiated* `MODULE_DECLARATION`s and did nothing in the type-only or `declare` cases. Combined with the `matched_type && !matched_runtime` return clause, the function returned `false` for `export = X` where `X` is a non-instantiated namespace, so the source-file emit loop treated `export = X;` as a runtime export and emitted `module.exports = X;` even though `X` had no JS binding.

After the fix, the namespace-name match flips into `matched_type` when the module is `declare` or non-instantiated, mirroring the existing treatment of interfaces, type aliases, and ambient classes/functions. The CommonJS emit now correctly produces just the `__esModule` marker for these files.

Fixes the conformance test `tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts` (was +1/-1).

## Test plan

- [x] `cargo nextest run -p tsz-emitter` — 1640 tests pass, 2 skipped.
- [x] `scripts/emit/run.sh --filter='exportNamespaceDeclarationRetainsVisibility' --js-only` — passes.
- [x] `scripts/emit/run.sh --filter='export' --max=200 --js-only` — 191/200 pass; 9 unrelated failures.
- [x] `scripts/emit/run.sh --filter='namespace' --max=200 --js-only` — 186/200 pass; 14 unrelated failures.
- [x] 4 new unit tests in `crates/tsz-emitter/tests/export_equals_type_only_namespace.rs`.