### PR TITLE
fix(checker): suppress TS2532 when TS2454 fires inside the receiver span

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -439,19 +439,29 @@ impl<'a> CheckerState<'a> {
         } else {
             object_type
         };
-        let receiver_start = self
+        let (receiver_start, receiver_end) = self
             .ctx
             .arena
             .get(access.expression)
-            .map(|node| node.pos)
-            .unwrap_or(u32::MAX);
+            .map(|node| (node.pos, node.end))
+            .unwrap_or((u32::MAX, u32::MAX));
+        // A receiver "has a DAA error" when:
+        //   1. The receiver expression node itself was flagged with TS2454, or
+        //   2. The property-access node was flagged, or
+        //   3. Any TS2454 diagnostic falls within the receiver's [pos, end) span.
+        //
+        // Case (3) covers composite receivers like `get(foo)` where the
+        // identifier `foo` is a sub-expression of the receiver (not the
+        // receiver itself) and was the DAA-flagged node. tsc suppresses
+        // TS18047/TS18048/TS18049 (and the legacy TS2531/TS2532/TS2533) on
+        // property access whenever the receiver expression contains a
+        // definite-assignment failure, because the cascade is meaningless
+        // once we already reported that the underlying variable has no value.
         let receiver_has_daa_error = self.ctx.daa_error_nodes.contains(&access.expression.0)
             || self.ctx.daa_error_nodes.contains(&idx.0)
-            || self
-                .ctx
-                .diagnostics
-                .iter()
-                .any(|diag| diag.code == 2454 && diag.start == receiver_start);
+            || self.ctx.diagnostics.iter().any(|diag| {
+                diag.code == 2454 && diag.start >= receiver_start && diag.start < receiver_end
+            });
         if !skip_flow_narrowing
             // When TS2454 already forced the receiver read back to its declared type,
             // keep property access on that declared type so member lookup and call

--- a/crates/tsz-checker/tests/definite_assignment_tests.rs
+++ b/crates/tsz-checker/tests/definite_assignment_tests.rs
@@ -2006,3 +2006,48 @@ fn test_ts2454_still_emitted_for_tdz_with_non_circular_annotation() {
         "TS2454 must still fire for normal TDZ companion, got: {diags:?}"
     );
 }
+
+/// Regression for `unionAndIntersectionInference1.ts`. When a property access
+/// receiver is a composite expression (e.g. a `CallExpression`) whose
+/// sub-expression is an uninitialized variable that fires TS2454, tsc
+/// suppresses TS2532 on the outer property access. The cascade is meaningless
+/// once the underlying variable has been reported as un-assigned.
+///
+/// Before the fix, the checker only recognised the receiver as DAA-flagged
+/// when the receiver node itself was the failing identifier, or when a
+/// TS2454 diagnostic started exactly at the receiver's start position. For
+/// `get(foo).toUpperCase()`, the receiver is `get(foo)` which starts before
+/// `foo`, so the heuristic missed it and TS2532 leaked through.
+#[test]
+fn test_ts2532_suppressed_when_ts2454_fires_in_call_receiver() {
+    let source = r"
+        type Maybe<T> = T | void;
+        function get<U>(x: U | void): U {
+            return null as any;
+        }
+        let foo: Maybe<string>;
+        get(foo).toUpperCase();
+    ";
+    let diags = diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        count_code(
+            &diags,
+            diagnostic_codes::VARIABLE_IS_USED_BEFORE_BEING_ASSIGNED
+        ),
+        1,
+        "TS2454 must fire on uninitialized `foo`, got: {diags:?}"
+    );
+    assert_eq!(
+        count_code(&diags, diagnostic_codes::OBJECT_IS_POSSIBLY_UNDEFINED),
+        0,
+        "TS2532 must be suppressed when TS2454 fires inside the receiver \
+         expression of a property access; tsc only reports the underlying \
+         use-before-assigned. Got: {diags:?}"
+    );
+}

--- a/docs/plan/claims/fix-checker-ts2532-suppress-when-ts2454-in-receiver.md
+++ b/docs/plan/claims/fix-checker-ts2532-suppress-when-ts2454-in-receiver.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/checker-ts2532-suppress-when-ts2454-in-receiver`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1439
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent
@@ -25,10 +25,12 @@ whose span lies within the receiver's `[pos, end]` range.
 
 ## Files Touched
 
-- `crates/tsz-checker/src/types/property_access_type/resolve.rs`
-- `crates/tsz-checker/tests/conformance_issues/...` (new regression test)
+- `crates/tsz-checker/src/types/property_access_type/resolve.rs` (~20 LOC)
+- `crates/tsz-checker/tests/definite_assignment_tests.rs` (+45 LOC test)
 
 ## Verification
 
-- `cargo nextest run -p tsz-checker --lib`
-- `./scripts/conformance/conformance.sh run --filter "unionAndIntersectionInference1" --verbose`
+- `cargo nextest run -p tsz-checker --lib` — 2893 / 2893 pass.
+- `cargo nextest run -p tsz-checker -E 'test(definite_assignment) | test(ts2454) | test(ts2532)'` — 81 / 81 pass.
+- `./scripts/conformance/conformance.sh run --filter "unionAndIntersectionInference1" --verbose` — TS2532 false positive eliminated.
+- Pre-commit (cargo fmt, clippy, wasm32 rustc, architecture guardrails, full nextest 13777) all pass.

--- a/docs/plan/claims/fix-checker-ts2532-suppress-when-ts2454-in-receiver.md
+++ b/docs/plan/claims/fix-checker-ts2532-suppress-when-ts2454-in-receiver.md
@@ -1,0 +1,34 @@
+# fix(checker): suppress TS2532 on property access when TS2454 fires within the receiver span
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-ts2532-suppress-when-ts2454-in-receiver`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+`unionAndIntersectionInference1.ts` produces a false TS2532 ("Object is
+possibly 'undefined'.") on `get(foo).toUpperCase()` where `foo` is an
+uninitialized `let foo: Maybe<string>`. tsc emits only TS2454 ("Variable
+'foo' is used before being assigned.") and suppresses TS2532 because the
+receiver expression contains a definite-assignment failure.
+
+Today the checker's `receiver_has_daa_error` heuristic only matches when the
+receiver itself is the DAA-flagged node, or when a TS2454 diagnostic starts
+exactly at the receiver's start position. For composite receivers like
+`get(foo)` (a `CallExpression` wrapping the failing identifier), neither
+condition holds, so TS2532 leaks through.
+
+This change extends `receiver_has_daa_error` to cover any TS2454 diagnostic
+whose span lies within the receiver's `[pos, end]` range.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/property_access_type/resolve.rs`
+- `crates/tsz-checker/tests/conformance_issues/...` (new regression test)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib`
+- `./scripts/conformance/conformance.sh run --filter "unionAndIntersectionInference1" --verbose`


### PR DESCRIPTION
## Summary

- When a property access has a composite receiver (e.g. `get(foo)`) and a sub-expression of that receiver is an uninitialized variable that fires TS2454, tsc emits only TS2454 and suppresses TS2532 ("Object is possibly 'undefined'.").
- The checker's `receiver_has_daa_error` heuristic only matched when the receiver itself was the DAA-flagged node, or when a TS2454 diagnostic started exactly at the receiver's start position. For `get(foo)`, the receiver `get(...)` starts before the inner identifier `foo`, so neither condition held and we emitted both TS2454 and TS2532.
- Extend the heuristic to cover any TS2454 diagnostic whose `start` falls within the receiver's `[pos, end)` span. Across all 413 conformance tests expecting TS2454, none also expect TS2532, confirming tsc's consistent behavior.
- Fixes the false TS2532 in `unionAndIntersectionInference1.ts` (`get(foo).toUpperCase()` where `foo: Maybe<string>` is uninitialized).

## Conformance impact

- `unionAndIntersectionInference1.ts`: TS2532 false positive removed. Test still fails on a separate TS7023/TS2322 issue (recursive arrow + intersection assignability) — out of scope here.
- No regressions across `definite_assignment` (81), narrowing, property access, strictNull, or full lib (2893) test suites.
- Architecture: change stays in the checker (`WHERE`); no solver internals or boundary helpers touched.

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib` — 2893 / 2893 pass.
- [x] `cargo nextest run -p tsz-checker -E 'test(definite_assignment) | test(ts2454) | test(ts2532)'` — 81 / 81 pass, including new `test_ts2532_suppressed_when_ts2454_fires_in_call_receiver`.
- [x] `./scripts/conformance/conformance.sh run --filter "definite"` — 4/4.
- [x] `./scripts/conformance/conformance.sh run --filter "propertyAccess"` — 25/26 (no change).
- [x] `./scripts/conformance/conformance.sh run --filter "narrowing"` — 26/29 (no change).
- [x] `./scripts/conformance/conformance.sh run --filter "strictNull"` — 5/5.
- [x] `./scripts/conformance/conformance.sh run --filter "unionAndIntersectionInference1" --verbose` — TS2532 extra removed.
- [x] Pre-commit: clippy zero warnings, wasm32 rustc gate, architecture guardrails, 13777 tests pass.