### PR TITLE
fix(solver): swap Function property resolution to boxed-interface-first

### DIFF
--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -1270,8 +1270,26 @@ impl<'a> PropertyAccessEvaluator<'a> {
         prop_name: &str,
         prop_atom: Atom,
     ) -> PropertyAccessResult {
-        // Try hardcoded well-known Function members first (fast path, avoids
-        // pulling in the full Function interface for every property access).
+        // STEP 1: Consult the boxed `Function` interface from lib.d.ts FIRST so
+        // user augmentations (e.g., `interface Function { now(): string; }`)
+        // and target-specific lib differences win over the hardcoded list
+        // below. Mirrors the primitive resolver at `resolve_intrinsic_property`
+        // — boxed first, hardcoded only as a no-lib bootstrap.
+        //
+        // Robustness audit (PR #O, item 15 in
+        // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`).
+        if let Some(boxed_type) =
+            crate::def::resolver::TypeResolver::get_boxed_type(self.db, IntrinsicKind::Function)
+        {
+            let result = self.resolve_property_access_inner(boxed_type, prop_name, Some(prop_atom));
+            if !result.is_not_found() {
+                return result;
+            }
+        }
+
+        // STEP 2: Hardcoded well-known Function members (no-lib / bootstrap path).
+        // Reached when the boxed `Function` interface is unavailable (no lib loaded)
+        // or didn't resolve the property.
         match prop_name {
             "apply" | "call" | "bind" => return self.method_result(TypeId::ANY),
             "toString" => return self.method_result(TypeId::STRING),
@@ -1284,18 +1302,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
         if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
             return result;
-        }
-
-        // Consult the boxed Function interface from lib.d.ts for augmented members.
-        // This handles user augmentations (e.g., `interface Function { now(): string; }`)
-        // and any Function members not in the hardcoded list above.
-        if let Some(boxed_type) =
-            crate::def::resolver::TypeResolver::get_boxed_type(self.db, IntrinsicKind::Function)
-        {
-            let result = self.resolve_property_access_inner(boxed_type, prop_name, Some(prop_atom));
-            if !result.is_not_found() {
-                return result;
-            }
         }
 
         PropertyAccessResult::PropertyNotFound {


### PR DESCRIPTION
Implements **PR #O (item 15)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`resolve_function_property` previously tried hardcoded well-known Function members (`apply`, `call`, `bind`, `toString`, `name`, `length`, `prototype`, `arguments`, `caller`) FIRST, then fell back to the boxed `Function` interface from lib.d.ts. This shadowed user augmentations (`interface Function { now(): string; }`) and target-specific lib differences — the boxed interface only ran for properties NOT in the hardcoded list.

This change reverses the order to match the primitive helper at `resolve_intrinsic_property` (lines 958-977): boxed-interface first, hardcoded only as a no-lib bootstrap fallback. User-augmented `Function` members now win, and lib-specific differences are not silently masked.

## Test plan
- [x] 5514/5514 `tsz-solver` lib tests pass
- [x] 2888/2888 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
