### PR TITLE
fix(lsp): delegate identifier text bypass to total resolve_identifier_text

### DIFF
--- a/crates/tsz-lsp/src/navigation/implementation.rs
+++ b/crates/tsz-lsp/src/navigation/implementation.rs
@@ -38,15 +38,20 @@ pub struct ImplementationResult {
 }
 
 impl<'a> GoToImplementationProvider<'a> {
-    /// Get the `escaped_text` for an identifier node, reading directly from `IdentifierData`.
+    /// Get the text for an identifier node.
     ///
-    /// This bypasses the interner-based `get_identifier_text` which requires the interner
-    /// to be transferred from the scanner to the arena (done by `into_arena()` but not
-    /// by `get_arena()`). The `escaped_text` field is always populated by the parser.
+    /// Delegates to the arena's `resolve_identifier_text`, which transparently
+    /// falls back to `IdentifierData::escaped_text` when the interner has not
+    /// resolved the atom (the case `get_arena()`-served arenas hit when the
+    /// scanner-side interner has not been transferred). Previously this was
+    /// a manual bypass; the bypass is no longer needed because
+    /// `resolve_identifier_text` is total. See robustness audit
+    /// `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md` item 13 (PR #M).
     fn get_identifier_escaped_text(&self, node_idx: NodeIndex) -> Option<&str> {
         let node = self.arena.get(node_idx)?;
         let data = self.arena.get_identifier(node)?;
-        Some(&data.escaped_text)
+        let text = self.arena.resolve_identifier_text(data);
+        if text.is_empty() { None } else { Some(text) }
     }
 
     /// Resolve the symbol at a node index.


### PR DESCRIPTION
## Summary

Implements **PR #M (item 13)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`crates/tsz-lsp/src/navigation/implementation.rs` had a hand-rolled `get_identifier_escaped_text` that read `IdentifierData::escaped_text` directly to bypass the interner-based path. The comment said the bypass was needed because `get_arena()` doesn't transfer the interner. That premise is stale: `NodeArena::resolve_identifier_text` already has the fallback to `escaped_text` when the interner returns an empty string (added by PR #1205), so the helper can simply delegate.

The other half of audit item 13 (`rename/core.rs`) uses a separate `extract_identifier_from_source` source-text fallback — not addressed in this PR; it has different semantics (handling shorthand / import expansion) that warrant a focused follow-up.

## Note

This branch carries the prior bundled fix from PR #1375 (Add Missing Imports stub drop + solver `match_same_arms` clippy fix). If #1375 lands first, this PR's diff vs. main will reduce to the single LSP file change.

## Test plan

- [x] 3733/3733 `tsz-lsp` tests pass, including all implementation/navigation tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
