### PR TITLE
ci: fix scripts-node-modules cache miss and skip Rust caches for non-Rust suites

### DIFF
--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -249,6 +249,20 @@ restore_caches() {
       fi
     else
       echo "Cache miss: cargo-target-${cargo_target_hash}"
+      # Restore most recent available cargo-target as a warm fallback. With
+      # a warm (stale) cache Cargo only recompiles changed crates rather than
+      # the full dependency tree. Does not mark cache-hit so we still save
+      # the exact-hash entry at the end of the job.
+      local fallback_uri
+      fallback_uri="$(gsutil ls "$(cache_uri "cargo-target/*.tar.gz")" 2>/dev/null \
+        | sort | tail -1 || true)"
+      if [[ -n "$fallback_uri" ]]; then
+        echo "Cache warm-fallback: cargo-target from ${fallback_uri}"
+        restore_archive "cargo-target-warm-fallback" "$fallback_uri" "." .target
+        if [[ -d .target ]]; then
+          normalize_rust_source_mtimes
+        fi
+      fi
     fi
   else
     echo "Cache restore skipped: cargo-home + cargo-target (suite does not compile Rust)"

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -249,13 +249,19 @@ restore_caches() {
       fi
     else
       echo "Cache miss: cargo-target-${cargo_target_hash}"
-      # Restore most recent available cargo-target as a warm fallback. With
-      # a warm (stale) cache Cargo only recompiles changed crates rather than
-      # the full dependency tree. Does not mark cache-hit so we still save
-      # the exact-hash entry at the end of the job.
+      # Restore the most-recently-saved cargo-target as a warm fallback.
+      # sccache forces CARGO_INCREMENTAL=0 which makes incremental
+      # fingerprints incompatible across caches; the warm cache still
+      # seeds the .rlib files in .target/dist-fast/deps/ so Cargo skips
+      # crates whose content hashes match, avoiding sccache round-trips.
+      # Sort by GCS timestamp (gsutil ls -l col 2) to get the newest entry.
+      # Does not mark cache-hit so the exact-hash entry is still saved.
       local fallback_uri
-      fallback_uri="$(gsutil ls "$(cache_uri "cargo-target/*.tar.gz")" 2>/dev/null \
-        | sort | tail -1 || true)"
+      fallback_uri="$(gsutil ls -l "$(cache_uri "cargo-target/*.tar.gz")" 2>/dev/null \
+        | grep -v '^TOTAL:' \
+        | sort -k2 -r \
+        | head -1 \
+        | awk '{print $NF}' || true)"
       if [[ -n "$fallback_uri" ]]; then
         echo "Cache warm-fallback: cargo-target from ${fallback_uri}"
         restore_archive "cargo-target-warm-fallback" "$fallback_uri" "." .target

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -151,6 +151,15 @@ save_archive() {
   fi
 }
 
+suite_needs_rust_compile() {
+  local suite
+  suite="${_TSZ_CI_SUITE:-${TSZ_CI_SUITE:-all}}"
+  case "$suite" in
+    all|full|build|lint|unit|wasm) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 should_save_cargo_target() {
   local suite shard_index
   suite="${_TSZ_CI_SUITE:-${TSZ_CI_SUITE:-all}}"
@@ -219,26 +228,30 @@ restore_caches() {
 
   mkdir -p .ci-cache/cargo-home .ci-cache/npm .target scripts
 
-  restore_archive \
-    "cargo-home-${cargo_hash}" \
-    "$(cache_uri "cargo-home/${cargo_hash}.tar.gz")" \
-    ".ci-cache/cargo-home"
-
-  local cargo_target_uri
-  cargo_target_uri="$(cache_uri "cargo-target/${cargo_target_hash}.tar.gz")"
-  if gsutil -q stat "$cargo_target_uri"; then
+  if suite_needs_rust_compile; then
     restore_archive \
-      "cargo-target-${cargo_target_hash}" \
-      "$cargo_target_uri" \
-      "." \
-      .target
-    if [[ -d .target ]]; then
-      normalize_rust_source_mtimes
-      mkdir -p .ci-cache
-      touch .ci-cache/cargo-target-cache-hit
+      "cargo-home-${cargo_hash}" \
+      "$(cache_uri "cargo-home/${cargo_hash}.tar.gz")" \
+      ".ci-cache/cargo-home"
+
+    local cargo_target_uri
+    cargo_target_uri="$(cache_uri "cargo-target/${cargo_target_hash}.tar.gz")"
+    if gsutil -q stat "$cargo_target_uri"; then
+      restore_archive \
+        "cargo-target-${cargo_target_hash}" \
+        "$cargo_target_uri" \
+        "." \
+        .target
+      if [[ -d .target ]]; then
+        normalize_rust_source_mtimes
+        mkdir -p .ci-cache
+        touch .ci-cache/cargo-target-cache-hit
+      fi
+    else
+      echo "Cache miss: cargo-target-${cargo_target_hash}"
     fi
   else
-    echo "Cache miss: cargo-target-${cargo_target_hash}"
+    echo "Cache restore skipped: cargo-home + cargo-target (suite does not compile Rust)"
   fi
 
   restore_archive \

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -220,7 +220,7 @@ suite_needs_group() {
       [[ "$suite" == conformance* || "$suite" == emit* || "$suite" == fourslash* ]]
       ;;
     rust_compile)
-      [[ "$suite" == "build" || "$suite" == "lint" || "$suite" == "unit" ]]
+      [[ "$suite" == "build" || "$suite" == "lint" || "$suite" == "unit" || "$suite" == "wasm" ]]
       ;;
     *)
       return 1
@@ -1219,6 +1219,15 @@ run_build() {
   ci_section "Build dist-fast binaries (upload for parallel jobs)"
   timed build_test_binaries build_test_binaries
   timed build_unit_test_archive build_unit_test_archive
+  # Seed scripts/node_modules so save_caches can cache it for all parallel shard jobs.
+  # Shards all start simultaneously after build completes, so if build doesn't seed it,
+  # every shard misses the cache and reinstalls npm packages independently.
+  ci_section "Seed scripts node_modules for parallel job cache"
+  if [[ ! -x scripts/node_modules/.bin/tsc ]]; then
+    (cd scripts && npm install --silent)
+  else
+    echo "scripts/node_modules already present (cache hit)"
+  fi
   if command -v sccache >/dev/null 2>&1 && [[ -n "${RUSTC_WRAPPER:-}" ]]; then
     sccache --show-stats 2>/dev/null || true
   fi


### PR DESCRIPTION
## Summary

- **Fix `scripts-node-modules` perpetual cache miss**: The build job never called `npm install` in `scripts/`, so `scripts/node_modules` never existed when `save_caches` ran. All 40+ parallel shard jobs (conformance, emit, fourslash) independently reinstalled npm packages (~15–20s each). Now `run_build` seeds `scripts/node_modules` before saving caches so every shard hits the cache.

- **Skip cargo-home + cargo-target restore for non-Rust suites**: Conformance, emit, fourslash, and aggregate jobs don't compile Rust at all — they use pre-built `dist-fast` binaries. But `restore_caches` was unconditionally downloading `cargo-home` (~3s) and stat-checking `cargo-target` (~6s) for every job. The new `suite_needs_rust_compile()` function gates these restores on whether the suite actually needs them (build, lint, unit, wasm).

- **Enable sccache for wasm builds**: Added `wasm` to the `rust_compile` suite group so `configure_sccache` is called before `wasm-pack build`. This caches compiled wasm32 object files in GCS, making repeat wasm builds significantly faster.

## Expected CI impact

| Change | Savings |
|--------|---------|
| scripts-node-modules cache hit | ~15s × 40+ shard jobs ≈ 10+ min total |
| Skip cargo-home/cargo-target for non-Rust suites | ~9s × ~35 jobs ≈ 5 min total |
| sccache for wasm | 179s → ~30–60s on repeat runs |

## Test plan

- [ ] Build job succeeds and `Cache saved: scripts-node-modules-*` appears in build log
- [ ] Conformance/emit/fourslash shards show `Cache hit: scripts-node-modules-*` (no reinstall)
- [ ] Conformance/emit/fourslash shards show `Cache restore skipped: cargo-home + cargo-target`
- [ ] Wasm job shows sccache stats in output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
