### PR TITLE
chore(checker): remove crate-wide allow(clippy::question_mark) + 8 spot-fixes

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1411,9 +1411,7 @@ impl<'a> CheckerState<'a> {
         let (Some(base_def), app_args) = query::application_base_def_and_args(db, type_id)? else {
             return None;
         };
-        let Some(def_info) = self.ctx.definition_store.get(base_def) else {
-            return None;
-        };
+        let def_info = self.ctx.definition_store.get(base_def)?;
         if def_info.kind != tsz_solver::def::DefKind::TypeAlias {
             return None;
         }

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -669,12 +669,8 @@ impl<'a> CheckerState<'a> {
         let mut visited: FxHashSet<NodeIndex> = FxHashSet::default();
 
         while visited.insert(current) {
-            let Some(class_node) = self.ctx.arena.get(current) else {
-                return None;
-            };
-            let Some(class_data) = self.ctx.arena.get_class(class_node) else {
-                return None;
-            };
+            let class_node = self.ctx.arena.get(current)?;
+            let class_data = self.ctx.arena.get_class(class_node)?;
 
             let mut getter_seen = false;
             let mut setter_seen = false;

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_targets.rs
@@ -203,23 +203,15 @@ impl<'a> CheckerState<'a> {
 
         for &member in &members {
             let (object_type, index_type) =
-                match crate::query_boundaries::common::index_access_types(self.ctx.types, member) {
-                    Some(parts) => parts,
-                    None => return None,
-                };
+                crate::query_boundaries::common::index_access_types(self.ctx.types, member)?;
             match shared_index {
                 Some(existing) if existing != index_type => return None,
                 Some(_) => {}
                 None => shared_index = Some(index_type),
             }
 
-            let prop_atom = match crate::query_boundaries::common::string_literal_value(
-                self.ctx.types,
-                index_type,
-            ) {
-                Some(atom) => atom,
-                None => return None,
-            };
+            let prop_atom =
+                crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)?;
             has_optional_property |= crate::query_boundaries::common::find_property_in_object(
                 self.ctx.types,
                 object_type,

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -462,16 +462,11 @@ impl<'a> FlowAnalyzer<'a> {
                         // setter parameter type while later reads must still use the
                         // getter surface. If the RHS isn't assignable to the read type of
                         // a property/element access, don't narrow future reads to the RHS.
-                        if self
-                            .assigned_type_respecting_access_read_surface(
-                                assignment_node,
-                                target,
-                                rhs_type,
-                            )
-                            .is_none()
-                        {
-                            return None;
-                        }
+                        self.assigned_type_respecting_access_read_surface(
+                            assignment_node,
+                            target,
+                            rhs_type,
+                        )?;
 
                         let declared_target_type = self
                             .binder

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -20,7 +20,6 @@
 #![allow(clippy::let_and_return)]
 #![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::needless_return)]
-#![allow(clippy::question_mark)]
 #![allow(clippy::redundant_clone)]
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::unnecessary_map_or)]

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1247,16 +1247,12 @@ impl<'a> CheckerState<'a> {
         let nested_target = self.evaluate_type_with_env(nested_target);
         let nested_target = self.resolve_type_for_property_access(nested_target);
         let resolved_target = self.prune_impossible_object_union_members_with_env(nested_target);
-        let Some(members) = query::union_members(self.ctx.types, resolved_target) else {
-            return None;
-        };
+        let members = query::union_members(self.ctx.types, resolved_target)?;
 
         let mut target_shapes = Vec::new();
         for &member in &members {
             let resolved_member = self.resolve_type_for_property_access(member);
-            let Some(shape) = query::object_shape(self.ctx.types, resolved_member) else {
-                return None;
-            };
+            let shape = query::object_shape(self.ctx.types, resolved_member)?;
             target_shapes.push(shape);
         }
         if target_shapes.is_empty() {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1626,9 +1626,7 @@ impl<'a> CheckerState<'a> {
         };
 
         let package_json_exports = all_arenas.iter().find_map(|arena| {
-            let Some(source_file) = arena.source_files.first() else {
-                return None;
-            };
+            let source_file = arena.source_files.first()?;
             let package_json = source_file.file_name.replace('\\', "/");
             if package_json == format!("{package_dir}/package.json") {
                 Some(Self::package_json_redirects_package_subpaths_to_js(

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -362,7 +362,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let Some(file_idx) = owner_file_hint
+        let file_idx = owner_file_hint
             .filter(|idx| *idx != u32::MAX)
             .or_else(|| {
                 self.ctx
@@ -384,10 +384,7 @@ impl<'a> CheckerState<'a> {
                     })
                 })
             })
-            .or_else(|| self.find_external_private_symbol_owner_file(&referenced_name))
-        else {
-            return None;
-        };
+            .or_else(|| self.find_external_private_symbol_owner_file(&referenced_name))?;
         if file_idx == self.ctx.current_file_idx as u32 {
             return None;
         }

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -415,10 +415,7 @@ impl<'a> CheckerState<'a> {
             return Some(type_id);
         }
 
-        let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, type_id)
-        else {
-            return None;
-        };
+        let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)?;
 
         let callable_members: Vec<_> = members
             .into_iter()


### PR DESCRIPTION
Partial **PR #Q (item 17)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`. Continues #1382-#1397.

Spot-fixes converted match/let-else patterns to `?` where the right-hand side returned None on miss:

1. `error_reporter/core/diagnostic_source/object_literal_targets.rs:206,216`
2. `checkers/generic_checker/constraint_validation.rs:1414`
3. `checkers/property_checker.rs:672,675`
4. `flow/control_flow/assignment.rs:465`
5. `state/state_checking/property.rs:1250,1257`
6. `state/state_checking_members/index_signature_checks.rs:1629`
7. `state/variable_checking/variable_helpers/declaration_emit.rs:365`
8. `types/computation/object_literal_context.rs:418`

## Test plan
- [x] `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean
- [x] 2886/2886 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
