### PR TITLE
chore(checker/module_resolution): trace module_specifier_candidates compatibility shim

### DIFF
--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -553,6 +553,18 @@ fn insert(
 /// No quoted / backslash / chain / dot-chain-variant / index / bare fan-out
 /// is produced.
 pub fn module_specifier_candidates(specifier: &str) -> Vec<String> {
+    // Robustness audit (PR #N, item 14 in
+    // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`): emit a structured
+    // trace at every invocation so the rate at which callers depend on this
+    // compatibility shim — and the specifiers that drive it — are visible.
+    // The audit's full solution collapses the legacy map and canonical-spec
+    // resolver into one entrypoint with one normalized key model; this
+    // visibility hook prepares the migration by exposing call sites.
+    tracing::trace!(
+        site = "module_resolution::module_specifier_candidates",
+        specifier = specifier,
+        "module-specifier compatibility-shim lookup"
+    );
     let Some(canonical) = normalize_import_specifier(specifier) else {
         // Quotes-only or empty input: the raw string is the only key the
         // caller could realistically match on.

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Foothold for **PR #N (item 14)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

`module_specifier_candidates` is a thin compatibility shim that builds multiple lookup keys for a module specifier (canonical, raw, extension-stripped stem) so legacy callers can probe maps keyed in different ways. The audit flags this shim as the visible symptom of two parallel resolver paths in `module_resolution.rs`: the new `resolve_from_source` entrypoint and the legacy `build_module_resolution_maps` flat map.

This change adds a single `tracing::trace!` at the shim's entry point with a `site=` label so:
- The rate at which legacy callers depend on multi-key fan-out is visible.
- Specific specifiers that drive the shim are observable.
- Future migration to a single normalized resolver (per audit #N's plan) can measure call-site coverage before flipping switches.

Pure visibility addition — no behavior change. Matches the foothold pattern from #1369, #1406, #1410, #1419, #1420.

## Test plan
- [x] 2889/2889 `tsz-checker` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
