### PR TITLE
feat(tsserver): add unimplemented_response helper for protocol stubs

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -1002,7 +1002,11 @@ impl Server {
         }
     }
 
-    // Stub handlers for protocol commands - return success with empty/minimal responses
+    // Stub handlers for protocol commands — return `success: true` with
+    // empty/minimal responses for commands whose semantics ARE "no result yet"
+    // (`compileOnSaveAffectedFileList` → `[]`, `compileOnSaveEmitFile` →
+    // `false`, async-acknowledged ones like `geterr`). This is the right
+    // shape when the empty body is a valid answer to the protocol question.
     pub(crate) fn stub_response(
         &self,
         seq: u64,
@@ -1017,6 +1021,37 @@ impl Server {
             success: true,
             message: None,
             body,
+        }
+    }
+
+    /// Return `success: false` with an explicit "not implemented" reason for
+    /// protocol commands that this server has not implemented yet.
+    ///
+    /// Distinguishes "feature unimplemented" from "feature produced an empty
+    /// result" — the prior `stub_response` collapsed both into `success: true`,
+    /// leaving clients no way to tell why a command returned nothing. New
+    /// unimplemented handlers should call this instead of `stub_response`.
+    ///
+    /// Robustness audit (PR #H, item 8 in
+    /// `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`).
+    #[allow(dead_code)]
+    pub(crate) fn unimplemented_response(
+        &self,
+        seq: u64,
+        request: &TsServerRequest,
+        reason: &str,
+    ) -> TsServerResponse {
+        TsServerResponse {
+            seq,
+            msg_type: "response".to_string(),
+            command: request.command.clone(),
+            request_seq: request.seq,
+            success: false,
+            message: Some(format!(
+                "Command '{}' is not implemented: {reason}",
+                request.command
+            )),
+            body: None,
         }
     }
 }


### PR DESCRIPTION
Foothold for **PR #H (item 8)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`stub_response` collapses three semantically-different responses into a single `success: true` with empty body:

- Async-acknowledgement (`geterr` fires diagnostic events later)
- Valid empty result (`compileOnSaveAffectedFileList` → `[]`, `compileOnSaveEmitFile` → `false`, `saveto` / `watchChange`)
- Genuinely unimplemented commands

Clients have no way to distinguish them.

This change adds a parallel `unimplemented_response` helper that returns `success: false` with a clear `Command 'X' is not implemented: <reason>` message. New unimplemented handlers should call it. The existing `stub_response` is left in place for the cases where empty `success: true` IS the right answer (its docstring is updated to describe the boundary).

Pure additive (`#[allow(dead_code)]` for now since no callers have migrated yet); follow-up PRs will move specific handlers over as their semantics are verified.

## Test plan
- [x] 1057/1057 `tsz-cli` tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
