### PR TITLE
feat(solver): unpack `[] | [X]` rest tuple unions to optional fixed params

### DIFF
--- a/crates/tsz-solver/src/tests/type_queries_function_rewrite_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_function_rewrite_tests.rs
@@ -98,3 +98,119 @@ fn unpack_tuple_rest_parameter_flattens_nested_tuple_rest_elements() {
     assert_eq!(unpacked[2].type_id, db.array(TypeId::STRING));
     assert!(unpacked[2].rest);
 }
+
+/// `(...args: [] | [X])` is the lib pattern used by `Iterator.next` /
+/// `AsyncIterator.next`. tsc treats it as equivalent to `(value?: X)` for
+/// signature compat. The unpacker must recognize the prefix-aligned union of
+/// fixed tuples and emit one optional parameter.
+#[test]
+fn unpack_tuple_rest_parameter_handles_empty_or_single_tuple_union() {
+    let db = TypeInterner::new();
+    let empty_tuple = db.tuple(vec![]);
+    let single_tuple = db.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let union_ty = db.union(vec![empty_tuple, single_tuple]);
+
+    let rest_param = ParamInfo {
+        name: None,
+        type_id: union_ty,
+        optional: false,
+        rest: true,
+    };
+
+    let unpacked = unpack_tuple_rest_parameter(&db, &rest_param);
+    assert_eq!(
+        unpacked.len(),
+        1,
+        "[] | [X] should flatten to a single optional param, got {unpacked:?}"
+    );
+    assert_eq!(unpacked[0].type_id, TypeId::STRING);
+    assert!(
+        unpacked[0].optional,
+        "shorter member missing position 0 → optional"
+    );
+    assert!(!unpacked[0].rest, "fixed-position param, not rest");
+}
+
+/// `[X] | [X, Y]` where positions agree on prefix should flatten to
+/// `[required X, optional Y]`.
+#[test]
+fn unpack_tuple_rest_parameter_handles_prefix_aligned_two_member_union() {
+    let db = TypeInterner::new();
+    let one = db.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let two = db.tuple(vec![
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let union_ty = db.union(vec![one, two]);
+
+    let rest_param = ParamInfo {
+        name: None,
+        type_id: union_ty,
+        optional: false,
+        rest: true,
+    };
+
+    let unpacked = unpack_tuple_rest_parameter(&db, &rest_param);
+    assert_eq!(unpacked.len(), 2);
+    assert_eq!(unpacked[0].type_id, TypeId::STRING);
+    assert!(!unpacked[0].optional, "position 0 covered by both members");
+    assert_eq!(unpacked[1].type_id, TypeId::NUMBER);
+    assert!(unpacked[1].optional, "position 1 only in the longer member");
+}
+
+/// Disagreeing first elements must NOT collapse — `[X] | [Y]` stays as a
+/// rest-typed param so callers fall back to the union-of-tuple handling at
+/// the call site (which iterates each tuple variant separately).
+#[test]
+fn unpack_tuple_rest_parameter_keeps_disagreeing_union_as_rest() {
+    let db = TypeInterner::new();
+    let s_tuple = db.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let n_tuple = db.tuple(vec![TupleElement {
+        type_id: TypeId::NUMBER,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let union_ty = db.union(vec![s_tuple, n_tuple]);
+
+    let rest_param = ParamInfo {
+        name: None,
+        type_id: union_ty,
+        optional: false,
+        rest: true,
+    };
+
+    let unpacked = unpack_tuple_rest_parameter(&db, &rest_param);
+    assert_eq!(
+        unpacked.len(),
+        1,
+        "non-prefix-aligned union must stay as a rest param"
+    );
+    assert!(unpacked[0].rest);
+    assert_eq!(unpacked[0].type_id, union_ty);
+}

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -627,6 +627,16 @@ pub fn unpack_tuple_rest_parameter(
         return vec![*param];
     }
 
+    // Union of prefix-aligned tuples (the lib's `[] | [TNext]` pattern in
+    // `Iterator.next` / `AsyncIterator.next`) is structurally equivalent to a
+    // list of optional fixed parameters. tsc treats `(...args: [] | [X])` as
+    // `(value?: X)` for signature compat, so unpack here too. Only fires when
+    // every union member is a fixed-length tuple (no rest tail) and shorter
+    // members are position-wise prefixes of the longest member.
+    if let Some(unpacked) = unpack_union_of_prefix_tuples(db, param.type_id) {
+        return unpacked;
+    }
+
     // Check if the rest parameter type is a tuple
     if let Some(tuple_elements) = get_tuple_elements(db, param.type_id) {
         let mut unpacked = Vec::new();
@@ -673,6 +683,88 @@ pub fn unpack_tuple_rest_parameter(
         // This handles cases like `...args: string[]` which should remain a rest parameter
         vec![*param]
     }
+}
+
+/// Unpack a union of prefix-aligned fixed tuples into a flat list of optional
+/// parameters. Returns `Some` only when:
+///
+/// - the input type is a union, and
+/// - every union member is a fixed-length tuple (no rest tail), and
+/// - every shorter member is the position-wise prefix of the longest member
+///   (positions 0..len(short) have identical types across members that include
+///   that position).
+///
+/// On a match, positions held by the longest tuple are emitted as `ParamInfo`s
+/// with `optional = true` for any position that some shorter member doesn't
+/// cover. Tuples that contain rest spread elements bail out — variadic shape
+/// can't be flattened.
+///
+/// Mirrors tsc's treatment of `(...args: [] | [X])` ≡ `(x?: X)` used in the
+/// `Iterator.next` / `AsyncIterator.next` lib signatures.
+fn unpack_union_of_prefix_tuples(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<Vec<crate::types::ParamInfo>> {
+    let members = get_union_members(db, type_id)?;
+    if members.len() < 2 {
+        return None;
+    }
+
+    // Collect each member's tuple elements; bail on any non-tuple or any tuple
+    // containing a rest/spread element (variadic shape can't be flattened).
+    let mut tuples: Vec<Vec<crate::types::TupleElement>> = Vec::with_capacity(members.len());
+    for &m in &members {
+        let elems = get_tuple_elements(db, m)?;
+        if elems.iter().any(|e| e.rest) {
+            return None;
+        }
+        tuples.push(elems);
+    }
+
+    // Find the longest tuple — it defines the parameter list shape.
+    let max_len = tuples.iter().map(|t| t.len()).max()?;
+    if max_len == 0 {
+        return None;
+    }
+
+    // Verify the prefix property: at each position, all members that have an
+    // element there must agree on type. tsc's `(...args: [] | [X])` pattern
+    // satisfies this trivially; mismatched unions like `[X] | [Y]` do not and
+    // should keep the rest-typed param.
+    let mut shape: Vec<crate::types::TupleElement> = Vec::with_capacity(max_len);
+    for pos in 0..max_len {
+        let mut element: Option<crate::types::TupleElement> = None;
+        let mut optional_at_pos = false;
+        for tuple in &tuples {
+            if pos >= tuple.len() {
+                optional_at_pos = true;
+                continue;
+            }
+            let candidate = &tuple[pos];
+            match &element {
+                None => element = Some(*candidate),
+                Some(existing) if existing.type_id != candidate.type_id => return None,
+                _ => {}
+            }
+        }
+        let mut e = element?;
+        if optional_at_pos {
+            e.optional = true;
+        }
+        shape.push(e);
+    }
+
+    Some(
+        shape
+            .into_iter()
+            .map(|e| crate::types::ParamInfo {
+                name: e.name,
+                type_id: e.type_id,
+                optional: e.optional,
+                rest: false,
+            })
+            .collect(),
+    )
 }
 
 /// Get the object shape ID for an object type.

--- a/docs/plan/claims/finish-pr-1381.md
+++ b/docs/plan/claims/finish-pr-1381.md
@@ -1,0 +1,63 @@
+# finish-pr-1381: ship `[] | [X]` rest tuple unpacking
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/solver-bivariant-params-only-method-compat`
+- **PR**: #1381
+- **Status**: ready
+- **Workstream**: 1 — Diagnostic Conformance / TS2416 false positives (foundation work)
+
+## Takeover Notes
+
+This file records the handover that moved PR #1381 from WIP/in-progress to
+ready-for-review. The implementation work was already in place from prior
+sessions (~259 LOC across solver + tests + claim file).
+
+## Actions Taken in This Slice
+
+1. Rebased `fix/solver-bivariant-params-only-method-compat` onto current
+   `origin/main` (which had landed PR #1387's `gcp-full-ci.sh` memory cap and
+   matching Cargo.toml comment). The pre-rebase diff against main showed
+   spurious reverts of those CI bits because the branch was off the older
+   `a0cdb8aea6` commit; rebase eliminated those phantom changes.
+2. Verified the diff is now solver-only:
+   - `crates/tsz-solver/src/type_queries/data/accessors.rs` (+92)
+   - `crates/tsz-solver/src/tests/type_queries_function_rewrite_tests.rs` (+116)
+   - `docs/plan/claims/fix-solver-unpack-tuple-rest-prefix-aligned-union.md` (+51)
+3. Ran the targeted test suite: `cargo nextest run -p tsz-solver --lib
+   type_queries_function_rewrite` → **6 passed, 0 failed**.
+4. Ran `cargo clippy -p tsz-solver --lib --no-deps` → no warnings.
+5. Updated existing claim file Status from `claim` → `ready` and stamped PR
+   number.
+6. Force-pushed the rebased branch.
+
+## Architecture Compliance
+
+- **§3 Responsibility Split**: Solver-only (`WHAT`). No checker, binder, or
+  boundary helper changes. Pure type-shape transformation lives where it
+  belongs.
+- **§4 Hard Architecture Rules**: No new checker access to solver internals.
+  No new `TypeKey` leakage. The new helper consumes the existing public
+  `get_union_members` / `get_tuple_elements` accessors.
+- **§11 Solver Contracts**: New helper is part of the same `accessors.rs` file
+  that already owns this kind of shape destructuring. No new caches, no
+  visitor-bypassing recursion.
+- **§22 / §23 TS2322 Rules**: N/A. This change does not touch
+  `query_boundaries/assignability` and does not introduce new
+  `CompatChecker` callers. It transforms parameter shape *before* any
+  relation/compat code runs.
+
+## Verification
+
+- `cargo nextest run -p tsz-solver --lib type_queries_function_rewrite` — 6 pass
+  (3 prior + 3 new).
+- `cargo clippy -p tsz-solver --lib --no-deps` — clean.
+- CI on the rebased push will run the full unit + conformance + emit lanes.
+- Per the PR body, the underlying conformance counts are net-zero in this
+  slice; this is documented foundation work.
+
+## Follow-up
+
+The original `customAsyncIterator.ts` target needs the `Promise<IteratorResult<T,
+any>>` vs `Promise<IteratorResult<T, void>>` return-type comparison fix to
+actually flip. That is documented in the PR body and the existing claim file
+under "Notes on `customAsyncIterator.ts`" and is out of scope for this slice.

--- a/docs/plan/claims/fix-solver-unpack-tuple-rest-prefix-aligned-union.md
+++ b/docs/plan/claims/fix-solver-unpack-tuple-rest-prefix-aligned-union.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/solver-bivariant-params-only-method-compat`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1381
+- **Status**: ready
 - **Workstream**: 1 — Diagnostic Conformance / TS2416 false positives (foundation work)
 
 ## Intent

--- a/docs/plan/claims/fix-solver-unpack-tuple-rest-prefix-aligned-union.md
+++ b/docs/plan/claims/fix-solver-unpack-tuple-rest-prefix-aligned-union.md
@@ -1,0 +1,51 @@
+# fix(solver): unpack `[] | [X]` rest tuple unions to optional fixed params
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/solver-bivariant-params-only-method-compat`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 — Diagnostic Conformance / TS2416 false positives (foundation work)
+
+## Intent
+
+The lib's `Iterator.next` / `AsyncIterator.next` declare their parameter as
+`...[value]: [] | [TNext]` — a rest binding whose tuple-list type is a union
+of fixed-length tuples. tsc treats this as structurally equivalent to
+`(value?: TNext)` for signature compat. tsz's `unpack_tuple_rest_parameter`
+only handled single fixed tuples (`[A, B, C]`); it left the union form alone,
+so the function-rules path could not reach the parameter-by-parameter
+comparison code that already handles optional/rest properly.
+
+This PR teaches `unpack_tuple_rest_parameter` to recognize the
+prefix-aligned union pattern and flatten it into a list of optional fixed
+parameters. Mirrors tsc's structural equivalence for this lib idiom.
+
+## Files Touched
+
+- `crates/tsz-solver/src/type_queries/data/accessors.rs`
+  — new `unpack_union_of_prefix_tuples` helper (~80 LOC) and a hook in
+  `unpack_tuple_rest_parameter` to call it before the existing single-tuple
+  fall-through. Bails on non-tuple union members, on tuples with rest tails,
+  and on disagreeing positions (so `[X] | [Y]` keeps the rest type).
+- `crates/tsz-solver/src/tests/type_queries_function_rewrite_tests.rs`
+  — three new tests pinning the behavior: `[] | [X]` → one optional,
+  `[X] | [X, Y]` → required + optional, `[X] | [Y]` → preserved as rest.
+
+## Verification
+
+- `cargo nextest run -p tsz-solver --lib type_queries_function_rewrite` — 6 pass
+  (3 existing + 3 new)
+- `cargo nextest run -p tsz-solver --lib` — 5517 pass
+- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — full suite
+
+## Notes on `customAsyncIterator.ts`
+
+The original target test for this work, `customAsyncIterator.ts`, does **not**
+flip with this change alone. End-to-end tracing showed the failure surfaces
+*before* parameter unpacking is reached: `check_function_subtype_impl` first
+runs `check_return_compat` on the Promise return types, and that comparison
+returns False for `Promise<IteratorResult<T, any>>` vs
+`Promise<IteratorResult<T, void>>` — a separate Application/instantiation
+comparison issue. This PR is a foundation (correctly handles the lib's
+parameter shape) so the eventual return-type fix can land cleanly without
+re-fighting the parameter side.


### PR DESCRIPTION
## Summary

Teaches `unpack_tuple_rest_parameter` to recognize the prefix-aligned tuple-union pattern used in lib `Iterator.next` / `AsyncIterator.next` and flatten it to optional fixed parameters — mirroring tsc's structural equivalence.

```ts
// Lib pattern (lib.es2015.iterable.d.ts, lib.es2018.asynciterable.d.ts):
interface AsyncIterator<T, TReturn = any, TNext = any> {
    next(...[value]: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
}
```

`(...args: [] | [X])` is structurally equivalent to `(value?: X)` in tsc. The unpacker now recognizes the union form and emits `[ParamInfo { type_id: X, optional: true, rest: false }]`.

## Scope

The new helper `unpack_union_of_prefix_tuples` only fires when:
- input is a union of fixed-length tuples (no rest tails)
- shorter members are position-wise prefixes of the longest member
- positions agree on type across covering members

Disagreeing first elements (e.g. `[X] | [Y]`) preserve the rest-typed param so the existing union-of-tuples handling at the call site (`subtype/rules/functions/checking.rs:697`) still applies.

## Test plan

- [x] 3 new unit tests: `[]|[X]`, `[X]|[X,Y]`, `[X]|[Y]` (preserved-as-rest)
- [x] All 5517 solver lib tests pass
- [x] Full conformance: 12183/12582 (no regressions, no improvements)

## Notes on `customAsyncIterator.ts`

This unpacker addition is a foundation. End-to-end fix for `customAsyncIterator.ts` (TS2416 false positive) requires additional work that's out of scope here:

End-to-end tracing (`--lib` experiments) shows the failure is triggered by **DOM lib loading**:
- `--lib esnext` (no DOM): test passes
- `--lib esnext.full` (with DOM): TS2416 false positive

DOM declares `FileSystemDirectoryHandleAsyncIterator extends AsyncIteratorObject<T, BuiltinIteratorReturn, unknown>` and similar. `BuiltinIteratorReturn` is the `intrinsic` keyword type that resolves to `undefined` or `any` based on `strictBuiltInIteratorReturn`. Loading DOM seems to pollute `IteratorResult` / `AsyncIterator` type-resolution in a way that breaks the `Promise<IteratorResult<T,any>>` vs `Promise<IteratorResult<T,void>>` return-type comparison.

The end-to-end fix needs to address one of:
1. `intrinsic` keyword handling for `BuiltinIteratorReturn`
2. AsyncIteratorObject merging across `es2018.asynciterable` + `esnext.disposable`
3. Type-alias Application variance with default-vs-explicit type args

PR #1377 has unit-test locks for the IteratorResult invariant. This PR ships the parameter-shape capability so the eventual return-type fix lands cleanly without re-fighting the parameter side.