### PR TITLE
chore(checker/speculation): rename guard locals to snap + drop stale doc ref

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -72,7 +72,7 @@ impl<'a> CheckerState<'a> {
         // Speculative attribute collection: save diagnostic checkpoint so side-effect
         // diagnostics (e.g. TS7006 from callback params without contextual typing) are
         // rolled back. Only the final TS2769 (if no overload matches) is kept.
-        let guard = DiagnosticSpeculationSnapshot::new(&self.ctx);
+        let snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
 
         // Collect JSX attributes: explicit + spread-merged, with override tracking
         let mut attrs_info = self.collect_jsx_provided_attrs(attributes_idx);
@@ -106,7 +106,7 @@ impl<'a> CheckerState<'a> {
         if attrs_info.has_any_spread {
             let has_non_zero_param = sigs.iter().any(|s| !s.params.is_empty());
             if has_non_zero_param {
-                guard.rollback(&mut self.ctx);
+                snap.rollback(&mut self.ctx);
                 return;
             }
         }
@@ -123,7 +123,7 @@ impl<'a> CheckerState<'a> {
             // overloads fail on arg count when any attributes exist.
             if sig.params.is_empty() {
                 if !has_any_attrs {
-                    guard.rollback(&mut self.ctx);
+                    snap.rollback(&mut self.ctx);
                     self.check_jsx_sfc_return_type(instantiated_return, tag_name_idx);
                     return;
                 }
@@ -165,7 +165,7 @@ impl<'a> CheckerState<'a> {
             if self.jsx_attrs_match_overload(&attrs_info, props_resolved, &default_props_keys) {
                 // Found a matching overload — done.
                 // Roll back speculative diagnostics from attribute collection.
-                guard.rollback(&mut self.ctx);
+                snap.rollback(&mut self.ctx);
                 self.check_jsx_sfc_return_type(instantiated_return, tag_name_idx);
                 return;
             }
@@ -189,7 +189,7 @@ impl<'a> CheckerState<'a> {
         // No overload matched — roll back speculative diagnostics and emit TS2769.
         // tsc often anchors at the tag name, but when every non-0-param overload
         // fails on the same explicit attribute, anchor that attribute instead.
-        guard.rollback(&mut self.ctx);
+        snap.rollback(&mut self.ctx);
         let anchor_idx =
             if considered_overload_failures > 0 && all_overload_failures_share_explicit_anchor {
                 shared_explicit_anchor_name

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -66,8 +66,9 @@ fn cleanup_ts2454_dedup(
 
 /// Snapshot of diagnostic state that speculative evaluation may corrupt.
 ///
-/// Created by `CheckerContext::begin_speculation` and consumed by the
-/// `SpeculationGuard` on drop/commit.
+/// Created by `CheckerContext::snapshot_diagnostics` and consumed by the
+/// `DiagnosticSpeculationSnapshot` holder via explicit `commit()` /
+/// `rollback()` (no `Drop` impl — see module preamble for rationale).
 pub(crate) struct DiagnosticSnapshot {
     /// Length of `ctx.diagnostics` at snapshot time (truncation point).
     pub diagnostics_len: usize,

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -268,11 +268,11 @@ impl CheckerState<'_> {
             rhs_node.kind,
             k if k == syntax_kind_ext::FUNCTION_EXPRESSION || k == syntax_kind_ext::ARROW_FUNCTION
         );
-        let diag_guard = suppress_provisional_body_diagnostics
+        let diag_snap = suppress_provisional_body_diagnostics
             .then(|| DiagnosticSpeculationSnapshot::new(&self.ctx));
         let rhs_type = self.get_type_of_node(rhs_idx);
-        if let Some(guard) = diag_guard {
-            guard.rollback(&mut self.ctx);
+        if let Some(snap) = diag_snap {
+            snap.rollback(&mut self.ctx);
         }
         rhs_type
     }

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1395,7 +1395,7 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
-                    let method_diag_guard = DiagnosticSpeculationSnapshot::new(&self.ctx);
+                    let method_diag_snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
                     let pre_refresh_snap = self.ctx.snapshot_diagnostics();
                     let mut method_type = self.get_type_of_function_impl(elem_idx, &method_request);
                     let has_concrete_method_context =
@@ -1417,7 +1417,7 @@ impl<'a> CheckerState<'a> {
                         && !this_property_accesses.is_empty()
                         && self.ctx.arena.get(method.body).is_some_and(|body_node| {
                             self.ctx
-                                .speculative_diagnostics_since(method_diag_guard.snapshot())
+                                .speculative_diagnostics_since(method_diag_snap.snapshot())
                                 .iter()
                                 .any(|diag| {
                                     diag.start >= body_node.pos
@@ -1431,7 +1431,7 @@ impl<'a> CheckerState<'a> {
                     }
 
                     if method_return_this_circularity {
-                        method_diag_guard.rollback(&mut self.ctx);
+                        method_diag_snap.rollback(&mut self.ctx);
                         self.invalidate_expression_for_contextual_retry(elem_idx);
                         let refined_method_type = crate::query_boundaries::assignability::get_function_return_type(
                             self.ctx.types,
@@ -1471,7 +1471,7 @@ impl<'a> CheckerState<'a> {
                             )),
                         );
                         self.ctx.this_type_stack.push(refined_this_type);
-                        let rerun_guard = DiagnosticSpeculationSnapshot::new(&self.ctx);
+                        let rerun_snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
                         let rerun_pre_refresh_snap = self.ctx.snapshot_diagnostics();
                         let _ = self.get_type_of_function_impl(elem_idx, &method_request);
                         if has_concrete_method_context {
@@ -1489,7 +1489,7 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.arena.get(*idx).map(|node| node.pos)
                                 })
                                 .collect();
-                        rerun_guard.rollback_filtered(&mut self.ctx, |diag| {
+                        rerun_snap.rollback_filtered(&mut self.ctx, |diag| {
                             let is_replaced_this_property_error =
                                 diag.code == 2339 && this_property_positions.contains(&diag.start);
                             !is_replaced_this_property_error

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -2143,14 +2143,14 @@ impl<'a> CheckerState<'a> {
                             .get(body)
                             .and_then(|body_node| self.ctx.arena.get_conditional_expr(body_node))
                             .is_some_and(|cond| {
-                                let guard = DiagnosticSpeculationSnapshot::new(&self.ctx);
+                                let snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
                                 let return_req =
                                     TypingRequest::with_contextual_type(expected_return_type);
                                 let mut when_true =
                                     self.get_type_of_node_with_request(cond.when_true, &return_req);
                                 let mut when_false = self
                                     .get_type_of_node_with_request(cond.when_false, &return_req);
-                                guard.rollback(&mut self.ctx);
+                                snap.rollback(&mut self.ctx);
                                 if is_async_for_context {
                                     when_true =
                                         self.unwrap_promise_type(when_true).unwrap_or(when_true);
@@ -2310,7 +2310,7 @@ impl<'a> CheckerState<'a> {
                                 self.type_has_unresolved_inference_holes(return_type)
                             })
                     });
-                let diag_guard = suppress_expression_body_diagnostics
+                let diag_snap = suppress_expression_body_diagnostics
                     .then(|| DiagnosticSpeculationSnapshot::new(&self.ctx));
                 // During type environment building (before is_checking_statements),
                 // skip full body checking for class methods/constructors. The class
@@ -2328,8 +2328,8 @@ impl<'a> CheckerState<'a> {
                 if !skip_body_check {
                     self.check_statement_with_request(body, &TypingRequest::NONE);
                 }
-                if let Some(guard) = diag_guard {
-                    guard.rollback(&mut self.ctx);
+                if let Some(snap) = diag_snap {
+                    snap.rollback(&mut self.ctx);
                 }
 
                 // For annotated generator expressions, check that Generator<TYield, any, any>

--- a/docs/plan/claims/chore-speculation-snapshot-callsite-rename.md
+++ b/docs/plan/claims/chore-speculation-snapshot-callsite-rename.md
@@ -1,0 +1,35 @@
+# chore(checker/speculation): rename `guard` callsite locals to `snap` + drop stale `SpeculationGuard` doc
+
+- **Date**: 2026-04-26
+- **Branch**: `chore/speculation-snapshot-callsite-rename`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: ROBUSTNESS_AUDIT_2026-04-26 item #5 (#E)
+
+## Intent
+
+Audit item #5 (Speculation guard documentation says rollback-on-drop, actually
+implicit-commits) was partially addressed by PR #1213 (`DiagnosticSpeculationGuard`
+→ `DiagnosticSpeculationSnapshot` rename) and PR #1364 (module preamble
+alignment). Two remaining inconsistencies:
+
+1. `crates/tsz-checker/src/context/speculation.rs:70` still references the
+   removed `SpeculationGuard` type in a doc-comment.
+2. Nine call-sites still bind the holder to a local named `guard`, perpetuating
+   the implication of RAII semantics. Rename to `snap` to match the type and
+   make the explicit-action discipline visible at the call-site.
+
+Behavior preserving: variable rename + doc-comment update, no logic change.
+
+## Files Touched
+
+- `crates/tsz-checker/src/context/speculation.rs` (1-line doc fix)
+- `crates/tsz-checker/src/checkers/jsx/overloads.rs` (4 callsites)
+- `crates/tsz-checker/src/types/function_type.rs` (2 callsites)
+- `crates/tsz-checker/src/types/computation/object_literal/computation.rs` (2 callsites)
+- `crates/tsz-checker/src/types/class_type/js_class_properties.rs` (1 callsite)
+
+## Verification
+
+- `cargo check -p tsz-checker` (passes)
+- `cargo nextest run -p tsz-checker --lib` (no behavior change)

--- a/docs/plan/claims/chore-speculation-snapshot-callsite-rename.md
+++ b/docs/plan/claims/chore-speculation-snapshot-callsite-rename.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `chore/speculation-snapshot-callsite-rename`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1379
+- **Status**: ready
 - **Workstream**: ROBUSTNESS_AUDIT_2026-04-26 item #5 (#E)
 
 ## Intent


### PR DESCRIPTION
## Intent
Audit item #5 (`docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`) — Speculation guard documentation says rollback-on-drop, actually implicit-commits. Mostly addressed by #1213 (type rename) and #1364 (module preamble alignment). Two stragglers remain:
1. `crates/tsz-checker/src/context/speculation.rs:70` still references the removed `SpeculationGuard` type.
2. Nine call sites bind the holder to a local named `guard`, perpetuating RAII implication.

## Roadmap Claim
- Added `docs/plan/claims/chore-speculation-snapshot-callsite-rename.md`.

## Planned Scope
- `crates/tsz-checker/src/context/speculation.rs` (1-line doc fix)
- `crates/tsz-checker/src/checkers/jsx/overloads.rs` (4 callsites)
- `crates/tsz-checker/src/types/function_type.rs` (2 callsites)
- `crates/tsz-checker/src/types/computation/object_literal/computation.rs` (2 callsites, including `method_diag_guard` and `rerun_guard`)
- `crates/tsz-checker/src/types/class_type/js_class_properties.rs` (1 callsite)

Variable rename only. No control-flow changes.

## Verification Plan
- `cargo check -p tsz-checker`
- `cargo nextest run -p tsz-checker --lib`