### PR TITLE
fix(checker): suppress false TS2456 for typeof through TYPE_LITERAL deferral

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -709,8 +709,13 @@ impl<'a> CheckerState<'a> {
     /// Walk the AST node tree under `root_idx` and return the SymbolId of any
     /// type-reference/identifier that resolves to a member of
     /// `ctx.symbol_resolution_set` and represents a type alias. Descends through
-    /// arrays, tuples, type literals, etc. so that `T5[]` is detected as
-    /// referencing `T5`.
+    /// arrays, tuples, unions, intersections, and parenthesized types so that
+    /// `T5[]` is detected as referencing `T5`. Stops at structural-deferral
+    /// wrappers (TYPE_LITERAL, MAPPED_TYPE, FUNCTION_TYPE, CONSTRUCTOR_TYPE),
+    /// because tsc creates those types lazily — property types and signature
+    /// types are not eagerly resolved during typeof-target type construction,
+    /// so a reference to a resolution-chain alias inside such a wrapper does
+    /// NOT make the chain directly circular.
     fn ast_finds_resolution_chain_alias(&self, root_idx: NodeIndex) -> Option<SymbolId> {
         let mut stack = vec![root_idx];
         while let Some(node_idx) = stack.pop() {
@@ -739,6 +744,21 @@ impl<'a> CheckerState<'a> {
                         return Some(sym_id);
                     }
                 }
+            }
+            // Skip descent into structural-deferral wrappers. tsc resolves
+            // property types and signature types lazily, so a chain-member
+            // reference inside `{ x: T }`, `() => T`, `new (...) => T`, or a
+            // mapped type is NOT eagerly resolved at typeof-target type
+            // construction time. Treating it as circular is a false positive.
+            // ARRAY_TYPE / TUPLE_TYPE intentionally still descend — tsc
+            // eagerly computes element types via getArrayType / getTupleType.
+            let k = node.kind;
+            if k == syntax_kind_ext::TYPE_LITERAL
+                || k == syntax_kind_ext::MAPPED_TYPE
+                || k == syntax_kind_ext::FUNCTION_TYPE
+                || k == syntax_kind_ext::CONSTRUCTOR_TYPE
+            {
+                continue;
             }
             // A TYPE_REFERENCE with type arguments creates a generic
             // instantiation boundary — descend into its children only if the

--- a/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
+++ b/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
@@ -76,3 +76,55 @@ fn test_no_ts2456_when_typeof_self_referencing_var_is_value() {
         "Expected no TS2456 for merged value+type with typeof self, got: {codes:?}"
     );
 }
+
+#[test]
+fn test_no_ts2456_when_typeof_target_references_alias_inside_type_literal() {
+    // Repro from `unionTypeWithRecursiveSubtypeReduction3.ts`:
+    //
+    //   declare var a27: { prop: number } | { prop: T27 };
+    //   type T27 = typeof a27;
+    //
+    // The reference to `T27` is wrapped inside a TYPE_LITERAL property type
+    // (`{ prop: T27 }`). tsc treats TYPE_LITERAL property types as lazily
+    // resolved during typeof-target type construction, so the cycle is
+    // structurally deferred and does NOT trigger TS2456.
+    let src = r#"
+        declare var a27: { prop: number } | { prop: T27 };
+        type T27 = typeof a27;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 when alias reference is inside a TYPE_LITERAL property, got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_no_ts2456_when_typeof_target_references_alias_inside_function_type() {
+    // `() => T` is structurally deferred — tsc does not eagerly compute
+    // signature types when constructing the variable's typeof target.
+    let src = r#"
+        declare var f: () => T;
+        type T = typeof f;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 when alias reference is inside a FUNCTION_TYPE, got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_no_ts2456_when_typeof_target_references_alias_inside_constructor_type() {
+    // `new () => T` is structurally deferred for the same reason as
+    // FUNCTION_TYPE.
+    let src = r#"
+        declare var c: new () => T;
+        type T = typeof c;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 when alias reference is inside a CONSTRUCTOR_TYPE, got: {codes:?}"
+    );
+}

--- a/docs/plan/claims/fix-checker-typeof-typeliteral-no-circular.md
+++ b/docs/plan/claims/fix-checker-typeof-typeliteral-no-circular.md
@@ -1,0 +1,39 @@
+# fix(checker): suppress false TS2456 for typeof through TYPE_LITERAL deferral
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-typeof-typeliteral-no-circular`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+`type T27 = typeof a27; declare var a27: { prop: number } | { prop: T27 };`
+should NOT emit TS2456. tsc treats TYPE_LITERAL property types as lazily
+resolved, so a self-reference inside `{ prop: T27 }` is structurally deferred.
+
+We currently walk the typeof-target's annotation AST in
+`ast_finds_resolution_chain_alias` and descend into all children, including
+TYPE_LITERAL/MAPPED_TYPE/FUNCTION_TYPE/CONSTRUCTOR_TYPE — these are the
+exact deferral wrappers tsc uses to terminate eager type construction.
+
+Fix: skip descent into structurally deferred wrapper kinds in the AST walk
+used for typeof annotation circularity detection.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/type_analysis/computed_helpers.rs` (~10 LOC)
+- `crates/tsz-checker/tests/...` regression test (~30 LOC)
+
+## Verification
+
+- `./scripts/conformance/conformance.sh run --filter unionTypeWithRecursiveSubtypeReduction3`
+- `./scripts/conformance/conformance.sh run --filter directDependenceBetweenTypeAliases`
+- `./scripts/conformance/conformance.sh run --filter circularTypeofWithVarOrFunc`
+- `cargo nextest run -p tsz-checker --lib`
+
+## Conformance Impact
+
+- +1 test (`unionTypeWithRecursiveSubtypeReduction3.ts`) flips PASS by removing
+  spurious TS2456. Note the secondary TS2322 fingerprint diff is on display
+  text and may also flip with the underlying type now resolving.

--- a/docs/plan/claims/fix-checker-typeof-typeliteral-no-circular.md
+++ b/docs/plan/claims/fix-checker-typeof-typeliteral-no-circular.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-typeof-typeliteral-no-circular`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1349
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent
@@ -27,10 +27,13 @@ used for typeof annotation circularity detection.
 
 ## Verification
 
-- `./scripts/conformance/conformance.sh run --filter unionTypeWithRecursiveSubtypeReduction3`
-- `./scripts/conformance/conformance.sh run --filter directDependenceBetweenTypeAliases`
-- `./scripts/conformance/conformance.sh run --filter circularTypeofWithVarOrFunc`
-- `cargo nextest run -p tsz-checker --lib`
+- `cargo nextest run -p tsz-checker --test type_alias_typeof_circular_tests` (7/7 PASS — 3 new)
+- `cargo nextest run -p tsz-checker --lib` (2847 PASS, no regressions)
+- `./scripts/conformance/conformance.sh run --filter unionTypeWithRecursiveSubtypeReduction3` (TS2456 removed)
+- `./scripts/conformance/conformance.sh run --filter directDependenceBetweenTypeAliases` (PASS — array case still circular)
+- `./scripts/conformance/conformance.sh run --filter circularTypeofWithVarOrFunc` (PASS — bare-ref still circular)
+- `./scripts/conformance/conformance.sh run --filter circular` (34/36 PASS, no regressions)
+- `./scripts/conformance/conformance.sh run --filter typeAlias` (42/44 PASS, no regressions)
 
 ## Conformance Impact
 


### PR DESCRIPTION
## Summary

Fixes false-positive TS2456 (`Type alias '...' circularly references itself`) when a `typeof`-based alias references the same alias inside a structurally-deferred wrapper of the target's annotation.

```ts
declare var a27: { prop: number } | { prop: T27 };
type T27 = typeof a27;  // tsc: no TS2456 (we previously emitted one)
```

## Root cause

`ast_finds_resolution_chain_alias` (in `state/type_analysis/computed_helpers.rs`) is the AST walker that detects when a `typeof X` alias's target annotation references any alias on the current resolution chain. It previously descended into all child nodes blindly. For:

```
{ prop: number } | { prop: T27 }
```

it walked UNION_TYPE → TYPE_LITERAL → property type → `T27` → matched `T27` in the resolution set → returned `Some(T27)` → emitted TS2456.

But tsc treats TYPE_LITERAL property types (and FUNCTION_TYPE / CONSTRUCTOR_TYPE / MAPPED_TYPE bodies) as **lazily resolved** during typeof-target type construction. The property/signature types are not eagerly fetched, so a chain-member reference inside one of those wrappers does NOT make the chain directly circular.

## Fix

Skip descent into structural-deferral wrappers (`TYPE_LITERAL`, `MAPPED_TYPE`, `FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`) in `ast_finds_resolution_chain_alias`.

`ARRAY_TYPE` and `TUPLE_TYPE` intentionally still descend — tsc eagerly computes element types via `getArrayType` / `getTupleType`, so existing tests like `var x: T5[]; type T5 = typeof x` (TS2456) keep firing.

## Test plan

- [x] `cargo nextest run -p tsz-checker --test type_alias_typeof_circular_tests` (7/7 PASS, +3 new)
- [x] `./scripts/conformance/conformance.sh run --filter unionTypeWithRecursiveSubtypeReduction3` — TS2456 is gone (residual fingerprint-only TS2322 mismatch is a separate display issue)
- [x] `./scripts/conformance/conformance.sh run --filter directDependenceBetweenTypeAliases` (PASS — array case still triggers TS2456)
- [x] `./scripts/conformance/conformance.sh run --filter circularTypeofWithVarOrFunc` (PASS — bare-ref typeof cycles still emit TS2456)
- [x] `./scripts/conformance/conformance.sh run --filter typeAlias` (no regressions)
- [x] `./scripts/conformance/conformance.sh run --filter circular` (no regressions)
- [x] `cargo nextest run -p tsz-checker --lib` (2847 PASS)

## Conformance impact

Removes the false-positive TS2456 from `unionTypeWithRecursiveSubtypeReduction3.ts`. The test now falls into the `fingerprint-only` category (TS2322 message displays alias name `T27` instead of expanded structural type) — a separate type-display issue not in scope here. KPI: wrong-code count decreases by 1 (TS2456 false positive eliminated), fingerprint-only count goes up by 1.

## Architecture notes

Pure checker-side AST inspection (`§3 WHERE`). No solver internal access, no `TypeKey` matching, no `query_boundaries` bypass. The fix mirrors the deferral-wrapper list already used by `alias_ast_is_deferred` for the direct-body path.