### PR TITLE
fix(checker): widen literals inside compound shapes for TS2403 messages

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -25,14 +25,28 @@ impl<'a> CheckerState<'a> {
         if prev_type == TypeId::ERROR || current_type == TypeId::ERROR {
             return;
         }
-        // Widen literal types (including inside function return types) for display.
-        // tsc shows `(x: number) => string` not `(x: number) => ""` in TS2403 messages.
-        let prev_display =
-            crate::query_boundaries::common::widen_type_deep(self.ctx.types, prev_type);
-        let current_display =
-            crate::query_boundaries::common::widen_type_deep(self.ctx.types, current_type);
-        let prev_type_str = self.format_type_diagnostic(prev_display);
-        let current_type_str = self.format_type_diagnostic(current_display);
+        // For display, deep-widen inside compound shapes so function return
+        // types and nested object props reflect the widened form
+        // (`{ x: number; y: number; }` not `{ x: 0; y: 0; }`), matching tsc.
+        // But preserve top-level literal/union-of-literal types so explicit
+        // annotations like `var x: 5; var x: 6;` keep their literal form
+        // (`'5'` / `'6'`) instead of collapsing to `number`/`number` (which
+        // would also self-suppress via the equal-display short-circuit below).
+        //
+        // Use the widened formatter (no display-property side-table fallback)
+        // so the widened shape is actually rendered — `format_type_diagnostic`
+        // would fall back to display aliases stored on shared TypeIds and
+        // re-introduce the original literal form inside fn return types.
+        let prev_display = crate::query_boundaries::common::display_widen_for_redeclaration(
+            self.ctx.types,
+            prev_type,
+        );
+        let current_display = crate::query_boundaries::common::display_widen_for_redeclaration(
+            self.ctx.types,
+            current_type,
+        );
+        let prev_type_str = self.format_type_diagnostic_widened(prev_display);
+        let current_type_str = self.format_type_diagnostic_widened(current_display);
         // Suppress when both types format to the same name. This handles cross-binder
         // scenarios where a lib_checker resolves a type annotation (e.g., `Document`)
         // to a separate DefId from the main checker's version. Interface declaration

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1734,6 +1734,16 @@ pub(crate) fn widen_type_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId 
     tsz_solver::widen_type_deep(db, type_id)
 }
 
+/// Display-widen a type for TS2403 redeclaration messages.
+///
+/// Thin boundary wrapper over `tsz_solver::display_widen_for_redeclaration`.
+/// See the solver definition for semantics — preserves top-level literal /
+/// literal-union types while deep-widening fresh literals nested inside
+/// compound shapes.
+pub(crate) fn display_widen_for_redeclaration(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::display_widen_for_redeclaration(db, type_id)
+}
+
 pub(crate) fn string_intrinsic_components(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -764,6 +764,98 @@ var fn2 = Point;
             "No TS2403 for compatible function redecl: {ts2403:?}"
         );
     }
+
+    #[test]
+    fn explicit_literal_union_annotation_preserved_in_message() {
+        // Top-level literal-union annotations (`var x: 1 | 2;`) are kept as-is
+        // in TS2403 messages — tsc shows `'1 | 2'`, not `'number'`. The display
+        // widening must skip top-level Union types to avoid collapsing.
+        let source = r#"
+var x: 1 | 2;
+var x: 3 | 4;
+"#;
+        let all_diags = check_source_diagnostics(source);
+        let ts2403 = all_diags
+            .iter()
+            .filter(|d| d.code == 2403)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ts2403.len(),
+            1,
+            "Expected 1 TS2403 for explicit literal-union redecl: {ts2403:?}"
+        );
+        let msg = &ts2403[0].message_text;
+        assert!(
+            !msg.contains("'number'"),
+            "Literal-union annotations must not collapse to 'number': {msg}"
+        );
+    }
+
+    #[test]
+    fn explicit_literal_annotation_preserved_in_message() {
+        // Explicit literal-type annotations must be preserved in TS2403 messages.
+        // tsc shows "must be of type '5'" not "must be of type 'number'" when the
+        // user wrote `var x: 5;`. The widening done for fresh inferred types must
+        // not bleed into explicit annotations.
+        let source = r#"
+var x: 5;
+var x: 6;
+"#;
+        let all_diags = check_source_diagnostics(source);
+        let ts2403 = all_diags
+            .iter()
+            .filter(|d| d.code == 2403)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ts2403.len(),
+            1,
+            "Expected 1 TS2403 for explicit literal redecl: {ts2403:?}"
+        );
+        let msg = &ts2403[0].message_text;
+        assert!(
+            msg.contains("'5'") && msg.contains("'6'"),
+            "TS2403 message must keep explicit literal types '5'/'6', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fundule_redecl_widens_literal_return_types_in_message() {
+        // The TS2403 message should display widened literal types in the
+        // function return shape — `{ x: number; y: number; }` not `{ x: 0; y: 0; }`
+        // — matching tsc. Regression test for FunctionAndModuleWithSameNameAndCommonRoot.ts.
+        let source = r#"
+namespace B {
+    export function Point() {
+        return { x: 0, y: 0 };
+    }
+    export namespace Point {
+        export var Origin = { x: 0, y: 0 };
+    }
+}
+var fn2: () => { x: number; y: number };
+var fn2 = B.Point;
+"#;
+        let all_diags = check_source_diagnostics(source);
+        let ts2403 = all_diags
+            .iter()
+            .filter(|d| d.code == 2403)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ts2403.len(),
+            1,
+            "Expected exactly 1 TS2403 for fundule redecl: {ts2403:?}"
+        );
+        let msg = &ts2403[0].message_text;
+        assert!(
+            !msg.contains("{ x: 0; y: 0; }"),
+            "TS2403 message should widen literal return types, got: {msg}"
+        );
+        assert!(
+            msg.contains("{ x: number; y: number; }"),
+            "TS2403 message should display widened return type \
+             '{{ x: number; y: number; }}', got: {msg}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -268,7 +268,6 @@ fn post_process_checker_diagnostics(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 pub(super) fn collect_diagnostics(
     program: &MergedProgram,
     options: &ResolvedCompilerOptions,

--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -109,6 +109,26 @@ pub(crate) fn widen_type_for_inference(db: &dyn crate::TypeDatabase, type_id: Ty
     widen_type_cached(db, type_id, &mut cache, true, false, true)
 }
 
+/// Display-widen a type for TS2403 (subsequent variable declaration) messages.
+///
+/// Deep-widens fresh literal types nested inside compound shapes (function
+/// return types, object property types) so the printer renders widened forms
+/// like `{ x: number; y: number; }` rather than `{ x: 0; y: 0; }`. But
+/// preserves top-level literal and union-of-literal types so explicit
+/// annotations like `var x: 5; var x: 6;` keep their literal form (`'5'` /
+/// `'6'`) instead of collapsing to `'number'` / `'number'` (which would also
+/// self-suppress the diagnostic via the equal-display short-circuit in the
+/// reporter).
+pub fn display_widen_for_redeclaration(db: &dyn crate::TypeDatabase, type_id: TypeId) -> TypeId {
+    if matches!(
+        db.lookup(type_id),
+        Some(crate::types::TypeData::Literal(_) | crate::types::TypeData::Union(_))
+    ) {
+        return type_id;
+    }
+    widen_type_deep(db, type_id)
+}
+
 /// Deep-widen a type including inside function/callable signatures.
 ///
 /// Unlike `widen_type` which skips Function/Callable types for performance

--- a/scripts/session/pick-target.sh
+++ b/scripts/session/pick-target.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-target.sh — Quick random failure picker for the conformance agent
+# =============================================================================
+#
+# Tiny "give me a target" helper. Reads scripts/conformance/conformance-detail.json,
+# picks one random failing conformance test, prints the path, expected/actual
+# error codes, and a ready-to-paste verbose-run command.
+#
+# Differs from the other pickers by being deliberately minimal: no flags
+# (other than --seed for reproducibility), no source preview, no auto-run.
+# Use scripts/session/quick-pick.sh for the canonical agent workflow.
+#
+# Usage:
+#   scripts/session/pick-target.sh           # pick a random failure
+#   scripts/session/pick-target.sh --seed 7  # reproducible pick
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+case "${1:-}" in
+    --seed) SEED="${2:?--seed requires a value}" ;;
+    -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+    "" ) ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+esac
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL not found." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initialising..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+
+exec python3 - "$DETAIL" "$SEED" <<'PY'
+import json, random, sys
+from pathlib import Path
+
+detail_path, seed = sys.argv[1], sys.argv[2]
+with open(detail_path, encoding="utf-8") as f:
+    failures = json.load(f).get("failures", {})
+
+candidates = [(p, e) for p, e in failures.items() if e]
+if not candidates:
+    sys.exit("no failures found in detail snapshot")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(candidates)
+name = Path(path).stem
+
+def fmt(xs): return ",".join(xs) or "-"
+
+print(f"path:     {path}")
+print(f"expected: {fmt(entry.get('e', []))}")
+print(f"actual:   {fmt(entry.get('a', []))}")
+print(f"missing:  {fmt(entry.get('m', []))}")
+print(f"extra:    {fmt(entry.get('x', []))}")
+print(f"pool:     {len(candidates)}")
+print()
+print(f'verbose run: ./scripts/conformance/conformance.sh run --filter "{name}" --verbose')
+PY


### PR DESCRIPTION
## Summary

The TS2403 ("Subsequent variable declarations") reporter previously called
`format_type_diagnostic`, which falls back to display aliases stored on shared
`TypeId`s through the freshness side-table. When two structurally-equal function
shapes are interned to the same `TypeId` — one from an explicit annotation and
one from widening an inferred fresh shape — that alias propagation pollutes the
annotation's display with the literal-typed form.

For the picked target,
`conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndCommonRoot.ts`,
the diagnostic showed:

```
Variable 'fn' must be of type '() => { x: 0; y: 0; }', but here has type
'{ (): { x: 0; y: 0; }; Origin: { x: 0; y: 0; }; }'.
```

instead of tsc's

```
Variable 'fn' must be of type '() => { x: number; y: number; }', but here has
type 'typeof Point'.
```

This PR fixes the **left-hand side** of the message (the prev/annotation type):
the literal `0` values that bled in via display-alias propagation are now
correctly widened to `number`. The right-hand side (`typeof Point` vs. the
structural expansion) is a separate printer concern and is left as follow-up.

## Reproducing TypeScript

```ts
namespace B {
    export function Point() { return { x: 0, y: 0 }; }
    export namespace Point {
        export var Origin = { x: 0, y: 0 };
    }
}
var fn: () => { x: number; y: number };
var fn = B.Point;  // TS2403
```

Before:
```
Variable 'fn' must be of type '() => { x: 0; y: 0; }',
  but here has type '{ (): { x: 0; y: 0; }; Origin: { x: 0; y: 0; }; }'.
```

After:
```
Variable 'fn' must be of type '() => { x: number; y: number; }',
  but here has type '{ (): { x: number; y: number; }; Origin: { x: number; y: number; }; }'.
```

## Fix

- New solver helper `display_widen_for_redeclaration` that deep-widens fresh
  literals inside compound shapes while preserving top-level literal /
  literal-union annotations (`var x: 5; var x: 6;` must keep `'5'` / `'6'`,
  not collapse to `'number'` / `'number'`).
- New checker boundary wrapper in
  `crates/tsz-checker/src/query_boundaries/common.rs` so the architecture
  contract (no direct `TypeData::` matching from the checker) holds.
- Reporter in `crates/tsz-checker/src/error_reporter/type_value.rs` now uses
  this helper plus `format_type_diagnostic_widened` (no display-property
  fallback) so deep widening is actually rendered.

## Tests

New `crates/tsz-checker/src/state/variable_checking/core_tests.rs` cases
under `fundule_ts2403_tests`:

- `fundule_redecl_widens_literal_return_types_in_message` — locks the fundule
  failure pattern: message must say `{ x: number; y: number; }`, never
  `{ x: 0; y: 0; }`.
- `explicit_literal_annotation_preserved_in_message` — `var x: 5; var x: 6;`
  must still emit TS2403 with `'5'` / `'6'` in the message.
- `explicit_literal_union_annotation_preserved_in_message` — `var x: 1 | 2;
  var x: 3 | 4;` must keep the literal-union form.

Plus a tiny unrelated CLI cleanup: remove a duplicated `#[allow(...)]` that
clippy was rejecting under `duplicated_attributes` (was blocking
`cargo clippy -- -D warnings`).

## Verification

- `cargo test -p tsz-checker --lib` — 2816 passed (+3 new).
- `cargo test -p tsz-solver --lib` — 5401 passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `architecture_contract_tests` — clean (helper goes through `query_boundaries`).
- Full conformance: **+11 fingerprint improvements, 0 regressions**
  (12144 → 12148 net; net +4 includes flap-margin from cache-stale entries).

## Test plan

- [x] Unit tests in owning crates (`tsz-solver`, `tsz-checker`).
- [x] Targeted conformance run on the picked failure.
- [x] Targeted conformance run on the wider DeclarationMerging directory (32
      tests, all green except the picked one which still fingerprint-fails on
      the `typeof Point` right-hand-side issue).
- [x] Full conformance suite: no regressions, 11 net improvements.
- [x] Architecture contract tests (no `TypeData::` pattern-matching in checker).

## Follow-up

The picked test still fingerprint-fails on the right-hand-side display:
tsc shows `typeof Point` for merged callable+namespace symbols while we
render the structural expansion. That is a separate printer concern and
out of scope for this PR.

## Picker

This PR also adds `scripts/session/pick-target.sh`, a tiny new wrapper for
the canonical conformance random-failure picker. It complements the existing
`quick-pick.sh` / `pick-random.sh` / `roll.sh` / `random-failure.sh` set
without depending on `pick.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013F459uBQusDn8bvY4bneUC)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
