### PR TITLE
fix(lsp,solver): drop stub Add Missing Imports + merge equivalent string-intrinsic match arms

### DIFF
--- a/crates/tsz-lsp/src/code_actions/code_action_editor_features.rs
+++ b/crates/tsz-lsp/src/code_actions/code_action_editor_features.rs
@@ -106,7 +106,14 @@ impl<'a> CodeActionProvider<'a> {
     /// Returns actions for:
     /// - `source.removeUnusedImports` — remove unused imports only
     /// - `source.sortImports` — sort import declarations only
-    /// - `source.addMissingImports` — placeholder for adding missing imports
+    ///
+    /// `source.addMissingImports` is intentionally NOT advertised: it would
+    /// need workspace-level import candidate resolution that this LSP does
+    /// not yet implement, and previously surfaced as an editor entry that
+    /// did nothing (`edit: None`). See robustness audit
+    /// `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md` item 16 (PR #P).
+    /// When the candidate-resolution path is added, advertise this action
+    /// only when at least one candidate is found.
     ///
     /// Note: `source.organizeImports` is handled separately in `organize_imports()`.
     pub fn source_actions(&self, root: tsz_parser::NodeIndex) -> Vec<CodeAction> {
@@ -121,17 +128,6 @@ impl<'a> CodeActionProvider<'a> {
         if let Some(action) = self.sort_imports_action(root) {
             actions.push(action);
         }
-
-        // Add missing imports (stub — needs workspace-level import candidates)
-        actions.push(CodeAction {
-            title: "Add Missing Imports".to_string(),
-            kind: CodeActionKind::SourceAddMissingImports,
-            edit: None,
-            is_preferred: false,
-            data: Some(serde_json::json!({
-                "fixName": "addMissingImports"
-            })),
-        });
 
         actions
     }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
@@ -90,22 +90,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.interner().string_intrinsic(kind, evaluated_arg)
             }
 
-            // For type parameters and other deferred types, keep as StringIntrinsic
+            // For type parameters and other deferred types, keep as StringIntrinsic.
+            //
+            // Also: for non-string primitive intrinsics that are pattern literal
+            // placeholders (number, bigint, boolean), preserve the StringMapping
+            // wrapping. tsc represents this as `Mapping<\`${T}\`>`, but storing
+            // `Mapping<T>` directly works as long as downstream consumers treat
+            // the type_arg as a stringification pattern. See `visit_literal` in
+            // the subtype visitor for the matching assignability rule.
+            //
+            // Without the primitive case, evaluation collapses to TypeId::ERROR,
+            // and downstream template-literal matching
+            // (e.g., `"1" <: \`${Uppercase<number>}\``) silently returns false
+            // instead of accepting the literal.
             TypeData::TypeParameter(_)
             | TypeData::Infer(_)
             | TypeData::KeyOf(_)
-            | TypeData::IndexAccess(_, _) => self.interner().string_intrinsic(kind, evaluated_arg),
-
-            // For non-string primitive intrinsics that are pattern literal placeholders
-            // (number, bigint, boolean), preserve the StringMapping wrapping. tsc represents
-            // this as `Mapping<\`${T}\`>`, but storing `Mapping<T>` directly works as long as
-            // downstream consumers treat the type_arg as a stringification pattern.
-            // See `visit_literal` in the subtype visitor for the matching assignability rule.
-            //
-            // Without this case, evaluation collapses to TypeId::ERROR, and downstream
-            // template-literal matching (e.g., `"1" <: \`${Uppercase<number>}\``) silently
-            // returns false instead of accepting the literal.
-            TypeData::Intrinsic(
+            | TypeData::IndexAccess(_, _)
+            | TypeData::Intrinsic(
                 IntrinsicKind::Number | IntrinsicKind::Bigint | IntrinsicKind::Boolean,
             ) => self.interner().string_intrinsic(kind, evaluated_arg),
 


### PR DESCRIPTION
## Summary

Two robustness fixes bundled because the second unblocks the first.

**LSP — drop stub `Add Missing Imports` source action.** Audit item 16 (PR #P from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`). `source_actions()` unconditionally pushed an `Add Missing Imports` code action with `edit: None`. Editors surfaced it as a clickable item that silently did nothing — the most user-hostile failure mode in the audit's "UX honesty" wave. Removed the unconditional advertisement; once workspace-level import-candidate resolution is wired up (`project::imports::auto_import_candidates_*` is the foundation), the action should be re-added gated on the candidate set being non-empty.

**Solver — merge equivalent `string_intrinsic` match arms.** A `clippy::match_same_arms` lint was failing on every clippy run on `main` HEAD (`crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs:94-110`), blocking the pre-commit hook for everyone. The two arms had identical bodies but different comments; merging them into one arm with the union of patterns satisfies clippy without losing the rationale.

## Test plan

- [x] 3733/3733 `tsz-lsp` tests pass
- [x] 5514/5514 `tsz-solver` lib tests pass
- [x] `cargo clippy -p tsz-solver -- -D warnings` clean (was failing on main)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
