### PR TITLE
test(checker): lock IteratorResult default-vs-void assignability invariant

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -32,6 +32,10 @@ stacker = "0.1.23"
 web-time = { workspace = true }
 
 [[test]]
+name = "generic_alias_assignability_pollution_tests"
+path = "tests/generic_alias_assignability_pollution_tests.rs"
+
+[[test]]
 name = "generator_annotation_mismatch_display_tests"
 path = "tests/generator_annotation_mismatch_display_tests.rs"
 

--- a/crates/tsz-checker/tests/generic_alias_assignability_pollution_tests.rs
+++ b/crates/tsz-checker/tests/generic_alias_assignability_pollution_tests.rs
@@ -1,0 +1,179 @@
+//! Regression tests for assignability of `IteratorResult<T>` (default
+//! `TReturn = any`) against `IteratorResult<T, void>`.
+//!
+//! See: TypeScript/tests/cases/compiler/customAsyncIterator.ts (false-
+//! positive TS2416 in CLI / conformance runs).
+//!
+//! The conformance test asserts that
+//!
+//! ```ts
+//! class ConstantIterator<T> implements AsyncIterator<T, void, T | undefined> {
+//!     async next(value?: T): Promise<IteratorResult<T>> { ... }
+//! }
+//! ```
+//!
+//! does NOT emit TS2416. tsc accepts the override because the class
+//! method's return type `Promise<IteratorResult<T, /*default*/ any>>` is
+//! structurally assignable to the interface's instantiated return type
+//! `Promise<IteratorResult<T, void>>` (the `value: any` member of the
+//! return-result branch absorbs the `void`).
+//!
+//! The baseline below covers the underlying assignability invariant in
+//! a unit-level shape. Reproducing the actual TS2416 emitted by CLI runs
+//! requires the comprehensive default-target lib graph and the
+//! implements-clause path; that is exercised as a conformance test.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tsz_binder::{BinderState, lib_loader::LibFile};
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::context::LibContext as CheckerLibContext;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::state::CheckerState;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn load_lib_files(names: &[&str]) -> Vec<Arc<LibFile>> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut loaded = Vec::new();
+    for name in names {
+        let candidates = [
+            manifest_dir.join(format!("../../scripts/node_modules/typescript/lib/{name}")),
+            manifest_dir.join(format!(
+                "../../scripts/conformance/node_modules/typescript/lib/{name}"
+            )),
+            manifest_dir.join(format!("../../TypeScript/lib/{name}")),
+        ];
+        for path in candidates {
+            if path.exists()
+                && let Ok(content) = std::fs::read_to_string(&path)
+            {
+                loaded.push(Arc::new(LibFile::from_source((*name).to_string(), content)));
+                break;
+            }
+        }
+    }
+    loaded
+}
+
+fn check_with_iterable_libs(source: &str) -> Vec<Diagnostic> {
+    // The minimum set required to make `IteratorResult<T>`,
+    // `Promise<T>`, and `AsyncIterator<T, ...>` resolvable.
+    let lib_files = load_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.es2015.core.d.ts",
+        "lib.es2015.collection.d.ts",
+        "lib.es2015.iterable.d.ts",
+        "lib.es2015.symbol.d.ts",
+        "lib.es2015.symbol.wellknown.d.ts",
+        "lib.es2015.promise.d.ts",
+        "lib.es2015.proxy.d.ts",
+        "lib.es2015.reflect.d.ts",
+        "lib.es2015.generator.d.ts",
+        "lib.es2016.array.include.d.ts",
+        "lib.es2018.asynciterable.d.ts",
+        "lib.es2018.asyncgenerator.d.ts",
+    ]);
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "Parse errors: {:?}",
+        parser.get_diagnostics()
+    );
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            target: ScriptTarget::ESNext,
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    );
+
+    if !lib_files.is_empty() {
+        let lib_contexts: Vec<_> = lib_files
+            .iter()
+            .map(|lib| CheckerLibContext {
+                arena: Arc::clone(&lib.arena),
+                binder: Arc::clone(&lib.binder),
+            })
+            .collect();
+        checker.ctx.set_lib_contexts(lib_contexts);
+        checker.ctx.set_actual_lib_file_count(lib_files.len());
+    }
+
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.clone()
+}
+
+fn semantic_error_codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    diagnostics
+        .iter()
+        .filter(|d| {
+            d.category == tsz_checker::diagnostics::DiagnosticCategory::Error && d.code != 2318 // TS2318 = Cannot find global type (test infra noise)
+        })
+        .map(|d| d.code)
+        .collect()
+}
+
+/// `IteratorResult<string>` (default `TReturn = any`) must be assignable
+/// to `IteratorResult<string, void>` directly.
+#[test]
+fn iterator_result_default_assignable_to_iterator_result_void() {
+    let diagnostics = check_with_iterable_libs(
+        r#"
+declare const c: IteratorResult<string>;
+const x: IteratorResult<string, void> = c;
+"#,
+    );
+    let codes = semantic_error_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "IteratorResult<string> should be assignable to IteratorResult<string, void>; got: {diagnostics:#?}"
+    );
+}
+
+/// Wrapping in an object property must preserve the assignability.
+#[test]
+fn property_of_iterator_result_default_assignable_to_iterator_result_void() {
+    let diagnostics = check_with_iterable_libs(
+        r#"
+declare const c: { val: IteratorResult<string> };
+const x: { val: IteratorResult<string, void> } = c;
+"#,
+    );
+    let codes = semantic_error_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "{{val: IteratorResult<string>}} should be assignable to {{val: IteratorResult<string, void>}}; got: {diagnostics:#?}"
+    );
+}
+
+/// Wrapping in `Promise<...>` must preserve the assignability — this
+/// is the form actually used in the lib `AsyncIterator.next` return
+/// type.
+#[test]
+fn promise_of_iterator_result_default_assignable_to_iterator_result_void() {
+    let diagnostics = check_with_iterable_libs(
+        r#"
+declare const c: Promise<IteratorResult<string>>;
+const x: Promise<IteratorResult<string, void>> = c;
+"#,
+    );
+    let codes = semantic_error_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "Promise<IteratorResult<string>> should be assignable to Promise<IteratorResult<string, void>>; got: {diagnostics:#?}"
+    );
+}

--- a/docs/plan/claims/fix-checker-async-iterator-tuple-rest-override.md
+++ b/docs/plan/claims/fix-checker-async-iterator-tuple-rest-override.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-async-iterator-tuple-rest-override`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1377
+- **Status**: ready
 - **Workstream**: 1 (Conformance)
 
 ## Intent

--- a/docs/plan/claims/fix-checker-async-iterator-tuple-rest-override.md
+++ b/docs/plan/claims/fix-checker-async-iterator-tuple-rest-override.md
@@ -1,0 +1,72 @@
+# test(checker): lock IteratorResult default-vs-void assignability
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-async-iterator-tuple-rest-override`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Conformance)
+
+## Intent
+
+Add unit-level tests that lock down the assignability invariant behind the
+false-positive TS2416 emitted on
+`TypeScript/tests/cases/compiler/customAsyncIterator.ts`:
+
+```ts
+class ConstantIterator<T> implements AsyncIterator<T, void, T | undefined> {
+    async next(value?: T): Promise<IteratorResult<T>> { ... }
+}
+```
+
+tsc accepts this because `Promise<IteratorResult<T, /*default*/ any>>` is
+structurally assignable to `Promise<IteratorResult<T, void>>` — but the
+CLI/conformance harness in tsz currently rejects it.
+
+The unit tests in this PR verify that `IteratorResult<T>` is assignable to
+`IteratorResult<T, void>` directly, when wrapped in an object property,
+and when wrapped in `Promise<...>`. They all pass on `main`, which
+demonstrates that the underlying solver invariant holds when libs are
+loaded explicitly.
+
+The conformance failure is therefore environment-dependent — likely a
+side-effect of how the CLI's transitive lib loader constructs the lib
+graph for `--target esnext`. A subsequent PR will narrow that down and
+fix it; this PR locks down the invariant so the eventual fix can rely on
+a green unit-test gate.
+
+## Files Touched
+
+- `crates/tsz-checker/Cargo.toml` (+4 LOC, register new test target)
+- `crates/tsz-checker/tests/generic_alias_assignability_pollution_tests.rs` (+165 LOC, new file)
+- `docs/plan/claims/fix-checker-async-iterator-tuple-rest-override.md` (this claim)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test generic_alias_assignability_pollution_tests` (3 tests pass)
+- `cargo nextest run -p tsz-checker --lib` (2886 tests pass, no regressions)
+- `./scripts/conformance/conformance.sh run --filter customAsyncIterator` still
+  reports the existing TS2416 false positive — this PR does not change the
+  conformance baseline; the regression test purely locks down the
+  invariant under unit-test conditions.
+
+## Notes for Follow-up
+
+- The conformance failure repro: `cargo run --release --bin tsz -- TypeScript/tests/cases/compiler/customAsyncIterator.ts` prints TS2416 at line 8.
+- A reduced repro outside conformance (for the actual bug, not the unit-test invariant):
+
+  ```ts
+  // Triggers in CLI but not in unit tests with the lib subset above.
+  interface I<TReturn> {
+      foo: IteratorResult<string, TReturn>;
+  }
+  declare const c: { val: IteratorResult<string> };
+  const x: { val: IteratorResult<string, void> } = c; // TS2322 in CLI
+  ```
+
+  The presence of an unrelated generic interface that references
+  `IteratorResult<string, TReturn>` with a free `TReturn` corrupts the
+  assignability check between `IteratorResult<string, any>` (default) and
+  `IteratorResult<string, void>`. The bug only reproduces when the lib's
+  actual `IteratorResult` declaration is used (a structurally identical
+  user-defined union alias does not trigger it), suggesting the corruption
+  is in evaluation/instantiation caching for lib-bound type aliases.


### PR DESCRIPTION
## Summary

- Adds three unit tests in a new `generic_alias_assignability_pollution_tests.rs` file that lock down the structural assignability of `IteratorResult<T>` (default `TReturn = any`) against `IteratorResult<T, void>` — directly, wrapped in an object property, and wrapped in `Promise<...>`.
- Adds a per-PR claim file under `docs/plan/claims/`.
- Conformance baseline unchanged.

## Context

`TypeScript/tests/cases/compiler/customAsyncIterator.ts` emits a false-positive `TS2416` in the CLI/conformance harness:

```ts
class ConstantIterator<T> implements AsyncIterator<T, void, T | undefined> {
    async next(value?: T): Promise<IteratorResult<T>> { ... }
}
```

tsc accepts this because `Promise<IteratorResult<T, /*default*/ any>>` is assignable to `Promise<IteratorResult<T, void>>`. tsz rejects it.

## Why unit tests, not a fix

The unit tests in this PR pass on `main`, which demonstrates the underlying solver invariant is correct under explicit lib loading. The conformance failure is therefore environment-dependent — a follow-up PR will narrow it down (transitive lib loading for `--target esnext` is the likely culprit) and fix it. This PR locks in the invariant so the eventual fix has a green unit-test gate.

A reduced repro that shows the bug only in the CLI environment (not unit tests):

```ts
interface I<TReturn> {
    foo: IteratorResult<string, TReturn>;
}
declare const c: { val: IteratorResult<string> };
const x: { val: IteratorResult<string, void> } = c; // TS2322 in CLI only
```

## Test plan

- [x] `cargo nextest run -p tsz-checker --test generic_alias_assignability_pollution_tests` (3 pass)
- [x] `cargo nextest run -p tsz-checker --lib` (2886 pass, no regressions)
- [x] `./scripts/conformance/conformance.sh run --filter customAsyncIterator` still reports the existing failure — baseline unchanged.