### PR TITLE
fix(parser): emit "',' expected" in object-literal recovery despite short distance

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -2943,9 +2943,14 @@ impl ParserState {
                 {
                     break;
                 } else {
-                    // Unexpected token (e.g., `.` in `{ m.x }`). Emit ',' expected
-                    // and skip to resync, matching tsc's delimited list recovery.
-                    self.error_comma_expected();
+                    // Bypass `error_comma_expected`'s 3-byte distance gate so the
+                    // recovery emits even when the separator sits 3 cols after a
+                    // prior emission (e.g. `{` after `:' expected.` at 3 cols out
+                    // in `{ class C4 {} }`). tsc's parseErrorAtPosition only
+                    // dedups exact same-position duplicates; `parse_error_at`'s
+                    // dedup mirrors that.
+                    use tsz_common::diagnostics::diagnostic_codes;
+                    self.parse_error_at_current_token("',' expected.", diagnostic_codes::EXPECTED);
                     self.next_token();
                 }
             }

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -3986,3 +3986,43 @@ fn test_array_terminated_by_close_bracket_keeps_clean_close() {
         "well-formed array literal must not emit diagnostics, got {diagnostics:?}"
     );
 }
+
+#[test]
+fn test_object_literal_comma_recovery_after_short_distance_colon_error() {
+    // Regression for conformance test
+    // `conformance/classes/nestedClassDeclaration.ts`:
+    //   `var x = {\n    class C4 {\n    }\n}`
+    // tsc emits TWO TS1005 errors here:
+    //   - `':' expected.` at column 11 (the `C` of `C4`)
+    //   - `',' expected.` at column 14 (the `{`)
+    // We previously emitted only the first because our `error_comma_expected`
+    // applies a 3-byte distance suppression that swallows the legitimate comma
+    // diagnostic when the gap is exactly 3 columns. tsc's `parseErrorAtPosition`
+    // dedups only on exact same position; the unexpected-token recovery path in
+    // `parse_object_literal` now bypasses the distance gate so it emits.
+    let source = "var x = {\n    class C4 {\n    }\n}\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let line2_offset = source.find("    class C4").expect("C4 line is in source") as u32;
+    let c4_pos = line2_offset + "    class ".len() as u32; // position of `C` in `C4`
+    let open_brace_pos = source.find("C4 {").expect("C4 { is in source") as u32 + 3; // position of `{`
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED
+                && d.start == c4_pos
+                && d.message == "':' expected."),
+        "expected TS1005 `':' expected.` at `C4`, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED
+                && d.start == open_brace_pos
+                && d.message == "',' expected."),
+        "expected TS1005 `',' expected.` at `{{` after `C4`, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- When `parse_object_literal` hits the unexpected-token recovery branch (e.g. `{` after a malformed shorthand-property emitted `':' expected.`), match tsc by emitting `',' expected.` regardless of distance to the prior emission. Our existing `error_comma_expected` applies a 3-byte distance suppression that swallowed the legitimate diagnostic when the gap was exactly 3 columns.
- For `var x = { class C4 {} }` (the `nestedClassDeclaration.ts` case): tsc emits `':' expected.` at `C4` (col 11) and `,' expected.` at `{` (col 14, distance 3). We were emitting only the first.
- Bypass the distance gate via `parse_error_at_current_token` directly. `parse_error_at`'s exact-position dedup still protects against true duplicates, mirroring tsc's `parseErrorAtPosition`.

Flips conformance fingerprint-only failure `conformance/classes/nestedClassDeclaration.ts` to PASS.

## Test plan

- [x] `cargo nextest run -p tsz-parser` — all 676 parser tests pass (including the new `test_object_literal_comma_recovery_after_short_distance_colon_error` regression)
- [x] `./scripts/conformance/conformance.sh run --filter "nestedClassDeclaration"` — flips to PASS (1/1)
- [x] `./scripts/conformance/conformance.sh run --filter "objectLiteral"` — 50/52 passing (no regression)
- [x] `./scripts/conformance/conformance.sh run --filter "parserObject"` — 13/13 passing
- [x] `./scripts/conformance/conformance.sh run --filter "parser"` — 788/794 passing (gain over baseline)

## Note

A drive-by `cargo fmt` change in `crates/tsz-checker/tests/conditional_infer_tests.rs` is included because the pre-commit hook's `cargo fmt` step kept re-applying it on top of the parser change. It's a no-op format-string conversion (`{}` arg → inline `{var}`) that the rest of the codebase has already migrated to.

Pre-commit nextest was skipped via `TSZ_SKIP_TESTS=1` because an unrelated `tsz-checker` test (`test_module_exports_object_literal_member_conflicts_with_module_augmentation`) fails on `origin/main` HEAD; verified parser changes in isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
