### PR TITLE
ci: increase unit shards from 4 to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       _TSZ_CI_UNIT_SHARD_INDEX: ${{ matrix.shard }}
-      _TSZ_CI_UNIT_SHARD_COUNT: 4
+      _TSZ_CI_UNIT_SHARD_COUNT: 8
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -508,7 +508,7 @@ run_unit_shard() {
   bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
   run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
   shard_index="$(num_or_zero "${_TSZ_CI_UNIT_SHARD_INDEX:-0}")"
-  shard_count="$(num_or_zero "${_TSZ_CI_UNIT_SHARD_COUNT:-4}")"
+  shard_count="$(num_or_zero "${_TSZ_CI_UNIT_SHARD_COUNT:-8}")"
 
   echo "Unit shard $((shard_index + 1))/${shard_count}"
 


### PR DESCRIPTION
## Summary

Unit shards were running 8.5–9.5 min each (including ~2 min fixed overhead per shard for archive download + cache restore). With 4 shards, unit wall time was ~9 min.

Doubling to 8 shards halves per-shard test load (~3.5 min of tests + ~2 min overhead = ~5.5 min per shard), cutting unit wall time from ~9 min to ~5.5 min.

The nextest archive is built once in the `build` job and reused by all shards via GCS, so adding shards doesn't increase compile time.

## Test plan

- [ ] All 8 unit shards pass
- [ ] Per-shard time ~5–6 min (down from ~9 min)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
