### PR TITLE
chore(checker): remove crate-wide allow(clippy::collapsible_if) + auto-fix

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -767,11 +767,9 @@ impl<'a> CheckerState<'a> {
             }
             if let Some(shape) =
                 crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
-            {
-                if shape.is_constructor {
+                && shape.is_constructor {
                     return true;
                 }
-            }
             if let Some(app) =
                 crate::query_boundaries::common::type_application(self.ctx.types, type_id)
             {
@@ -784,11 +782,10 @@ impl<'a> CheckerState<'a> {
                 if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
                     self.ctx.types,
                     app.base,
-                ) {
-                    if shape.is_constructor {
+                )
+                    && shape.is_constructor {
                         return true;
                     }
-                }
             }
             false
         };

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -840,8 +840,8 @@ impl<'a> CheckerState<'a> {
         //     effective = boolean → NOT assignable to number ✗
         //   `({ x = undefined } = a)` where `a.x` is `number | undefined`:
         //     effective = number | undefined → NOT assignable to number ✗
-        if has_default && self.ctx.compiler_options.strict_null_checks {
-            if crate::query_boundaries::common::type_contains_undefined(self.ctx.types, prop_type) {
+        if has_default && self.ctx.compiler_options.strict_null_checks
+            && crate::query_boundaries::common::type_contains_undefined(self.ctx.types, prop_type) {
                 let non_undefined = crate::query_boundaries::flow::narrow_destructuring_default(
                     self.ctx.types,
                     prop_type,
@@ -854,7 +854,6 @@ impl<'a> CheckerState<'a> {
                     return;
                 }
             }
-        }
         let target_type = self.get_type_of_assignment_target(target_idx);
         if target_type == TypeId::ANY || target_type == TypeId::ERROR {
             return;

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -959,8 +959,8 @@ impl<'a> CheckerState<'a> {
 
         // If the component has construct signatures (class component), validate against
         // them — mirrors `validate_new_expression_type_arguments` for `new` expressions.
-        if let Some(shape) = query::callable_shape_for_type(self.ctx.types, resolved) {
-            if !shape.construct_signatures.is_empty() {
+        if let Some(shape) = query::callable_shape_for_type(self.ctx.types, resolved)
+            && !shape.construct_signatures.is_empty() {
                 let type_arg_error_anchor =
                     type_args_list.nodes.first().copied().unwrap_or(element_idx);
                 let matching: Vec<_> = shape
@@ -1023,7 +1023,6 @@ impl<'a> CheckerState<'a> {
                 self.validate_type_args_against_params(&type_params, type_args_list);
                 return false;
             }
-        }
 
         // Function component (call signatures): validate via call type-arg path.
         let result = self.validate_call_type_arguments(resolved, type_args_list, element_idx);

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -828,8 +828,8 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                                         }
                                     };
 
-                                    if let Some((allowed, span)) = existing_info {
-                                        if !allowed {
+                                    if let Some((allowed, span)) = existing_info
+                                        && !allowed {
                                             // tsc reports TS2567 at BOTH the new enum in
                                             // the augmentation AND at the original
                                             // declaration's name. Emit both for parity.
@@ -851,7 +851,6 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                                                 );
                                             }
                                         }
-                                    }
                                     if register_value_name(&ident.escaped_text, enm.name)
                                         && let Some(node) = self.ctx.arena.get(enm.name)
                                     {

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -1055,11 +1055,10 @@ impl<'a> CheckerState<'a> {
                         _ => arena.get_enum(node).and_then(|enum_decl| {
                             self.get_identifier_text_from_idx(enum_decl.name)
                         }),
-                    } {
-                        if name == import_name {
+                    }
+                        && name == import_name {
                             has_named_value = true;
                         }
-                    }
                     if is_default {
                         has_default_value = true;
                     }

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1822,15 +1822,14 @@ impl<'a> CheckerState<'a> {
                 elem_node.kind,
                 syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                     | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-            ) {
-                if !skip_deep_elaboration
+            )
+                && !skip_deep_elaboration
                     && self.try_elaborate_assignment_source_error(elem_idx, target_element_type)
                 {
                     elaborated = true;
                     continue;
                 }
                 // Fall through to the non-object element check below.
-            }
 
             // For function/conditional elements, try to elaborate without a guard.
             if matches!(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -113,8 +113,8 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types,
                 raw_callee_type,
                 args.nodes.len(),
-            ) {
-                if let Some(param_type) = raw_sig
+            )
+                && let Some(param_type) = raw_sig
                     .params
                     .get(arg_index)
                     .map(|param| param.type_id)
@@ -140,7 +140,6 @@ impl<'a> CheckerState<'a> {
                             Some(self.ctx.types.union2(target, TypeId::UNDEFINED));
                     }
                 }
-            }
         }
         let contextual_target = raw_call_param_property_target
             .or(object_property_target)

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -1415,8 +1415,7 @@ impl<'a> CheckerState<'a> {
             // Process ReadonlyArray<T> first to avoid matching inner Array<T>.
             if slice.starts_with("ReadonlyArray<")
                 && (i == 0 || !text.as_bytes()[i - 1].is_ascii_alphanumeric())
-            {
-                if let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 14) {
+                && let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 14) {
                     let end = i + 14 + inner.len() + 1; // "ReadonlyArray<" + inner + ">"
                     if is_extends_constraint_position(text, i) {
                         out.push_str(&text[i..end]);
@@ -1431,12 +1430,10 @@ impl<'a> CheckerState<'a> {
                     i = end;
                     continue;
                 }
-            }
 
             if slice.starts_with("Array<")
                 && (i == 0 || !text.as_bytes()[i - 1].is_ascii_alphanumeric())
-            {
-                if let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 6) {
+                && let Some(inner) = Self::extract_balanced_angle_bracket_content(text, i + 6) {
                     let end = i + 6 + inner.len() + 1; // "Array<" + inner + ">"
                     if is_extends_constraint_position(text, i) {
                         out.push_str(&text[i..end]);
@@ -1451,7 +1448,6 @@ impl<'a> CheckerState<'a> {
                     i = end;
                     continue;
                 }
-            }
 
             if let Some(ch) = slice.chars().next() {
                 out.push(ch);

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -343,11 +343,10 @@ impl<'a> CheckerState<'a> {
         // For deferred conditional types, check if the conditional is ambiguous
         // (tsc shows the branch union rather than the alias form).
         let is_cond = crate::query_boundaries::common::is_conditional_type(self.ctx.types, ty);
-        if is_cond {
-            if let Some(branch_union) = self.compute_ambiguous_conditional_display(ty) {
+        if is_cond
+            && let Some(branch_union) = self.compute_ambiguous_conditional_display(ty) {
                 return self.format_type_for_assignability_message(branch_union);
             }
-        }
 
         let evaluated = self.evaluate_type_for_assignability(ty);
         let use_eval = self.should_use_evaluated_assignability_display(ty, evaluated);

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -1061,17 +1061,15 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         // Try left.constructor === right
-        if let Some(base) = self.get_constructor_property_base(bin.left) {
-            if let Some(instance_type) = self.instance_type_from_constructor(bin.right) {
+        if let Some(base) = self.get_constructor_property_base(bin.left)
+            && let Some(instance_type) = self.instance_type_from_constructor(bin.right) {
                 return Some((TypeGuard::Constructor(instance_type), base));
             }
-        }
         // Try left === right.constructor
-        if let Some(base) = self.get_constructor_property_base(bin.right) {
-            if let Some(instance_type) = self.instance_type_from_constructor(bin.left) {
+        if let Some(base) = self.get_constructor_property_base(bin.right)
+            && let Some(instance_type) = self.instance_type_from_constructor(bin.left) {
                 return Some((TypeGuard::Constructor(instance_type), base));
             }
-        }
         None
     }
 }

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1251,12 +1251,11 @@ impl<'a> CheckerState<'a> {
                         .and_then(|members| members.get(segment))
                 })
             {
-                if let Some(current_file_idx) = current_file_idx {
-                    if !self.ctx.has_symbol_file_index(member_sym) {
+                if let Some(current_file_idx) = current_file_idx
+                    && !self.ctx.has_symbol_file_index(member_sym) {
                         self.ctx
                             .register_symbol_file_target(member_sym, current_file_idx);
                     }
-                }
                 current_sym = member_sym;
                 continue;
             }
@@ -1268,12 +1267,11 @@ impl<'a> CheckerState<'a> {
                     segment,
                     &mut visited_aliases,
                 ) {
-                    if let Some(current_file_idx) = current_file_idx {
-                        if !self.ctx.has_symbol_file_index(member_sym) {
+                    if let Some(current_file_idx) = current_file_idx
+                        && !self.ctx.has_symbol_file_index(member_sym) {
                             self.ctx
                                 .register_symbol_file_target(member_sym, current_file_idx);
                         }
-                    }
                     current_sym = member_sym;
                     continue;
                 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -14,7 +14,6 @@
 //! is an alias to the thin checker.
 
 #![allow(dead_code)]
-#![allow(clippy::collapsible_if)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::uninlined_format_args)]

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -135,32 +135,28 @@ impl<'a> CheckerState<'a> {
         // (e.g., TS1047 "rest can't be optional" for `...arg?`, TS1014 "rest not last"
         // for `...x, y`). The empty-name check below still catches truly malformed rest params.
         if !param.dot_dot_dot_token {
-            if let Some(name_node) = self.ctx.arena.get(param.name) {
-                if (name_node.this_node_has_error() || name_node.this_or_subtree_has_error())
+            if let Some(name_node) = self.ctx.arena.get(param.name)
+                && (name_node.this_node_has_error() || name_node.this_or_subtree_has_error())
                     && !preserve_on_strict_mode_parse_error
                 {
                     return;
                 }
-            }
             // Also check parent chain (parameter → function/arrow) for parse errors
             if let Some(ext) = self.ctx.arena.get_extended(param.name) {
                 // param.name's parent is ParameterDeclaration; its parent is the function/arrow
                 let param_decl = ext.parent;
-                if let Some(param_node) = self.ctx.arena.get(param_decl) {
-                    if param_node.this_or_subtree_has_error()
+                if let Some(param_node) = self.ctx.arena.get(param_decl)
+                    && param_node.this_or_subtree_has_error()
                         && !preserve_on_strict_mode_parse_error
                     {
                         return;
                     }
-                }
                 if let Some(param_ext) = self.ctx.arena.get_extended(param_decl)
                     && let Some(func_node) = self.ctx.arena.get(param_ext.parent)
-                {
-                    if func_node.this_or_subtree_has_error() && !preserve_on_strict_mode_parse_error
+                    && func_node.this_or_subtree_has_error() && !preserve_on_strict_mode_parse_error
                     {
                         return;
                     }
-                }
             }
 
             // Suppress TS7006 when a scanner-level parse error (e.g. TS1127 invalid character)

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -268,19 +268,17 @@ impl<'a> CheckerState<'a> {
         let name_or_arg = left_access.name_or_argument;
 
         // exports.<name> / exports["<name>"]
-        if let Some(ident) = arena.get_identifier_at(expr_idx) {
-            if ident.escaped_text == "exports" {
+        if let Some(ident) = arena.get_identifier_at(expr_idx)
+            && ident.escaped_text == "exports" {
                 return Self::commonjs_static_member_name_in_arena(arena, name_or_arg)
                     .map(|name| (name, None));
             }
-        }
 
         // module.exports.<name> / module["exports"].<name>
-        if let Some(container_node) = arena.get(expr_idx) {
-            if container_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || container_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            {
-                if let Some(container_access) = arena.get_access_expr(container_node) {
+        if let Some(container_node) = arena.get(expr_idx)
+            && (container_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || container_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+                && let Some(container_access) = arena.get_access_expr(container_node) {
                     let is_module_exports =
                         if container_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
                             arena
@@ -304,8 +302,6 @@ impl<'a> CheckerState<'a> {
                             .map(|n| (n, None));
                     }
                 }
-            }
-        }
 
         // <alias>.<name> where alias is in export_aliases
         arena

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -248,8 +248,7 @@ impl<'a> CheckerState<'a> {
                 // correctly.
                 if let Some(shape) =
                     crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, result)
-                {
-                    if !shape.construct_signatures.is_empty() {
+                    && !shape.construct_signatures.is_empty() {
                         let prototype_name = self.ctx.types.intern_string("prototype");
                         if let Some(proto_prop) =
                             shape.properties.iter().find(|p| p.name == prototype_name)
@@ -257,7 +256,6 @@ impl<'a> CheckerState<'a> {
                             result = proto_prop.type_id;
                         }
                     }
-                }
             }
             return Some(result);
         }
@@ -314,32 +312,27 @@ impl<'a> CheckerState<'a> {
                 if let Some(exports) = self
                     .ctx
                     .module_exports_for_module(self.ctx.binder, &candidate)
-                {
-                    if let Some(sym_id) = exports.get("export=") {
+                    && let Some(sym_id) = exports.get("export=") {
                         found = Some(sym_id);
                         break;
                     }
-                }
             }
-            if found.is_none() {
-                if let Some(all_binders) = &self.ctx.all_binders {
+            if found.is_none()
+                && let Some(all_binders) = &self.ctx.all_binders {
                     for binder in all_binders.iter() {
                         for candidate in module_specifier_candidates(module_name) {
                             if let Some(exports) =
                                 self.ctx.module_exports_for_module(binder, &candidate)
-                            {
-                                if let Some(sym_id) = exports.get("export=") {
+                                && let Some(sym_id) = exports.get("export=") {
                                     found = Some(sym_id);
                                     break;
                                 }
-                            }
                         }
                         if found.is_some() {
                             break;
                         }
                     }
                 }
-            }
             found?
         };
 

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -318,19 +318,15 @@ impl<'a> CheckerState<'a> {
 
             if let Some(shape) = query::object_shape(self.ctx.types, type_id)
                 && let Some(sym_id) = shape.symbol
-            {
-                if let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
+                && let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
                     return Some(info);
                 }
-            }
 
             if let Some(shape) = query::callable_shape(self.ctx.types, type_id)
                 && let Some(sym_id) = shape.symbol
-            {
-                if let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
+                && let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
                     return Some(info);
                 }
-            }
         }
 
         None

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -643,11 +643,10 @@ impl StatementChecker {
                     }
 
                     // If the condition always throws, the incrementer is unreachable
-                    if !init_terminates && condition_terminates && incrementor.is_some() {
-                        if !state.report_unreachable_code_at_terminating_iife_body(incrementor) {
+                    if !init_terminates && condition_terminates && incrementor.is_some()
+                        && !state.report_unreachable_code_at_terminating_iife_body(incrementor) {
                             state.report_unreachable_code_at_node(incrementor);
                         }
-                    }
 
                     let prev_unreachable = state.is_unreachable();
                     let prev_reported = state.has_reported_unreachable();

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -757,8 +757,8 @@ impl<'a> CheckerState<'a> {
                     // binder symbol so noUnusedLocals does not falsely report it as unused.
                     // Skip write context: `Foo["key"] = expr` is not a read.
                     let is_write_target = self.property_access_is_direct_write_target(idx);
-                    if !is_write_target {
-                        if let Some((class_idx, _)) =
+                    if !is_write_target
+                        && let Some((class_idx, _)) =
                             self.resolve_class_for_access(access.expression, object_type_for_access)
                             && let Some(&class_sym_id) =
                                 self.ctx.binder.node_symbols.get(&class_idx.0)
@@ -775,7 +775,6 @@ impl<'a> CheckerState<'a> {
                                 .borrow_mut()
                                 .insert(member_sym_id);
                         }
-                    }
                 }
             }
 
@@ -1038,8 +1037,7 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.binder.node_symbols.get(&class_idx.0)
                                 && let Some(class_symbol) = self.ctx.binder.get_symbol(class_sym_id)
                                 && let Some(ref members) = class_symbol.members
-                            {
-                                if let Some(member_sym_id) = members.get(&property_name) {
+                                && let Some(member_sym_id) = members.get(&property_name) {
                                     self.ctx
                                         .referenced_symbols
                                         .borrow_mut()
@@ -1049,7 +1047,6 @@ impl<'a> CheckerState<'a> {
                                         .borrow_mut()
                                         .insert(member_sym_id);
                                 }
-                            }
                         }
                         // In write context (assignment target), prefer the setter type.
                         Some(effective_write_result(type_id, write_type))

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -73,11 +73,10 @@ impl<'a> CheckerState<'a> {
         // ID, causing false TS2448/TS2454 (cross-binder SymbolId collision).
         // Cross-file symbols (e.g., UMD global aliases from `export as namespace`)
         // have no same-file TDZ — they are evaluated when their origin file loads.
-        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id) {
-            if file_idx != self.ctx.current_file_idx {
+        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && file_idx != self.ctx.current_file_idx {
                 return false;
             }
-        }
         let is_tdz_in_static_block =
             self.is_variable_used_before_declaration_in_static_block(sym_id, idx);
         let is_tdz_in_property_initializer =
@@ -1209,8 +1208,8 @@ impl<'a> CheckerState<'a> {
                 if let Some(mapped_id) = crate::query_boundaries::common::mapped_type_id(
                     self.ctx.types,
                     target_prop_type,
-                ) {
-                    if let Some(nested_partial) = self.extract_inference_from_mapped_type_target(
+                )
+                    && let Some(nested_partial) = self.extract_inference_from_mapped_type_target(
                         prop.initializer,
                         mapped_id,
                         type_param_names,
@@ -1218,7 +1217,6 @@ impl<'a> CheckerState<'a> {
                         properties.push(tsz_solver::PropertyInfo::new(name_atom, nested_partial));
                         continue;
                     }
-                }
 
                 // Get the function shape for the target property
                 let target_fn_shape =
@@ -1403,8 +1401,8 @@ impl<'a> CheckerState<'a> {
             }
             // Handle method declarations - for mapped types, these typically aren't at this level
             // but handle them for completeness
-            else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION {
-                if let Some(method) = self.ctx.arena.get_method_decl(elem_node) {
+            else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION
+                && let Some(method) = self.ctx.arena.get_method_decl(elem_node) {
                     // Check if this method is "thisless" (no params, no this)
                     let has_params = !method.parameters.nodes.is_empty();
                     if has_params {
@@ -1421,7 +1419,6 @@ impl<'a> CheckerState<'a> {
                         self.speculative_type_of_function(elem_idx, &TypingRequest::NONE);
                     properties.push(tsz_solver::PropertyInfo::new(name_atom, value_type));
                 }
-            }
         }
 
         if properties.is_empty() {

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -661,11 +661,10 @@ impl<'a> CheckerState<'a> {
                             }
                             if let Some(parent_node) = self.ctx.arena.get(parent) {
                                 for comment in comments.iter().rev() {
-                                    if comment.end <= parent_node.pos
+                                    if (comment.end <= parent_node.pos
                                         || (comment.pos <= parent_node.pos
-                                            && comment.end <= parent_node.end)
-                                    {
-                                        if tsz_common::comments::is_jsdoc_comment(
+                                            && comment.end <= parent_node.end))
+                                        && tsz_common::comments::is_jsdoc_comment(
                                             comment,
                                             source_text,
                                         ) {
@@ -674,7 +673,6 @@ impl<'a> CheckerState<'a> {
                                                 comment.pos,
                                             );
                                         }
-                                    }
                                 }
                                 current = parent;
                             } else {

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -956,8 +956,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // uses ES-style exports (no `export=`). `resolve_import_symbol` returns None in that
             // case so `resolved_sym_id == left_sym_id`. Look up the member directly in the
             // imported module's ES exports.
-            if resolved_sym_id == left_sym_id {
-                if let Some(left_sym) = self
+            if resolved_sym_id == left_sym_id
+                && let Some(left_sym) = self
                     .ctx
                     .binder
                     .get_symbol_with_libs(left_sym_id, &lib_binders)
@@ -989,7 +989,6 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         return Some(self.ensure_def_id_with_alias(member_sym_id));
                     }
                 }
-            }
 
             // Also check lib contexts for the member (e.g., global namespace types)
             for lib_ctx in self.ctx.lib_contexts.iter() {


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382-#1396.

`cargo clippy --fix` collapsed nested `if x { if y { ... } }` patterns into `if x && y { ... }` across 21 files in tsz-checker.

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
