### PR TITLE
fix(parser): emit "',' expected" when array is closed by `)` or `}`

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2807,7 +2807,18 @@ impl ParserState {
                     // This handles cases like: [1 2 3] instead of [1, 2, 3]
                     self.error_comma_expected();
                 } else {
-                    // Not followed by an element, so we're really done
+                    // Match tsc's parseDelimitedList: when the array is terminated by an
+                    // outer-context closer (e.g. `)` from an enclosing call, `}` from a
+                    // block), report "',' expected" first. parse_expected(]) then runs at
+                    // the same position and gets dedup'd, so the user sees the comma
+                    // diagnostic that tsc would produce instead of a "']' expected" that
+                    // points the user at the wrong fix.
+                    if matches!(
+                        self.token(),
+                        SyntaxKind::CloseParenToken | SyntaxKind::CloseBraceToken
+                    ) {
+                        self.error_comma_expected();
+                    }
                     break;
                 }
             }

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -3916,3 +3916,73 @@ var b =~;
         "Diagnostic fingerprints must match tsc exactly, got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn test_array_terminated_by_close_paren_emits_comma_expected() {
+    // Regression for conformance test
+    // `destructuringParameterDeclaration2.ts` line 8:
+    //   `a0([1, "string", [["world"]]);`
+    // The outer `[` is never closed before the `)`. tsc reports a single TS1005
+    // `',' expected.` at the `)`. Before this fix, we reported `']' expected.`
+    // because the array-literal loop broke without first emitting the missing-
+    // separator diagnostic that tsc's parseDelimitedList unconditionally emits.
+    let source = "a0([1, \"string\", [[\"world\"]]);\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+
+    let close_paren_pos = source.find(')').expect("`)` is in the source") as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED
+                && d.start == close_paren_pos
+                && d.message == "',' expected."),
+        "expected TS1005 `',' expected.` at the `)`, got {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED
+                && d.start == close_paren_pos
+                && d.message == "']' expected."),
+        "TS1005 `']' expected.` at the `)` should be dedup'd by the comma error, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_array_terminated_by_close_brace_emits_comma_expected() {
+    // Sibling case: array literal terminated by an enclosing `}` (e.g. block
+    // boundary). Same expectation — tsc reports `,' expected` rather than
+    // `]' expected`.
+    let source = "{ const x = [1, 2 }\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+
+    let close_brace_pos = source.find('}').expect("`}` is in the source") as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED
+                && d.start == close_brace_pos
+                && d.message == "',' expected."),
+        "expected TS1005 `',' expected.` at the `}}`, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_array_terminated_by_close_bracket_keeps_clean_close() {
+    // Sanity guard: a normal `[1, 2]` must not gain a spurious comma diagnostic.
+    let source = "var a = [1, 2];\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.is_empty(),
+        "well-formed array literal must not emit diagnostics, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- When an array literal terminates against `)` or `}` (e.g. an enclosing call's close-paren when the inner `[` was the unclosed one), match tsc by emitting `',' expected.` first. The follow-up `']' expected.` is then dedup'd by `parse_error_at`'s same-position rule, mirroring tsc's `parseErrorAtPosition` behavior.
- Before: `a0([1, "string", [["world"]]);` reported `']' expected.` at `)` — pointing the user at the wrong fix.
- After: reports `',' expected.` at `)` — same as tsc.

Flips conformance fingerprint-only failure `destructuringParameterDeclaration2.ts` to PASS.

## Test plan

- [x] `cargo nextest run -p tsz-parser` — all 675 parser tests pass (including 3 new regression tests)
- [x] `./scripts/conformance/conformance.sh run --filter "destructuringParameterDeclaration2"` — flips to PASS
- [x] `./scripts/conformance/conformance.sh run --filter "destructuring"` — 162/174 (no regression in the 11 pre-existing fingerprint-only failures)
- [x] `./scripts/conformance/conformance.sh run --filter "parserArray"` — 15/15
- [x] `./scripts/conformance/conformance.sh run --filter "parserError"` — 47/47
- [x] `./scripts/conformance/conformance.sh run --filter "expression"` — 365/380 (no new fingerprint mismatches)

## Note

Pre-commit nextest was skipped via `TSZ_SKIP_TESTS=1` because an unrelated `tsz-checker` test (`test_module_exports_object_literal_member_conflicts_with_module_augmentation`) fails on `origin/main` HEAD; verified parser changes in isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
