### PR TITLE
fix(checker): keep TS2502 self-reference for alias-prior redeclarations

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -120,6 +120,40 @@ impl<'a> CheckerState<'a> {
                     return false;
                 }
             }
+            // Filter out alias-style prior declarations (imports / UMD namespace
+            // exports). These bind a name to another module's surface but do not
+            // establish a value-typed binding in the redeclaring scope, so
+            // `typeof X` inside a later same-named `const X` declaration is
+            // genuinely circular (matches tsc's TS2502 behaviour for cases like
+            // `import * as foo` + `declare global { const foo: typeof foo; }`).
+            if let Some(other_node) = self.ctx.arena.get(other) {
+                let kind = other_node.kind;
+                if kind == syntax_kind_ext::NAMESPACE_IMPORT
+                    || kind == syntax_kind_ext::IMPORT_CLAUSE
+                    || kind == syntax_kind_ext::IMPORT_SPECIFIER
+                    || kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                    || kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                    || kind == syntax_kind_ext::NAMESPACE_EXPORT
+                    || kind == syntax_kind_ext::EXPORT_SPECIFIER
+                {
+                    return false;
+                }
+                // The UMD `export as namespace foo` (and a few namespace-export
+                // forms) record the export_clause identifier as the declaration
+                // node; check the parent kind to filter that case as well.
+                if kind == SyntaxKind::Identifier as u16
+                    && let Some(other_ext) = self.ctx.arena.get_extended(other)
+                    && let Some(parent_node) = self.ctx.arena.get(other_ext.parent)
+                    && (parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                        || parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT
+                        || parent_node.kind == syntax_kind_ext::IMPORT_CLAUSE
+                        || parent_node.kind == syntax_kind_ext::NAMESPACE_IMPORT
+                        || parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+                        || parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER)
+                {
+                    return false;
+                }
+            }
             true
         })
     }

--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -1204,3 +1204,66 @@ const b = async () => 0
         assert_eq!(ts2322.len(), 1, "Expected exactly 1 TS2322: {ts2322:?}");
     }
 }
+
+#[cfg(test)]
+mod ts2502_alias_prior_decl_tests {
+    //! TS2502 self-reference detection should not be suppressed when the prior
+    //! declaration of the same name is an alias (import/UMD namespace export).
+    //! Aliases bind a name to another module's surface but do not establish a
+    //! value-typed binding in the redeclaring scope, so `typeof X` inside a
+    //! later `const X` declaration with the same name is genuinely circular.
+    //!
+    //! Mirrors tsc behavior for cases like
+    //!   import * as foo from './foo';
+    //!   declare global { const foo: typeof foo; }
+    //! (conformance/compiler/crashDeclareGlobalTypeofExport.ts)
+    use super::test_utils::check_and_collect;
+
+    #[test]
+    fn umd_namespace_export_does_not_suppress_ts2502() {
+        // `export as namespace foo` is a UMD alias — it should NOT be
+        // treated as a prior value declaration that satisfies `typeof foo`
+        // for a later `const foo` declaration.
+        let source = "export as namespace foo;\n\
+            declare global {\n\
+            \x20\x20\x20\x20const foo: typeof foo;\n\
+            }";
+        let errors = check_and_collect(source, 2502);
+        assert_eq!(
+            errors.len(),
+            1,
+            "Expected 1 TS2502 (UMD alias should not suppress self-reference): {errors:?}"
+        );
+        assert!(
+            errors[0].1.contains("'foo'"),
+            "Diagnostic should reference 'foo': {errors:?}"
+        );
+    }
+
+    #[test]
+    fn block_scoped_var_still_suppresses_ts2502_unchanged() {
+        // Regression guard: `var p: T1; var p: typeof p;` is the canonical
+        // valid redeclaration where `typeof p` legitimately resolves to the
+        // prior var's annotation, so TS2502 must remain suppressed.
+        let source = "var p: number;\nvar p: typeof p;";
+        let errors = check_and_collect(source, 2502);
+        assert_eq!(
+            errors.len(),
+            0,
+            "Expected no TS2502 for legitimate var/var typeof redecl: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn no_prior_decl_self_reference_still_fires() {
+        // Regression guard: a lone `const foo: typeof foo` (no prior decl)
+        // must continue to emit TS2502.
+        let source = "const foo: typeof foo = 0 as any;";
+        let errors = check_and_collect(source, 2502);
+        assert_eq!(
+            errors.len(),
+            1,
+            "Expected 1 TS2502 for lone const self-reference: {errors:?}"
+        );
+    }
+}

--- a/docs/plan/claims/fix-checker-ts2502-skip-alias-prior-decl.md
+++ b/docs/plan/claims/fix-checker-ts2502-skip-alias-prior-decl.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-ts2502-skip-alias-prior-decl`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1363
+- **Status**: ready
 - **Workstream**: 1 (Diagnostic Conformance)
 
 ## Intent

--- a/docs/plan/claims/fix-checker-ts2502-skip-alias-prior-decl.md
+++ b/docs/plan/claims/fix-checker-ts2502-skip-alias-prior-decl.md
@@ -1,0 +1,57 @@
+# fix(checker): keep TS2502 self-reference for alias-prior redeclarations
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-ts2502-skip-alias-prior-decl`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the missing TS2502 in
+`conformance/compiler/crashDeclareGlobalTypeofExport.ts`. tsc emits both
+TS2451 (redeclare) and TS2502 ("'foo' is referenced directly or
+indirectly in its own type annotation") for:
+
+```ts
+import * as foo from './foo'
+export as namespace foo
+declare global { const foo: typeof foo; }
+```
+
+tsz emits only TS2451. Root cause: `has_prior_value_declaration_for_symbol`
+treats *any* non-block-scoped prior declaration as a prior-value-decl
+that suppresses the TS2502 self-reference check (the canonical
+`var p: T1; var p: typeof p;` case). It currently filters only
+block-scoped vars (let/const/using), so import aliases and UMD
+namespace exports satisfy the suppression even though they bind to
+another module's surface and never establish a value-typed binding in
+the redeclaring scope.
+
+Add `NAMESPACE_IMPORT`, `IMPORT_CLAUSE`, `IMPORT_SPECIFIER`,
+`IMPORT_EQUALS_DECLARATION`, `NAMESPACE_EXPORT_DECLARATION`, and
+`EXPORT_SPECIFIER` to the filter (plus the identifier-with-alias-parent
+shape the UMD path records as the declaration node) so alias-style
+prior decls no longer suppress TS2502.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/variable_checking/core.rs`
+  (~33 LOC: extend `has_prior_value_declaration_for_symbol` to also
+   exclude alias/import/UMD-namespace declarations)
+- `crates/tsz-checker/src/state/variable_checking/core_tests.rs`
+  (+63 LOC, 3 new tests: UMD case (positive), `var/var typeof`
+   regression guard, lone-const self-ref regression guard)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib ts2502_alias_prior_decl`
+  (3 PASS)
+- `cargo nextest run -p tsz-checker --lib` (2865 PASS, 0 regressions)
+- `./scripts/conformance/conformance.sh run --filter "crashDeclareGlobalTypeofExport"`
+  (1/1 PASS)
+- Full conformance: `crashDeclareGlobalTypeofExport.ts` flips PASS.
+  Two listed regressions (`valueOfTypedArray.ts`,
+  `jsExportMemberMergedWithModuleAugmentation2.ts`) are pre-existing
+  drift from already-merged PRs on `main` — they fail identically
+  with the change reverted (verified via `git stash`).


### PR DESCRIPTION
## Summary

- Fix the missing TS2502 in `conformance/compiler/crashDeclareGlobalTypeofExport.ts` (`all-missing` failure: tsc emits `[TS2451, TS2502]`, tsz only emits `[TS2451]`).
- Root cause: `has_prior_value_declaration_for_symbol` treats any non-block-scoped prior declaration as a "prior value declaration" that suppresses the TS2502 self-reference check. Imports/aliases (which bind a name to another module's surface, not a value-typed binding in the redeclaring scope) were incorrectly treated as suppressors.
- Extend the filter to also exclude alias-style declaration kinds plus the identifier-with-alias-parent shape that the UMD path records as the declaration node.

## Repro

```ts
// bar.d.ts
import * as foo from './foo'
export as namespace foo
export = foo;

declare global {
    const foo: typeof foo; // tsc: TS2451 + TS2502; tsz before: TS2451 only
}
```

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib ts2502_alias_prior_decl` (3/3 PASS — UMD case + 2 regression guards)
- [x] `cargo nextest run -p tsz-checker --lib` (2865 PASS, 0 regressions)
- [x] `./scripts/conformance/conformance.sh run --filter "crashDeclareGlobalTypeofExport"` (1/1 PASS)
- [x] Full conformance: `crashDeclareGlobalTypeofExport.ts` flips PASS. The two listed "regressions" (`valueOfTypedArray.ts`, `jsExportMemberMergedWithModuleAugmentation2.ts`) reproduce identically against `main` with this change reverted — they are pre-existing drift in the baseline file from already-merged PRs, not caused by this fix.