### PR TITLE
fix(parser): parse asserts type predicates in any type position

### DIFF
--- a/crates/tsz-binder/tests/lib_loader.rs
+++ b/crates/tsz-binder/tests/lib_loader.rs
@@ -299,7 +299,7 @@ fn get_suggested_lib_finalization_family_is_es2021() {
     assert_eq!(get_suggested_lib_for_type("ErrorOptions"), "es2021");
 }
 
-/// Disposable / `AsyncDisposable` suggest `esnext`.
+/// `Disposable` / `AsyncDisposable` suggest `esnext`.
 #[test]
 fn get_suggested_lib_disposable_is_esnext() {
     assert_eq!(get_suggested_lib_for_type("Disposable"), "esnext");

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -110,7 +110,11 @@ impl ParserState {
         let snapshot = self.scanner.save_state();
         let current = self.current_token;
         self.next_token();
-        let is_param = self.is_identifier_or_keyword() || self.is_token(SyntaxKind::ThisKeyword);
+        // Matches tsc's `nextTokenIsIdentifierOrKeywordOnSameLine`: a line break
+        // before the next token means ASI applies — `asserts` is a type reference,
+        // not the start of a predicate.
+        let is_param = (self.is_identifier_or_keyword() || self.is_token(SyntaxKind::ThisKeyword))
+            && !self.scanner.has_preceding_line_break();
         self.scanner.restore_state(snapshot);
         self.current_token = current;
         is_param
@@ -141,7 +145,12 @@ impl ParserState {
     }
 
     pub(crate) fn parse_type_with_predicates(&mut self, allow_type_predicates: bool) -> NodeIndex {
-        if allow_type_predicates && self.is_asserts_type_predicate_start() {
+        // `asserts` type predicates can appear in any type position (matches tsc's
+        // `parseNonArrayType` which always recognises `AssertsKeyword + ident-on-same-line`).
+        // When the resulting predicate is in an invalid context the checker emits
+        // TS1228 from `get_type_from_type_node`. The lookahead here is what
+        // distinguishes a predicate from a plain `asserts` type reference.
+        if self.is_asserts_type_predicate_start() {
             return self.parse_asserts_type_predicate();
         }
 

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -3009,6 +3009,79 @@ fn type_predicate_in_function() {
 }
 
 #[test]
+fn asserts_type_predicate_in_setter_parameter_type() {
+    // tsc parses `asserts <ident-on-same-line>` predicates in any type position
+    // and emits TS1228 later when the predicate is in an invalid context.
+    // Previously the parser only accepted them in return-type position, so this
+    // setter parameter type produced a stray TS1005 (',' expected) instead.
+    //
+    // `declare class Wat { set p2(x: asserts this is string); }`
+    let (parser, root) = parse_source("declare class Wat { set p2(x: asserts this is string); }");
+    assert_no_errors(&parser, "asserts predicate in setter parameter type");
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let class = arena.get_class(stmt_node).expect("class");
+    let setter_idx = class.members.nodes[0];
+    let setter = arena.get(setter_idx).expect("setter");
+    assert_eq!(setter.kind, syntax_kind_ext::SET_ACCESSOR);
+    let acc = arena.get_accessor(setter).expect("accessor data");
+    let param_idx = acc.parameters.nodes[0];
+    let param_node = arena.get(param_idx).expect("parameter");
+    let param = arena.get_parameter(param_node).expect("parameter data");
+    let type_node = arena.get(param.type_annotation).expect("type annotation");
+    assert_eq!(
+        type_node.kind,
+        syntax_kind_ext::TYPE_PREDICATE,
+        "setter parameter type should parse as TYPE_PREDICATE, not a stray identifier"
+    );
+    let predicate = arena
+        .get_type_predicate(type_node)
+        .expect("type predicate data");
+    assert!(
+        predicate.asserts_modifier,
+        "predicate should carry the asserts modifier"
+    );
+}
+
+#[test]
+fn asserts_type_predicate_in_type_alias() {
+    // `type T = asserts x is string;` — same family of bug. Even though this is
+    // semantically invalid (the checker reports TS1228), the parser must not
+    // emit a TS1005 here. Matches tsc's behaviour where asserts predicates are
+    // recognised by `parseNonArrayType` regardless of context.
+    let (parser, _root) = parse_source("type T = asserts x is string;");
+    let parser_diags = parser.get_diagnostics();
+    assert!(
+        !parser_diags
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED),
+        "asserts predicate in type alias must not produce TS1005, got: {:?}",
+        parser_diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn asserts_identifier_with_line_break_is_type_reference() {
+    // `asserts` followed by a line break is just an identifier in type position
+    // (ASI). tsc's `nextTokenIsIdentifierOrKeywordOnSameLine` enforces this; the
+    // tsz lookahead used to ignore the line break, which would have parsed
+    // `asserts\n  bar` as an ill-formed predicate had we entered the branch.
+    let (parser, root) = parse_source("type T = asserts\n;");
+    assert_no_errors(&parser, "asserts as plain type reference");
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let alias = arena.get_type_alias(stmt_node).expect("type alias");
+    let alias_type = arena.get(alias.type_node).expect("alias type");
+    assert_eq!(
+        alias_type.kind,
+        syntax_kind_ext::TYPE_REFERENCE,
+        "trailing newline should keep `asserts` as a TypeReference"
+    );
+}
+
+#[test]
 fn import_with_attributes() {
     // `import data from './data.json' with { type: 'json' };`
     let (parser, root) = parse_source("import data from './data.json' with { type: 'json' };");

--- a/scripts/session/pick-now.sh
+++ b/scripts/session/pick-now.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pick-now.sh — Tiny "give me a target right now" random failure picker
+# =============================================================================
+#
+# A minimal-effort wrapper that:
+#   1. Ensures the TypeScript submodule is initialised (so verbose runs work).
+#   2. Picks one random failing conformance test from the offline snapshot.
+#   3. Prints path, expected/actual codes, category, and a verbose-run command.
+#
+# Usage:
+#   scripts/session/pick-now.sh                 # any failure
+#   scripts/session/pick-now.sh --seed 7        # reproducible pick
+#   scripts/session/pick-now.sh --code TS2322   # restrict to one error code
+#
+# Designed to be the absolute fastest path from "I want to start" to a
+# concrete target. If you want more (source preview, source TS, ts run, etc.)
+# use scripts/session/quick-pick.sh or scripts/session/pick-random.sh.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+SEED=""
+CODE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --seed) SEED="${2:-}"; shift 2 ;;
+        --code) CODE="${2:-}"; shift 2 ;;
+        -h|--help) sed -n '2,21p' "$0"; exit 0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL not found." >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule missing — initialising..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript >&2
+fi
+
+exec python3 - "$DETAIL" "$SEED" "$CODE" <<'PY'
+import json, random, sys
+from pathlib import Path
+
+detail_path, seed, code = sys.argv[1:4]
+
+with open(detail_path, encoding="utf-8") as f:
+    failures = json.load(f).get("failures", {})
+
+def classify(entry):
+    e = entry.get("e", [])
+    a = entry.get("a", [])
+    m = entry.get("m", [])
+    x = entry.get("x", [])
+    if not e and a:
+        return "false-positive"
+    if e and not a:
+        return "all-missing"
+    if set(e) == set(a):
+        return "fingerprint-only"
+    if m and not x:
+        return "only-missing"
+    if x and not m:
+        return "only-extra"
+    return "wrong-code"
+
+candidates = []
+for path, entry in failures.items():
+    if not entry:
+        continue
+    codes = (
+        set(entry.get("e", []))
+        | set(entry.get("a", []))
+        | set(entry.get("m", []))
+        | set(entry.get("x", []))
+    )
+    if code and code not in codes:
+        continue
+    candidates.append((path, entry))
+
+if not candidates:
+    sys.exit("no matching failures")
+
+rng = random.Random(int(seed)) if seed else random.Random()
+path, entry = rng.choice(candidates)
+filter_name = Path(path).stem
+
+def fmt(xs):
+    return ",".join(xs) or "-"
+
+print(f"path:     {path}")
+print(f"category: {classify(entry)}")
+print(f"expected: {fmt(entry.get('e', []))}")
+print(f"actual:   {fmt(entry.get('a', []))}")
+print(f"missing:  {fmt(entry.get('m', []))}")
+print(f"extra:    {fmt(entry.get('x', []))}")
+print(f"pool:     {len(candidates)}")
+print()
+print(
+    f'verbose run: ./scripts/conformance/conformance.sh run --filter "{filter_name}" --verbose'
+)
+PY


### PR DESCRIPTION
## Summary

Random failure picked: `conformance/controlFlow/assertionTypePredicates1.ts`.
Root cause: tsz only parsed `asserts X is T` predicates in return-type
positions, so a setter parameter type like `(x: asserts this is string)`
emitted a stray TS1005 (`',' expected`) instead of TS1228 (the predicate
node never reached the checker).

tsc's `parseNonArrayType` always parses an `AssertsKeyword` followed by
an identifier or keyword on the same line as an asserts type predicate;
the checker emits TS1228 later when the predicate parent isn't a
function/method signature. tsz now matches that behaviour and adds the
missing same-line lookahead so `asserts <newline> X` keeps `asserts` as
a type reference (matches tsc's `nextTokenIsIdentifierOrKeywordOnSameLine`).

```ts
declare class Wat {
  // before: TS1005 (`,' expected`) on `this`
  // after : TS1228 (`A type predicate is only allowed in return type
  //                  position for functions and methods.`)
  set p2(x: asserts this is string);
}
```

## Conformance impact

Full suite: **12158 / 12582 (was 12144) — net +14 passing tests, no
genuine regressions.** The one apparent PASS→FAIL
(`importCallExpressionDeclarationEmit1.ts`) passes when run in isolation
— it's a known parallel-runner flake that `verify-all.sh` already
retries.

`assertionTypePredicates1.ts` itself still fails (it expects TS2775,
TS2776, TS7027 — full-feature work for the asserts predicate semantics
— and is out of scope for this PR), but the 4 spurious TS1005
diagnostics it used to emit are gone.

## What's in here

1. **`fix(parser): parse asserts type predicates in any type position`**
   The actual fix in `crates/tsz-parser/src/parser/state_types.rs`,
   plus three new unit tests in `crates/tsz-parser/tests/parser_unit_tests.rs`
   (setter parameter, type alias, ASI line-break keeps `asserts` as a
   TypeReference).
2. **`chore: fix preexisting clippy doc_markdown / duplicated_attributes`**
   Backticks for type names in lib_loader.rs doc comments and a stray
   duplicated `#[allow(clippy::too_many_arguments)]` in
   `crates/tsz-cli/src/driver/check.rs`. These were blocking
   `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
   the gate `scripts/session/verify-all.sh` runs.
3. **`scripts(session): add pick-now.sh tiny random-failure picker`**
   A zero-config wrapper alongside the existing pickers (uses
   `conformance-detail.json`, prints path/category/codes/pool/verbose
   command, auto-initialises the TypeScript submodule when missing).

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --package tsz-parser` — 668 passed
- `cargo test --package tsz-checker --lib` — 2836 passed
- `./scripts/conformance/conformance.sh run --filter "assertionTypePredicates1" --verbose` — TS1005 no longer emitted
- Full conformance: **12158 / 12582 (+14, no real regressions)**

## Test plan

- [x] Three new parser unit tests cover the setter-parameter, type-alias,
      and ASI line-break paths.
- [x] Full conformance run shows +14 net wins, no real regressions
      (one flaky parallel-only failure passes in isolation).
- [x] No checker- or solver-side changes; assignability/diagnostic
      pipelines unchanged.

https://claude.ai/code/session_01C6LtkSMozhT74Gk7vDnURV


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6LtkSMozhT74Gk7vDnURV)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
