### PR TITLE
ci: move benchmarks to Cloud Build c3-88, deploy website independently

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,12 +9,6 @@ on:
       - 'docs/architecture.html'
       - 'AGENTS.md'
       - '.github/workflows/gh-pages.yml'
-  # Disabled: CI completions create a nonstop stream of deploy triggers
-  # that cancel each other. Use schedule + manual dispatch instead.
-  # workflow_run:
-  #   workflows: ["CI"]
-  #   types: [completed]
-  #   branches: [main]
   schedule:
     - cron: '0 6 * * *'  # Daily at 6am UTC
   workflow_dispatch:
@@ -25,9 +19,8 @@ permissions:
   id-token: write
 
 concurrency:
-  # Full benchmark suite is ~75 minutes — never cancel one in flight.
-  # The `check` job below also early-exits if another deploy is already
-  # running, so in-between commits during a run are dropped (not queued).
+  # Never cancel an in-flight deploy — the check job skips if one is already
+  # running so we don't queue up stale work.
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
@@ -46,9 +39,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Bench is ~75 min. If another run is already in_progress we
-          # ignore this trigger entirely — when the running one finishes,
-          # the next *new* trigger gets to start fresh.
           IN_FLIGHT=$(gh api \
             "repos/${{ github.repository }}/actions/workflows/gh-pages.yml/runs?status=in_progress&per_page=20" \
             --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length")
@@ -67,75 +57,20 @@ jobs:
       - name: Check for changes since last deploy
         id: diff
         run: |
-          # If another run is already busy, drop this trigger entirely.
           if [ "${{ steps.in_flight.outputs.in_flight }}" = "true" ]; then
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          # Always deploy for non-schedule triggers
           if [ "${{ github.event_name }}" != "schedule" ]; then
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          # For schedule: check if there are new commits in the last 25 hours
           if git log --since="25 hours ago" --oneline | grep -q .; then
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "No changes since last deploy, skipping"
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           fi
-
-  benchmark:
-    needs: check
-    if: needs.check.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          # bench-vs-tsgo.sh uses .target-bench/ for LTO builds — cache it
-          workspaces: ". -> .target-bench"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install hyperfine
-        run: |
-          wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
-          sudo dpkg -i hyperfine_1.18.0_amd64.deb
-
-      - name: Run benchmarks
-        # Run the full benchmark suite (no --quick) so the website renders
-        # all categories instead of the ~16-entry quick subset.
-        # `continue-on-error` so the upload step still runs when individual
-        # benches OOM the GitHub runner (e.g. `large-ts-repo`); the bench
-        # script's EXIT trap writes whatever rows DID complete to
-        # artifacts/bench-vs-tsgo-*.json before exiting.
-        run: ./scripts/bench/bench-vs-tsgo.sh --json
-        timeout-minutes: 75
-        continue-on-error: true
-
-      - name: Upload benchmark data
-        # `if: always()` so we still upload the partial JSON written by the
-        # bench script's EXIT trap when the runner kills the bench midway.
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-data
-          path: artifacts/bench-vs-tsgo-*.json
-          retention-days: 7
-          if-no-files-found: warn
 
   wasm:
     needs: check
@@ -173,7 +108,7 @@ jobs:
           retention-days: 7
 
   build:
-    needs: [check, benchmark, wasm]
+    needs: [check, wasm]
     if: ${{ always() && needs.check.outputs.should_deploy == 'true' && !cancelled() && needs.wasm.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
@@ -183,23 +118,28 @@ jobs:
         with:
           node-version: '22'
 
-      # Download latest CI metrics if triggered by CI workflow
-      - name: Download CI metrics
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v4
-        with:
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-          pattern: ci-metrics-*
-          merge-multiple: true
-          path: .ci-metrics
-        continue-on-error: true
-
-      - name: Download benchmark data
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-data
-          path: crates/tsz-website/data
+      # Benchmarks now run on Cloud Build (c3-88, 88 vCPU) via cloudbuild-bench.yaml
+      # and publish results to GCS. We download the latest result here so the site
+      # always deploys immediately without waiting for a benchmark run.
+      - name: Download latest benchmark data from GCS
+        env:
+          SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+            echo "No GCS credentials — using checked-in benchmark data"
+            exit 0
+          fi
+          printf '%s' "$SCCACHE_GCS_KEY_JSON" > /tmp/gcs-key.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcs-key.json
+          LATEST=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/latest.json
+          if gsutil -q stat "$LATEST" 2>/dev/null; then
+            gsutil cp "$LATEST" crates/tsz-website/data/benchmarks.json
+            echo "Downloaded fresh benchmark data from GCS ($(date -u))"
+          else
+            echo "No latest.json in GCS yet — using checked-in benchmark data"
+          fi
+          rm -f /tmp/gcs-key.json
         continue-on-error: true
 
       - name: Download WASM
@@ -208,16 +148,6 @@ jobs:
           name: wasm-web
           path: pkg/web
         continue-on-error: true
-
-      # Rename to expected filename
-      - name: Prepare benchmark data
-        run: |
-          if ls crates/tsz-website/data/bench-vs-tsgo-*.json 1>/dev/null 2>&1; then
-            mv crates/tsz-website/data/bench-vs-tsgo-*.json crates/tsz-website/data/benchmarks.json
-            echo "Benchmark data ready"
-          else
-            echo "No benchmark data available, will use sample data"
-          fi
 
       - name: Install dependencies
         run: cd crates/tsz-website && npm install

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -1,0 +1,119 @@
+steps:
+  # Step 1: Acquire a GCS-backed mutex so only one benchmark runs at a time.
+  # If the lock is already held, we write nothing to /workspace and subsequent
+  # steps exit early — no duplicate benchmark runs ever overlap.
+  - id: acquire-lock
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
+      if gsutil -q stat "$LOCK_URI" 2>/dev/null; then
+        holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
+        echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
+      else
+        echo "$BUILD_ID" | gsutil cp -q - "$LOCK_URI"
+        echo "Lock acquired for BUILD_ID=$BUILD_ID"
+        touch /workspace/bench-enabled
+      fi
+
+  # Step 2: Run the full benchmark suite on the beefy c3-88 node.
+  - id: bench
+    name: rust:1.90-bookworm
+    timeout: 3000s
+    env:
+      - 'TSC_NPM_SPEC=6.0.2'
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      if [[ ! -f /workspace/bench-enabled ]]; then
+        echo "Benchmark skipped (another run is in progress)."
+        exit 0
+      fi
+
+      echo "=== Installing deps ==="
+      apt-get update -q
+      apt-get install -y -q hyperfine curl git jq
+      # Node.js 22
+      curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null
+      apt-get install -y -q nodejs
+
+      echo "=== Versions ==="
+      rustc --version && cargo --version && hyperfine --version && node --version
+
+      echo "=== Init TypeScript submodule (shallow — for benchmark fixtures) ==="
+      expected_ref="$(cat scripts/ci/typescript-submodule-ref | tr -d '[:space:]')"
+      echo "TypeScript ref: ${expected_ref}"
+      rm -rf TypeScript
+      git clone --filter=blob:none https://github.com/microsoft/TypeScript.git TypeScript
+      git -C TypeScript fetch --depth 1 origin "$expected_ref"
+      git -C TypeScript checkout --detach FETCH_HEAD
+      echo "TypeScript submodule ready"
+
+      echo "=== Running full benchmark ==="
+      ./scripts/bench/bench-vs-tsgo.sh \
+        --json \
+        --json-file /workspace/bench-results.json \
+        2>&1 | tee /workspace/bench-run.log
+
+  # Step 3: Publish results to GCS and trigger a website redeploy.
+  - id: publish
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
+      BENCH_BUCKET=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs
+
+      # Always release the lock when we exit (success or failure).
+      release_lock() {
+        if [[ -f /workspace/bench-enabled ]]; then
+          echo "Releasing benchmark lock..."
+          gsutil rm -f "$LOCK_URI" 2>/dev/null || true
+        fi
+      }
+      trap release_lock EXIT
+
+      if [[ ! -f /workspace/bench-enabled ]]; then
+        echo "Nothing to publish — benchmark was skipped."
+        exit 0
+      fi
+
+      if [[ ! -f /workspace/bench-results.json ]]; then
+        echo "No bench-results.json found — benchmark may have failed or timed out"
+        tail -100 /workspace/bench-run.log || true
+        exit 1
+      fi
+
+      echo "=== Publishing results ==="
+      TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+      gsutil cp /workspace/bench-results.json "${BENCH_BUCKET}/${TIMESTAMP}.json"
+      gsutil cp /workspace/bench-results.json "${BENCH_BUCKET}/latest.json"
+      echo "Saved to ${BENCH_BUCKET}/${TIMESTAMP}.json and latest.json"
+
+      echo "=== Triggering website redeploy ==="
+      GITHUB_TOKEN="$(gcloud secrets versions access latest \
+        --secret=github_runner_token --project=tsz-ci 2>/dev/null || true)"
+      if [[ -n "$GITHUB_TOKEN" ]]; then
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/mohsen1/tsz/actions/workflows/gh-pages.yml/dispatches \
+          -d '{"ref":"main"}')
+        if [[ "$http_code" == "204" ]]; then
+          echo "Website deploy triggered successfully."
+        else
+          echo "Warning: GitHub dispatch returned HTTP $http_code"
+        fi
+      else
+        echo "Warning: could not read github_runner_token — website not re-triggered"
+      fi
+
+options:
+  pool:
+    name: projects/thirdface-ai-oauth/locations/us-central1/workerPools/tsz-ci-c3-88
+  logging: CLOUD_LOGGING_ONLY
+  automapSubstitutions: true
+
+timeout: 3600s

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -1,5 +1,7 @@
 steps:
   # Step 1: Acquire a GCS-backed mutex so only one benchmark runs at a time.
+  # Uses x-goog-if-generation-match:0 for an atomic create — GCS rejects the
+  # write if the object already exists, eliminating the TOCTOU race.
   # If the lock is already held, we write nothing to /workspace and subsequent
   # steps exit early — no duplicate benchmark runs ever overlap.
   - id: acquire-lock
@@ -8,18 +10,20 @@ steps:
       #!/usr/bin/env bash
       set -euo pipefail
       LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
-      if gsutil -q stat "$LOCK_URI" 2>/dev/null; then
-        holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
-        echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
-      else
-        echo "$BUILD_ID" | gsutil cp -q - "$LOCK_URI"
+      if echo "$BUILD_ID" | gsutil -h 'x-goog-if-generation-match:0' cp -q - "$LOCK_URI" 2>/dev/null; then
         echo "Lock acquired for BUILD_ID=$BUILD_ID"
         touch /workspace/bench-enabled
+      else
+        holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
+        echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
       fi
 
   # Step 2: Run the full benchmark suite on the beefy c3-88 node.
+  # allowFailure: true ensures the publish step always runs even if bench
+  # crashes or times out, so the lock is always released.
   - id: bench
     name: rust:1.90-bookworm
+    allowFailure: true
     timeout: 3000s
     env:
       - 'TSC_NPM_SPEC=6.0.2'
@@ -83,7 +87,7 @@ steps:
       if [[ ! -f /workspace/bench-results.json ]]; then
         echo "No bench-results.json found — benchmark may have failed or timed out"
         tail -100 /workspace/bench-run.log || true
-        exit 1
+        exit 0  # lock is released by the EXIT trap; don't publish stale data
       fi
 
       echo "=== Publishing results ==="


### PR DESCRIPTION
## Summary

- **Removes** the `benchmark` job from `gh-pages.yml` — it ran on `ubuntu-latest` (2 vCPU), OOM'd on large suites, and blocked website deploys for 75+ minutes
- **Adds** `cloudbuild-bench.yaml`: a 3-step Cloud Build pipeline that runs on the private `tsz-ci-c3-88` pool (88 vCPU)
  - Step 1 (`acquire-lock`): GCS object mutex — only one benchmark in flight at a time; concurrent main pushes skip gracefully
  - Step 2 (`bench`): installs deps, clones TypeScript, runs `bench-vs-tsgo.sh --json`, streams log to `/workspace/bench-run.log`
  - Step 3 (`publish`): saves results to both `bench-runs/${TIMESTAMP}.json` and `bench-runs/latest.json`; triggers `gh-pages.yml` via `workflow_dispatch`; releases mutex on exit (including failures)
- **`gh-pages.yml` build job** now downloads `latest.json` from GCS at deploy time → website deploys immediately, always showing the latest benchmark data without waiting for a fresh run

## Infrastructure

Cloud Build trigger `tsz-bench-on-main-push` created in `thirdface-ai-oauth/us-central1` (2nd gen, GitHub connection `tsz-github`) pointing to `cloudbuild-bench.yaml`.

## Test plan
- [ ] Merge to main → Cloud Build trigger fires → benchmark runs on c3-88 → `latest.json` published to GCS
- [ ] Website deploy workflow runs → downloads `latest.json` → deploys updated site
- [ ] Second push to main while benchmark in progress → lock held → bench step skips cleanly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
