### PR TITLE
fix(checker): preserve JSDoc generic display name; anchor TS2744 at offending identifier

### DIFF
--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -568,6 +568,7 @@ impl<'a> CheckerState<'a> {
             use crate::query_boundaries::common::instantiate_generic;
             let instantiated =
                 instantiate_generic(self.ctx.types, body_type, &type_params, &type_args);
+            self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
             return Some(instantiated);
         }
 
@@ -614,7 +615,33 @@ impl<'a> CheckerState<'a> {
         // Lazy(DefId) references in value positions for correct type name display.
         use crate::query_boundaries::common::instantiate_generic;
         let instantiated = instantiate_generic(self.ctx.types, body_type, &type_params, &type_args);
+        // Register a display def `Name<Args>` so diagnostics format the
+        // instantiated type with its original alias plus the supplied args
+        // (`ClassComponent<any>`), matching tsc behavior. The typedef path
+        // (`resolve_jsdoc_generic_typedef_type`) does the same registration.
+        self.register_jsdoc_generic_display_name(base_name, &type_args, instantiated);
         Some(instantiated)
+    }
+
+    /// Register a display def `BaseName<Arg1, Arg2, ...>` for an instantiated
+    /// generic JSDoc type reference so diagnostics preserve the original
+    /// alias plus the supplied type arguments.
+    fn register_jsdoc_generic_display_name(
+        &mut self,
+        base_name: &str,
+        type_args: &[TypeId],
+        instantiated: TypeId,
+    ) {
+        if instantiated == TypeId::ERROR || instantiated == TypeId::UNKNOWN {
+            return;
+        }
+        let args_display = type_args
+            .iter()
+            .map(|&arg| self.format_type_diagnostic(arg))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let display_name = format!("{base_name}<{args_display}>");
+        let _ = self.ensure_jsdoc_instantiated_display_def(&display_name, instantiated);
     }
     pub(in crate::jsdoc::resolution) fn parse_jsdoc_tuple_type(
         &mut self,
@@ -1595,13 +1622,7 @@ impl<'a> CheckerState<'a> {
 
         use crate::query_boundaries::common::instantiate_generic;
         let instantiated = instantiate_generic(self.ctx.types, body_type, &type_params, type_args);
-        let args_display = type_args
-            .iter()
-            .map(|&arg| self.format_type_diagnostic(arg))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let display_name = format!("{base_name}<{args_display}>");
-        let _ = self.ensure_jsdoc_instantiated_display_def(&display_name, instantiated);
+        self.register_jsdoc_generic_display_name(base_name, type_args, instantiated);
         Some(instantiated)
     }
     // NOTE: jsdoc_has_readonly_tag, jsdoc_access_level, find_orphaned_extends_tags_for_statements,

--- a/crates/tsz-checker/src/tests/dispatch_tests.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests.rs
@@ -1017,6 +1017,51 @@ b(1);
 }
 
 #[test]
+fn jsdoc_type_tag_with_generic_interface_preserves_args_in_diagnostic() {
+    // Regression: assignability messages must preserve `Name<Args>` for
+    // generic interface/class refs (not just `@typedef`s) referenced from
+    // a JSDoc `@type` annotation. See: subclassThisTypeAssignable01
+    // conformance test where
+    // `/** @type {ClassComponent<any>} */ const test9 = new C();`
+    // previously produced "...is not assignable to type 'ClassComponent'."
+    // instead of "...is not assignable to type 'ClassComponent<any>'."
+    use crate::test_utils::check_source;
+    use crate::CheckerOptions;
+    let diags = check_source(
+        r#"
+interface Box<T> { value: T }
+class C { constructor() { this.q = 1; } }
+
+/** @type {Box<string>} */
+const b = new C();
+"#,
+        "test.ts",
+        CheckerOptions {
+            check_js: true,
+            ..CheckerOptions::default()
+        },
+    );
+    // Must mention the instantiated alias name with type arguments.
+    let assignability_codes = [2322u32, 2741];
+    assert!(
+        diags.iter().any(|d| assignability_codes.contains(&d.code)
+            && d.message_text.contains("Box<string>")),
+        "Expected an assignability message to mention `Box<string>`, got: {diags:?}"
+    );
+    // Must NOT show the bare `Box` (without type arguments) in any
+    // assignability-class diagnostic.
+    let has_bare = diags.iter().any(|d| {
+        assignability_codes.contains(&d.code)
+            && d.message_text.contains(" 'Box'")
+            && !d.message_text.contains("Box<")
+    });
+    assert!(
+        !has_bare,
+        "Expected no assignability message to show bare `Box`, got: {diags:?}"
+    );
+}
+
+#[test]
 fn jsdoc_callback_nested_params_build_one_object_parameter() {
     let diags = check_js_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -530,11 +530,13 @@ impl<'a> CheckerState<'a> {
             let mut refs_in_default = Vec::new();
             self.collect_type_references_in_type(param.default, &all_names, &mut refs_in_default);
 
-            for (_ref_node, ref_name) in &refs_in_default {
+            for &(ref_node, ref ref_name) in &refs_in_default {
                 if !declared_before.contains(ref_name.as_str()) {
-                    // This is a forward reference — emit TS2744
+                    // This is a forward reference — emit TS2744 anchored at
+                    // the offending identifier (matches tsc), not at the
+                    // start of the entire default-type expression.
                     self.error_at_node_msg(
-                        param.default,
+                        ref_node,
                         crate::diagnostics::diagnostic_codes::TYPE_PARAMETER_DEFAULTS_CAN_ONLY_REFERENCE_PREVIOUSLY_DECLARED_TYPE_PARAMETERS,
                         &[],
                     );

--- a/crates/tsz-checker/tests/generic_tests.rs
+++ b/crates/tsz-checker/tests/generic_tests.rs
@@ -487,6 +487,46 @@ interface ITest<P extends Prefixes, E extends AllPrefixData = PrefixData<P>> { }
     );
 }
 
+/// TS2744 position must anchor at the offending forward-referenced identifier
+/// inside the type-parameter default, not at the start of the entire default
+/// expression. tsc points at the identifier itself.
+///
+/// Regression test for `subclassThisTypeAssignable01` conformance test.
+#[test]
+fn test_type_parameter_default_forward_ref_anchors_on_identifier() {
+    let source = r#"
+interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> { tag: number }
+interface Lifecycle<Attrs, State> { x: number }
+"#;
+    let diagnostics = crate::test_utils::check_source_diagnostics(source);
+    let ts2744 = diagnostics
+        .iter()
+        .filter(|d| d.code == 2744)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ts2744.len(),
+        1,
+        "Expected exactly one TS2744 forward-reference, got: {diagnostics:?}"
+    );
+    let diag = ts2744[0];
+    // The offending identifier is the second `State` inside the default
+    // `Lifecycle<Attrs, State>`. Locate the second occurrence of `State`
+    // that follows the `=` in the default position.
+    let bytes = source.as_bytes();
+    let eq_pos = source.find('=').expect("default `=` present");
+    let after_eq = &source[eq_pos..];
+    // First `State` after `=` is inside `Lifecycle<Attrs, State>`.
+    let rel = after_eq
+        .find("State")
+        .expect("State identifier after `=`");
+    let expected_pos = (eq_pos + rel) as u32;
+    assert_eq!(
+        diag.start, expected_pos,
+        "Expected TS2744 to anchor at the forward-referenced `State` identifier (pos={expected_pos}), got start={} in {bytes:?}",
+        diag.start
+    );
+}
+
 /// Generic function references passed as callback arguments should be properly
 /// instantiated, not cause the earlier arguments to be deferred from inference.
 /// Regression test for: `map("", identity)` incorrectly inferred T as `unknown`

--- a/docs/plan/claims/fix-jsdoc-generic-type-display-name.md
+++ b/docs/plan/claims/fix-jsdoc-generic-type-display-name.md
@@ -1,0 +1,29 @@
+# fix(checker): preserve display name for JSDoc generic interface refs
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/jsdoc-generic-type-display-name`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance — fingerprint parity
+
+## Intent
+
+When a JSDoc `@type {ClassComponent<any>}` annotation resolves to a generic
+interface (or class/type-alias) reference, the JSDoc resolver instantiates
+the interface body but never registers a display def for the instantiated
+type. As a result, diagnostics format the type as `'ClassComponent'` instead
+of `'ClassComponent<any>'`. The typedef path already does this — extend the
+same registration to the non-typedef path so `Name<Args>` survives display.
+
+This fixes the fingerprint-only failure in
+`subclassThisTypeAssignable01.ts` on the `file1.js` line.
+
+## Files Touched
+
+- `crates/tsz-checker/src/jsdoc/resolution/type_construction.rs` (~30 LOC)
+- `crates/tsz-checker/src/tests/dispatch_tests.rs` (regression test)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (passes)
+- `./scripts/conformance/conformance.sh run --filter "subclassThisTypeAssignable01" --verbose` (fingerprint-mismatch reduced)

--- a/docs/plan/claims/fix-jsdoc-generic-type-display-name.md
+++ b/docs/plan/claims/fix-jsdoc-generic-type-display-name.md
@@ -1,29 +1,42 @@
-# fix(checker): preserve display name for JSDoc generic interface refs
+# fix(checker): preserve JSDoc generic display name; anchor TS2744 at offending identifier
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/jsdoc-generic-type-display-name`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1450
+- **Status**: ready
 - **Workstream**: Conformance — fingerprint parity
 
 ## Intent
 
-When a JSDoc `@type {ClassComponent<any>}` annotation resolves to a generic
-interface (or class/type-alias) reference, the JSDoc resolver instantiates
-the interface body but never registers a display def for the instantiated
-type. As a result, diagnostics format the type as `'ClassComponent'` instead
-of `'ClassComponent<any>'`. The typedef path already does this — extend the
-same registration to the non-typedef path so `Name<Args>` survives display.
+Two fingerprint-only mismatches in `subclassThisTypeAssignable01.ts`:
 
-This fixes the fingerprint-only failure in
-`subclassThisTypeAssignable01.ts` on the `file1.js` line.
+1. JSDoc `@type {ClassComponent<any>}` lost its type arguments in
+   diagnostics ("Type 'C' is not assignable to type 'ClassComponent'.").
+   The typedef path already registers a display def
+   `Name<Args>` after instantiation; the non-typedef path
+   (`resolve_jsdoc_generic_type`) didn't. Extracted a small helper
+   `register_jsdoc_generic_display_name` and called it from both paths.
+
+2. TS2744 "type parameter defaults can only reference previously declared
+   type parameters" anchored at the start of the entire default-type
+   expression (col 64 for `Lifecycle<Attrs, State>`). tsc anchors at the
+   offending identifier itself (col 81 for the second `State`).
+   `collect_type_references_in_type` already returns the offending
+   `NodeIndex`; switched the emission to use it.
 
 ## Files Touched
 
-- `crates/tsz-checker/src/jsdoc/resolution/type_construction.rs` (~30 LOC)
+- `crates/tsz-checker/src/jsdoc/resolution/type_construction.rs` (+24/-7 LOC)
+- `crates/tsz-checker/src/types/type_checking/core.rs` (+5/-3 LOC)
 - `crates/tsz-checker/src/tests/dispatch_tests.rs` (regression test)
+- `crates/tsz-checker/tests/generic_tests.rs` (regression test)
 
 ## Verification
 
-- `cargo nextest run -p tsz-checker --lib` (passes)
-- `./scripts/conformance/conformance.sh run --filter "subclassThisTypeAssignable01" --verbose` (fingerprint-mismatch reduced)
+- `cargo nextest run -p tsz-checker --lib` (2907/2908 pass; 1 pre-existing
+  unrelated LOC failure in `error_reporter/core/diagnostic_source.rs`)
+- `./scripts/conformance/conformance.sh run --filter "subclassThisTypeAssignable01" --verbose`
+  (1/1 PASS, was 0/1 fingerprint-only)
+- `./scripts/conformance/conformance.sh run --filter "typeParameter"`
+  (98/101 PASS; no new failures)
+- `./scripts/conformance/conformance.sh run --filter "default"` (42/43, no new failures)


### PR DESCRIPTION
## Summary

Fixes the fingerprint-only failure in `subclassThisTypeAssignable01.ts`,
which had two distinct fingerprint mismatches:

### 1. JSDoc `@type` lost generic type arguments in diagnostics

`/** @type {ClassComponent<any>} */` resolves a generic interface ref but
the JSDoc resolver never registered a display def for the instantiated
type, so diagnostics showed `'ClassComponent'` instead of
`'ClassComponent<any>'`. The typedef path already does this — extracted a
small helper `register_jsdoc_generic_display_name` and called it from
both `resolve_jsdoc_generic_type` (interface/class/type-alias path) and
`resolve_jsdoc_generic_typedef_type` (typedef path).

### 2. TS2744 anchored at start of default expression instead of offending identifier

For
```ts
interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> { ... }
```
tsc anchors TS2744 at the second `State` identifier (col 81), but tsz
anchored at the start of the entire default-type expression `Lifecycle...`
(col 64). `collect_type_references_in_type` already returns the offending
`NodeIndex`; the emission was discarding it. Switched it to use the
offending identifier.

## Test plan

- [x] Unit regression test in `tsz-checker` (`dispatch_tests.rs`) for the
      JSDoc display-name fix.
- [x] Unit regression test in `tsz-checker/tests/generic_tests.rs` for
      the TS2744 position fix.
- [x] `cargo nextest run -p tsz-checker --lib` — 2907/2908 pass; 1
      pre-existing unrelated LOC failure (`error_reporter/core/diagnostic_source.rs`).
- [x] `./scripts/conformance/conformance.sh run --filter "subclassThisTypeAssignable01"`
      → **1/1 PASS** (was 0/1 fingerprint-only).
- [x] `./scripts/conformance/conformance.sh run --filter "typeParameter"`
      → 98/101 PASS, no new failures.
- [x] `./scripts/conformance/conformance.sh run --filter "default"`
      → 42/43 PASS, no new failures.
- [x] `./scripts/conformance/conformance.sh run --filter "jsdoc"`
      → 358/377 PASS, no new failures.