### PR TITLE
fix(checker/jsdoc): break on first preceding comment match + add container guard

### DIFF
--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -451,6 +451,24 @@ impl<'a> CheckerState<'a> {
                 break;
             }
             let parent_node = self.ctx.arena.get(parent)?;
+            // Stop before checking statement-level containers whose "leading
+            // JSDoc" belongs to their first child statement, not to the node
+            // we started the walk from. Without this guard, walking from a
+            // function expression up through its enclosing SourceFile/Block
+            // could pick up `@type {function(): T}` from an unrelated
+            // preceding declaration. Mirrors the guard in
+            // `try_jsdoc_with_ancestor_walk` (params.rs).
+            use tsz_parser::parser::syntax_kind_ext as sk;
+            if matches!(
+                parent_node.kind,
+                sk::SOURCE_FILE
+                    | sk::BLOCK
+                    | sk::MODULE_BLOCK
+                    | sk::CASE_CLAUSE
+                    | sk::DEFAULT_CLAUSE
+            ) {
+                break;
+            }
             for comment in comments.iter().rev() {
                 if comment.end <= parent_node.pos
                     && is_jsdoc_comment(comment, source_text)
@@ -460,6 +478,13 @@ impl<'a> CheckerState<'a> {
                     )
                 {
                     return Some(span);
+                }
+                // Stop at the first preceding comment to avoid scanning
+                // earlier (unrelated) JSDoc that may match the function
+                // shape but belong to a different declaration. Mirrors the
+                // early break in the loop at lines 430-443 above.
+                if comment.end <= parent_node.pos {
+                    break;
                 }
             }
             current = parent;

--- a/crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs
@@ -62,3 +62,49 @@ fn ts2355_falls_back_to_name_when_no_jsdoc_return_type() {
         "no JSDoc return type means no TS2355; got: {diagnostics:#?}"
     );
 }
+
+#[test]
+fn ts2355_anchors_on_owner_jsdoc_after_unrelated_function_decl_above() {
+    // Regression for PR #1431 followup: the parent-walk loop in
+    // `jsdoc_function_return_type_span_for_function` (lookup.rs ~lines
+    // 454-464) previously scanned ALL earlier comments (no early break) and
+    // lacked the SOURCE_FILE/BLOCK container guard that
+    // `try_jsdoc_with_ancestor_walk` (params.rs ~lines 697-732) uses.
+    //
+    // This test pins the canonical "JSDoc on a `function f()` declaration
+    // located right after an unrelated earlier `@type {function(): T}`
+    // annotation" anchor: the diagnostic for `f` must point at *f's own*
+    // `number` token, not at the earlier unrelated `number` token. With the
+    // buggy parent walk, when the immediate-leading-comment loop fails to
+    // resolve via the function node directly, the parent walk would step
+    // through the SOURCE_FILE container without the guard and find the
+    // unrelated comment.
+    let source = "/** @type {function(): number} */\nvar prior = 1;\n/** @type {function(): number} */\nfunction f() {}\n";
+
+    let diagnostics = check_source(source, "a.js", options_js_strict());
+
+    let ts2355: Vec<_> = diagnostics.iter().filter(|d| d.code == 2355).collect();
+    assert_eq!(
+        ts2355.len(),
+        1,
+        "expected exactly one TS2355 (for f), got: {diagnostics:#?}"
+    );
+
+    // Find the *second* `number` occurrence -- f's own `@type` token.
+    let first_number_pos = source.find("number").expect("first number") as u32;
+    let second_number_pos = source[first_number_pos as usize + 1..]
+        .find("number")
+        .expect("second number") as u32
+        + first_number_pos
+        + 1;
+
+    let diag = ts2355[0];
+    assert_eq!(
+        (diag.start, diag.length),
+        (second_number_pos, "number".len() as u32),
+        "TS2355 must anchor on f's *own* @type return token at {second_number_pos}, \
+         not at the earlier unrelated `number` at {first_number_pos}; got start={} length={}",
+        diag.start,
+        diag.length,
+    );
+}


### PR DESCRIPTION
## Summary

Followup to PR #1431. The parent-walk loop in `crates/tsz-checker/src/jsdoc/lookup.rs` (`jsdoc_function_return_type_span_for_function`, ~lines 454-464) was missing two safeguards that the canonical `try_jsdoc_with_ancestor_walk` (`crates/tsz-checker/src/jsdoc/params.rs:697-732`) already has:

1. **Early break on first preceding comment match** — without it, the loop scanned ALL earlier comments and could match an unrelated `@type {function(): T}` JSDoc from a prior declaration. Mirrors the early break in the same file at lines 430-443.
2. **`SOURCE_FILE` / `BLOCK` / `MODULE_BLOCK` / `CASE_CLAUSE` / `DEFAULT_CLAUSE` container guard** — without it, the walk could step into statement-level containers whose "leading JSDoc" actually belongs to their first child statement, picking up unrelated `@type` JSDoc. Mirrors the guard at `params.rs:710-722`.

## Changes

- `crates/tsz-checker/src/jsdoc/lookup.rs` (lines 445-491): added both safeguards to the parent-walk loop in `jsdoc_function_return_type_span_for_function`.
- `crates/tsz-checker/tests/jsdoc_function_return_type_anchor_tests.rs`: added regression test `ts2355_anchors_on_owner_jsdoc_after_unrelated_function_decl_above` that pins TS2355 anchoring to the function's *own* `@type` token even when an unrelated function-shape JSDoc precedes it.

## Test plan

- [x] `cargo nextest run -p tsz-checker -E 'test(jsdoc)'` (332 passed, 0 failed)
- [x] New test passes: `ts2355_anchors_on_owner_jsdoc_after_unrelated_function_decl_above`
- [x] `cargo check -p tsz-checker` clean

## Note on the regression test

The test serves as a behavioral guardrail. The misanchor scenario currently requires the *immediate*-leading-comment loop (lookup.rs:430-443) to fail before the parent-walk loop runs — that precondition is hard to construct in current tsz state. The test pins the canonical anchor so any future regression in either loop catches the misattribution. The architectural fix is the primary deliverable: it removes a latent footgun and aligns the function with the canonical pattern in `params.rs`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
