### PR TITLE
fix(checker): suppress TS2786 for SFCs returning never

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -584,8 +584,14 @@ impl<'a> CheckerState<'a> {
                             self.ctx.types,
                             return_type,
                         );
-                        if non_null_return == TypeId::NEVER
-                            || !self.is_assignable_to(non_null_return, element_type)
+                        // `never` after stripping nullish means the SFC only
+                        // returns nullish values (or unreachable). tsc treats
+                        // this as a valid JSX return type because `never` is
+                        // assignable to anything (e.g. `function F() { return null!; }`).
+                        // Mirrors the construct-signature handling below and
+                        // `check_jsx_sfc_return_type` (which also early-exits on never).
+                        if non_null_return != TypeId::NEVER
+                            && !self.is_assignable_to(non_null_return, element_type)
                         {
                             all_valid = false;
                         }

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -383,6 +383,30 @@ fn jsx_call_signature_returning_element_or_null_no_ts2786() {
     );
 }
 
+/// TS2786 should NOT fire for SFCs whose inferred return type is `never`
+/// (e.g. `function MyComp(props) { return null!; }`). `never` is the bottom
+/// type and is assignable to `JSX.Element`. Mirrors tsc behavior — see
+/// conformance test `spellingSuggestionJSXAttribute.tsx`.
+#[test]
+fn jsx_sfc_returning_never_no_ts2786() {
+    let diagnostics = check_jsx_codes(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface IntrinsicElements { }
+        }
+        function MyComp(props: { className?: string }) {
+            return null!;
+        }
+        <MyComp className="" />;
+        "#,
+    );
+    assert!(
+        !diagnostics.contains(&2786),
+        "SFC returning never (bottom type) should not emit TS2786, got: {diagnostics:?}"
+    );
+}
+
 /// TS2607: When `ElementAttributesProperty` specifies a property name (e.g. `pr`)
 /// and the class component instance type doesn't have that property,
 /// emit "JSX element class does not support attributes".

--- a/docs/plan/claims/fix-jsx-ts2786-never-sfc-return.md
+++ b/docs/plan/claims/fix-jsx-ts2786-never-sfc-return.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/jsx-ts2786-never-sfc-return`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1442
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent

--- a/docs/plan/claims/fix-jsx-ts2786-never-sfc-return.md
+++ b/docs/plan/claims/fix-jsx-ts2786-never-sfc-return.md
@@ -1,0 +1,35 @@
+# fix(checker): suppress TS2786 for SFCs whose return type is never
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/jsx-ts2786-never-sfc-return`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+`check_jsx_component_return_type` was emitting a spurious TS2786
+("'X' cannot be used as a JSX component") for SFCs whose return type
+strips to `never` after nullish removal — e.g.
+`function MyComp(props) { return null!; }`. `null!` narrows to `never`,
+which is the bottom type and IS assignable to `JSX.Element`. tsc
+accepts this and emits no TS2786. Aligns the SFC branch with the
+construct-signature branch (which already treats `stripped == NEVER`
+as valid) and with `check_jsx_sfc_return_type` (which already early-
+exits on `never`).
+
+Fixes conformance test
+`TypeScript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx`
+(removes spurious TS2786 from actual codes; brings the test from
+`only-extra` failure to error-code-level parity).
+
+## Files Touched
+
+- `crates/tsz-checker/src/checkers/jsx/extraction.rs` (~10 LOC)
+- `crates/tsz-checker/src/checkers/jsx/tests.rs` (regression test)
+- `scripts/conformance/conformance-baseline.txt` (drop spurious TS2786)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib jsx_` (199 tests pass)
+- `./scripts/conformance/conformance.sh run --filter "spellingSuggestionJSXAttribute" --verbose` (codes match expected)

--- a/scripts/conformance/conformance-baseline.txt
+++ b/scripts/conformance/conformance-baseline.txt
@@ -12574,7 +12574,7 @@ XFAIL TypeScript/tests/cases/compiler/moduleAugmentationDoesNamespaceEnumMergeOf
 XFAIL TypeScript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts | expected:[] actual:[TS2749]
 XFAIL TypeScript/tests/cases/compiler/promiseTry.ts | expected:[] actual:[TS2345,TS2578]
 XFAIL TypeScript/tests/cases/compiler/recursiveConditionalTypes.ts | expected:[TS2322,TS2345,TS2589] actual:[TS2322,TS2339,TS2345,TS2589]
-XFAIL TypeScript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx | expected:[TS2322,TS2769] actual:[TS2322,TS2769,TS2786]
+XFAIL TypeScript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx | expected:[TS2322,TS2769] actual:[TS2322,TS2769]
 XFAIL TypeScript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts | expected:[TS2344] actual:[]
 XFAIL TypeScript/tests/cases/conformance/classes/mixinAccessModifiers.ts | expected:[TS2339,TS2341,TS2445,TS2509,TS2564] actual:[TS2339,TS2341,TS2445,TS2509,TS2564]
 XFAIL TypeScript/tests/cases/conformance/classes/mixinAccessors1.ts | expected:[] actual:[TS5088]


### PR DESCRIPTION
## Summary

- `check_jsx_component_return_type` was emitting a spurious TS2786 ("'X' cannot be used as a JSX component") for SFCs whose return type strips to `never` after nullish removal — e.g. `function MyComp(props) { return null!; }`. `null!` narrows to `never`, which is the bottom type and IS assignable to `JSX.Element`. tsc accepts this and emits no TS2786.
- Aligns the SFC branch with the construct-signature branch (already treats `stripped == NEVER` as valid) and with `check_jsx_sfc_return_type` (already early-exits on `never`).
- Fixes conformance test `TypeScript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx`: moves it from `only-extra` (we emitted spurious TS2786 on `<MyComp2 .../>`) to error-code-level parity. Only fingerprint position/message differences remain (already tracked under the existing XFAIL).

## Test plan

- [x] New regression unit test `jsx_sfc_returning_never_no_ts2786` in `crates/tsz-checker/src/checkers/jsx/tests.rs`.
- [x] `cargo nextest run -p tsz-checker --lib jsx_` (199/199 pass).
- [x] `./scripts/conformance/conformance.sh run --filter "spellingSuggestionJSXAttribute" --verbose` — actual codes now equal expected `[TS2322, TS2769]` (was `[TS2322, TS2769, TS2786]`).
- [x] Conformance baseline updated to drop the spurious TS2786 entry.
- [x] Pre-commit suite (13,777 tests across 117 binaries) passes.