### PR TITLE
chore(checker): remove crate-wide allow(clippy::doc_markdown) + auto-fix

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1141,9 +1141,9 @@ impl<'a> CheckerContext<'a> {
         binder.alias_partners.contains_key(&sym_id)
     }
 
-    /// Reverse lookup: find the TYPE_ALIAS partner that points at
+    /// Reverse lookup: find the `TYPE_ALIAS` partner that points at
     /// `alias_sym_id`. Used by the type-position symbol resolver to redirect
-    /// an ALIAS symbol back to its merged TYPE_ALIAS counterpart. Prefers
+    /// an ALIAS symbol back to its merged `TYPE_ALIAS` counterpart. Prefers
     /// the project-wide map; falls back to the per-binder map for
     /// standalone callers.
     pub fn alias_partner_reverse(

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1030,7 +1030,7 @@ pub struct CheckerContext<'a> {
     /// binders. The full merged map lives here once; per-file cross-file
     /// lookup binders leave their `reexports` field empty and the
     /// `ctx.reexports_for_file` accessor consults this first. Avoids the
-    /// O(N · map_size) deep clone that used to materialize a copy of the
+    /// O(N · `map_size`) deep clone that used to materialize a copy of the
     /// program-wide map into every one of N cross-file binders.
     pub program_reexports: Option<Arc<tsz_binder::FileReexportsMap>>,
     /// Program-wide wildcard re-exports map; see `program_reexports`.
@@ -1345,14 +1345,14 @@ pub struct ProjectEnv {
     /// `global_module_exports_index` slot. Drivers populate this from
     /// `SkeletonIndex::build_module_exports_index(&program.module_exports)`
     /// — note the projection consumes the post-merge `program.module_exports`
-    /// (which holds globally-remapped SymbolIds), NOT per-binder data, so
+    /// (which holds globally-remapped `SymbolIds`), NOT per-binder data, so
     /// once arenas become evictable in Phase 5 the merged module-exports
     /// index can still be built without retaining per-file binder state.
     ///
     /// SymbolId-coupling rationale: the projection passes through globally-
-    /// remapped SymbolIds — exactly what consumers (e.g. `type_only.rs`,
+    /// remapped `SymbolIds` — exactly what consumers (e.g. `type_only.rs`,
     /// `state/type_resolution/module.rs`) expect to dereference against
-    /// `all_binders[file_idx]`. Pre-merge local SymbolIds (the trap in
+    /// `all_binders[file_idx]`. Pre-merge local `SymbolIds` (the trap in
     /// PR #1145 for the file-locals index) are intentionally NOT recorded
     /// in the skeleton at extract time.
     pub skeleton_module_exports_index: Option<GlobalModuleExportsIndex>,

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
         formatter.format(type_id).into_owned()
     }
 
-    /// Format an Intersection type that has an Application display_alias, showing the
+    /// Format an Intersection type that has an Application `display_alias`, showing the
     /// structural intersection form (not the application alias). Matches tsc's behavior
     /// for branded primitive types in assignability messages: e.g., `Brand<T>` displayed
     /// as `Number & { __brand: T }` with widened member types and capitalized primitives.
@@ -958,7 +958,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Check if an intersection type contains a fresh anonymous object member
-    /// (one with display_properties and no symbol name).
+    /// (one with `display_properties` and no symbol name).
     fn intersection_has_fresh_anonymous_object(&self, ty: TypeId) -> bool {
         crate::query_boundaries::common::intersection_members(self.ctx.types.as_type_database(), ty)
             .is_some_and(|members| {

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -320,8 +320,8 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     /// Walk the parent chain from `node_idx` to find the nearest enclosing
-    /// function-like node (FUNCTION_DECLARATION, FUNCTION_EXPRESSION, ARROW_FUNCTION,
-    /// METHOD_DECLARATION, GET_ACCESSOR, SET_ACCESSOR, or CONSTRUCTOR).
+    /// function-like node (`FUNCTION_DECLARATION`, `FUNCTION_EXPRESSION`, `ARROW_FUNCTION`,
+    /// `METHOD_DECLARATION`, `GET_ACCESSOR`, `SET_ACCESSOR`, or CONSTRUCTOR).
     ///
     /// Returns `NodeIndex::NONE` if the node is at module/global scope.
     fn find_enclosing_function_node(&self, node_idx: NodeIndex) -> NodeIndex {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -14,7 +14,6 @@
 //! is an alias to the thin checker.
 
 #![allow(dead_code)]
-#![allow(clippy::doc_markdown)]
 
 extern crate self as tsz_checker;
 

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -2007,7 +2007,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// tsc reports TS4094 at the `export` keyword (col 1), not the `class` keyword.
     /// When the class is an expression inside an export statement, the parent node
-    /// starts at `export`. When it's a ClassDeclaration with own `export default`
+    /// starts at `export`. When it's a `ClassDeclaration` with own `export default`
     /// modifiers, the first modifier starts before the class keyword.
     fn get_anonymous_class_export_anchor(
         &self,

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -756,7 +756,7 @@ impl<'a> CheckerState<'a> {
     /// `ctx.symbol_resolution_set` and represents a type alias. Descends through
     /// arrays, tuples, unions, intersections, and parenthesized types so that
     /// `T5[]` is detected as referencing `T5`. Stops at structural-deferral
-    /// wrappers (TYPE_LITERAL, MAPPED_TYPE, FUNCTION_TYPE, CONSTRUCTOR_TYPE),
+    /// wrappers (`TYPE_LITERAL`, `MAPPED_TYPE`, `FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`),
     /// because tsc creates those types lazily — property types and signature
     /// types are not eagerly resolved during typeof-target type construction,
     /// so a reference to a resolution-chain alias inside such a wrapper does

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -125,7 +125,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Format a type for TS2741 messages, showing the merged object form
-    /// instead of following display_alias to intersection types.
+    /// instead of following `display_alias` to intersection types.
     pub fn format_type_diagnostic_flattened(&self, type_id: TypeId) -> String {
         let mut formatter = self
             .ctx

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -143,34 +143,32 @@ impl<'a> CheckerState<'a> {
             // a later same-named `const X` declaration is genuinely circular.
             // For symbol-type caching we keep imports as valid prior declarations
             // so that module augmentations cannot overwrite a JS-export type.
-            if exclude_aliases {
-                if let Some(other_node) = self.ctx.arena.get(other) {
-                    let kind = other_node.kind;
-                    if kind == syntax_kind_ext::NAMESPACE_IMPORT
-                        || kind == syntax_kind_ext::IMPORT_CLAUSE
-                        || kind == syntax_kind_ext::IMPORT_SPECIFIER
-                        || kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                        || kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
-                        || kind == syntax_kind_ext::NAMESPACE_EXPORT
-                        || kind == syntax_kind_ext::EXPORT_SPECIFIER
-                    {
-                        return false;
-                    }
-                    // The UMD `export as namespace foo` (and a few namespace-export
-                    // forms) record the export_clause identifier as the declaration
-                    // node; check the parent kind to filter that case as well.
-                    if kind == SyntaxKind::Identifier as u16
-                        && let Some(other_ext) = self.ctx.arena.get_extended(other)
-                        && let Some(parent_node) = self.ctx.arena.get(other_ext.parent)
-                        && (parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
-                            || parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT
-                            || parent_node.kind == syntax_kind_ext::IMPORT_CLAUSE
-                            || parent_node.kind == syntax_kind_ext::NAMESPACE_IMPORT
-                            || parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
-                            || parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER)
-                    {
-                        return false;
-                    }
+            if exclude_aliases && let Some(other_node) = self.ctx.arena.get(other) {
+                let kind = other_node.kind;
+                if kind == syntax_kind_ext::NAMESPACE_IMPORT
+                    || kind == syntax_kind_ext::IMPORT_CLAUSE
+                    || kind == syntax_kind_ext::IMPORT_SPECIFIER
+                    || kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                    || kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                    || kind == syntax_kind_ext::NAMESPACE_EXPORT
+                    || kind == syntax_kind_ext::EXPORT_SPECIFIER
+                {
+                    return false;
+                }
+                // The UMD `export as namespace foo` (and a few namespace-export
+                // forms) record the export_clause identifier as the declaration
+                // node; check the parent kind to filter that case as well.
+                if kind == SyntaxKind::Identifier as u16
+                    && let Some(other_ext) = self.ctx.arena.get_extended(other)
+                    && let Some(parent_node) = self.ctx.arena.get(other_ext.parent)
+                    && (parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                        || parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT
+                        || parent_node.kind == syntax_kind_ext::IMPORT_CLAUSE
+                        || parent_node.kind == syntax_kind_ext::NAMESPACE_IMPORT
+                        || parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+                        || parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER)
+                {
+                    return false;
                 }
             }
             true

--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -1053,8 +1053,8 @@ var p: M2.Point;
 /// (e.g., `export interface Point { ... }` and `export var Point = 1`), accessing
 /// the property on the namespace value object should return the VARIABLE type,
 /// not the interface type. Previously, `symbol_has_exported_value_declaration` didn't
-/// check the `export` modifier on the grandparent VariableStatement (it only checked
-/// for EXPORT_DECLARATION wrapper and declare context), so the exported variable
+/// check the `export` modifier on the grandparent `VariableStatement` (it only checked
+/// for `EXPORT_DECLARATION` wrapper and declare context), so the exported variable
 /// was excluded from the namespace object type, resulting in `{}` instead of
 /// `{ Point: number }`.
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -990,7 +990,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Check if a type's ObjectShape comes from a class expression (anonymous class).
+    /// Check if a type's `ObjectShape` comes from a class expression (anonymous class).
     ///
     /// Used for TS4094: only class expressions need declaration-emit type literals,
     /// so only they require the private/protected member check.
@@ -1015,7 +1015,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Emit TS4094 for each private/protected member of an instance type, using the
-    /// solver's ObjectShape to include inherited members (not just direct AST members).
+    /// solver's `ObjectShape` to include inherited members (not just direct AST members).
     ///
     /// Properties are reported in alphabetical order to match tsc's output.
     pub(crate) fn report_instance_type_private_members_as_ts4094(

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -125,7 +125,7 @@ pub fn check_with_options(source: &str, options: CheckerOptions) -> Vec<Diagnost
 
 #[cfg(test)]
 mod tests {
-    //! Self-tests for the test_utils helpers themselves.
+    //! Self-tests for the `test_utils` helpers themselves.
     //!
     //! These pin the contracts that 100s of checker tests rely on:
     //! - `check_source_diagnostics` ≡ `check_source(source, "test.ts", default)`.

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -4253,7 +4253,7 @@ fn test_no_inline_visitor_calls_in_checker_modules() {
 /// outside `query_boundaries/`. All solver function calls must go through boundary wrappers.
 ///
 /// This guard catches top-level solver function calls like `tsz_solver::is_conditional_type(...)`
-/// that bypass the query_boundaries layer. Struct/enum paths like `tsz_solver::TypeId` and
+/// that bypass the `query_boundaries` layer. Struct/enum paths like `tsz_solver::TypeId` and
 /// sub-namespace paths like `tsz_solver::operations::property::` are excluded from this check
 /// since they're either data types (handled by `test_solver_imports_go_through_query_boundaries`)
 /// or internal solver modules with their own boundary guards.
@@ -4332,7 +4332,7 @@ fn test_no_inline_solver_function_calls_in_checker_modules() {
 /// Callers should use `query_boundaries::common::widen_type` (free function) or
 /// `self.widen_literal_type()` (method on `CheckerState`) instead.
 ///
-/// Current ceiling: 0 occurrences — all calls migrated to query_boundaries.
+/// Current ceiling: 0 occurrences — all calls migrated to `query_boundaries`.
 #[test]
 fn test_direct_widening_calls_ceiling() {
     let checker_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -4635,7 +4635,7 @@ fn test_direct_binary_op_evaluator_construction_ceiling() {
 /// These bypass the query boundary layer. Wrappers should be created in
 /// `query_boundaries/` over time. This ceiling must only decrease.
 ///
-/// Current ceiling: 0 occurrences (all migrated to query_boundaries).
+/// Current ceiling: 0 occurrences (all migrated to `query_boundaries`).
 #[test]
 fn test_direct_property_access_evaluator_construction_ceiling() {
     let checker_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");

--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -1806,12 +1806,12 @@ class Comp<T extends Foo, S> extends Component<S & State<T>>
     );
 }
 
-/// Regression test: generic overloads with ThisType markers should not produce
+/// Regression test: generic overloads with `ThisType` markers should not produce
 /// false TS2339 on `this` property accesses inside object literal methods.
 ///
 /// The issue was that during overload resolution, the first-pass argument
 /// collection uses union-contextual types with unresolved type parameters.
-/// The ThisType<Data & Readonly<Props> & Instance> marker extracted from the
+/// The `ThisType`<Data & Readonly<Props> & Instance> marker extracted from the
 /// callable had uninstantiated Data/Props, causing `this.bar` to fail. The
 /// fix defers the hard-error rejection for generic overloads until after the
 /// instantiated retry, which re-evaluates with concrete types.

--- a/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
@@ -165,8 +165,8 @@ consume(make((x) => {
     );
 }
 
-/// Return-context seeding in compute_contextual_types should set
-/// had_return_context_substitution when the Round 1 substitution
+/// Return-context seeding in `compute_contextual_types` should set
+/// `had_return_context_substitution` when the Round 1 substitution
 /// already contains the same value, preventing unnecessary retries
 /// that could clear valid diagnostics.
 #[test]

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -15,7 +15,7 @@ impl CheckerState<'_> {
     /// Push the enclosing JS class's `@template T` JSDoc-derived type
     /// parameters into `type_parameter_scope` for the lifetime of a
     /// surrounding check (typically a class-member walk or a method-type
-    /// build). Returns the list of (name, previous_value) entries that
+    /// build). Returns the list of (name, `previous_value`) entries that
     /// `pop_enclosing_jsdoc_class_template_types` consumes to restore the
     /// scope on exit. Returns an empty Vec for non-JS files.
     pub(crate) fn push_enclosing_jsdoc_class_template_types(
@@ -60,7 +60,7 @@ impl CheckerState<'_> {
     /// 3-tuple shape `(name, previous, false)` that fits the
     /// `jsdoc_type_param_updates` accumulator used by
     /// `get_type_of_function_impl`. The third bool is the
-    /// "shadowed_class_param" flag, always `false` for class-level pushes.
+    /// "`shadowed_class_param`" flag, always `false` for class-level pushes.
     pub(crate) fn push_enclosing_jsdoc_class_template_types_with_flag(
         &mut self,
         node_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -1334,7 +1334,7 @@ impl<'a> CheckerState<'a> {
 
     /// Extract inference from an object literal whose target type is a mapped type.
     ///
-    /// For patterns like VuexStoreOptions where `modules` has type
+    /// For patterns like `VuexStoreOptions` where `modules` has type
     /// `{ [k in keyof Modules]: VuexStoreOptions<Modules[k], never> }` and the initializer is
     /// `{ foo: { state() {...}, mutations: {...} } }`, we need to:
     /// 1. For each property key (e.g., `foo`), extract the partial type from the property value

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1903,7 +1903,7 @@ impl<'a> CheckerState<'a> {
 
     /// Return the class's syntactic name, or `"(anonymous)"` if the class
     /// expression has no name. Unlike `get_bound_class_name_from_decl`, this
-    /// does NOT fall back to an enclosing VariableDeclaration name — tsc
+    /// does NOT fall back to an enclosing `VariableDeclaration` name — tsc
     /// uses this stricter form for TS18013 messages.
     fn get_syntactic_class_name_or_anonymous(&self, class_idx: NodeIndex) -> String {
         self.ctx

--- a/crates/tsz-checker/tests/assertion_overlap_keyof_primitive_tests.rs
+++ b/crates/tsz-checker/tests/assertion_overlap_keyof_primitive_tests.rs
@@ -8,7 +8,7 @@
 //! assertion overlap purposes it is comparable to any of those primitives
 //! (or their literals). tsc's `isTypeComparableTo` walks the `keyof` to its
 //! key-space union; without this case, an assertion like
-//! `(k as string)` falls through to the property-overlap check (KeyOf has
+//! `(k as string)` falls through to the property-overlap check (`KeyOf` has
 //! no extractable properties) and emits a false-positive TS2352.
 
 use crate::context::CheckerOptions;

--- a/crates/tsz-checker/tests/assertion_overlap_object_primitive_tests.rs
+++ b/crates/tsz-checker/tests/assertion_overlap_object_primitive_tests.rs
@@ -9,14 +9,14 @@
 //! returned false when both sides had no extractable properties:
 //! `types_have_common_properties_relaxed` short-circuits on the
 //! "both empty" branch. tsc treats the `object` primitive as overlapping
-//! with any object-like type, and walks a TypeParameter's constraint
+//! with any object-like type, and walks a `TypeParameter`'s constraint
 //! when the source is the empty object type `{}`.
 //!
 //! Two narrow rules added in `types_are_comparable_for_assertion_inner`:
 //!   1. `object` primitive ↔ Object/Array/Tuple/Callable/Function/Intersection
 //!      → comparable.
 //!   2. `{}` (empty object: no required props, no index sigs) ↔
-//!      TypeParameter with constraint → recurse against the constraint.
+//!      `TypeParameter` with constraint → recurse against the constraint.
 //!
 //! The "narrow to {}" gating is important: fully unwrapping any source's
 //! type-parameter constraint would over-permit assertions like

--- a/crates/tsz-checker/tests/jsdoc_satisfies_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_satisfies_tests.rs
@@ -145,7 +145,7 @@ export default /** @satisfies {Foo} */ ({});
 
 /// JSDoc @param types on exported functions should suppress TS7006.
 /// The JSDoc comment is before `export`, but function pos is at `function`.
-/// Regression test: find_jsdoc_for_function must walk up to ExportDeclaration.
+/// Regression test: `find_jsdoc_for_function` must walk up to `ExportDeclaration`.
 #[test]
 fn test_jsdoc_param_suppresses_ts7006_exported_function() {
     let source = r#"


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382-#1391, #1394, #1395.

`cargo clippy --fix` wrapped 30+ unbacktick'd identifiers across 20 files (`CheckerContext`, `SymbolId`, `TypeId`, `NodeIndex`, etc.) so docs render correctly and rustdoc lints stay enforced going forward.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
