### PR TITLE
fix(checker): fall back to any/unknown for invalid catch annotations

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -608,12 +608,15 @@ impl<'a> CheckerState<'a> {
                 checker.check_type_for_missing_names_skip_top_level_ref(var_decl.type_annotation);
                 checker.check_type_for_parameter_properties(var_decl.type_annotation);
                 let type_id = checker.get_type_from_type_node(var_decl.type_annotation);
-                // TS1196: Catch clause variable type annotation must be 'any' or 'unknown'
-                if is_catch_variable
+                // TS1196: Catch clause variable type annotation must be 'any' or 'unknown'.
+                // When the annotation is invalid, fall back to the catch-variable default
+                // (any/unknown) so the catch body sees the same type tsc uses, preventing
+                // cascade errors like TS2339 on `e.method()` or destructured names.
+                let invalid_catch_annotation = is_catch_variable
                     && type_id != TypeId::ANY
                     && type_id != TypeId::UNKNOWN
-                    && !checker.type_contains_error(type_id)
-                {
+                    && !checker.type_contains_error(type_id);
+                if invalid_catch_annotation {
                     use crate::diagnostics::diagnostic_codes;
                     checker.error_at_node(
                         var_decl.type_annotation,
@@ -621,7 +624,13 @@ impl<'a> CheckerState<'a> {
                         diagnostic_codes::CATCH_CLAUSE_VARIABLE_TYPE_ANNOTATION_MUST_BE_ANY_OR_UNKNOWN_IF_SPECIFIED,
                     );
                 }
-                type_id
+                if invalid_catch_annotation {
+                    flow_boundary::resolve_catch_variable_type(
+                        checker.ctx.use_unknown_in_catch_variables(),
+                    )
+                } else {
+                    type_id
+                }
             } else if is_catch_variable {
                 // Route catch variable type resolution through the flow
                 // observation boundary for centralized policy.
@@ -2345,7 +2354,23 @@ impl<'a> CheckerState<'a> {
             // This type is used for both default-value checking and for assigning types to
             // binding element symbols created by the binder.
             let pattern_type = if var_decl.type_annotation.is_some() {
-                self.get_type_from_type_node(var_decl.type_annotation)
+                let annotated = self.get_type_from_type_node(var_decl.type_annotation);
+                // Catch-clause variables with an invalid type annotation (anything other
+                // than `any`/`unknown`) trigger TS1196. Mirror tsc by falling back to the
+                // catch-variable default for the binding pattern so destructured names
+                // like `({ x }: object)` don't cascade into spurious TS2339s alongside
+                // the TS1196 emitted on the annotation.
+                if is_catch_variable
+                    && annotated != TypeId::ANY
+                    && annotated != TypeId::UNKNOWN
+                    && !self.type_contains_error(annotated)
+                {
+                    flow_boundary::resolve_catch_variable_type(
+                        self.ctx.use_unknown_in_catch_variables(),
+                    )
+                } else {
+                    annotated
+                }
             } else if let Some(jsdoc_type) = jsdoc_declared_type {
                 jsdoc_type
             } else if let Some(inferred) =

--- a/crates/tsz-checker/tests/flow_observation_boundary_tests.rs
+++ b/crates/tsz-checker/tests/flow_observation_boundary_tests.rs
@@ -195,6 +195,86 @@ try {
     );
 }
 
+/// When a catch clause has an invalid type annotation (anything other than
+/// `any`/`unknown`), tsc emits TS1196 on the annotation but treats the variable
+/// as `any`/`unknown` in the body. Regression for
+/// catchClauseWithTypeAnnotation.ts: `catch (e: number) { e.toLowerCase(); }`
+/// must NOT cascade into a TS2339 on `.toLowerCase`.
+#[test]
+fn catch_invalid_type_annotation_does_not_cascade_property_errors() {
+    let diags = tsz_checker::test_utils::check_source(
+        r#"
+function f() {
+    try { console.log(); }
+    catch (e: number) {
+        console.log(e.toLowerCase());
+    }
+}
+"#,
+        "test.ts",
+        CheckerOptions {
+            use_unknown_in_catch_variables: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts1196 = codes(&diags, 1196);
+    assert_eq!(
+        ts1196.len(),
+        1,
+        "Expected exactly one TS1196 for invalid catch annotation, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    let ts2339 = codes(&diags, 2339);
+    assert!(
+        ts2339.is_empty(),
+        "Invalid catch annotation should fall back to any/unknown — \
+         no TS2339 should fire on body property accesses, got: {:?}",
+        ts2339.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+/// Same fallback behavior must apply when the catch clause uses a destructuring
+/// binding pattern. Regression for catchClauseWithTypeAnnotation.ts:
+/// `catch ({ x }: object) { }` and `catch ({ x }: SomeType) { }` should emit
+/// only TS1196 on the annotation — no spurious TS2339 on `x`.
+#[test]
+fn catch_destructure_invalid_type_annotation_does_not_cascade_property_errors() {
+    let diags = tsz_checker::test_utils::check_source(
+        r#"
+interface Foo { y: number; }
+function f() {
+    try { } catch ({ x }: object) { }
+    try { } catch ({ x }: Foo) { }
+}
+"#,
+        "test.ts",
+        CheckerOptions {
+            use_unknown_in_catch_variables: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts1196 = codes(&diags, 1196);
+    assert_eq!(
+        ts1196.len(),
+        2,
+        "Expected two TS1196 for invalid catch annotations, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    let ts2339 = codes(&diags, 2339);
+    assert!(
+        ts2339.is_empty(),
+        "Invalid catch destructure annotation should fall back to any/unknown — \
+         no TS2339 should fire on bound names, got: {:?}",
+        ts2339.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
 // =============================================================================
 // For-of destructuring
 // =============================================================================

--- a/docs/plan/claims/fix-checker-catch-invalid-annotation-falls-back-to-any.md
+++ b/docs/plan/claims/fix-checker-catch-invalid-annotation-falls-back-to-any.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-catch-invalid-annotation-falls-back-to-any`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1393
+- **Status**: ready
 - **Workstream**: Conformance — fingerprint parity
 
 ## Intent

--- a/docs/plan/claims/fix-checker-catch-invalid-annotation-falls-back-to-any.md
+++ b/docs/plan/claims/fix-checker-catch-invalid-annotation-falls-back-to-any.md
@@ -1,0 +1,34 @@
+# fix(checker): fall back to any/unknown when catch clause has invalid type annotation
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-catch-invalid-annotation-falls-back-to-any`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance — fingerprint parity
+
+## Intent
+
+When a catch clause variable has a type annotation that is neither `any` nor
+`unknown` (e.g. `catch (e: number)` or `catch ({ x }: object)`), `tsc` emits
+TS1196 on the annotation and treats the variable as the catch-variable default
+(`any` / `unknown`) for the body. tsz currently keeps the user-provided
+(invalid) type, which cascades into spurious TS2339 errors on legitimate
+property access (`e.toLowerCase()`) and on destructured names (`{ x }: object`).
+
+Mirror tsc by routing through the existing `flow_boundary::resolve_catch_variable_type`
+helper whenever the annotation is invalid, both in `compute_final_type` and in
+the binding-pattern path used for destructuring catch declarations.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/variable_checking/core.rs` (~25 LOC change in two
+  branches: scalar catch declared_type and destructure pattern_type)
+- `crates/tsz-checker/tests/flow_observation_boundary_tests.rs` (+2 regression tests)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (2886 pass, 9 skipped)
+- `cargo nextest run -p tsz-checker --test flow_observation_boundary_tests` (38 pass)
+- `./scripts/conformance/conformance.sh run --filter "Catch"` → 24/24 PASS
+- `./scripts/conformance/conformance.sh run --filter "catchClauseWithTypeAnnotation"`
+  flips from fingerprint-only failure to PASS (3 spurious TS2339 fingerprints removed).


### PR DESCRIPTION
## Summary

When a catch clause variable has a type annotation that is neither `any` nor `unknown` (e.g. `catch (e: number)` or `catch ({ x }: object)`), `tsc` emits TS1196 on the annotation but treats the variable as the catch-variable default (`any`/`unknown`) for the body. tsz was keeping the user-provided invalid type, which cascaded into spurious TS2339 errors on legitimate property access (`e.toLowerCase()`) and on destructured names (`{ x }: object`).

Mirror `tsc` by routing through the existing `flow_boundary::resolve_catch_variable_type` helper whenever the annotation is invalid — both in `compute_final_type` (scalar catch decls) and in the binding-pattern path used for destructuring catch declarations.

## Conformance Impact

- Flips `catchClauseWithTypeAnnotation.ts` from fingerprint-only failure to PASS
- Removes 3 spurious TS2339 fingerprints (lines 25:23, 38:22, 39:22 in stripped source)
- All 24 catch-related conformance tests still pass
- All 3 try-statements conformance tests still pass

## Files Changed

- `crates/tsz-checker/src/state/variable_checking/core.rs` (~25 LOC, two branches)
- `crates/tsz-checker/tests/flow_observation_boundary_tests.rs` (+2 regression tests)
- `docs/plan/claims/fix-checker-catch-invalid-annotation-falls-back-to-any.md` (new claim file)

## Test Plan

- [x] `cargo nextest run -p tsz-checker --test flow_observation_boundary_tests` — 38/38 PASS (including 2 new regression tests)
- [x] `cargo nextest run -p tsz-checker --lib` — 2886 tests pass, 9 skipped
- [x] `./scripts/conformance/conformance.sh run --filter "catchClauseWithTypeAnnotation"` — PASS (was fingerprint-only)
- [x] `./scripts/conformance/conformance.sh run --filter "Catch"` — 24/24 PASS
- [x] `./scripts/conformance/conformance.sh run --filter "tryStatements"` — 3/3 PASS

## Architecture Notes

- Routes catch-variable fallback through the existing `flow_boundary::resolve_catch_variable_type` helper (boundary policy already centralized — §3, §11).
- No new ad-hoc type algorithm in the checker; reuses the same path used for unannotated catch variables (§4).
- Mirrors tsc's TS1196 semantics one-to-one (§21).