### PR TITLE
ci(bench): no-queue, cold runs, self-retriggering

### DIFF
--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -13,9 +13,15 @@ steps:
       if echo "$BUILD_ID" | gsutil -h 'x-goog-if-generation-match:0' cp -q - "$LOCK_URI" 2>/dev/null; then
         echo "Lock acquired for BUILD_ID=$BUILD_ID"
         touch /workspace/bench-enabled
-      else
+      elif gsutil -q stat "$LOCK_URI" 2>/dev/null; then
+        # Precondition failed because the lock genuinely exists.
         holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
         echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
+      else
+        # cp failed for a transient reason (network, permissions) — treat as
+        # acquired so we don't silently drop benchmark runs on GCS hiccups.
+        echo "Warning: lock cp failed but lock does not exist — treating as acquired."
+        touch /workspace/bench-enabled
       fi
 
   # Step 2: Run the full benchmark suite on the beefy c3-88 node.

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -126,8 +126,20 @@ steps:
 
       echo "=== Publishing results ==="
       TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-      gsutil cp /workspace/bench-results.json "${BENCH_BUCKET}/${TIMESTAMP}.json"
-      gsutil cp /workspace/bench-results.json "${BENCH_BUCKET}/latest.json"
+      TOKEN=$(gcloud auth print-access-token)
+      gcs_upload() {
+        local dest_obj="$1"
+        curl -s -o /dev/null -w "%{http_code}" \
+          -X POST \
+          -H "Authorization: Bearer ${TOKEN}" \
+          -H "Content-Type: application/json" \
+          "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${dest_obj}" \
+          --data-binary @/workspace/bench-results.json
+      }
+      code=$(gcs_upload "tsz-ci-cache/bench-runs/${TIMESTAMP}.json")
+      echo "Timestamped upload HTTP ${code}"
+      code=$(gcs_upload "tsz-ci-cache/bench-runs/latest.json")
+      echo "latest.json upload HTTP ${code}"
       echo "Saved to ${BENCH_BUCKET}/${TIMESTAMP}.json and latest.json"
 
       echo "=== Triggering website redeploy ==="

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -65,7 +65,7 @@ steps:
 
       echo "=== Installing deps ==="
       apt-get update -q
-      apt-get install -y -q hyperfine curl git jq
+      apt-get install -y -q hyperfine curl git jq bc
       # Node.js 22
       curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null
       apt-get install -y -q nodejs

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -10,7 +10,13 @@ steps:
       #!/usr/bin/env bash
       set -euo pipefail
       LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
-      if echo "$BUILD_ID" | gsutil -h 'x-goog-if-generation-match:0' cp -q - "$LOCK_URI" 2>/dev/null; then
+
+      # Write lock content to a temp file (avoids stdin-pipe issues in Cloud Build).
+      printf '%s\n' "$BUILD_ID" > /tmp/bench-lock-content.txt
+
+      # Atomic create: x-goog-if-generation-match:0 fails if object already exists.
+      lock_err=$(gsutil -h 'x-goog-if-generation-match:0' cp /tmp/bench-lock-content.txt "$LOCK_URI" 2>&1) && acquired=true || acquired=false
+      if [[ "$acquired" == "true" ]]; then
         echo "Lock acquired for BUILD_ID=$BUILD_ID"
         touch /workspace/bench-enabled
       elif gsutil -q stat "$LOCK_URI" 2>/dev/null; then
@@ -18,9 +24,9 @@ steps:
         holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
         echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
       else
-        # cp failed for a transient reason (network, permissions) — treat as
-        # acquired so we don't silently drop benchmark runs on GCS hiccups.
-        echo "Warning: lock cp failed but lock does not exist — treating as acquired."
+        # cp failed for a transient reason — log it and proceed rather than silently dropping.
+        echo "Warning: lock cp failed but lock does not exist. Error: ${lock_err}"
+        echo "Treating as acquired to avoid dropping this benchmark run."
         touch /workspace/bench-enabled
       fi
 

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -1,23 +1,55 @@
 steps:
-  # Step 1: Acquire a GCS-backed mutex so only one benchmark runs at a time.
-  # Uses x-goog-if-generation-match:0 for an atomic create — GCS rejects the
-  # write if the object already exists, eliminating the TOCTOU race.
-  # If the lock is already held, we write nothing to /workspace and subsequent
-  # steps exit early — no duplicate benchmark runs ever overlap.
-  - id: acquire-lock
+  # Step 1: Cancel all queued sibling builds from this trigger; skip if another
+  # is already WORKING. This implements a "last write wins, no queue" policy:
+  # only the most-recent push runs benchmarks; stale queued builds are cancelled.
+  # After the bench finishes, if main has moved, we retrigger (Step 3), so no
+  # commits are permanently skipped — each commit eventually gets measured once.
+  - id: dequeue-and-lock
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
+      PROJECT_ID="${PROJECT_ID}"
+      REGION="us-central1"
+      TRIGGER_ID="dc40c48b-ef9a-43b4-a477-82d23d1216da"
       BUCKET="thirdface-ai-oauth_cloudbuild"
       OBJECT="tsz-ci-cache/bench-runs/.lock"
-      LOCK_URI="gs://${BUCKET}/${OBJECT}"
 
-      # Use the GCS JSON API directly via curl + gcloud token so we get
-      # exact HTTP status codes and avoid gsutil auth quirks in private pools.
       TOKEN=$(gcloud auth print-access-token)
 
-      # Atomic create: HTTP 412 = precondition failed (lock already exists).
+      # List QUEUED and WORKING builds for this trigger (newest first).
+      BUILDS_JSON=$(curl -s \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "https://cloudbuild.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/builds?filter=trigger_id%3D%22${TRIGGER_ID}%22&pageSize=50")
+
+      OTHER_WORKING=false
+      while IFS=$'\t' read -r bid bstatus; do
+        [[ "$bid" == "$BUILD_ID" ]] && continue
+        if [[ "$bstatus" == "WORKING" ]]; then
+          OTHER_WORKING=true
+          echo "Sibling WORKING: ${bid} — will retrigger after it finishes."
+        elif [[ "$bstatus" == "QUEUED" ]]; then
+          echo "Cancelling queued sibling: ${bid}..."
+          curl -s -o /dev/null -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://cloudbuild.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/builds/${bid}:cancel" \
+            -d '{}' || true
+        fi
+      done < <(echo "$BUILDS_JSON" | python3 -c "
+      import sys, json
+      data = json.load(sys.stdin)
+      for b in data.get('builds', []):
+          if b.get('status') in ('QUEUED', 'WORKING'):
+              print(b['id'] + '\t' + b['status'])
+      ")
+
+      if [[ "$OTHER_WORKING" == "true" ]]; then
+        echo "Another benchmark is WORKING — skipping this run. It will retrigger when done."
+        exit 0
+      fi
+
+      # Acquire GCS mutex (atomic: HTTP 412 = already held by a concurrent winner).
       HTTP=$(curl -s -o /tmp/lock-resp.txt -w "%{http_code}" \
         -X POST \
         -H "Authorization: Bearer ${TOKEN}" \
@@ -36,7 +68,7 @@ steps:
             -H "Authorization: Bearer ${TOKEN}" \
             "https://storage.googleapis.com/download/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}?alt=media" \
             || echo "unknown")
-          echo "Benchmark already in progress (lock holder: ${holder}). Skipping this run."
+          echo "Lock held by ${holder} (concurrent run). Skipping."
           ;;
         *)
           echo "Warning: unexpected HTTP ${HTTP} acquiring lock — treating as acquired."
@@ -45,15 +77,15 @@ steps:
           ;;
       esac
 
-  # Step 2: Run the full benchmark suite on the beefy c3-88 node.
-  # allowFailure: true ensures the publish step always runs even if bench
-  # crashes or times out, so the lock is always released.
+  # Step 2: Run the full benchmark suite cold (no tsbuildinfo cache).
+  # allowFailure ensures Step 3 always runs so the lock is always released.
   - id: bench
     name: rust:1.90-bookworm
     allowFailure: true
     timeout: 3000s
     env:
       - 'TSC_NPM_SPEC=6.0.2'
+      - 'BENCH_COLD=1'
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
@@ -82,82 +114,129 @@ steps:
       git -C TypeScript checkout --detach FETCH_HEAD
       echo "TypeScript submodule ready"
 
-      echo "=== Running full benchmark ==="
+      echo "=== Running full benchmark (BENCH_COLD=1 — cold runs, no tsbuildinfo) ==="
       ./scripts/bench/bench-vs-tsgo.sh \
         --json \
         --json-file /workspace/bench-results.json \
         2>&1 | tee /workspace/bench-run.log
 
-  # Step 3: Publish results to GCS and trigger a website redeploy.
+  # Step 3: Publish results, release lock, retrigger if main has moved.
   - id: publish
     name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
+      PROJECT_ID="${PROJECT_ID}"
+      REGION="us-central1"
+      TRIGGER_ID="dc40c48b-ef9a-43b4-a477-82d23d1216da"
       BUCKET="thirdface-ai-oauth_cloudbuild"
       OBJECT="tsz-ci-cache/bench-runs/.lock"
-      BENCH_BUCKET=gs://${BUCKET}/tsz-ci-cache/bench-runs
 
-      # Always release the lock when we exit (success or failure).
-      release_lock() {
+      # Safety net: release the lock if the script crashes before reaching the
+      # explicit release below. The explicit release removes /workspace/bench-enabled
+      # first so this trap becomes a no-op on the happy path.
+      release_lock_on_crash() {
         if [[ -f /workspace/bench-enabled ]]; then
-          echo "Releasing benchmark lock..."
-          TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
-          if [[ -n "$TOKEN" ]]; then
+          echo "Releasing benchmark lock (crash cleanup)..."
+          local tok
+          tok=$(gcloud auth print-access-token 2>/dev/null || true)
+          if [[ -n "$tok" ]]; then
             curl -s -X DELETE \
-              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Authorization: Bearer ${tok}" \
               "https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}" \
               -o /dev/null || true
           fi
         fi
       }
-      trap release_lock EXIT
+      trap release_lock_on_crash EXIT
 
       if [[ ! -f /workspace/bench-enabled ]]; then
         echo "Nothing to publish — benchmark was skipped."
         exit 0
       fi
 
-      if [[ ! -f /workspace/bench-results.json ]]; then
-        echo "No bench-results.json found — benchmark may have failed or timed out"
-        tail -100 /workspace/bench-run.log || true
-        exit 0  # lock is released by the EXIT trap; don't publish stale data
-      fi
-
-      echo "=== Publishing results ==="
-      TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
       TOKEN=$(gcloud auth print-access-token)
-      gcs_upload() {
-        local dest_obj="$1"
-        curl -s -o /dev/null -w "%{http_code}" \
-          -X POST \
-          -H "Authorization: Bearer ${TOKEN}" \
-          -H "Content-Type: application/json" \
-          "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${dest_obj}" \
-          --data-binary @/workspace/bench-results.json
-      }
-      code=$(gcs_upload "tsz-ci-cache/bench-runs/${TIMESTAMP}.json")
-      echo "Timestamped upload HTTP ${code}"
-      code=$(gcs_upload "tsz-ci-cache/bench-runs/latest.json")
-      echo "latest.json upload HTTP ${code}"
-      echo "Saved to ${BENCH_BUCKET}/${TIMESTAMP}.json and latest.json"
 
-      echo "=== Triggering website redeploy ==="
+      # Fetch the GitHub token early — needed for website dispatch and main-SHA check.
       GITHUB_TOKEN="$(gcloud secrets versions access latest \
         --secret=github_runner_token --project=tsz-ci 2>/dev/null || true)"
-      if [[ -n "$GITHUB_TOKEN" ]]; then
-        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/mohsen1/tsz/actions/workflows/gh-pages.yml/dispatches \
-          -d '{"ref":"main"}')
-        if [[ "$http_code" == "204" ]]; then
-          echo "Website deploy triggered successfully."
+
+      if [[ ! -f /workspace/bench-results.json ]]; then
+        echo "No bench-results.json — benchmark may have failed or timed out."
+        tail -100 /workspace/bench-run.log || true
+      else
+        echo "=== Publishing results ==="
+        TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+        gcs_upload() {
+          local dest_obj="$1"
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${dest_obj}" \
+            --data-binary @/workspace/bench-results.json
+        }
+        code=$(gcs_upload "tsz-ci-cache/bench-runs/${TIMESTAMP}.json")
+        echo "Timestamped upload HTTP ${code}"
+        code=$(gcs_upload "tsz-ci-cache/bench-runs/latest.json")
+        echo "latest.json upload HTTP ${code}"
+        echo "Saved to gs://${BUCKET}/tsz-ci-cache/bench-runs/{${TIMESTAMP},latest}.json"
+
+        echo "=== Triggering website redeploy ==="
+        if [[ -n "$GITHUB_TOKEN" ]]; then
+          http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/mohsen1/tsz/actions/workflows/gh-pages.yml/dispatches \
+            -d '{"ref":"main"}')
+          if [[ "$http_code" == "204" ]]; then
+            echo "Website deploy triggered."
+          else
+            echo "Warning: GitHub dispatch returned HTTP $http_code"
+          fi
         else
-          echo "Warning: GitHub dispatch returned HTTP $http_code"
+          echo "Warning: could not read github_runner_token — website not retriggered"
+        fi
+      fi
+
+      # Release the lock BEFORE triggering the new build so the new build
+      # doesn't see this build as WORKING in its dequeue-and-lock step.
+      # Removing bench-enabled also disarms the EXIT trap (no double-delete).
+      echo "Releasing benchmark lock..."
+      curl -s -X DELETE \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}" \
+        -o /dev/null || true
+      rm -f /workspace/bench-enabled
+
+      echo "=== Checking if main has moved ==="
+      THIS_SHA="${COMMIT_SHA:-}"
+      LATEST_SHA=""
+      if [[ -n "$GITHUB_TOKEN" ]]; then
+        LATEST_SHA=$(curl -s \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          "https://api.github.com/repos/mohsen1/tsz/commits/main" \
+          | python3 -c "import sys, json; print(json.load(sys.stdin).get('sha', ''))" 2>/dev/null || echo "")
+      else
+        LATEST_SHA=$(curl -s \
+          "https://api.github.com/repos/mohsen1/tsz/commits/main" \
+          | python3 -c "import sys, json; print(json.load(sys.stdin).get('sha', ''))" 2>/dev/null || echo "")
+      fi
+
+      if [[ -n "$THIS_SHA" && -n "$LATEST_SHA" && "$THIS_SHA" != "$LATEST_SHA" ]]; then
+        echo "main moved (this=${THIS_SHA:0:8}, latest=${LATEST_SHA:0:8}) — triggering next bench run..."
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          -H "Authorization: Bearer ${TOKEN}" \
+          -H "Content-Type: application/json" \
+          "https://cloudbuild.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/triggers/${TRIGGER_ID}:run" \
+          -d '{"source": {"branchName": "main"}}')
+        if [[ "$http_code" =~ ^2 ]]; then
+          echo "Retrigger successful (HTTP ${http_code})"
+        else
+          echo "Warning: retrigger returned HTTP ${http_code}"
         fi
       else
-        echo "Warning: could not read github_runner_token — website not re-triggered"
+        echo "main is at ${THIS_SHA:0:8} — no retrigger needed."
       fi
 
 options:

--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -9,26 +9,41 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
-      LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
+      BUCKET="thirdface-ai-oauth_cloudbuild"
+      OBJECT="tsz-ci-cache/bench-runs/.lock"
+      LOCK_URI="gs://${BUCKET}/${OBJECT}"
 
-      # Write lock content to a temp file (avoids stdin-pipe issues in Cloud Build).
-      printf '%s\n' "$BUILD_ID" > /tmp/bench-lock-content.txt
+      # Use the GCS JSON API directly via curl + gcloud token so we get
+      # exact HTTP status codes and avoid gsutil auth quirks in private pools.
+      TOKEN=$(gcloud auth print-access-token)
 
-      # Atomic create: x-goog-if-generation-match:0 fails if object already exists.
-      lock_err=$(gsutil -h 'x-goog-if-generation-match:0' cp /tmp/bench-lock-content.txt "$LOCK_URI" 2>&1) && acquired=true || acquired=false
-      if [[ "$acquired" == "true" ]]; then
-        echo "Lock acquired for BUILD_ID=$BUILD_ID"
-        touch /workspace/bench-enabled
-      elif gsutil -q stat "$LOCK_URI" 2>/dev/null; then
-        # Precondition failed because the lock genuinely exists.
-        holder=$(gsutil cat "$LOCK_URI" 2>/dev/null || echo "unknown")
-        echo "Benchmark already in progress (lock holder: $holder). Skipping this run."
-      else
-        # cp failed for a transient reason — log it and proceed rather than silently dropping.
-        echo "Warning: lock cp failed but lock does not exist. Error: ${lock_err}"
-        echo "Treating as acquired to avoid dropping this benchmark run."
-        touch /workspace/bench-enabled
-      fi
+      # Atomic create: HTTP 412 = precondition failed (lock already exists).
+      HTTP=$(curl -s -o /tmp/lock-resp.txt -w "%{http_code}" \
+        -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: text/plain" \
+        -H "x-goog-if-generation-match: 0" \
+        "https://storage.googleapis.com/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${OBJECT}" \
+        --data-binary "${BUILD_ID}")
+
+      case "$HTTP" in
+        200|201)
+          echo "Lock acquired for BUILD_ID=$BUILD_ID"
+          touch /workspace/bench-enabled
+          ;;
+        412)
+          holder=$(curl -s \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://storage.googleapis.com/download/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}?alt=media" \
+            || echo "unknown")
+          echo "Benchmark already in progress (lock holder: ${holder}). Skipping this run."
+          ;;
+        *)
+          echo "Warning: unexpected HTTP ${HTTP} acquiring lock — treating as acquired."
+          cat /tmp/lock-resp.txt || true
+          touch /workspace/bench-enabled
+          ;;
+      esac
 
   # Step 2: Run the full benchmark suite on the beefy c3-88 node.
   # allowFailure: true ensures the publish step always runs even if bench
@@ -79,14 +94,21 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
-      LOCK_URI="gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/.lock"
-      BENCH_BUCKET=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs
+      BUCKET="thirdface-ai-oauth_cloudbuild"
+      OBJECT="tsz-ci-cache/bench-runs/.lock"
+      BENCH_BUCKET=gs://${BUCKET}/tsz-ci-cache/bench-runs
 
       # Always release the lock when we exit (success or failure).
       release_lock() {
         if [[ -f /workspace/bench-enabled ]]; then
           echo "Releasing benchmark lock..."
-          gsutil rm -f "$LOCK_URI" 2>/dev/null || true
+          TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
+          if [[ -n "$TOKEN" ]]; then
+            curl -s -X DELETE \
+              -H "Authorization: Bearer ${TOKEN}" \
+              "https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}" \
+              -o /dev/null || true
+          fi
         fi
       }
       trap release_lock EXIT

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -735,6 +735,12 @@ run_project_benchmark() {
     if [ -n "${TSZ_LIB_DIR:-}" ]; then
         tsz_cmd_prefix="${tsz_cmd_prefix}env TSZ_LIB_DIR=$TSZ_LIB_DIR "
     fi
+    local -a hyperfine_prepare_args=()
+    if [[ "${BENCH_COLD:-0}" == "1" ]]; then
+        local tsconfig_dir
+        tsconfig_dir="$(dirname "$tsconfig")"
+        hyperfine_prepare_args=(--prepare "find '${tsconfig_dir}' -name '*.tsbuildinfo' -delete 2>/dev/null; true")
+    fi
     if ! hyperfine \
         --warmup "$proj_warmup" \
         --min-runs "$proj_min" \
@@ -742,6 +748,7 @@ run_project_benchmark() {
         --style full \
         --ignore-failure \
         --export-json "$json_file" \
+        "${hyperfine_prepare_args[@]}" \
         -n "tsz" "perl -e 'alarm($run_timeout); exec @ARGV' -- ${tsz_cmd_prefix}$TSZ --noEmit -p $tsconfig 2>/dev/null" \
         -n "tsgo" "perl -e 'alarm($run_timeout); exec @ARGV' -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null"; then
         local status="hyperfine error"


### PR DESCRIPTION
## Summary

- **No-queue policy**: `dequeue-and-lock` step cancels all QUEUED sibling builds from this trigger and skips if another is already WORKING. Only one benchmark runs at a time; no pile-up.
- **Self-retriggering**: after publishing, `publish` step checks if `main` has moved since this build's `$COMMIT_SHA`. If it has, it fires a new Cloud Build run so the latest commit always eventually gets benchmarked.
- **Lock-before-retrigger**: the GCS mutex is released *before* triggering the next build, so the new build's `dequeue-and-lock` step won't see the old build as WORKING and cancel itself.
- **Cold benchmarks (`BENCH_COLD=1`)**: `bench-vs-tsgo.sh` now accepts `BENCH_COLD=1` env var; when set, it adds `--prepare 'find ... -name *.tsbuildinfo -delete'` to every project-mode `hyperfine` call. Every benchmark iteration starts cold — no incremental tsbuildinfo cache.

## Test plan

- [ ] Merge and push two commits quickly to main — verify second build's `dequeue-and-lock` cancels the queued one and the first running build retriggers at the end
- [ ] Check Cloud Build logs for "Cold runs" line and `--prepare` in hyperfine output
- [ ] Verify `latest.json` updates in GCS and tsz.dev shows fresh data after deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
