### PR TITLE
fix(checker): anchor binding-default TS2322 on the binding name

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -1513,3 +1513,78 @@ function ft1<T extends string>(
         ts2345s.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
+
+/// `function h({ prop = "baz" }: StringUnion)` — when a binding-element default
+/// is a non-elaboratable expression (e.g. a string literal that doesn't fit a
+/// literal-union target), tsc anchors TS2322 on the binding name (`prop`)
+/// rather than the initializer expression (`"baz"`).
+///
+/// Regression test for
+/// `conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts`.
+#[test]
+fn binding_default_string_lit_anchors_at_binding_name() {
+    let source = r#"
+interface StringUnion { prop: "foo" | "bar"; }
+function h({ prop = "baz" }: StringUnion) {}
+"#;
+    let diagnostics = diagnostics_for(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322 for non-fitting binding default");
+
+    // Locate the binding name `prop` and the initializer `"baz"` in the
+    // source so the assertion stays robust if surrounding text changes.
+    let prop_offset = source.find("prop = ").expect("expected `prop = `") as u32;
+    let baz_offset = source.find("\"baz\"").expect("expected `\"baz\"`") as u32;
+
+    assert_eq!(
+        diag.start, prop_offset,
+        "TS2322 should anchor at the binding name `prop` (offset {prop_offset}), \
+         not the initializer `\"baz\"` (offset {baz_offset}); got: {diag:?}"
+    );
+    assert!(
+        diag.message_text.contains("\"baz\"")
+            && diag.message_text.contains("\"foo\" | \"bar\""),
+        "TS2322 message should still describe the actual mismatch (\"baz\" vs literal union), \
+         got: {:?}",
+        diag.message_text
+    );
+}
+
+/// Even though the binding-default anchor walks to the binding name, an arrow
+/// function default with a body return-type mismatch (e.g.
+/// `function f({ show: x = v => v }: Show)` where `Show.show` returns `string`)
+/// should still elaborate to the body expression — the elaboration path
+/// (`try_elaborate_function_arg_return_error`) overrides the binding-name
+/// anchor with its own body anchor. This test pins that contract.
+#[test]
+fn binding_default_arrow_body_return_mismatch_still_elaborates_to_body() {
+    let source = r#"
+interface Show { show: (x: number) => string; }
+function f({ show: showRename = v => v }: Show) {}
+"#;
+    let diagnostics = diagnostics_for(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322 for arrow body return type mismatch");
+
+    // The error must anchor at the second `v` (the body), not at `show:`,
+    // `showRename`, or the whole arrow `v => v`.
+    let body_offset = {
+        let arrow_idx = source.find("v => v").expect("expected `v => v`");
+        let body_start = arrow_idx + "v => ".len();
+        body_start as u32
+    };
+    assert_eq!(
+        diag.start, body_offset,
+        "TS2322 for arrow body return mismatch should anchor at the body expression \
+         (offset {body_offset}); got: {diag:?}"
+    );
+    assert!(
+        diag.message_text.contains("'number'") && diag.message_text.contains("'string'"),
+        "TS2322 should describe the body return-type mismatch (number vs string), got: {:?}",
+        diag.message_text
+    );
+}

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -731,9 +731,16 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
         }
         s
     };
+    // Binding-default and conditional-branch assignability checks must route
+    // through the central `check_assignable_or_report*` family. Accept either
+    // the initializer-anchored variant (`check_assignable_or_report`) or the
+    // explicit-anchor variant (`check_assignable_or_report_at`) so the test
+    // stays robust as anchors get tuned without bypassing the gateway.
     assert!(
-        type_checking_src.contains("check_assignable_or_report("),
-        "binding/default-value assignability should route through check_assignable_or_report"
+        type_checking_src.contains("check_assignable_or_report(")
+            || type_checking_src.contains("check_assignable_or_report_at("),
+        "binding/default-value assignability should route through check_assignable_or_report \
+         or check_assignable_or_report_at (central TS2322 gateway helpers)"
     );
     assert!(
         type_checking_src.contains("ensure_relation_input_ready("),

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1296,11 +1296,21 @@ impl<'a> CheckerState<'a> {
             // regardless of whether the property type includes undefined.
             // Even for required properties, if the user provides a default value,
             // tsc still validates it against the declared type.
+            //
+            // tsc anchors binding-default TS2322 on the binding name (e.g. `prop`
+            // in `function h({ prop = "baz" }: StringUnion)`) rather than on the
+            // initializer expression. Source-side elaboration paths (arrow body
+            // return, object/array literals) still override this anchor with
+            // their own body/property positions via
+            // `try_elaborate_assignment_source_error`, so passing the binding
+            // name only affects the fallback anchor for non-elaborated value
+            // mismatches.
             if check_default_assignability {
-                let _ = self.check_assignable_or_report(
+                let _ = self.check_assignable_or_report_at(
                     default_value_type,
                     element_type,
                     element_data.initializer,
+                    element_data.name,
                 );
             }
         }

--- a/docs/plan/claims/fix-binding-default-name-anchor-v2.md
+++ b/docs/plan/claims/fix-binding-default-name-anchor-v2.md
@@ -1,0 +1,21 @@
+**2026-04-26 19:30:00**
+
+# fix(checker): anchor binding-default TS2322 on the binding name
+
+Status: claim
+Branch: fix/binding-default-name-anchor-v2
+
+Goal: align tsc fingerprint for `function h({ prop = "baz" }: StringUnion)`-style
+destructuring defaults so TS2322 emits at the binding name (`prop`) rather than
+the initializer expression (`"baz"`). Source-side elaboration paths (arrow-body
+return, object/array literals) keep their own anchors.
+
+Test target:
+- `TypeScript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts`
+  (was fingerprint-only, now flips one extra+one missing fingerprint to match).
+
+Scope: thin checker change in `check_binding_element_with_request` to switch
+from `check_assignable_or_report` to `check_assignable_or_report_at` with
+`diag_idx = element_data.name`. Solver and boundary helpers untouched.
+
+Conformance impact: net +3 tests (12183 -> 12186), 0 regressions.


### PR DESCRIPTION
## Summary

- Anchor binding-element default TS2322 on the binding name (e.g. `prop` in
  `function h({ prop = "baz" }: StringUnion)`) rather than the initializer
  expression. Source-side elaboration paths (arrow body return, object/array
  literals) still override the anchor with their own positions, so existing
  fingerprints stay intact.
- Switch `check_binding_element_with_request` from
  `check_assignable_or_report` to `check_assignable_or_report_at` and pass
  `element_data.name` as `diag_idx`.
- Add two regression tests pinning the new binding-name anchor and the
  existing arrow-body elaboration anchor; relax the architecture contract
  test to accept either gateway helper variant.

## Conformance impact

- Net **+3 tests** (12183 -> 12186), 0 regressions on the full
  conformance suite.
- Improvements:
  - `compiler/jsExportMemberMergedWithModuleAugmentation2.ts`
  - `conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts`
  - `conformance/types/literal/templateLiteralTypes5.ts`
- Original target test
  `conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts`
  goes from 3 fingerprint mismatches (1 extra, 2 missing) to 1 missing
  (the unrelated `let { stringIdentity: id = arg => arg.length }: StringIdentity`
  case still needs deeper inference work).

## Test plan

- [x] `cargo nextest run --package tsz-checker --lib` — 2891 tests pass.
- [x] Full pre-commit suite (13770 tests across 117 binaries) passes.
- [x] `./scripts/conformance/conformance.sh run --filter "contextuallyTypedBindingInitializerNegative" --verbose`
      shows the binding-name anchor now matches tsc.
- [x] Full conformance run shows net +3, 0 regressions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
