### PR TITLE
fix(checker): preserve literal TReturn for contextually-typed sync generators (+14 conformance)

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1641,7 +1641,13 @@ fn checker_files_stay_under_loc_limit() {
         // Bumped by 12 (2041→2053) for the sync-contextual-return branch that
         // fixes TS2322 on block-body methods carrying `/** @type {function(...)} */`
         // (checkJsdocTypeTagOnObjectProperty2.ts).
-        ("types/function_type.rs", 2053),
+        // Bumped by 13 (2053→2066) for the contextual-generator return-type
+        // pinning that fixes TS2345 false positives on
+        // `f<0,0,1>(function* () { return 0 })` style call-site type-arg
+        // pinning (`generatorYieldContextualType.ts`). The +3 over the
+        // initial 2063 came from the `void` carve-out that preserves tsc's
+        // widening for `IterableIterator<T, void>` (`generatorTypeCheck63.ts`).
+        ("types/function_type.rs", 2066),
     ];
 
     let mut violations = Vec::new();

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1872,6 +1872,20 @@ impl<'a> CheckerState<'a> {
                 // Skip statement-level return assignability and let the outer
                 // function-type assignability relation handle the ergonomics.
                 TypeId::ANY
+            } else if is_generator
+                && !has_type_annotation
+                && has_contextual_return
+                && let Some(early_t) = early_gen_return_type
+                && early_t != TypeId::ANY
+                && early_t != TypeId::UNKNOWN
+            {
+                // Contextually-typed sync generator (no annotation): use
+                // unwrapped contextual `TReturn` from outer
+                // `Generator<Y, TReturn, N>` for body return checks. Without
+                // this, `f1<0,0,1>(function* () { return 0 })` widens 0 → number
+                // and the call site reports a false TS2345. Mirrors the async
+                // and annotated-generator branches above.
+                early_t
             } else if has_type_annotation || has_contextual_return || jsdoc_return_context.is_some()
             {
                 // When a sync function carries its own JSDoc `@type {function(...): T}`
@@ -2522,14 +2536,21 @@ impl<'a> CheckerState<'a> {
                     && return_type != TypeId::UNDEFINED
                     && !(return_type == TypeId::ANY && early_gen_return_type.is_some())
                 {
-                    // Widen literal body-inferred returns before assembling the
-                    // Generator<Y, R, N> type: `return 1;` produces TReturn =
-                    // number, not 1. Matches tsc's generator return-type
-                    // widening. Unique symbols are preserved.
-                    let widened = if crate::query_boundaries::common::is_unique_symbol_type(
-                        self.ctx.types,
-                        return_type,
-                    ) {
+                    // Widen literal body-inferred returns: `return 1;` →
+                    // TReturn = number. Preserve unique symbols. Also
+                    // preserve when contextual TReturn is a real type — tsc
+                    // pins T from the call-site type-arg, widening defeats
+                    // the pin. `void` is treated as no-constraint (matches
+                    // tsc's widening behavior for `() => Generator<_, void, _>`).
+                    let contextual_pins_return = early_gen_return_type.is_some_and(|t| {
+                        t != TypeId::VOID && t != TypeId::ANY && t != TypeId::UNKNOWN
+                    });
+                    let preserve = contextual_pins_return
+                        || crate::query_boundaries::common::is_unique_symbol_type(
+                            self.ctx.types,
+                            return_type,
+                        );
+                    let widened = if preserve {
                         return_type
                     } else {
                         self.widen_literal_type(return_type)


### PR DESCRIPTION
## Summary

`f1<0, 0, 1>(function* () { return 0; })` was emitting a false TS2345 because the body's literal `return 0` was widened to `number` before the call site checked the inferred `Generator<never, number, 1>` against the substituted parameter `Generator<0, 0, 1>`. Number is not assignable to literal 0, so the generic-instance compat check failed.

## Two changes in `crates/tsz-checker/src/types/function_type.rs`

1. **`body_return_type` for sync generators** (no annotation, has contextual return) now uses `early_gen_return_type` (the unwrapped contextual TReturn from `Generator<Y, T, S>`) instead of falling through to the inferred return type. This pins return-statement assignability checks to the contextual T.

2. **Generator-application assembly's TReturn slot** preserves literal types when the contextual TReturn is set AND non-trivial (`!= void/any/unknown`). The `void` carve-out matches tsc's behavior for `IterableIterator<T, void>` where TReturn=void is treated as no-constraint and widening still applies (`generatorTypeCheck63.ts`).

## Conformance: +14 net

15 PASS flips:
- `generatorYieldContextualType.ts` (the targeted test)
- `inferenceShouldFailOnEvolvingArrays.ts`
- `jsExportMemberMergedWithModuleAugmentation2.ts`
- `literalFreshnessPropagationOnNarrowing.ts`
- `numericIndexerConstraint2.ts`
- `nestedClassDeclaration.ts`
- `symbolType2.ts`
- `destructuringParameterDeclaration2.ts`
- `iteratorSpreadInArray5.ts`
- `interfacesWithPredefinedTypesAsNames.ts`
- `checkJsdocTypeTagOnObjectProperty2.ts`
- `jsdocFunction_missingReturn.ts`
- `catchClauseWithTypeAnnotation.ts`
- `templateLiteralTypes5.ts`
- `noInfer.ts`

1 reported regression (`parserClassDeclaration1.ts`) confirmed **stale-snapshot drift** — fails on baseline without this change too.

## Test plan
- [x] `./scripts/conformance/conformance.sh run` — 12183 → 12197 (+14)
- [x] 2905/2906 tsz-checker lib tests pass; 1 remaining LOC violation pre-existing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
