### PR TITLE
fix(checker): only strip optional-property undefined when stripped type is callable

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -391,19 +391,31 @@ impl<'a> CheckerState<'a> {
                             matches!(lookup_presence, ContextualPropertyPresence::Present);
                         let mut property_context_type =
                             self.contextual_object_property_type_for_lookup(ctx_type, &name);
-                        // For optional properties (e.g., `set?` in ProxyHandler), the
-                        // contextual type includes `undefined` from optionality. When
+                        // For optional callable properties (e.g., `set?` in ProxyHandler),
+                        // the contextual type includes `undefined` from optionality. When
                         // the property IS present in the literal, that `undefined` is
-                        // irrelevant — the property is being assigned, not read. Strip
-                        // it so the callable type flows through for generic inference
-                        // (e.g., `deprecate<T extends Function>(fn: T): T` should
-                        // infer T as the handler type, not fall back to `Function`).
+                        // irrelevant for callable inference — strip it so a generic
+                        // wrapper like `deprecate<T extends Function>(fn: T): T` can
+                        // infer T as the handler function type rather than falling back
+                        // to `Function`.
+                        //
+                        // Restrict the strip to callable property types so non-callable
+                        // optional properties (e.g., `y?: number` in `{ y?: number }`)
+                        // keep `undefined` in their contextual type. tsc's
+                        // `getTypeOfPropertyOfContextualType` always returns
+                        // `T | undefined` for such optional properties, so a generic
+                        // call like `match<T>(cb)` used as a value still infers
+                        // `T = number | undefined` and TS18048 fires inside the
+                        // callback as expected.
                         if let Some(pct) = property_context_type {
                             let stripped = crate::query_boundaries::common::remove_undefined(
                                 self.ctx.types,
                                 pct,
                             );
-                            if stripped != TypeId::UNDEFINED && stripped != pct {
+                            if stripped != TypeId::UNDEFINED
+                                && stripped != pct
+                                && self.stripped_property_context_is_callable(stripped)
+                            {
                                 property_context_type = Some(stripped);
                             }
                         }

--- a/crates/tsz-checker/src/types/computation/object_literal/mod.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/mod.rs
@@ -184,4 +184,40 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn get_type_of_object_literal(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_object_literal_with_request(idx, &TypingRequest::NONE)
     }
+
+    /// Decide whether stripping `undefined` from an optional property's
+    /// contextual type is appropriate.
+    ///
+    /// We only strip when the post-strip type is callable (Function, Callable
+    /// with call signatures, an intersection containing call signatures, or a
+    /// union whose remaining members are callable). Non-callable property
+    /// types (e.g. `number | undefined` for `y?: number`) keep `undefined` so
+    /// inference into nested generic calls preserves tsc's behavior of seeing
+    /// the optional property as `T | undefined` from the read side.
+    pub(crate) fn stripped_property_context_is_callable(&self, type_id: TypeId) -> bool {
+        if type_id == TypeId::UNDEFINED || type_id == TypeId::NEVER {
+            return false;
+        }
+        if crate::query_boundaries::common::has_call_signatures(self.ctx.types, type_id) {
+            return true;
+        }
+        if crate::query_boundaries::common::is_callable_type(self.ctx.types, type_id) {
+            return true;
+        }
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, type_id)
+        {
+            return members
+                .iter()
+                .all(|&m| self.stripped_property_context_is_callable(m));
+        }
+        if let Some(members) =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, type_id)
+        {
+            return members
+                .iter()
+                .any(|&m| self.stripped_property_context_is_callable(m));
+        }
+        false
+    }
 }

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -242,14 +242,19 @@ declare function foo2(point: [number?]): boolean;
 foo2([match(y => y > 0)]);
 "#;
     let diags = relevant_diagnostics(source);
-    // When a property IS present in an object literal, tsc strips `undefined`
-    // from the optional property's contextual type. So `{ y: match(y => ...) }`
-    // gives `match` a contextual return type of `number`, not `number | undefined`.
-    // Only the tuple case `[match(y => ...)]` preserves `undefined` from `number?`.
+    // tsc's `getTypeOfPropertyOfContextualType` returns `T | undefined` for
+    // optional properties, so the contextual return type seen by `match<T>`
+    // when used as a property value is `number | undefined`. With T inferred
+    // to `number | undefined`, the callback parameter `y` is possibly
+    // undefined and TS18048 fires inside the body. The tuple `[number?]`
+    // exhibits the same behavior at element 0.
+    //
+    // See `contextuallyTypedOptionalProperty.ts` in the TypeScript conformance
+    // suite (issue #55164) for the canonical baseline expecting both errors.
     let ts18048_count = diags.iter().filter(|(code, _)| *code == 18048).count();
     assert_eq!(
-        ts18048_count, 1,
-        "Expected TS18048 only for tuple optional-wrapper site (object literal strips undefined). Diagnostics: {diags:#?}"
+        ts18048_count, 2,
+        "Expected TS18048 for both optional-wrapper callback sites. Diagnostics: {diags:#?}"
     );
 }
 

--- a/docs/plan/claims/fix-contextual-strip-undefined-only-for-callable.md
+++ b/docs/plan/claims/fix-contextual-strip-undefined-only-for-callable.md
@@ -1,0 +1,50 @@
+# fix(checker): only strip optional-property undefined when stripped type is callable
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/contextual-strip-undefined-only-for-callable`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: Workstream 1 (conformance fixes — fingerprint parity)
+
+## Intent
+
+Fix `contextuallyTypedOptionalProperty.ts` (TS18048 missing on `foo({ y: match(y => y > 0) })`).
+
+The previous strip in `object_literal/computation.rs` removed `undefined`
+from the contextual type of every optional property assignment so that
+`set: deprecate(arrow, ...)` would infer `T = handlerFn` instead of
+`handlerFn | undefined`. That over-eager strip also dropped `undefined`
+from non-callable optional properties (e.g. `y?: number`), suppressing
+TS18048 inside generic callbacks like `match<T>(cb: (value: T) => boolean): T`.
+
+The fix gates the strip on whether the stripped (post-`remove_undefined`)
+type is callable (Function, Callable with call signatures, or a union /
+intersection thereof). Non-callable types like `number | undefined` keep
+`undefined` so `match<T>` infers `T = number | undefined` and TS18048
+fires inside the callback as tsc expects.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/computation/object_literal/computation.rs`
+  — gate the `remove_undefined` call on `stripped_property_context_is_callable(stripped)`.
+- `crates/tsz-checker/src/types/computation/object_literal/mod.rs`
+  — add `stripped_property_context_is_callable` helper that recurses
+  through unions/intersections.
+- `crates/tsz-checker/tests/generic_call_inference_tests.rs`
+  — flip `generic_return_context_preserves_undefined_through_optional_wrappers`
+  back to expecting both TS18048 errors (original tsc baseline behavior).
+
+## Verification
+
+- Targeted conformance: `contextuallyTypedOptionalProperty.ts` flips
+  FAIL → PASS.
+- Full conformance: 12183 → 12189 (+6, no regressions). Other improvements:
+  `jsExportMemberMergedWithModuleAugmentation2.ts`,
+  `literalFreshnessPropagationOnNarrowing.ts`,
+  `iteratorSpreadInArray5.ts`,
+  `catchClauseWithTypeAnnotation.ts`,
+  `templateLiteralTypes5.ts`.
+- `cargo nextest run -p tsz-checker` (5397 pass).
+- `cargo nextest run -p tsz-cli` (1057 pass).
+- LOC contract: helper relocated to `mod.rs` to keep `computation.rs`
+  under the 2000 LOC ceiling.


### PR DESCRIPTION
## Summary

- Fix `contextuallyTypedOptionalProperty.ts` (issue #55164 baseline). tsz was missing the second TS18048 inside `foo({ y: match(y => y > 0) })` because the checker stripped `undefined` from every optional property's contextual type when typing object-literal property assignments.
- The strip was added so callable wrappers like `deprecate<T extends Function>(fn: T): T` used as `set: deprecate(arrow, ...)` could infer `T = handlerFn` instead of `handlerFn | undefined`, but it also dropped `undefined` from non-callable optional properties such as `y?: number`. Generic calls used as property values (`match<T>`) lost their `T = number | undefined` inference and the TS18048 inside the callback body never fired.
- Gate the strip on whether the post-`remove_undefined` type is callable (Function, Callable with call signatures, or a union/intersection thereof). Non-callable property types now keep `undefined` so generic inference flows like tsc's `getTypeOfPropertyOfContextualType`.

## Conformance impact

- `contextuallyTypedOptionalProperty.ts`: FAIL → PASS.
- Net: 12183 → 12189 (+6, no regressions). Other improvements:
  - `jsExportMemberMergedWithModuleAugmentation2.ts`
  - `literalFreshnessPropagationOnNarrowing.ts`
  - `iteratorSpreadInArray5.ts`
  - `catchClauseWithTypeAnnotation.ts`
  - `templateLiteralTypes5.ts`

## Test plan

- [x] `cargo nextest run -p tsz-checker` (5397 pass)
- [x] `cargo nextest run -p tsz-cli` (1057 pass)
- [x] `./scripts/conformance/conformance.sh run --filter contextuallyTypedOptionalProperty --verbose` (1/1 passes)
- [x] Full conformance run: 12189/12582 (+6 vs main, no regressions)
- [x] Architecture LOC contract preserved (`stripped_property_context_is_callable` lives in `object_literal/mod.rs` to keep `computation.rs` under the 2000 LOC ceiling)
- [x] Updated `generic_return_context_preserves_undefined_through_optional_wrappers` to expect both TS18048 errors (matching the tsc baseline for #55164).