### PR TITLE
fix(emit): preserve source layout for missing-name property access

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -64,5 +64,9 @@ path = "tests/object_literal_recovery_tests.rs"
 name = "prefix_unary_recovery_tests"
 path = "tests/prefix_unary_recovery_tests.rs"
 
+[[test]]
+name = "property_access_recovery_tests"
+path = "tests/property_access_recovery_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/src/emitter/expressions/access.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/access.rs
@@ -218,11 +218,33 @@ impl<'a> Printer<'a> {
             self.map_token_after(expr_node.end, node.end, b'.');
         }
         self.write_dot_token(access.expression);
-        // When the property name is missing (error recovery, e.g. `bar.\n}`),
-        // tsc emits the dot followed by a newline so the expression statement's
-        // semicolon ends up on its own line: `bar.\n    ;`
+        // When the property name is missing (error recovery), the source layout
+        // determines whether tsc breaks to a new line:
+        // - `bar.\n}` -> emit `bar.\n    ;` (newline preserved when source had a
+        //   line break between the dot and the next significant token)
+        // - `window. ` (EOF, no newline) -> emit `window.;` on a single line
+        // We detect a newline by inspecting the source text between the
+        // expression end (just before the dot) and the property access end
+        // (where the missing name would have been emitted).
         if access.name_or_argument.is_none() {
-            self.write_line();
+            let mut emit_newline = false;
+            if let Some(text) = self.source_text
+                && let Some(expr_node) = self.arena.get(access.expression)
+            {
+                // Iterate over raw bytes — the only character we look for is
+                // ASCII `\n` (0x0A), which never appears inside a multibyte
+                // UTF-8 sequence, so byte iteration is safe regardless of
+                // node-end / character boundary alignment.
+                let bytes = text.as_bytes();
+                let start = std::cmp::min(expr_node.end as usize, bytes.len());
+                let end = std::cmp::min(node.end as usize, bytes.len());
+                if start <= end && bytes[start..end].contains(&b'\n') {
+                    emit_newline = true;
+                }
+            }
+            if emit_newline {
+                self.write_line();
+            }
             return;
         }
         self.emit_property_name_without_import_substitution(access.name_or_argument);

--- a/crates/tsz-emitter/tests/property_access_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/property_access_recovery_tests.rs
@@ -1,0 +1,103 @@
+//! Integration tests for property-access emit error recovery.
+//!
+//! When the parser encounters a `.` not followed by an identifier (e.g. EOF,
+//! a newline + brace, or a newline + reserved word), it synthesizes a missing
+//! identifier and emits TS1003 "Identifier expected." The emitter must mirror
+//! tsc's whitespace handling around the missing name:
+//!
+//! - When the source has a newline between the dot and the next token (e.g.
+//!   `bar.\n}`), tsc breaks the dot onto its own line and pushes the
+//!   following statement (`;`) to the next indented line:
+//!   ```js
+//!   bar.
+//!   ;
+//!   ```
+//! - When the source has no newline (e.g. `var p2 = window. ` at EOF), tsc
+//!   keeps the trailing `;` on the same line as the dot:
+//!   ```js
+//!   var p2 = window.;
+//!   ```
+//!
+//! This guards both layouts so future emit changes can't regress one shape
+//! while fixing the other.
+//!
+//! See:
+//! - `crates/tsz-emitter/src/emitter/expressions/access.rs`
+//!   (`emit_property_access`, missing-name newline branch)
+
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn print_es2015(source: &str) -> String {
+    parse_and_print_with_opts(source, PrintOptions::es6())
+}
+
+/// Source `var p2 = window. ` (TypeScript test
+/// `incompleteDottedExpressionAtEOF`) — the source has only trailing
+/// whitespace (no newline) after the dot. tsc emits everything on one line:
+/// `var p2 = window.;`. We must NOT inject an extra newline before the `;`.
+#[test]
+fn dotted_expression_at_eof_keeps_trailing_semicolon_on_same_line() {
+    let source = "var p2 = window. ";
+    let output = print_es2015(source);
+    // The dot must be followed by `;` on the same line — no `\n` between
+    // `.` and `;`.
+    assert!(
+        output.contains("window.;"),
+        "expected `window.;` on a single line; output:\n{output}"
+    );
+    assert!(
+        !output.contains("window.\n"),
+        "no newline should follow the dot when the source had none; output:\n{output}"
+    );
+}
+
+/// Source `bar.\n}` (TypeScript test `parse1.ts`) — there IS a newline
+/// between the dot and the close-brace. tsc preserves that line break:
+/// `bar.\n    ;`. The dot stays on its own line and the synthetic `;`
+/// drops to the next indented line.
+#[test]
+fn dotted_expression_followed_by_newline_breaks_to_new_line() {
+    let source = "var bar = 42;\nfunction foo() {\n bar.\n}\n";
+    let output = print_es2015(source);
+    // The dot must be followed by a newline, then the `;` on its own line.
+    // We assert the substring so future indentation-tweak commits stay
+    // resilient — what matters is that `bar.\n` precedes `;`, not the exact
+    // amount of leading whitespace before the `;`.
+    assert!(
+        output.contains("bar.\n"),
+        "expected `bar.` followed by newline; output:\n{output}"
+    );
+    // The `;` should be on a separate line from `bar.`.
+    let dot_line_end = output.find("bar.\n").expect("bar. with newline");
+    let after_dot = &output[dot_line_end + "bar.\n".len()..];
+    assert!(
+        after_dot.trim_start().starts_with(';'),
+        "expected `;` to follow on the next line; output:\n{output}"
+    );
+}
+
+/// Source `class C { test() { this.\n} } var x = new C();`
+/// (TypeScript test `classAbstractCrashedOnce`) — the dot is the last
+/// non-whitespace token in a method body, with a newline before the
+/// closing braces. tsc emits the dot then breaks to a new line for the
+/// synthetic `;`.
+#[test]
+fn dotted_expression_in_method_body_breaks_to_new_line() {
+    let source = "class C {\n    test() {\n        this.\n    }\n}\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("this.\n"),
+        "expected `this.` followed by newline; output:\n{output}"
+    );
+    let dot_line_end = output.find("this.\n").expect("this. with newline");
+    let after_dot = &output[dot_line_end + "this.\n".len()..];
+    assert!(
+        after_dot.trim_start().starts_with(';'),
+        "expected `;` to follow on the next line; output:\n{output}"
+    );
+}

--- a/docs/plan/claims/fix-emit-incomplete-dotted-eof-newline.md
+++ b/docs/plan/claims/fix-emit-incomplete-dotted-eof-newline.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/emit-incomplete-dotted-eof-newline`
-- **PR**: TBD (drafting)
+- **PR**: #1403
 - **Status**: ready
 - **Workstream**: 2 (Emit pass-rate)
 

--- a/docs/plan/claims/fix-emit-incomplete-dotted-eof-newline.md
+++ b/docs/plan/claims/fix-emit-incomplete-dotted-eof-newline.md
@@ -1,0 +1,36 @@
+# fix(emit): only insert newline after recovery dot when source had one
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/emit-incomplete-dotted-eof-newline`
+- **PR**: TBD (drafting)
+- **Status**: ready
+- **Workstream**: 2 (Emit pass-rate)
+
+## Intent
+
+Fix `incompleteDottedExpressionAtEOF.ts` JS emit. When the parser recovers
+from a missing identifier after `.` (e.g. `var p2 = window. ` at EOF), the
+emitter previously always wrote a newline after the dot, producing
+`window.\n;`. tsc only breaks the line when the original source had a
+newline between the dot and the next significant token. With no newline in
+the source (EOF case), tsc emits `window.;` on a single line; with a
+newline (e.g. `bar.\n}`), tsc preserves the break and emits `bar.\n    ;`.
+
+The fix inspects raw source bytes between the receiver-expression's end
+and the property-access node's end. If a `\n` is present, we keep the
+existing line break; otherwise we leave the synthetic trailing token on
+the same line, matching tsc.
+
+## Files Touched
+
+- `crates/tsz-emitter/src/emitter/expressions/access.rs` (+18 / -3 LOC)
+- `crates/tsz-emitter/Cargo.toml` (+4 LOC, register the new test target)
+- `crates/tsz-emitter/tests/property_access_recovery_tests.rs` (new, ~104 LOC)
+
+## Verification
+
+- `cargo nextest run -p tsz-emitter --test property_access_recovery_tests` (3/3 pass)
+- `cargo nextest run -p tsz-emitter` (1656/1656 pass, 2 skipped)
+- `./scripts/emit/run.sh --filter=incompleteDottedExpressionAtEOF` (1/1 pass — was failing pre-fix with `+2/-1 lines` diff)
+- `./scripts/emit/run.sh --filter=parse1` (1/1 pass — no regression on the `bar.\n}` case)
+- `./scripts/emit/run.sh --filter=classAbstractCrashedOnce` (1/1 pass — no regression on the `this.\n}` case)


### PR DESCRIPTION
## Summary

When the parser recovers from a missing identifier after `.` (e.g. `var p2 = window. ` at EOF), the emitter previously always wrote a newline after the dot, producing `window.\n;`. tsc only breaks the line when the original source had a newline between the dot and the next significant token.

This PR inspects the raw source bytes between the receiver expression's end and the property-access node's end to decide whether to emit a newline:

- `bar.\n}` -> keep break: `bar.\n    ;` (matches `parse1.ts` baseline)
- `window. ` (EOF, no newline) -> stay on one line: `window.;` (matches `incompleteDottedExpressionAtEOF.ts` baseline)

Byte iteration is safe because we only look for ASCII `\n` (0x0A), which never appears inside a multibyte UTF-8 sequence.

## Why this layer

The fix lives in the **emitter** (`crates/tsz-emitter/src/emitter/expressions/access.rs`). Per `.claude/CLAUDE.md` §3, emit/print decisions belong to the emitter — this is purely an output-layout concern (no type semantics involved). The parser already produces the right AST shape (`name_or_argument: NodeIndex::NONE`); only the emit decision needed adjusting.

## Files Touched

- `crates/tsz-emitter/src/emitter/expressions/access.rs` (+22 / -3 LOC) — read source bytes between expression end and node end; only emit newline if a `\n` is present.
- `crates/tsz-emitter/Cargo.toml` (+4) — register the new integration test.
- `crates/tsz-emitter/tests/property_access_recovery_tests.rs` (new, 103 LOC) — three regression tests covering all three observed shapes.
- `docs/plan/claims/fix-emit-incomplete-dotted-eof-newline.md` — claim file.

## Test plan

- [x] `cargo nextest run -p tsz-emitter --test property_access_recovery_tests` (3/3 pass)
- [x] `cargo nextest run -p tsz-emitter` (1656/1656 pass, 2 skipped) — no regressions in the broader emitter test suite.
- [x] `./scripts/emit/run.sh --filter=incompleteDottedExpressionAtEOF` flips from fail (`+2/-1 lines`) to pass.
- [x] `./scripts/emit/run.sh --filter=parse1` (1/1 pass) — `bar.\n}` shape preserved.
- [x] `./scripts/emit/run.sh --filter=classAbstractCrashedOnce` (1/1 pass) — `this.\n}` shape preserved.