### PR TITLE
feat(website): add built-at SHA link to footer

### DIFF
--- a/crates/tsz-website/src/_data/build.js
+++ b/crates/tsz-website/src/_data/build.js
@@ -1,0 +1,5 @@
+const sha = process.env.GITHUB_SHA || "";
+export default {
+  sha,
+  sha7: sha.slice(0, 7),
+};

--- a/crates/tsz-website/src/_includes/layouts/base.njk
+++ b/crates/tsz-website/src/_includes/layouts/base.njk
@@ -30,7 +30,7 @@
     {{ content | safe }}
   </main>
   <footer class="site-footer">
-    <p>tsz - a TypeScript compiler in Rust. Apache-2.0 License.</p>
+    <p>tsz - a TypeScript compiler in Rust. Apache-2.0 License.{% if build.sha %} Built at <a href="https://github.com/mohsen1/tsz/commit/{{ build.sha }}">{{ build.sha7 }}</a>.{% endif %}</p>
   </footer>
   {{ extra_scripts | safe }}
 </body>


### PR DESCRIPTION
## Summary

- Adds `crates/tsz-website/src/_data/build.js` that reads `GITHUB_SHA` and exports `sha` + `sha7` (first 7 chars)
- Updates `base.njk` footer to render a minimal `Built at <commit-short-sha>` link when `GITHUB_SHA` is set
- No-op locally (empty string → condition is falsy, link is omitted)

## Test plan

- [ ] Verify website build in CI shows commit SHA in footer
- [ ] Verify local dev build shows no SHA link (GITHUB_SHA not set)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
