### PR TITLE
fix(checker/assignability): unsuppress TS2322 for bare T → `${T}`

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1026,7 +1026,25 @@ impl<'a> CheckerState<'a> {
             || (should_suppress_for_complex_type(target)
                 && contains_type_parameters(source)
                 && !is_callable_or_function(target)
-                && !target_contains_indexed_access())
+                && !target_contains_indexed_access()
+                // Don't suppress when target is a template-literal pattern and the
+                // source is a bare type parameter. The pattern `${T}` is *not*
+                // trivially assignable from a bare T: T's instantiation could be
+                // a literal subtype ("a") that does not structurally match the
+                // template's pattern. tsc emits TS2322 for these cases (see
+                // templateLiteralTypes5.ts:14:11 — `const test1: \`${T3}\` = x`).
+                // Restrict the carve-out to bare type-parameter sources so that
+                // template-vs-template generic comparisons (e.g.
+                // `\`...${Uppercase<T>}.4\`` vs `\`...${Uppercase<T>}.3\``) keep
+                // their existing suppression — tsc tolerates those under generic
+                // constraint relationships.
+                && !(crate::query_boundaries::common::is_template_literal_type(
+                    self.ctx.types,
+                    target,
+                ) && crate::query_boundaries::common::is_type_parameter(
+                    self.ctx.types,
+                    source,
+                )))
             // Suppress TS2322 for callable types where the source contains generic type
             // parameters that may not have been fully inferred from context. When both
             // source and target contain type parameters that are COMPLETELY disjoint

--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -1445,3 +1445,71 @@ function f() {
         "destructuring declaration with empty pattern must not emit TS2353; got: {ts2353:?}"
     );
 }
+
+/// Regression: TS2322 must fire when a bare type parameter is assigned to a
+/// template-literal pattern referencing the same type parameter.
+///
+/// `tsc` reports TS2322 here because `\`${T}\`` is an opaque pattern type;
+/// `T`'s instantiation could be a literal subtype that does not structurally
+/// match the template, so the assignment is not statically sound. Without the
+/// template-literal carve-out in `should_suppress_assignability_diagnostic`,
+/// the generic "complex type" suppression would silently accept it because
+/// `\`${T}\`` "contains" T but is not itself a type parameter.
+///
+/// Repros the missing fingerprint at
+/// `templateLiteralTypes5.ts(14,11)`.
+#[test]
+fn type_parameter_to_template_literal_of_self_emits_ts2322() {
+    let source = r#"
+function f<T extends "a" | "b">(x: T) {
+    const test1: `${T}` = x;
+}
+"#;
+    let diags = diagnostics_for(source);
+    let ts2322s: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322s.is_empty(),
+        "expected TS2322 for `T -> \\`${{T}}\\`` assignment; diagnostics: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    let lhs_diag = ts2322s
+        .iter()
+        .find(|d| d.message_text.contains("'T'") && d.message_text.contains("`${T}`"))
+        .expect("expected TS2322 message naming T and `${T}`");
+    let test1_start = source.find("test1").expect("expected variable name") as u32;
+    assert_eq!(
+        lhs_diag.start, test1_start,
+        "TS2322 should anchor at the variable declaration name (test1)"
+    );
+}
+
+/// Companion check: template-literal vs template-literal assignments where
+/// both sides share a type parameter (e.g. `\`${Uppercase<T>}\``) must keep
+/// their existing suppression. This locks in the narrowness of the
+/// template-literal carve-out so it does not regress
+/// `templateLiteralTypes3.ts` (where tsc accepts the spread of values typed
+/// `Uppercase<\`1.${T}.4\`>` against an inferred `Uppercase<\`1.${T}.3\`>`).
+#[test]
+fn template_literal_to_template_literal_with_generic_intrinsic_does_not_emit_ts2345() {
+    let source = r#"
+type DotString = `${string}.${string}.${string}`;
+declare function spread<P extends DotString>(...args: P[]): P;
+function ft1<T extends string>(
+    u1: Uppercase<`1.${T}.3`>,
+    u2: Uppercase<`1.${T}.4`>,
+) {
+    spread(u1, u2);
+}
+"#;
+    let diags = diagnostics_for(source);
+    let ts2345s: Vec<_> = diags.iter().filter(|d| d.code == 2345).collect();
+    assert!(
+        ts2345s.is_empty(),
+        "template-vs-template generic intrinsic spread must stay suppressed; \
+         got TS2345 diagnostics: {:?}",
+        ts2345s.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}

--- a/docs/plan/claims/fix-checker-template-literal-suppression-typeparam-source.md
+++ b/docs/plan/claims/fix-checker-template-literal-suppression-typeparam-source.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-template-literal-suppression-typeparam-source`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1386
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent

--- a/docs/plan/claims/fix-checker-template-literal-suppression-typeparam-source.md
+++ b/docs/plan/claims/fix-checker-template-literal-suppression-typeparam-source.md
@@ -1,0 +1,43 @@
+# fix(checker/assignability): unsuppress TS2322 for `T -> \`${T}\`` patterns
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-template-literal-suppression-typeparam-source`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+Restore `tsc` parity for assigning a bare type parameter to a template
+literal pattern that references the same type parameter (for example
+`const test1: \`${T}\` = x;` inside `function f<T extends "a"|"b">(x: T)`).
+The existing `should_suppress_assignability_diagnostic` "complex type"
+heuristic was silently swallowing TS2322 here because `\`${T}\`` "contains"
+T but is not itself a type parameter, so the generic
+`contains_type_parameters && !type_parameter_like` suppression fired. The
+fix narrows that suppression with a template-literal-target / bare
+type-parameter-source carve-out, so the actual assignability query runs
+and the canonical solver diagnostic surfaces. The carve-out stays narrow
+on purpose: template-vs-template generic assignments that `tsc` tolerates
+(e.g. `\`...${Uppercase<T>}.4\``  vs `\`...${Uppercase<T>}.3\``) keep
+their existing suppression.
+
+## Files Touched
+
+- `crates/tsz-checker/src/assignability/assignability_checker.rs`
+  (~16 LOC: extend the suppression call site with a template-literal
+  target / type-parameter source carve-out)
+- `crates/tsz-checker/src/assignability/assignment_checker_tests.rs`
+  (~55 LOC: two regression tests — one locks in the new TS2322
+  emission, one locks in the still-suppressed template-vs-template path)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (2888 pass)
+- `cargo nextest run -p tsz-solver --lib` (5514 pass)
+- `./scripts/conformance/conformance.sh run --filter "templateLiteral"`
+  (templateLiteralTypes5 now PASS; templateLiteralTypes3 stays PASS;
+  no other template-literal regressions)
+- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run`:
+  net 12183 -> 12184 (+1), one improvement
+  (`templateLiteralTypes5.ts`), zero new failures.


### PR DESCRIPTION
## Summary

Restore `tsc` parity for assigning a bare type parameter to a template
literal pattern that references the same type parameter.

```ts
function f<T extends "a" | "b">(x: T) {
    const test1: `${T}` = x;   // tsc: TS2322. tsz before this PR: silently OK.
}
```

The "complex type" suppression in
`should_suppress_assignability_diagnostic` was eating TS2322 for this
shape because `\`${T}\`` *contains* the type parameter `T` but is not
itself a type parameter, so the generic
`contains_type_parameters && !type_parameter_like` test fired and
short-circuited the assignability query before the solver was called.

That assignment is **not** trivially sound: `T`'s instantiation could be
a literal subtype (`"a"`) that does not structurally match the template's
pattern.

This PR adds a narrow carve-out: skip the suppression **only when the
target is a template literal AND the source is a bare type parameter**.
That restores parity for the failing fingerprint without disturbing
template-vs-template generic comparisons that `tsc` tolerates (e.g.
`\`...${Uppercase<T>}.4\`` vs `\`...${Uppercase<T>}.3\``), which keep
their existing suppression — so `templateLiteralTypes3.ts` stays
passing.

Locked in with two regression tests:

- `type_parameter_to_template_literal_of_self_emits_ts2322` — fails
  before this PR, passes after.
- `template_literal_to_template_literal_with_generic_intrinsic_does_not_emit_ts2345`
  — guards the suppression boundary so future widening of the carve-out
  is caught.

## Conformance Impact

- `templateLiteralTypes5.ts` flips FAIL → PASS.
- Net 12183 → 12184 (+1), zero new failures.

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` (2890 pass)
- [x] `cargo nextest run -p tsz-solver --lib` (5514 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "templateLiteral"` — `templateLiteralTypes5.ts` PASS, no regressions in the family.
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — 12183 → 12184 (+1), one improvement, zero regressions.