### PR TITLE
ci(website): reject GCS bench data where all timings are zero

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -134,8 +134,15 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcs-key.json
           LATEST=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/latest.json
           if gsutil -q stat "$LATEST" 2>/dev/null; then
-            gsutil cp "$LATEST" crates/tsz-website/data/benchmarks.json
-            echo "Downloaded fresh benchmark data from GCS ($(date -u))"
+            gsutil cp "$LATEST" /tmp/bench-latest.json
+            # Reject data where bc was missing and all timings are zero.
+            nonzero=$(jq '[.results[]? | select(.tsz_ms > 0)] | length' /tmp/bench-latest.json 2>/dev/null || echo "0")
+            if [ "${nonzero}" -gt 0 ]; then
+              cp /tmp/bench-latest.json crates/tsz-website/data/benchmarks.json
+              echo "Downloaded fresh benchmark data from GCS (${nonzero} valid results, $(date -u))"
+            else
+              echo "GCS data has no valid timing results — keeping checked-in benchmark data"
+            fi
           else
             echo "No latest.json in GCS yet — using checked-in benchmark data"
           fi

--- a/crates/tsz-website/src/_data/benchmark_charts.js
+++ b/crates/tsz-website/src/_data/benchmark_charts.js
@@ -285,7 +285,7 @@ function generateCharts(data) {
 </div>`;
   }
 
-  const results = data.results.filter((r) => r.tsz_ms != null && r.tsgo_ms != null);
+  const results = data.results.filter((r) => r.tsz_ms != null && r.tsz_ms > 0 && r.tsgo_ms != null && r.tsgo_ms > 0);
   if (!results.length) return `<div class="bench-placeholder">No valid benchmark results found.</div>`;
   const grouped = new Map();
   for (const row of results) {

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -113,7 +113,7 @@ function renderMeanChart(results) {
 </div>`;
   }
 
-  const valid = results.filter((r) => Number.isFinite(r.tsz_ms) && Number.isFinite(r.tsgo_ms));
+  const valid = results.filter((r) => Number.isFinite(r.tsz_ms) && r.tsz_ms > 0 && Number.isFinite(r.tsgo_ms) && r.tsgo_ms > 0);
   if (!valid.length) {
     return `<div class="bench-placeholder">No valid benchmark rows found.</div>`;
   }


### PR DESCRIPTION
## Problem

Previous bench runs installed everything except `bc`, so hyperfine timing values were computed as `0` (printf + empty bc output → 0). The gh-pages deploy would download this zero-data from GCS and overwrite the valid checked-in `benchmarks.json`, causing the website to display empty/zero bars.

## Fix

- **gh-pages.yml**: validate the downloaded GCS JSON with `jq` before accepting it. If no result has `tsz_ms > 0`, keep the checked-in data instead.
- **benchmark_charts.js** / **benchmark_mean_chart.js**: add `> 0` guard to the result filter — zero-timing rows produce meaningless 2px bars and pollute the mean calculation.

## Effect

- Today's website deploy will use the valid checked-in data (72 results from 14:22) rather than the GCS zeros.
- Once the current Cloud Build bench run (a4de9da5, with `bc` installed + `BENCH_COLD=1`) finishes, it will upload valid data and future deploys will pick it up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
