### PR TITLE
chore(ci): address review findings from #1387 #1405 #1423 #1429

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -131,6 +131,7 @@ jobs:
             exit 0
           fi
           printf '%s' "$SCCACHE_GCS_KEY_JSON" > /tmp/gcs-key.json
+          trap 'rm -f /tmp/gcs-key.json' EXIT
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcs-key.json
           LATEST=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/latest.json
           if gsutil -q stat "$LATEST" 2>/dev/null; then
@@ -139,7 +140,6 @@ jobs:
           else
             echo "No latest.json in GCS yet — using checked-in benchmark data"
           fi
-          rm -f /tmp/gcs-key.json
         continue-on-error: true
 
       - name: Download WASM

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -176,10 +176,25 @@ steps:
             "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${dest_obj}" \
             --data-binary @/workspace/bench-results.json
         }
+        # curl returns exit 0 on HTTP 4xx/5xx (unlike gsutil), so we must inspect
+        # the captured status code and abort the publish step if either upload
+        # fails — otherwise the website redeploy below would publish stale data.
+        check_http_ok() {
+          local label="$1" status="$2"
+          case "$status" in
+            200|201|204) return 0 ;;
+            *)
+              echo "error: ${label} upload failed with HTTP ${status}" >&2
+              exit 1
+              ;;
+          esac
+        }
         code=$(gcs_upload "tsz-ci-cache/bench-runs/${TIMESTAMP}.json")
         echo "Timestamped upload HTTP ${code}"
+        check_http_ok "timestamped" "$code"
         code=$(gcs_upload "tsz-ci-cache/bench-runs/latest.json")
         echo "latest.json upload HTTP ${code}"
+        check_http_ok "latest.json" "$code"
         echo "Saved to gs://${BUCKET}/tsz-ci-cache/bench-runs/{${TIMESTAMP},latest}.json"
 
         echo "=== Triggering website redeploy ==="

--- a/docs/plan/claims/ci-cap-cargo-build-jobs-by-memory.md
+++ b/docs/plan/claims/ci-cap-cargo-build-jobs-by-memory.md
@@ -20,7 +20,8 @@ codegen units per binary.
 
 This PR adds a `default_cargo_build_jobs()` helper that takes
 `min(HOST_CPUS, host_memory_mb / TSZ_CI_CARGO_MB_PER_JOB)` with a default
-6144 MiB per job (so 32 vCPU × 128 GiB → 21 jobs, leaving headroom).
+12288 MiB per job (so 32 vCPU × 128 GiB → 10 jobs, leaving ~8 GiB headroom
+for cargo metadata + the OS; on an 8 vCPU × 32 GiB host → 2 jobs).
 
 ## Files Touched
 

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -33,7 +33,7 @@ default_cargo_build_jobs() {
   cpu_jobs="$HOST_CPUS"
   mem_mb="$(awk '/MemTotal:/ { printf "%d\n", $2 / 1024 }' /proc/meminfo 2>/dev/null || echo 0)"
   mem_per_job_mb="${TSZ_CI_CARGO_MB_PER_JOB:-12288}"
-  if [[ "$mem_mb" =~ ^[0-9]+$ && "$mem_mb" -gt 0 && "$mem_per_job_mb" -gt 0 ]]; then
+  if [[ "$mem_mb" =~ ^[0-9]+$ && "$mem_mb" -gt 0 && "$mem_per_job_mb" =~ ^[0-9]+$ && "$mem_per_job_mb" -gt 0 ]]; then
     mem_jobs=$((mem_mb / mem_per_job_mb))
     if (( mem_jobs < 1 )); then mem_jobs=1; fi
     if (( cpu_jobs > mem_jobs )); then
@@ -1224,7 +1224,11 @@ run_build() {
   # every shard misses the cache and reinstalls npm packages independently.
   ci_section "Seed scripts node_modules for parallel job cache"
   if [[ ! -x scripts/node_modules/.bin/tsc ]]; then
-    (cd scripts && npm install --silent)
+    if command -v npm >/dev/null 2>&1; then
+      (cd scripts && npm install --silent)
+    else
+      echo "warn: npm not found in build image; skipping scripts/node_modules seed (shards will reinstall on cache-miss)" >&2
+    fi
   else
     echo "scripts/node_modules already present (cache hit)"
   fi


### PR DESCRIPTION
## Summary

Bundles five small follow-up fixes raised during code review of recently-merged CI/infra PRs (#1387, #1405, #1423, #1429). All five are defensive improvements to scripts/workflows; no semantic behavior changes when inputs are well-formed.

## Findings addressed

### 1. `scripts/ci/gcp-full-ci.sh` — numeric guard on `TSZ_CI_CARGO_MB_PER_JOB` (from #1387)
The `default_cargo_build_jobs()` guard checked `mem_mb` was numeric but trusted `mem_per_job_mb` raw. A non-numeric override like `TSZ_CI_CARGO_MB_PER_JOB=12288m` made `[[ "$mem_per_job_mb" -gt 0 ]]` print `integer expression expected`. Added the same `=~ ^[0-9]+$` regex used by sibling `default_fourslash_workers` / `default_conformance_workers`.

### 2. `docs/plan/claims/ci-cap-cargo-build-jobs-by-memory.md` — refresh stale default (from #1387)
Doc claimed "6144 MiB per job (so 32 vCPU x 128 GiB -> 21 jobs)" but the merged code uses 12288. Updated text to reflect the real default and recomputed the example: 32 vCPU x 128 GiB -> 10 jobs; also added an 8 vCPU x 32 GiB -> 2 jobs example for smaller hosts.

### 3. `scripts/ci/gcp-full-ci.sh` — guard `npm install` in `run_build` (from #1405)
The seed-step in `run_build` ran `npm install` unconditionally on cache-miss, but the `rust:1.90-bookworm` Cloud Build image has no npm. Wrapped in `command -v npm` check; logs a warning and continues if absent (shards will reinstall on cache-miss as before, just no seeding optimization).

### 4. `.github/workflows/gh-pages.yml` — scrub GCS key on EXIT (from #1423)
With `set -euo pipefail`, a `gsutil cp` failure aborts the step before the trailing `rm -f /tmp/gcs-key.json` runs, leaking the credential file. Added `trap 'rm -f /tmp/gcs-key.json' EXIT` immediately after writing the key. Removed the now-redundant trailing `rm`.

### 5. `cloudbuild-bench.yaml` — validate `curl` HTTP status after upload (from #1429)
`curl` returns exit 0 on HTTP 4xx/5xx (unlike `gsutil`), so the captured `$code` was logged but never checked. The website redeploy step ran even when the `latest.json` upload failed, publishing stale data. Added a `check_http_ok` helper that aborts the publish step (exit 1) on any non-2xx; the EXIT-trap-driven lock release still runs.

## Test plan

- [x] `bash -n scripts/ci/gcp-full-ci.sh` (parses)
- [x] YAML round-trips for `.github/workflows/gh-pages.yml` and `cloudbuild-bench.yaml`
- [ ] CI green on this PR (smoke-tests #1, #3 paths)
- [ ] Next bench run confirms HTTP-status check is exercised (no behavior change in success path)

Source PRs: #1387 #1405 #1423 #1429
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
