### PR TITLE
ci(bench): use gcloud triggers run for retrigger (fixes 403)

### DIFF
--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -240,15 +240,13 @@ steps:
 
       if [[ -n "$THIS_SHA" && -n "$LATEST_SHA" && "$THIS_SHA" != "$LATEST_SHA" ]]; then
         echo "main moved (this=${THIS_SHA:0:8}, latest=${LATEST_SHA:0:8}) — triggering next bench run..."
-        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-          -H "Authorization: Bearer ${TOKEN}" \
-          -H "Content-Type: application/json" \
-          "https://cloudbuild.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/triggers/${TRIGGER_ID}:run" \
-          -d '{"source": {"branchName": "main"}}')
-        if [[ "$http_code" =~ ^2 ]]; then
-          echo "Retrigger successful (HTTP ${http_code})"
+        if gcloud builds triggers run "$TRIGGER_ID" \
+            --branch=main \
+            --project="$PROJECT_ID" \
+            --region="$REGION" 2>&1; then
+          echo "Retrigger successful"
         else
-          echo "Warning: retrigger returned HTTP ${http_code}"
+          echo "Warning: retrigger failed (gcloud exit $?)"
         fi
       else
         echo "main is at ${THIS_SHA:0:8} — no retrigger needed."


### PR DESCRIPTION
The curl-based trigger:run call returned HTTP 403. Switch to `gcloud builds triggers run` which uses the SA's ambient credentials and handles 2nd-gen trigger auth correctly. Also granted the compute SA `roles/cloudbuild.builds.builder` via IAM.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
