### PR TITLE
fix(parser,checker,emitter): emit `[...?T]` for rest tuple with optional inner

### DIFF
--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -328,12 +328,25 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     }
                     seen_optional = true;
                     if let Some(wrapped) = self.ctx.arena.get_wrapped_type(elem_node) {
-                        let elem_type = self.check(wrapped.type_node);
+                        // OPTIONAL_TYPE wrapping REST_TYPE represents the
+                        // (invalid) `[...T?]` form. tsc still parses and
+                        // displays it as `[...?T]`, so we mark the element as
+                        // both rest and optional and unwrap the inner type.
+                        let (inner_idx, is_rest_optional) = if let Some(inner_node) =
+                            self.ctx.arena.get(wrapped.type_node)
+                            && inner_node.kind == syntax_kind_ext::REST_TYPE
+                            && let Some(inner_wrapped) = self.ctx.arena.get_wrapped_type(inner_node)
+                        {
+                            (inner_wrapped.type_node, true)
+                        } else {
+                            (wrapped.type_node, false)
+                        };
+                        let elem_type = self.check(inner_idx);
                         elements.push(TupleElement {
                             type_id: elem_type,
                             name: None,
                             optional: true,
-                            rest: false,
+                            rest: is_rest_optional,
                         });
                     }
                 } else if elem_node.kind == syntax_kind_ext::REST_TYPE {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs
@@ -289,6 +289,23 @@ fn probe_dts_tuple_labeled_optional_rest() {
 }
 
 #[test]
+fn probe_dts_tuple_optional_rest_unlabeled() {
+    // The (invalid) tuple form `[...T?]` is parsed by tsc as a rest element
+    // wrapping an optional inner type, and printed as `[...?T]` in declaration
+    // emit. Regression cover for restTupleElements1 (T09).
+    let output = emit_dts("export type T = [...string?];");
+    println!("PROBE rest+optional tuple:\n{output}");
+    assert!(output.contains("[...?string]"), "rest+optional: {output}");
+    // A trailing `?` on a non-rest tuple element must remain `[T?]`.
+    let output2 = emit_dts("export type U = [string?];");
+    println!("PROBE optional tuple:\n{output2}");
+    assert!(output2.contains("[string?]"), "optional only: {output2}");
+    // A bare rest element keeps its existing `[...T]` form.
+    let output3 = emit_dts("export type V = [...string[]];");
+    assert!(output3.contains("[...string[]]"), "rest only: {output3}");
+}
+
+#[test]
 fn probe_dts_mapped_type_as_clause() {
     let output =
         emit_dts("export type MappedWithAs<T> = { [K in keyof T as `get${string & K}`]: T[K] };");

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -615,6 +615,18 @@ impl<'a> DeclarationEmitter<'a> {
             // Optional type (T? in tuple elements)
             k if k == syntax_kind_ext::OPTIONAL_TYPE => {
                 if let Some(wrapped) = self.arena.get_wrapped_type(type_node) {
+                    // OPTIONAL_TYPE wrapping a REST_TYPE represents the
+                    // (invalid) `[...T?]` tuple form. tsc parses this and
+                    // displays it as `[...?T]` in declaration emit, so emit
+                    // the rest prefix followed by `?` then the inner type.
+                    if let Some(inner_node) = self.arena.get(wrapped.type_node)
+                        && inner_node.kind == syntax_kind_ext::REST_TYPE
+                        && let Some(inner_wrapped) = self.arena.get_wrapped_type(inner_node)
+                    {
+                        self.write("...?");
+                        self.emit_type(inner_wrapped.type_node);
+                        return;
+                    }
                     // Parenthesize complex types before `?` to avoid ambiguity
                     let needs_parens = if let Some(inner) = self.arena.get(wrapped.type_node) {
                         inner.kind == syntax_kind_ext::UNION_TYPE

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -1078,10 +1078,15 @@ impl ParserState {
 
             if self.is_identifier_or_keyword() {
                 self.next_token(); // consume identifier
-                let has_question = self.parse_optional(SyntaxKind::QuestionToken);
+                // Optional `?` may appear before `:` for labeled patterns: `...name?: T`.
+                // Only require a `:` to identify a labeled rest member; a trailing `?`
+                // without a `:` (e.g. `[...name?]`) is the optional rest type pattern,
+                // not a labeled rest, so we fall through to parse it as a regular type.
+                let _has_question = self.parse_optional(SyntaxKind::QuestionToken);
                 let has_colon = self.is_token(SyntaxKind::ColonToken);
-                if has_colon || has_question {
-                    // Labeled rest element: ...name: T - delegate to named tuple member
+                if has_colon {
+                    // Labeled rest element: ...name: T or ...name?: T -
+                    // delegate to named tuple member which re-parses from `...`.
                     self.scanner.restore_state(snapshot);
                     self.current_token = saved_token;
                     return self.parse_named_tuple_member();
@@ -1093,16 +1098,40 @@ impl ParserState {
             self.current_token = saved_token;
 
             self.next_token(); // consume ...
+            // Mirror the regular tuple element path: parse the inner type with
+            // IN_TUPLE_ELEMENT context so a postfix `?` is reserved for the
+            // tuple-level optional marker (e.g. `[...T?]`) instead of being
+            // consumed as a JSDoc nullable.
+            let saved_flags = self.context_flags;
+            self.context_flags |= crate::parser::state::CONTEXT_FLAG_IN_TUPLE_ELEMENT;
             let element_type = self.parse_type();
-            let end_pos = self.token_end();
-            return self.arena.add_wrapped_type(
+            self.context_flags = saved_flags;
+            let rest_end = self.token_end();
+            let rest_node = self.arena.add_wrapped_type(
                 syntax_kind_ext::REST_TYPE,
                 start_pos,
-                end_pos,
+                rest_end,
                 crate::parser::node::WrappedTypeData {
                     type_node: element_type,
                 },
             );
+
+            // Trailing `?` after a rest element (e.g. `[...T?]`) is invalid TS
+            // (TS17019), but tsc still parses it as an optional wrapping the
+            // rest so the type displays as `[...?T]` in declaration emit.
+            if self.parse_optional(SyntaxKind::QuestionToken) {
+                let end_pos = self.token_end();
+                return self.arena.add_wrapped_type(
+                    syntax_kind_ext::OPTIONAL_TYPE,
+                    start_pos,
+                    end_pos,
+                    crate::parser::node::WrappedTypeData {
+                        type_node: rest_node,
+                    },
+                );
+            }
+
+            return rest_node;
         }
 
         // Check if this is a named tuple element: name: T or name?: T

--- a/docs/plan/claims/fix-parser-checker-emitter-rest-tuple-optional.md
+++ b/docs/plan/claims/fix-parser-checker-emitter-rest-tuple-optional.md
@@ -1,0 +1,32 @@
+# fix(parser,checker,emitter): emit `[...?T]` for rest tuple with optional inner
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/parser-checker-emitter-rest-tuple-optional`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (JS Emit And Declaration Emit Pass Rate)
+
+## Intent
+
+The (invalid) tuple form `[...T?]` is parsed by tsc as a rest element wrapping
+an optional inner type and printed as `[...?T]` in declaration emit. tsz was
+mishandling it across three layers, producing output like `[...string?: ]` or
+`[...string?]`. This change fixes the parser to detect and represent the
+pattern, the checker to flatten the `OPTIONAL_TYPE`-over-`REST_TYPE` shape into
+a single tuple element with both flags set, and the declaration emitter to
+print the canonical `[...?T]` form. Unblocks `restTupleElements1` in the
+declaration-emit suite.
+
+## Files Touched
+
+- `crates/tsz-parser/src/parser/state_types.rs` (~25 LOC)
+- `crates/tsz-checker/src/types/type_node.rs` (~15 LOC)
+- `crates/tsz-emitter/src/declaration_emitter/type_emission.rs` (~14 LOC)
+- `crates/tsz-emitter/src/declaration_emitter/tests/probes_issues.rs` (~17 LOC, regression test)
+
+## Verification
+
+- `cargo nextest run -p tsz-parser --lib` (666 tests pass)
+- `cargo nextest run -p tsz-checker --lib` (2854 tests pass)
+- `cargo nextest run -p tsz-emitter --lib` (1607 tests pass)
+- `scripts/emit/run.sh --filter restTupleElements1` (DTS now passes)

--- a/docs/plan/claims/fix-parser-checker-emitter-rest-tuple-optional.md
+++ b/docs/plan/claims/fix-parser-checker-emitter-rest-tuple-optional.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/parser-checker-emitter-rest-tuple-optional`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1356
+- **Status**: ready
 - **Workstream**: 2 (JS Emit And Declaration Emit Pass Rate)
 
 ## Intent


### PR DESCRIPTION
## Summary

- Fix the multi-layer bug where the (invalid) tuple form `[...T?]` was emitted as `[...string?: ]` or `[...string?]` instead of the tsc-canonical `[...?T]` shape in declaration emit.
- Tightens the parser lookahead so a trailing `?` without a `:` after `...identifier` is treated as the optional marker rather than a labeled-rest member, threads `IN_TUPLE_ELEMENT` context into the rest path so the inner type does not eat the `?` as a JSDoc nullable, propagates the `rest` flag in the checker when an `OPTIONAL_TYPE` wraps a `REST_TYPE`, and updates the declaration emitter to print the canonical `...?T` ordering for that shape.
- Unblocks `restTupleElements1` in the declaration-emit suite (was `+1/-1` lines fail).

## Test plan

- [x] `cargo nextest run -p tsz-parser --lib` (666 tests pass)
- [x] `cargo nextest run -p tsz-checker --lib` (2854 tests pass)
- [x] `cargo nextest run -p tsz-emitter --lib` (1607 tests pass) including new `probe_dts_tuple_optional_rest_unlabeled` regression
- [x] `scripts/emit/run.sh --filter restTupleElements1` passes both JS and DTS
- [x] No regressions in `--filter tuple`, `--filter optional`, `--filter variadicTuple` runs (all previously-failing tests still in their pre-existing state)