### PR TITLE
perf(binder): Arc-wrap node_scope_ids for shared per-file binders

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -108,7 +108,7 @@ impl BinderState {
 
             if is_global_augmentation {
                 if module.body.is_some() {
-                    self.node_scope_ids
+                    Arc::make_mut(&mut self.node_scope_ids)
                         .insert(module.body.0, self.current_scope_id);
                     // Set flag so interface declarations inside are tracked as augmentations
                     let was_in_global_augmentation = self.in_global_augmentation;
@@ -161,7 +161,7 @@ impl BinderState {
                             Arc::make_mut(&mut self.shorthand_ambient_modules)
                                 .insert(module_specifier);
                         } else {
-                            self.node_scope_ids
+                            Arc::make_mut(&mut self.node_scope_ids)
                                 .insert(module.body.0, self.current_scope_id);
                             let was_in_augmentation = self.in_module_augmentation;
                             let prev_module = self.current_augmented_module.take();
@@ -287,7 +287,7 @@ impl BinderState {
                     Arc::make_mut(&mut self.shorthand_ambient_modules).insert(lit.text.clone());
                 }
             } else {
-                self.node_scope_ids
+                Arc::make_mut(&mut self.node_scope_ids)
                     .insert(module.body.0, self.current_scope_id);
             }
 

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -42,7 +42,10 @@ fn is_js_like_file_name(file_name: &str) -> bool {
 }
 
 impl BinderStateScopeInputs {
-    pub(super) fn with_scopes(scopes: Vec<Scope>, node_scope_ids: FxHashMap<u32, ScopeId>) -> Self {
+    pub(super) fn with_scopes(
+        scopes: Vec<Scope>,
+        node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
+    ) -> Self {
         Self {
             scopes,
             node_scope_ids,
@@ -194,7 +197,7 @@ impl BinderState {
             hoisted_vars: Vec::new(),
             hoisted_functions: Vec::new(),
             scopes: Vec::with_capacity(32),
-            node_scope_ids: FxHashMap::with_capacity_and_hasher(64, Default::default()),
+            node_scope_ids: Arc::new(FxHashMap::with_capacity_and_hasher(64, Default::default())),
             current_scope_id: ScopeId::NONE,
             debugger: ModuleResolutionDebugger::new(),
             global_augmentations: Arc::new(FxHashMap::default()),
@@ -264,7 +267,7 @@ impl BinderState {
         self.hoisted_vars.clear();
         self.hoisted_functions.clear();
         self.scopes.clear();
-        self.node_scope_ids.clear();
+        Arc::make_mut(&mut self.node_scope_ids).clear();
         self.current_scope_id = ScopeId::NONE;
         self.debugger.clear();
         Arc::make_mut(&mut self.global_augmentations).clear();
@@ -436,7 +439,7 @@ impl BinderState {
             hoisted_vars: Vec::new(),
             hoisted_functions: Vec::new(),
             scopes: Vec::new(),
-            node_scope_ids: FxHashMap::default(),
+            node_scope_ids: Arc::new(FxHashMap::default()),
             current_scope_id: ScopeId::NONE,
             debugger: ModuleResolutionDebugger::new(),
             global_augmentations: Arc::new(FxHashMap::default()),
@@ -478,7 +481,7 @@ impl BinderState {
         file_locals: SymbolTable,
         node_symbols: Arc<FxHashMap<u32, SymbolId>>,
         scopes: Vec<Scope>,
-        node_scope_ids: FxHashMap<u32, ScopeId>,
+        node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
     ) -> Self {
         Self::from_bound_state_with_scopes_and_augmentations(
             BinderOptions::default(),
@@ -638,7 +641,7 @@ impl BinderState {
 
         // Map node to this scope
         if node.is_some() {
-            self.node_scope_ids.insert(node.0, new_scope_id);
+            Arc::make_mut(&mut self.node_scope_ids).insert(node.0, new_scope_id);
         }
 
         // Update current scope
@@ -1019,7 +1022,7 @@ impl BinderState {
 
         // Initialize persistent scope system
         self.scopes.clear();
-        self.node_scope_ids.clear();
+        Arc::make_mut(&mut self.node_scope_ids).clear();
         self.current_scope_id = ScopeId::NONE;
         self.top_level_flow.clear();
 
@@ -1818,7 +1821,7 @@ impl BinderState {
         };
 
         Arc::make_mut(&mut self.node_flow).retain(|node_id, _| keep_node(node_id));
-        self.node_scope_ids.retain(|node_id, _| keep_node(node_id));
+        Arc::make_mut(&mut self.node_scope_ids).retain(|node_id, _| keep_node(node_id));
         Arc::make_mut(&mut self.switch_clause_to_switch).retain(|node_id, _| keep_node(node_id));
     }
 }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -342,8 +342,13 @@ pub struct BinderState {
     // ===== Persistent Scope System (for stateless checking) =====
     /// Persistent scopes - enables querying scope information without traversal order
     pub scopes: Vec<Scope>,
-    /// Map from AST node (that creates a scope) to its `ScopeId`
-    pub node_scope_ids: FxHashMap<u32, ScopeId>,
+    /// Map from AST node (that creates a scope) to its `ScopeId`.
+    ///
+    /// `Arc`-wrapped so per-file binders constructed by the CLI driver
+    /// share via `Arc::clone` instead of deep-cloning. Mutated only
+    /// during binding (in `state/core.rs::enter_persistent_scope` and
+    /// `modules/binding.rs`); read-only post-bind.
+    pub node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
     /// Current active `ScopeId` during binding
     pub current_scope_id: ScopeId,
 
@@ -910,7 +915,7 @@ pub struct ResolutionStats {
 #[derive(Debug, Default)]
 pub struct BinderStateScopeInputs {
     pub scopes: Vec<Scope>,
-    pub node_scope_ids: FxHashMap<u32, ScopeId>,
+    pub node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
     pub global_augmentations: Arc<FxHashMap<String, Vec<GlobalAugmentation>>>,
     pub module_augmentations: Arc<FxHashMap<String, Vec<ModuleAugmentation>>>,
     pub augmentation_target_modules: Arc<FxHashMap<SymbolId, String>>,

--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -152,12 +152,12 @@ const l1: L1 = 2; // Must not error
     );
 }
 
-/// Downstream check: BuildTree recursive conditional type should terminate
+/// Downstream check: `BuildTree` recursive conditional type should terminate
 /// at depth N now that `Prepend<V, T>` infers correctly for mixed
 /// fixed+rest params.
 ///
 /// Without the `match_rest_infer_tuple` fix, `Prepend<any, I>` collapsed
-/// to `any` and BuildTree never terminated, producing a false TS2741.
+/// to `any` and `BuildTree` never terminated, producing a false TS2741.
 /// With the fix, the unit-level Prepend behaviour above is correct, but
 /// the recursive conditional-type instantiation here still emits TS2741
 /// because of separate recursion/fuel limits in the conditional-type
@@ -199,8 +199,7 @@ const grandUser: GrandUser = {
     let codes = tsz_checker::test_utils::check_source_codes(source);
     assert!(
         !codes.contains(&2741),
-        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {:?}",
-        codes
+        "Must NOT emit TS2741 — BuildTree must terminate at depth 2 without false property-missing errors, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1347,10 +1347,7 @@ var array: number[] = [0, 1, ...strs];
         1,
         "expected exactly one TS2322; got {}: {:?}",
         ts2322.len(),
-        ts2322
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
     let message = &ts2322[0].message_text;
     assert!(
@@ -1358,8 +1355,7 @@ var array: number[] = [0, 1, ...strs];
         "expected per-element 'string' vs 'number' elaboration; got {message:?}"
     );
     assert!(
-        !message.contains("(number | string)[]")
-            && !message.contains("(string | number)[]"),
+        !message.contains("(number | string)[]") && !message.contains("(string | number)[]"),
         "expected per-element elaboration, not whole-array message; got {message:?}"
     );
 }
@@ -1394,9 +1390,6 @@ var c: MyNumberArray = [...strs];
         drilled.is_empty(),
         "expected NOT to drill into per-element spread error for custom \
          array-subtype target; got {:?}",
-        drilled
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        drilled.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2799,7 +2799,7 @@ fn build_lib_bound_file_for_interface_checks(
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),
         scopes: Vec::new(),
-        node_scope_ids: FxHashMap::default(),
+        node_scope_ids: std::sync::Arc::new(FxHashMap::default()),
         parse_diagnostics: Vec::new(),
         global_augmentations: FxHashMap::default(),
         module_augmentations: FxHashMap::default(),

--- a/crates/tsz-core/src/api/wasm/parser.rs
+++ b/crates/tsz-core/src/api/wasm/parser.rs
@@ -579,7 +579,7 @@ impl Parser {
             "\n=== Node -> Scope Mappings ({}) ===",
             binder.node_scope_ids.len()
         ));
-        for (&node_idx, &scope_id) in &binder.node_scope_ids {
+        for (&node_idx, &scope_id) in binder.node_scope_ids.iter() {
             result.push(format!(
                 "  NodeIndex({}) -> ScopeId({})",
                 node_idx, scope_id.0

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -499,8 +499,12 @@ pub struct BindResult {
     pub declaration_arenas: Arc<DeclarationArenaMap>,
     /// Persistent scopes for stateless checking
     pub scopes: Vec<Scope>,
-    /// Map from AST node to scope ID
-    pub node_scope_ids: FxHashMap<u32, ScopeId>,
+    /// Map from AST node to scope ID.
+    ///
+    /// `Arc`-wrapped to mirror `BinderState.node_scope_ids` so per-file
+    /// binders share via `Arc::clone` instead of deep-cloning. Read-only
+    /// after binding completes.
+    pub node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
     /// Parse diagnostics
     pub parse_diagnostics: Vec<ParseDiagnostic>,
     /// Shorthand ambient modules (`declare module "foo"` without body)
@@ -1439,8 +1443,12 @@ pub struct BoundFile {
     pub module_declaration_exports_publicly: FxHashMap<u32, bool>,
     /// Persistent scopes (symbol IDs are global after merge)
     pub scopes: Vec<Scope>,
-    /// Map from AST node to scope ID
-    pub node_scope_ids: FxHashMap<u32, ScopeId>,
+    /// Map from AST node to scope ID.
+    ///
+    /// `Arc`-wrapped to mirror `BinderState.node_scope_ids` so per-file
+    /// binders share via `Arc::clone` instead of deep-cloning. Read-only
+    /// after binding completes.
+    pub node_scope_ids: Arc<FxHashMap<u32, ScopeId>>,
     /// Parse diagnostics
     pub parse_diagnostics: Vec<ParseDiagnostic>,
     /// Global augmentations (interface declarations inside `declare global` blocks)
@@ -4118,7 +4126,7 @@ fn build_lib_bound_file_for_interface_checks(
         declaration_arenas,
         module_declaration_exports_publicly: FxHashMap::default(),
         scopes: Vec::new(),
-        node_scope_ids: FxHashMap::default(),
+        node_scope_ids: Arc::new(FxHashMap::default()),
         parse_diagnostics: Vec::new(),
         global_augmentations: FxHashMap::default(),
         module_augmentations: FxHashMap::default(),


### PR DESCRIPTION
## Summary

`node_scope_ids: FxHashMap<u32, ScopeId>` is populated during binding (in `state/core.rs::enter_persistent_scope` and `modules/binding.rs`) and read-only post-bind. Per-file binders previously deep-cloned this per binder construction.

Wrap in `Arc` end-to-end:

- 4 `.insert()` sites + 1 `.retain()` + 2 `.clear()` sites use `Arc::make_mut` (free when refcount=1 during bind).
- Per-file binder construction shares via `Arc::clone` instead of deep-cloning.
- `from_bound_state_with_scopes` signature accepts `Arc<...>` so test callers can pass `file.node_scope_ids.clone()` (Arc::clone) rather than dereferencing.
- `wasm/parser.rs` iteration loop updated to `.iter()` because `&Arc<T>` doesn't implement `IntoIterator`.

Same pattern as #1399 (lib_symbol_reverse_remap), #1404 (expando_properties), #1409 (switch_clause_to_switch), #1416 (module_declaration_exports_publicly).

## Test plan

- [x] `cargo check --workspace --tests` — clean
- [x] `cargo nextest run -p tsz-binder` — 448 / 448 passed
- [x] `cargo nextest run -p tsz-checker --lib` — 2889 / 2889 passed
- [x] `cargo clippy -p tsz-binder --tests -- -D warnings` — clean
- [ ] CI conformance + emit + fourslash
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
