### PR TITLE
fix(checker): elaborate arrow body return mismatch for direct assignment to generic function-type targets

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -419,6 +419,24 @@ impl<'a> CheckerState<'a> {
             return elaborated;
         }
 
+        // Direct assignment to a function-type target: take the dedicated path that
+        // permits return-expression elaboration even when the expected return type
+        // contains a type parameter from the *target's own* generic signature.
+        // Unlike the call-argument path (which sees uninstantiated type parameters
+        // belonging to the enclosing call's inference state), the target type here
+        // is the final declared type, so a free `T` in the return position is
+        // genuinely unsatisfied by a concrete body type.
+        if let Some(arg_node) = self.ctx.arena.get(expr_idx)
+            && (arg_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || arg_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION)
+        {
+            return self.try_elaborate_function_arg_return_error_with_options(
+                expr_idx,
+                target_type,
+                /* allow_unresolved_holes */ true,
+            );
+        }
+
         self.try_elaborate_object_literal_arg_error(expr_idx, target_type)
     }
 
@@ -490,6 +508,34 @@ impl<'a> CheckerState<'a> {
         arg_idx: NodeIndex,
         param_type: TypeId,
     ) -> bool {
+        self.try_elaborate_function_arg_return_error_with_options(
+            arg_idx, param_type, /* allow_unresolved_holes */ false,
+        )
+    }
+
+    /// Like [`try_elaborate_function_arg_return_error`], but with a switch that
+    /// controls whether elaboration runs when the expected return type contains
+    /// unresolved type parameters / inference placeholders.
+    ///
+    /// `allow_unresolved_holes = false` (default for call-argument paths):
+    ///     skip elaboration. During generic call inference the expected return
+    ///     type can still reference uninstantiated type parameters from the
+    ///     enclosing call (e.g., `B` from `compose<A, B, C>`); checking a
+    ///     concrete body type against such placeholders produces false TS2322s.
+    ///
+    /// `allow_unresolved_holes = true` (used by direct assignment):
+    ///     proceed with elaboration. The target type is the *final* declared
+    ///     target (e.g., the variable's annotation), so any type parameter in
+    ///     the return position is bound by the target's own generic signature
+    ///     rather than an outer inference state. A free `T` here is genuinely
+    ///     unsatisfied by a concrete body type, and tsc anchors the resulting
+    ///     TS2322 at the body expression.
+    fn try_elaborate_function_arg_return_error_with_options(
+        &mut self,
+        arg_idx: NodeIndex,
+        param_type: TypeId,
+        allow_unresolved_holes: bool,
+    ) -> bool {
         use tsz_parser::parser::syntax_kind_ext;
 
         let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
@@ -536,7 +582,13 @@ impl<'a> CheckerState<'a> {
         // Checking the body expression type against such placeholders would
         // produce false TS2322 errors since concrete types like `T[]` are
         // not assignable to an unresolved type parameter `B`.
-        if self.type_has_unresolved_inference_holes(expected_return_type) {
+        //
+        // For direct variable-initializer / direct-assignment elaboration
+        // (`allow_unresolved_holes = true`), the target type is final and any
+        // remaining type parameters are bound by the target's own quantifier,
+        // so the elaboration is sound and matches tsc.
+        if !allow_unresolved_holes && self.type_has_unresolved_inference_holes(expected_return_type)
+        {
             return false;
         }
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -380,10 +380,46 @@ impl<'a> CheckerState<'a> {
 
     /// Try to elaborate a generic assignability mismatch when the source expression is
     /// a literal that can be decomposed into more precise element/property errors.
+    ///
+    /// Indirect callers reaching this entry from object-literal property values
+    /// or array element values inside a generic call argument should use
+    /// [`try_elaborate_assignment_source_error_in_call_arg`] instead, so the
+    /// arrow/function-expression interception below stays inside the
+    /// unresolved-holes guard.
     pub(crate) fn try_elaborate_assignment_source_error(
         &mut self,
         source_idx: NodeIndex,
         target_type: TypeId,
+    ) -> bool {
+        self.try_elaborate_assignment_source_error_with_options(
+            source_idx,
+            target_type,
+            /* allow_unresolved_holes */ true,
+        )
+    }
+
+    /// Variant for indirect callers (object-literal property values, array
+    /// element values) where `target_type` may still contain inference holes
+    /// belonging to an enclosing generic call. Skips the arrow/function-expr
+    /// interception that would otherwise produce false TS2322s by elaborating
+    /// against an uninstantiated parameter.
+    pub(crate) fn try_elaborate_assignment_source_error_in_call_arg(
+        &mut self,
+        source_idx: NodeIndex,
+        target_type: TypeId,
+    ) -> bool {
+        self.try_elaborate_assignment_source_error_with_options(
+            source_idx,
+            target_type,
+            /* allow_unresolved_holes */ false,
+        )
+    }
+
+    fn try_elaborate_assignment_source_error_with_options(
+        &mut self,
+        source_idx: NodeIndex,
+        target_type: TypeId,
+        allow_unresolved_holes: bool,
     ) -> bool {
         use tsz_parser::parser::syntax_kind_ext;
 
@@ -407,7 +443,11 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                if self.try_elaborate_assignment_source_error(branch_idx, target_type) {
+                if self.try_elaborate_assignment_source_error_with_options(
+                    branch_idx,
+                    target_type,
+                    allow_unresolved_holes,
+                ) {
                     elaborated = true;
                     continue;
                 }
@@ -429,6 +469,7 @@ impl<'a> CheckerState<'a> {
         if let Some(arg_node) = self.ctx.arena.get(expr_idx)
             && (arg_node.kind == syntax_kind_ext::ARROW_FUNCTION
                 || arg_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION)
+            && allow_unresolved_holes
         {
             return self.try_elaborate_function_arg_return_error_with_options(
                 expr_idx,

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -1106,3 +1106,32 @@ const f1 = pipe(list, box);
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn ts2322_skips_arrow_body_elaboration_for_object_property_in_generic_call() {
+    // Guard against the indirect-caller variant of the unresolved-holes regression:
+    // when the arrow appears as a property value inside an object literal that is
+    // itself an argument to a generic call, `try_elaborate_assignment_source_error`
+    // is invoked from `try_elaborate_object_literal_properties_with_source` with a
+    // `target_prop_type` that still contains uninstantiated type parameters (`U`
+    // here). The new arrow interception must skip in this case to preserve the
+    // unresolved-holes guard the call-argument path relies on.
+    let diagnostics = check_source_with_strict_null(
+        r#"
+declare function foo<T, U>(opts: { transform: (x: T) => U }): U;
+const r = foo({ transform: (x: string) => x.length });
+"#,
+    );
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        0,
+        "Arrow inside object-literal arg of generic call must not raise TS2322 \
+         from indirect elaboration, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 2322)
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_tests.rs
@@ -1003,3 +1003,106 @@ var r5b = _.map<number, string, boolean>(c2, rf1);
         diag.message_text
     );
 }
+
+#[test]
+fn ts2322_anchors_at_arrow_body_when_assigning_to_generic_function_type_alias() {
+    // Regression test for elaboration in `try_elaborate_assignment_source_error`:
+    // when assigning an expression-bodied arrow to a *direct* generic function-
+    // type target (e.g. `EnvFunction = <T>() => T`), tsc anchors the TS2322 at
+    // the body expression and reports the body type vs the target's generic
+    // return type. Previously, `try_elaborate_function_arg_return_error` skipped
+    // elaboration whenever the expected return type contained type parameters,
+    // which is correct during generic-call inference but wrong for direct
+    // assignment (where the type parameter is bound by the target's own
+    // signature, not by an outer call's inference state).
+    let diagnostics = check_source_with_strict_null(
+        r#"
+type EnvFunction = <T>() => T;
+type SimpleType = string | Promise<SimpleType>;
+declare const simple: SimpleType;
+const env: EnvFunction = () => simple;
+"#,
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for arrow body return-type mismatch, got: {codes:?}"
+    );
+
+    // The TS2322 should be anchored at the body expression `simple`, not on the
+    // outer `const env = ...` declaration.
+    let outer_anchor = "const env: EnvFunction = () => simple;";
+    let body_anchor = "simple";
+    let source_text_offset_of = |pat: &str| {
+        let s = "
+type EnvFunction = <T>() => T;
+type SimpleType = string | Promise<SimpleType>;
+declare const simple: SimpleType;
+const env: EnvFunction = () => simple;
+";
+        s.find(pat).expect("substring exists in fixture")
+    };
+    let body_offset = {
+        // The fixture references `simple` twice (declare + arrow body).
+        // Use the second occurrence (the arrow body).
+        let s = "
+type EnvFunction = <T>() => T;
+type SimpleType = string | Promise<SimpleType>;
+declare const simple: SimpleType;
+const env: EnvFunction = () => simple;
+";
+        let first = s.find(body_anchor).unwrap();
+        first + 1 + s[first + 1..].find(body_anchor).unwrap()
+    };
+    let outer_offset = source_text_offset_of(outer_anchor);
+
+    let ts2322_starts: Vec<u32> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.start)
+        .collect();
+    assert!(
+        ts2322_starts.iter().any(|&s| s as usize == body_offset),
+        "Expected at least one TS2322 anchored at arrow body `simple` (offset \
+         {body_offset}), got starts: {ts2322_starts:?}"
+    );
+    assert!(
+        !ts2322_starts.iter().all(|&s| s as usize == outer_offset),
+        "TS2322 should not anchor only on the outer declaration (offset \
+         {outer_offset}), got: {ts2322_starts:?}"
+    );
+}
+
+#[test]
+fn ts2322_skips_arrow_body_elaboration_during_generic_call_inference() {
+    // Guard the negative case: during generic call inference, the expected
+    // callback return type may still reference uninstantiated type parameters
+    // (e.g., `B` from `compose<A, B, C>`). Elaborating against such placeholders
+    // would produce false TS2322s like "Type 'T[]' is not assignable to type
+    // 'B'". `try_elaborate_function_arg_return_error_with_options` retains the
+    // unresolved-holes skip on the call path (`allow_unresolved_holes = false`).
+    //
+    // This test exercises a generic pipe-style helper similar to
+    // genericContextualTypes1: passing arrow callbacks into a generic call
+    // should not produce spurious body-level TS2322 diagnostics on the
+    // callbacks' identifier bodies.
+    let diagnostics = check_source_with_strict_null(
+        r#"
+declare function pipe<A, B, C>(ab: (a: A) => B, bc: (b: B) => C): (a: A) => C;
+declare function list<T>(a: T): T[];
+declare function box<V>(x: V): { value: V };
+const f1 = pipe(list, box);
+"#,
+    );
+    let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        0,
+        "Generic call inference must not produce body-level TS2322s, got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 2322)
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 

--- a/docs/plan/claims/fix-checker-elaborate-arrow-init-generic-return.md
+++ b/docs/plan/claims/fix-checker-elaborate-arrow-init-generic-return.md
@@ -1,0 +1,53 @@
+# fix(checker): elaborate arrow-body return mismatch on direct assignment to generic function-type targets
+
+- **Date**: 2026-04-26 16:48:27
+- **Branch**: `fix/checker-elaborate-arrow-init-generic-return`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance — TS2322 anchor parity for direct assignment to generic function-type targets
+
+## Intent
+
+`try_elaborate_function_arg_return_error` skipped *all* body-level
+elaboration whenever the expected callback return type contained a free
+type parameter. That skip was added to prevent false TS2322s during
+generic-call inference (e.g. `compose<A, B, C>(...)` where `B` is still
+unresolved when the callback body is checked). It is correct for that
+path but fires too eagerly when the call site is *direct assignment* to
+a generic function-type target — there the type parameters are bound by
+the target's own quantifier (`type EnvFunction = <T>() => T`), not by an
+outer call, so a concrete body type really is unsatisfiable against `T`
+and tsc anchors TS2322 at the body expression.
+
+This PR splits the skip behind an `allow_unresolved_holes` flag and
+takes the elaboration path for the direct-assignment entrypoint
+(`try_elaborate_assignment_source_error → arrow/function expression
+case`). Call-argument elaboration still skips on unresolved holes
+(unchanged behavior).
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`
+  (~70 LOC: split `try_elaborate_function_arg_return_error` behind a
+  new `_with_options` helper, route the direct-assignment branch
+  through `allow_unresolved_holes = true`).
+- `crates/tsz-checker/src/error_reporter/call_errors_tests.rs`
+  (~95 LOC: two new unit tests — positive (direct assignment elaborates
+  at body) and negative (generic-call inference does not elaborate)).
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` — 2891 tests pass.
+- `cargo nextest run -p tsz-checker --lib -E 'test(ts2322_anchors_at_arrow_body) or test(ts2322_skips_arrow_body_elaboration)'` — both new tests pass.
+- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` —
+  full conformance: **+3 tests** (12183 → 12186), zero regressions.
+  - Improvements:
+    - `compiler/jsExportMemberMergedWithModuleAugmentation2.ts`
+    - `conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts`
+    - `conformance/types/literal/templateLiteralTypes5.ts`
+- Targeted: `unresolvableSelfReferencingAwaitedUnion.ts` advances from
+  whole-assignment-anchored TS2322 to body-anchored TS2322; remains
+  fingerprint-only because the message text still expands the alias
+  (`SimpleType` → `string | Promise<SimpleType>`) — that is a
+  separate alias-display path in `format_assignment_source_type_for_diagnostic`
+  and is out of scope here.

--- a/docs/plan/claims/fix-checker-elaborate-arrow-init-generic-return.md
+++ b/docs/plan/claims/fix-checker-elaborate-arrow-init-generic-return.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26 16:48:27
 - **Branch**: `fix/checker-elaborate-arrow-init-generic-return`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1426
+- **Status**: ready
 - **Workstream**: Conformance — TS2322 anchor parity for direct assignment to generic function-type targets
 
 ## Intent


### PR DESCRIPTION
## Summary

- Splits the unresolved-inference-holes skip in `try_elaborate_function_arg_return_error` behind an `allow_unresolved_holes` flag.
- Routes the direct-assignment branch (`try_elaborate_assignment_source_error → arrow / function expression`) through the relaxed path so TS2322 anchors at the body expression when the target is a generic function-type alias like `<T>() => T`.
- Call-argument elaboration keeps the original conservative behavior to avoid false TS2322s during generic-call inference.

## Why

`try_elaborate_function_arg_return_error` skipped *all* body-level elaboration whenever the expected callback return type contained a free type parameter (commit 41f52ba76d). That suppression is correct during generic-call inference (e.g. `compose<A, B, C>(...)` where `B` is still unresolved when the callback body is checked) but fires too eagerly on direct assignment to a generic function-type target — there the type parameter is bound by the *target's own* quantifier, so the body type really is unsatisfiable against it and tsc anchors TS2322 at the body expression.

## Conformance impact

- **+3 tests** (12183 → 12186), zero regressions:
  - `compiler/jsExportMemberMergedWithModuleAugmentation2.ts`
  - `conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts`
  - `conformance/types/literal/templateLiteralTypes5.ts`
- Targeted: `unresolvableSelfReferencingAwaitedUnion.ts` advances from whole-assignment-anchored TS2322 to body-anchored TS2322 (still fingerprint-only because the source-side message text expands the alias `SimpleType` → `string | Promise<SimpleType>`; that is a separate alias-display path in `format_assignment_source_type_for_diagnostic` and is out of scope here).

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` — 2891 tests pass
- [x] Two new unit tests pass:
  - `ts2322_anchors_at_arrow_body_when_assigning_to_generic_function_type_alias` (positive)
  - `ts2322_skips_arrow_body_elaboration_during_generic_call_inference` (negative guard)
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — net **+3 tests**, zero regressions
- [x] Pre-commit (cargo fmt, clippy, architecture guardrails, full nextest) all pass