### PR TITLE
perf(binder): Arc-wrap switch_clause_to_switch for shared per-file binders

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -1206,7 +1206,7 @@ impl BinderState {
                             has_default_clause = true;
                         }
 
-                        self.switch_clause_to_switch.insert(clause_idx.0, idx);
+                        Arc::make_mut(&mut self.switch_clause_to_switch).insert(clause_idx.0, idx);
 
                         self.current_flow = pre_switch_flow;
                         if clause.expression.is_some() {

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -190,7 +190,7 @@ impl BinderState {
             cross_file_node_symbols: FxHashMap::default(),
             node_flow: Arc::new(FxHashMap::with_capacity_and_hasher(128, Default::default())),
             top_level_flow: FxHashMap::default(),
-            switch_clause_to_switch: FxHashMap::default(),
+            switch_clause_to_switch: Arc::new(FxHashMap::default()),
             hoisted_vars: Vec::new(),
             hoisted_functions: Vec::new(),
             scopes: Vec::with_capacity(32),
@@ -260,7 +260,7 @@ impl BinderState {
         self.cross_file_node_symbols.clear();
         Arc::make_mut(&mut self.node_flow).clear();
         self.top_level_flow.clear();
-        self.switch_clause_to_switch.clear();
+        Arc::make_mut(&mut self.switch_clause_to_switch).clear();
         self.hoisted_vars.clear();
         self.hoisted_functions.clear();
         self.scopes.clear();
@@ -432,7 +432,7 @@ impl BinderState {
             cross_file_node_symbols: FxHashMap::default(),
             node_flow: Arc::new(FxHashMap::default()),
             top_level_flow: FxHashMap::default(),
-            switch_clause_to_switch: FxHashMap::default(),
+            switch_clause_to_switch: Arc::new(FxHashMap::default()),
             hoisted_vars: Vec::new(),
             hoisted_functions: Vec::new(),
             scopes: Vec::new(),
@@ -1819,7 +1819,6 @@ impl BinderState {
 
         Arc::make_mut(&mut self.node_flow).retain(|node_id, _| keep_node(node_id));
         self.node_scope_ids.retain(|node_id, _| keep_node(node_id));
-        self.switch_clause_to_switch
-            .retain(|node_id, _| keep_node(node_id));
+        Arc::make_mut(&mut self.switch_clause_to_switch).retain(|node_id, _| keep_node(node_id));
     }
 }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -329,7 +329,11 @@ pub struct BinderState {
     /// Flow node after each top-level statement (for incremental binding).
     pub(crate) top_level_flow: FxHashMap<u32, FlowNodeId>,
     /// Map case/default clause nodes to their containing switch statement.
-    pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver
+    /// share via `Arc::clone` instead of deep-cloning. Mutated only during
+    /// binding (in `binding/declaration.rs`) and read-only post-bind.
+    pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     /// Hoisted var declarations
     pub(crate) hoisted_vars: Vec<(String, NodeIndex)>,
     /// Hoisted function declarations
@@ -914,7 +918,7 @@ pub struct BinderStateScopeInputs {
     pub modules_with_export_equals: FxHashSet<String>,
     pub flow_nodes: Arc<FlowNodeArena>,
     pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
-    pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
+    pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     pub expando_properties: FxHashMap<String, FxHashSet<String>>,
     pub alias_partners: FxHashMap<SymbolId, SymbolId>,
 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2806,7 +2806,7 @@ fn build_lib_bound_file_for_interface_checks(
         augmentation_target_modules: FxHashMap::default(),
         flow_nodes: std::sync::Arc::new(tsz::binder::FlowNodeArena::default()),
         node_flow: std::sync::Arc::new(FxHashMap::default()),
-        switch_clause_to_switch: FxHashMap::default(),
+        switch_clause_to_switch: std::sync::Arc::new(FxHashMap::default()),
         is_external_module: lib_file.binder.is_external_module,
         expando_properties: FxHashMap::default(),
         file_features: tsz::binder::FileFeatures::NONE,

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -553,8 +553,11 @@ pub struct BindResult {
     /// `node_flow`.
     pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
-    /// Used by control flow analysis for switch exhaustiveness checking
-    pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
+    /// Used by control flow analysis for switch exhaustiveness checking.
+    ///
+    /// `Arc`-wrapped so per-file binders share via `Arc::clone` instead of
+    /// deep-cloning. Read-only after binding completes.
+    pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     /// Whether this file is an external module (has imports/exports)
     pub is_external_module: bool,
     /// Expando property assignments detected during binding
@@ -1461,8 +1464,11 @@ pub struct BoundFile {
     /// and `node_symbols` (#1227) Arc migrations.
     pub node_flow: Arc<FxHashMap<u32, FlowNodeId>>,
     /// Map from switch clause `NodeIndex` to parent switch statement `NodeIndex`
-    /// Used by control flow analysis for switch exhaustiveness checking
-    pub switch_clause_to_switch: FxHashMap<u32, NodeIndex>,
+    /// Used by control flow analysis for switch exhaustiveness checking.
+    ///
+    /// `Arc`-wrapped so per-file binders share via `Arc::clone` instead of
+    /// deep-cloning. Read-only after binding completes.
+    pub switch_clause_to_switch: Arc<FxHashMap<u32, NodeIndex>>,
     /// Whether this file is an external module (has imports/exports)
     pub is_external_module: bool,
     /// Expando property assignments detected during binding
@@ -4105,7 +4111,7 @@ fn build_lib_bound_file_for_interface_checks(
         augmentation_target_modules: FxHashMap::default(),
         flow_nodes: Arc::new(FlowNodeArena::default()),
         node_flow: Arc::new(FxHashMap::default()),
-        switch_clause_to_switch: FxHashMap::default(),
+        switch_clause_to_switch: Arc::new(FxHashMap::default()),
         is_external_module: lib_file.binder.is_external_module,
         expando_properties: FxHashMap::default(),
         file_features: crate::binder::FileFeatures::NONE,


### PR DESCRIPTION
## Summary

`switch_clause_to_switch: FxHashMap<u32, NodeIndex>` is populated during binding and read-only post-bind. Per-file binders previously deep-cloned this per binder construction.

Wrap in `Arc` end-to-end (`BinderState`, `BinderStateScopeInputs`, `BindResult`, `BoundFile`):

- 2 binding-time mutation sites (`.insert()` in switch case binding, `.retain()` in `prune_for_incremental_rebind`) and 1 `.clear()` in `reset_for_file_bind` use `Arc::make_mut` (free when refcount=1 during bind).
- Per-file binder construction shares via `Arc::clone` (atomic refcount bump) instead of deep-cloning.

Same pattern as #1399 (lib_symbol_reverse_remap), #1404 (expando_properties), and earlier PRs #1202/#1227.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run -p tsz-binder` — 448 / 448 passed
- [x] `cargo nextest run -p tsz-checker --lib` — 2888 / 2888 passed
- [ ] CI conformance + emit + fourslash

Note: full nextest skipped via `TSZ_SKIP_TESTS=1` because of pre-existing main test failure (`test_module_exports_object_literal_member_conflicts_with_module_augmentation`) that reproduces unchanged on `origin/main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
