### PR TITLE
fix(checker): expand Application-backed Intersection for branded-primitive TS2739 messages

### DIFF
--- a/crates/tsz-binder/tests/lib_loader.rs
+++ b/crates/tsz-binder/tests/lib_loader.rs
@@ -239,7 +239,7 @@ fn get_suggested_lib_default_es2015() {
     assert_eq!(get_suggested_lib_for_type(""), "es2015");
 }
 
-/// SharedArrayBuffer family is es2017.
+/// `SharedArrayBuffer` family is es2017.
 #[test]
 fn get_suggested_lib_shared_array_buffer_is_es2017() {
     assert_eq!(get_suggested_lib_for_type("SharedArrayBuffer"), "es2017");
@@ -250,7 +250,7 @@ fn get_suggested_lib_shared_array_buffer_is_es2017() {
     assert_eq!(get_suggested_lib_for_type("Atomics"), "es2017");
 }
 
-/// AsyncGenerator family is es2018.
+/// `AsyncGenerator` family is es2018.
 #[test]
 fn get_suggested_lib_async_generator_is_es2018() {
     assert_eq!(get_suggested_lib_for_type("AsyncGenerator"), "es2018");
@@ -264,7 +264,7 @@ fn get_suggested_lib_async_generator_is_es2018() {
     );
 }
 
-/// BigInt family is es2020.
+/// `BigInt` family is es2020.
 #[test]
 fn get_suggested_lib_bigint_is_es2020() {
     assert_eq!(get_suggested_lib_for_type("BigInt"), "es2020");
@@ -281,7 +281,7 @@ fn get_suggested_lib_bigint_is_es2020() {
     );
 }
 
-/// FinalizationRegistry / WeakRef / AggregateError / ErrorOptions are es2021.
+/// `FinalizationRegistry` / `WeakRef` / `AggregateError` / `ErrorOptions` are es2021.
 #[test]
 fn get_suggested_lib_finalization_family_is_es2021() {
     assert_eq!(get_suggested_lib_for_type("FinalizationRegistry"), "es2021");
@@ -299,7 +299,7 @@ fn get_suggested_lib_finalization_family_is_es2021() {
     assert_eq!(get_suggested_lib_for_type("ErrorOptions"), "es2021");
 }
 
-/// Disposable / AsyncDisposable suggest `esnext`.
+/// `Disposable` / `AsyncDisposable` suggest `esnext`.
 #[test]
 fn get_suggested_lib_disposable_is_esnext() {
     assert_eq!(get_suggested_lib_for_type("Disposable"), "esnext");

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -31,6 +31,34 @@ impl<'a> CheckerState<'a> {
         formatter.format(type_id).into_owned()
     }
 
+    /// Format an Intersection type that has an Application display_alias, showing the
+    /// structural intersection form (not the application alias). Matches tsc's behavior
+    /// for branded primitive types in assignability messages: e.g., `Brand<T>` displayed
+    /// as `Number & { __brand: T }` with widened member types and capitalized primitives.
+    fn format_intersection_expanding_application_alias(&mut self, type_id: TypeId) -> String {
+        let mut formatter = self
+            .ctx
+            .create_diagnostic_type_formatter()
+            .with_skip_application_alias_for_intersections()
+            .with_capitalize_primitive_intersection_members()
+            .with_preserve_optional_parameter_surface_syntax(false);
+        formatter.format(type_id).into_owned()
+    }
+
+    /// Returns true if the intersection type at `type_id` has at least one
+    /// primitive member (number, string, or boolean). Used to distinguish
+    /// branded primitive intersections (e.g. `number & { __brand: T }`) from
+    /// intersections of only non-primitive types (e.g. `ClassAlias & FnAlias`).
+    fn intersection_has_primitive_member(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::intersection_members(self.ctx.types, type_id).is_some_and(
+            |members| {
+                members
+                    .iter()
+                    .any(|&m| m == TypeId::NUMBER || m == TypeId::STRING || m == TypeId::BOOLEAN)
+            },
+        )
+    }
+
     pub(crate) fn truncate_property_receiver_display(display: String) -> String {
         const MAX_PROPERTY_RECEIVER_DISPLAY_CHARS: usize = 320;
         let should_truncate = display.starts_with("Omit<") || display.starts_with("merge<");
@@ -347,6 +375,28 @@ impl<'a> CheckerState<'a> {
         if let Some(alias_name) = self.lookup_type_alias_name_for_display(display_ty) {
             return alias_name;
         }
+
+        // Application-backed primitive Intersection: when an Application (e.g.
+        // `Brand<T>`) evaluates to an Intersection that contains at least one
+        // primitive member (number/string/boolean), tsc always shows the structural
+        // intersection form with capitalized primitives and widened member types.
+        // e.g. `Brand<{ view: 0; }>` → `Number & { __brand: { view: number; }; }`
+        //
+        // Intersections of only non-primitive types (e.g. `ClassAlias & FnAlias`)
+        // should still show the Application alias name.
+        if crate::query_boundaries::common::is_intersection_type(self.ctx.types, display_ty)
+            && self
+                .ctx
+                .types
+                .get_display_alias(display_ty)
+                .is_some_and(|alias| {
+                    crate::query_boundaries::common::is_generic_application(self.ctx.types, alias)
+                })
+            && self.intersection_has_primitive_member(display_ty)
+        {
+            return self.format_intersection_expanding_application_alias(display_ty);
+        }
+
         if is_generic_callable(self, display_ty)
             && self
                 .ctx

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -1172,6 +1172,19 @@ impl<'a> TypeFormatter<'a> {
     /// Format an intersection member, parenthesizing union types.
     /// `(A | B) & (C | D)` is semantically different from `A | B & C | D`.
     fn format_intersection_member(&mut self, id: TypeId) -> String {
+        // tsc displays primitive members of intersection types using their apparent
+        // (boxed) names: `number` → `Number`, `string` → `String`, `boolean` → `Boolean`.
+        if self.capitalize_primitive_intersection_members {
+            if id == TypeId::NUMBER {
+                return "Number".to_string();
+            }
+            if id == TypeId::STRING {
+                return "String".to_string();
+            }
+            if id == TypeId::BOOLEAN {
+                return "Boolean".to_string();
+            }
+        }
         let formatted = self.format(id);
         // Only parenthesize if the type is a union AND the formatted result
         // actually contains `|` (i.e., wasn't collapsed to a named alias).

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -106,6 +106,16 @@ pub struct TypeFormatter<'a> {
     /// type and the current type is an Object. Used for TS2741 messages where
     /// tsc shows the merged object form instead of the intersection form.
     skip_intersection_display_alias: bool,
+    /// When true, don't follow `display_alias` when it points to an Application
+    /// type and the current type is an Intersection. Used for TS2739 messages
+    /// where tsc shows the structural `Number & { __brand: T }` form instead of
+    /// the branded alias `Brand<T>`.
+    skip_application_alias_for_intersections: bool,
+    /// When true, format the primitive members of an intersection type using their
+    /// apparent/boxed names: `Number` instead of `number`, `String` instead of
+    /// `string`, `Boolean` instead of `boolean`. tsc always uses the capitalized
+    /// forms for primitive members in intersection type display.
+    capitalize_primitive_intersection_members: bool,
     /// When true, preserve a longer generic alias prefix while eliding nested
     /// structural object branches. Used for long property receiver diagnostics.
     long_property_receiver_display: bool,
@@ -135,6 +145,8 @@ impl<'a> TypeFormatter<'a> {
             preserve_array_generic_form: false,
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
+            skip_application_alias_for_intersections: false,
+            capitalize_primitive_intersection_members: false,
             long_property_receiver_display: false,
             long_property_receiver_object_elision_end_depth: 26,
         }
@@ -319,6 +331,8 @@ impl<'a> TypeFormatter<'a> {
             preserve_array_generic_form: false,
             skip_application_alias_names: false,
             skip_intersection_display_alias: false,
+            skip_application_alias_for_intersections: false,
+            capitalize_primitive_intersection_members: false,
             long_property_receiver_display: false,
             long_property_receiver_object_elision_end_depth: 26,
         }
@@ -428,6 +442,22 @@ impl<'a> TypeFormatter<'a> {
     /// in TS2741 messages, not the intersection form.
     pub const fn with_skip_intersection_display_alias(mut self) -> Self {
         self.skip_intersection_display_alias = true;
+        self
+    }
+
+    /// Don't follow `display_alias` when the current type is an Intersection
+    /// and the alias points to an Application. tsc shows the structural
+    /// `Number & { __brand: T }` form instead of the branded alias `Brand<T>`.
+    pub const fn with_skip_application_alias_for_intersections(mut self) -> Self {
+        self.skip_application_alias_for_intersections = true;
+        self
+    }
+
+    /// Show capitalized primitive names (`Number`, `String`, `Boolean`) for
+    /// primitive members of intersection types, matching tsc's apparent-type
+    /// display for branded primitives in error messages.
+    pub const fn with_capitalize_primitive_intersection_members(mut self) -> Self {
+        self.capitalize_primitive_intersection_members = true;
         self
     }
 
@@ -815,12 +845,18 @@ impl<'a> TypeFormatter<'a> {
                     false
                 };
 
-            let skip_intersection_alias = self.skip_intersection_display_alias
+            let skip_intersection_alias = (self.skip_intersection_display_alias
                 && matches!(
                     self.interner.lookup(alias_origin),
                     Some(TypeData::Intersection(_))
                 )
-                && matches!(&key, TypeData::Object(_) | TypeData::ObjectWithIndex(_));
+                && matches!(&key, TypeData::Object(_) | TypeData::ObjectWithIndex(_)))
+                || (self.skip_application_alias_for_intersections
+                    && matches!(
+                        self.interner.lookup(alias_origin),
+                        Some(TypeData::Application(_))
+                    )
+                    && matches!(&key, TypeData::Intersection(_)));
 
             // Skip the alias chase when the alias points to a distributive
             // conditional Application that will distribute (boolean or union

--- a/crates/tsz-solver/src/diagnostics/format/tests.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests.rs
@@ -516,6 +516,70 @@ fn format_intersection_preserves_named_types() {
     );
 }
 
+#[test]
+fn capitalize_primitive_intersection_members_number() {
+    // tsc shows `Number` (capitalized) for `number` members in intersections
+    let db = TypeInterner::new();
+    let brand_prop = PropertyInfo::new(db.intern_string("__brand"), TypeId::STRING);
+    let obj = db.factory().object(vec![brand_prop]);
+    let intersection = db.intersection2(TypeId::NUMBER, obj);
+
+    let mut fmt = TypeFormatter::new(&db).with_capitalize_primitive_intersection_members();
+    let result = fmt.format(intersection);
+    assert!(
+        result.starts_with("Number"),
+        "Primitive member `number` should be capitalized to `Number` in intersections, got: {result}"
+    );
+}
+
+#[test]
+fn capitalize_primitive_intersection_members_string() {
+    let db = TypeInterner::new();
+    let brand_prop = PropertyInfo::new(db.intern_string("tag"), TypeId::NUMBER);
+    let obj = db.factory().object(vec![brand_prop]);
+    let intersection = db.intersection2(TypeId::STRING, obj);
+
+    let mut fmt = TypeFormatter::new(&db).with_capitalize_primitive_intersection_members();
+    let result = fmt.format(intersection);
+    assert!(
+        result.starts_with("String"),
+        "Primitive member `string` should be capitalized to `String`, got: {result}"
+    );
+}
+
+#[test]
+fn skip_application_alias_for_intersections_expands_branded_primitive() {
+    // When skip_application_alias_for_intersections is set, an Intersection
+    // whose display_alias points to an Application should show the structural form.
+    let db = TypeInterner::new();
+    let brand_prop = PropertyInfo::new(db.intern_string("__brand"), TypeId::STRING);
+    let obj = db.factory().object(vec![brand_prop]);
+    let intersection = db.intersection2(TypeId::NUMBER, obj);
+
+    // Simulate Brand<string> → number & { __brand: string } with display_alias
+    let app = db.application(db.lazy(crate::def::DefId(1)), vec![TypeId::STRING]);
+    db.store_display_alias(intersection, app);
+
+    // Without flag: follows alias and would format the application
+    // With flag: shows structural intersection instead
+    let mut fmt = TypeFormatter::new(&db)
+        .with_skip_application_alias_for_intersections()
+        .with_capitalize_primitive_intersection_members();
+    let result = fmt.format(intersection);
+    assert!(
+        result.contains(" & "),
+        "Should show structural intersection, not application alias, got: {result}"
+    );
+    assert!(
+        result.starts_with("Number"),
+        "Primitive member should be capitalized, got: {result}"
+    );
+    assert!(
+        result.contains("__brand"),
+        "Object member should be visible, got: {result}"
+    );
+}
+
 // =================================================================
 // Object type formatting
 // =================================================================

--- a/docs/plan/claims/claude-exciting-keller-raRPb.md
+++ b/docs/plan/claims/claude-exciting-keller-raRPb.md
@@ -1,0 +1,36 @@
+# fix(checker): expand Application-backed Intersection for branded-primitive TS2739 messages
+
+- **Date**: 2026-04-26
+- **Branch**: `claude/exciting-keller-raRPb`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: conformance fingerprint parity
+
+## Intent
+
+tsc always shows the structural Intersection form (e.g. `Number & { __brand: T }`) for branded
+primitive types in TS2739 assignability messages, rather than the Application alias form
+(e.g. `Brand<T>`). This PR fixes the type formatter to:
+1. Skip Application display-alias for Intersections that contain at least one primitive member.
+2. Capitalize primitive members in intersections (`number` → `Number`, `string` → `String`,
+   `boolean` → `Boolean`), matching tsc's apparent-type display for branded primitives.
+
+Root cause: the display_alias mechanism redirected branded Intersection types back to their
+Application origin. The check was missing for the Intersection-with-Application-alias case
+(only the Object-with-Intersection-alias case was handled).
+
+## Files Touched
+
+- `crates/tsz-solver/src/diagnostics/format/mod.rs` — new flags and skip logic
+- `crates/tsz-solver/src/diagnostics/format/compound.rs` — primitive capitalization in intersection members
+- `crates/tsz-solver/src/diagnostics/format/tests.rs` — 3 new unit tests
+- `crates/tsz-checker/src/error_reporter/core_formatting.rs` — detection + dispatch for the new path
+
+## Verification
+
+- `cargo check --package tsz-checker` — clean
+- `cargo check --package tsz-solver` — clean
+- `cargo test --package tsz-solver -- capitalize_primitive skip_application_alias` — 3 pass
+- `./scripts/conformance/conformance.sh run --filter intersectionAsWeakTypeSource --verbose` — PASS
+- `./scripts/conformance/conformance.sh run --max 200` — 200/200, no regressions
+- Full suite: see PR CI


### PR DESCRIPTION
## Summary

- **Root cause**: The `display_alias` skip logic only covered the `Object`+`Intersection` case (TS2741 path). When a branded primitive like `Brand<T> = number & { __brand: T }` is used in a TS2739 message, the Intersection stored a `display_alias` pointing back to the `Application`, causing the formatter to display `Brand<T>` instead of the structural form `Number & { __brand: T }` that tsc uses.
- **Fix**: Extended `skip_intersection_alias` in `TypeFormatter` to also skip `display_alias` when the current type is an `Intersection` whose alias points to an `Application` — but only when the intersection contains at least one primitive member (to avoid incorrectly expanding non-primitive branded intersections like `Wat<T> = ClassAlias<T> & FnAlias<T>`).
- **Primitive capitalization**: Added a formatter flag to capitalize `number`→`Number`, `string`→`String`, `boolean`→`Boolean` for intersection members, matching tsc's apparent-type display for branded primitives.

## Files changed

| File | Change |
|------|--------|
| `crates/tsz-solver/src/diagnostics/format/mod.rs` | New `skip_application_alias_for_intersections` and `capitalize_primitive_intersection_members` flags + extended `skip_intersection_alias` check |
| `crates/tsz-solver/src/diagnostics/format/compound.rs` | Primitive capitalization in `format_intersection_member` |
| `crates/tsz-solver/src/diagnostics/format/tests.rs` | 3 new unit tests |
| `crates/tsz-checker/src/error_reporter/core_formatting.rs` | Detection via boundary helpers (`is_generic_application`, `is_intersection_type`, `intersection_members`) + dispatch to new formatter path |
| `crates/tsz-binder/tests/lib_loader.rs` | Fix 8 pre-existing `doc_markdown` clippy warnings |
| `docs/plan/claims/claude-exciting-keller-raRPb.md` | Claim file |

## Test plan

- [x] 3 new unit tests in `tsz-solver` pass (`capitalize_primitive_intersection_members_number`, `capitalize_primitive_intersection_members_string`, `skip_application_alias_for_intersections_expands_branded_primitive`)
- [x] `intersectionAsWeakTypeSource` conformance test: PASS
- [x] `aliasInstantiationExpressionGenericIntersectionNoCrash2` (non-primitive intersection case): PASS — no false expansion
- [x] Pre-existing `valueOfTypedArray.ts` failure confirmed pre-existing (fails without this change too; snapshot was stale)
- [x] `cargo clippy` clean (zero warnings)
- [x] Architecture guardrails pass (no forbidden cross-layer patterns)

https://claude.ai/code/session_01LrbEQy442PjJBzbrKgwfcJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrbEQy442PjJBzbrKgwfcJ)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
