### PR TITLE
fix(checker): emit TS1100 for arguments/eval in destructuring patterns

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -64,6 +64,10 @@ name = "ts1210_arguments_param_in_class_tests"
 path = "tests/ts1210_arguments_param_in_class_tests.rs"
 
 [[test]]
+name = "ts1100_destructuring_arguments_tests"
+path = "tests/ts1100_destructuring_arguments_tests.rs"
+
+[[test]]
 name = "ts2307_per_site_dedup_tests"
 path = "tests/ts2307_per_site_dedup_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1313,6 +1313,22 @@ impl<'a> CheckerState<'a> {
             self.check_strict_mode_reserved_name_at(element_data.name, element_data.name);
         }
 
+        // TS1100: Check binding element name for `eval` or `arguments` in strict mode.
+        // Covers destructuring patterns like `var { arguments } = ...` and
+        // `var [eval] = [1]` in strict mode. tsc emits this as a grammar error on
+        // the destructured identifier, so we mirror it here. In non-ambient class
+        // bodies, `arguments` becomes TS1210 (handled by emit_eval_or_arguments_strict_mode_error).
+        if let Some(name_node) = self.ctx.arena.get(element_data.name)
+            && name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+            && let Some(ident) = self.ctx.arena.get_identifier(name_node)
+            && crate::state_checking::is_eval_or_arguments(&ident.escaped_text)
+            && self.is_strict_mode_for_node(element_data.name)
+            && !self.ctx.is_declaration_file()
+        {
+            let name = ident.escaped_text.clone();
+            self.emit_eval_or_arguments_strict_mode_error(element_data.name, &name);
+        }
+
         // If the name is a nested binding pattern, recursively check it
         if let Some(name_node) = self.ctx.arena.get(element_data.name)
             && (name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN

--- a/crates/tsz-checker/tests/ts1100_destructuring_arguments_tests.rs
+++ b/crates/tsz-checker/tests/ts1100_destructuring_arguments_tests.rs
@@ -1,0 +1,139 @@
+//! TS1100 regression tests for `arguments`/`eval` used as a binding name in
+//! a destructuring pattern. tsc emits "Invalid use of 'arguments' in strict
+//! mode." for these forms; the simple `var arguments` path is already covered
+//! by `state/variable_checking/core.rs`, but destructuring patterns flow
+//! through `check_binding_element_with_request` and previously skipped the
+//! TS1100 check entirely. See conformance test
+//! `emitArrowFunctionWhenUsingArguments17_ES6` for the original target.
+//!
+//! Outside strict mode, none of these forms should fire TS1100.
+
+use tsz_checker::test_utils::{check_source_code_messages as get_diagnostics, check_with_options};
+use tsz_common::CheckerOptions;
+
+#[test]
+fn arguments_in_object_destructuring_emits_ts1100_in_strict_mode() {
+    // The conformance target: `var { arguments } = { arguments: "hello" };`
+    // inside a strict-mode function body.
+    let source = r#"
+"use strict";
+function f() {
+    var { arguments } = { arguments: "hello" };
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts1100_arguments: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("arguments"))
+        .collect();
+    assert!(
+        !ts1100_arguments.is_empty(),
+        "expected TS1100 for `arguments` in object-destructuring binding (strict mode); got: {diags:#?}"
+    );
+}
+
+#[test]
+fn eval_in_object_destructuring_emits_ts1100_in_strict_mode() {
+    let source = r#"
+"use strict";
+function f() {
+    var { eval } = { eval: "hello" };
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts1100_eval: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("'eval'"))
+        .collect();
+    assert!(
+        !ts1100_eval.is_empty(),
+        "expected TS1100 for `eval` in object-destructuring binding (strict mode); got: {diags:#?}"
+    );
+}
+
+#[test]
+fn arguments_in_array_destructuring_emits_ts1100_in_strict_mode() {
+    let source = r#"
+"use strict";
+function f() {
+    var [arguments] = ["hello"];
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts1100_arguments: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("arguments"))
+        .collect();
+    assert!(
+        !ts1100_arguments.is_empty(),
+        "expected TS1100 for `arguments` in array-destructuring binding (strict mode); got: {diags:#?}"
+    );
+}
+
+#[test]
+fn arguments_in_destructuring_renaming_emits_ts1100_in_strict_mode() {
+    // `{ x: arguments }` renames `x` to local binding `arguments`. The bound
+    // name is what matters for TS1100, not the property name.
+    let source = r#"
+"use strict";
+function f() {
+    var { x: arguments } = { x: "hello" };
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts1100_arguments: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("arguments"))
+        .collect();
+    assert!(
+        !ts1100_arguments.is_empty(),
+        "expected TS1100 for `{{ x: arguments }}` renaming binding (strict mode); got: {diags:#?}"
+    );
+}
+
+#[test]
+fn arguments_in_destructuring_no_ts1100_outside_strict_mode() {
+    // No `"use strict"` directive AND `always_strict` disabled — tsc does not
+    // emit TS1100 for `arguments` in a non-strict-mode binding.
+    let source = r#"
+function f() {
+    var { arguments } = { arguments: "hello" };
+}
+"#;
+    let opts = CheckerOptions {
+        always_strict: false,
+        ..Default::default()
+    };
+    let diags: Vec<(u32, String)> = check_with_options(source, opts)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect();
+    let ts1100_arguments: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("arguments"))
+        .collect();
+    assert!(
+        ts1100_arguments.is_empty(),
+        "TS1100 should NOT fire for `arguments` destructuring outside strict mode; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn nested_destructuring_arguments_emits_ts1100_in_strict_mode() {
+    // Nested destructuring: the inner `arguments` should still be caught.
+    let source = r#"
+"use strict";
+function f() {
+    var { a: { arguments } } = { a: { arguments: "x" } };
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts1100_arguments: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 1100 && msg.contains("arguments"))
+        .collect();
+    assert!(
+        !ts1100_arguments.is_empty(),
+        "expected TS1100 for nested destructuring `arguments` (strict mode); got: {diags:#?}"
+    );
+}

--- a/docs/plan/claims/fix-checker-ts1100-destructuring-arguments.md
+++ b/docs/plan/claims/fix-checker-ts1100-destructuring-arguments.md
@@ -1,0 +1,30 @@
+# fix(checker): emit TS1100 for `arguments`/`eval` in destructuring patterns
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-ts1100-destructuring-arguments`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance fingerprint parity (TS1100 in strict mode)
+
+## Intent
+
+In strict mode, tsc emits TS1100 ("Invalid use of 'arguments' in strict mode")
+when `arguments` (or `eval`) appears as a binding name inside a destructuring
+pattern, e.g. `var { arguments } = ...`. tsz currently only checks the simple
+`var arguments` case in `state/variable_checking/core.rs`, missing identifiers
+inside object/array binding patterns. Add the TS1100 check inside
+`check_binding_element_with_request` (next to the existing TS1212/1213/1214
+binding-element check) so destructuring patterns are covered. This brings the
+conformance test `emitArrowFunctionWhenUsingArguments17_ES6` to fingerprint
+parity with tsc.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/type_checking/core.rs` (~25 LOC: emit TS1100/TS1210 for binding-element identifiers named `arguments`/`eval`)
+- `crates/tsz-checker/tests/ts1100_destructuring_arguments_tests.rs` (new regression test)
+
+## Verification
+
+- `./scripts/conformance/conformance.sh run --filter "emitArrowFunctionWhenUsingArguments17_ES6" --verbose` → expected pass
+- `cargo nextest run -p tsz-checker --test ts1100_destructuring_arguments_tests`
+- Targeted no-regression: filter on `ts1100`, `arguments`, `destructuring`

--- a/docs/plan/claims/fix-checker-ts1100-destructuring-arguments.md
+++ b/docs/plan/claims/fix-checker-ts1100-destructuring-arguments.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-ts1100-destructuring-arguments`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1362
+- **Status**: ready
 - **Workstream**: Conformance fingerprint parity (TS1100 in strict mode)
 
 ## Intent
@@ -25,6 +25,9 @@ parity with tsc.
 
 ## Verification
 
-- `./scripts/conformance/conformance.sh run --filter "emitArrowFunctionWhenUsingArguments17_ES6" --verbose` → expected pass
-- `cargo nextest run -p tsz-checker --test ts1100_destructuring_arguments_tests`
-- Targeted no-regression: filter on `ts1100`, `arguments`, `destructuring`
+- `./scripts/conformance/conformance.sh run --filter "emitArrowFunctionWhenUsingArguments17_ES6" --verbose` → 1/1 PASS (was fingerprint-only fail)
+- `./scripts/conformance/conformance.sh run --filter "emitArrowFunctionWhenUsingArguments"` → 38/38 pass
+- `cargo nextest run -p tsz-checker --test ts1100_destructuring_arguments_tests` → 6/6 pass
+- `cargo nextest run -p tsz-checker` → 5346/5346 pass (no regressions)
+- `cargo nextest run -p tsz-core --lib` → 2987/2987 pass (no regressions)
+- `./scripts/conformance/conformance.sh run --filter "destructur"` → 168/182 pass (no new regressions vs baseline)


### PR DESCRIPTION
## Summary

- In strict mode, tsc emits TS1100 (\"Invalid use of 'arguments' in strict mode\") when `arguments` (or `eval`) appears as a binding name inside an object or array destructuring pattern. tsz only checked the simple `var arguments = ...` case in `state/variable_checking/core.rs`, so destructuring forms like `var { arguments } = ...` were silently accepted.
- Add the TS1100 check inside `check_binding_element_with_request`, right next to the existing TS1212/1213/1214 binding-element check, routing through the shared `emit_eval_or_arguments_strict_mode_error` helper. That helper already handles class context (TS1210) and module context (TS1215), so the fix mirrors all three cases without duplicating policy.
- Brings conformance test `emitArrowFunctionWhenUsingArguments17_ES6` to fingerprint parity with tsc (was fingerprint-only failure).

## Root cause

`check_binding_element_with_request` in `crates/tsz-checker/src/types/type_checking/core.rs` already calls `check_strict_mode_reserved_name_at` for binding elements (TS1212-style reserved words), but had no parallel check for `eval`/`arguments` (TS1100). The existing variable-decl path at `state/variable_checking/core.rs:498` only fires when `var_name` is `Some(...)`, which is `None` for destructuring patterns — so destructured `arguments` skipped the check entirely.

## Architecture notes

- `WHERE` (checker orchestration), not `WHAT` — adding the TS1100 emission at the existing diagnostic seam.
- Reuses `emit_eval_or_arguments_strict_mode_error`, which is the canonical entry point that already encodes the TS1100/TS1210/TS1215 routing policy.
- Same suppression conditions as existing variable-decl path: skip when `is_declaration_file()` and require `is_strict_mode_for_node(name)`.

## Test plan

- [x] `cargo nextest run -p tsz-checker --test ts1100_destructuring_arguments_tests` (6 new regression tests, all pass)
- [x] `cargo nextest run -p tsz-checker` (5346 tests, all pass)
- [x] `cargo nextest run -p tsz-core --lib` (2987 tests, all pass)
- [x] `./scripts/conformance/conformance.sh run --filter \"emitArrowFunctionWhenUsingArguments17_ES6\" --verbose` → PASS (was fingerprint-only fail)
- [x] `./scripts/conformance/conformance.sh run --filter \"emitArrowFunctionWhenUsingArguments\"` → 38/38 pass
- [x] `./scripts/conformance/conformance.sh run --filter \"Arguments\"` → 130/134 pass (4 failures are pre-existing, unrelated to this fix)
- [x] `./scripts/conformance/conformance.sh run --filter \"destructur\"` → 168/182 pass; no new regressions vs baseline (4 tests flipped to pass from snapshot drift)