### PR TITLE
chore(checker): remove crate-wide allow(clippy::needless_return)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -16,7 +16,6 @@
 #![allow(dead_code)]
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::doc_markdown)]
-#![allow(clippy::needless_return)]
 #![allow(clippy::uninlined_format_args)]
 
 extern crate self as tsz_checker;


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues PR #1382's incremental removal of the crate-wide `#![allow(...)]` set in `crates/tsz-checker/src/lib.rs`.

`needless_return` was in the allow list with no current triggers. Free removal — no source changes needed beyond dropping the line.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
