### PR TITLE
ci: fix unit OOM and increase fourslash to 8 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,14 +177,14 @@ jobs:
     needs: [gate, build]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       _TSZ_CI_FOURSLASH_SHARD_INDEX: ${{ matrix.shard }}
-      _TSZ_CI_FOURSLASH_SHARD_COUNT: 4
+      _TSZ_CI_FOURSLASH_SHARD_COUNT: 8
       TSZ_CI_FOURSLASH_WORKERS: 8
     steps:
       - uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
     timeout-minutes: 15
     env:
       GITHUB_SHA: ${{ github.sha }}
-      _TSZ_CI_FOURSLASH_SHARD_COUNT: 4
+      _TSZ_CI_FOURSLASH_SHARD_COUNT: 8
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,8 @@ lto = "thin"
 
 [profile.ci-unit]
 # Used by cargo nextest in CI unit suite to cap peak LLVM memory.
-# 256 codegen-units (dev default) × HOST_CPUS concurrent jobs = OOM on large runners.
+# debug=2 (inherited from dev) × codegen-units × concurrent jobs = OOM on 8-CPU runners.
+# Disabling debug info is the single largest memory win (~3-4× reduction in LLVM backend RSS).
 inherits = "dev"
-codegen-units = 16
+debug = false
+codegen-units = 8

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -907,7 +907,7 @@ run_fourslash_aggregate() {
   local bucket run_key
   bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
   run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
-  local expected_shards="${_TSZ_CI_FOURSLASH_SHARD_COUNT:-${TSZ_CI_FOURSLASH_SHARDS:-4}}"
+  local expected_shards="${_TSZ_CI_FOURSLASH_SHARD_COUNT:-${TSZ_CI_FOURSLASH_SHARDS:-8}}"
 
   if [[ -z "$bucket" || "$run_key" == "unknown" ]]; then
     echo "error: cannot aggregate — no bucket or run key available" >&2

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -860,7 +860,7 @@ run_fourslash_shard() {
   bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
   run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
   shard_index="$(num_or_zero "${_TSZ_CI_FOURSLASH_SHARD_INDEX:-0}")"
-  shard_count="$(num_or_zero "${_TSZ_CI_FOURSLASH_SHARD_COUNT:-4}")"
+  shard_count="$(num_or_zero "${_TSZ_CI_FOURSLASH_SHARD_COUNT:-8}")"
 
   mkdir -p "$LOG_DIR/fourslash"
   echo "Fourslash shard ${shard_index}/${shard_count}: workers=${FOURSLASH_WORKERS}"


### PR DESCRIPTION
## Summary

- **Unit OOM fix**: `ci-unit` profile inherited `debug=2` (full DWARF) from `dev`, causing `tsz-checker` test compilation to be SIGKILL'd on the 8-CPU/32GB Cloud Run runners. Added `debug = false` and reduced `codegen-units` 16→8.
- **Fourslash 8 shards**: Longest shard in the last run was ~9 min (fourslash-1 and -3). Doubling to 8 shards targets ~4-5 min per shard. Timeout trimmed 30→20 min.

## Test plan
- [ ] `unit` job passes (no SIGKILL during tsz-checker compilation)
- [ ] 8 fourslash shards all complete within 20 min timeout
- [ ] fourslash-aggregate passes baseline check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
