### PR TITLE
chore(checker): remove crate-wide allow(clippy::unnecessary_map_or) + 2 spot-fixes

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -296,7 +296,7 @@ impl<'a> CheckerState<'a> {
                         let mut chars = n.chars();
                         let is_ident = chars
                             .next()
-                            .map_or(false, |c| c == '_' || c == '$' || c.is_ascii_alphabetic())
+                            .is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphabetic())
                             && chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric());
                         if is_ident {
                             n.to_string()

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -23,7 +23,6 @@
 #![allow(clippy::question_mark)]
 #![allow(clippy::redundant_clone)]
 #![allow(clippy::uninlined_format_args)]
-#![allow(clippy::unnecessary_map_or)]
 
 extern crate self as tsz_checker;
 

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -418,7 +418,7 @@ impl<'a> CheckerState<'a> {
                 .map(tsz_binder::SymbolId);
             if resolved == Some(alias_sid) {
                 let pos = node.pos;
-                if best.map_or(true, |(p, _)| pos >= p) {
+                if best.is_none_or(|(p, _)| pos >= p) {
                     *best = Some((pos, node_idx));
                 }
             }


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382, #1383, #1384, #1388.

Spot-fixes:
1. `checkers/jsx/props/validation.rs:299` — `map_or(false, ...)` → `is_some_and(...)`
2. `types/type_checking/type_alias_checking.rs:421` — `map_or(true, ...)` → `is_none_or(...)`

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
