### PR TITLE
fix(cli): suppress predefined-name TS2427s when void/null interface present

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -123,6 +123,20 @@ const fn is_reserved_type_name_declaration_diagnostic(code: u32) -> bool {
     matches!(code, 2427 | 2457)
 }
 
+/// Returns true if a TS2427 diagnostic message refers to a hard reserved
+/// keyword that triggers a parser error in tsc (`void` or `null`). When such
+/// an interface declaration is present in a source file, tsc only surfaces
+/// the TS2427 for that hard-keyword interface and suppresses TS2427 for any
+/// other reserved-name interfaces in the same file. This mirrors tsc's
+/// behavior in `interfacesWithPredefinedTypesAsNames.ts` and similar tests.
+fn is_hard_keyword_interface_name_2427(diag: &Diagnostic) -> bool {
+    if diag.code != 2427 {
+        return false;
+    }
+    diag.message_text == "Interface name cannot be 'void'."
+        || diag.message_text == "Interface name cannot be 'null'."
+}
+
 fn keep_checker_diagnostic_when_program_has_real_syntax_errors(code: u32) -> bool {
     // tsc suppresses type-level semantic diagnostics when any source file in the
     // program has a real syntax error, but it still reports declaration-name
@@ -196,6 +210,30 @@ fn post_process_checker_diagnostics(
     let has_ts2754 = file.parse_diagnostics.iter().any(|d| d.code == 2754);
     if has_ts2754 {
         checker_diagnostics.retain(|diag| diag.code < 2000);
+    }
+
+    // When the file contains an `interface void {}` or `interface null {}`
+    // declaration, tsc only emits TS2427 for that hard-keyword interface and
+    // suppresses TS2427 for ANY other interfaces in the same file (including
+    // ones with predefined-type names like `any`, `number`, etc.). This is
+    // because tsc's parser produces a parse error for hard-keyword names,
+    // which prevents the lazy diagnostic queue from running for the other
+    // interface declarations. We don't currently emit a parse error in our
+    // parser for `void`/`null` as interface names, so we model the same
+    // suppression by filtering out non-hard-keyword TS2427 when a
+    // hard-keyword TS2427 is present.
+    let has_hard_keyword_ts2427 = checker_diagnostics
+        .iter()
+        .any(is_hard_keyword_interface_name_2427);
+    if has_hard_keyword_ts2427 {
+        checker_diagnostics.retain(|diag| {
+            // Keep all non-TS2427 diagnostics untouched.
+            if diag.code != 2427 {
+                return true;
+            }
+            // Among TS2427, keep only the hard-keyword (`void`/`null`) ones.
+            is_hard_keyword_interface_name_2427(diag)
+        });
     }
 
     // When TS5107/TS5101 deprecation diagnostics are present, suppress the most

--- a/crates/tsz-cli/tests/tsc_compat_tests.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests.rs
@@ -1750,3 +1750,92 @@ fn deprecated_module_amd_accepted() {
         "Deprecated --module amd should not produce TS6046: {output}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TS2427: Interface name reserved-word handling.
+//
+// tsc only emits ONE TS2427 (for the hard-keyword interface name `void` or
+// `null`) when such an interface declaration is present in a file. Other
+// reserved-name interfaces (`any`, `number`, etc.) in the SAME file have
+// their TS2427 suppressed because tsc's parser produces a parse error for
+// the hard-keyword name, which cascade-suppresses the lazy diagnostics for
+// the other interface declarations.
+// Regression test for the conformance failure on
+// `interfacesWithPredefinedTypesAsNames.ts`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tsc_parity_ts2427_void_suppresses_other_predefined_names() {
+    if !tsc_available() {
+        return;
+    }
+    let temp = TempDir::new("ts2427_void_suppresses").expect("temp dir");
+    write_file(
+        &temp.path.join("test.ts"),
+        "interface any { }\n\
+         interface number { }\n\
+         interface string { }\n\
+         interface boolean { }\n\
+         interface void {}\n\
+         interface unknown {}\n\
+         interface never {}\n",
+    );
+    assert_tsc_tsz_match(
+        &temp.path,
+        &["--target", "es2015", "--noEmit", "--pretty", "false", "test.ts"],
+        "TS2427 void hard-keyword suppresses other predefined-name TS2427s",
+    );
+}
+
+#[test]
+fn tsc_parity_ts2427_null_suppresses_other_predefined_names() {
+    if !tsc_available() {
+        return;
+    }
+    let temp = TempDir::new("ts2427_null_suppresses").expect("temp dir");
+    write_file(
+        &temp.path.join("test.ts"),
+        "interface any { }\n\
+         interface null {}\n",
+    );
+    // We don't currently emit the TS1005 (";" expected) parse error that tsc
+    // produces for `interface null {}`, so a strict tsc-tsz match isn't
+    // possible here yet. Instead, pin the behavioral invariant we DO care
+    // about: the TS2427 for `null` is kept while the TS2427 for `any` is
+    // suppressed in the same file.
+    let (_code, output) = run_tsz_with_exit_code(
+        &temp.path,
+        &["--target", "es2015", "--noEmit", "--pretty", "false", "test.ts"],
+    )
+    .expect("tsz binary not found");
+    assert!(
+        output.contains("Interface name cannot be 'null'."),
+        "Expected TS2427 for `null`. Output:\n{output}"
+    );
+    assert!(
+        !output.contains("Interface name cannot be 'any'."),
+        "TS2427 for `any` should be suppressed when `null` is present. \
+         Output:\n{output}"
+    );
+}
+
+#[test]
+fn tsc_parity_ts2427_any_alone_still_reported() {
+    if !tsc_available() {
+        return;
+    }
+    let temp = TempDir::new("ts2427_any_only").expect("temp dir");
+    write_file(
+        &temp.path.join("test.ts"),
+        "interface any { }\n\
+         interface number { }\n",
+    );
+    // Without `void`/`null`, tsc reports TS2427 for both interfaces. This
+    // test pins that the suppression only kicks in when a hard-keyword
+    // interface name is present.
+    assert_tsc_tsz_match(
+        &temp.path,
+        &["--target", "es2015", "--noEmit", "--pretty", "false", "test.ts"],
+        "TS2427 still reported for predefined names when no hard keyword present",
+    );
+}

--- a/docs/plan/claims/fix-ts2427-void-null-suppress-others.md
+++ b/docs/plan/claims/fix-ts2427-void-null-suppress-others.md
@@ -1,0 +1,42 @@
+# fix(cli): TS2427 hard-keyword interface name suppresses other predefined-name TS2427s
+
+- **Date**: 2026-04-26 17:41:38
+- **Branch**: `fix/ts2427-void-null-suppress-others`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance fingerprint parity
+
+## Intent
+
+When a file contains `interface void {}` or `interface null {}`, tsc only
+emits the TS2427 for the hard-keyword name and suppresses TS2427 for any
+other reserved-name interfaces (`any`, `number`, etc.) in the same file.
+This is because tsc's parser produces a parse error for the hard-keyword
+name, which cascade-suppresses the lazy diagnostic queue for the other
+declarations.
+
+We don't currently emit a parse error for `void`/`null` as interface names
+(intentional; see `state_declarations.rs`), so tsz over-emits 6 TS2427
+diagnostics on `interfacesWithPredefinedTypesAsNames.ts` while tsc emits 1.
+
+This PR mirrors tsc's effective behavior in the CLI driver's
+`post_process_checker_diagnostics`: when a hard-keyword (`void`/`null`)
+TS2427 is present, suppress all OTHER TS2427 in the same file. The
+hard-keyword TS2427 is identified via its diagnostic message (since the
+checker doesn't expose a richer kind for it).
+
+## Files Touched
+
+- `crates/tsz-cli/src/driver/check.rs` (~30 LOC)
+- `crates/tsz-cli/tests/tsc_compat_tests.rs` (~75 LOC, 3 new tests)
+
+## Verification
+
+- `cargo nextest run --package tsz-cli` (1063 tests pass, 15 skipped)
+- `cargo nextest run --package tsz-checker --lib` (2889 tests pass)
+- `./scripts/conformance/conformance.sh run --filter "interfacesWithPredefinedTypesAsNames"` (1/1 PASS)
+- Full conformance: `12183 -> 12187 (+4)` net improvements, no regressions.
+  - `interfacesWithPredefinedTypesAsNames.ts`
+  - `jsExportMemberMergedWithModuleAugmentation2.ts`
+  - `catchClauseWithTypeAnnotation.ts`
+  - `templateLiteralTypes5.ts`

--- a/docs/plan/claims/fix-ts2427-void-null-suppress-others.md
+++ b/docs/plan/claims/fix-ts2427-void-null-suppress-others.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26 17:41:38
 - **Branch**: `fix/ts2427-void-null-suppress-others`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1432
+- **Status**: ready
 - **Workstream**: Conformance fingerprint parity
 
 ## Intent


### PR DESCRIPTION
## Summary

- tsc 6.0.3 emits only one TS2427 (for the hard-keyword name) when a file contains `interface void {}` or `interface null {}`, even when other reserved-name interfaces (`any`, `number`, etc.) are present in the same file.
- The CLI driver now mirrors that behavior by dropping every TS2427 except the hard-keyword one when both kinds appear together.
- Fixes the `interfacesWithPredefinedTypesAsNames.ts` conformance failure and three other tests as a side effect.

## Why CLI-level

tsc's behavior comes from its parser producing a parse error for the hard-keyword interface name, which cascade-suppresses the lazy diagnostic queue for the other interface declarations. Our parser intentionally accepts `void`/`null` as interface names without a parse error (per the comment in `state_declarations.rs`), so the cleanest place to mirror tsc's net effect is the existing diagnostic post-processing in `tsz-cli`.

The checker still emits the per-interface TS2427s so direct unit tests of `check_interface_declaration` keep working as they did before.

## Test plan

- [x] `cargo nextest run --package tsz-cli` — 1063 pass, 15 skipped
- [x] `cargo nextest run --package tsz-checker --lib` — 2889 pass
- [x] `./scripts/conformance/conformance.sh run --filter "interfacesWithPredefinedTypesAsNames"` — 1/1 PASS
- [x] `scripts/safe-run.sh ./scripts/conformance/conformance.sh run` — 12183 → 12187 (+4), no regressions:
  - `interfacesWithPredefinedTypesAsNames.ts`
  - `jsExportMemberMergedWithModuleAugmentation2.ts`
  - `catchClauseWithTypeAnnotation.ts`
  - `templateLiteralTypes5.ts`
- [x] Three new `tsc_parity_ts2427_*` integration tests pin the suppression behavior.