### PR TITLE
feat(checker/context): add ParseHealth struct + parse_health() helper

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use compiler_options::should_resolve_jsdoc_for_file;
 mod constructors;
 mod core;
 mod def_mapping;
+mod parse_health;
+pub use parse_health::ParseHealth;
 mod import_extension_flags;
 mod lib_queries;
 mod module_entity;

--- a/crates/tsz-checker/src/context/parse_health.rs
+++ b/crates/tsz-checker/src/context/parse_health.rs
@@ -1,0 +1,81 @@
+//! Read-only summary of the source file's parse-health state.
+//!
+//! Bundles the dense cluster of parse-error booleans on `CheckerContext`
+//! (`has_parse_errors`, `has_syntax_parse_errors`, `has_real_syntax_errors`,
+//! `has_structural_parse_errors`) plus the four position vectors into a
+//! single value passed through diagnostic-emission code paths.
+//!
+//! Robustness audit (PR #I, item 9 in
+//! `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`).
+
+use super::CheckerContext;
+
+/// Read-only summary of the source file's parse-health state.
+///
+/// Diagnostic-emission paths can take a `ParseHealth` instead of reading
+/// individual mutable `CheckerContext` flags, reducing the risk of state
+/// leakage and nested-call confusion.
+#[derive(Debug, Clone, Copy)]
+pub struct ParseHealth<'b> {
+    pub has_parse_errors: bool,
+    pub has_syntax_parse_errors: bool,
+    pub has_real_syntax_errors: bool,
+    pub has_structural_parse_errors: bool,
+    pub syntax_parse_error_positions: &'b [u32],
+    pub real_syntax_error_positions: &'b [u32],
+    pub all_parse_error_positions: &'b [u32],
+    pub nullable_type_parse_error_positions: &'b [u32],
+}
+
+impl<'b> ParseHealth<'b> {
+    /// True when the file has any parse-related issue (broadest test). Use
+    /// this in suppression paths that should also fire for grammar-only
+    /// violations (e.g. TS2695 for malformed JSON).
+    #[inline]
+    #[must_use]
+    pub const fn has_any_parse_issue(&self) -> bool {
+        self.has_parse_errors
+            || self.has_syntax_parse_errors
+            || self.has_real_syntax_errors
+            || self.has_structural_parse_errors
+    }
+
+    /// True when at least one position vector contains the given start
+    /// position. Cheaper than letting callers walk all four vectors when
+    /// they only need a "near a parse error" check.
+    #[inline]
+    #[must_use]
+    pub fn any_position_contains(&self, pos: u32) -> bool {
+        self.syntax_parse_error_positions.contains(&pos)
+            || self.real_syntax_error_positions.contains(&pos)
+            || self.all_parse_error_positions.contains(&pos)
+            || self.nullable_type_parse_error_positions.contains(&pos)
+    }
+}
+
+impl<'a> CheckerContext<'a> {
+    /// Borrow the parse-health flags as a single read-only value.
+    ///
+    /// Intended replacement for direct field reads of `has_parse_errors`,
+    /// `has_syntax_parse_errors`, etc. New diagnostic-emission paths
+    /// should accept a `ParseHealth<'_>` argument instead of reaching
+    /// into `&CheckerContext` for the individual flags. Existing fields
+    /// stay public until callers migrate.
+    ///
+    /// Robustness audit (PR #I, item 9 in
+    /// `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`).
+    #[inline]
+    #[must_use]
+    pub fn parse_health(&self) -> ParseHealth<'_> {
+        ParseHealth {
+            has_parse_errors: self.has_parse_errors,
+            has_syntax_parse_errors: self.has_syntax_parse_errors,
+            has_real_syntax_errors: self.has_real_syntax_errors,
+            has_structural_parse_errors: self.has_structural_parse_errors,
+            syntax_parse_error_positions: &self.syntax_parse_error_positions,
+            real_syntax_error_positions: &self.real_syntax_error_positions,
+            all_parse_error_positions: &self.all_parse_error_positions,
+            nullable_type_parse_error_positions: &self.nullable_type_parse_error_positions,
+        }
+    }
+}

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Foothold for **PR #I (item 9)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`CheckerContext` exposes a dense cluster of parse-error booleans (`has_parse_errors`, `has_syntax_parse_errors`, `has_real_syntax_errors`, `has_structural_parse_errors`) plus four position vectors. Diagnostic emission paths read these as ambient mutable state, increasing the risk of state leakage on nested calls or missed restores.

This change adds a `ParseHealth` struct (in `crates/tsz-checker/src/context/parse_health.rs`) that bundles the four bools and four position slices into a single read-only value, plus a `CheckerContext::parse_health()` helper that returns a borrowed snapshot.

Two convenience methods:
- `has_any_parse_issue()` — broadest test (any of the four bools).
- `any_position_contains(pos)` — search across all four position vectors.

New diagnostic-emission paths should accept a `ParseHealth<'_>` argument instead of reaching into `&CheckerContext` for individual fields. The existing fields stay public until callers migrate one cluster at a time (per the audit's per-suppression migration plan).

Pure additive — no behavior change.

## Test plan
- [x] 2889/2889 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
