### PR TITLE
feat(parser): add NodeArena::is_missing_recovery_identifier helper

### DIFF
--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -151,6 +151,31 @@ impl NodeArena {
         }
     }
 
+    /// Returns `true` when the node is an identifier synthesized by parser
+    /// error recovery — i.e. an empty-text identifier with `Atom::NONE`
+    /// produced by helpers like `create_missing_expression`. Distinguishes
+    /// recovery placeholders from genuine empty-named identifiers (which
+    /// the scanner would never produce, but downstream synthesizers might).
+    ///
+    /// Use this to suppress cascading diagnostics or skip semantic checks
+    /// that would treat a placeholder as a meaningful name. Codifies the
+    /// implicit `escaped_text.is_empty() && atom == Atom::NONE` heuristic
+    /// that several call sites already use ad-hoc, into a stable API.
+    ///
+    /// Robustness audit (PR #L, item 12 in
+    /// `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`).
+    #[inline]
+    #[must_use]
+    pub fn is_missing_recovery_identifier(&self, index: NodeIndex) -> bool {
+        let Some(node) = self.get(index) else {
+            return false;
+        };
+        let Some(ident) = self.get_identifier(node) else {
+            return false;
+        };
+        ident.atom == tsz_common::interner::Atom::NONE && ident.escaped_text.is_empty()
+    }
+
     /// Get the owned text of an `Identifier` node. Returns `None` for any
     /// other kind, including `PrivateIdentifier` — mirrors the common
     /// caller-side pattern that pre-filters on `SyntaxKind::Identifier`
@@ -1979,3 +2004,88 @@ impl Node {
 //  add_opt_child, add_list, add_opt_list)
 
 // NodeAccess trait and NodeInfo are in node_view.rs
+
+#[cfg(test)]
+mod is_missing_recovery_identifier_tests {
+    use super::*;
+    use crate::parser::node::NodeArena;
+    use tsz_common::interner::Atom;
+    use tsz_scanner::SyntaxKind;
+
+    #[test]
+    fn returns_true_for_synthesized_recovery_placeholder() {
+        let mut arena = NodeArena::with_capacity(8);
+        let idx = arena.add_identifier(
+            SyntaxKind::Identifier as u16,
+            0,
+            0,
+            IdentifierData {
+                atom: Atom::NONE,
+                escaped_text: String::new(),
+                original_text: None,
+                type_arguments: None,
+            },
+        );
+        assert!(arena.is_missing_recovery_identifier(idx));
+    }
+
+    #[test]
+    fn returns_false_for_real_named_identifier() {
+        let mut arena = NodeArena::with_capacity(8);
+        // A real identifier has a non-NONE atom AND non-empty escaped_text;
+        // either condition alone is enough for the helper to reject it.
+        let idx = arena.add_identifier(
+            SyntaxKind::Identifier as u16,
+            0,
+            3,
+            IdentifierData {
+                atom: Atom(1),
+                escaped_text: "foo".to_string(),
+                original_text: None,
+                type_arguments: None,
+            },
+        );
+        assert!(!arena.is_missing_recovery_identifier(idx));
+    }
+
+    #[test]
+    fn returns_false_when_only_atom_is_set() {
+        let mut arena = NodeArena::with_capacity(8);
+        let idx = arena.add_identifier(
+            SyntaxKind::Identifier as u16,
+            0,
+            0,
+            IdentifierData {
+                atom: Atom(1),
+                escaped_text: String::new(),
+                original_text: None,
+                type_arguments: None,
+            },
+        );
+        assert!(!arena.is_missing_recovery_identifier(idx));
+    }
+
+    #[test]
+    fn returns_false_when_only_escaped_text_is_set() {
+        let mut arena = NodeArena::with_capacity(8);
+        let idx = arena.add_identifier(
+            SyntaxKind::Identifier as u16,
+            0,
+            3,
+            IdentifierData {
+                atom: Atom::NONE,
+                escaped_text: "x".to_string(),
+                original_text: None,
+                type_arguments: None,
+            },
+        );
+        assert!(!arena.is_missing_recovery_identifier(idx));
+    }
+
+    #[test]
+    fn returns_false_for_non_identifier_node() {
+        let arena = NodeArena::with_capacity(8);
+        // Default-init NodeIndex points at nothing — get() returns None.
+        assert!(!arena.is_missing_recovery_identifier(NodeIndex::NONE));
+    }
+}


### PR DESCRIPTION
Foothold for **PR #L (item 12)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`create_missing_expression` (in `state.rs:2689`) builds an Identifier with `Atom::NONE` and empty `escaped_text` to keep the AST structurally valid during parser error recovery. Several downstream consumers re-derive that heuristic ad-hoc to distinguish recovery placeholders from real (empty) identifiers.

This change codifies the heuristic as a stable public API: `NodeArena::is_missing_recovery_identifier(idx) -> bool`. Returns `true` exactly when:

- The node is an Identifier (kind check via `get_identifier`).
- `atom == Atom::NONE`.
- `escaped_text.is_empty()`.

Both conditions are required — either alone could be a real identifier that happened to have lost its atom or its text.

The audit's full solution adds a dedicated syntax kind or flag bit, but flags storage on `Node` is u16 with no free bits, so a stable behavioral helper is the smallest viable visibility step today.

## Test plan
- [x] 5/5 new tests pass (`is_missing_recovery_identifier_tests` mod)
- [x] 673/673 existing parser tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
