### PR TITLE
fix(emitter): hoist CJS private-field var before __esModule preamble

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -52,5 +52,9 @@ path = "tests/parenthesized_iife_tests.rs"
 name = "export_equals_type_only_namespace"
 path = "tests/export_equals_type_only_namespace.rs"
 
+[[test]]
+name = "cjs_hoisted_var_position_tests"
+path = "tests/cjs_hoisted_var_position_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1619,6 +1619,18 @@ impl<'a> Printer<'a> {
         }
 
         // Insert hoisted temp declarations (for-of iterator lowering + assignment destructuring).
+        // In CommonJS module mode, these `var` declarations belong BEFORE the
+        // `Object.defineProperty(exports, "__esModule", { value: true })` preamble and
+        // any `exports.X = void 0;` initializations to match tsc layout. The CJS preamble
+        // path captures the pre-preamble offset in `cjs_destr_hoist_byte_offset`; when set,
+        // route hoisted temps through that position instead of the post-preamble
+        // `hoisted_var_byte_offset`.
+        let (hoist_byte_offset, hoist_line) = if self.ctx.is_commonjs() {
+            (self.cjs_destr_hoist_byte_offset, self.cjs_destr_hoist_line)
+        } else {
+            (hoisted_var_byte_offset, hoisted_var_line)
+        };
+
         let mut ref_vars = Vec::new();
         ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());
         ref_vars.extend(self.hoisted_for_of_temps.iter().cloned());
@@ -1626,13 +1638,13 @@ impl<'a> Printer<'a> {
         if !ref_vars.is_empty() {
             let var_decl = format!("var {};", ref_vars.join(", "));
             self.writer
-                .insert_line_at(hoisted_var_byte_offset, hoisted_var_line, &var_decl);
+                .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
         }
 
         if !self.hoisted_assignment_value_temps.is_empty() {
             let var_decl = format!("var {};", self.hoisted_assignment_value_temps.join(", "));
             self.writer
-                .insert_line_at(hoisted_var_byte_offset, hoisted_var_line, &var_decl);
+                .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
         }
 
         // Insert CJS destructuring export temps before the __esModule marker.

--- a/crates/tsz-emitter/tests/cjs_hoisted_var_position_tests.rs
+++ b/crates/tsz-emitter/tests/cjs_hoisted_var_position_tests.rs
@@ -1,0 +1,130 @@
+//! Regression tests for CJS module hoisted-var insertion position.
+//!
+//! In CommonJS module mode, tsc emits hoisted temp `var` declarations
+//! (e.g. `var _Foo_field;` for class private field `WeakMaps`, `var _a;` for
+//! assignment destructuring) BEFORE the
+//! `Object.defineProperty(exports, "__esModule", { value: true })` preamble
+//! and any `exports.X = void 0;` initializations. tsz now routes these
+//! `hoisted_assignment_temps` (and friends) through the pre-preamble
+//! insertion offset (`cjs_destr_hoist_byte_offset`) when CJS mode is
+//! active.
+//!
+//! Source: `crates/tsz-emitter/src/emitter/source_file/emit.rs`
+//! (the hoisted-vars insertion block at the bottom of the source-file
+//! emitter).
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn parse_lower_print(source: &str, opts: PrintOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+/// `var _Foo_field;` for a class private field in CJS module mode must come
+/// BEFORE `Object.defineProperty(exports, "__esModule", ...)`. tsc places
+/// all hoisted class-lowering vars at the very top of the file body, after
+/// `"use strict";` and helpers, but before any CJS preamble.
+#[test]
+fn cjs_class_private_field_var_before_es_module_preamble() {
+    let source = r#"export class Foo {
+    #field = true;
+    f() {
+        this.#field = this.#field;
+        #field in this;
+    }
+}
+"#;
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2020,
+            module: ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    );
+
+    let var_pos = output
+        .find("var _Foo_field;")
+        .expect("expected `var _Foo_field;` declaration; output:\n{output}");
+    let preamble_pos = output
+        .find("Object.defineProperty(exports, \"__esModule\"")
+        .expect("expected CJS __esModule preamble; output:\n{output}");
+
+    assert!(
+        var_pos < preamble_pos,
+        "private-field WeakMap var must be hoisted BEFORE the __esModule \
+         preamble in CJS mode.\nvar pos: {var_pos}, preamble pos: \
+         {preamble_pos}\noutput:\n{output}"
+    );
+}
+
+/// Assignment destructuring temp `var _a;` from
+/// `export const [] = [];` must be hoisted BEFORE the CJS preamble. This
+/// path was already correct (it goes through `cjs_destructuring_export_temps`)
+/// but the test pins the contract so it cannot regress alongside the
+/// `hoisted_assignment_temps` reroute.
+#[test]
+fn cjs_destructuring_export_temp_before_es_module_preamble() {
+    let source = "export const [] = [];\n";
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            module: ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    );
+
+    let var_pos = output
+        .find("var _a;")
+        .expect("expected `var _a;` declaration; output:\n{output}");
+    let preamble_pos = output
+        .find("Object.defineProperty(exports, \"__esModule\"")
+        .expect("expected CJS __esModule preamble; output:\n{output}");
+
+    assert!(
+        var_pos < preamble_pos,
+        "destructuring temp must be hoisted BEFORE the __esModule preamble \
+         in CJS mode.\nvar pos: {var_pos}, preamble pos: {preamble_pos}\n\
+         output:\n{output}"
+    );
+}
+
+/// In NON-CJS module mode (ES2015 modules), there is no `__esModule`
+/// preamble. The hoisted private-field var simply sits at the top of the
+/// emitted body after `"use strict";` (if any) and helpers. This test
+/// asserts that we did not break the non-CJS path: the var must still be
+/// emitted somewhere in the output (i.e. routing did not silently drop it).
+#[test]
+fn esm_class_private_field_var_still_emitted() {
+    let source = r#"export class Foo {
+    #field = true;
+    f() {
+        this.#field = this.#field;
+        #field in this;
+    }
+}
+"#;
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2020,
+            module: ModuleKind::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("var _Foo_field;"),
+        "non-CJS lowering must still emit the private-field WeakMap var; \
+         output:\n{output}"
+    );
+    assert!(
+        !output.contains("Object.defineProperty(exports, \"__esModule\""),
+        "ES2015 module mode must not emit a CJS __esModule preamble; \
+         output:\n{output}"
+    );
+}

--- a/docs/plan/claims/fix-emitter-cjs-private-field-var-position.md
+++ b/docs/plan/claims/fix-emitter-cjs-private-field-var-position.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/emitter-cjs-private-field-var-position`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1348
+- **Status**: ready
 - **Workstream**: 2 (JS Emit pass rate)
 
 ## Intent
@@ -17,6 +17,9 @@ In CommonJS module mode, tsc emits hoisted temp `var` declarations (e.g. `var _F
 
 ## Verification
 
-- `cargo nextest run -p tsz-emitter`
-- `./scripts/emit/run.sh --filter importHelpersNoHelpersForPrivateFields`
-- Targeted no-regression: `./scripts/emit/run.sh --filter privateName` and `./scripts/emit/run.sh --filter exportEmptyArrayBindingPattern`
+- `cargo nextest run -p tsz-emitter` (1645 tests pass)
+- `./scripts/emit/run.sh --filter=importHelpersNoHelpersForPrivateFields` (now passes)
+- Full emit suite: net +1 JS pass (1197 -> 1196 failures); two close-to-passing CJS tests
+  shrunk their diff. No regressions across class / decorator / commonjs / importHelpers /
+  async / generator / destructuring / loop / forof / staticBlock / declarationEmit /
+  usingDeclar filter groups.

--- a/docs/plan/claims/fix-emitter-cjs-private-field-var-position.md
+++ b/docs/plan/claims/fix-emitter-cjs-private-field-var-position.md
@@ -1,0 +1,22 @@
+# fix(emitter): position CJS hoisted assignment temps before __esModule preamble
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/emitter-cjs-private-field-var-position`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (JS Emit pass rate)
+
+## Intent
+
+In CommonJS module mode, tsc emits hoisted temp `var` declarations (e.g. `var _Foo_field;` for class private field WeakMaps, `var _a;` for assignment destructuring) BEFORE the `Object.defineProperty(exports, "__esModule", { value: true })` preamble and any `exports.X = void 0;` initializations. tsz currently inserts these after the preamble for the `hoisted_assignment_temps` channel (used by class private field lowering), causing diff failures such as `importHelpersNoHelpersForPrivateFields`. This PR routes `hoisted_assignment_temps` and `hoisted_for_of_temps` through the existing pre-preamble insertion offset (`cjs_destr_hoist_byte_offset`) when CommonJS preamble was emitted, matching tsc layout.
+
+## Files Touched
+
+- `crates/tsz-emitter/src/emitter/source_file/emit.rs` (~10 LOC change to the hoisted-vars insertion block)
+- New regression unit test under `crates/tsz-emitter/tests` covering the private-field + CJS scenario.
+
+## Verification
+
+- `cargo nextest run -p tsz-emitter`
+- `./scripts/emit/run.sh --filter importHelpersNoHelpersForPrivateFields`
+- Targeted no-regression: `./scripts/emit/run.sh --filter privateName` and `./scripts/emit/run.sh --filter exportEmptyArrayBindingPattern`


### PR DESCRIPTION
## Summary

In CommonJS module mode, tsc emits hoisted temp `var` declarations (e.g. `var _Foo_field;` for class private field WeakMaps, `var _a;` for assignment destructuring) BEFORE the `Object.defineProperty(exports, "__esModule", { value: true })` preamble and any `exports.X = void 0;` initializations. tsz was inserting these through `hoisted_var_byte_offset`, captured AFTER the CJS preamble, so private-field WeakMap vars and other hoisted temps appeared after the preamble.

The CJS preamble path already captures a pre-preamble offset in `cjs_destr_hoist_byte_offset` for destructuring export temps; this PR routes `hoisted_assignment_temps`, `hoisted_for_of_temps`, and `hoisted_assignment_value_temps` through that same offset when CJS is active so they match tsc layout. Non-CJS module modes are unchanged.

## Why

- Workstream 2 (JS emit pass rate). Recent emit fixes targeted JS specific quirks; this fix addresses a layout mismatch that was costing baseline parity for class private fields under CommonJS.
- Architecture compliance: emitter-only (§13). No checker/solver changes.

## Test plan

- [x] New regression unit tests in `crates/tsz-emitter/tests/cjs_hoisted_var_position_tests.rs` (3 tests, all pass)
- [x] `cargo nextest run -p tsz-emitter` (1645 tests pass)
- [x] Verified `importHelpersNoHelpersForPrivateFields` now passes via `./scripts/emit/run.sh --filter=...`
- [x] Full emit suite: net **+1 JS pass** (1197 -> 1196 failures), no regressions; two close-to-passing CJS tests (`emitClassExpressionInDeclarationFile2`, `variableDeclarationDeclarationEmitUniqueSymbolPartialStatement`) shrunk their diff
- [x] No regressions across `class`, `decorator`, `commonjs`, `importHelpers`, `async`, `generator`, `destructuring`, `loop`, `forof`, `staticBlock`, `declarationEmit`, `usingDeclar` filter groups

## Files

- `crates/tsz-emitter/src/emitter/source_file/emit.rs` (+12/-2 LOC: select pre-preamble offset for hoisted temps in CJS mode)
- `crates/tsz-emitter/tests/cjs_hoisted_var_position_tests.rs` (new, 3 tests)
- `crates/tsz-emitter/Cargo.toml` (+4 LOC: register new test binary)
- `docs/plan/claims/fix-emitter-cjs-private-field-var-position.md` (new claim file)