### PR TITLE
perf(binder): Arc-wrap expando_properties for shared per-file binders

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -2460,7 +2460,7 @@ impl BinderState {
             || obj_key == "exports"
             || obj_key.starts_with("exports.")
         {
-            self.expando_properties
+            Arc::make_mut(&mut self.expando_properties)
                 .entry(obj_key)
                 .or_default()
                 .insert(prop_name);
@@ -2489,7 +2489,7 @@ impl BinderState {
             != 0
             && (symbol.flags & symbol_flags::CLASS) == 0
         {
-            self.expando_properties
+            Arc::make_mut(&mut self.expando_properties)
                 .entry(obj_key.clone())
                 .or_default()
                 .insert(prop_name);
@@ -2526,7 +2526,7 @@ impl BinderState {
                     && (init_node.kind == syntax_kind_ext::CLASS_EXPRESSION
                         || init_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION));
             if is_expando_init {
-                self.expando_properties
+                Arc::make_mut(&mut self.expando_properties)
                     .entry(obj_key)
                     .or_default()
                     .insert(prop_name);

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -173,7 +173,7 @@ impl BinderState {
             current_scope: SymbolTable::new(),
             scope_stack: Vec::with_capacity(16),
             file_locals: SymbolTable::new(),
-            expando_properties: FxHashMap::default(),
+            expando_properties: Arc::new(FxHashMap::default()),
             declared_modules: FxHashSet::default(),
             is_external_module: false,
             is_strict_scope: false,
@@ -240,7 +240,7 @@ impl BinderState {
         self.current_scope.clear();
         self.scope_stack.clear();
         self.file_locals.clear();
-        self.expando_properties.clear();
+        Arc::make_mut(&mut self.expando_properties).clear();
         self.declared_modules.clear();
         self.is_external_module = false;
         self.is_strict_scope = false;
@@ -415,7 +415,7 @@ impl BinderState {
             current_scope: SymbolTable::new(),
             scope_stack: Vec::new(),
             file_locals,
-            expando_properties: FxHashMap::default(),
+            expando_properties: Arc::new(FxHashMap::default()),
             declared_modules: FxHashSet::default(),
             is_external_module: false,
             is_strict_scope: false,

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -246,7 +246,13 @@ pub struct BinderState {
     /// Expando property assignments: maps identifier name → set of property names
     /// that were assigned via `X.prop = value` patterns (single-level property access).
     /// Used to suppress false TS2339 errors on read-side property accesses.
-    pub expando_properties: FxHashMap<String, FxHashSet<String>>,
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver share
+    /// via `Arc::clone` (atomic refcount bump) instead of deep-cloning the
+    /// nested `FxHashMap<String, FxHashSet<String>>`. Mutations during binding
+    /// go through `Arc::make_mut` (free when refcount=1, the case during a
+    /// single file's bind); read-only post-bind.
+    pub expando_properties: Arc<FxHashMap<String, FxHashSet<String>>>,
     /// Ambient module declarations by specifier (e.g. "pkg", "./types")
     pub declared_modules: FxHashSet<String>,
     /// Whether the current source file is an external module (has top-level import/export).
@@ -928,7 +934,7 @@ pub struct BinderStateScopeInputs {
     pub flow_nodes: Arc<FlowNodeArena>,
     pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
-    pub expando_properties: FxHashMap<String, FxHashSet<String>>,
+    pub expando_properties: Arc<FxHashMap<String, FxHashSet<String>>>,
     pub alias_partners: FxHashMap<SymbolId, SymbolId>,
 }
 

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1347,10 +1347,7 @@ var array: number[] = [0, 1, ...strs];
         1,
         "expected exactly one TS2322; got {}: {:?}",
         ts2322.len(),
-        ts2322
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
     let message = &ts2322[0].message_text;
     assert!(
@@ -1358,8 +1355,7 @@ var array: number[] = [0, 1, ...strs];
         "expected per-element 'string' vs 'number' elaboration; got {message:?}"
     );
     assert!(
-        !message.contains("(number | string)[]")
-            && !message.contains("(string | number)[]"),
+        !message.contains("(number | string)[]") && !message.contains("(string | number)[]"),
         "expected per-element elaboration, not whole-array message; got {message:?}"
     );
 }
@@ -1394,9 +1390,6 @@ var c: MyNumberArray = [...strs];
         drilled.is_empty(),
         "expected NOT to drill into per-element spread error for custom \
          array-subtype target; got {:?}",
-        drilled
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        drilled.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2808,7 +2808,7 @@ fn build_lib_bound_file_for_interface_checks(
         node_flow: std::sync::Arc::new(FxHashMap::default()),
         switch_clause_to_switch: std::sync::Arc::new(FxHashMap::default()),
         is_external_module: lib_file.binder.is_external_module,
-        expando_properties: FxHashMap::default(),
+        expando_properties: std::sync::Arc::new(FxHashMap::default()),
         file_features: tsz::binder::FileFeatures::NONE,
         lib_symbol_reverse_remap: std::sync::Arc::new(FxHashMap::default()),
         semantic_defs: std::sync::Arc::new(FxHashMap::default()),

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -565,8 +565,11 @@ pub struct BindResult {
     pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     /// Whether this file is an external module (has imports/exports)
     pub is_external_module: bool,
-    /// Expando property assignments detected during binding
-    pub expando_properties: FxHashMap<String, FxHashSet<String>>,
+    /// Expando property assignments detected during binding.
+    ///
+    /// `Arc`-wrapped to mirror `BinderState.expando_properties` so the
+    /// merge can move it into per-file binders without deep-cloning.
+    pub expando_properties: Arc<FxHashMap<String, FxHashSet<String>>>,
     /// Per-file alias partners from binder (`TYPE_ALIAS` → `ALIAS` mapping, pre-remap)
     pub alias_partners: FxHashMap<SymbolId, SymbolId>,
     pub file_features: crate::binder::FileFeatures,
@@ -745,7 +748,7 @@ impl BindResult {
             * (std::mem::size_of::<u32>() + std::mem::size_of::<NodeIndex>() + 8);
 
         // expando_properties
-        for (k, v) in &self.expando_properties {
+        for (k, v) in self.expando_properties.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             for s in v {
                 size += s.capacity() + std::mem::size_of::<u64>();
@@ -1476,8 +1479,13 @@ pub struct BoundFile {
     pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     /// Whether this file is an external module (has imports/exports)
     pub is_external_module: bool,
-    /// Expando property assignments detected during binding
-    pub expando_properties: FxHashMap<String, FxHashSet<String>>,
+    /// Expando property assignments detected during binding.
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver
+    /// (cross-file lookup + primary checker, ~2N for N files) share via
+    /// `Arc::clone` instead of deep-cloning the nested map. Read-only
+    /// after `bind_source_file` completes.
+    pub expando_properties: Arc<FxHashMap<String, FxHashSet<String>>>,
     pub file_features: crate::binder::FileFeatures,
     /// Reverse mapping for merged lib symbols: remapped `SymbolId` ->
     /// (`lib_binder_idx`, original lib-local `SymbolId`).
@@ -1587,7 +1595,7 @@ impl BoundFile {
             * (std::mem::size_of::<u32>() + std::mem::size_of::<NodeIndex>() + 8);
 
         // expando_properties
-        for (k, v) in &self.expando_properties {
+        for (k, v) in self.expando_properties.iter() {
             size += k.capacity() + std::mem::size_of::<u64>();
             for s in v {
                 size += s.capacity() + std::mem::size_of::<u64>();
@@ -1902,25 +1910,27 @@ fn append_unique_declarations(existing: &mut Vec<NodeIndex>, incoming: &[NodeInd
 fn remap_expando_properties(
     expando: &FxHashMap<String, FxHashSet<String>>,
     id_remap: &FxHashMap<SymbolId, SymbolId>,
-) -> FxHashMap<String, FxHashSet<String>> {
-    expando
-        .iter()
-        .map(|(obj_name, props)| {
-            let remapped_props = props
-                .iter()
-                .map(|prop| {
-                    if let Some(old_id_str) = prop.strip_prefix("__unique_")
-                        && let Ok(old_id) = old_id_str.parse::<u32>()
-                        && let Some(&new_id) = id_remap.get(&SymbolId(old_id))
-                    {
-                        return format!("__unique_{}", new_id.0);
-                    }
-                    prop.clone()
-                })
-                .collect();
-            (obj_name.clone(), remapped_props)
-        })
-        .collect()
+) -> Arc<FxHashMap<String, FxHashSet<String>>> {
+    Arc::new(
+        expando
+            .iter()
+            .map(|(obj_name, props)| {
+                let remapped_props = props
+                    .iter()
+                    .map(|prop| {
+                        if let Some(old_id_str) = prop.strip_prefix("__unique_")
+                            && let Ok(old_id) = old_id_str.parse::<u32>()
+                            && let Some(&new_id) = id_remap.get(&SymbolId(old_id))
+                        {
+                            return format!("__unique_{}", new_id.0);
+                        }
+                        prop.clone()
+                    })
+                    .collect();
+                (obj_name.clone(), remapped_props)
+            })
+            .collect(),
+    )
 }
 
 /// Pre-populate a `DefinitionStore` from the merged `semantic_defs` map.
@@ -4127,7 +4137,7 @@ fn build_lib_bound_file_for_interface_checks(
         node_flow: Arc::new(FxHashMap::default()),
         switch_clause_to_switch: Arc::new(FxHashMap::default()),
         is_external_module: lib_file.binder.is_external_module,
-        expando_properties: FxHashMap::default(),
+        expando_properties: Arc::new(FxHashMap::default()),
         file_features: crate::binder::FileFeatures::NONE,
         lib_symbol_reverse_remap: Arc::new(FxHashMap::default()),
         semantic_defs: Arc::new(FxHashMap::default()),

--- a/crates/tsz-lsp/src/project/core.rs
+++ b/crates/tsz-lsp/src/project/core.rs
@@ -430,7 +430,7 @@ impl ProjectFile {
         }
 
         // expando_properties
-        for (k, v) in &b.expando_properties {
+        for (k, v) in b.expando_properties.iter() {
             size += k.capacity() + 8;
             for s in v {
                 size += s.capacity() + 8;


### PR DESCRIPTION
## Summary

`expando_properties: FxHashMap<String, FxHashSet<String>>` is populated during binding (in `binding/declaration.rs`) and read-only post-bind. Per-file binders constructed by the CLI driver previously deep-cloned the nested map (outer `FxHashMap` + inner `FxHashSet<String>`) per binder — ~2N copies on N-file projects, each with String-keyed allocations.

This PR wraps it in `Arc` end-to-end (`BinderState`, `BinderStateScopeInputs`, `BindResult`, `BoundFile`):

- 3 binding-time mutation sites use `Arc::make_mut` (free when refcount=1 during bind).
- `clear()` in `reset_for_file_bind` uses `Arc::make_mut`.
- `remap_expando_properties` returns `Arc<...>` (avoids one extra wrap at the call site).
- Per-file binder construction shares via `Arc::clone` (atomic refcount bump) instead of deep-cloning.

Iteration loops `for (k, v) in &b.expando_properties` updated to `.iter()` since `&Arc<T>` doesn't implement IntoIterator. Reads via `.get(...)`, `.contains_key(...)` etc. work unchanged through Deref.

Same pattern as #1399 (lib_symbol_reverse_remap) and earlier PRs #1202/#1227 (flow_nodes/node_flow/semantic_defs/node_symbols).

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run -p tsz-binder` — 448 / 448 passed
- [x] `cargo nextest run -p tsz-checker --lib` — 2886 / 2886 passed
- [ ] CI conformance + emit + fourslash

Note: full nextest skipped via `TSZ_SKIP_TESTS=1` because of pre-existing main test failure (`test_module_exports_object_literal_member_conflicts_with_module_augmentation`) that reproduces unchanged on `origin/main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
