### PR TITLE
fix(parser): keep `<T> yield` as missing-expression in generator recovery

### DIFF
--- a/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
+++ b/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
@@ -8,7 +8,7 @@
 //! hasn't been registered in the type environment yet. Previously this caused
 //! fresh literals like `'currency'` to be widened to `string`, producing false
 //! TS2322 errors. The fix forces a stronger Lazy resolution before retrying the
-//! keyof evaluation, plus an IndexAccess fallback that looks up property types
+//! keyof evaluation, plus an `IndexAccess` fallback that looks up property types
 //! through the contextual property API.
 //!
 //! Repro for the original arrayToLocaleStringES2015 / ES2020 conformance cases.

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -593,11 +593,13 @@ impl ParserState {
         // (right after `>`), matching tsc behavior.
         let after_gt_full_start = self.token_full_start();
 
-        // TypeScript doesn't allow bare 'yield' after type assertion
-        // Unlike 'await', 'yield' is not allowed as a simple unary expression in this context
-        // Example: <number> yield 0 → TS1109 "Expression expected"
-        // But:     <number> (yield 0) → valid (parens make it a primary expression)
-        if self.is_token(SyntaxKind::YieldKeyword) {
+        // `<number> yield 0` inside a generator: tsc's parseSimpleUnaryExpression
+        // does not handle YieldKeyword, so it leaves the assertion expression
+        // missing and re-parses `yield 0` as a separate yield statement. Mirror
+        // that — report TS1109 and use NodeIndex::NONE for the inner expression.
+        // (`<number> (yield 0)` is fine: parens make it a primary expression.)
+        let yield_after_gt = self.in_generator_context() && self.is_token(SyntaxKind::YieldKeyword);
+        if yield_after_gt {
             use tsz_common::diagnostics::diagnostic_codes;
             self.parse_error_at_current_token(
                 "Expression expected.",
@@ -605,7 +607,11 @@ impl ParserState {
             );
         }
 
-        let expression = self.parse_unary_expression();
+        let expression = if yield_after_gt {
+            NodeIndex::NONE
+        } else {
+            self.parse_unary_expression()
+        };
         if expression.is_none() {
             use tsz_common::diagnostics::diagnostic_codes;
             if self.should_report_error() {

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -375,6 +375,98 @@ fn precedence_type_assertion_angle_bracket() {
     );
 }
 
+/// Regression: `<number> yield 0` inside a generator must NOT consume `yield`
+/// into the type assertion's expression. tsc's `parseSimpleUnaryExpression`
+/// does not handle `YieldKeyword`, so the type assertion ends with a missing
+/// expression, TS1109 is reported at `yield`, and `yield 0` becomes a
+/// separate yield expression statement.
+///
+/// Conformance test `castOfYield` (`tests/cases/compiler/castOfYield.ts`)
+/// pinned this shape: tsc emits `;` (empty stmt) followed by `yield 0;`.
+#[test]
+fn type_assertion_does_not_consume_yield_in_generator() {
+    let (parser, root) = parse_source("function* f() { <number> (yield 0); <number> yield 0; }");
+    let arena = parser.get_arena();
+
+    // Locate the generator function body.
+    let func_idx = get_first_statement(arena, root);
+    let func_node = arena.get(func_idx).expect("function decl");
+    let func = arena
+        .get_function(func_node)
+        .expect("function declaration data");
+    let body_node = arena.get(func.body).expect("function body");
+    let block = arena.get_block(body_node).expect("block data");
+    let body_stmts = &block.statements.nodes;
+
+    // After the fix, the body has 3 statements:
+    //   1) ExpressionStatement: `<number> (yield 0)` — well-formed type assertion
+    //   2) ExpressionStatement: `<number>` with a missing expression (recovery)
+    //   3) ExpressionStatement: `yield 0` as a separate yield expression
+    assert_eq!(
+        body_stmts.len(),
+        3,
+        "expected 3 statements, got {}: {:?}",
+        body_stmts.len(),
+        body_stmts
+            .iter()
+            .map(|&i| arena.get(i).map(|n| n.kind))
+            .collect::<Vec<_>>()
+    );
+
+    // First statement: type assertion wrapping parenthesized yield (valid).
+    let s1_node = arena.get(body_stmts[0]).expect("stmt 1");
+    let s1_expr_stmt = arena.get_expression_statement(s1_node).expect("expr stmt");
+    let s1_inner = arena
+        .get(s1_expr_stmt.expression)
+        .expect("type assertion node");
+    assert_eq!(
+        s1_inner.kind,
+        syntax_kind_ext::TYPE_ASSERTION,
+        "first stmt should be a TypeAssertion"
+    );
+
+    // Second statement: type assertion with NO inner expression (recovery).
+    let s2_node = arena.get(body_stmts[1]).expect("stmt 2");
+    let s2_expr_stmt = arena.get_expression_statement(s2_node).expect("expr stmt");
+    let s2_inner = arena
+        .get(s2_expr_stmt.expression)
+        .expect("type assertion node");
+    assert_eq!(
+        s2_inner.kind,
+        syntax_kind_ext::TYPE_ASSERTION,
+        "second stmt should be a TypeAssertion"
+    );
+    let s2_assert = arena
+        .get_type_assertion(s2_inner)
+        .expect("type assertion data");
+    assert!(
+        s2_assert.expression.is_none(),
+        "type assertion before bare `yield` must have no inner expression"
+    );
+
+    // Third statement: yield expression statement.
+    let s3_node = arena.get(body_stmts[2]).expect("stmt 3");
+    let s3_expr_stmt = arena.get_expression_statement(s3_node).expect("expr stmt");
+    let s3_inner = arena.get(s3_expr_stmt.expression).expect("yield expr node");
+    assert_eq!(
+        s3_inner.kind,
+        syntax_kind_ext::YIELD_EXPRESSION,
+        "third stmt should be a YieldExpression"
+    );
+
+    // The recovery must report exactly one TS1109 (Expression expected) at `yield`,
+    // not two diagnostics at the same site.
+    let ts1109_count = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::EXPRESSION_EXPECTED)
+        .count();
+    assert_eq!(
+        ts1109_count, 1,
+        "expected exactly one TS1109 for `<number> yield 0`, got {ts1109_count}"
+    );
+}
+
 #[test]
 fn precedence_instanceof_and_in() {
     // `a instanceof B` and `a in b` should parse without errors

--- a/docs/plan/claims/fix-parser-emitter-cast-of-yield-empty-stmt.md
+++ b/docs/plan/claims/fix-parser-emitter-cast-of-yield-empty-stmt.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/parser-emitter-cast-of-yield-empty-stmt`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1367
+- **Status**: ready
 - **Workstream**: 2 (JS Emit Pass Rate)
 
 ## Intent

--- a/docs/plan/claims/fix-parser-emitter-cast-of-yield-empty-stmt.md
+++ b/docs/plan/claims/fix-parser-emitter-cast-of-yield-empty-stmt.md
@@ -1,0 +1,42 @@
+# fix(parser): keep `<T> yield` as missing-expression + separate yield stmt
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/parser-emitter-cast-of-yield-empty-stmt`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (JS Emit Pass Rate)
+
+## Intent
+
+`parse_type_assertion` reported TS1109 when it saw `<number> yield 0` inside
+a generator, but then still called `parse_unary_expression`, which consumed
+the `yield 0` as the type assertion's inner expression. tsc's
+`parseSimpleUnaryExpression` does **not** handle `YieldKeyword`, so tsc
+recovers with a missing inner expression and re-parses `yield 0` as a
+separate yield expression statement. The mismatch produced one fewer line
+of JS output than tsc for the conformance test `castOfYield`.
+
+This change mirrors tsc: when we see `YieldKeyword` after `>` in a
+generator, report TS1109 and use `NodeIndex::NONE` for the assertion's
+inner expression instead of consuming the yield. The remaining tokens
+(`yield 0`) parse normally as the next statement, producing the empty `;`
+plus standalone `yield 0;` shape that tsc emits.
+
+## Files Touched
+
+- `crates/tsz-parser/src/parser/state_types_jsx.rs` (~10 LOC: surgical
+  guard in `parse_type_assertion` for `YieldKeyword` in generator context)
+- `crates/tsz-parser/tests/parser_unit_tests.rs` (regression test
+  `type_assertion_does_not_consume_yield_in_generator`)
+
+## Verification
+
+- `cargo nextest run -p tsz-parser` (670 tests pass, +1 new)
+- `cargo nextest run -p tsz-emitter` (1650 tests pass, no regressions)
+- `cargo nextest run -p tsz-checker --lib` (2878 tests pass)
+- `./scripts/conformance/conformance.sh run --filter castOfYield` (1/1 pass)
+- `./scripts/conformance/conformance.sh run --filter yield` (107/107 pass)
+- `./scripts/conformance/conformance.sh run --filter cast` (9/9 pass)
+- `./scripts/conformance/conformance.sh run --filter asyncFunction` (80/80 pass)
+- Emit suite: JS pass rate 91.1% → 91.1% with `castOfYield` flipping
+  fail → pass (12324 → 12325, +1; total fail 1202 → 1201).


### PR DESCRIPTION
## Summary

- `parse_type_assertion` saw `<number> yield 0` inside a generator and reported TS1109, but then still consumed `yield 0` as the assertion's inner expression. tsc's `parseSimpleUnaryExpression` does not handle `YieldKeyword`, so tsc keeps the inner expression missing and re-parses `yield 0` as a separate yield expression statement.
- Mirror tsc: when we see `YieldKeyword` after `>` in a generator context, report TS1109 and use `NodeIndex::NONE` for the assertion's inner expression instead of consuming the yield.
- Conformance test `castOfYield` flips fail → pass; emit JS pass count 12324 → 12325 (+1, no regressions). Workstream 2 (JS Emit Pass Rate).

## Test plan

- [x] New regression unit test: `tsz-parser` `type_assertion_does_not_consume_yield_in_generator`
- [x] `cargo nextest run -p tsz-parser` (670 tests pass, +1 new)
- [x] `cargo nextest run -p tsz-emitter` (1650 tests pass)
- [x] `cargo nextest run -p tsz-checker --lib` (2878 tests pass)
- [x] `./scripts/conformance/conformance.sh run --filter castOfYield` (1/1)
- [x] `./scripts/conformance/conformance.sh run --filter yield` (107/107)
- [x] `./scripts/conformance/conformance.sh run --filter cast` (9/9)
- [x] `./scripts/conformance/conformance.sh run --filter TypeAssertion` (36/36)
- [x] `./scripts/conformance/conformance.sh run --filter asyncFunction` (80/80)
- [x] Full emit suite (`scripts/safe-run.sh ./scripts/emit/run.sh --skip-build`): 12325 JS passes (was 12324), no regressions
- [x] Pre-commit gate (20508 tests pass)