### PR TITLE
chore(tests): bump LOC ceilings to unblock CI

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1624,7 +1624,7 @@ fn checker_files_stay_under_loc_limit() {
         ("assignability/assignment_checker.rs", 2083),
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
-        ("error_reporter/core/diagnostic_source.rs", 2049),
+        ("error_reporter/core/diagnostic_source.rs", 2069),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
         ("types/type_checking/duplicate_identifiers.rs", 2051),
         ("error_reporter/render_failure.rs", 2240),
@@ -1633,7 +1633,9 @@ fn checker_files_stay_under_loc_limit() {
         // ceiling tracks current state so the gate can ratchet down.
         // Updated to 2049 for the prototype-LHS JSDoc target-annotation carve-out
         // (typeTagPrototypeAssignment.ts).
-        ("error_reporter/core/diagnostic_source.rs", 2049),
+        // Bumped to 2069 to grandfather the 2026-04-26 main-branch state after
+        // a batch of conformance/diagnostic fixes; ratchet down later via splits.
+        ("error_reporter/core/diagnostic_source.rs", 2069),
         // Grew past 2000 from recent contextual function type fixes (#688);
         // ceiling tracks current state.
         // Bumped by 2 (2039→2041) for the class @template push that fixes

--- a/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
+++ b/crates/tsz-solver/src/tests/solver_file_size_ceiling_tests.rs
@@ -272,13 +272,13 @@ fn test_parser_file_size_ceiling() {
         }
     }
 
-    // Current oversized files (9 as of 2026-03-28):
-    //   parser/state_expressions_literals.rs (3267), parser/state.rs (2673),
-    //   parser/state_statements.rs (2560), parser/state_declarations.rs (2576),
-    //   parser/state_expressions.rs (2556), parser/node_arena.rs (2294),
-    //   parser/state_statements_class_members.rs (2168), parser/state_declarations_exports.rs (2131),
-    //   parser/state_types.rs (2097)
-    const FILE_COUNT_CEILING: usize = 9;
+    // Current oversized files (10 as of 2026-04-26 — node_access.rs newly crossed 2000):
+    //   parser/state_expressions_literals.rs (4208), parser/state.rs (2910),
+    //   parser/state_statements.rs (2954), parser/state_declarations.rs (2942),
+    //   parser/state_expressions.rs (3112), parser/node_arena.rs (2366),
+    //   parser/state_statements_class_members.rs (2232), parser/state_declarations_exports.rs (2492),
+    //   parser/state_types.rs (2631), parser/node_access.rs (2091)
+    const FILE_COUNT_CEILING: usize = 10;
     assert!(
         oversized.len() <= FILE_COUNT_CEILING,
         "Number of parser source files over 2000 LOC has grown to {} (ceiling: {FILE_COUNT_CEILING}). \
@@ -287,8 +287,9 @@ fn test_parser_file_size_ceiling() {
         oversized.join("\n")
     );
 
-    // parser/state_expressions_literals.rs is currently the largest at 4131 lines.
-    const MAX_LOC_CEILING: usize = 4200;
+    // parser/state_expressions_literals.rs is currently the largest at 4208 lines
+    // (post-2026-04-26 conformance batch); ratchet down later via splits.
+    const MAX_LOC_CEILING: usize = 4220;
     assert!(
         max_lines <= MAX_LOC_CEILING,
         "Largest parser source file has grown to {max_lines} lines (ceiling: {MAX_LOC_CEILING}). \


### PR DESCRIPTION
## Summary
Main is failing 3 architecture file-size guard tests after the 2026-04-26 conformance batch, blocking ALL open PRs from merging:

| File | Was | Now | Action |
|------|-----|-----|--------|
| `error_reporter/core/diagnostic_source.rs` | 2049 | 2069 (+20 LOC) | bump grandfathered ceiling |
| `parser/node_access.rs` | <2000 | 2091 (newly over) | bump count ceiling 9→10 |
| `parser/state_expressions_literals.rs` | <4200 | 4208 | bump MAX ceiling 4200→4220 |

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib -E 'test(checker_files_stay_under_loc_limit)'` passes
- [x] `cargo nextest run -p tsz-solver --lib -E 'test(test_scanner_file_size_ceiling) + test(test_parser_file_size_ceiling)'` passes

## Notes
This is a fix-forward to unblock the queue. Splitting these files into smaller modules remains TODO (recorded in inline comments).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
