### PR TITLE
fix(binder): clear lib_symbol_reverse_remap in reset() (PR #1399 followup)

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -277,6 +277,7 @@ impl BinderState {
         self.current_augmented_module = None;
         Arc::make_mut(&mut self.lib_binders).clear();
         Arc::make_mut(&mut self.lib_symbol_ids).clear();
+        Arc::make_mut(&mut self.lib_symbol_reverse_remap).clear();
         Arc::make_mut(&mut self.module_exports).clear();
         Arc::make_mut(&mut self.reexports).clear();
         Arc::make_mut(&mut self.wildcard_reexports).clear();

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -2556,6 +2556,33 @@ fn binder_reset_clears_state() {
     assert!(binder.scopes.is_empty(), "reset should clear scopes");
 }
 
+#[test]
+fn binder_reset_clears_lib_symbol_reverse_remap() {
+    use crate::SymbolId;
+
+    let mut binder = BinderState::new();
+
+    // Insert a fake reverse-remap entry. This map is normally populated by
+    // the lib-merge path (`crates/tsz-binder/src/state/lib_merge.rs`); the
+    // LSP re-bind path calls `reset()` before `bind_source_file()`, so any
+    // stale entry that survives `reset()` would feed into the downstream
+    // `lib_symbol_reverse_remap.contains_key(...)` check in
+    // `crates/tsz-checker/src/state/type_analysis/cross_file.rs`.
+    Arc::make_mut(&mut binder.lib_symbol_reverse_remap).insert(SymbolId(42), (7, SymbolId(13)));
+
+    assert!(
+        !binder.lib_symbol_reverse_remap.is_empty(),
+        "precondition: fake reverse-remap entry should be present"
+    );
+
+    binder.reset();
+
+    assert!(
+        binder.lib_symbol_reverse_remap.is_empty(),
+        "reset should clear lib_symbol_reverse_remap (PR #1399 followup)"
+    );
+}
+
 // =============================================================================
 // 14. SYMBOL ARENA TESTS
 // =============================================================================


### PR DESCRIPTION
## Summary
- Address Devin review on #1399: `BinderState::reset()` was missing the `Arc::make_mut(&mut self.lib_symbol_reverse_remap).clear()` line.
- LSP re-bind calls `reset()` before `bind_source_file()`, so without the clear, stale `SymbolId` entries persist between files and feed into `cross_file.rs:586`'s `contains_key` check, causing incorrect cross-file resolution.

## Test plan
- [x] New unit test `binder_reset_clears_lib_symbol_reverse_remap` in `crates/tsz-binder/src/state/tests.rs`
- [x] `cargo nextest run -p tsz-binder --lib` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
