### PR TITLE
fix(checker): allow literal narrowing for keyof/IndexAccess on Lazy lib types

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -360,6 +360,10 @@ name = "contextual_typing_tests"
 path = "tests/contextual_typing_tests.rs"
 
 [[test]]
+name = "contextual_literal_keyof_lib_tests"
+path = "tests/contextual_literal_keyof_lib_tests.rs"
+
+[[test]]
 name = "infer_extends_constraint_substitution_tests"
 path = "tests/infer_extends_constraint_substitution_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -318,6 +318,51 @@ impl<'a> CheckerState<'a> {
             if evaluated != ctx_type && evaluated != TypeId::ERROR {
                 return self.contextual_type_allows_literal_inner(evaluated, literal_type, visited);
             }
+            // Fallback: when `evaluate_type_with_env` could not make progress
+            // on a `keyof Lazy(LibType)` because the lib def has not been
+            // registered in `TypeEnvironment` yet, force a stronger Lazy
+            // resolution and retry the evaluation. Without this, fresh
+            // string literals like `'currency'` get widened to `string`
+            // even though the keyof target accepts the literal.
+            if let Some(keyof_inner) = keyof_inner_type(self.ctx.types, ctx_type)
+                && lazy_def_id(self.ctx.types, keyof_inner).is_some()
+            {
+                self.ensure_relation_input_ready(keyof_inner);
+                let resolved_inner = self.evaluate_type_with_env(keyof_inner);
+                if resolved_inner != keyof_inner {
+                    let new_keyof = self.ctx.types.factory().keyof(resolved_inner);
+                    let evaluated2 = self.evaluate_type_with_env(new_keyof);
+                    if evaluated2 != new_keyof && evaluated2 != TypeId::ERROR {
+                        return self.contextual_type_allows_literal_inner(
+                            evaluated2,
+                            literal_type,
+                            visited,
+                        );
+                    }
+                }
+            }
+        }
+        // IndexAccess fallback: when `evaluate_type_with_env` could not make
+        // progress on `Object[Key]` (typically because `Object` is a `Lazy`
+        // ref to a lib-namespace interface like `Intl.NumberFormatOptions`
+        // whose def has not been registered in `TypeEnvironment` yet), look
+        // up the property type directly via the contextual property API.
+        // Without this, fresh literals like `'currency'` get widened to
+        // `string` even though the indexed-access target accepts the literal.
+        if let Some((object_type, index_type)) = index_access_types(self.ctx.types, ctx_type)
+            && let Some(prop_name_atom) = common::string_literal_value(self.ctx.types, index_type)
+        {
+            self.ensure_relation_input_ready(object_type);
+            let lookup_object = self.evaluate_type_with_env(object_type);
+            let prop_name = self.ctx.types.resolve_atom(prop_name_atom);
+            if let Some(prop_type) = self
+                .ctx
+                .types
+                .contextual_property_type(lookup_object, &prop_name)
+                && visited.insert(prop_type)
+            {
+                return self.contextual_type_allows_literal_inner(prop_type, literal_type, visited);
+            }
         }
         // Generic `keyof` contexts preserve literal arguments.
         if let Some(keyof_inner) = keyof_inner_type(self.ctx.types, ctx_type)

--- a/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
+++ b/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
@@ -1,0 +1,112 @@
+//! Regression tests for contextual literal narrowing through `keyof Lazy(LibType)`
+//! and `IndexAccess(Lazy(LibType), key)`.
+//!
+//! When a string literal is assigned to an indexed-access or keyof target whose
+//! object/operand is a `Lazy(DefId)` reference to a namespace interface (such as
+//! `Intl.NumberFormatOptions` from the lib, or a user-declared namespace),
+//! `evaluate_type_with_env` may not be able to resolve the Lazy because the def
+//! hasn't been registered in the type environment yet. Previously this caused
+//! fresh literals like `'currency'` to be widened to `string`, producing false
+//! TS2322 errors. The fix forces a stronger Lazy resolution before retrying the
+//! keyof evaluation, plus an IndexAccess fallback that looks up property types
+//! through the contextual property API.
+//!
+//! Repro for the original arrayToLocaleStringES2015 / ES2020 conformance cases.
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
+}
+
+const NS_PRELUDE: &str = r#"
+declare namespace Lib {
+    interface StyleRegistry {
+        decimal: never;
+        percent: never;
+        currency: never;
+    }
+    type Style = keyof StyleRegistry;
+    interface Options {
+        style?: Style | undefined;
+        currency?: string | undefined;
+    }
+}
+"#;
+
+/// `const x: T = 'currency'` where `type T = Lib.Options['style']` must keep
+/// the fresh literal narrow rather than widening to `string`. tsc accepts this
+/// assignment (the literal matches `keyof StyleRegistry | undefined`).
+#[test]
+fn keeps_literal_narrow_via_alias_to_namespace_indexed_access() {
+    let mut source = String::from(NS_PRELUDE);
+    source.push_str(
+        r#"
+type S = Lib.Options["style"];
+const x: S = "currency";
+"#,
+    );
+    let diagnostics = check(&source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "literal 'currency' must satisfy contextual `keyof StyleRegistry | undefined` via Lazy alias; got {ts2322:?}",
+    );
+}
+
+/// Direct indexed access on a namespace interface (`Lib.Options['style']`)
+/// must also preserve fresh literals. This is the bare form before any alias
+/// indirection.
+#[test]
+fn keeps_literal_narrow_via_direct_namespace_indexed_access() {
+    let mut source = String::from(NS_PRELUDE);
+    source.push_str(
+        r#"
+const x: Lib.Options["style"] = "currency";
+"#,
+    );
+    let diagnostics = check(&source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "literal 'currency' must satisfy contextual `Lib.Options['style']`; got {ts2322:?}",
+    );
+}
+
+/// Intersection of a namespace interface with `{}` must surface the
+/// inner-property contextual type so an object literal property keeps its
+/// fresh literal type. tsc accepts this; tsz used to widen to `string`.
+#[test]
+fn intersection_with_namespace_keeps_property_literal_narrow() {
+    let mut source = String::from(NS_PRELUDE);
+    source.push_str(
+        r#"
+const x: Lib.Options & {} = { style: "currency" };
+"#,
+    );
+    let diagnostics = check(&source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "object literal `{{ style: 'currency' }}` must satisfy intersection target; got {ts2322:?}",
+    );
+}
+
+/// Aliasing the intersection (`type T = Lib.X & {}`) must also narrow.
+#[test]
+fn alias_of_intersection_with_namespace_keeps_property_literal_narrow() {
+    let mut source = String::from(NS_PRELUDE);
+    source.push_str(
+        r#"
+type T = Lib.Options & {};
+const x: T = { style: "currency" };
+"#,
+    );
+    let diagnostics = check(&source);
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "object literal must narrow via aliased intersection target; got {ts2322:?}",
+    );
+}

--- a/docs/plan/claims/fix-contextual-literal-indexed-access-lib.md
+++ b/docs/plan/claims/fix-contextual-literal-indexed-access-lib.md
@@ -1,0 +1,60 @@
+# fix(checker): allow literal narrowing for keyof Lazy(LibType) and IndexAccess(Lazy(LibType), key)
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/contextual-literal-indexed-access-lib`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: conformance — false positive on `arrayToLocaleStringES2015` /
+  `arrayToLocaleStringES2020` and any case where a fresh literal targets an
+  indexed-access or keyof on a Lazy lib-namespace interface.
+
+## Intent
+
+`contextual_type_allows_literal_inner` widens fresh string literals when the
+contextual type is `keyof Lazy(NumberFormatOptionsStyleRegistry)` or
+`IndexAccess(Lazy(NumberFormatOptions), 'style')`. The first-pass
+`evaluate_type_with_env` returns the same type because the lib `Lazy` def
+hasn't been registered in `TypeEnvironment` yet, and subsequent classification
+returns `NotAllowed`, causing `'currency'` to widen to `string`.
+
+This fix:
+
+1. **`keyof Lazy` fallback**: when the keyof inner is a Lazy with no progress
+   from `evaluate_type_with_env`, force `ensure_relation_input_ready` on the
+   inner, re-evaluate, and retry the keyof evaluation.
+2. **`IndexAccess(Lazy, "key")` fallback**: when the indexed-access object is
+   a Lazy and the index is a literal string, resolve via `ensure_relation_input_ready`
+   then look up the property type through the existing solver
+   `contextual_property_type` query and recurse.
+
+Both fallbacks respect the architecture: no checker pattern-matching of solver
+internals; resolution goes through `evaluate_type_with_env` and the
+`contextual_property_type` boundary helper.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/type_analysis/computed_helpers.rs` (~40 LOC)
+- `crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs` (new, ~95 LOC)
+- `crates/tsz-checker/Cargo.toml` (+4 LOC test entry)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` — 2836 passed
+- `cargo nextest run -p tsz-checker --test contextual_literal_keyof_lib_tests` — 4 passed (new)
+- `./scripts/conformance/conformance.sh run --max 200` — 200/200 (no regressions in smoke)
+- `arrayToLocaleStringES5` test now passes (was failing); ES2015/ES2020 still fail
+  on the call-argument-object-literal path (separate code path; needs follow-up).
+
+## Repros that now pass
+
+```ts
+// Variable annotation with alias to lib indexed-access
+type S = Intl.NumberFormatOptions["style"];
+const x: S = "currency"; // OK (was TS2322)
+
+// Direct indexed-access on lib namespace
+const y: Intl.NumberFormatOptions["style"] = "currency"; // OK (was TS2322)
+
+// Intersection of lib namespace with `{}`
+const z: Intl.NumberFormatOptions & {} = { style: "currency" }; // OK (was TS2322)
+```


### PR DESCRIPTION
## Summary

- When the contextual type for a string literal is `keyof Lazy(LibType)` or `IndexAccess(Lazy(LibType), \"key\")` and the lib def has not been registered in `TypeEnvironment` yet, `evaluate_type_with_env` cannot make progress, so `classify_for_contextual_literal` returns `NotAllowed` and fresh literals like `'currency'` get widened to `string`. This causes false TS2322 / TS2345 errors against intersection or indexed-access targets that should accept the literal.
- Adds two narrow fallbacks inside `contextual_type_allows_literal_inner` that force `ensure_relation_input_ready` on the inner Lazy, re-evaluate, and either rebuild the keyof or look up the property type via the existing solver `contextual_property_type` boundary helper. Both fallbacks then recurse so the existing union/keyof/literal logic stays in charge of the narrowing decision.
- Adds `crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs` (4 tests) covering alias-of-indexed-access, direct indexed-access, intersection, and alias-of-intersection patterns using a synthetic namespace so the regression test does not depend on the real lib loader.

```ts
type S = Intl.NumberFormatOptions[\"style\"];
const x: S = \"currency\"; // OK (was TS2322)

const y: Intl.NumberFormatOptions[\"style\"] = \"currency\"; // OK (was TS2322)

const z: Intl.NumberFormatOptions & {} = { style: \"currency\" }; // OK (was TS2322)
```

## Architecture notes

- No checker pattern-matching of solver internals; resolution flows through `evaluate_type_with_env` and the `contextual_property_type` query boundary.
- Both fallbacks recurse back into `contextual_type_allows_literal_inner`, so the existing union/keyof/literal classification stays the single decision gate.

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` (2836 passed, 0 regressions)
- [x] `cargo nextest run -p tsz-checker --test contextual_literal_keyof_lib_tests` (4/4 passed)
- [x] `./scripts/conformance/conformance.sh run --max 200` (200/200, no smoke regressions)
- [x] Manual repros verified for the three patterns above
- [ ] Full `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` (pending in CI)

## Known follow-up

- The original conformance failures `arrayToLocaleStringES2015.ts` and `arrayToLocaleStringES2020.ts` still fail because they use object-literal call arguments (`arr.toLocaleString(\"en-US\", { style: \"currency\", currency: \"EUR\" })`), which take a different code path through call-argument property typing where the literal gets re-typed without contextual on a later pass. That fix is a separate change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
