### PR TITLE
fix(checker): preserve outer index-signature target in TS2322 missing-property render

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -662,9 +662,19 @@ impl<'a> CheckerState<'a> {
         } else {
             self.format_type_diagnostic(source_type)
         };
-        let is_source_primitive = (source_type != tsz_solver::TypeId::OBJECT
-            && crate::query_boundaries::common::is_primitive_type(self.ctx.types, source_type))
-            || is_primitive_type_name(&display_src_str);
+        // Distinguish "outer source is primitive" (e.g. `let y: Foo = 42`) from
+        // "inner source_type is primitive" (e.g. assigning `{ one: number }` to
+        // `{ [k: string]: Foo }`, where the solver reports `MissingProperty(foo,
+        // src_ty=number, tgt_ty=Foo)` describing the failed nested check). In
+        // the first case we want the primitive-vs-target message; in the second
+        // we want the OUTER source/target shown, not the inner property types.
+        let outer_source_is_primitive =
+            crate::query_boundaries::common::is_primitive_type(self.ctx.types, source)
+                || is_primitive_type_name(&display_src_str);
+        let inner_source_type_is_primitive = source_type != tsz_solver::TypeId::OBJECT
+            && crate::query_boundaries::common::is_primitive_type(self.ctx.types, source_type);
+        let is_source_primitive =
+            outer_source_is_primitive || (depth > 0 && inner_source_type_is_primitive);
         if is_source_primitive {
             let tgt_str = self.format_type_diagnostic(target_type);
             let message = format_message(

--- a/crates/tsz-checker/tests/class_index_signature_compat_tests.rs
+++ b/crates/tsz-checker/tests/class_index_signature_compat_tests.rs
@@ -2,6 +2,53 @@
 
 use crate::test_utils::check_source_code_messages as compile_and_get_diagnostics;
 
+/// Regression for `numericIndexerConstraint2.ts`: when assigning a plain
+/// object to an indexed-access target whose value type has named members the
+/// source lacks, the solver returns a nested `MissingProperty` describing
+/// that inner mismatch (e.g. `MissingProperty { property_name: "foo",
+/// source_type: number, target_type: Foo }`). The renderer must still report
+/// the OUTER source/target in the TS2322 message — i.e. show the full index
+/// signature `{ [index: string]: Foo; }` as the target, not the inner value
+/// type `Foo`. Earlier code mis-classified the assignment as a "primitive
+/// source" because `source_type` (the inner property type) was primitive,
+/// even though the actual outer source is an object.
+#[test]
+fn ts2322_index_signature_target_displays_outer_type_when_inner_property_primitive_mismatches() {
+    let diags = compile_and_get_diagnostics(
+        r#"
+class Foo { foo() { } }
+declare var x: { [index: string]: Foo; };
+var a: { one: number; } = { one: 1 };
+x = a;
+"#,
+    );
+
+    let matching: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| {
+            *code == 2322
+                && msg.contains("Type '{ one: number; }'")
+                && msg.contains("not assignable to type '{ [index: string]: Foo; }'")
+        })
+        .collect();
+
+    assert!(
+        !matching.is_empty(),
+        "Expected TS2322 message naming the OUTER index-signature target '{{ [index: string]: Foo; }}', got: {diags:#?}",
+    );
+
+    // And we must NOT have leaked the inner property value type `'Foo'` into
+    // the top-level message.
+    let leaked_inner: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg)| *code == 2322 && msg.contains("not assignable to type 'Foo'."))
+        .collect();
+    assert!(
+        leaked_inner.is_empty(),
+        "TS2322 must not collapse to inner index value type 'Foo'; got: {diags:#?}",
+    );
+}
+
 #[test]
 fn class_extends_reports_incompatible_string_index_signature() {
     let diagnostics = compile_and_get_diagnostics(

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 

--- a/docs/plan/claims/fix-index-sig-target-display-ts2322.md
+++ b/docs/plan/claims/fix-index-sig-target-display-ts2322.md
@@ -1,0 +1,38 @@
+# fix(checker): preserve outer index-signature target in TS2322 missing-property render
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/index-sig-target-display-ts2322`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Conformance — fingerprint-only TS2322 fixes)
+
+## Intent
+
+Fix `numericIndexerConstraint2.ts` (and the wider class of similar tests
+where the solver's `MissingProperty` reason describes an inner index-
+signature value-type mismatch). The checker's `render_missing_property`
+currently mis-classifies these as "primitive source" cases because the
+inner `source_type` happens to be a primitive (e.g. `number` from
+`{ one: number }`), and then prints the inner value type (e.g. `Foo`) as
+the top-level target. tsc instead reports the OUTER source/target — e.g.
+`Type '{ one: number; }' is not assignable to type '{ [index: string]: Foo; }'.`.
+
+The fix tightens the `is_source_primitive` predicate so the primitive
+shortcut only triggers when the OUTER source itself is primitive (or
+displays as a primitive name). The pre-existing depth>0 behavior is
+preserved — nested renders still pass through the inner
+`source_type`/`target_type` for property-level elaboration.
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/render_failure.rs` (≈10 LOC change)
+- `crates/tsz-checker/tests/class_index_signature_compat_tests.rs`
+  (added regression test)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (2890/2890 pass)
+- `./scripts/conformance/conformance.sh run --filter numericIndexerConstraint2 --verbose`
+  flips from fingerprint-only FAIL to PASS
+- `./scripts/conformance/conformance.sh run --filter "indexedAccess"` /
+  `--filter "indexer"` / `--filter "primitive"` show no regressions vs main

--- a/docs/plan/claims/fix-index-sig-target-display-ts2322.md
+++ b/docs/plan/claims/fix-index-sig-target-display-ts2322.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/index-sig-target-display-ts2322`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1422
+- **Status**: ready
 - **Workstream**: 1 (Conformance — fingerprint-only TS2322 fixes)
 
 ## Intent


### PR DESCRIPTION
## Summary

- Fix `numericIndexerConstraint2.ts` (a fingerprint-only failure where we emitted the right TS2322 code but the wrong type display): tsc shows `Type '{ one: number; }' is not assignable to type '{ [index: string]: Foo; }'.` while we collapsed to `... not assignable to type 'Foo'.` (the inner index-signature value type).
- Root cause: in `render_missing_property` the `is_source_primitive` shortcut was triggering whenever the inner `source_type` from the `MissingProperty` reason was primitive, even when the outer `source` is an object. The shortcut then printed the inner `target_type` (e.g. `Foo`) as the top-level target.
- Fix: tighten the shortcut so it only fires when the OUTER `source` itself is primitive (or displays with a primitive name). Depth>0 (nested) renders still pass through inner property types so property-level elaboration is unchanged.

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` (2890/2890 pass)
- [x] `./scripts/conformance/conformance.sh run --filter numericIndexerConstraint2 --verbose` flips from fingerprint-only FAIL to PASS
- [x] No regressions on `--filter "indexedAccess"`, `--filter "indexer"`, `--filter "primitive"`
- [x] Pre-commit hooks (formatter / clippy / wasm warnings / arch guardrails / 13771 nextest) all pass
- [ ] Awaiting CI confirmation