### PR TITLE
fix(solver): accept literals against StringMapping over non-string primitives

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
@@ -96,6 +96,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             | TypeData::KeyOf(_)
             | TypeData::IndexAccess(_, _) => self.interner().string_intrinsic(kind, evaluated_arg),
 
+            // For non-string primitive intrinsics that are pattern literal placeholders
+            // (number, bigint, boolean), preserve the StringMapping wrapping. tsc represents
+            // this as `Mapping<\`${T}\`>`, but storing `Mapping<T>` directly works as long as
+            // downstream consumers treat the type_arg as a stringification pattern.
+            // See `visit_literal` in the subtype visitor for the matching assignability rule.
+            //
+            // Without this case, evaluation collapses to TypeId::ERROR, and downstream
+            // template-literal matching (e.g., `"1" <: \`${Uppercase<number>}\``) silently
+            // returns false instead of accepting the literal.
+            TypeData::Intrinsic(
+                IntrinsicKind::Number | IntrinsicKind::Bigint | IntrinsicKind::Boolean,
+            ) => self.interner().string_intrinsic(kind, evaluated_arg),
+
             // Handle chained string intrinsics: Uppercase<Lowercase<T>>
             // Same-kind string mappings are idempotent: Uppercase<Uppercase<T>> = Uppercase<T>.
             // Different kinds must remain nested because compositions like

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -136,13 +136,43 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         if let LiteralValue::String(_) = value
             && let Some((kind, type_arg)) =
                 string_intrinsic_components(self.checker.interner, self.target)
-            && type_arg == TypeId::STRING
         {
+            // Rule: a string literal `s` is assignable to `Mapping<T>` iff
+            //   1. Mapping(s) == s (the literal is at the fixed-point of the mapping), AND
+            //   2. s is in the pattern set of T.
+            //
+            // For T == string, condition 2 is trivially true (any literal is in string).
+            // For T == number / bigint / boolean (pattern-literal placeholders), we check
+            // that s matches the stringification template `\`${T}\``. This mirrors tsc,
+            // which represents `Mapping<\`${number}\`>` as a StringMapping over a
+            // TemplateLiteral and accepts e.g. `"1"` for `Uppercase<\`${number}\`>`.
             let transformed = self
                 .checker
                 .evaluate_type(self.checker.interner.string_intrinsic(kind, self.source));
             if transformed == self.source {
-                return SubtypeResult::True;
+                if type_arg == TypeId::STRING {
+                    return SubtypeResult::True;
+                }
+
+                // Construct the underlying pattern target. For non-string primitive
+                // type args, wrap as `\`${type_arg}\`` so the standard template-literal
+                // pattern matcher decides set membership.
+                let pattern_target = match self.checker.interner.lookup(type_arg) {
+                    Some(TypeData::TemplateLiteral(_))
+                    | Some(TypeData::Intrinsic(IntrinsicKind::String)) => type_arg,
+                    _ => self
+                        .checker
+                        .interner
+                        .template_literal(vec![crate::types::TemplateSpan::Type(type_arg)]),
+                };
+                if pattern_target != self.source
+                    && self
+                        .checker
+                        .check_subtype(self.source, pattern_target)
+                        .is_true()
+                {
+                    return SubtypeResult::True;
+                }
             }
         }
         if let Some(t_lit) = literal_value(self.checker.interner, self.target) {

--- a/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
+++ b/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
@@ -283,6 +283,128 @@ fn uppercase_template_literal_accepts_only_uppercase_suffixes() {
     );
 }
 
+// =============================================================================
+// String mapping over non-string primitive type args (number, bigint, boolean).
+// tsc represents these as `Mapping<\`${T}\`>`; tsz collapses them to `Mapping<T>`
+// during evaluation but must still accept literals matching the underlying
+// stringification pattern (e.g. `"1"` for `Uppercase<\`${number}\`>`).
+// =============================================================================
+
+#[test]
+fn uppercase_over_number_template_accepts_digit_literal() {
+    let interner = TypeInterner::new();
+
+    let number_template = interner.template_literal(vec![TemplateSpan::Type(TypeId::NUMBER)]);
+    let uppercase_number_template =
+        interner.string_intrinsic(StringIntrinsicKind::Uppercase, number_template);
+
+    let one_literal = interner.literal_string("1");
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(one_literal, uppercase_number_template),
+        r#""1" should be assignable to Uppercase<`${number}`> (uppercase of "1" is "1", and "1" matches `${number}`)"#
+    );
+}
+
+#[test]
+fn lowercase_over_number_template_accepts_digit_literal() {
+    let interner = TypeInterner::new();
+
+    let number_template = interner.template_literal(vec![TemplateSpan::Type(TypeId::NUMBER)]);
+    let lowercase_number_template =
+        interner.string_intrinsic(StringIntrinsicKind::Lowercase, number_template);
+
+    let one_literal = interner.literal_string("1");
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(one_literal, lowercase_number_template),
+        r#""1" should be assignable to Lowercase<`${number}`>"#
+    );
+}
+
+#[test]
+fn uppercase_over_number_template_rejects_non_digit_literal() {
+    let interner = TypeInterner::new();
+
+    let number_template = interner.template_literal(vec![TemplateSpan::Type(TypeId::NUMBER)]);
+    let uppercase_number_template =
+        interner.string_intrinsic(StringIntrinsicKind::Uppercase, number_template);
+
+    // "ABC" is uppercase but doesn't match `${number}`.
+    let abc_literal = interner.literal_string("ABC");
+    // "abc" is neither uppercase nor a number stringification.
+    let abc_lower = interner.literal_string("abc");
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(abc_literal, uppercase_number_template),
+        r#""ABC" should NOT be assignable to Uppercase<`${number}`>"#
+    );
+    assert!(
+        !checker.is_subtype_of(abc_lower, uppercase_number_template),
+        r#""abc" should NOT be assignable to Uppercase<`${number}`>"#
+    );
+}
+
+#[test]
+fn nested_uppercase_lowercase_over_number_template_accepts_digit_literal() {
+    let interner = TypeInterner::new();
+
+    // Uppercase<Lowercase<`${number}`>>
+    let number_template = interner.template_literal(vec![TemplateSpan::Type(TypeId::NUMBER)]);
+    let lowercase_number =
+        interner.string_intrinsic(StringIntrinsicKind::Lowercase, number_template);
+    let upper_lower_number =
+        interner.string_intrinsic(StringIntrinsicKind::Uppercase, lowercase_number);
+
+    let one_literal = interner.literal_string("1");
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(one_literal, upper_lower_number),
+        r#""1" should be assignable to Uppercase<Lowercase<`${number}`>>"#
+    );
+}
+
+#[test]
+fn evaluate_uppercase_over_number_intrinsic_is_preserved() {
+    use crate::types::IntrinsicKind;
+
+    let interner = TypeInterner::new();
+
+    // After evaluation, `Uppercase<number>` (the *intrinsic*, not the template
+    // literal) must NOT collapse to TypeId::ERROR. We preserve the StringMapping
+    // wrapping so downstream consumers (template literal pattern matcher,
+    // visit_literal) can still apply the assignability rule.
+    let uppercase_number =
+        interner.string_intrinsic(StringIntrinsicKind::Uppercase, TypeId::NUMBER);
+    let evaluated = evaluate_type(&interner, uppercase_number);
+
+    assert_ne!(
+        evaluated,
+        TypeId::ERROR,
+        "Uppercase<number> must not evaluate to ERROR; it should preserve the StringMapping wrapping"
+    );
+    // The result should still be a StringMapping over a number-pattern argument.
+    if let Some(TypeData::StringIntrinsic { kind, type_arg }) = interner.lookup(evaluated) {
+        assert_eq!(kind, StringIntrinsicKind::Uppercase);
+        assert!(
+            type_arg == TypeId::NUMBER
+                || matches!(
+                    interner.lookup(type_arg),
+                    Some(TypeData::TemplateLiteral(_))
+                        | Some(TypeData::Intrinsic(IntrinsicKind::Number))
+                ),
+            "type arg should be number or `${{number}}`, got {:?}",
+            interner.lookup(type_arg)
+        );
+    } else {
+        panic!(
+            "expected StringIntrinsic after evaluation, got {:?}",
+            interner.lookup(evaluated)
+        );
+    }
+}
+
 #[test]
 fn assignability_query_normalizes_nested_uppercase_intrinsics() {
     let interner = TypeInterner::new();

--- a/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
+++ b/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
@@ -302,7 +302,7 @@ fn uppercase_over_number_template_accepts_digit_literal() {
     let mut checker = SubtypeChecker::new(&interner);
     assert!(
         checker.is_subtype_of(one_literal, uppercase_number_template),
-        r#""1" should be assignable to Uppercase<`${number}`> (uppercase of "1" is "1", and "1" matches `${number}`)"#
+        "\"1\" should be assignable to Uppercase<`${{number}}`> (uppercase of \"1\" is \"1\", and \"1\" matches `${{number}}`)"
     );
 }
 
@@ -318,7 +318,7 @@ fn lowercase_over_number_template_accepts_digit_literal() {
     let mut checker = SubtypeChecker::new(&interner);
     assert!(
         checker.is_subtype_of(one_literal, lowercase_number_template),
-        r#""1" should be assignable to Lowercase<`${number}`>"#
+        "\"1\" should be assignable to Lowercase<`${{number}}`>"
     );
 }
 
@@ -338,11 +338,11 @@ fn uppercase_over_number_template_rejects_non_digit_literal() {
     let mut checker = SubtypeChecker::new(&interner);
     assert!(
         !checker.is_subtype_of(abc_literal, uppercase_number_template),
-        r#""ABC" should NOT be assignable to Uppercase<`${number}`>"#
+        "\"ABC\" should NOT be assignable to Uppercase<`${{number}}`>"
     );
     assert!(
         !checker.is_subtype_of(abc_lower, uppercase_number_template),
-        r#""abc" should NOT be assignable to Uppercase<`${number}`>"#
+        "\"abc\" should NOT be assignable to Uppercase<`${{number}}`>"
     );
 }
 
@@ -361,7 +361,7 @@ fn nested_uppercase_lowercase_over_number_template_accepts_digit_literal() {
     let mut checker = SubtypeChecker::new(&interner);
     assert!(
         checker.is_subtype_of(one_literal, upper_lower_number),
-        r#""1" should be assignable to Uppercase<Lowercase<`${number}`>>"#
+        "\"1\" should be assignable to Uppercase<Lowercase<`${{number}}`>>"
     );
 }
 

--- a/docs/plan/claims/fix-solver-string-mapping-non-string-arg.md
+++ b/docs/plan/claims/fix-solver-string-mapping-non-string-arg.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/solver-string-mapping-non-string-arg`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1366
+- **Status**: ready
 - **Workstream**: 1 (Diagnostic Conformance)
 
 ## Intent
@@ -72,3 +72,4 @@ Two compounding bugs in the solver:
   fix.
 - Regression sample: `--filter String` 325/336, `--filter template`
   197/205 — no regressions vs main.
+- Full conformance: **+34 PASS vs baseline (12144 → 12178)**.

--- a/docs/plan/claims/fix-solver-string-mapping-non-string-arg.md
+++ b/docs/plan/claims/fix-solver-string-mapping-non-string-arg.md
@@ -1,0 +1,74 @@
+# fix(solver): accept literals against StringMapping over non-string primitives
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/solver-string-mapping-non-string-arg`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the false-positive TS2322 emitted by tsz when assigning a string
+literal to a string-mapping wrapper applied to a non-string primitive
+pattern, e.g.:
+
+```ts
+declare var y: Uppercase<`${number}`>;
+y = "1";  // tsc accepts; tsz incorrectly errored
+```
+
+This affected the `stringLiteralsAssignedToStringMappings.ts` conformance
+target and any similar pattern using `Uppercase<\`${number}\`>`,
+`Lowercase<\`${number}\`>`, or nested compositions over `${bigint}` /
+`${boolean}`.
+
+## Root cause
+
+Two compounding bugs in the solver:
+
+1. **`evaluate_string_intrinsic` returned `TypeId::ERROR`** when the type
+   argument was a non-string primitive intrinsic (`number`, `bigint`,
+   `boolean`). After tsz's eager normalization
+   `Uppercase<\`${number}\`>` → `\`${Uppercase<number>}\``, the inner
+   `Uppercase<number>` evaluated to ERROR, derailing downstream pattern
+   matching.
+2. **`visit_literal` only accepted `Mapping<string>` targets** (the
+   fixed-point check `Mapping(literal) == literal` was gated on
+   `type_arg == TypeId::STRING`). Even after fixing (1), the rule didn't
+   apply when the target was `Uppercase<number>`.
+
+## Fix
+
+- `crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs`:
+  preserve `Mapping<T>` for `T ∈ {number, bigint, boolean}` instead of
+  collapsing to ERROR. Mirrors tsc's preservation of pattern-literal
+  placeholder types via `getStringMappingType` + `isPatternLiteralType`.
+- `crates/tsz-solver/src/relations/subtype/visitor.rs`:
+  generalize the literal-to-StringMapping rule. A string literal `s` is
+  assignable to `Mapping<T>` iff (a) `Mapping(s_value) == s_value` AND
+  (b) `s` matches the stringification template `\`${T}\`` (computed by
+  the existing template-literal pattern matcher).
+
+## Files Touched
+
+- `crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs`
+  (+11 LOC: preserve StringMapping for non-string primitive args)
+- `crates/tsz-solver/src/relations/subtype/visitor.rs`
+  (+27 LOC, -3 LOC: generalize the literal-vs-mapping fixed-point rule)
+- `crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs`
+  (+122 LOC: 5 new unit tests pinning the new behaviour and rejection
+   semantics)
+
+## Verification
+
+- `cargo nextest run -p tsz-solver` — 5514 PASS, 0 FAIL.
+- `cargo nextest run -p tsz-solver -E 'test(uppercase_over_number) or
+  test(lowercase_over_number) or
+  test(nested_uppercase_lowercase_over_number) or
+  test(evaluate_uppercase_over_number_intrinsic_is_preserved)'` — 5/5 PASS.
+- Targeted conformance: `stringLiteralsAssignedToStringMappings.ts`
+  drops from 5 emitted errors → 3 (matches tsc's count); now blocked
+  only on type-display parity and line-offset bugs orthogonal to this
+  fix.
+- Regression sample: `--filter String` 325/336, `--filter template`
+  197/205 — no regressions vs main.


### PR DESCRIPTION
## Summary

Fix a false-positive `TS2322` when a string literal is assigned to a string mapping wrapping a non-string primitive pattern (e.g. `Uppercase<\`${number}\`>`, `Lowercase<\`${bigint}\`>`, etc.).

```ts
declare var y: Uppercase<`${number}`>;
y = "1";  // tsc accepts; tsz incorrectly rejected
```

## Root cause

Two compounding solver bugs:

1. **`evaluate_string_intrinsic` collapsed `Mapping<T>` to `TypeId::ERROR`** when `T` was a non-string primitive intrinsic (`number`, `bigint`, `boolean`). After tsz's eager normalization rewrites `Uppercase<\`${number}\`>` to `\`${Uppercase<number>}\``, the inner `Uppercase<number>` evaluated to ERROR, derailing template-literal pattern matching.
2. **`visit_literal` only accepted `Mapping<string>` targets.** The fixed-point check `Mapping(literal) == literal` was gated on `type_arg == TypeId::STRING`. Even after fixing (1), the rule never fired for `Uppercase<number>`.

## Fix

- `crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs`: preserve `Mapping<T>` for `T ∈ {number, bigint, boolean}` instead of returning ERROR. Mirrors tsc's `getStringMappingType` + `isPatternLiteralType` preservation.
- `crates/tsz-solver/src/relations/subtype/visitor.rs`: generalize the literal-vs-mapping rule. A string literal `s` is assignable to `Mapping<T>` iff
  - `Mapping(s_value) == s_value` (fixed-point), AND
  - `s` matches the stringification template `\`${T}\`` (delegated to the existing template-literal pattern matcher).

## Test plan

- [x] 5 new unit tests in `crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs` (positive + rejection + nested + evaluation invariants).
- [x] `cargo nextest run -p tsz-solver` — 5514 PASS, 0 FAIL.
- [x] Targeted conformance: `stringLiteralsAssignedToStringMappings.ts` no longer emits the false positive on `y = "1";`. The test remains fingerprint-only blocked on orthogonal display issues (line offsets, source-literal widening, target alias display).
- [x] Regression sample: `--filter String` 325/336 PASS, `--filter template` 197/205 PASS — no regressions introduced.