### PR TITLE
docs(checker,binder): clarify intentional design behind lib-bypass + merge-skip

### DIFF
--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -282,6 +282,23 @@ impl BinderState {
             return Some(found);
         }
 
+        // Pre-merge: lib symbols still live in their per-lib `file_locals`,
+        // so we have to traverse `lib_binders` directly to find them.
+        //
+        // Post-merge: every globally-visible lib symbol has been hoisted into
+        // `self.file_locals` by `merge_lib_contexts_into_binder` (Phase 3).
+        // Module-scoped lib names that do NOT belong in the global scope are
+        // intentionally excluded from the merge — re-walking `lib_binders`
+        // would put them back. Callers that legitimately need access to those
+        // module-scoped lib symbols (lib augmentation handlers, the checker's
+        // type-position resolver) probe `lib_contexts.file_locals` themselves
+        // and apply their own scope-filter.
+        //
+        // Robustness audit (PR #B, item 2 in
+        // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`): the gating is
+        // deliberate, not a bug. See the matching comments in
+        // `crates/tsz-checker/src/symbols/symbol_resolver.rs` at the
+        // `resolve_identifier_symbol` and `resolve_type_symbol` fallbacks.
         if !self.lib_symbols_merged {
             for lib_binder in lib_binders {
                 if let Some(sym_id) = lib_binder.file_locals.get(name)

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -456,11 +456,37 @@ impl<'a> CheckerState<'a> {
         );
 
         // IMPORTANT: If the binder didn't find the symbol, check lib_contexts directly as a fallback.
-        // The binder's method has a bug where it only queries lib_binders when lib_symbols_merged is FALSE.
-        // After lib symbols are merged into the main binder, lib_symbols_merged is set to TRUE,
-        // causing the binder to skip lib lookup entirely. By checking lib_contexts.file_locals
-        // directly here as a fallback, we bypass that bug and ensure global symbols are always resolved.
-        // This matches the pattern used successfully in generators.rs (lookup_global_type).
+        //
+        // # Why this fallback exists (and why it is NOT a bug)
+        //
+        // The binder's `resolve_identifier_with_filter` deliberately gates its
+        // `lib_binders` traversal on `!self.lib_symbols_merged`. After
+        // `merge_lib_contexts_into_binder` runs, the main binder's `file_locals`
+        // is supposed to carry every globally-visible lib symbol — so the
+        // binder skips re-walking `lib_binders` to avoid re-introducing the
+        // symbols it just merged.
+        //
+        // Phase 3 of the merge intentionally EXCLUDES file_locals belonging to
+        // external-module lib files unless the name appears in the lib's
+        // `global_augmentations` map (`crates/tsz-binder/src/state/lib_merge.rs`,
+        // around the `is_external_module && !global_augmentations.contains_key`
+        // check). This prevents module-scoped names like the `class Iterator`
+        // in `es2025.iterator.d.ts` from contaminating the global scope of
+        // user code that doesn't explicitly augment.
+        //
+        // BUT: some lookups DO need access to those module-scoped lib symbols
+        // (e.g. when generators.rs walks the iterator chain). The fallback
+        // below queries `lib_contexts.file_locals` directly so those callers
+        // can find the symbol. `should_skip_lib_symbol` filters the candidates
+        // to keep the global pollution boundary intact.
+        //
+        // Robustness audit (PR #B, item 2 in
+        // `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`): the audit's
+        // initial framing ("the binder has a bug") was misleading — the
+        // skip-after-merge is deliberate, and the divergence is a coordinated
+        // policy. A future restructure should hoist the merge-phase filter and
+        // the checker-side fallback into a single declarative resolver
+        // boundary so the policy is co-located.
         if result.is_none() && !ignore_libs {
             // Get the identifier name
             let name = if let Some(ident) = self.ctx.arena.get_identifier_at(idx) {
@@ -726,12 +752,24 @@ impl<'a> CheckerState<'a> {
         };
 
         // IMPORTANT: Check lib_contexts directly BEFORE calling binder's resolve_identifier_with_filter.
-        // The binder's method has a bug where it only queries lib_binders when lib_symbols_merged is FALSE.
-        // After lib symbols are merged into the main binder, lib_symbols_merged is set to TRUE,
-        // causing the binder to skip lib lookup entirely. By checking lib_contexts.file_locals
-        // directly here, we bypass that bug and ensure global type symbols are always resolved.
-        // However, skip this early check when the name is declared in a local scope (namespace, etc.)
-        // so that local symbols can shadow global ones.
+        //
+        // The binder's `resolve_identifier_with_filter` skips `lib_binders` when
+        // `self.lib_symbols_merged == true`. The skip is deliberate (see the
+        // long comment at `resolve_identifier_symbol` above for why), but the
+        // merge phase intentionally excludes external-module lib file_locals
+        // unless the name is in `global_augmentations`. For type-position
+        // resolution we still need access to those module-scoped lib symbols
+        // (e.g. lib types referenced from user augmentations), so we probe
+        // `lib_contexts.file_locals` directly here.
+        //
+        // The `name_in_local_scope` short-circuit ensures local declarations
+        // (namespaces, modules) shadow global lib types — without it, an
+        // ambient `class Iterator` in a target lib would mask a user-defined
+        // namespace-local `Iterator`.
+        //
+        // Robustness audit (PR #B, item 2): see the matching comment at
+        // `resolve_identifier_symbol`. This is the type-position twin of
+        // that bypass.
         if !ignore_libs && !name_in_local_scope {
             for lib_ctx in self.ctx.lib_contexts.iter() {
                 if let Some(lib_sym_id) = lib_ctx.binder.file_locals.get(name) {

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Foothold for **PR #B (item 2)** from `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

The audit framed the checker's `lib_contexts.file_locals` bypass and the binder's post-merge `lib_binders` skip as "the binder has a bug; bypass it". Investigation showed the framing is misleading: the skip-after-merge is **deliberate**, the merge phase intentionally excludes external-module `file_locals` from the global scope (see Phase 3 of `merge_lib_contexts_into_binder`), and the checker's bypass exists precisely to give type-position lookups access to those intentionally non-merged module-scoped lib symbols. The two halves are a coordinated policy spread across two crates, not a buggy patchwork.

This change replaces the misleading "there is a bug" comments at three sites with a long-form explanation of the merge-phase contract:

- `crates/tsz-checker/src/symbols/symbol_resolver.rs` — `resolve_identifier_symbol` fallback (value position)
- `crates/tsz-checker/src/symbols/symbol_resolver.rs` — `resolve_type_symbol` early-check (type position)
- `crates/tsz-binder/src/state/resolution.rs` — `resolve_identifier_with_filter` post-merge skip

Each comment now points to its sibling and to the audit item, so a future reader can find the policy boundary without re-deriving it.

Pure documentation — no behavior change. The audit's full PR #B ("unify the two halves into a single declarative resolver boundary") remains future work.

## Test plan
- [x] 2889/2889 `tsz-checker` lib tests pass
- [x] 321/321 `tsz-binder` lib tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
