### PR TITLE
fix(checker): TS2322 parameter anchor + JSDoc-typed method shorthand body returns

### DIFF
--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -859,6 +859,21 @@ impl<'a> CheckerState<'a> {
         let mut saw_assignment_binary = false;
         let mut var_decl: Option<NodeIndex> = None;
 
+        // If the starting node is itself a Parameter, that IS the assignment
+        // site (parameter name = default-value initializer). Walking up would
+        // land at the enclosing function expression — which starts at `(` —
+        // and anchor TS2322 on the open paren instead of the parameter name.
+        // Return the parameter so `normalized_anchor_span` can pick up the
+        // `param.name` span and tsc's column reporting matches.
+        if self
+            .ctx
+            .arena
+            .get(current)
+            .is_some_and(|n| n.kind == syntax_kind_ext::PARAMETER)
+        {
+            return current;
+        }
+
         // If the starting node is itself a VariableDeclaration, capture it
         // immediately. This handles the common case where the diagnostic
         // index is the variable declaration node.

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1631,7 +1631,10 @@ fn checker_files_stay_under_loc_limit() {
         // ceiling tracks current state.
         // Bumped by 2 (2039→2041) for the class @template push that fixes
         // jsdocTemplateClass.ts TS2304 false positive.
-        ("types/function_type.rs", 2041),
+        // Bumped by 12 (2041→2053) for the sync-contextual-return branch that
+        // fixes TS2322 on block-body methods carrying `/** @type {function(...)} */`
+        // (checkJsdocTypeTagOnObjectProperty2.ts).
+        ("types/function_type.rs", 2053),
     ];
 
     let mut violations = Vec::new();

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1874,14 +1874,30 @@ impl<'a> CheckerState<'a> {
                 TypeId::ANY
             } else if has_type_annotation || has_contextual_return || jsdoc_return_context.is_some()
             {
+                // When a sync function carries its own JSDoc `@type {function(...): T}`
+                // (e.g. a method shorthand whose owning property declares the method's
+                // type), check block-body returns against the contextual return type.
+                // Mirrors the async branch above. Function expressions whose contextual
+                // type comes from outside (callback parameters) are excluded so we
+                // don't double-report at the inner return AND the call site.
+                let has_direct_callable_jsdoc = !is_async_for_context
+                    && !is_generator
+                    && has_contextual_return
+                    && !has_type_annotation
+                    && jsdoc_return_context.is_none()
+                    && self
+                        .jsdoc_callable_type_annotation_for_node_direct(idx)
+                        .is_some();
+                let sync_ctx = has_direct_callable_jsdoc
+                    .then_some(return_context_for_circularity)
+                    .flatten()
+                    .filter(|&t| t != TypeId::ANY && t != TypeId::UNKNOWN);
                 // Use the pre-evaluation annotated return type when available.
                 // evaluate_application_type() (line 1305) expands Application
                 // types (e.g., Promise<U>) into structural object forms, which
                 // destroys the Application wrapper needed for correct type
-                // display in TS2322 messages. The annotated type preserves
-                // the original Application so the formatter can show
-                // "Promise<U>" instead of just "Promise".
-                annotated_return_type.unwrap_or(return_type)
+                // display in TS2322 messages.
+                sync_ctx.unwrap_or_else(|| annotated_return_type.unwrap_or(return_type))
             } else {
                 // When the return type was purely inferred from the body (no
                 // annotation, no contextual type, no JSDoc @returns), push ANY

--- a/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
+++ b/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
@@ -806,3 +806,89 @@ fn extract_param_names_byte_offsets() {
     assert!(jsdoc[names[0].1..].starts_with("@param"));
     assert!(jsdoc[names[1].1..].starts_with("@param"));
 }
+
+// =========================================================================
+// JSDoc @type {function(...)} on object property — checkJsdocTypeTagOnObjectProperty2
+// =========================================================================
+
+/// Method shorthand inside an object literal whose property carries
+/// `/** @type {function(number): number} */` should have its block-body
+/// returns checked against the contextual return type. tsc reports TS2322
+/// at `return "42";` because the JSDoc-declared return is `number`.
+///
+/// Before the fix, `body_return_type` for a sync contextually-typed function
+/// fell back to the inferred body type (`string`), which made the return
+/// statement check trivially succeed.
+#[test]
+fn jsdoc_type_function_on_method_shorthand_checks_block_body_return_type() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        r#"// @ts-check
+const obj = {
+  /** @type {function(number): number} */
+  method1(n1) {
+      return "42";
+  },
+};
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected exactly one TS2322 (string -> number) on the method body return; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    let msg = &ts2322[0].message_text;
+    assert!(
+        msg.contains("string") && msg.contains("number"),
+        "Expected TS2322 message to mention string and number, got: {msg}"
+    );
+}
+
+/// Arrow function with a parameter default whose value type does not match
+/// the JSDoc-declared callable parameter type should anchor TS2322 at the
+/// parameter name, not at the enclosing arrow function's `(` token.
+///
+/// Before the fix, `assignment_anchor_node` walked up from the Parameter to
+/// the ArrowFunction and returned the function's start position (`(`), which
+/// shifted the diagnostic column one to the left of tsc's anchor.
+#[test]
+fn jsdoc_type_function_param_default_anchors_at_parameter_name() {
+    let diags = crate::test_utils::check_js_source_diagnostics(
+        r#"// @ts-check
+/** @type {function(number): number} */
+const f = (num="0") => num + 42;
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected exactly one TS2322 for the param default mismatch; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+
+    // The diagnostic must anchor at `num`, not at the preceding `(`.
+    // `f = (num` — the parameter name `num` follows `f = (`. The diagnostic
+    // start should match the byte offset of `n` in `num`, and its length
+    // should be 3 (the identifier).
+    let source = "// @ts-check\n/** @type {function(number): number} */\nconst f = (num=\"0\") => num + 42;\n";
+    let num_pos = source.find("(num=").expect("paren-num present") + 1; // skip '('
+    let diag = ts2322[0];
+    assert_eq!(
+        diag.start as usize, num_pos,
+        "TS2322 must anchor at the parameter name `num` (offset {num_pos}); got diagnostic at offset {}",
+        diag.start
+    );
+    assert_eq!(
+        diag.length, 3,
+        "TS2322 length must equal len(`num`) = 3; got {}",
+        diag.length
+    );
+}

--- a/crates/tsz-cli/tests/args_tests.rs
+++ b/crates/tsz-cli/tests/args_tests.rs
@@ -883,8 +883,6 @@ fn parses_use_define_for_class_fields() {
 
 #[test]
 fn target_to_script_target_covers_every_variant() {
-    use crate::config::ModuleResolutionKind as _; // ensure alias path compiles
-
     let cases = [
         (Target::Es5, ScriptTarget::ES5),
         (Target::Es2015, ScriptTarget::ES2015),

--- a/scripts/session/random-pick.sh
+++ b/scripts/session/random-pick.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# random-pick.sh — Quick random conformance failure picker
+# =============================================================================
+#
+# A minimal, dependency-free random failure picker. Reads the offline snapshot
+# at scripts/conformance/conformance-detail.json and prints one random failure.
+#
+# Usage:
+#   scripts/session/random-pick.sh           # any random failure
+#   scripts/session/random-pick.sh TS2322    # filter by error code
+#
+# Prints: path, category, expected/actual/missing/extra codes, pool size, and
+# the verbose run command. Pure shell + python3 stdlib.
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DETAIL="$REPO_ROOT/scripts/conformance/conformance-detail.json"
+
+if [[ ! -f "$DETAIL" ]]; then
+    echo "error: $DETAIL missing" >&2
+    echo "  run: scripts/safe-run.sh ./scripts/conformance/conformance.sh snapshot" >&2
+    exit 1
+fi
+
+if [[ ! -d "$REPO_ROOT/TypeScript/tests" ]]; then
+    echo "TypeScript submodule not initialized — initializing..." >&2
+    git -C "$REPO_ROOT" submodule update --init --depth 1 TypeScript
+fi
+
+CODE_FILTER="${1:-}"
+
+python3 - "$DETAIL" "$CODE_FILTER" <<'PY'
+import json, random, sys
+from pathlib import Path
+
+detail_path = sys.argv[1]
+code_filter = sys.argv[2] or None
+
+with open(detail_path, encoding="utf-8") as f:
+    failures = json.load(f).get("failures", {})
+
+def codes(entry):
+    return set(entry.get("e", [])) | set(entry.get("a", [])) | \
+           set(entry.get("m", [])) | set(entry.get("x", []))
+
+def category(entry):
+    e, a, m, x = entry.get("e", []), entry.get("a", []), entry.get("m", []), entry.get("x", [])
+    if not e and a: return "false-positive"
+    if e and not a: return "all-missing"
+    if set(e) == set(a): return "fingerprint-only"
+    if m and not x: return "only-missing"
+    if x and not m: return "only-extra"
+    return "wrong-code"
+
+candidates = [(p, e) for p, e in failures.items()
+              if e and (not code_filter or code_filter in codes(e))]
+if not candidates:
+    sys.exit(f"no matching failures (code={code_filter})")
+
+path, entry = random.choice(candidates)
+filter_name = Path(path).stem
+
+print(f"path:     {path}")
+print(f"category: {category(entry)}")
+print(f"expected: {','.join(entry.get('e', [])) or '-'}")
+print(f"actual:   {','.join(entry.get('a', [])) or '-'}")
+print(f"missing:  {','.join(entry.get('m', [])) or '-'}")
+print(f"extra:    {','.join(entry.get('x', [])) or '-'}")
+print(f"pool:     {len(candidates)}")
+print()
+print(f'verbose run: ./scripts/conformance/conformance.sh run --filter "{filter_name}" --verbose')
+PY


### PR DESCRIPTION
## Summary

Random pick from `scripts/session/random-pick.sh` landed on
`conformance/jsdoc/checkJsdocTypeTagOnObjectProperty2.ts` (a
fingerprint-only failure: error codes matched, but message positions and
counts diverged from `tsc`). Two underlying checker bugs surfaced; both
are fixed at the root cause. Net conformance impact:

- **41 `FAIL → PASS` improvements**
- **1 `PASS → FAIL`** — `compiler/valueOfTypedArray.ts`, **independently
  verified to fail on `main` with these changes stashed**, so this is
  baseline drift, not a regression introduced by this PR.
- **Net: 12144 → 12182 (+38 tests)**

```ts
// 0.js (allowJs, checkJs, strictNullChecks)
const obj = {
  /** @type {function(number): number} */
  method1(n1) {
      return "42";  // TS2322: 'string' is not assignable to 'number'  ← previously missed
  },
  /** @type {function(number): number} */
  arrowFunc: (num="0") => num + 42,  // TS2322 anchored at `num`, not at `(`  ← off-by-one fixed
};
```

## Root causes

### 1) `assignment_anchor_node` walked past `Parameter` to the enclosing function

`check_parameter_initializers` calls
`check_assignable_or_report(init_type, declared_type, param_idx)`.
Inside the assignability gate, `error_type_not_assignable_with_reason_at`
runs `RewriteAssignment` anchor resolution, which walks up from
`Parameter` to `ARROW_FUNCTION` / `FUNCTION_EXPRESSION` and returns the
function expression as the anchor. Function expressions start at `(`,
which is where `tsz` was anchoring TS2322 — one column to the left of
`tsc`, which anchors at the parameter name.

Fix: short-circuit `assignment_anchor_node` when the starting node is
itself a `Parameter`. `normalized_anchor_span` already maps a
`Parameter` anchor to `param.name`, so the diagnostic now lands on the
parameter identifier exactly where `tsc` puts it.

### 2) Sync method-shorthand block returns weren't checked against the contextual return type

`get_type_of_function_impl`'s `body_return_type` selection had a
dedicated branch for *async* contextually-typed functions that pushes
`return_context_for_circularity` so block-body returns are checked
against the declared return. The sync path (e.g., a method shorthand
under `/** @type {function(number): number} */`) fell through to the
*inferred* body type, which trivially matched and silently dropped the
diagnostic.

Fix: mirror the async branch for sync. Push the contextual return type
when the function carries its own JSDoc `@type {function(...)}`
(`jsdoc_callable_type_annotation_for_node_direct(idx).is_some()`),
is sync, has no explicit annotation, no `@returns` JSDoc, and a usable
contextual return type.

The JSDoc-direct guard is what avoids regressing callbacks. For
`function(){return "foo"}` inside `arr.map(...)`, the contextual type
comes from the caller's parameter, not from JSDoc on the closure — that
mismatch is already reported once at the call site, and we must not
double-report at the inner return. Verified by re-running
`compiler/contextualTyping33.ts` (and the broader contextual-typing
regression set) end-to-end.

## Architecture compliance

- Both fixes stay inside the existing checker boundaries.
- No new checker-local relation logic; no construction of solver
  internals from the checker.
- TS2322 still flows through `query_boundaries/assignability` →
  `diagnose_assignment_failure_with_anchor` → `push_diagnostic`.
- The JSDoc-direct check re-uses
  `jsdoc_callable_type_annotation_for_node_direct`, the same boundary
  helper that `object_literal::computation` already uses to wire the
  method's contextual type — no new entrypoint.
- The grandfathered LOC ceiling for `types/function_type.rs` is bumped
  2041 → 2053 (rationale recorded inline alongside the previous bumps).

## Tests

Two unit tests in `tsz-checker`'s `jsdoc::params::tests` module via
`check_js_source_diagnostics`:

- `jsdoc_type_function_on_method_shorthand_checks_block_body_return_type`
- `jsdoc_type_function_param_default_anchors_at_parameter_name`

Both fail before the patch, pass after, and assert the exact diagnostic
offset/length so future re-anchoring regressions trip immediately.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  ✓ (after the drive-by clippy fixes in commit 2)
- `cargo nextest run --package tsz-checker --lib` — 2880/2880 passed
- `cargo nextest run --package tsz-solver --lib` — 5509/5509 passed
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` —
  12182/12582 passed; **net +38**, no real PASS→FAIL regressions.

## Commits

1. `chore(scripts): add random conformance failure picker` — adds
   `scripts/session/random-pick.sh`, the minimal random picker used to
   surface this target.
2. `chore: fix preexisting clippy warnings` — two unrelated
   `clippy::doc_markdown` / `unused-imports` errors that the workspace
   `-D warnings` clippy gate now flags after a recent toolchain bump.
   Required for `verify-all.sh` to pass on this branch.
3. `fix(checker): TS2322 parameter anchor + JSDoc-typed method
   shorthand body returns` — the actual fix, unit tests, and LOC
   ceiling bump.

## Test plan

- [x] Target test `checkJsdocTypeTagOnObjectProperty2.ts` passes
- [x] Reduced repro for the parameter-anchor bug now matches `tsc`
- [x] Reduced repro for the missing method-shorthand TS2322 now matches
      `tsc`
- [x] No real regressions in the full conformance suite
- [x] No regressions in JSDoc-related tests in particular
      (`./scripts/conformance/conformance.sh run --filter "jsdoc"`)
- [x] Architecture guardrails pre-commit hook passes (boundary
      guardrail, wasm32 lint, clippy, fmt)

https://claude.ai/code/session_01UnT2PH7brpR67N2NUVwAMR


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnT2PH7brpR67N2NUVwAMR)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
