### PR TITLE
chore(checker): remove crate-wide allow(clippy::uninlined_format_args) + auto-fix sites

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -989,7 +989,7 @@ var r5b = _.map<number, string, boolean>(c2, rf1);
     let diag = diagnostics
         .iter()
         .find(|d| d.code == 2345)
-        .unwrap_or_else(|| panic!("expected TS2345, got: {:?}", codes));
+        .unwrap_or_else(|| panic!("expected TS2345, got: {codes:?}"));
 
     assert!(
         diag.message_text

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 #![allow(clippy::doc_markdown)]
-#![allow(clippy::uninlined_format_args)]
 
 extern crate self as tsz_checker;
 

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1891,8 +1891,7 @@ interface B extends A {}
         assert_eq!(
             ts2413.len(),
             1,
-            "Expected exactly 1 TS2413 (on A), not a duplicate at B's name. Got: {:?}",
-            diags
+            "Expected exactly 1 TS2413 (on A), not a duplicate at B's name. Got: {diags:?}"
         );
     }
 

--- a/crates/tsz-checker/tests/ts2428_tests.rs
+++ b/crates/tsz-checker/tests/ts2428_tests.rs
@@ -401,12 +401,10 @@ type A = {}"#;
     let codes: Vec<u32> = diags.iter().map(|d| d.0).collect();
     assert!(
         codes.contains(&2395),
-        "Should emit TS2395 (not TS2300) when type alias has mixed export/local: got {:?}",
-        codes
+        "Should emit TS2395 (not TS2300) when type alias has mixed export/local: got {codes:?}"
     );
     assert!(
         !codes.contains(&2300),
-        "Should NOT emit TS2300 when TS2395 is emitted: got {:?}",
-        codes
+        "Should NOT emit TS2300 when TS2395 is emitted: got {codes:?}"
     );
 }

--- a/crates/tsz-checker/tests/value_usage_tests.rs
+++ b/crates/tsz-checker/tests/value_usage_tests.rs
@@ -445,8 +445,7 @@ const make = () => {
     let ts18004_count = diags.iter().filter(|d| d.code == 18004).count();
     assert!(
         ts18004_count >= 1,
-        "Expected TS18004 for missing shorthand property value, got diagnostics: {:?}",
-        diags
+        "Expected TS18004 for missing shorthand property value, got diagnostics: {diags:?}"
     );
 }
 
@@ -471,13 +470,11 @@ Test(({ b = '5' } = {}));
 
     assert_eq!(
         ts18004_count, 1,
-        "Expected exactly one TS18004 for missing shorthand property value, got diagnostics: {:?}",
-        diags
+        "Expected exactly one TS18004 for missing shorthand property value, got diagnostics: {diags:?}"
     );
     assert_eq!(
         ts2304_count, 0,
-        "Expected no duplicate TS2304 alongside TS18004 for shorthand assignment in JS, got diagnostics: {:?}",
-        diags
+        "Expected no duplicate TS2304 alongside TS18004 for shorthand assignment in JS, got diagnostics: {diags:?}"
     );
 }
 
@@ -494,8 +491,7 @@ function f(x: unknown) {
     let ts18046_count = diags.iter().filter(|d| d.code == 18046).count();
     assert!(
         ts18046_count >= 2,
-        "Expected at least 2 TS18046 for property/element access on unknown, got {ts18046_count}. Diagnostics: {:?}",
-        diags
+        "Expected at least 2 TS18046 for property/element access on unknown, got {ts18046_count}. Diagnostics: {diags:?}"
     );
     // Should NOT emit TS2339 for unknown type accesses
     let ts2339_count = diags.iter().filter(|d| d.code == 2339).count();
@@ -516,8 +512,7 @@ ns.foo.bar();
     let ts18046_count = diags.iter().filter(|d| d.code == 18046).count();
     assert_eq!(
         ts18046_count, 0,
-        "Expected no TS18046 for namespace import access fallback, got diagnostics: {:?}",
-        diags
+        "Expected no TS18046 for namespace import access fallback, got diagnostics: {diags:?}"
     );
 }
 
@@ -613,15 +608,13 @@ let r = x < 1;
     let ts18048_count = diags.iter().filter(|d| d.code == 18048).count();
     assert!(
         ts18048_count >= 1,
-        "Expected TS18048 for `number | undefined` operand, got diagnostics: {:?}",
-        diags
+        "Expected TS18048 for `number | undefined` operand, got diagnostics: {diags:?}"
     );
 
     let ts2365_count = diags.iter().filter(|d| d.code == 2365).count();
     assert_eq!(
         ts2365_count, 0,
-        "Should suppress TS2365 when TS18048 is emitted, got diagnostics: {:?}",
-        diags
+        "Should suppress TS2365 when TS18048 is emitted, got diagnostics: {diags:?}"
     );
 }
 
@@ -636,8 +629,7 @@ let r = item.id < 5;
     let ts18048 = diags.iter().find(|d| d.code == 18048);
     assert!(
         ts18048.is_some(),
-        "Expected TS18048 for optional property comparison, got diagnostics: {:?}",
-        diags
+        "Expected TS18048 for optional property comparison, got diagnostics: {diags:?}"
     );
 
     let has_item_dot_id_message = diags.iter().any(|d| {
@@ -647,15 +639,13 @@ let r = item.id < 5;
     });
     assert!(
         has_item_dot_id_message,
-        "Expected TS18048 message for 'item.id', got diagnostics: {:?}",
-        diags
+        "Expected TS18048 message for 'item.id', got diagnostics: {diags:?}"
     );
 
     let ts2365_count = diags.iter().filter(|d| d.code == 2365).count();
     assert_eq!(
         ts2365_count, 0,
-        "Should suppress TS2365 for optional property nullish check, got diagnostics: {:?}",
-        diags
+        "Should suppress TS2365 for optional property nullish check, got diagnostics: {diags:?}"
     );
 }
 
@@ -693,7 +683,6 @@ type Cps = MyParams<typeof C>;
     let ts2344_count = diags.iter().filter(|d| d.code == 2344).count();
     assert!(
         ts2344_count >= 1,
-        "Expected TS2344 for MyParams<typeof C> (class has no call signatures), got {ts2344_count}. Diagnostics: {:?}",
-        diags
+        "Expected TS2344 for MyParams<typeof C> (class has no call signatures), got {ts2344_count}. Diagnostics: {diags:?}"
     );
 }


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382, #1383, #1384, #1388, #1389, #1391, #1394.

`cargo clippy --fix` applied to:
- `src/error_reporter/call_errors_tests.rs`
- `src/state/state_checking_members/index_signature_checks.rs`
- `tests/ts2428_tests.rs`
- `tests/value_usage_tests.rs`

All sites switched from `format!("{}", x)` style to `format!("{x}")`.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
