### PR TITLE
fix(checker): elaborate array-literal element TS2322 for generic param with concrete constraint

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1807,8 +1807,23 @@ impl<'a> CheckerState<'a> {
             Some(arr) => arr.clone(),
             None => return false,
         };
+        // When the call argument targets a generic parameter, normally we skip
+        // element-wise elaboration because the parameter type still contains
+        // unresolved type parameters. However, when the resolved target type
+        // (e.g., a constraint substituted in for a violated type parameter)
+        // is fully concrete, elaboration is safe and matches tsc's behavior
+        // of pointing at the offending element with TS2322.
         if self.call_argument_targets_generic_parameter(arg_idx) {
-            return false;
+            let db = self.ctx.types.as_type_database();
+            let target_unresolved =
+                crate::query_boundaries::common::contains_type_parameters(db, effective_param_type)
+                    || crate::query_boundaries::common::contains_infer_types(
+                        db,
+                        effective_param_type,
+                    );
+            if target_unresolved {
+                return false;
+            }
         }
 
         let ctx_helper = tsz_solver::ContextualTypeContext::with_expected_and_options(

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -48,8 +48,25 @@ impl<'a> CheckerState<'a> {
         let Some(arr) = self.ctx.arena.get_literal_expr(arg_node).cloned() else {
             return false;
         };
+        // When the call argument targets a generic parameter, normally we skip
+        // element-wise elaboration because the parameter type still contains
+        // unresolved type parameters and any element comparison would be
+        // meaningless. However, when the source and target types themselves
+        // are fully concrete (e.g., `number[]` vs `string[]` after a type
+        // parameter constraint violation has substituted the constraint as
+        // the target), elaboration is safe and matches tsc's behavior of
+        // pointing at the offending element with TS2322.
         if self.call_argument_targets_generic_parameter(arg_idx) {
-            return false;
+            let db = self.ctx.types.as_type_database();
+            let source_unresolved =
+                crate::query_boundaries::common::contains_type_parameters(db, source_type)
+                    || crate::query_boundaries::common::contains_infer_types(db, source_type);
+            let target_unresolved =
+                crate::query_boundaries::common::contains_type_parameters(db, target_type)
+                    || crate::query_boundaries::common::contains_infer_types(db, target_type);
+            if source_unresolved || target_unresolved {
+                return false;
+            }
         }
 
         let effective_target_type = self.evaluate_type_with_env(target_type);

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1958,9 +1958,16 @@ const result = f([["", true], ["", 0]]);
 "#;
         let errors = check_source_codes(source);
         let semantic_errors: Vec<_> = errors.into_iter().filter(|&c| c != 2318).collect();
+        // tsc emits TS2322 ("Type 'number' is not assignable to type 'boolean'.")
+        // on the inner element when V is inferred from the first entry
+        // and the second entry's V mismatches. Earlier we incorrectly
+        // surfaced TS2345 on the whole array argument because element-wise
+        // elaboration was suppressed for any call argument targeting a
+        // generic parameter; we now elaborate when the resolved target
+        // element type is concrete.
         assert!(
-            semantic_errors.contains(&2345),
-            "Heterogeneous generic entries should produce TS2345, got: {semantic_errors:?}"
+            semantic_errors.contains(&2322),
+            "Heterogeneous generic entries should produce TS2322 element elaboration, got: {semantic_errors:?}"
         );
     }
 

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -4280,3 +4280,56 @@ fn1({});
         "annotated `{{ a: \"x\" }}` must not be widened to `{{ a: string; }}` in diagnostics, got: {target_messages:#?}"
     );
 }
+
+/// Regression for `inferenceShouldFailOnEvolvingArrays.ts`:
+///
+/// Calling a generic function whose parameter type is `{ [K in U]: T }[U]`
+/// (e.g. `function f<T extends string[], U extends string>(arg: { [K in U]: T }[U])`)
+/// with an array literal whose element types violate the constraint of `T`
+/// (e.g. `f([42])` against `T extends string[]`) should produce a TS2322
+/// element-level error pointing at the offending element, matching tsc's
+/// behavior. Previously the elaboration was suppressed because the *raw*
+/// parameter type contains type parameters; the elaboration must still run
+/// when the resolved source/target types are concrete.
+#[test]
+fn ts2322_array_element_elaborated_when_generic_param_resolves_to_concrete_constraint() {
+    let source = r#"
+function logFirstLength<T extends string[], U extends string>(arg: { [K in U]: T }[U]): T {
+    return arg;
+}
+logFirstLength([42]);
+"#;
+    let options = CheckerOptions {
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    let diagnostics = with_lib_contexts(source, "test.ts", options);
+
+    let ts2322_count = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .count();
+    let ts2345_count = diagnostics
+        .iter()
+        .filter(|(code, _)| {
+            *code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .count();
+
+    assert!(
+        ts2322_count >= 1,
+        "Expected at least one TS2322 element elaboration for array-literal arg in generic call, got 0. Diagnostics: {diagnostics:#?}"
+    );
+    assert_eq!(
+        ts2345_count, 0,
+        "Expected no TS2345 on the whole array argument once element-level TS2322 is emitted. Diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, msg)| {
+            *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && msg.contains("'number'")
+                && msg.contains("'string'")
+        }),
+        "Expected TS2322 message mentioning 'number' and 'string' for the array element, got: {diagnostics:#?}"
+    );
+}

--- a/docs/plan/claims/fix-conformance-pick-1.md
+++ b/docs/plan/claims/fix-conformance-pick-1.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/conformance-pick-1`
-- **PR**: TBD
+- **PR**: #1424
 - **Status**: ready
 - **Workstream**: conformance fingerprint parity
 

--- a/docs/plan/claims/fix-conformance-pick-1.md
+++ b/docs/plan/claims/fix-conformance-pick-1.md
@@ -1,0 +1,41 @@
+# fix(checker): elaborate array-literal element error when generic param resolves to concrete
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/conformance-pick-1`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: conformance fingerprint parity
+
+## Intent
+
+When a call argument is an array literal targeting a generic parameter
+(e.g. `f<T extends string[], U extends string>(arg: { [K in U]: T }[U])`),
+both array-literal elaboration paths bailed out early via
+`call_argument_targets_generic_parameter`. tsc, however, still emits a
+TS2322 element-level error pointing at the offending element when
+inference falls back to the constraint and the resolved source/target
+types are concrete (e.g., `number[]` vs `string[]`).
+
+This change keeps the heuristic but only short-circuits when the
+*resolved* source/target types still contain unresolved type parameters
+or infer placeholders. When both sides are concrete, elaboration
+proceeds as it would for a non-generic call, matching tsc.
+
+Flips `inferenceShouldFailOnEvolvingArrays.ts` from FAIL to PASS.
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs` (+15 LOC)
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs` (+19 LOC)
+- `crates/tsz-checker/tests/ts2322_tests.rs` (+50 LOC regression test)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test ts2322_tests -E 'test(ts2322_array_element_elaborated_when_generic_param_resolves_to_concrete_constraint)'` (1 test passes)
+- `./scripts/conformance/conformance.sh run --filter "inferenceShouldFailOnEvolvingArrays"` (1/1 PASS)
+- `./scripts/conformance/conformance.sh run --filter "arrayLiteral"` (19/19 PASS)
+- `./scripts/conformance/conformance.sh run --filter "indexedAccess"` (13/13 PASS)
+- `./scripts/conformance/conformance.sh run --filter "elaboration"` (1/1 PASS)
+- `./scripts/conformance/conformance.sh run --filter "tuple"` (30/37 — same as baseline)
+- `./scripts/conformance/conformance.sh run --filter "mappedType"` (45/55 — same as baseline)
+- `./scripts/conformance/conformance.sh run --filter "callWith"` (9/9 PASS)


### PR DESCRIPTION
## Summary

When a call argument is an array literal targeting a generic parameter
(e.g. `f<T extends string[], U extends string>(arg: { [K in U]: T }[U])`),
both array-literal elaboration paths bailed out via
`call_argument_targets_generic_parameter`. tsc still emits a TS2322
element-level error pointing at the offending element when inference
falls back to the constraint and the resolved source/target types are
concrete (e.g. `number[]` vs `string[]`).

This change keeps the heuristic but only short-circuits when the
*resolved* source/target types still contain unresolved type parameters
or infer placeholders. When both sides are concrete, elaboration
proceeds as for a non-generic call, matching tsc's TS2322 element
elaboration.

Flips `inferenceShouldFailOnEvolvingArrays.ts` from FAIL to PASS.

## Conformance

- Target test: `TypeScript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts`
- Before: FAIL (missing TS2322 elements; extra TS2345 on whole array)
- After: PASS

## Test plan

- [x] Add regression test `ts2322_array_element_elaborated_when_generic_param_resolves_to_concrete_constraint`
- [x] `cargo nextest run -p tsz-checker --test ts2322_tests` (regression test passes)
- [x] `./scripts/conformance/conformance.sh run --filter "inferenceShouldFailOnEvolvingArrays"` (1/1 PASS)
- [x] No-regression smoke checks (arrayLiteral 19/19, indexedAccess 13/13, elaboration 1/1, tuple 30/37 same as baseline, mappedType 45/55 same as baseline, callWith 9/9)

## Architecture notes

Per CLAUDE.md §22: this fix is in the checker's elaboration helpers
(WHERE) — the diagnostic location/orchestration. It does not change any
solver relation (WHAT) and routes type-parameter detection through the
existing `query_boundaries::common::contains_type_parameters` /
`contains_infer_types` helpers.