### PR TITLE
fix(checker): elide synthetic optional `| undefined` for union callable arg display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1185,7 +1185,15 @@ impl<'a> CheckerState<'a> {
             return "IArguments".to_string();
         }
 
+        // When the only literal-sensitive member of the parameter type is
+        // `undefined` contributed by an optional parameter (`b?: T`), tsc
+        // strips the synthetic `| undefined` and widens the argument display
+        // for the underlying target. Skip the literal-preserving branch in
+        // that case so the argument widens to its widened display type
+        // (e.g. `string` instead of `'"hello"'`).
         if self.is_literal_sensitive_assignment_target(param_type)
+            && !self
+                .literal_sensitivity_is_only_synthetic_optional_undefined(param_type, arg_idx)
             && let Some(display) = self.literal_call_argument_display(arg_idx)
         {
             return display;
@@ -1265,6 +1273,36 @@ impl<'a> CheckerState<'a> {
         let evaluated = self.evaluate_type_for_assignability(param_type);
         query_common::union_members(self.ctx.types, param_type).is_some()
             || query_common::union_members(self.ctx.types, evaluated).is_some()
+    }
+
+    /// Returns `true` when `param_type` is a union whose literal-sensitive
+    /// members are limited to the synthetic `undefined` introduced by an
+    /// optional parameter (`b?: T`) — i.e. dropping `undefined` from the
+    /// union leaves a non-literal-sensitive target. In that case the call
+    /// argument display should widen to the underlying target rather than
+    /// preserve the literal text, matching tsc's diagnostic surface.
+    fn literal_sensitivity_is_only_synthetic_optional_undefined(
+        &mut self,
+        param_type: TypeId,
+        arg_idx: NodeIndex,
+    ) -> bool {
+        if !self.enclosing_call_parameter_is_optional_non_rest(arg_idx) {
+            return false;
+        }
+        let stripped = match query_common::union_members(self.ctx.types, param_type) {
+            Some(members) => {
+                let kept: Vec<TypeId> = members
+                    .into_iter()
+                    .filter(|m| *m != TypeId::UNDEFINED)
+                    .collect();
+                if kept.is_empty() {
+                    return false;
+                }
+                self.ctx.types.factory().union_preserve_members(kept)
+            }
+            None => return false,
+        };
+        !self.is_literal_sensitive_assignment_target(stripped)
     }
 
     fn contextual_function_argument_display(
@@ -1690,6 +1728,19 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
+        self.callee_param_is_optional_non_rest_at(callee_type, arg_pos)
+    }
+
+    /// Returns `true` when the callee's parameter at `arg_pos` is optional (and
+    /// non-rest) for at least one callable shape reachable from `callee_type`.
+    /// For union callees we walk the members so that the synthetic `| undefined`
+    /// surface contributed by an optional parameter (e.g. `b?: number`) is
+    /// elided in diagnostics, matching tsc's display rules.
+    fn callee_param_is_optional_non_rest_at(
+        &mut self,
+        callee_type: TypeId,
+        arg_pos: usize,
+    ) -> bool {
         let param_is_optional_non_rest = |params: &[tsz_solver::ParamInfo]| {
             params
                 .get(arg_pos)
@@ -1703,13 +1754,27 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        query_common::call_signatures_for_type(self.ctx.types, callee_type).is_some_and(
+        if query_common::call_signatures_for_type(self.ctx.types, callee_type).is_some_and(
             |signatures| {
                 signatures
                     .iter()
                     .any(|sig| param_is_optional_non_rest(&sig.params))
             },
-        )
+        ) {
+            return true;
+        }
+
+        // Union of callables: tsc's union-call rules synthesise the parameter
+        // type as `T | undefined` when at least one member treats the slot as
+        // optional. Treat the surface as optional in that case so the display
+        // strips the synthetic `| undefined`, matching tsc.
+        if let Some(members) = query_common::union_members(self.ctx.types, callee_type) {
+            return members
+                .into_iter()
+                .any(|member| self.callee_param_is_optional_non_rest_at(member, arg_pos));
+        }
+
+        false
     }
 
     fn enclosing_call_arg_position(&mut self, arg_idx: NodeIndex) -> Option<(TypeId, usize)> {

--- a/crates/tsz-checker/tests/optional_param_display_tests.rs
+++ b/crates/tsz-checker/tests/optional_param_display_tests.rs
@@ -99,6 +99,83 @@ const f2: (a: string) => string = f1;
     }
 }
 
+/// TS2345 against a union-of-callables target where the optional parameter
+/// surface contributes the only literal-sensitive `undefined` member must
+/// elide that synthetic `| undefined` and widen the literal argument
+/// display, matching tsc.
+///
+/// Conformance: `unionTypeCallSignatures.ts` (lines 36, 42, 48 in tsc cache).
+/// Before this fix, the diagnostic read:
+///   `Argument of type '"hello"' is not assignable to parameter of type 'number | undefined'.`
+/// tsc emits:
+///   `Argument of type 'string' is not assignable to parameter of type 'number'.`
+#[test]
+fn ts2345_union_callable_optional_param_widens_synthetic_undefined() {
+    let source = r#"
+declare var u: { (a: string, b?: number): string; } | { (a: string, b?: number): number; };
+u('hello', "hello");
+"#;
+    let diags = check_strict(source);
+    let ts2345: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2345).collect();
+    assert!(
+        !ts2345.is_empty(),
+        "expected TS2345 for the wrong-typed second arg; got: {diags:?}"
+    );
+    let msg = &ts2345[0].1;
+    assert!(
+        msg.contains("Argument of type 'string'"),
+        "TS2345 should widen the literal argument display (got literal text \
+         when the union's `| undefined` is synthetic from the optional `?:`). \
+         Got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Argument of type '\"hello\"'"),
+        "TS2345 should not preserve the literal argument text when the union \
+         on the parameter is purely a synthetic optional `| undefined`. \
+         Got: {msg:?}"
+    );
+    assert!(
+        msg.contains("parameter of type 'number'"),
+        "TS2345 should strip the synthetic `| undefined` from the parameter \
+         display for an optional non-rest slot in a union of callables. \
+         Got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("number | undefined"),
+        "TS2345 should not display `number | undefined` when the union arises \
+         only from the optional parameter in a union of callable shapes. \
+         Got: {msg:?}"
+    );
+}
+
+/// TS2345 against a union of callables where one member omits the slot
+/// entirely (`b?` in one, no `b` in the other) must still elide the
+/// synthetic `| undefined`, since the slot is "optional" in the union sense.
+#[test]
+fn ts2345_union_callable_mixed_arity_optional_param_widens() {
+    let source = r#"
+declare var u: { (a: string, b?: number): string; } | { (a: string): number; };
+u('hello', "hello");
+"#;
+    let diags = check_strict(source);
+    let ts2345: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2345).collect();
+    assert!(
+        !ts2345.is_empty(),
+        "expected TS2345 for the wrong-typed second arg; got: {diags:?}"
+    );
+    let msg = &ts2345[0].1;
+    assert!(
+        msg.contains("Argument of type 'string'"),
+        "TS2345 should widen the literal argument display for mixed-arity \
+         union callable. Got: {msg:?}"
+    );
+    assert!(
+        msg.contains("parameter of type 'number'"),
+        "TS2345 should strip the synthetic `| undefined` for mixed-arity \
+         union callable. Got: {msg:?}"
+    );
+}
+
 /// Sanity: when the parameter is EXPLICITLY typed `T | undefined`, the
 /// display preserves `T | undefined`. The fix only suppresses the
 /// implicit-undefined-from-`?` case, not explicit annotations.

--- a/docs/plan/claims/fix-union-type-call-signatures-fingerprint.md
+++ b/docs/plan/claims/fix-union-type-call-signatures-fingerprint.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/union-type-call-signatures-fingerprint`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1459
+- **Status**: ready
 - **Workstream**: Conformance fingerprint parity (Tier 1 type-display-parity)
 
 ## Intent

--- a/docs/plan/claims/fix-union-type-call-signatures-fingerprint.md
+++ b/docs/plan/claims/fix-union-type-call-signatures-fingerprint.md
@@ -1,0 +1,48 @@
+# fix(checker): widen literal arg display when union callable's `| undefined` is synthetic optional
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/union-type-call-signatures-fingerprint`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: Conformance fingerprint parity (Tier 1 type-display-parity)
+
+## Intent
+
+When TS2345 fires for an argument against a union of callables whose
+optional parameter (`b?: T`) contributes the synthetic `| undefined` to
+the unioned parameter type, tsc widens the argument display (e.g.
+`'string'` instead of `'"hello"'`) and strips the synthetic
+`| undefined` from the parameter display (e.g. `'number'` instead of
+`'number | undefined'`). Today tsz preserves the literal text and the
+synthetic union — producing a fingerprint mismatch on
+`unionTypeCallSignatures.ts` and similar tests. This PR extends the
+existing optional-non-rest predicate to walk union members and gates the
+literal-sensitive argument branch on whether the union is purely a
+synthetic optional `| undefined`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs`
+  (~50 LOC change)
+- `crates/tsz-checker/tests/optional_param_display_tests.rs`
+  (+72 LOC: two regression tests)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib -E "test(union_callable)"`
+  (2 new regression tests pass)
+- `cargo nextest run -p tsz-checker --lib`
+  (2915/2916 pass; the one failure is a pre-existing LOC-limit test for
+  `error_reporter/core/diagnostic_source.rs`, untouched by this PR)
+- `./scripts/conformance/conformance.sh run --filter "unionTypeCallSignatures.ts"`
+  removes 2 extra-fingerprint TS2345 lines (`'"hello"' → 'number | undefined'`)
+  and resolves 2 of 3 missing-fingerprint TS2345 lines (lines 36, 48 of the
+  test). The remaining missing (line 27) is a separate root cause —
+  unequal-signature-count union calls do not emit TS2345 — out of scope
+  for this fix.
+- `./scripts/conformance/conformance.sh run --filter "optionalFunctionArg"`
+  (1/1 still pass — no regression on existing optional-param display)
+- `./scripts/conformance/conformance.sh run --filter "callSignature"`
+  (40/40 still pass)
+- `./scripts/conformance/conformance.sh run --filter "assignmentCompat"`
+  (120/128 — same as on `main`, no regression)


### PR DESCRIPTION
## Summary

When TS2345 fires for an argument against a union of callables whose optional parameter (`b?: T`) contributes the synthetic `| undefined` to the unioned parameter type, tsc widens the argument display and strips the synthetic `| undefined` from the parameter display. tsz preserves the literal text and shows the synthetic union, producing fingerprint mismatches on `unionTypeCallSignatures.ts` and similar tests.

This PR fixes two checker-display sites that missed the union-callable case:

1. `enclosing_call_parameter_is_optional_non_rest` only inspected `function_shape_for_type` and `call_signatures_for_type`. Neither collects signatures from union members, so the predicate returned `false` for union callables. Extended it to walk union members.
2. `format_call_argument_type_for_diagnostic` consulted `is_literal_sensitive_assignment_target(param_type)` directly. For `number | undefined` that returns true (because `undefined` is literal-sensitive), preserving the literal text. Added a guard `literal_sensitivity_is_only_synthetic_optional_undefined` that skips the literal-preserving branch when the only literal-sensitive member is the optional-induced `undefined`, letting the standard widening path run.

## Conformance impact

Verified via filtered conformance:

- `unionTypeCallSignatures.ts` (lines 36, 48): two extra `TS2345 'string' is not assignable to 'number | undefined'` fingerprints cleared and replaced with the correct `'string'` -> `'number'` text. The remaining missing TS2345 (line 27, unequal-signature-count union call not emitting TS2345 at all) is a separate root cause out of scope here.
- `optionalFunctionArg`: 1/1 still pass.
- `callSignature`: 40/40 still pass.
- `assignmentCompat`: 120/128 unchanged from main.

## Test plan

- [x] Regression tests added in `crates/tsz-checker/tests/optional_param_display_tests.rs`:
  - `ts2345_union_callable_optional_param_widens_synthetic_undefined`
  - `ts2345_union_callable_mixed_arity_optional_param_widens`
- [x] `cargo nextest run -p tsz-checker --lib`: 2915/2916 pass; the one failure is a pre-existing LOC-limit test for `error_reporter/core/diagnostic_source.rs`, untouched by this PR.
- [x] No regression on filtered conformance areas listed above.