### PR TITLE
chore(checker): remove crate-wide allow(clippy::redundant_clone) + 4 spot-fixes

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/identifier_source_display.rs
@@ -247,7 +247,7 @@ mod tests {
     fn stable_declaration_resolves_to_variable_decl_node() {
         let source = "let xs = [{ a: 1 }, { a: 2 }];\n".to_string();
 
-        let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+        let mut parser = ParserState::new("syn.ts".to_string(), source);
         let root = parser.parse_source_file();
         let arena = parser.get_arena();
         let mut binder = BinderState::new();

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -908,7 +908,7 @@ mod tests {
     fn stable_value_declaration_resolves_to_class_node() {
         let source = "class Foo extends Bar {}\n".to_string();
 
-        let mut parser = ParserState::new("syn.ts".to_string(), source.clone());
+        let mut parser = ParserState::new("syn.ts".to_string(), source);
         let root = parser.parse_source_file();
         let arena = parser.get_arena();
         let mut binder = BinderState::new();

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -19,7 +19,6 @@
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::let_and_return)]
 #![allow(clippy::needless_return)]
-#![allow(clippy::redundant_clone)]
 #![allow(clippy::uninlined_format_args)]
 
 extern crate self as tsz_checker;

--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -702,7 +702,7 @@ pub fn resolve_specifier_via_file_index(
     // dot-chain specifiers (`.`, `./`, `..`, `../..`) fall through here
     // and resolve to src_dir (or an ancestor) + `/index.<ext>` below.
     let joined = if src_dir.is_empty() {
-        spec_norm.clone()
+        spec_norm
     } else {
         let mut s = String::with_capacity(src_dir.len() + 1 + spec_norm.len());
         s.push_str(src_dir);

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -441,7 +441,7 @@ impl<'a> CheckerState<'a> {
             .to_string();
 
         let mut export_keys = vec![
-            target_file_name.clone(),
+            target_file_name,
             normalized_file_name,
             normalized_without_dot,
             target_file_stem,

--- a/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
+++ b/crates/tsz-checker/src/types/computation/complex_js_constructor.rs
@@ -228,7 +228,7 @@ impl<'a> CheckerState<'a> {
                     .collect()
             } else {
                 fallback_param_type_map
-                    .clone()
+                    .take()
                     .unwrap_or_else(|| self.js_class_body_param_type_map(body_idx))
             };
 


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382, #1383, #1384 — fourth crate-wide allow.

Spot-fixes applied:
1. `module_resolution.rs:705` — drop `spec_norm.clone()` in if branch.
2. `error_reporter/core/identifier_source_display.rs:250` — test fixture `source.clone()` redundant.
3. `error_reporter/suggestions.rs:911` — same shape.
4. `state/variable_checking/variable_helpers/declaration_emit.rs:447` — drop `target_file_name.clone()` (only consumed once).
5. `types/computation/complex_js_constructor.rs:231` — `fallback_param_type_map.clone().unwrap_or_else(...)` → `.take().unwrap_or_else(...)`.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
