### PR TITLE
chore(checker): remove crate-wide allow(clippy::let_and_return); apply one spot-fix

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -1464,10 +1464,10 @@ impl<'a> CheckerState<'a> {
         if sig.type_params.is_empty() {
             // Non-generic class: explicit type args are irrelevant; use the first
             // parameter directly.
-            return sig.params.first().map(|p| {
-                let evaluated = self.evaluate_type_with_env(p.type_id);
-                evaluated
-            });
+            return sig
+                .params
+                .first()
+                .map(|p| self.evaluate_type_with_env(p.type_id));
         }
 
         // Only substitute when the arity matches (count validation already ran).

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -17,7 +17,6 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::collapsible_match)]
 #![allow(clippy::doc_markdown)]
-#![allow(clippy::let_and_return)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::redundant_clone)]
 #![allow(clippy::uninlined_format_args)]


### PR DESCRIPTION
## Summary

Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Item 17 calls for incrementally removing the broad `#![allow(...)]` set in `crates/tsz-checker/src/lib.rs` and re-adding `#[allow(...)]` only where justified.

This PR removes ONE entry — `clippy::let_and_return` — and applies the single spot-fix it surfaced in `checkers/jsx/extraction.rs:1467-1470`:

```rust
return sig.params.first().map(|p| {
    let evaluated = self.evaluate_type_with_env(p.type_id);
    evaluated
});
```

becomes

```rust
return sig.params.first().map(|p| self.evaluate_type_with_env(p.type_id));
```

## Test plan

- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
