### PR TITLE
fix(checker): gate fresh-literal property widening on freshness flag

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -257,6 +257,15 @@ impl<'a> CheckerState<'a> {
         else {
             return ty;
         };
+        // Only widen properties when the outer object type is itself a fresh
+        // object literal (e.g. inferred return type from `() => ({ a: 1 })`).
+        // Annotated types like `{ a: "x" }` carry the user's intent and must
+        // not have their literal property types widened away in diagnostics —
+        // tsc preserves them as-is, so when we receive a non-fresh shape here
+        // we have to leave it untouched.
+        if !crate::query_boundaries::common::is_fresh_object_type(self.ctx.types, ty) {
+            return ty;
+        }
         let mut widened_shape = shape.as_ref().clone();
         let mut changed = false;
         for prop in &mut widened_shape.properties {

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -4244,3 +4244,39 @@ u2.email = e;
         "Expected TS2412 for exact-optional property write mismatch, got: {diagnostics:#?}"
     );
 }
+
+/// Regression test for `widen_fresh_object_literal_properties_for_display`:
+/// the helper must only widen literal property types when the outer object
+/// is itself a *fresh* object literal. Annotated types like `{ a: "x" }`
+/// carry the user's intent and must not have their literal property types
+/// widened away in TS2741/TS2345 diagnostics.
+///
+/// Before the fix, `widen_fresh_object_literal_properties_for_display`
+/// always widened all literal properties regardless of freshness, so the
+/// annotated parameter type `{ a: "x" }` was rendered as `{ a: string; }`
+/// in TS2345/TS2741 diagnostics — diverging from `tsc`, which preserves
+/// `{ a: "x" }` because the user wrote it that way.
+#[test]
+fn test_ts2741_annotated_literal_target_preserves_literal_property() {
+    let source = r#"
+const fn1 = (s: { a: "x" }) => {};
+fn1({});
+"#;
+    let diagnostics = get_all_diagnostics(source);
+    let target_messages: Vec<&str> = diagnostics
+        .iter()
+        .map(|(_, message)| message.as_str())
+        .collect();
+    assert!(
+        target_messages
+            .iter()
+            .any(|m| m.contains("'{ a: \"x\"; }'")),
+        "expected annotated literal target `{{ a: \"x\"; }}` to be preserved verbatim, got: {target_messages:#?}"
+    );
+    assert!(
+        !target_messages
+            .iter()
+            .any(|m| m.contains("'{ a: string; }'")),
+        "annotated `{{ a: \"x\" }}` must not be widened to `{{ a: string; }}` in diagnostics, got: {target_messages:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

`widen_fresh_object_literal_properties_for_display` previously widened all literal property types regardless of object freshness, so annotated targets like `{ a: \"x\" }` rendered as `{ a: string; }` in TS2741/TS2345 diagnostics.

This diverged from `tsc`, which preserves the user's literal annotation. Match tsc by widening only when the outer object type is itself a fresh object literal (e.g. inferred return type of `() => ({ a: 1 })`). Annotated types preserve their literal property types.

## Diagnostic impact

Improves `typeSatisfaction_errorLocations1` fingerprint parity. After the fix the TS2741 target display reads:

```
Property 'a' is missing in type '{}' but required in type '{ a: true; }'.
```

instead of the previous (widened) form:

```
Property 'a' is missing in type '{}' but required in type '{ a: boolean; }'.
```

The conformance test still has other fingerprint differences (TS2322 `'1'` vs `'number'`, TS2345 missing on lines 17/19, position offsets) — those require separate fixes. This change is a clean step toward parity that doesn't regress anything else.

## Test plan
- [x] Add regression test `test_ts2741_annotated_literal_target_preserves_literal_property` in `crates/tsz-checker/tests/ts2322_tests.rs`
- [x] All 136 `tsz-checker::ts2322_tests` pass
- [x] All 2888 `tsz-checker` unit tests pass
- [x] Targeted conformance: 14/16 `typeSatisfaction*` tests pass (the 2 fails were already failing for different reasons)
- [x] No regressions on a 1000-test conformance smoke run