### PR TITLE
chore(lsp/signature_help): trace textual fallback entry points

### DIFF
--- a/crates/tsz-lsp/src/signature_help.rs
+++ b/crates/tsz-lsp/src/signature_help.rs
@@ -1982,6 +1982,18 @@ impl<'a> SignatureHelpProvider<'a> {
         &self,
         cursor_offset: u32,
     ) -> Option<TextualTypeArgumentTrigger> {
+        // Robustness audit (PR #F, item 6 in
+        // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`): emit a
+        // structured trace at every invocation so the rate at which
+        // signature help depends on byte-level source-text scanning is
+        // visible. The audit's full solution extracts an
+        // `IncompleteCallContext` / `IncompleteCodeQuery` service; this
+        // is the visibility-first foothold.
+        tracing::trace!(
+            site = "signature_help::find_textual_type_argument_trigger",
+            cursor_offset = cursor_offset,
+            "LSP signature help fell back to text-scanning for type-argument trigger"
+        );
         let bytes = self.source_text.as_bytes();
         if bytes.is_empty() {
             return None;
@@ -2061,6 +2073,12 @@ impl<'a> SignatureHelpProvider<'a> {
         cursor_offset: u32,
         type_cache: &mut Option<tsz_checker::TypeCache>,
     ) -> Option<SignatureHelp> {
+        // Audit PR #F: see `find_textual_type_argument_trigger`.
+        tracing::trace!(
+            site = "signature_help::signature_help_for_textual_call",
+            cursor_offset = cursor_offset,
+            "LSP signature help fell back to text-scanning for incomplete call site"
+        );
         let trigger = self.find_textual_call_trigger(cursor_offset)?;
         let callee_expr =
             self.find_identifier_node_at_offset(trigger.callee_offset, &trigger.callee_name)?;
@@ -2202,6 +2220,12 @@ impl<'a> SignatureHelpProvider<'a> {
         cursor_offset: u32,
         type_cache: &mut Option<tsz_checker::TypeCache>,
     ) -> Option<SignatureHelp> {
+        // Audit PR #F: see `find_textual_type_argument_trigger`.
+        tracing::trace!(
+            site = "signature_help::signature_help_for_textual_type_arguments",
+            cursor_offset = cursor_offset,
+            "LSP signature help fell back to text-scanning for type-argument completion"
+        );
         let trigger = self.find_textual_type_argument_trigger(cursor_offset)?;
         let callee_expr =
             self.find_identifier_node_at_offset(trigger.callee_offset, &trigger.callee_name)?;


### PR DESCRIPTION
Foothold for **PR #F (item 6)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

Three textual signature-help fallbacks back-scan source text bytes for incomplete call/type-argument trigger detection:

- `find_textual_type_argument_trigger`
- `signature_help_for_textual_call`
- `signature_help_for_textual_type_arguments`

The audit's concern: byte-level scanning is wrong for comments, strings, overloaded members, computed names, Unicode identifiers, declared interfaces, namespace-qualified names, etc.

This change adds `tracing::trace!` at each entry point with a `site=` label so the rate of textual-fallback usage and the cursor offsets that drive it are observable. Pure visibility addition; no behavior change.

The audit's full solution extracts an `IncompleteCallContext` / `IncompleteCodeQuery` service; this is the visibility-first foothold matching #1369, #1406, #1410, #1419.

## Test plan
- [x] 3733/3733 `tsz-lsp` tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
