### PR TITLE
perf(binder): Arc-wrap module_declaration_exports_publicly for shared per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -214,7 +214,7 @@ impl BinderState {
                         is_exported = true;
                     }
                 }
-                self.module_declaration_exports_publicly
+                std::sync::Arc::make_mut(&mut self.module_declaration_exports_publicly)
                     .insert(idx.0, is_exported);
 
                 if self.in_global_augmentation {

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -183,7 +183,7 @@ impl BinderState {
             scope_chain: Vec::with_capacity(32),
             current_scope_idx: 0,
             node_symbols: Arc::new(FxHashMap::with_capacity_and_hasher(256, Default::default())),
-            module_declaration_exports_publicly: FxHashMap::default(),
+            module_declaration_exports_publicly: Arc::new(FxHashMap::default()),
             symbol_arenas: Arc::new(FxHashMap::default()),
             declaration_arenas: Arc::new(FxHashMap::default()),
             sym_to_decl_indices: Arc::new(FxHashMap::default()),
@@ -253,7 +253,7 @@ impl BinderState {
         self.scope_chain.clear();
         self.current_scope_idx = 0;
         Arc::make_mut(&mut self.node_symbols).clear();
-        self.module_declaration_exports_publicly.clear();
+        Arc::make_mut(&mut self.module_declaration_exports_publicly).clear();
         Arc::make_mut(&mut self.symbol_arenas).clear();
         Arc::make_mut(&mut self.declaration_arenas).clear();
         Arc::make_mut(&mut self.sym_to_decl_indices).clear();
@@ -425,7 +425,7 @@ impl BinderState {
             scope_chain: Vec::new(),
             current_scope_idx: 0,
             node_symbols,
-            module_declaration_exports_publicly: FxHashMap::default(),
+            module_declaration_exports_publicly: Arc::new(FxHashMap::default()),
             symbol_arenas: Arc::new(FxHashMap::default()),
             declaration_arenas: Arc::new(FxHashMap::default()),
             sym_to_decl_indices: Arc::new(FxHashMap::default()),

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -286,7 +286,11 @@ pub struct BinderState {
     /// when refcount=1, the case during a single binder's construction).
     pub node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
-    pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver
+    /// share via `Arc::clone` instead of deep-cloning. Mutated only
+    /// during binding (in `modules/binding.rs`); read-only post-bind.
+    pub module_declaration_exports_publicly: Arc<FxHashMap<u32, bool>>,
     /// Symbol-to-arena mapping for cross-file declaration lookup (legacy, stores last arena).
     ///
     /// Wrapped in `Arc` so the merged cross-file map can be shared across N
@@ -902,7 +906,7 @@ pub struct BinderStateScopeInputs {
     pub module_augmentations: Arc<FxHashMap<String, Vec<ModuleAugmentation>>>,
     pub augmentation_target_modules: Arc<FxHashMap<SymbolId, String>>,
     pub module_exports: Arc<FxHashMap<String, SymbolTable>>,
-    pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
+    pub module_declaration_exports_publicly: Arc<FxHashMap<u32, bool>>,
     pub reexports: Arc<FileReexportsMap>,
     pub wildcard_reexports: Arc<WildcardReexportsMap>,
     pub wildcard_reexports_type_only: Arc<WildcardReexportsTypeOnlyMap>,

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2797,7 +2797,7 @@ fn build_lib_bound_file_for_interface_checks(
         node_symbols: std::sync::Arc::new(node_symbols),
         symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
-        module_declaration_exports_publicly: FxHashMap::default(),
+        module_declaration_exports_publicly: std::sync::Arc::new(FxHashMap::default()),
         scopes: Vec::new(),
         node_scope_ids: FxHashMap::default(),
         parse_diagnostics: Vec::new(),

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -490,7 +490,7 @@ pub struct BindResult {
     /// `semantic_defs`; this is the same template applied to `node_symbols`.
     pub node_symbols: Arc<FxHashMap<u32, SymbolId>>,
     /// Export visibility of namespace/module declaration nodes after binder rules.
-    pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
+    pub module_declaration_exports_publicly: Arc<FxHashMap<u32, bool>>,
     /// Symbol-to-arena mapping for cross-file declaration lookup (including lib symbols)
     pub symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     /// Declaration-to-arena mapping for precise cross-file declaration lookup.
@@ -1428,7 +1428,7 @@ pub struct BoundFile {
     /// Per-file declaration-to-arena mapping captured during binding.
     pub declaration_arenas: DeclarationArenaMap,
     /// Export visibility of namespace/module declaration nodes after binder rules.
-    pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
+    pub module_declaration_exports_publicly: Arc<FxHashMap<u32, bool>>,
     /// Persistent scopes (symbol IDs are global after merge)
     pub scopes: Vec<Scope>,
     /// Map from AST node to scope ID
@@ -4096,7 +4096,7 @@ fn build_lib_bound_file_for_interface_checks(
         node_symbols: Arc::new(node_symbols),
         symbol_arenas: (*program.symbol_arenas).clone(),
         declaration_arenas,
-        module_declaration_exports_publicly: FxHashMap::default(),
+        module_declaration_exports_publicly: Arc::new(FxHashMap::default()),
         scopes: Vec::new(),
         node_scope_ids: FxHashMap::default(),
         parse_diagnostics: Vec::new(),


### PR DESCRIPTION
## Summary

`module_declaration_exports_publicly: FxHashMap<u32, bool>` is populated during binding and read-only post-bind. Per-file binders previously deep-cloned this per binder construction.

Wrap in `Arc` end-to-end (`BinderState`, `BinderStateScopeInputs`, `BindResult`, `BoundFile`):

- Single binding-time mutation site (`.insert()` in module declaration binding) and 1 `.clear()` in `reset_for_file_bind` use `Arc::make_mut` (free when refcount=1 during bind).
- Per-file binder construction shares via `Arc::clone` (atomic refcount bump) instead of deep-cloning.

Same pattern as #1399 (lib_symbol_reverse_remap), #1404 (expando_properties), #1409 (switch_clause_to_switch).

## Test plan

- [x] cargo check --workspace — clean
- [x] cargo nextest run -p tsz-binder — 448 / 448 passed
- [x] cargo nextest run -p tsz-checker --lib — 2889 / 2889 passed
- [ ] CI conformance + emit + fourslash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
