### PR TITLE
fix(checker)+ci(unit): restore JS-export type + shard unit tests via nextest archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,17 +73,24 @@ jobs:
         run: scripts/ci/github-suite.sh lint
 
   unit:
-    name: unit
+    name: unit-${{ matrix.shard }}
     needs: [gate, build]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
-    timeout-minutes: 60
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    env:
+      _TSZ_CI_UNIT_SHARD_INDEX: ${{ matrix.shard }}
+      _TSZ_CI_UNIT_SHARD_COUNT: 4
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Run unit suite
-        run: scripts/ci/github-suite.sh unit
+      - name: Run unit shard
+        run: scripts/ci/github-suite.sh unit-shard
 
   wasm:
     name: wasm

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -67,6 +67,23 @@ impl<'a> CheckerState<'a> {
     }
 
     fn has_prior_value_declaration_for_symbol(&self, decl_idx: NodeIndex) -> bool {
+        self.has_prior_value_declaration_for_symbol_impl(decl_idx, false)
+    }
+
+    // TS2502 variant: alias-style declarations (imports, namespace exports) do not
+    // establish a value-typed binding in the redeclaring scope, so `typeof X` inside
+    // a later same-named declaration is genuinely circular.  Use this variant only for
+    // the circularity check; the general variant is used for symbol-type caching so
+    // that module augmentations cannot overwrite a prior JS-export type.
+    fn has_prior_value_declaration_for_ts2502(&self, decl_idx: NodeIndex) -> bool {
+        self.has_prior_value_declaration_for_symbol_impl(decl_idx, true)
+    }
+
+    fn has_prior_value_declaration_for_symbol_impl(
+        &self,
+        decl_idx: NodeIndex,
+        exclude_aliases: bool,
+    ) -> bool {
         let Some(sym_id) = self.ctx.binder.get_node_symbol(decl_idx).or_else(|| {
             self.ctx
                 .arena
@@ -120,38 +137,40 @@ impl<'a> CheckerState<'a> {
                     return false;
                 }
             }
-            // Filter out alias-style prior declarations (imports / UMD namespace
-            // exports). These bind a name to another module's surface but do not
-            // establish a value-typed binding in the redeclaring scope, so
-            // `typeof X` inside a later same-named `const X` declaration is
-            // genuinely circular (matches tsc's TS2502 behaviour for cases like
-            // `import * as foo` + `declare global { const foo: typeof foo; }`).
-            if let Some(other_node) = self.ctx.arena.get(other) {
-                let kind = other_node.kind;
-                if kind == syntax_kind_ext::NAMESPACE_IMPORT
-                    || kind == syntax_kind_ext::IMPORT_CLAUSE
-                    || kind == syntax_kind_ext::IMPORT_SPECIFIER
-                    || kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
-                    || kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
-                    || kind == syntax_kind_ext::NAMESPACE_EXPORT
-                    || kind == syntax_kind_ext::EXPORT_SPECIFIER
-                {
-                    return false;
-                }
-                // The UMD `export as namespace foo` (and a few namespace-export
-                // forms) record the export_clause identifier as the declaration
-                // node; check the parent kind to filter that case as well.
-                if kind == SyntaxKind::Identifier as u16
-                    && let Some(other_ext) = self.ctx.arena.get_extended(other)
-                    && let Some(parent_node) = self.ctx.arena.get(other_ext.parent)
-                    && (parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
-                        || parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT
-                        || parent_node.kind == syntax_kind_ext::IMPORT_CLAUSE
-                        || parent_node.kind == syntax_kind_ext::NAMESPACE_IMPORT
-                        || parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
-                        || parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER)
-                {
-                    return false;
+            // When checking for TS2502 circular references, alias-style prior
+            // declarations (imports / UMD namespace exports) do not establish a
+            // value-typed binding in the redeclaring scope, so `typeof X` inside
+            // a later same-named `const X` declaration is genuinely circular.
+            // For symbol-type caching we keep imports as valid prior declarations
+            // so that module augmentations cannot overwrite a JS-export type.
+            if exclude_aliases {
+                if let Some(other_node) = self.ctx.arena.get(other) {
+                    let kind = other_node.kind;
+                    if kind == syntax_kind_ext::NAMESPACE_IMPORT
+                        || kind == syntax_kind_ext::IMPORT_CLAUSE
+                        || kind == syntax_kind_ext::IMPORT_SPECIFIER
+                        || kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                        || kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                        || kind == syntax_kind_ext::NAMESPACE_EXPORT
+                        || kind == syntax_kind_ext::EXPORT_SPECIFIER
+                    {
+                        return false;
+                    }
+                    // The UMD `export as namespace foo` (and a few namespace-export
+                    // forms) record the export_clause identifier as the declaration
+                    // node; check the parent kind to filter that case as well.
+                    if kind == SyntaxKind::Identifier as u16
+                        && let Some(other_ext) = self.ctx.arena.get_extended(other)
+                        && let Some(parent_node) = self.ctx.arena.get(other_ext.parent)
+                        && (parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                            || parent_node.kind == syntax_kind_ext::NAMESPACE_EXPORT
+                            || parent_node.kind == syntax_kind_ext::IMPORT_CLAUSE
+                            || parent_node.kind == syntax_kind_ext::NAMESPACE_IMPORT
+                            || parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+                            || parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER)
+                    {
+                        return false;
+                    }
                 }
             }
             true
@@ -1318,6 +1337,13 @@ impl<'a> CheckerState<'a> {
             // previously-established type, not circularly to itself.
             // This matches tsc behavior where `var p: Point; var p: typeof p;` is valid and
             // where `function f(x: A) { var x: typeof x; }` uses the parameter surface.
+            //
+            // Two variants are used intentionally:
+            // - ts2502: excludes alias-style declarations (imports) so that `typeof a` inside
+            //   a same-named `const a` is treated as circular (crashDeclareGlobalTypeofExport).
+            // - general: includes imports so that module-augmentation declarations cannot
+            //   overwrite the JS-export type established by `import { a }`.
+            let is_redeclaration_for_ts2502 = self.has_prior_value_declaration_for_ts2502(decl_idx);
             let is_redeclaration = self.has_prior_value_declaration_for_symbol(decl_idx);
             let is_js_require_binding = self.ctx.is_js_file()
                 && self.ctx.compiler_options.check_js
@@ -1325,7 +1351,7 @@ impl<'a> CheckerState<'a> {
                 && self
                     .get_require_module_specifier(var_decl.initializer)
                     .is_some();
-            if var_decl.type_annotation.is_some() && !is_redeclaration {
+            if var_decl.type_annotation.is_some() && !is_redeclaration_for_ts2502 {
                 let accessor_circular =
                     self.type_literal_has_circular_accessor_reference(var_decl.type_annotation);
                 // Try AST-based check first (catches complex circularities that confuse the solver)

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -185,7 +185,7 @@ suite_needs_group() {
       [[ "$suite" == "lint" ]]
       ;;
     unit)
-      [[ "$suite" == "unit" ]]
+      [[ "$suite" == "unit" || "$suite" == "unit-shard" ]]
       ;;
     wasm)
       [[ "$suite" == "wasm" ]]
@@ -426,18 +426,88 @@ nextest_allow_no_tests() {
   return "$rc"
 }
 
+_UNIT_TEST_PACKAGES=(
+  -p tsz-common
+  -p tsz-scanner
+  -p tsz-parser
+  -p tsz-binder
+  -p tsz-solver
+  -p tsz-checker
+  -p tsz-emitter
+  -p tsz-lsp
+  -p tsz-core
+)
+
 run_unit_tests() {
   ci_section "Workspace nextest suites"
   cargo nextest run --profile ci --cargo-profile ci-unit --no-tests=pass \
-    -p tsz-common \
-    -p tsz-scanner \
-    -p tsz-parser \
-    -p tsz-binder \
-    -p tsz-solver \
-    -p tsz-checker \
-    -p tsz-emitter \
-    -p tsz-lsp \
-    -p tsz-core
+    "${_UNIT_TEST_PACKAGES[@]}"
+}
+
+build_unit_test_archive() {
+  ci_section "Build unit test archive"
+  local bucket run_key archive_uri tmp_archive
+  bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
+  run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
+
+  if [[ -z "$bucket" ]]; then
+    echo "No GCS bucket configured, skipping unit test archive"
+    return 0
+  fi
+
+  archive_uri="${bucket}/unit-archive/${run_key}.tar.zst"
+
+  if gsutil -q stat "$archive_uri" 2>/dev/null; then
+    echo "Unit test archive already exists for ${run_key}: ${archive_uri}"
+    return 0
+  fi
+
+  tmp_archive="$(mktemp -d)/unit-tests.tar.zst"
+  echo "Building unit test archive → ${tmp_archive}"
+  cargo nextest archive \
+    --cargo-profile ci-unit \
+    --archive-file "$tmp_archive" \
+    --no-tests=pass \
+    "${_UNIT_TEST_PACKAGES[@]}"
+
+  echo "Uploading unit test archive → ${archive_uri}"
+  gsutil -q cp "$tmp_archive" "$archive_uri"
+  rm -f "$tmp_archive"
+  echo "Unit test archive uploaded: ${archive_uri}"
+}
+
+run_unit_shard() {
+  ci_section "Unit shard"
+  local bucket run_key shard_index shard_count archive_uri tmp_archive
+  bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
+  run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
+  shard_index="$(num_or_zero "${_TSZ_CI_UNIT_SHARD_INDEX:-0}")"
+  shard_count="$(num_or_zero "${_TSZ_CI_UNIT_SHARD_COUNT:-4}")"
+
+  echo "Unit shard $((shard_index + 1))/${shard_count}"
+
+  if [[ -z "$bucket" ]]; then
+    echo "No GCS bucket — running all unit tests without sharding"
+    run_unit_tests
+    return
+  fi
+
+  archive_uri="${bucket}/unit-archive/${run_key}.tar.zst"
+  tmp_archive="$(mktemp -d)/unit-tests.tar.zst"
+
+  echo "Downloading unit test archive: ${archive_uri}"
+  if ! gsutil -q cp "$archive_uri" "$tmp_archive"; then
+    echo "warning: unit test archive not found for ${run_key}; falling back to full build" >&2
+    run_unit_tests
+    return
+  fi
+
+  cargo nextest run \
+    --archive-file "$tmp_archive" \
+    --profile ci \
+    --no-tests=pass \
+    --partition "count:$((shard_index + 1))/${shard_count}"
+  rm -f "$tmp_archive"
 }
 
 build_test_binaries() {
@@ -1122,6 +1192,7 @@ aggregate_fourslash() {
 run_build() {
   ci_section "Build dist-fast binaries (upload for parallel jobs)"
   timed build_test_binaries build_test_binaries
+  timed build_unit_test_archive build_unit_test_archive
   if command -v sccache >/dev/null 2>&1 && [[ -n "${RUSTC_WRAPPER:-}" ]]; then
     sccache --show-stats 2>/dev/null || true
   fi
@@ -1171,6 +1242,9 @@ main() {
     unit)
       timed run_unit_tests run_unit_tests
       ;;
+    unit-shard)
+      timed run_unit_shard run_unit_shard
+      ;;
     wasm)
       timed build_wasm build_wasm
       ;;
@@ -1211,7 +1285,7 @@ main() {
       ;;
     *)
       echo "error: unknown CI suite '${suite}'" >&2
-      echo "valid suites: all, build, lint, unit, wasm, conformance, conformance-aggregate, emit, emit-shard, emit-aggregate, fourslash, fourslash-shard, fourslash-aggregate" >&2
+      echo "valid suites: all, build, lint, unit, unit-shard, wasm, conformance, conformance-aggregate, emit, emit-shard, emit-aggregate, fourslash, fourslash-shard, fourslash-aggregate" >&2
       return 2
       ;;
   esac

--- a/scripts/ci/github-suite.sh
+++ b/scripts/ci/github-suite.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-suite="${1:?usage: $0 <build|lint|unit|wasm|conformance|conformance-aggregate|emit|emit-shard|emit-aggregate|fourslash|fourslash-shard|fourslash-aggregate>}"
+suite="${1:?usage: $0 <build|lint|unit|unit-shard|wasm|conformance|conformance-aggregate|emit|emit-shard|emit-aggregate|fourslash|fourslash-shard|fourslash-aggregate>}"
 export _TSZ_CI_SUITE="$suite"
 export TSZ_CI_SUITE="$suite"
 export _TSZ_CI_CACHE_BUCKET="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache}}"


### PR DESCRIPTION
## Summary

- **Bug fix**: `test_module_exports_object_literal_member_conflicts_with_module_augmentation` was silently broken since PR #1363. Module augmentation `const a: number` was overwriting the JS-export `string` type for `a`, suppressing the expected TS2322 on `const n: number = a`.
- **Unit sharding**: `unit` GHA job split into 4 parallel `unit-shard` jobs (20 min each) using nextest archive-based sharding — compilation happens once in `build`, shards only run tests.

## Root cause

PR #1363 added alias-style filtering to `has_prior_value_declaration_for_symbol` to correctly handle TS2502 circular references (`import * as foo` + `declare global { const foo: typeof foo; }`). But the same function is also used to gate **symbol-type caching**: when `is_redeclaration = false`, the cache is overwritten. With the filter applied, `import { a }` (IMPORT_SPECIFIER) no longer counted as a prior value declaration, so the augmentation's `const a: number` overwrote `a`'s cached type from `string` to `number`.

## Fix

Split `has_prior_value_declaration_for_symbol` into two variants:
- `has_prior_value_declaration_for_symbol` — alias-inclusive (for symbol-type caching)
- `has_prior_value_declaration_for_ts2502` — alias-exclusive (for circular self-reference checks)

The TS2502 check now uses the alias-exclusive variant; caching still uses alias-inclusive. Both the fixed test and the `crashDeclareGlobalTypeofExport` conformance test pass.

## Unit sharding

The `build` job now calls `build_unit_test_archive` which runs `cargo nextest archive --cargo-profile ci-unit` and uploads to GCS keyed by SHA. Each `unit-shard` downloads the archive and runs `--partition count:N/4` — zero recompilation per shard.

- Old: 1 × 60-min job (OOM risk, serial)
- New: 4 × 20-min jobs (parallel, archive-based, no recompile)
- Fallback: if archive unavailable, shard runs full `run_unit_tests`

Closes #1394 (supersedes the `#[ignore]` workaround).

## Test plan
- [x] `test_module_exports_object_literal_member_conflicts_with_module_augmentation` passes locally
- [x] `crashDeclareGlobalTypeofExport` conformance test passes (1/1)
- [x] Full checker lib suite: 13750 tests pass
- [ ] CI: unit-shard-0..3 all green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
