### PR TITLE
fix(parser,emitter): drop empty shorthand from extra commas in object literal

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -56,5 +56,9 @@ path = "tests/export_equals_type_only_namespace.rs"
 name = "cjs_hoisted_var_position_tests"
 path = "tests/cjs_hoisted_var_position_tests.rs"
 
+[[test]]
+name = "object_literal_recovery_tests"
+path = "tests/object_literal_recovery_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -623,6 +623,18 @@ impl<'a> Printer<'a> {
                 let Some(prop_node) = self.arena.get(prop) else {
                     continue;
                 };
+                // Skip error-recovery shorthand placeholders synthesized when the parser
+                // encounters an unexpected non-name token (e.g. extra commas: `{ x: 0,, }`).
+                // The synthesized Identifier name has zero width (pos == end) and an empty
+                // text — emitting it would produce stray commas in the output.
+                if prop_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT
+                    && let Some(shorthand) = self.arena.get_shorthand_property(prop_node)
+                    && let Some(name_node) = self.arena.get(shorthand.name)
+                    && name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                    && name_node.pos == name_node.end
+                {
+                    continue;
+                }
                 // Emit leading comments before the first property (e.g. /** own x*/)
                 if i == 0 {
                     self.emit_unemitted_comments_between(open_brace_end, prop_node.pos);

--- a/crates/tsz-emitter/tests/object_literal_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/object_literal_recovery_tests.rs
@@ -1,0 +1,75 @@
+//! Integration tests for object-literal emit error recovery.
+//!
+//! When the parser encounters an unexpected token in property-name position
+//! (e.g. extra commas: `{ x: 0,, }`), it emits a `TS1136 Property assignment
+//! expected` diagnostic and synthesizes a placeholder `SHORTHAND_PROPERTY_ASSIGNMENT`.
+//! The emitter must NOT print stray commas/text from these zero-width
+//! placeholders. This guards the parser/emitter coordination that fixes
+//! the `parseErrorDoubleCommaInCall` conformance test.
+//!
+//! See:
+//! - `crates/tsz-parser/src/parser/state_expressions_literals.rs`
+//!   (`parse_property_name`)
+//! - `crates/tsz-emitter/src/emitter/expressions/literals.rs`
+//!   (`emit_object_literal` skip-empty-shorthand guard)
+
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn print_es2015(source: &str) -> String {
+    parse_and_print_with_opts(source, PrintOptions::es6())
+}
+
+/// Source `Boolean({ x: 0,, });` (TypeScript test
+/// `parseErrorDoubleCommaInCall.ts`) must emit the same `Boolean({ x: 0, });`
+/// shape that tsc produces — no stray `,,` placeholder line.
+#[test]
+fn double_comma_in_call_does_not_emit_stray_commas() {
+    let source = "Boolean({\n    x: 0,,\n});\n";
+    let output = print_es2015(source);
+    assert!(
+        !output.contains(",,"),
+        "double comma should not survive emit; output:\n{output}"
+    );
+    assert!(
+        output.contains("x: 0"),
+        "first property must still be emitted; output:\n{output}"
+    );
+}
+
+/// Trailing `,,}` at end of object literal must collapse to a single trailing
+/// comma (or none) — never produce extra empty lines with commas.
+#[test]
+fn trailing_double_comma_collapses() {
+    let source = "var o = { a: 1,, };\n";
+    let output = print_es2015(source);
+    assert!(
+        !output.contains(",,"),
+        "trailing double comma should not survive emit; output:\n{output}"
+    );
+    assert!(
+        output.contains("a: 1"),
+        "valid property must still be emitted; output:\n{output}"
+    );
+}
+
+/// Object literal followed by close-brace immediately after a comma in source
+/// (`{ a: 1, }`) must continue to emit normally — this guards that the
+/// recovery fix doesn't disturb the legitimate trailing-comma path.
+#[test]
+fn legitimate_trailing_comma_preserved() {
+    let source = "var o = { a: 1, b: 2, };\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("a: 1"),
+        "first property must be emitted; output:\n{output}"
+    );
+    assert!(
+        output.contains("b: 2"),
+        "second property must be emitted; output:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -3849,6 +3849,31 @@ impl ParserState {
                         "Property assignment expected.",
                         diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
                     );
+                    // For object-literal terminators/separators (`,`, `}`, `;`, EOF), do NOT
+                    // consume the token. Consuming a `,` here causes us to synthesize a
+                    // SHORTHAND_PROPERTY_ASSIGNMENT with an empty name, which then prints
+                    // the source-text comma in the emitted output (e.g. `{ x: 0,, }` →
+                    // `{ x: 0,\n    ,, }`). Returning an empty Identifier without consuming
+                    // lets the outer object-literal loop see the separator and recover.
+                    if matches!(
+                        self.token(),
+                        SyntaxKind::CommaToken
+                            | SyntaxKind::CloseBraceToken
+                            | SyntaxKind::SemicolonToken
+                            | SyntaxKind::EndOfFileToken
+                    ) {
+                        return self.arena.add_identifier(
+                            SyntaxKind::Identifier as u16,
+                            start_pos,
+                            start_pos,
+                            IdentifierData {
+                                atom: self.scanner.interner_mut().intern(""),
+                                escaped_text: String::new(),
+                                original_text: None,
+                                type_arguments: None,
+                            },
+                        );
+                    }
                 }
 
                 // OPTIMIZATION: Capture atom for O(1) comparison

--- a/docs/plan/claims/fix-parser-emitter-empty-shorthand-from-comma.md
+++ b/docs/plan/claims/fix-parser-emitter-empty-shorthand-from-comma.md
@@ -1,0 +1,65 @@
+# fix(parser,emitter): drop synthesized empty shorthand from extra commas in object literal
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/parser-emitter-empty-shorthand-from-comma`
+- **PR**: (to be created)
+- **Status**: claim
+- **Workstream**: 2 (JS Emit pass rate)
+
+## Intent
+
+Source `Boolean({ x: 0,, });` (TypeScript test `parseErrorDoubleCommaInCall`)
+emitted `Boolean({\n    x: 0,\n    ,,\n});` instead of tsc's
+`Boolean({\n    x: 0,\n});`. The cause is a coordination bug between parser
+error recovery and emitter:
+
+1. `parse_property_name` on a `,` token consumes the comma and synthesizes a
+   fake `Identifier` node that wraps it. `parse_property_assignment` then
+   wraps that into a `SHORTHAND_PROPERTY_ASSIGNMENT` whose source text is
+   the comma itself.
+2. The object-literal emitter prints this synthesized shorthand using the
+   source text (and the `find_token_end_before_trivia` heuristic that asks
+   "is the previous byte a comma?"), producing the stray `,,` line.
+
+## Fix
+
+Two coordinated, behavior-preserving changes:
+
+- **Parser** (`state_expressions_literals.rs::parse_property_name`): when the
+  current token is one of the object-literal terminators/separators
+  (`,`, `}`, `;`, EOF), emit the `TS1136 Property assignment expected`
+  diagnostic but do NOT consume the token. Return a zero-width empty
+  `Identifier` so the outer `parse_object_literal` loop sees the separator
+  and recovers cleanly.
+- **Emitter** (`expressions/literals.rs::emit_object_literal`): skip
+  `SHORTHAND_PROPERTY_ASSIGNMENT` placeholders whose name is a zero-width
+  empty `Identifier`. These are unambiguously the parser's synthesized
+  recovery placeholders and have no source text to print.
+
+This satisfies CLAUDE.md §13 (the emitter still owns formatting decisions
+and never performs semantic validation; it only filters placeholder nodes
+the parser flagged as recovery artifacts).
+
+## Files Touched
+
+- `crates/tsz-parser/src/parser/state_expressions_literals.rs` (~20 LOC,
+  conditional in `parse_property_name`'s `_` branch).
+- `crates/tsz-emitter/src/emitter/expressions/literals.rs` (~10 LOC, guard
+  in the multi-line object literal emit loop).
+- `crates/tsz-emitter/tests/object_literal_recovery_tests.rs` (new file,
+  3 regression tests).
+- `crates/tsz-emitter/Cargo.toml` (register the new test target).
+
+## Verification
+
+- `cargo nextest run -p tsz-parser --lib` — 666 tests pass.
+- `cargo nextest run -p tsz-emitter --lib` — 1606 tests pass.
+- `cargo nextest run -p tsz-emitter --test object_literal_recovery_tests`
+  — 3 new tests pass.
+- `./scripts/emit/run.sh --filter=parseErrorDoubleCommaInCall --js-only`
+  — 1/1 passes (was 0/1 before fix).
+- `./scripts/emit/run.sh --filter=objectLiteral --js-only` — 135/162 pass
+  (no regressions vs baseline).
+- `./scripts/emit/run.sh --filter=parseError --js-only` — 3/7 pass (was 2/7
+  before fix; the new pass is `parseErrorDoubleCommaInCall`, no other tests
+  changed).

--- a/docs/plan/claims/fix-parser-emitter-empty-shorthand-from-comma.md
+++ b/docs/plan/claims/fix-parser-emitter-empty-shorthand-from-comma.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/parser-emitter-empty-shorthand-from-comma`
-- **PR**: (to be created)
-- **Status**: claim
+- **PR**: #1360
+- **Status**: ready
 - **Workstream**: 2 (JS Emit pass rate)
 
 ## Intent


### PR DESCRIPTION
## Summary

Source `Boolean({ x: 0,, });` (TypeScript test `parseErrorDoubleCommaInCall`) emitted `Boolean({ x: 0,\n    ,, });` instead of tsc's `Boolean({ x: 0, });`. Two coordinated, behavior-preserving fixes:

- **Parser** (`state_expressions_literals.rs::parse_property_name`): when the current token is an object-literal terminator (`,`, `}`, `;`, EOF) in property-name position, emit the `TS1136` diagnostic but do NOT consume the token. Return a zero-width empty `Identifier` so the outer `parse_object_literal` loop sees the separator and recovers cleanly.
- **Emitter** (`expressions/literals.rs::emit_object_literal`): skip `SHORTHAND_PROPERTY_ASSIGNMENT` placeholders whose name is a zero-width empty `Identifier`. These are unambiguously parser-recovery artifacts with no source text to print.

This satisfies CLAUDE.md §13 — the emitter only filters placeholder nodes flagged by the parser, never performs semantic validation.

Adds `tests/object_literal_recovery_tests.rs` with 3 regression integration tests (one for the original failing case, one for `{ a: 1,, }`, one for the legitimate `{ a: 1, b: 2, }` trailing-comma path to guard against over-broad filtering).

## Impact

- `parseErrorDoubleCommaInCall` JS emit test now passes (was failing).
- `objectLiteral` filter: 135/162 (unchanged from baseline — no regressions).
- `parseError` filter: 3/7 (was 2/7 — net +1 from the fixed test).
- All 666 `tsz-parser` lib tests pass.
- All 1606 `tsz-emitter` lib tests pass.
- All 3 new integration tests pass.

## Test plan

- [x] `cargo nextest run -p tsz-parser --lib`
- [x] `cargo nextest run -p tsz-emitter --lib`
- [x] `cargo nextest run -p tsz-emitter --test object_literal_recovery_tests`
- [x] `./scripts/emit/run.sh --filter=parseErrorDoubleCommaInCall --js-only`
- [x] `./scripts/emit/run.sh --filter=objectLiteral --js-only` (no regressions)
- [x] `./scripts/conformance/conformance.sh run --filter "parseError"` (3/3 pass)