### PR TITLE
fix(checker): require Symbol.iterator for ES2015+ destructuring (TS2488)

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -1104,11 +1104,11 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // TypeScript also allows array destructuring for "array-like" types
-        // (types with numeric index signatures) even without [Symbol.iterator]()
-        if self.has_numeric_index_signature(resolved_type) {
-            return true;
-        }
+        // ES2015+ destructuring requires actual Symbol.iterator support. A
+        // numeric index signature alone (e.g. `interface F { [idx: number]: boolean }`)
+        // is not enough — tsc emits TS2488 for those types in es2015+ mode. Only
+        // ES5 with `downlevelIteration=false` reads the numeric index signature
+        // path, and that case is already handled above when `target.is_es5()`.
 
         // Not iterable - emit TS2488
         self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target);

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1400,3 +1400,33 @@ var c: MyNumberArray = [...strs];
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn test_destructuring_index_signature_only_emits_ts2488_in_es2015() {
+    // Pinned by `destructuringArrayBindingPatternAndAssignment2.ts`. tsc emits
+    // TS2488 for `var [c4, c5, c6] = foo(1)` when `foo` returns an interface
+    // whose only iterable-shaped surface is a numeric index signature. Without
+    // an actual `[Symbol.iterator]()` method, ES2015+ destructuring is not
+    // permitted: a numeric index signature is not enough on its own.
+    let source = r"
+interface F {
+    [idx: number]: boolean;
+}
+function foo(idx: number): F {
+    return { 2: true };
+}
+var [c4, c5, c6] = foo(1);
+";
+
+    let diagnostics = check_source_diagnostics(source);
+    let ts2488_count = diagnostics.iter().filter(|d| d.code == 2488).count();
+    assert!(
+        ts2488_count >= 1,
+        "Expected at least 1 TS2488 for destructuring an interface with only a \
+         numeric index signature in ES2015+, got {ts2488_count}: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/docs/plan/claims/fix-destructure-array-like-iterability.md
+++ b/docs/plan/claims/fix-destructure-array-like-iterability.md
@@ -1,0 +1,53 @@
+# fix(checker): require Symbol.iterator for ES2015+ destructuring (TS2488)
+
+- **Date**: 2026-04-26
+- **Time**: 2026-04-26 19:50:00
+- **Branch**: `fix/conformance-quick-pick-1777225619`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+Conformance test
+`TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts`
+expects TS2488 (`Type 'F' must have a '[Symbol.iterator]()' method that returns
+an iterator.`) for `var [c4, c5, c6] = foo(1)` where `foo` returns
+`interface F { [idx: number]: boolean }`. Tsc requires actual `[Symbol.iterator]`
+support for ES2015+ destructuring; a numeric index signature is not enough.
+
+`crates/tsz-checker/src/checkers/iterable_checker.rs::check_destructuring_iterability`
+had a lenient short-circuit that returned `true` (no TS2488) whenever the
+resolved type had a numeric index signature, even on ES2015+ targets. That
+short-circuit is incorrect once the ES5 path above (`target.is_es5()`) has
+already handled the legacy case. Removing the lenient branch lets ES2015+
+destructuring fall through to `emit_ts2488_not_iterable` for index-signature-only
+types, matching tsc.
+
+## Root cause
+
+`is_iterable_type` in the same file already covers Array/Tuple/StringLiteral,
+union/intersection, classified objects with explicit Symbol.iterator, and
+type-parameter constraints. The numeric-index-signature relaxation was a
+generic compatibility shim that should never have applied past the ES5
+fast-path. Tsc emits TS2488 for these types regardless of index signatures.
+
+## Files Touched
+
+- `crates/tsz-checker/src/checkers/iterable_checker.rs` — drop the
+  `has_numeric_index_signature(resolved_type)` short-circuit at the end of
+  `check_destructuring_iterability`. The ES5 path already handles legacy
+  array-like destructuring before reaching this branch.
+- `crates/tsz-checker/tests/spread_rest_tests.rs` — add
+  `test_destructuring_index_signature_only_emits_ts2488_in_es2015` regression
+  test pinning the new behavior.
+
+## Verification
+
+- `cargo nextest run --package tsz-checker --lib` — 2894 unit tests, all pass.
+- `cargo nextest run --package tsz-checker -E 'test(test_destructuring_index_signature)'` — new test passes.
+- `./scripts/conformance/conformance.sh run --filter "destructuringArrayBindingPatternAndAssignment2" --verbose`
+  — TS2488 now emitted at line 35:5 (`F` not iterable). Two unrelated TS2488
+  fingerprints (3:6 and 3:12, nested empty-array destructure on `undefined`)
+  remain, but those involve nested-pattern-on-empty-array iteration which is a
+  separate root cause.


### PR DESCRIPTION
## Summary

- Drops the lenient numeric-index-signature short-circuit in `check_destructuring_iterability` so that ES2015+ destructuring of an interface like `interface F { [idx: number]: boolean }` correctly emits TS2488. Tsc requires an actual `[Symbol.iterator]` method on the destructure source for ES2015+ targets — a numeric index signature alone is not enough.
- Pinned by conformance test `destructuringArrayBindingPatternAndAssignment2.ts`. The previously-missing TS2488 fingerprint (`Type 'F' must have a '[Symbol.iterator]()' method...`) is now emitted at the expected position. Two other TS2488 fingerprints in the same test (nested empty-array destructure → `undefined` iteration) remain — those involve a separate nested-pattern path.

## Files

- `crates/tsz-checker/src/checkers/iterable_checker.rs` — drop the `has_numeric_index_signature(resolved_type)` short-circuit at the tail of `check_destructuring_iterability`. ES5 destructuring continues to handle the legacy array-like fallback above this branch.
- `crates/tsz-checker/tests/spread_rest_tests.rs` — `test_destructuring_index_signature_only_emits_ts2488_in_es2015` regression test pinning the new behavior.
- `docs/plan/claims/fix-destructure-array-like-iterability.md` — claim doc.

## Test plan

- [x] `cargo nextest run --package tsz-checker --lib` — 2894 tests pass.
- [x] `cargo nextest run --package tsz-checker -E 'test(test_destructuring_index_signature)'` — new test passes.
- [x] `./scripts/conformance/conformance.sh run --filter "destructuringArrayBindingPatternAndAssignment2" --verbose` — TS2488 for `F` is now emitted (line 35:5 in our numbering vs tsc's 34:5; conformance fingerprint check normalizes the directive-line offset).
- [ ] Full conformance suite — pending CI.