### PR TITLE
perf(binder): drop dead SymbolTable clone into ScopeContext.locals

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -594,9 +594,14 @@ impl BinderState {
         };
         if let Some(root_scope) = binder.scopes.first() {
             binder.current_scope = root_scope.table.clone();
-            let mut root_context =
-                ScopeContext::new(root_scope.kind, root_scope.container_node, None);
-            root_context.locals = root_scope.table.clone();
+            // `ScopeContext::new` already initialises `locals` to an empty
+            // `SymbolTable`. Production scope-chain readers only access
+            // `container_node`, `container_kind`, and `parent_idx` — never
+            // `locals` — so cloning the root scope's table into it was
+            // dead work (a full `FxHashMap<String, SymbolId>` deep copy
+            // per `from_bound_state_with_scopes_and_augmentations` call,
+            // which fires once per file checker spawn).
+            let root_context = ScopeContext::new(root_scope.kind, root_scope.container_node, None);
             binder.scope_chain.push(root_context);
             binder.current_scope_id = ScopeId(0);
             binder.current_scope_idx = 0;

--- a/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
+++ b/crates/tsz-checker/tests/contextual_literal_keyof_lib_tests.rs
@@ -8,7 +8,7 @@
 //! hasn't been registered in the type environment yet. Previously this caused
 //! fresh literals like `'currency'` to be widened to `string`, producing false
 //! TS2322 errors. The fix forces a stronger Lazy resolution before retrying the
-//! keyof evaluation, plus an IndexAccess fallback that looks up property types
+//! keyof evaluation, plus an `IndexAccess` fallback that looks up property types
 //! through the contextual property API.
 //!
 //! Repro for the original arrayToLocaleStringES2015 / ES2020 conformance cases.


### PR DESCRIPTION
## Summary

`from_bound_state_with_scopes_and_augmentations` cloned the root scope's symbol table twice — once into `binder.current_scope` (which the binder hot path actually reads) and once into `root_context.locals`, which is **never read** anywhere in the production crates:

```
$ rg '\.locals\b' crates/ --type rust
crates/tsz-binder/src/state/core.rs:599: root_context.locals = ... // dead write
crates/tsz-binder/tests/scopes_tests.rs: ... // tests only
```

Production scope-chain readers only access `container_node`, `container_kind`, and `parent_idx`. Removing the dead write saves one full `FxHashMap<String, SymbolId>` deep copy per file checker spawn — that's 4893 spawns on `large-ts-repo`, each cloning the file's root scope (lib + global symbols, can be hundreds of `String` keys per file).

The companion edit (a one-character doc-markdown auto-fix in a test file) was applied by the pre-commit lint hook on commit; it's unrelated.

## Test plan

- [x] `cargo nextest run -p tsz-binder` — 448 / 448 passed
- [x] `cargo nextest run -p tsz-checker --lib` — 2878 / 2878 passed
- [x] Pre-commit hook (clippy + nextest across affected crates) — 19847 / 19847 passed
- [x] `large-ts-repo` standalone single-file run: 51.79s wall (no regression vs ~50s pre-change baseline)
- [ ] CI conformance + emit + fourslash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
