### PR TITLE
chore(checker/dispatch): trace TypeId::ANY fallbacks in 5 dispatch sites

### DIFF
--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -373,6 +373,14 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 {
                     // `this` in a class or object literal member but enclosing_class
                     // not yet set. Suppress TS2683 - `this` is contextually typed.
+                    //
+                    // Robustness audit (PR #J, item 10): emit a structured trace
+                    // so the rate of unresolved-`this` ANY fallbacks is visible.
+                    tracing::debug!(
+                        site = "dispatch::this_unresolved_class_or_object_literal_member",
+                        idx = idx.0,
+                        "TypeId::ANY fallback (unresolved enclosing this scope)"
+                    );
                     TypeId::ANY
                 } else if self.checker.ctx.no_implicit_this()
                     && !self.checker.is_js_file()
@@ -554,7 +562,15 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             .get_class_constructor_type_with_request(idx, &class, request)
                     }
                 } else {
-                    // Return ANY to prevent cascading TS2571 errors
+                    // Return ANY to prevent cascading TS2571 errors.
+                    //
+                    // Robustness audit (PR #J, item 10): emit a structured trace
+                    // so the rate of class-target-resolution ANY fallbacks is visible.
+                    tracing::debug!(
+                        site = "dispatch::class_constructor_target_unresolved",
+                        idx = idx.0,
+                        "TypeId::ANY fallback (cascading-TS2571 suppression)"
+                    );
                     TypeId::ANY
                 }
             }
@@ -1875,6 +1891,14 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 }
                 // new.target returns the constructor function or undefined.
                 // Return any as a safe fallback.
+                //
+                // Robustness audit (PR #J, item 10): emit a structured trace
+                // so the rate of `new.target` ANY fallbacks is visible.
+                tracing::debug!(
+                    site = "dispatch::new_target_meta_property",
+                    idx = idx.0,
+                    "TypeId::ANY fallback (new.target meta-property)"
+                );
                 TypeId::ANY
             }
             // Default case - unknown node kind is an error

--- a/crates/tsz-checker/src/dispatch_yield.rs
+++ b/crates/tsz-checker/src/dispatch_yield.rs
@@ -197,6 +197,13 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 }
             });
         if !is_in_generator {
+            // Robustness audit (PR #J, item 10): emit a structured trace
+            // so the rate of yield-outside-generator ANY fallbacks is visible.
+            tracing::debug!(
+                site = "dispatch_yield::yield_outside_generator",
+                idx = idx.0,
+                "TypeId::ANY fallback (yield outside generator; TS1163 already from parser)"
+            );
             return TypeId::ANY;
         }
 
@@ -682,6 +689,14 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 self.checker.ctx.generator_had_ts7057 = true;
             }
         }
+        // Robustness audit (PR #J, item 10): emit a structured trace so the
+        // rate of yield-result ANY fallbacks (no generator next-type, no
+        // explicit return annotation) is visible.
+        tracing::debug!(
+            site = "dispatch_yield::yield_result_no_generator_context",
+            idx = idx.0,
+            "TypeId::ANY fallback (yield expression with no generator next-type context)"
+        );
         TypeId::ANY
     }
 


### PR DESCRIPTION
Implements **PR #J (item 10)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

Five "safe ANY fallback" sites in `dispatch.rs` and `dispatch_yield.rs` masked distinguishable failure modes: parse-recovery error, unresolved-semantic error, real TypeScript `any` collapsed to one type. Once a node became `any`, downstream errors disappeared without a visibility hook.

This change adds `tracing::debug!` at all five cited sites with a `site=` label so each fallback is observable in the trace stream:

- `dispatch::this_unresolved_class_or_object_literal_member`
- `dispatch::class_constructor_target_unresolved`
- `dispatch::new_target_meta_property`
- `dispatch_yield::yield_outside_generator`
- `dispatch_yield::yield_result_no_generator_context`

Behavior unchanged — same `TypeId::ANY` returns, just visible. **PR #J's sentinel-but-not-`any` redesign remains future work**; this is the visibility-first foothold matching #1369's pattern for `try_borrow_mut`.

## Test plan
- [x] 2888/2888 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
