### PR TITLE
fix(checker): anchor TS2355 on JSDoc return-type for JS functions

### DIFF
--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -402,6 +402,71 @@ impl<'a> CheckerState<'a> {
         Some((comment_pos + expr_offset as u32 + 4, type_expr.len() as u32))
     }
 
+    /// Locate the source span of the return type inside a JSDoc
+    /// `@type {function(...): ReturnType}` annotation attached to `func_idx`.
+    ///
+    /// Used by TS2355/TS2366 emission so the diagnostic underlines the JSDoc
+    /// return type (matching tsc) instead of the function name. Returns
+    /// `None` if the function has no JSDoc `@type` annotation, or the
+    /// annotation is not a `function(...)` form with an explicit return type.
+    pub(crate) fn jsdoc_function_return_type_span_for_function(
+        &self,
+        func_idx: NodeIndex,
+    ) -> Option<(u32, u32)> {
+        use tsz_common::comments::is_jsdoc_comment;
+
+        if !self.ctx.should_resolve_jsdoc() {
+            return None;
+        }
+        let sf = self.source_file_data_for_node(func_idx)?;
+        if sf.comments.is_empty() {
+            return None;
+        }
+        let source_text: &str = &sf.text;
+        let comments = &sf.comments;
+        let func_node = self.ctx.arena.get(func_idx)?;
+
+        // Look for a JSDoc comment immediately preceding the function node.
+        for comment in comments.iter().rev() {
+            if comment.end <= func_node.pos
+                && is_jsdoc_comment(comment, source_text)
+                && let Some(span) = Self::jsdoc_type_tag_function_return_type_span_in_source(
+                    source_text,
+                    comment.pos,
+                )
+            {
+                return Some(span);
+            }
+            if comment.end <= func_node.pos {
+                break;
+            }
+        }
+
+        // Walk up the parent chain (e.g. `const f = function () {}`).
+        let mut current = func_idx;
+        for _ in 0..4 {
+            let ext = self.ctx.arena.get_extended(current)?;
+            let parent = ext.parent;
+            if parent.is_none() {
+                break;
+            }
+            let parent_node = self.ctx.arena.get(parent)?;
+            for comment in comments.iter().rev() {
+                if comment.end <= parent_node.pos
+                    && is_jsdoc_comment(comment, source_text)
+                    && let Some(span) = Self::jsdoc_type_tag_function_return_type_span_in_source(
+                        source_text,
+                        comment.pos,
+                    )
+                {
+                    return Some(span);
+                }
+            }
+            current = parent;
+        }
+        None
+    }
+
     /// Emit TS2694 for JSDoc qualified type names `A.B` whose root `A` is
     /// a plain value (not a namespace/module/type container). tsc's JSDoc
     /// checker treats this as "Namespace 'A' has no exported member 'B'";

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -365,6 +365,9 @@ mod jsdoc_callback_rest_tests;
 #[path = "../tests/jsdoc_cross_file_typedef_tests.rs"]
 mod jsdoc_cross_file_typedef_tests;
 #[cfg(test)]
+#[path = "../tests/jsdoc_function_return_type_anchor_tests.rs"]
+mod jsdoc_function_return_type_anchor_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
 mod jsdoc_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -793,6 +793,7 @@ impl<'a> CheckerState<'a> {
             return_type,
             has_type_annotation,
             has_declared_return,
+            has_jsdoc_return_type,
         );
 
         self.pop_return_type();
@@ -1102,6 +1103,7 @@ impl<'a> CheckerState<'a> {
         return_type: TypeId,
         has_type_annotation: bool,
         has_declared_return: bool,
+        has_jsdoc_return_type: bool,
     ) {
         let is_async = func.is_async;
         let is_generator = func.asterisk_token;
@@ -1194,33 +1196,55 @@ impl<'a> CheckerState<'a> {
         }
 
         if check_explicit_return_paths && requires_return && falls_through {
-            // For JSDoc @type, the error node is the function name/node
-            // (there's no separate type annotation node in the AST).
+            // For JSDoc-typed functions in JS files, prefer anchoring on the
+            // JSDoc return-type span (e.g. underline `number` inside
+            // `@type {function(): number}`) so the diagnostic matches tsc.
+            // Fall back to function name / node when no JSDoc span resolves.
+            let jsdoc_span = if !has_type_annotation && has_jsdoc_return_type {
+                self.jsdoc_function_return_type_span_for_function(func_idx)
+            } else {
+                None
+            };
             let error_node = if has_type_annotation {
                 func.type_annotation
+            } else if func.name.is_some() {
+                func.name
             } else {
-                // JSDoc: use function name if available, otherwise function itself
-                if func.name.is_some() {
-                    func.name
-                } else {
-                    func_idx
-                }
+                func_idx
             };
             if !has_return {
                 use crate::diagnostics::diagnostic_codes;
-                self.error_at_node(
-                    error_node,
-                    "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
-                    diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
-                );
+                if let Some((start, length)) = jsdoc_span {
+                    self.error_at_position(
+                        start,
+                        length,
+                        "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
+                        diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
+                    );
+                } else {
+                    self.error_at_node(
+                        error_node,
+                        "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
+                        diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
+                    );
+                }
             } else {
                 // TS2366: always emit when return type doesn't include undefined
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                self.error_at_node(
-                    error_node,
-                    diagnostic_messages::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
-                    diagnostic_codes::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
-                );
+                if let Some((start, length)) = jsdoc_span {
+                    self.error_at_position(
+                        start,
+                        length,
+                        diagnostic_messages::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
+                        diagnostic_codes::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
+                    );
+                } else {
+                    self.error_at_node(
+                        error_node,
+                        diagnostic_messages::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
+                        diagnostic_codes::FUNCTION_LACKS_ENDING_RETURN_STATEMENT_AND_RETURN_TYPE_DOES_NOT_INCLUDE_UNDEFINE,
+                    );
+                }
             }
         }
         // TS2355 for `undefined | T` return types with no returns at all.
@@ -1235,6 +1259,11 @@ impl<'a> CheckerState<'a> {
             && !is_generator
             && self.type_requires_return_ts2355(check_return_type)
         {
+            let jsdoc_span = if !has_type_annotation && has_jsdoc_return_type {
+                self.jsdoc_function_return_type_span_for_function(func_idx)
+            } else {
+                None
+            };
             let error_node = if has_type_annotation {
                 func.type_annotation
             } else if func.name.is_some() {
@@ -1243,11 +1272,20 @@ impl<'a> CheckerState<'a> {
                 func_idx
             };
             use crate::diagnostics::diagnostic_codes;
-            self.error_at_node(
-                error_node,
-                "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
-                diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
-            );
+            if let Some((start, length)) = jsdoc_span {
+                self.error_at_position(
+                    start,
+                    length,
+                    "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
+                    diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
+                );
+            } else {
+                self.error_at_node(
+                    error_node,
+                    "A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.",
+                    diagnostic_codes::A_FUNCTION_WHOSE_DECLARED_TYPE_IS_NEITHER_UNDEFINED_VOID_NOR_ANY_MUST_RETURN_A_V,
+                );
+            }
         } else if check_explicit_return_paths
             && check_return_type == TypeId::UNKNOWN
             && has_type_annotation

--- a/crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs
@@ -1,0 +1,64 @@
+//! Regression tests for TS2355/TS2366 anchor positions when the return type
+//! is provided through a JSDoc `@type {function(): T}` annotation in JS files.
+//!
+//! tsc anchors the diagnostic on the JSDoc return-type token (e.g. `number`
+//! within `@type {function(): number}`) rather than on the function name.
+//! These tests pin that anchor so we don't regress.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn options_js_strict() -> CheckerOptions {
+    CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+#[test]
+fn ts2355_anchors_on_jsdoc_function_return_type_for_function_declaration() {
+    // Test mirrors `conformance/jsdoc/jsdocFunction_missingReturn.ts`. tsc
+    // points TS2355 at `number` within the JSDoc `function(): number` type
+    // expression. Anchor must be on that token, not on the function name.
+    let source = "/** @type {function(): number} */\nfunction f() {}\n";
+
+    let diagnostics = check_source(source, "a.js", options_js_strict());
+
+    let ts2355: Vec<_> = diagnostics.iter().filter(|d| d.code == 2355).collect();
+    assert_eq!(
+        ts2355.len(),
+        1,
+        "expected exactly one TS2355 for missing return value, got: {diagnostics:#?}"
+    );
+
+    let number_pos = source.find("number").expect("number in JSDoc") as u32;
+    let diag = ts2355[0];
+    assert_eq!(
+        (diag.start, diag.length),
+        (number_pos, "number".len() as u32),
+        "TS2355 should anchor on the JSDoc return type 'number', got start={} length={} (expected start={} length={})",
+        diag.start,
+        diag.length,
+        number_pos,
+        "number".len()
+    );
+}
+
+#[test]
+fn ts2355_falls_back_to_name_when_no_jsdoc_return_type() {
+    // Without a JSDoc `@type {function(): T}` annotation, TS2355 should not
+    // fire at all because there's no declared return type to enforce. This
+    // test guards against accidentally widening the JSDoc anchor path so it
+    // fires for plain JS functions.
+    let source = "function f() {}\n";
+
+    let diagnostics = check_source(source, "a.js", options_js_strict());
+
+    let ts2355 = diagnostics.iter().filter(|d| d.code == 2355).count();
+    assert_eq!(
+        ts2355, 0,
+        "no JSDoc return type means no TS2355; got: {diagnostics:#?}"
+    );
+}

--- a/docs/plan/claims/fix-jsdoc-ts2355-anchor.md
+++ b/docs/plan/claims/fix-jsdoc-ts2355-anchor.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/jsdoc-ts2355-anchor`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1431
+- **Status**: ready
 - **Workstream**: Conformance fingerprint parity
 
 ## Intent

--- a/docs/plan/claims/fix-jsdoc-ts2355-anchor.md
+++ b/docs/plan/claims/fix-jsdoc-ts2355-anchor.md
@@ -1,0 +1,40 @@
+# fix(checker): anchor TS2355 on JSDoc return-type token for JS function declarations
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/jsdoc-ts2355-anchor`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance fingerprint parity
+
+## Intent
+
+`conformance/jsdoc/jsdocFunction_missingReturn.ts` was a fingerprint-only
+failure: tsc anchors TS2355 on the JSDoc return-type token (`number` inside
+`@type {function(): number}`) while we anchored on the function name. This
+PR adds a JSDoc lookup helper that resolves the source span of the JSDoc
+return-type token for a function and threads it into the TS2355/TS2366
+emission paths in `function_declaration_checks.rs`. When the helper resolves
+a span, the diagnostic uses that span; otherwise the legacy fall-back to
+function name / function node is preserved.
+
+## Files Touched
+
+- `crates/tsz-checker/src/jsdoc/lookup.rs` (~66 LOC new helper
+  `jsdoc_function_return_type_span_for_function`).
+- `crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs`
+  (~60 LOC change: thread `has_jsdoc_return_type` into
+  `check_function_return_paths`, prefer the JSDoc span on the
+  `requires_return && falls_through` and `undefined | T` TS2355 branches).
+- `crates/tsz-checker/src/lib.rs` (~3 LOC test registration).
+- `crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs`
+  (~67 LOC, two regression tests: pinned anchor + no-JSDoc fall-back).
+
+## Verification
+
+- `cargo nextest run -p tsz-checker -E 'test(jsdoc_function_return_type_anchor)'`
+  (2/2 passed).
+- `cargo nextest run -p tsz-checker --lib` (2891 tests pass).
+- `./scripts/conformance/conformance.sh run --filter "jsdocFunction_missingReturn"`
+  flips to PASS (was fingerprint-only).
+- `./scripts/conformance/conformance.sh run --filter "jsdoc"` 359/377 (95.2%)
+  vs baseline 358/377 (95.0%): +1 fix, no regressions.


### PR DESCRIPTION
## Summary
- `conformance/jsdoc/jsdocFunction_missingReturn.ts` was fingerprint-only: tsc anchors TS2355 on the JSDoc return-type token (`number` inside `@type {function(): number}`), we anchored on the function name.
- Adds a JSDoc lookup helper `jsdoc_function_return_type_span_for_function` and threads `has_jsdoc_return_type` through `check_function_return_paths` so TS2355 / TS2366 use the JSDoc return-type span when available, with the function-name fall-back preserved.
- Includes two regression tests pinning the new anchor (and the no-JSDoc fall-back) plus a claim file under `docs/plan/claims/`.

## Test plan
- [x] `cargo nextest run -p tsz-checker -E 'test(jsdoc_function_return_type_anchor)'` (2/2)
- [x] `cargo nextest run -p tsz-checker --lib` (2891/2891)
- [x] `./scripts/conformance/conformance.sh run --filter "jsdocFunction_missingReturn"` flips to PASS (1/1)
- [x] `./scripts/conformance/conformance.sh run --filter "jsdoc"` 359/377 (95.2%) vs baseline 358/377 (95.0%) — +1 fix, no regressions
- [x] `./scripts/conformance/conformance.sh run --filter "ReturnStatement"` 22/22 (no regressions)
- [x] `./scripts/conformance/conformance.sh run --filter "missingReturn"` 3/3