### PR TITLE
chore(arch): pin architecture health metric 6 (Speculation Guard struct names)

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -555,6 +555,27 @@ SNAPSHOT_ROLLBACK_FILE_COUNT_CHECKS = [
     ),
 ]
 
+# Pin architecture health metric 6 ("Speculation APIs with surprising
+# non-RAII behavior") in `docs/plan/ROADMAP.md`.
+#
+# After PR #1213 renamed `DiagnosticSpeculationGuard → DiagnosticSpeculationSnapshot`
+# the speculation surface no longer carries `…Guard` types whose name
+# implies RAII rollback-on-drop while the implementation is implicit-commit.
+# This guard pins the rename: any new `pub(crate) struct …Guard` on the
+# speculation surface re-introduces the same ambiguity and must update
+# the cap (deliberately) or use a `…Snapshot` name (preferred). The
+# scan looks at the speculation file directly so the check is local
+# and cheap.
+#
+# Each entry: (description, file_path, max_guard_struct_count).
+SPECULATION_GUARD_NAME_CHECKS = [
+    (
+        "Checker speculation boundary: number of `…Guard` structs in speculation.rs (architecture health metric 6)",
+        ROOT / "crates" / "tsz-checker" / "src" / "context" / "speculation.rs",
+        0,
+    ),
+]
+
 # Pin the count of LSP feature-dispatch methods in
 # `crates/tsz-lsp/src/project/features.rs` (architecture health metric 7
 # in `docs/plan/ROADMAP.md` — "LSP/WASM semantic features implemented
@@ -943,6 +964,68 @@ def scan_lsp_feature_method_count(
     return []
 
 
+_SPECULATION_GUARD_STRUCT_PATTERN = re.compile(
+    r"^[ \t]*pub(?:\([^)]*\))?\s+struct\s+(\w*Guard\w*)\b"
+)
+
+
+def scan_speculation_guard_struct_count(
+    path: pathlib.Path, max_guard_count: int
+) -> list[str]:
+    """Count `…Guard` struct declarations in the speculation file and
+    report when over `max_guard_count` (architecture health metric 6).
+
+    Architecture health metric 6 ("Speculation APIs with surprising
+    non-RAII behavior", `docs/plan/ROADMAP.md`) was originally violated
+    by `DiagnosticSpeculationGuard`, whose name implied RAII rollback
+    while the implementation did implicit-commit-on-drop. PR #1213
+    renamed it to `DiagnosticSpeculationSnapshot`. This guard pins
+    the rename: any new `pub(crate) struct …Guard` re-introduces the
+    same ambiguity.
+
+    The match runs against the literal speculation file
+    (`crates/tsz-checker/src/context/speculation.rs`); doc-comment
+    references like `SpeculationGuard` in narrative text don't match
+    because the regex requires the `pub … struct …` prefix on a non-
+    comment line.
+    """
+    if not path.exists():
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    guard_lines: list[tuple[int, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            continue
+        m = _SPECULATION_GUARD_STRUCT_PATTERN.match(line)
+        if m:
+            guard_lines.append((line_no, m.group(1)))
+
+    if len(guard_lines) > max_guard_count:
+        try:
+            rel_path = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            rel_path = str(path)
+        hits = [
+            f"speculation `…Guard` struct: {rel_path}:{line_no} {name}"
+            for line_no, name in guard_lines
+        ]
+        hits.append(
+            f"total `…Guard` structs in {rel_path}: {len(guard_lines)} "
+            f"(cap {max_guard_count}; rename to `…Snapshot` to match "
+            f"the speculation surface's actual implicit-commit-on-drop "
+            f"semantics — workstream-4 Speculation Policy 3 / "
+            f"`docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md` item 5)"
+        )
+        return hits
+    return []
+
+
 def scan_struct_field_count(
     path: pathlib.Path, struct_name: str, max_fields: int
 ) -> list[str]:
@@ -1287,6 +1370,12 @@ def main() -> int:
 
     for name, file_path, max_methods in LSP_FEATURE_METHOD_COUNT_CHECKS:
         hits = scan_lsp_feature_method_count(file_path, max_methods)
+        total_hits += len(hits)
+        if hits:
+            failures.append((name, hits))
+
+    for name, file_path, max_guard_count in SPECULATION_GUARD_NAME_CHECKS:
+        hits = scan_speculation_guard_struct_count(file_path, max_guard_count)
         total_hits += len(hits)
         if hits:
             failures.append((name, hits))

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -1134,5 +1134,92 @@ class ArchGuardLspFeatureMethodCountTests(unittest.TestCase):
             )
 
 
+class ArchGuardSpeculationGuardNameTests(unittest.TestCase):
+    """Pin architecture health metric 6 ("Speculation APIs with surprising
+    non-RAII behavior"). Verifies `scan_speculation_guard_struct_count`."""
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def _write(self, tmp: pathlib.Path, name: str, contents: str) -> pathlib.Path:
+        path = tmp / name
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_no_guard_struct_passes_at_cap_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            path = self._write(
+                tmp,
+                "speculation.rs",
+                "pub(crate) struct DiagnosticSpeculationSnapshot { snapshot: u32 }\n",
+            )
+            self.assertEqual(
+                self.arch_guard.scan_speculation_guard_struct_count(path, 0),
+                [],
+            )
+
+    def test_one_guard_struct_fires_at_cap_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            path = self._write(
+                tmp,
+                "speculation.rs",
+                "pub(crate) struct DiagnosticSpeculationGuard { snapshot: u32 }\n",
+            )
+            hits = self.arch_guard.scan_speculation_guard_struct_count(path, 0)
+            self.assertEqual(len(hits), 2)
+            self.assertIn("DiagnosticSpeculationGuard", hits[0])
+
+    def test_doc_comment_guard_reference_does_not_match(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            path = self._write(
+                tmp,
+                "speculation.rs",
+                "/// Replaces the legacy `SpeculationGuard` struct.\n"
+                "pub(crate) struct DiagnosticSpeculationSnapshot {}\n",
+            )
+            self.assertEqual(
+                self.arch_guard.scan_speculation_guard_struct_count(path, 0),
+                [],
+            )
+
+    def test_pub_struct_guard_matches_too(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = pathlib.Path(tmp)
+            path = self._write(
+                tmp,
+                "speculation.rs",
+                "pub struct OuterGuard { inner: u32 }\n",
+            )
+            hits = self.arch_guard.scan_speculation_guard_struct_count(path, 0)
+            self.assertTrue(any("OuterGuard" in h for h in hits))
+
+    def test_check_is_registered(self):
+        names = [
+            entry[0] for entry in self.arch_guard.SPECULATION_GUARD_NAME_CHECKS
+        ]
+        self.assertTrue(
+            any("metric 6" in name for name in names),
+            "Speculation guard-name check missing from "
+            "SPECULATION_GUARD_NAME_CHECKS",
+        )
+
+    def test_real_speculation_file_passes_at_pinned_cap(self):
+        """The live speculation.rs must satisfy the pinned cap of 0
+        `…Guard` structs (PR #1213 already renamed the only offender)."""
+        for entry in self.arch_guard.SPECULATION_GUARD_NAME_CHECKS:
+            name, file_path, max_guard_count = entry
+            hits = self.arch_guard.scan_speculation_guard_struct_count(
+                file_path, max_guard_count
+            )
+            self.assertEqual(
+                hits,
+                [],
+                f"{name}: cap is too tight — guard fires at the live count.",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Architecture health metric 6 in `docs/plan/ROADMAP.md` is "Speculation APIs with surprising non-RAII behavior". PR #1213 renamed `DiagnosticSpeculationGuard → DiagnosticSpeculationSnapshot` to remove the misleading "Guard" name (the type is implicit-commit-on-drop, not RAII rollback). The metric was de-facto satisfied but had no detector; nothing prevented a future `pub(crate) struct …Guard` from re-introducing the same ambiguity.

This change adds a `scan_speculation_guard_struct_count` arch_guard scanner that counts `pub … struct …Guard…` declarations in `crates/tsz-checker/src/context/speculation.rs` and fails when the count exceeds the cap (currently 0).

6 colocated unit tests lock:

- empty file passes at cap 0
- a single `…Guard` struct fires at cap 0
- doc-comment references to `SpeculationGuard` do NOT match
- `pub struct` (no `pub(crate)`) matches too
- the check is registered in `SPECULATION_GUARD_NAME_CHECKS`
- the live speculation.rs satisfies the pinned cap (no off-by-one)

Pure additive — no behavior change to compilation.

## Test plan
- [x] `python3 scripts/arch/arch_guard.py` clean
- [x] 6/6 new unit tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
