### PR TITLE
fix(parser): preserve duplicate extends clauses for JS emit parity

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -68,5 +68,9 @@ path = "tests/prefix_unary_recovery_tests.rs"
 name = "property_access_recovery_tests"
 path = "tests/property_access_recovery_tests.rs"
 
+[[test]]
+name = "duplicate_extends_recovery_tests"
+path = "tests/duplicate_extends_recovery_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-emitter/tests/duplicate_extends_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/duplicate_extends_recovery_tests.rs
@@ -1,0 +1,72 @@
+//! Integration tests for duplicate `extends` clause emit error recovery.
+//!
+//! When the parser encounters a class with a duplicate `extends` keyword
+//! (e.g. `class D extends C extends C { ... }`), tsc reports TS1172 but
+//! still preserves both heritage clauses in the AST so JS emit prints the
+//! source verbatim (`class D extends C extends C { ... }`). The parser
+//! ships both clauses to the emitter so this matches tsc's
+//! `extendsClauseAlreadySeen` and `extendsClauseAlreadySeen2` baselines.
+//!
+//! See:
+//! - `crates/tsz-parser/src/parser/state_statements_class.rs`
+//!   (`parse_heritage_clause_extends` duplicate-keyword recovery)
+//! - `crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs`
+//!   (heritage-clause emission loop)
+//! - `TypeScript/tests/baselines/reference/extendsClauseAlreadySeen.js`
+//! - `TypeScript/tests/baselines/reference/extendsClauseAlreadySeen2.js`
+
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_print_with_opts;
+
+fn print_es2015(source: &str) -> String {
+    parse_and_print_with_opts(source, PrintOptions::es6())
+}
+
+/// Source `class D extends C extends C { baz() { } }` (TypeScript test
+/// `extendsClauseAlreadySeen.ts`) must emit both `extends C extends C`
+/// clauses verbatim. The duplicate-clause TS1172 diagnostic is parser-side
+/// and does not affect the emitted JS.
+#[test]
+fn class_duplicate_extends_emits_both_clauses_verbatim() {
+    let source = "class C {\n}\nclass D extends C extends C {\n    baz() { }\n}\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("class D extends C extends C"),
+        "expected duplicate `extends C extends C` to round-trip; got:\n{output}"
+    );
+}
+
+/// `class D extends A extends B { ... }` must emit `class D extends A extends B`
+/// even when the duplicate clause references a different base type. Each
+/// duplicate `extends` keyword introduces its own heritage clause node so the
+/// emitter prints them in source order.
+#[test]
+fn class_duplicate_extends_distinct_bases_emits_both_clauses() {
+    let source = "class A {}\nclass B {}\nclass D extends A extends B { baz() {} }\n";
+    let output = print_es2015(source);
+    assert!(
+        output.contains("class D extends A extends B"),
+        "expected `extends A extends B` to round-trip; got:\n{output}"
+    );
+}
+
+/// Duplicate `implements` clauses do NOT appear in JS output (interfaces are
+/// type-only). Confirm we still strip `implements` cleanly even though
+/// duplicate `extends` is now preserved.
+#[test]
+fn class_duplicate_implements_does_not_appear_in_js() {
+    let source = "class C {\n}\nclass D implements C implements C {\n    baz() { }\n}\n";
+    let output = print_es2015(source);
+    assert!(
+        !output.contains("implements"),
+        "implements clauses must not appear in JS emit; got:\n{output}"
+    );
+    assert!(
+        output.contains("class D"),
+        "expected `class D` to be emitted; got:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -1489,11 +1489,6 @@ impl ParserState {
             ));
         }
 
-        if is_duplicate {
-            self.skip_heritage_type_references_for_recovery();
-            return None;
-        }
-
         let type_ref = self.parse_heritage_type_reference();
         let mut type_refs = vec![type_ref];
 
@@ -1512,12 +1507,17 @@ impl ParserState {
                 );
                 break;
             }
-            self.parse_error_at(
-                self.token_pos(),
-                0,
-                "Classes can only extend a single class.",
-                diagnostic_codes::CLASSES_CAN_ONLY_EXTEND_A_SINGLE_CLASS,
-            );
+            // Only emit "Classes can only extend a single class" for the first
+            // (non-duplicate) extends clause. For a duplicate `extends` clause,
+            // the duplicate-keyword diagnostic already covers the bases.
+            if !is_duplicate {
+                self.parse_error_at(
+                    self.token_pos(),
+                    0,
+                    "Classes can only extend a single class.",
+                    diagnostic_codes::CLASSES_CAN_ONLY_EXTEND_A_SINGLE_CLASS,
+                );
+            }
             let extra_ref = self.parse_heritage_type_reference();
             type_refs.push(extra_ref);
         }

--- a/crates/tsz-parser/tests/parser_unit_tests.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests.rs
@@ -1573,7 +1573,12 @@ fn class_extends_implements() {
 }
 
 #[test]
-fn class_duplicate_extends_recovery_discards_duplicate_clause_types() {
+fn class_duplicate_extends_recovery_keeps_duplicate_clause_types() {
+    // tsc reports TS1172 ('extends' clause already seen) but still preserves
+    // the duplicate clause in the AST so JS emit prints `extends A extends B`
+    // verbatim (matching tsc baseline output for `extendsClauseAlreadySeen`
+    // and `parserClassDeclaration2`).  Checker iterators that take the
+    // .first() heritage clause continue to ignore the duplicate.
     let (parser, root) = parse_source("class C extends A extends B {}");
     let codes: Vec<u32> = parser
         .get_diagnostics()
@@ -1593,16 +1598,26 @@ fn class_duplicate_extends_recovery_discards_duplicate_clause_types() {
     let heritage = class.heritage_clauses.as_ref().expect("heritage clauses");
     assert_eq!(
         heritage.nodes.len(),
-        1,
-        "duplicate extends recovery should keep only the first heritage clause"
+        2,
+        "duplicate extends recovery should keep both heritage clauses for emit parity"
     );
 
-    let clause_node = arena.get(heritage.nodes[0]).expect("heritage node");
-    let clause = arena.get_heritage(clause_node).expect("heritage data");
+    let first_node = arena.get(heritage.nodes[0]).expect("first heritage node");
+    let first = arena.get_heritage(first_node).expect("first heritage data");
     assert_eq!(
-        clause.types.nodes.len(),
+        first.types.nodes.len(),
         1,
-        "duplicate extends recovery should keep only the first base type"
+        "first extends clause should keep its base type"
+    );
+
+    let second_node = arena.get(heritage.nodes[1]).expect("second heritage node");
+    let second = arena
+        .get_heritage(second_node)
+        .expect("second heritage data");
+    assert_eq!(
+        second.types.nodes.len(),
+        1,
+        "duplicate extends clause should keep its base type so emit prints it"
     );
 }
 

--- a/docs/plan/claims/fix-emit-js-recovery-3.md
+++ b/docs/plan/claims/fix-emit-js-recovery-3.md
@@ -1,0 +1,82 @@
+# fix(parser): preserve duplicate `extends` clauses for emit parity
+
+- **Date**: 2026-04-26
+- **Time**: 2026-04-26 15:57:36
+- **Branch**: `fix/emit-js-recovery-3`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 2 (Emit pass rate)
+
+## Intent
+
+Fix duplicate-`extends`-clause emit parity for the JS suite. Two TypeScript
+conformance baselines drive this:
+
+- `extendsClauseAlreadySeen.ts` (`class D extends C extends C { baz() {} }`)
+- `extendsClauseAlreadySeen2.ts` (same shape)
+
+tsc reports TS1172 for the duplicate `extends` keyword but still preserves
+both heritage clauses in the AST so the JS emitter prints
+`class D extends C extends C { ... }` verbatim. Our parser was discarding
+the duplicate clause via `skip_heritage_type_references_for_recovery`,
+yielding `class D extends C { ... }` and a 2-test deficit.
+
+The duplicate `implements` case is unaffected: implements clauses never
+appear in JS output, so the existing recovery is correct.
+
+## Root Cause
+
+`crates/tsz-parser/src/parser/state_statements_class.rs` ::
+`parse_heritage_clause_extends` returned `None` for the duplicate clause
+after reporting TS1172, throwing away the parsed type-references. The
+emitter (which loops every heritage clause and prints ` extends T1, T2`)
+never saw the duplicate.
+
+## Fix
+
+Drop the early `return None` for the duplicate `extends` clause. The
+function now parses the type-reference(s) and creates a normal
+`HeritageClause` AST node for the duplicate, exactly like the first
+clause. Suppress the secondary `Classes can only extend a single class.`
+TS1174 diagnostic for the duplicate clause path so we do not double up
+errors with the TS1172 we already emit.
+
+Existing checker iterators that consume heritage clauses already loop
+with `for &clause in heritage_clauses.nodes` and either `break`/`return`
+on the first `ExtendsKeyword` clause they find, so the second clause is
+ignored by the type system but visible to the emitter.
+
+The implements duplicate-keyword path keeps the existing
+`skip_heritage_type_references_for_recovery` recovery — the JS emitter
+strips implements anyway, so there is no parity gap there.
+
+## Files Touched
+
+- `crates/tsz-parser/src/parser/state_statements_class.rs`
+  (drop early return for duplicate `extends`; gate TS1174 on
+  `!is_duplicate`)
+- `crates/tsz-parser/tests/parser_unit_tests.rs`
+  (`class_duplicate_extends_recovery_*` updated to lock the new
+  two-clause shape; the implements-side test is unchanged)
+- `crates/tsz-emitter/tests/duplicate_extends_recovery_tests.rs` (new
+  integration test, 3 cases — duplicate same base, duplicate distinct
+  base, implements duplicate stays stripped)
+- `crates/tsz-emitter/Cargo.toml` (register the new
+  `duplicate_extends_recovery_tests` test target)
+
+## Verification
+
+- `cargo nextest run -p tsz-parser` (673/673 pass — including the
+  rewritten `class_duplicate_extends_recovery_*` lock-in test)
+- `cargo nextest run -p tsz-checker --lib` (2888/2888 pass — no checker
+  regression from the new duplicate clauses)
+- `cargo nextest run -p tsz-emitter` (1659/1659 pass — including the 3
+  new `duplicate_extends_recovery_tests` cases)
+- `bash scripts/emit/run.sh --filter=extendsClauseAlreadySeen --js-only`
+  flips both `extendsClauseAlreadySeen` and `extendsClauseAlreadySeen2`
+  from `+1/-1 lines` to PASS.
+- `bash scripts/emit/run.sh --filter=parserClassDeclaration --js-only`
+  (27/27 pass — broader heritage-clause regression check).
+
+Net JS-emit movement: +2 tests (84.0 → 84.2 % at the time of writing,
+within sampling noise on the full suite).

--- a/docs/plan/claims/fix-emit-js-recovery-3.md
+++ b/docs/plan/claims/fix-emit-js-recovery-3.md
@@ -3,8 +3,8 @@
 - **Date**: 2026-04-26
 - **Time**: 2026-04-26 15:57:36
 - **Branch**: `fix/emit-js-recovery-3`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1408
+- **Status**: ready
 - **Workstream**: 2 (Emit pass rate)
 
 ## Intent


### PR DESCRIPTION
## Summary

- Fixes 2 emit baselines (`extendsClauseAlreadySeen`, `extendsClauseAlreadySeen2`) where `class D extends C extends C { ... }` was emitting `class D extends C { ... }`.
- Parser was discarding the duplicate `extends` clause via `skip_heritage_type_references_for_recovery` after reporting TS1172. Drop the early return so both heritage clauses are parsed and attached to the class AST.
- Suppress redundant TS1174 (`Classes can only extend a single class`) on the duplicate-clause path; TS1172 already covers the parser error.
- Implements duplicate-keyword path stays as-is (implements clauses don't appear in JS emit).

## Architecture

- Per CLAUDE.md §13, this is emitter-correctness work driven by parser AST shape — no semantic validation in the emitter.
- Existing checker iterators that consume heritage clauses already loop and `break`/`return` on the first `ExtendsKeyword` clause they find (see `class_type/core.rs`, `access_super.rs`, `class_summary.rs`, `class_type/constructor.rs`), so the duplicate clause is invisible to type checking but visible to emit, matching tsc's behavior.

## Test plan

- [x] `cargo nextest run -p tsz-parser` — 673/673 pass (rewritten `class_duplicate_extends_recovery_*` lock-in test now requires two heritage clauses).
- [x] `cargo nextest run -p tsz-checker --lib` — 2888/2888 pass (no regression).
- [x] `cargo nextest run -p tsz-emitter` — 1659/1659 pass (3 new `duplicate_extends_recovery_tests` cases).
- [x] `bash scripts/emit/run.sh --filter=extendsClauseAlreadySeen --js-only` — both tests now PASS.
- [x] `bash scripts/emit/run.sh --filter=parserClassDeclaration --js-only` — 27/27 pass (heritage-clause regression check).
- [x] `bash scripts/emit/run.sh --filter=implementsClauseAlreadySeen --js-only` — passes (implements duplicate behavior preserved).

## Files changed

- `crates/tsz-parser/src/parser/state_statements_class.rs`
- `crates/tsz-parser/tests/parser_unit_tests.rs`
- `crates/tsz-emitter/tests/duplicate_extends_recovery_tests.rs` (new)
- `crates/tsz-emitter/Cargo.toml`
- `docs/plan/claims/fix-emit-js-recovery-3.md` (new)

Net JS-emit movement: +2 tests.