### PR TITLE
chore(checker): remove crate-wide allow(clippy::missing_const_for_fn) + 4 spot-fixes

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -18,7 +18,6 @@
 #![allow(clippy::collapsible_match)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::let_and_return)]
-#![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::question_mark)]
 #![allow(clippy::redundant_clone)]

--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -223,12 +223,12 @@ pub struct TargetIndex<'a> {
 
 impl<'a> TargetIndex<'a> {
     /// Number of usable (non-skipped) target entries in the index.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.targets.len()
     }
 
     /// True when the index holds no targets.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.targets.is_empty()
     }
 }

--- a/crates/tsz-checker/src/symbols/alias_cycle.rs
+++ b/crates/tsz-checker/src/symbols/alias_cycle.rs
@@ -57,7 +57,7 @@ impl AliasCycleTracker {
     }
 
     #[inline]
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.guard.depth() as usize
     }
 

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -1848,7 +1848,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Returns the string representation of unary operators that are not allowed
     /// on the left-hand side of exponentiation (`**`).
-    fn unary_operator_name(op: u16) -> Option<&'static str> {
+    const fn unary_operator_name(op: u16) -> Option<&'static str> {
         match op {
             k if k == SyntaxKind::MinusToken as u16 => Some("-"),
             k if k == SyntaxKind::PlusToken as u16 => Some("+"),


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382, #1383, #1384, #1388, #1389.

Marks 4 helpers `const fn`:
- `module_resolution.rs:226,231` — `TargetIndex::{len,is_empty}`
- `symbols/alias_cycle.rs:60` — `AliasCycleTracker::len`
- `types/computation/binary.rs:1851` — `unary_operator_name` match

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
