### PR TITLE
fix(checker): stop typeof-chain TS2456 walker at structural-wrapper kinds

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -740,6 +740,25 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+            // Stop descending at AST kinds that break the "directly depends on"
+            // chain per the TypeScript spec. Type literals, function/constructor
+            // types, and mapped types wrap their inner type references inside
+            // structural members — references inside them are deferred and do
+            // NOT form a direct cycle with the surrounding alias.
+            //
+            // Mirrors `compiler/unionTypeWithRecursiveSubtypeReduction3.ts` and
+            // the legal cases in
+            // `conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`
+            // (e.g. `type T10 = { x: T10 } | { new(v: T10): string }`).
+            if matches!(
+                node.kind,
+                k if k == syntax_kind_ext::TYPE_LITERAL
+                    || k == syntax_kind_ext::FUNCTION_TYPE
+                    || k == syntax_kind_ext::CONSTRUCTOR_TYPE
+                    || k == syntax_kind_ext::MAPPED_TYPE
+            ) {
+                continue;
+            }
             // A TYPE_REFERENCE with type arguments creates a generic
             // instantiation boundary — descend into its children only if the
             // ref itself isn't the chain target.

--- a/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
+++ b/crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs
@@ -76,3 +76,28 @@ fn test_no_ts2456_when_typeof_self_referencing_var_is_value() {
         "Expected no TS2456 for merged value+type with typeof self, got: {codes:?}"
     );
 }
+
+/// Mirrors `compiler/unionTypeWithRecursiveSubtypeReduction3.ts`. When a
+/// `typeof X` alias's target variable has a UNION annotation whose recursive
+/// reference to the alias only appears in structurally-wrapped positions
+/// (e.g. `{ prop: T27 }`), tsc resolves the alias as an ordinary deferred
+/// recursive type and does NOT emit TS2456. The follow-up `var s: string = b`
+/// produces only TS2322. We must mirror this — emitting an extra TS2456 here
+/// turns a single-error test into a two-error failure.
+#[test]
+fn test_no_ts2456_when_typeof_target_has_union_with_structurally_wrapped_self_ref() {
+    let src = r#"
+        declare var a27: { prop: number } | { prop: T27 };
+        type T27 = typeof a27;
+
+        declare var b: T27;
+        var s: string = b;
+    "#;
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "tsc emits no TS2456 when `typeof <var>` references a variable whose \
+         union annotation only references the alias inside structurally-wrapped \
+         union members (e.g. `{{ prop: T27 }}`); got: {codes:?}"
+    );
+}

--- a/docs/plan/claims/fix-typeof-chain-structural-wrapper-stop-walk.md
+++ b/docs/plan/claims/fix-typeof-chain-structural-wrapper-stop-walk.md
@@ -1,0 +1,57 @@
+# fix(checker): stop typeof-chain TS2456 walker at structural-wrapper kinds
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/typeof-chain-structural-wrapper-stop-walk`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the spurious extra TS2456 on
+`compiler/unionTypeWithRecursiveSubtypeReduction3.ts` and similar tests where
+a `typeof <var>` alias's target variable has an annotation that only
+references the alias from inside a structurally-wrapped position.
+
+Per the TypeScript spec
+(`conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`):
+
+> A type query directly depends on the type of the referenced entity.
+> A type literal does NOT directly depend on its property types.
+
+`ast_finds_resolution_chain_alias` (used by
+`typeof_target_annotation_refs_resolution_chain` in
+`computed_helpers.rs`) walked through ALL child AST nodes of the target
+variable's annotation, including children of `TYPE_LITERAL`,
+`FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`, and `MAPPED_TYPE`. That made
+`type T27 = typeof a27; declare var a27: { prop: number } | { prop: T27 };`
+look like a direct circular reference even though the only self-reference
+hides inside `{ prop: T27 }`, where tsc treats it as a structurally-deferred
+recursive type.
+
+The fix stops the walker at those four wrapper kinds. Direct-dependency
+kinds (`UNION_TYPE`, `INTERSECTION_TYPE`, `ARRAY_TYPE`, `TUPLE_TYPE`,
+`TYPE_QUERY`, `TYPE_REFERENCE`) keep descending so the existing
+`type T = typeof x; var x: T[]` cycle still emits TS2456.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/type_analysis/computed_helpers.rs`
+  (~15 LOC: `ast_finds_resolution_chain_alias` skips `TYPE_LITERAL`,
+   `FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`, `MAPPED_TYPE`)
+- `crates/tsz-checker/tests/type_alias_typeof_circular_tests.rs`
+  (+22 LOC, one new test pinning the structural-wrapper case)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test type_alias_typeof_circular_tests`
+  (5 PASS)
+- `cargo nextest run -p tsz-checker -E 'test(circular)'` (25 PASS)
+- `cargo nextest run -p tsz-checker -E 'test(/type_alias|recursive|union_type|TS2456/)'`
+  (110 PASS)
+- `cargo nextest run -p tsz-checker --lib` (2852 PASS, no regressions)
+- `cargo nextest run -p tsz-core -E 'test(/circular|2456|recursive/)'`
+  (18 PASS)
+- Conformance impact: `unionTypeWithRecursiveSubtypeReduction3.ts` flips
+  from FAIL (TS2322 + extra TS2456) to PASS (TS2322 only). Other
+  candidates with the same shape may also flip.

--- a/docs/plan/claims/fix-typeof-chain-structural-wrapper-stop-walk.md
+++ b/docs/plan/claims/fix-typeof-chain-structural-wrapper-stop-walk.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/typeof-chain-structural-wrapper-stop-walk`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1355
+- **Status**: ready
 - **Workstream**: 1 (Diagnostic Conformance)
 
 ## Intent


### PR DESCRIPTION
## Summary

- `ast_finds_resolution_chain_alias` walked into every child of the target variable's annotation, including the contents of `TYPE_LITERAL`, `FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`, and `MAPPED_TYPE`. That made `type T = typeof a; declare var a: { p: T } | { p: number }` look like a direct circular reference even though the only self-reference hides inside `{ p: T }`, where tsc treats it as a structurally-deferred recursive type.
- Per the TS spec (`conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts`), type literals and function/constructor/mapped types do NOT propagate direct dependency. Stop the walker there. `UNION_TYPE` / `INTERSECTION_TYPE` / `ARRAY_TYPE` / `TUPLE_TYPE` / `TYPE_QUERY` / `TYPE_REFERENCE` keep descending so the existing `type T = typeof x; var x: T[]` cycle still emits TS2456.

## What tsc does vs what tsz did

For `compiler/unionTypeWithRecursiveSubtypeReduction3.ts`:
```ts
declare var a27: { prop: number } | { prop: T27 };
type T27 = typeof a27;
declare var b: T27;
var s: string = b;  // expected: only TS2322
```
- tsc: `[TS2322]`
- tsz before: `[TS2322, TS2456]` (extra)
- tsz after: `[TS2322]`

## Test plan

- [x] `cargo nextest run -p tsz-checker --test type_alias_typeof_circular_tests` (5 pass — 1 new + 4 pre-existing)
- [x] `cargo nextest run -p tsz-checker -E 'test(circular)'` (25 pass)
- [x] `cargo nextest run -p tsz-checker -E 'test(/type_alias|recursive|union_type|TS2456/)'` (110 pass)
- [x] `cargo nextest run -p tsz-checker --lib` (2852 pass, no regressions)
- [x] `cargo nextest run -p tsz-core -E 'test(/circular|2456|recursive/)'` (18 pass)
- [x] Pre-commit hook ran 13673 tests, all passed