### PR TITLE
fix(checker): elaborate array-literal spread element mismatch to spread expression

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1733,8 +1733,35 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            // Skip spread elements
+            // Spread elements: when the target is a plain array element type
+            // (not a tuple), check the spread's iterated element type against
+            // the contextual element type. This matches tsc's behavior of
+            // reporting `Type 'X' is not assignable to type 'Y'` at the
+            // spread expression for cases like
+            //   `var arr: number[] = [0, 1, ...new SymbolIterator]`.
+            //
+            // Custom array subtypes (e.g., `interface Foo extends Array<T>`)
+            // keep tsc's whole-assignment TS2322; we only handle plain
+            // `T[]` / `readonly T[]` here.
             if elem_node.kind == syntax_kind_ext::SPREAD_ELEMENT {
+                if tuple_target_elements.is_some() {
+                    continue;
+                }
+                if !self.target_is_plain_array_for_spread_elaboration(effective_param_type) {
+                    continue;
+                }
+                if let Some(target_element_type) =
+                    ctx_helper.get_array_element_type().or_else(|| {
+                        crate::query_boundaries::common::array_element_type(
+                            self.ctx.types,
+                            effective_param_type,
+                        )
+                    })
+                    && self
+                        .try_elaborate_spread_element_array_mismatch(elem_idx, target_element_type)
+                {
+                    elaborated = true;
+                }
                 continue;
             }
 
@@ -1865,6 +1892,106 @@ impl<'a> CheckerState<'a> {
         }
 
         elaborated
+    }
+
+    /// Returns true when `target` evaluates to a plain `T[]` or
+    /// `readonly T[]` type, suitable for per-element spread elaboration.
+    /// Custom interfaces/classes that extend `Array<T>` keep tsc's
+    /// whole-assignment TS2322, so we exclude them here.
+    fn target_is_plain_array_for_spread_elaboration(&mut self, target: TypeId) -> bool {
+        let target = self.resolve_lazy_type(target);
+        if crate::query_boundaries::common::is_array_type(self.ctx.types, target) {
+            return true;
+        }
+        // readonly T[] — accept by recursing into the inner type.
+        if let Some(inner) =
+            crate::query_boundaries::common::get_readonly_inner(self.ctx.types, target)
+        {
+            return self.target_is_plain_array_for_spread_elaboration(inner);
+        }
+        false
+    }
+
+    /// Elaborate a spread element inside an array literal whose contextual
+    /// element type doesn't match the spread's iterated element type.
+    ///
+    /// For `var arr: number[] = [0, 1, ...new SymbolIterator]`, tsc reports
+    /// `TS2322 'symbol' is not assignable to 'number'` at the spread
+    /// element span (`...new SymbolIterator`), anchoring the diagnostic on
+    /// the spread argument rather than on the assignment target.
+    ///
+    /// Returns true when an elaborated diagnostic is emitted at the spread
+    /// expression, so the caller can suppress the outer assignment error.
+    fn try_elaborate_spread_element_array_mismatch(
+        &mut self,
+        spread_idx: NodeIndex,
+        target_element_type: TypeId,
+    ) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let Some(spread_node) = self.ctx.arena.get(spread_idx) else {
+            return false;
+        };
+        if spread_node.kind != syntax_kind_ext::SPREAD_ELEMENT {
+            return false;
+        }
+        let Some(spread_data) = self.ctx.arena.get_spread(spread_node).cloned() else {
+            return false;
+        };
+
+        if target_element_type.is_any_unknown_or_error() {
+            return false;
+        }
+
+        // Compute the spread argument's iterated element type. If the
+        // argument is itself a tuple, use array element semantics so the
+        // resulting type compares like the union of element types.
+        let spread_expr_type = self.get_type_of_node(spread_data.expression);
+        let spread_expr_type = self.resolve_lazy_type(spread_expr_type);
+        if spread_expr_type.is_any_unknown_or_error() {
+            return false;
+        }
+
+        let iterated_element_type = self.for_of_element_type(spread_expr_type, false);
+        if iterated_element_type.is_any_unknown_or_error() {
+            return false;
+        }
+        if iterated_element_type == target_element_type {
+            return false;
+        }
+        // Don't elaborate when the iterated type is the same as the spread
+        // expression type — that means we couldn't actually compute an
+        // iterator element type (e.g., the iterator protocol resolution
+        // failed).  Falling through to the outer assignment error is a
+        // better message than printing the spread type itself.
+        if iterated_element_type == spread_expr_type {
+            return false;
+        }
+        if self.is_assignable_to(iterated_element_type, target_element_type) {
+            return false;
+        }
+
+        // Format types directly (do not route through the assignability
+        // diagnostic pipeline, which would recompute the source display
+        // from the spread expression's own type and end up printing the
+        // spread receiver — e.g. `'SymbolIterator'` — instead of the
+        // iterated element type — `'symbol'`).
+        let source_display = self.format_type(iterated_element_type);
+        let target_display = self.format_type(target_element_type);
+        let message = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_display, &target_display],
+        );
+        // Anchor at the spread element itself (which spans the `...` prefix
+        // plus the inner expression), matching tsc's column. tsc reports at
+        // the start of the `...` token rather than the inner expression
+        // (e.g. column 30 of `[0, 1, ...new SymbolIterator]`, not column 33).
+        self.error_at_node(
+            spread_idx,
+            &message,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+        true
     }
 
     /// Check if all properties of an object literal are assignable to the

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1316,3 +1316,87 @@ var z = { ...x };
         "Expected TS2698 for spreading undefined in expression context, got {ts2698_count}"
     );
 }
+
+/// When an array literal contains a spread element whose iterated value
+/// type doesn't match the contextual array element type, tsc reports the
+/// element-vs-element TS2322 anchored on the spread expression instead of
+/// the whole-array TS2322 at the assignment.
+///
+/// Regression for TypeScript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts:
+///   var array: number[] = [0, 1, ...new SymbolIterator];
+/// Expected message at the spread expression:
+///   `Type 'symbol' is not assignable to type 'number'`.
+///
+/// We use a hand-rolled iterable instead of `new SymbolIterator` so the
+/// test does not depend on the lib-loaded `Symbol.iterator` machinery
+/// (the test harness intentionally skips lib contexts).
+#[test]
+fn test_array_spread_iterator_element_mismatch_elaborates_to_spread() {
+    let source = r#"
+declare let strs: string[];
+var array: number[] = [0, 1, ...strs];
+"#;
+    let diagnostics = check_source_diagnostics(source);
+
+    // Should produce exactly one TS2322 — the elaborated element-level
+    // message anchored at the spread expression, not the whole-array
+    // fallback.
+    let ts2322: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got {}: {:?}",
+        ts2322.len(),
+        ts2322
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+    let message = &ts2322[0].message_text;
+    assert!(
+        message.contains("'string'") && message.contains("'number'"),
+        "expected per-element 'string' vs 'number' elaboration; got {message:?}"
+    );
+    assert!(
+        !message.contains("(number | string)[]")
+            && !message.contains("(string | number)[]"),
+        "expected per-element elaboration, not whole-array message; got {message:?}"
+    );
+}
+
+/// Custom interfaces extending `Array<T>` keep the whole-assignment TS2322
+/// rather than per-element spread elaboration. This pins the negative case
+/// for the spread-element elaboration path in
+/// `try_elaborate_array_literal_elements`.
+#[test]
+fn test_array_spread_does_not_elaborate_for_custom_array_subtype() {
+    let source = r#"
+interface MyNumberArray extends Array<number> {}
+declare let strs: string[];
+var c: MyNumberArray = [...strs];
+"#;
+    let diagnostics = check_source_diagnostics(source);
+
+    // We should not see a per-element `'string' is not assignable to 'number'`
+    // (which would mean we drilled into the spread). Either no diagnostic
+    // (lib not loaded — `MyNumberArray` resolves loosely) or a whole-array
+    // TS2322 against MyNumberArray is acceptable.
+    let drilled: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == 2322
+                && d.message_text.contains("'string'")
+                && d.message_text.contains("'number'")
+                && !d.message_text.contains("string[]")
+        })
+        .collect();
+    assert!(
+        drilled.is_empty(),
+        "expected NOT to drill into per-element spread error for custom \
+         array-subtype target; got {:?}",
+        drilled
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+}

--- a/docs/plan/claims/fix-spread-element-context-elaboration.md
+++ b/docs/plan/claims/fix-spread-element-context-elaboration.md
@@ -1,9 +1,11 @@
+**2026-04-26 16:05:00**
+
 # fix(checker): elaborate array-literal spread element mismatch to spread expression
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/spread-element-context-elaboration`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1413
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent
@@ -12,21 +14,32 @@ When an array literal contains a spread element whose iterated element type
 is not assignable to the contextual array element type (e.g.
 `var array: number[] = [0, 1, ...new SymbolIterator]`), tsc reports
 `TS2322 'symbol' is not assignable to 'number'` at the spread expression
-position. tsz currently widens the array literal to `(number | symbol)[]`
-and emits the assignment error at the variable position.
+position. tsz previously widened the array literal to `(number | symbol)[]`
+and emitted the assignment error at the variable position.
 
 This PR teaches `try_elaborate_array_literal_elements` to drill into spread
-elements: when an array contextual element type is available and the
-spread's `for_of_element_type` is not assignable to the contextual element
-type, emit TS2322 at the spread expression with the iterated element type
-vs. contextual element type.
+elements: when the contextual target is a plain `T[]` / `readonly T[]` and
+the spread's `for_of_element_type` is not assignable to the contextual
+element type, emit TS2322 anchored on the spread element node.
+
+Restricted to plain array targets so custom interfaces extending `Array<T>`
+keep tsc's whole-assignment TS2322 message and position.
+
+Format types via `format_type` rather than the assignability diagnostic
+pipeline (which would re-derive the source display from the spread
+receiver, e.g. `'SymbolIterator'`, instead of the iterated element type
+`'symbol'`).
 
 ## Files Touched
 
-- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs` (~30 LOC)
-- `crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs` (potentially)
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs` (~125 LOC: spread-elaboration helper + plain-array gate)
+- `crates/tsz-checker/tests/spread_rest_tests.rs` (~85 LOC: positive + negative regression tests)
+- `docs/plan/claims/fix-spread-element-context-elaboration.md` (this file)
 
 ## Verification
 
-- `cargo nextest run -p tsz-checker --lib` (full pass)
-- `./scripts/conformance/conformance.sh run --filter "iteratorSpreadInArray5"` (passes)
+- Targeted: `./scripts/conformance/conformance.sh run --filter "iteratorSpreadInArray5"` passes (1/1)
+- Adjacent: `./scripts/conformance/conformance.sh run --filter "iteratorSpread"` (23/23), `--filter "arrayLiteral"` (19/19)
+- Unit: `cargo nextest run -p tsz-checker --lib` (2890/2890)
+- Unit: `cargo nextest run -p tsz-checker --test spread_rest_tests` (65/65)
+- Architecture: contract test passes (no direct `TypeData::ReadonlyType` import — uses `query_boundaries::common::get_readonly_inner`)

--- a/docs/plan/claims/fix-spread-element-context-elaboration.md
+++ b/docs/plan/claims/fix-spread-element-context-elaboration.md
@@ -1,0 +1,32 @@
+# fix(checker): elaborate array-literal spread element mismatch to spread expression
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/spread-element-context-elaboration`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+When an array literal contains a spread element whose iterated element type
+is not assignable to the contextual array element type (e.g.
+`var array: number[] = [0, 1, ...new SymbolIterator]`), tsc reports
+`TS2322 'symbol' is not assignable to 'number'` at the spread expression
+position. tsz currently widens the array literal to `(number | symbol)[]`
+and emits the assignment error at the variable position.
+
+This PR teaches `try_elaborate_array_literal_elements` to drill into spread
+elements: when an array contextual element type is available and the
+spread's `for_of_element_type` is not assignable to the contextual element
+type, emit TS2322 at the spread expression with the iterated element type
+vs. contextual element type.
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs` (~30 LOC)
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs` (potentially)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (full pass)
+- `./scripts/conformance/conformance.sh run --filter "iteratorSpreadInArray5"` (passes)


### PR DESCRIPTION
## Summary

- For array literals with spread elements whose iterated value type doesn't match the contextual array element type, drill the TS2322 error down to the spread expression instead of widening the array literal and reporting at the assignment.
- Restrict elaboration to plain \`T[]\` / \`readonly T[]\` targets — custom array subtypes (e.g. \`interface Foo extends Array<T>\`) keep tsc's whole-array TS2322 message.
- Use \`format_type\` directly so the source display reflects the iterated element type (\`'symbol'\`) rather than the spread receiver type (\`'SymbolIterator'\`).

Conformance: makes \`TypeScript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts\` pass.

Before:
\`\`\`
test.ts:14:5 TS2322 Type '(number | symbol)[]' is not assignable to type 'number[]'.
\`\`\`

After (matches tsc):
\`\`\`
test.ts:14:30 TS2322 Type 'symbol' is not assignable to type 'number'.
\`\`\`

## Test plan

- [x] Targeted: \`./scripts/conformance/conformance.sh run --filter \"iteratorSpreadInArray5\"\` passes
- [x] All \`./scripts/conformance/conformance.sh run --filter \"iteratorSpread\"\` (23/23) pass
- [x] All \`./scripts/conformance/conformance.sh run --filter \"arrayLiteral\"\` (19/19) pass
- [x] All \`./scripts/conformance/conformance.sh run --filter \"spread\"\` test pass-rate unchanged (3 pre-existing failures unrelated to my change)
- [x] \`cargo nextest run -p tsz-checker --test spread_rest_tests\` (65/65)
- [x] \`cargo nextest run -p tsz-checker --lib\` (2890/2890)
- [x] Architecture contract test passes (no \`tsz_solver::TypeData\` direct imports — uses \`query_boundaries::common::get_readonly_inner\` instead)
- [x] Regression unit tests added for both positive (plain \`T[]\` target) and negative (custom array subtype target) paths