### PR TITLE
chore(checker/flow): trace flow-fallback resolver entry

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -98,6 +98,18 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     pub(super) fn fallback_expression_type_from_syntax(&self, expr: NodeIndex) -> Option<TypeId> {
+        // Robustness audit (PR #K, item 11 in
+        // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`): this is the
+        // entry point of the syntax-driven fallback type resolver used by
+        // flow-narrowing when the main checker pipeline hasn't yet typed
+        // an expression. Trace each invocation so the rate at which
+        // narrowing depends on the second resolver — and any divergence
+        // from main-checker results — becomes observable.
+        tracing::trace!(
+            site = "flow::fallback_expression_type_from_syntax",
+            expr_idx = expr.0,
+            "flow-fallback resolver entered"
+        );
         let expr = self.skip_parens_and_assertions(expr);
         if let Some(literal_type) = self.literal_type_from_node(expr) {
             return Some(widen_literal_to_primitive(self.interner, literal_type));

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Foothold for **PR #K (item 11)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`assignment_fallback.rs` is a syntax-driven second type resolver used by flow-narrowing when the main checker pipeline hasn't yet typed an expression. The audit's concern: if the fallback and main resolver disagree, narrowing becomes inconsistent — and the divergence is invisible.

This change adds a single `tracing::trace!` at the public entry point `fallback_expression_type_from_syntax` so:

- The rate at which narrowing depends on the second resolver is observable.
- Future redesigns (route-through-main-checker per audit's PR #K) can measure the exact call sites that need migration.

Pure visibility addition — no behavior change. Matches the foothold pattern from #1369 (try_borrow_mut) and #1406 (TypeId::ANY dispatch).

## Test plan
- [x] 2889/2889 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
