### PR TITLE
chore(checker): remove crate-wide allow(clippy::collapsible_match)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 #![allow(clippy::collapsible_if)]
-#![allow(clippy::collapsible_match)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::let_and_return)]
 #![allow(clippy::missing_const_for_fn)]


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382 (let_and_return) and #1383 (needless_return) — third crate-wide allow with no current triggers. Free removal.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
