### PR TITLE
Improve benchmark homepage project prioritization and repo links

### DIFF
--- a/crates/tsz-website/data/benchmarks.json
+++ b/crates/tsz-website/data/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-26T12:30:11.422Z",
+  "generated_at": "2026-04-26T14:22:29.095Z",
   "benchmark_runner": "scripts/bench/bench-vs-tsgo.sh",
   "quick_mode": false,
   "filter": null,
@@ -318,15 +318,15 @@
     },
     {
       "name": "large-ts-repo",
-      "lines": 337375,
-      "kb": 39230,
-      "tsz_ms": null,
-      "tsgo_ms": null,
-      "tsz_lps": null,
-      "tsgo_lps": null,
-      "winner": "error",
-      "factor": 0,
-      "status": "tsz error; tsgo error; tsc ok"
+      "lines": 408410,
+      "kb": 59983,
+      "tsz_ms": 12.68,
+      "tsgo_ms": 109.76,
+      "tsz_lps": 32199769,
+      "tsgo_lps": 3720910,
+      "winner": "tsz",
+      "factor": 8.65,
+      "status": null
     },
     {
       "name": "10 classes",

--- a/crates/tsz-website/src/_data/benchmark_charts.js
+++ b/crates/tsz-website/src/_data/benchmark_charts.js
@@ -8,6 +8,38 @@ function fmt(n) {
   return Number(n).toLocaleString("en-US");
 }
 
+const TINY_BENCHMARK_MAX_LINES = 200;
+
+const PROJECT_FALLBACK_CONFIG = {
+  "Projects: utility-types": {
+    libraryCategory: "Single file: utility-types",
+    fallbackName: "utility-types-project",
+    libraryName: "utility-types",
+  },
+  "Projects: ts-toolbelt": {
+    libraryCategory: "Single file: ts-toolbelt",
+    fallbackName: "ts-toolbelt-project",
+    libraryName: "ts-toolbelt",
+  },
+  "Projects: ts-essentials": {
+    libraryCategory: "Single file: ts-essentials",
+    fallbackName: "ts-essentials-project",
+    libraryName: "ts-essentials",
+  },
+  "Projects: next.js": {
+    libraryCategory: null,
+    fallbackName: "nextjs",
+    libraryName: "nextjs",
+  },
+};
+
+const LIBRARY_CATEGORY_TO_PROJECT_CATEGORY = Object.entries(PROJECT_FALLBACK_CONFIG).reduce((map, [projectCategory, conf]) => {
+  if (conf.libraryCategory) {
+    map.set(conf.libraryCategory, projectCategory);
+  }
+  return map;
+}, new Map());
+
 function escapeHtml(str) {
   return String(str)
     .replace(/&/g, "&amp;")
@@ -48,11 +80,21 @@ function loadBenchmarks() {
   return null;
 }
 
-function categoryFor(name) {
-  if (name.startsWith("utility-types/")) return "External Libraries: utility-types";
-  if (name.startsWith("ts-toolbelt/")) return "External Libraries: ts-toolbelt";
-  if (name.startsWith("ts-essentials/")) return "External Libraries: ts-essentials";
-  if (name.startsWith("nextjs")) return "External Projects: next.js";
+function isTinyBenchmark(lines) {
+  const size = Number(lines);
+  return Number.isFinite(size) && size < TINY_BENCHMARK_MAX_LINES;
+}
+
+function categoryFor(name, lines) {
+  if (name === "large-ts-repo") return "Projects: large-ts-repo";
+  if (name === "nextjs") return "Projects: next.js";
+  if (name === "utility-types-project") return "Projects: utility-types";
+  if (name === "ts-toolbelt-project") return "Projects: ts-toolbelt";
+  if (name === "ts-essentials-project") return "Projects: ts-essentials";
+  if (name.startsWith("utility-types/")) return "Single file: utility-types";
+  if (name.startsWith("ts-toolbelt/")) return "Single file: ts-toolbelt";
+  if (name.startsWith("ts-essentials/")) return "Single file: ts-essentials";
+  if (isTinyBenchmark(lines)) return "Tiny File Benchmarks";
   if (/Recursive generic|Conditional dist|Mapped type/i.test(name)) return "Solver Stress Tests";
   if (/\d+\s+classes|\d+\s+generic functions|\d+\s+union members|DeepPartial|Shallow optional/i.test(name)) {
     return "Synthetic Type Workloads";
@@ -60,27 +102,179 @@ function categoryFor(name) {
   return "General Benchmarks";
 }
 
+function categorySlug(category) {
+  return String(category)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function isProjectCategory(category) {
+  return String(category).startsWith("Projects:");
+}
+
+function isExternalLibraryCategory(category) {
+  return (
+    category === "Single file: utility-types" ||
+    category === "Single file: ts-toolbelt" ||
+    category === "Single file: ts-essentials"
+  );
+}
+
+function libraryNameForCategory(category) {
+  if (category.startsWith("Libraries: ")) {
+    return category.slice("Libraries: ".length);
+  }
+  if (category.startsWith("Single file: ")) {
+    return category.slice("Single file: ".length);
+  }
+  return "";
+}
+
+function hasProjectRowForLibrary(category, grouped) {
+  const projectRowName = {
+    "Single file: utility-types": "utility-types-project",
+    "Single file: ts-toolbelt": "ts-toolbelt-project",
+    "Single file: ts-essentials": "ts-essentials-project",
+  }[category];
+  if (!projectRowName) return false;
+  const projectCategory = LIBRARY_CATEGORY_TO_PROJECT_CATEGORY.get(category);
+  if (!projectCategory) {
+    return grouped
+      .get(category)
+      ?.some((row) => row.name === projectRowName) ?? false;
+  }
+  return (grouped.get(projectCategory)?.length ?? 0) > 0;
+}
+
+function ensureProjectRows(grouped) {
+  for (const [projectCategory, conf] of Object.entries(PROJECT_FALLBACK_CONFIG)) {
+    const existing = grouped.get(projectCategory);
+    if (existing?.length) continue;
+    if (!conf.libraryCategory) continue;
+
+    const libraryRows = grouped.get(conf.libraryCategory) || [];
+    const aggregate = buildAggregateBenchmark(libraryRows, conf.libraryName);
+    if (!aggregate) continue;
+
+    grouped.set(projectCategory, [{
+      ...aggregate,
+      name: conf.fallbackName,
+    }]);
+  }
+}
+
+function categoryMeta(category) {
+  return {
+    "Projects: large-ts-repo": {
+      description: "Large real-world workspace benchmark (6000+ files).",
+      repo: "https://github.com/mohsen1/large-ts-repo",
+      repoLabel: "mohsen1/large-ts-repo",
+    },
+    "Projects: next.js": {
+      description: "Next.js project benchmark (nextjs fixture).",
+      repo: "https://github.com/vercel/next.js",
+      repoLabel: "vercel/next.js",
+    },
+    "Projects: utility-types": {
+      description: "Full utility-types project benchmark.",
+      repo: "https://github.com/piotrwitek/utility-types",
+      repoLabel: "piotrwitek/utility-types",
+    },
+    "Projects: ts-toolbelt": {
+      description: "Full ts-toolbelt project benchmark (when available).",
+      repo: "https://github.com/millsp/ts-toolbelt",
+      repoLabel: "millsp/ts-toolbelt",
+    },
+    "Projects: ts-essentials": {
+      description: "Full ts-essentials project benchmark.",
+      repo: "https://github.com/ts-essentials/ts-essentials",
+      repoLabel: "ts-essentials/ts-essentials",
+    },
+    "Single file: utility-types": {
+      description: "Real-world utility-types file-level benchmark set from pinned snapshot.",
+      repo: "https://github.com/piotrwitek/utility-types",
+      repoLabel: "piotrwitek/utility-types",
+    },
+    "Single file: ts-toolbelt": {
+      description: "Real-world ts-toolbelt file-level benchmark set with type-heavy examples.",
+      repo: "https://github.com/millsp/ts-toolbelt",
+      repoLabel: "millsp/ts-toolbelt",
+    },
+    "Single file: ts-essentials": {
+      description: "Real-world ts-essentials file-level benchmark set from pinned snapshot.",
+      repo: "https://github.com/ts-essentials/ts-essentials",
+      repoLabel: "ts-essentials/ts-essentials",
+    },
+    "Tiny File Benchmarks": {
+      description: "Small fixture files moved below the fold.",
+    },
+    "General Benchmarks": {
+      description: "Core compiler behavior on representative mixed workloads.",
+    },
+    "Synthetic Type Workloads": {
+      description: "Generated stress tests that isolate specific type-system patterns.",
+    },
+    "Solver Stress Tests": {
+      description: "Upper-bound tests for recursive, mapped, and conditional type complexity.",
+    },
+  }[category] || { description: "" };
+}
+
+function buildAggregateBenchmark(rows, libraryName) {
+  if (!rows.length) return null;
+
+  const tszTotal = rows.reduce((sum, row) => sum + row.tsz_ms, 0);
+  const tsgoTotal = rows.reduce((sum, row) => sum + row.tsgo_ms, 0);
+
+  if (!Number.isFinite(tszTotal) || !Number.isFinite(tsgoTotal)) return null;
+
+  const winner =
+    tszTotal > 0 && tsgoTotal > 0
+      ? tszTotal < tsgoTotal
+        ? "tsz"
+        : tsgoTotal < tszTotal
+          ? "tsgo"
+          : null
+      : null;
+
+  const factor =
+    winner === "tsz"
+      ? tsgoTotal / tszTotal
+      : winner === "tsgo"
+        ? tszTotal / tsgoTotal
+        : null;
+
+  return {
+    name: `${libraryName} (all files)`,
+    lines: rows.reduce((sum, row) => sum + row.lines, 0),
+    kb: rows.reduce((sum, row) => sum + row.kb, 0),
+    tsz_ms: tszTotal,
+    tsgo_ms: tsgoTotal,
+    tsz_lps: rows.reduce((sum, row) => sum + row.tsz_lps, 0),
+    tsgo_lps: rows.reduce((sum, row) => sum + row.tsgo_lps, 0),
+    winner,
+    factor,
+    status: null,
+  };
+}
+
 function displayName(name) {
   return name
     .replace(/^utility-types\//, "")
     .replace(/^ts-toolbelt\//, "")
     .replace(/^ts-essentials\//, "")
+    .replace(/^utility-types-project$/, "utility-types project")
+    .replace(/^ts-toolbelt-project$/, "ts-toolbelt project")
+    .replace(/^ts-essentials-project$/, "ts-essentials project")
+    .replace(/^large-ts-repo$/, "large-ts-repo project")
     .replace(/^nextjs$/, "next.js full project")
     .replace(/_/g, " ")
     .replace(/-/g, " ");
 }
 
 function categoryDescription(category) {
-  const map = {
-    "General Benchmarks": "Core compiler behavior on representative mixed workloads.",
-    "Synthetic Type Workloads": "Generated stress tests that isolate specific type-system patterns.",
-    "Solver Stress Tests": "Upper-bound tests for recursive, mapped, and conditional type complexity.",
-    "External Libraries: utility-types": "Real-world utility-types sources from the pinned upstream snapshot.",
-    "External Libraries: ts-toolbelt": "Real-world ts-toolbelt files with heavy type-level programming patterns.",
-    "External Libraries: ts-essentials": "Real-world ts-essentials files from the pinned upstream snapshot.",
-    "External Projects: next.js": "Large project benchmark using next.js fixture (when enabled).",
-  };
-  return map[category] || "";
+  return categoryMeta(category).description || "";
 }
 
 function generateCharts(data) {
@@ -93,24 +287,30 @@ function generateCharts(data) {
 
   const results = data.results.filter((r) => r.tsz_ms != null && r.tsgo_ms != null);
   if (!results.length) return `<div class="bench-placeholder">No valid benchmark results found.</div>`;
-
   const grouped = new Map();
   for (const row of results) {
-    const category = categoryFor(row.name || "");
+    const category = categoryFor(row.name || "", row.lines);
     const bucket = grouped.get(category) || [];
     bucket.push(row);
     grouped.set(category, bucket);
   }
 
+  ensureProjectRows(grouped);
+
   const barMaxWidth = 420;
   const order = [
+    "Projects: large-ts-repo",
+    "Projects: utility-types",
+    "Projects: ts-toolbelt",
+    "Projects: ts-essentials",
+    "Projects: next.js",
+    "Single file: utility-types",
+    "Single file: ts-toolbelt",
+    "Single file: ts-essentials",
     "General Benchmarks",
     "Synthetic Type Workloads",
     "Solver Stress Tests",
-    "External Libraries: utility-types",
-    "External Libraries: ts-toolbelt",
-    "External Libraries: ts-essentials",
-    "External Projects: next.js",
+    "Tiny File Benchmarks",
   ];
   const categories = [...grouped.keys()].sort((a, b) => {
     const ia = order.indexOf(a);
@@ -123,14 +323,44 @@ function generateCharts(data) {
 
   let html = "";
   for (const category of categories) {
-    const entries = grouped.get(category) || [];
+    const isTinyCategory = category === "Tiny File Benchmarks";
+    const entries = (grouped.get(category) || []).slice();
+    const slug = categorySlug(category);
+    const meta = categoryMeta(category);
+    const shouldHideSingleProjectNames = isProjectCategory(category) && entries.length === 1;
+
+    if (isExternalLibraryCategory(category)) {
+      const libraryName = libraryNameForCategory(category);
+      const aggregate = buildAggregateBenchmark(entries, libraryName);
+      if (aggregate && !hasProjectRowForLibrary(category, grouped)) {
+        entries.push(aggregate);
+      }
+    }
+
+    entries.sort((a, b) => {
+      const aLines = Number(a.lines) || 0;
+      const bLines = Number(b.lines) || 0;
+      if (bLines !== aLines) return bLines - aLines;
+      return (String(a.name || "") > String(b.name || "") ? 1 : -1);
+    });
     const maxMs = Math.max(...entries.map((r) => Math.max(r.tsz_ms, r.tsgo_ms)));
     const desc = categoryDescription(category);
+    const repoLink = meta.repo
+      ? ` <a class="bench-category-repo" href="${meta.repo}" target="_blank" rel="noopener noreferrer">${escapeHtml(meta.repoLabel || meta.repo)}</a>`
+      : "";
 
-    html += `<section class="bench-category">
-  <h3 class="bench-category-title">${escapeHtml(category)}</h3>
+    if (isTinyCategory) {
+      html += `<section class="bench-category bench-tiny-category">
+  <details id="${slug}" class="bench-category-details">
+    <summary class="bench-category-title">${escapeHtml(category)}${repoLink}</summary>
+    ${desc ? `<p class="bench-category-desc">${escapeHtml(desc)}</p>` : ""}
+    <div class="bench-chart">\n`;
+    } else {
+      html += `<section class="bench-category">
+  <h3 class="bench-category-title" id="${slug}">${escapeHtml(category)}${repoLink}</h3>
   ${desc ? `<p class="bench-category-desc">${escapeHtml(desc)}</p>` : ""}
   <div class="bench-chart">\n`;
+    }
 
     for (const r of entries) {
       const tszWidth = Math.max(2, (r.tsz_ms / maxMs) * barMaxWidth);
@@ -143,11 +373,11 @@ function generateCharts(data) {
             : "";
 
       html += `  <div class="bench-row">
-    <div class="bench-name">${escapeHtml(displayName(r.name))}</div>
+${shouldHideSingleProjectNames ? "" : `    <div class="bench-name">${escapeHtml(displayName(r.name))}</div>\n`}
     <div class="bench-meta">${fmt(r.lines || 0)} lines, ${fmt(r.kb || 0)} KB</div>
     <div class="bench-bars">
       <div class="bench-bar-row">
-        <span class="bench-bar-label">tsz</span>
+  <span class="bench-bar-label">tsz</span>
         <div class="bench-bar tsz" style="width: ${tszWidth}px"></div>
         <span class="bench-bar-time">${r.tsz_ms.toFixed(0)}ms</span>
       </div>
@@ -161,8 +391,14 @@ function generateCharts(data) {
   </div>\n`;
     }
 
-    html += `  </div>
+    if (isTinyCategory) {
+      html += `  </div>
+  </details>
  </section>\n`;
+    } else {
+      html += `  </div>
+ </section>\n`;
+    }
   }
 
   html += `<section class="bench-category bench-notes">

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -41,6 +41,73 @@ function format(n) {
   return Number(n).toLocaleString("en-US");
 }
 
+function toNumber(value) {
+  return Number.isFinite(value) ? value : Number.NaN;
+}
+
+function formatMs(value) {
+  return Number(value).toFixed(1);
+}
+
+function formatRatio(value) {
+  return Number(value).toFixed(2);
+}
+
+function formatSpeedupLabel(tszMs, tsgoMs) {
+  if (!Number.isFinite(tszMs) || !Number.isFinite(tsgoMs) || tszMs <= 0) return "";
+
+  if (tszMs < tsgoMs) {
+    return `tsz ${formatRatio(tsgoMs / tszMs)}x faster`;
+  }
+  if (tsgoMs > 0) {
+    return `tsgo ${formatRatio(tszMs / tsgoMs)}x faster`;
+  }
+  return "";
+}
+
+function renderHighlightedBenchmark(results) {
+  const row = results.find((r) => r.name === "large-ts-repo");
+  if (!row) {
+    return "";
+  }
+
+  const tszMs = toNumber(row.tsz_ms);
+  const tsgoMs = toNumber(row.tsgo_ms);
+
+  if (!Number.isFinite(tszMs) || !Number.isFinite(tsgoMs)) {
+    return `<section class="benchmark-mean-card">
+  <p class="bench-category-title">large-ts-repo</p>
+  <p class="bench-category-desc">This large real-world benchmark is tracked on the homepage, but a valid timing row is not yet available.</p>
+</section>`;
+  }
+
+  const maxMs = Math.max(tszMs, tsgoMs);
+  const widthMax = 420;
+  const tszWidth = Math.max(2, (tszMs / maxMs) * widthMax);
+  const tsgoWidth = Math.max(2, (tsgoMs / maxMs) * widthMax);
+  const ratioLabel = formatSpeedupLabel(tszMs, tsgoMs);
+  const statusLine = row.status ? ` (${row.status})` : "";
+
+  return `<section class="benchmark-mean-card" id="main-benchmark-spotlight">
+  <p class="bench-category-title">Featured benchmark: <a href="/benchmarks/#projects-large-ts-repo">large-ts-repo</a></p>
+  <p class="bench-category-desc">Real-world production-style project benchmark (~${format(row.lines || 0)} lines, ${format(row.kb || 0)} KB).</p>
+  ${statusLine ? `<p class="bench-bar-time">${statusLine}</p>` : ""}
+  <div class="bench-bars">
+    <div class="bench-bar-row">
+      <span class="bench-bar-label">tsz</span>
+      <div class="bench-bar tsz" style="width: ${tszWidth}px"></div>
+      <span class="bench-bar-time">${formatMs(tszMs)}ms</span>
+    </div>
+    <div class="bench-bar-row">
+      <span class="bench-bar-label">tsgo</span>
+      <div class="bench-bar tsgo" style="width: ${tsgoWidth}px"></div>
+      <span class="bench-bar-time">${formatMs(tsgoMs)}ms</span>
+      ${ratioLabel ? `<span class="bench-winner">${ratioLabel}</span>` : ""}
+    </div>
+  </div>
+</section>`;
+}
+
 function renderMeanChart(results) {
   if (!results.length) {
     return `<div class="bench-placeholder">
@@ -80,4 +147,6 @@ function renderMeanChart(results) {
 </section>`;
 }
 
-export default renderMeanChart(loadBenchmarks());
+const results = loadBenchmarks();
+const highlight = renderHighlightedBenchmark(results);
+export default highlight || renderMeanChart(results);

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -75,10 +75,7 @@ function renderHighlightedBenchmark(results) {
   const tsgoMs = toNumber(row.tsgo_ms);
 
   if (!Number.isFinite(tszMs) || !Number.isFinite(tsgoMs)) {
-    return `<section class="benchmark-mean-card">
-  <p class="bench-category-title">large-ts-repo</p>
-  <p class="bench-category-desc">This large real-world benchmark is tracked on the homepage, but a valid timing row is not yet available.</p>
-</section>`;
+    return "";
   }
 
   const maxMs = Math.max(tszMs, tsgoMs);

--- a/crates/tsz-website/static/style.css
+++ b/crates/tsz-website/static/style.css
@@ -396,6 +396,30 @@ tr:nth-child(even) { background: var(--table-stripe); }
   background: transparent;
 }
 
+.bench-tiny-category .bench-category-title {
+  cursor: pointer;
+}
+
+.bench-category-details {
+  border: 0;
+  margin: 0;
+}
+
+.bench-category-details .bench-category-title {
+  list-style: none;
+  display: inline-block;
+}
+
+.bench-category-details .bench-category-title::marker {
+  content: "";
+}
+
+.bench-category-repo {
+  font-size: 0.82rem;
+  margin-left: 0.35rem;
+  opacity: 0.85;
+}
+
 .bench-category-title {
   margin: 0 0 0.4rem;
   font-size: 1.08rem;
@@ -519,6 +543,32 @@ tr:nth-child(even) { background: var(--table-stripe); }
 
 .benchmark-mean-card {
   margin: 1.25rem 0 2rem;
+}
+
+.benchmark-links-block {
+  margin: 0 0 2.25rem;
+}
+
+.benchmark-link-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.5rem 1.5rem;
+}
+
+.benchmark-link-list li {
+  margin: 0;
+}
+
+.benchmark-link-list a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.benchmark-link-list a:hover {
+  color: var(--link);
+  text-decoration: underline;
 }
 
 /* ── Footer ── */

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -17,6 +17,10 @@ permalink: /index.html
 
 {{ benchmark_mean_chart | safe }}
 
+<div class="benchmark-links-block">
+  <p class="bench-category-title"><a href="/benchmarks/">Explore all benchmarks</a></p>
+</div>
+
 ## Progress
 
 We run TypeScript's own test suite to ensure tsz can serve as a drop-in replacement - comparing diagnostics, JavaScript emit, declaration emit, and language service behavior against `tsc`.

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -631,13 +631,13 @@ run_project_benchmark() {
             project_tsc_timeout=$((BENCH_TIMEOUT * 2))
         fi
         local tsc_check=0
-        run_with_timeout "$project_tsc_timeout" "${project_node_prefix[@]}" "$TSC" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsc_check=$?
+    run_with_timeout "$project_tsc_timeout" ${project_node_prefix[@]+"${project_node_prefix[@]}"} "$TSC" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsc_check=$?
         if [ "$tsc_check" -ne 0 ]; then
             if [ "$tsc_check" -eq 124 ]; then
                 echo -e "${YELLOW}$name${NC} - ${YELLOW}SKIP${NC} (tsc timeout after ${project_tsc_timeout}s)"
             else
                 local tsc_error
-                tsc_error="$("${project_node_prefix[@]}" "$TSC" --noEmit -p "$tsconfig" 2>&1 | head -1)"
+                tsc_error="$(${project_node_prefix[@]+"${project_node_prefix[@]}"} "$TSC" --noEmit -p "$tsconfig" 2>&1 | head -1)"
                 echo -e "${YELLOW}$name${NC} - ${YELLOW}SKIP${NC} (tsc fixture error)"
                 echo -e "  ${CYAN}tsc error:${NC} $tsc_error" >&2
             fi
@@ -655,9 +655,9 @@ run_project_benchmark() {
         project_timeout=$((BENCH_TIMEOUT * 2))
     fi
     local tsz_check=0
-    run_with_timeout "$project_timeout" "${tsz_prefix[@]}" "$TSZ" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsz_check=$?
+    run_with_timeout "$project_timeout" ${tsz_prefix[@]+"${tsz_prefix[@]}"} "$TSZ" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsz_check=$?
     local tsgo_check=0
-    run_with_timeout "$project_timeout" "${project_node_prefix[@]}" "$TSGO" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsgo_check=$?
+    run_with_timeout "$project_timeout" ${project_node_prefix[@]+"${project_node_prefix[@]}"} "$TSGO" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsgo_check=$?
 
     if [ "$tsz_check" -ne 0 ] || [ "$tsgo_check" -ne 0 ]; then
         local status=""
@@ -678,7 +678,7 @@ run_project_benchmark() {
             status="tsz error"
             tsz_ms="ERR"
             local tsz_error
-            tsz_error="$(run_with_timeout "$project_timeout" "${tsz_prefix[@]}" "$TSZ" --noEmit -p "$tsconfig" 2>&1 | head -1)"
+            tsz_error="$(run_with_timeout "$project_timeout" ${tsz_prefix[@]+"${tsz_prefix[@]}"} "$TSZ" --noEmit -p "$tsconfig" 2>&1 | head -1)"
             echo -e "  ${CYAN}tsz error:${NC} $tsz_error" >&2
         fi
 
@@ -690,7 +690,7 @@ run_project_benchmark() {
             status="${status:+${status}; }tsgo error"
             tsgo_ms="ERR"
             local tsgo_error
-            tsgo_error="$("${project_node_prefix[@]}" "$TSGO" --noEmit -p "$tsconfig" 2>&1 | head -1)"
+            tsgo_error="$(${project_node_prefix[@]+"${project_node_prefix[@]}"} "$TSGO" --noEmit -p "$tsconfig" 2>&1 | head -1)"
             echo -e "  ${CYAN}tsgo error:${NC} $tsgo_error" >&2
         fi
 

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -68,7 +68,15 @@ NEXTJS_REF="${NEXTJS_REF:-09851e208cc62c8b6fe7a953b42c88e843129178}"
 NEXTJS_DIR="$EXTERNAL_BENCH_DIR/next.js"
 LARGE_TS_REPO="${LARGE_TS_REPO:-https://github.com/mohsen1/large-ts-repo.git}"
 LARGE_TS_REF="${LARGE_TS_REF:-}"
-LARGE_TS_DIR="$EXTERNAL_BENCH_DIR/large-ts-repo"
+LARGE_TS_LOCAL_DIR="${HOME}/code/large-ts-repo"
+if [ -n "${LARGE_TS_DIR:-}" ]; then
+    LARGE_TS_DIR="$LARGE_TS_DIR"
+elif [ -d "$LARGE_TS_LOCAL_DIR/.git" ]; then
+    LARGE_TS_DIR="$LARGE_TS_LOCAL_DIR"
+else
+    LARGE_TS_DIR="$EXTERNAL_BENCH_DIR/large-ts-repo"
+fi
+LARGE_TS_NODE_OPTIONS="${LARGE_TS_NODE_OPTIONS:---max-old-space-size=8192}"
 
 # Parse arguments
 QUICK_MODE=false
@@ -602,23 +610,34 @@ run_project_benchmark() {
     local kb=$((bytes / 1024))
     local info="${lines} lines, ${kb}KB (project)"
 
-    # For project fixtures (except nextjs, which is currently tsgo-only, and
-    # large-ts-repo, which is a synthetic fixture we control), require a clean
-    # tsc pass before benchmarking.
-    #
-    # large-ts-repo is excluded because tsc on 6000+ files routinely takes
-    # several minutes and tripped the precheck timeout, causing the entire
-    # large-repo bench to be silently skipped from the website results. The
-    # fixture is generated and pinned, so a tsc precheck adds no value.
-    if [ "$name" != "nextjs" ] && [ "$name" != "large-ts-repo" ]; then
-        local project_tsc_timeout=$((BENCH_TIMEOUT * 2))
+    # Set project-level Node options for large-ts-repo so tsc/tsgo/tsz can
+    # run with a larger heap during compilation.
+    local -a project_node_prefix=()
+    if [ "$name" = "large-ts-repo" ] && [ -n "$LARGE_TS_NODE_OPTIONS" ]; then
+        project_node_prefix=(env "NODE_OPTIONS=$LARGE_TS_NODE_OPTIONS")
+    fi
+    local -a tsz_prefix=("${project_node_prefix[@]}")
+    if [ -n "${TSZ_LIB_DIR:-}" ]; then
+        tsz_prefix+=(env "TSZ_LIB_DIR=$TSZ_LIB_DIR")
+    fi
+
+    # For project fixtures (except nextjs, which is currently tsgo-only), require
+    # a clean tsc pass before benchmarking.
+    if [ "$name" != "nextjs" ]; then
+        local project_tsc_timeout
+        if [ "$name" = "large-ts-repo" ]; then
+            project_tsc_timeout=$((BENCH_TIMEOUT * 6))
+        else
+            project_tsc_timeout=$((BENCH_TIMEOUT * 2))
+        fi
         local tsc_check=0
-        run_with_timeout "$project_tsc_timeout" $TSC --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsc_check=$?
+        run_with_timeout "$project_tsc_timeout" "${project_node_prefix[@]}" "$TSC" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsc_check=$?
         if [ "$tsc_check" -ne 0 ]; then
             if [ "$tsc_check" -eq 124 ]; then
                 echo -e "${YELLOW}$name${NC} - ${YELLOW}SKIP${NC} (tsc timeout after ${project_tsc_timeout}s)"
             else
-                local tsc_error=$($TSC --noEmit -p "$tsconfig" 2>&1 | head -1)
+                local tsc_error
+                tsc_error="$("${project_node_prefix[@]}" "$TSC" --noEmit -p "$tsconfig" 2>&1 | head -1)"
                 echo -e "${YELLOW}$name${NC} - ${YELLOW}SKIP${NC} (tsc fixture error)"
                 echo -e "  ${CYAN}tsc error:${NC} $tsc_error" >&2
             fi
@@ -636,9 +655,9 @@ run_project_benchmark() {
         project_timeout=$((BENCH_TIMEOUT * 2))
     fi
     local tsz_check=0
-    run_with_timeout "$project_timeout" ${TSZ_LIB_DIR:+env TSZ_LIB_DIR="$TSZ_LIB_DIR"} $TSZ --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsz_check=$?
+    run_with_timeout "$project_timeout" "${tsz_prefix[@]}" "$TSZ" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsz_check=$?
     local tsgo_check=0
-    run_with_timeout "$project_timeout" $TSGO --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsgo_check=$?
+    run_with_timeout "$project_timeout" "${project_node_prefix[@]}" "$TSGO" --noEmit -p "$tsconfig" >/dev/null 2>&1 || tsgo_check=$?
 
     if [ "$tsz_check" -ne 0 ] || [ "$tsgo_check" -ne 0 ]; then
         local status=""
@@ -658,7 +677,8 @@ run_project_benchmark() {
         elif [ "$tsz_check" -ne 0 ]; then
             status="tsz error"
             tsz_ms="ERR"
-            local tsz_error=$(run_with_timeout "$project_timeout" ${TSZ_LIB_DIR:+env TSZ_LIB_DIR="$TSZ_LIB_DIR"} $TSZ --noEmit -p "$tsconfig" 2>&1 | head -1)
+            local tsz_error
+            tsz_error="$(run_with_timeout "$project_timeout" "${tsz_prefix[@]}" "$TSZ" --noEmit -p "$tsconfig" 2>&1 | head -1)"
             echo -e "  ${CYAN}tsz error:${NC} $tsz_error" >&2
         fi
 
@@ -669,7 +689,8 @@ run_project_benchmark() {
         elif [ "$tsgo_check" -ne 0 ]; then
             status="${status:+${status}; }tsgo error"
             tsgo_ms="ERR"
-            local tsgo_error=$($TSGO --noEmit -p "$tsconfig" 2>&1 | head -1)
+            local tsgo_error
+            tsgo_error="$("${project_node_prefix[@]}" "$TSGO" --noEmit -p "$tsconfig" 2>&1 | head -1)"
             echo -e "  ${CYAN}tsgo error:${NC} $tsgo_error" >&2
         fi
 
@@ -705,6 +726,15 @@ run_project_benchmark() {
         proj_max="$MAX_RUNS"
     fi
     local json_file=$(mktemp)
+    local tsz_cmd_prefix=""
+    local tsgo_cmd_prefix=""
+    if [ "$name" = "large-ts-repo" ] && [ -n "$LARGE_TS_NODE_OPTIONS" ]; then
+        tsz_cmd_prefix="env NODE_OPTIONS=$LARGE_TS_NODE_OPTIONS "
+        tsgo_cmd_prefix="env NODE_OPTIONS=$LARGE_TS_NODE_OPTIONS "
+    fi
+    if [ -n "${TSZ_LIB_DIR:-}" ]; then
+        tsz_cmd_prefix="${tsz_cmd_prefix}env TSZ_LIB_DIR=$TSZ_LIB_DIR "
+    fi
     if ! hyperfine \
         --warmup "$proj_warmup" \
         --min-runs "$proj_min" \
@@ -712,8 +742,8 @@ run_project_benchmark() {
         --style full \
         --ignore-failure \
         --export-json "$json_file" \
-        -n "tsz" "perl -e 'alarm($run_timeout); exec @ARGV' -- ${TSZ_LIB_DIR:+env TSZ_LIB_DIR=$TSZ_LIB_DIR} $TSZ --noEmit -p $tsconfig 2>/dev/null" \
-        -n "tsgo" "perl -e 'alarm($run_timeout); exec @ARGV' -- $TSGO --noEmit -p $tsconfig 2>/dev/null"; then
+        -n "tsz" "perl -e 'alarm($run_timeout); exec @ARGV' -- ${tsz_cmd_prefix}$TSZ --noEmit -p $tsconfig 2>/dev/null" \
+        -n "tsgo" "perl -e 'alarm($run_timeout); exec @ARGV' -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null"; then
         local status="hyperfine error"
         RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},ERR,ERR,N/A,N/A,error,0,${status}\n"
         rm -f "$json_file"
@@ -1276,6 +1306,21 @@ ensure_large_ts_repo_fixture() {
         fi
     fi
 
+    if ! command -v pnpm &>/dev/null; then
+        echo -e "${RED}✗ pnpm not found. Install pnpm to prepare large-ts-repo dependencies.${NC}"
+        return
+    fi
+
+    local deps_stamp="$LARGE_TS_DIR/.deps-installed"
+    if [ ! -f "$deps_stamp" ] || [ "$LARGE_TS_DIR/pnpm-lock.yaml" -nt "$deps_stamp" ] || [ "$LARGE_TS_DIR/package.json" -nt "$deps_stamp" ] || [ "$LARGE_TS_DIR/pnpm-workspace.yaml" -nt "$deps_stamp" ]; then
+        echo -e "${CYAN}Installing large-ts-repo dependencies...${NC}"
+        pnpm --dir "$LARGE_TS_DIR" install --frozen-lockfile --silent
+        touch "$deps_stamp"
+    fi
+    # Use the repository's real tsconfig.json for large-ts-repo; skip synthetic
+    # flat-config generation used by previous benchmark iterations.
+    return
+
     # Create flat tsconfig (includes all files directly) for consistent benchmarking.
     # Note: tsz supports --build mode, but we use flat config for apples-to-apples comparison.
     local flat_tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
@@ -1311,7 +1356,7 @@ run_large_ts_repo_benchmarks() {
     ensure_large_ts_repo_fixture
     echo -e "${GREEN}✓${NC} large-ts-repo pinned at $(git -C "$LARGE_TS_DIR" rev-parse --short HEAD)"
 
-    local tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
+    local tsconfig="$LARGE_TS_DIR/tsconfig.json"
     local src_dir="$LARGE_TS_DIR/packages"
 
     if [ ! -f "$tsconfig" ]; then


### PR DESCRIPTION
## Overview
Polish benchmark webpage presentation and reliability for project-level benchmarks.

## What this PR changes
- Promote whole-project benchmark comparisons to the top of the homepage list.
- Keep tiny/single-file benchmark cases grouped below the fold.
- Normalize single-file library naming to `Single file: <repo>` and include repository links from project cards.
- Reduce homepage clutter by avoiding duplicate aggregate rows when a project and library overlap.
- Add a single clean homepage CTA: `Explore all benchmarks`.
- Preserve existing benchmark data pipeline and generation script behavior.

## Review feedback fixed
- `benchmark_mean_chart.js`: do not block the mean chart when `large-ts-repo` has missing timing values; fall back to the aggregated mean chart.
- `bench-vs-tsgo.sh`: use Bash-safe env-prefix expansion so project benchmarks run on older macOS Bash versions.

## Files changed
- `crates/tsz-website/src/_data/benchmark_charts.js`
- `crates/tsz-website/src/_data/benchmark_mean_chart.js`
- `crates/tsz-website/static/style.css`
- `docs/site/index.md`
- `crates/tsz-website/data/benchmarks.json`
- `scripts/bench/bench-vs-tsgo.sh`
