### PR TITLE
fix(checker): type elided array literal slots as Required undefined

### DIFF
--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -489,8 +489,45 @@ impl<'a> CheckerState<'a> {
         let mut element_types = Vec::new();
         let mut element_nodes = Vec::new();
         let mut tuple_elements = Vec::new();
+        // Total element count for tuple contextual typing. Elided slots count toward
+        // the position of subsequent elements (e.g. `[42,,true]` has length 3 with
+        // an undefined slot at index 1), matching tsc's `elementCount = elements.length`.
+        let total_elem_count = array.elements.nodes.len();
         for (index, &elem_idx) in array.elements.nodes.iter().enumerate() {
             if elem_idx.is_none() {
+                // Elided element (hole) in array literal: `[a, , b]` has an
+                // OmittedExpression at index 1. tsc types `OmittedExpression` as
+                // `undefinedWideningType` (see `case SyntaxKind.OmittedExpression`
+                // in checkExpressionWorker) and pushes it as a Required element
+                // when `exactOptionalPropertyTypes` is OFF — the resulting source
+                // tuple `[number, undefined, true]` then assigns to `[number, string?, boolean?]`
+                // because each Required source slot of type `undefined` is widened to
+                // `T | undefined` against an Optional target slot in tuple subtyping.
+                //
+                // For destructuring targets (`[a, , b] = expr`) the elision is a
+                // "skip" rather than a value, so preserve the current skip behavior.
+                if self.ctx.in_destructuring_target {
+                    continue;
+                }
+                let undef_type = TypeId::UNDEFINED;
+                if tuple_context.is_some()
+                    || force_tuple_for_union_context
+                    || force_tuple_for_mapped
+                    || force_tuple_for_constraint_hint
+                    || force_tuple_for_tuple_like
+                    || self.ctx.in_const_assertion
+                {
+                    tuple_elements.push(TupleElement {
+                        type_id: undef_type,
+                        name: None,
+                        optional: false,
+                        rest: false,
+                    });
+                } else {
+                    element_types.push(undef_type);
+                    // Note: we don't add to element_nodes since there is no node
+                    // for an elision. Excess property checks are skipped for the slot.
+                }
                 continue;
             }
 
@@ -502,8 +539,7 @@ impl<'a> CheckerState<'a> {
                 crate::context::TypingRequest::NONE
             } else if let Some(ref helper) = ctx_helper {
                 if tuple_context.is_some() {
-                    let elem_count = array.elements.nodes.iter().filter(|n| n.is_some()).count();
-                    match helper.get_tuple_element_type_with_count(index, elem_count) {
+                    match helper.get_tuple_element_type_with_count(index, total_elem_count) {
                         Some(ty) => request.read().contextual(ty),
                         None => crate::context::TypingRequest::NONE,
                     }
@@ -677,17 +713,19 @@ impl<'a> CheckerState<'a> {
             // `[ObjType, string]`), each element that is an object literal must be checked for
             // excess properties against the expected tuple element type. This mirrors the array
             // context path (below) but uses per-position tuple element types.
+            //
+            // Use the source-position-aligned tuple_index (matching the contextual extractor's
+            // index) so excess property checks line up with the correct contextual element type
+            // even when the array literal contains elisions like `[ {x:1}, , {y:2} ]`.
             if let Some(ref helper) = ctx_helper {
-                let elem_count = array.elements.nodes.iter().filter(|n| n.is_some()).count();
-                let mut tuple_index = 0usize;
-                for &elem_idx in &array.elements.nodes {
+                for (tuple_index, &elem_idx) in array.elements.nodes.iter().enumerate() {
                     if elem_idx.is_none() {
                         continue;
                     }
                     if let Some(elem_node) = self.ctx.arena.get(elem_idx)
                         && elem_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-                        && let Some(expected_type) =
-                            helper.get_tuple_element_type_with_count(tuple_index, elem_count)
+                        && let Some(expected_type) = helper
+                            .get_tuple_element_type_with_count(tuple_index, total_elem_count)
                     {
                         let elem_type = tuple_elements
                             .get(tuple_index)
@@ -699,7 +737,6 @@ impl<'a> CheckerState<'a> {
                             elem_idx,
                         );
                     }
-                    tuple_index += 1;
                 }
             }
             return factory.tuple(tuple_elements);
@@ -954,6 +991,51 @@ let x: [...(string | number)[]] = arr;
         assert!(
             !errors.contains(&2322),
             "array is still assignable to rest-only tuple, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn elided_array_literal_element_typed_as_undefined_required() {
+        // Regression for conformance test optionalTupleElements1.ts:
+        // an elision (hole) in a non-destructuring array literal — e.g. `[42,,true]` —
+        // must produce a tuple slot with type `undefined` (Required), matching tsc's
+        // OmittedExpression -> undefinedWideningType. Previously the slot was dropped,
+        // which both shifted subsequent positions and caused contextual typing to
+        // mismatch optional tuple targets.
+        //
+        // `T3 = [number, string?, boolean?]` accepts `[42,,true]` because the source
+        // tuple `[number, undefined, true]` (all Required) widens each Required
+        // `undefined` against an Optional target slot to `T | undefined`.
+        let source = r#"
+type T3 = [number, string?, boolean?];
+type T4 = [number?, string?, boolean?];
+let t3: T3;
+let t4: T4;
+t3 = [42, , true];
+t4 = [42, , true];
+t4 = [, "hello", true];
+t4 = [, , true];
+"#;
+        let errors = check_source_codes(source);
+        assert!(
+            !errors.contains(&2322),
+            "elided array literal slots should produce undefined-typed Required tuple slots, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn elided_array_literal_in_array_context_pushes_undefined() {
+        // Without a tuple contextual type, an elision still contributes
+        // `undefined` to the resulting array element type. tsc widens
+        // `[1, , 3]` (no contextual) to `(number | undefined)[]`, so the
+        // array literal is assignable to `(number | undefined)[]`.
+        let source = r#"
+const xs: (number | undefined)[] = [1, , 3];
+"#;
+        let errors = check_source_codes(source);
+        assert!(
+            !errors.contains(&2322),
+            "[1, , 3] should be assignable to (number | undefined)[], got: {errors:?}"
         );
     }
 }

--- a/docs/plan/claims/fix-checker-array-literal-elision-undefined.md
+++ b/docs/plan/claims/fix-checker-array-literal-elision-undefined.md
@@ -1,0 +1,49 @@
+# fix(checker): type elided array literal slots as Required undefined
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/conformance-target`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance — array literal element typing parity
+
+## Intent
+
+Match tsc's treatment of `OmittedExpression` in non-destructuring array
+literals. tsc types a hole (e.g. `[42, , true]`) as
+`undefinedWideningType` and pushes it as a `Required` tuple slot, so the
+resulting source type is `[number, undefined, true]`. Required source
+slots of type `undefined` then satisfy optional target tuple slots like
+`string?` because the tuple subtype rule widens optional target slots to
+`T | undefined` for required source elements.
+
+Previously tsz dropped the elided slot entirely, which both shifted the
+positions of subsequent elements and lost the `undefined` value type.
+This caused `optionalTupleElements1.ts` to emit four extra TS2322
+diagnostics on `t3 = [42,,true]`, `t4 = [42,,true]`, `t4 = [,"hello",
+true]`, and `t4 = [,,true]`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/types/computation/array_literal.rs`
+  (~50 LOC: handle `elem_idx.is_none()` to push `undefined` Required tuple
+  element / array element; switch tuple `elem_count` to source-position
+  length so contextual extraction stays aligned across elisions; fix
+  excess-property-check loop to use the same source-aligned index)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib elided_array_literal` — two new
+  unit tests pass.
+- `cargo nextest run -p tsz-checker --lib` — 2907/2908 pass; the only
+  failure (`checker_files_stay_under_loc_limit` on
+  `error_reporter/core/diagnostic_source.rs`) is pre-existing on `main`
+  and unrelated to this change.
+- `cargo nextest run -p tsz-solver --lib` — 5518/5519 pass; the only
+  failure (`solver_file_size_ceiling_tests::test_parser_file_size_ceiling`)
+  is pre-existing on `main`.
+- `./scripts/conformance/conformance.sh run --filter "optionalTupleElements1"`
+  → 1/1 passed (was 0/1 fingerprint-only on `main`).
+- `./scripts/conformance/conformance.sh run --filter "tuple"`
+  → 31/37 passed (baseline had 30/37; net +1 with no regressions).
+- `./scripts/conformance/conformance.sh run --filter "arrayLiteral"`
+  → 19/19 passed (no regressions).

--- a/docs/plan/claims/fix-checker-array-literal-elision-undefined.md
+++ b/docs/plan/claims/fix-checker-array-literal-elision-undefined.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/conformance-target`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1453
+- **Status**: ready
 - **Workstream**: Conformance — array literal element typing parity
 
 ## Intent


### PR DESCRIPTION
## Summary

- Match tsc's `OmittedExpression → undefinedWideningType` rule in non-destructuring array literals: `[42, , true]` now becomes `[number, undefined, true]` (Required slots) instead of dropping the elided slot entirely.
- Source-aligned tuple element count keeps contextual extraction in sync with elision positions.
- Destructuring targets still skip elisions (their semantic is "ignore this slot").

Fixes the four spurious TS2322 fingerprints on `tests/cases/conformance/types/tuple/optionalTupleElements1.ts` (was fingerprint-only failure with codes-correct, message/position-wrong; now passes 1/1).

## Why this is a checker fix, not a solver fix

This is a `WHERE` issue (§3): the checker is converting an array literal AST into a tuple `TypeData`. The tsc reference handles `OmittedExpression` directly inside its `checkArrayLiteral`, treating it as a Required slot of `undefinedWideningType`. The solver's tuple subtype rule already handles the resulting `[number, undefined, true] <: [number, string?, boolean?]` correctly via the existing `target_optional && !source_optional → target | undefined` widening at `crates/tsz-solver/src/relations/subtype/rules/tuples.rs:199-203`.

## Files Touched

- `crates/tsz-checker/src/types/computation/array_literal.rs` (~50 LOC change + two new unit tests)
- `docs/plan/claims/fix-checker-array-literal-elision-undefined.md` (new claim file)

## Test plan

- [x] `cargo nextest run -p tsz-checker --lib elided_array_literal` — two new regression tests pass
- [x] `cargo nextest run -p tsz-checker --lib` — 2907/2908 pass (the 1 fail is a pre-existing LOC-limit violation on `error_reporter/core/diagnostic_source.rs`, unrelated to this PR)
- [x] `cargo nextest run -p tsz-solver --lib` — 5518/5519 pass (the 1 fail is the pre-existing `test_parser_file_size_ceiling`)
- [x] `./scripts/conformance/conformance.sh run --filter "optionalTupleElements1"` → 1/1 PASS (was 0/1 fingerprint-only)
- [x] `./scripts/conformance/conformance.sh run --filter "tuple"` → 31/37 (baseline 30/37, +1 net)
- [x] `./scripts/conformance/conformance.sh run --filter "arrayLiteral"` → 19/19, no regressions
- [x] `./scripts/conformance/conformance.sh run --filter "spread"` → no new failures vs baseline
- [x] `./scripts/conformance/conformance.sh run --filter "destructur"` → no new failures vs baseline

## Notes

I'll mark the PR ready once CI is green.