### PR TITLE
fix(checker): emit TS2493/TS2339 for every out-of-bounds destructuring assignment target

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -1366,7 +1366,6 @@ impl<'a> CheckerState<'a> {
                     ),
                     diagnostic_codes::TUPLE_TYPE_OF_LENGTH_HAS_NO_ELEMENT_AT_INDEX,
                 );
-                return;
             }
             return;
         }
@@ -1409,7 +1408,6 @@ impl<'a> CheckerState<'a> {
                         &format!("Property '{index}' does not exist on type '{type_str}'.",),
                         diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
                     );
-                    return;
                 }
             }
         }

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -158,3 +158,74 @@ var t9 = <[A, I]>classCDTuple;
         diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }
+
+/// Regression for `emitCapturingThisInTupleDestructuring1.ts`: when an array
+/// destructuring assignment has multiple targets that exceed the source tuple
+/// length, tsc emits TS2493 for **each** out-of-bounds element, not just the
+/// first. The previous implementation early-returned after the first
+/// diagnostic, dropping subsequent out-of-bounds errors.
+#[test]
+fn test_ts2493_destructuring_assignment_emits_for_each_out_of_bounds_element() {
+    let diagnostics = check_source_diagnostics(
+        r"
+declare let array: [any];
+declare let a: any;
+declare let b: any;
+declare let c: any;
+[a, b, c] = array;
+",
+    );
+    let ts2493_count = diagnostics.iter().filter(|d| d.code == 2493).count();
+    assert_eq!(
+        ts2493_count, 2,
+        "Expected TS2493 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
+        ts2493_count,
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 2493)
+            .map(|d| d.message_text.clone())
+            .collect::<Vec<_>>()
+    );
+    // One diagnostic per out-of-bounds index — verify both messages mention
+    // the right index numbers.
+    let messages: Vec<String> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2493)
+        .map(|d| d.message_text.clone())
+        .collect();
+    assert!(
+        messages.iter().any(|m| m.contains("at index '1'")),
+        "Expected TS2493 message mentioning index '1', got: {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("at index '2'")),
+        "Expected TS2493 message mentioning index '2', got: {messages:?}"
+    );
+}
+
+/// Regression for the union-of-tuples branch of array destructuring
+/// assignment bounds checking: TS2339 must fire for **each** element where
+/// every union member is out of bounds, not just the first.
+#[test]
+fn test_ts2339_union_destructuring_assignment_emits_for_each_out_of_bounds_element() {
+    let diagnostics = check_source_diagnostics(
+        r"
+declare let u: [boolean] | [string];
+declare let a: any;
+declare let b: any;
+declare let c: any;
+[a, b, c] = u;
+",
+    );
+    let ts2339_count = diagnostics.iter().filter(|d| d.code == 2339).count();
+    assert_eq!(
+        ts2339_count, 2,
+        "Expected TS2339 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
+        ts2339_count,
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 2339)
+            .map(|d| d.message_text.clone())
+            .collect::<Vec<_>>()
+    );
+}

--- a/docs/plan/claims/fix-destructuring-assignment-tuple-bounds-all.md
+++ b/docs/plan/claims/fix-destructuring-assignment-tuple-bounds-all.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/destructuring-assignment-tuple-bounds-all`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1463
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent

--- a/docs/plan/claims/fix-destructuring-assignment-tuple-bounds-all.md
+++ b/docs/plan/claims/fix-destructuring-assignment-tuple-bounds-all.md
@@ -1,0 +1,32 @@
+# fix(checker): emit TS2493/TS2339 for every out-of-bounds element in array destructuring assignment
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/destructuring-assignment-tuple-bounds-all`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+`check_tuple_destructuring_bounds` (in the array-destructuring-assignment
+path) emitted TS2493 (single-tuple) and TS2339 (union-of-tuples) only for the
+**first** out-of-bounds element, then early-returned. tsc emits one
+diagnostic per out-of-bounds target. Removing the early `return;` after the
+emit makes the loop continue to flag every remaining element. Fixes
+`emitCapturingThisInTupleDestructuring1.ts`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`
+  (drop two `return;` statements in `check_tuple_destructuring_bounds`)
+- `crates/tsz-checker/tests/tuple_index_access_tests.rs` (two new regression
+  tests — TS2493 and TS2339 multi-element destructuring assignment)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test tuple_index_access_tests`
+  (10/10 pass, including 2 new regression tests)
+- `./scripts/conformance/conformance.sh run --filter "emitCapturingThisInTupleDestructuring"`
+  (2/2 pass — was 1/2 before)
+- `./scripts/conformance/conformance.sh run --filter "destructuring"`
+  (162/174 pass — same as before)


### PR DESCRIPTION
## Summary

- `check_tuple_destructuring_bounds` (in array-destructuring-assignment) early-returned after emitting the first out-of-bounds diagnostic. tsc emits one diagnostic per out-of-bounds target.
- Removing the two `return;` statements after the emit (single-tuple TS2493 and union-of-tuples TS2339) lets the loop continue and report every remaining element.
- Fixes `emitCapturingThisInTupleDestructuring1.ts` (length-1 source tuple assigned into a 3-element pattern, expects two TS2493 — one for index 1 and one for index 2).

## Test plan

- [x] `cargo nextest run -p tsz-checker --test tuple_index_access_tests` (10/10, including 2 new regression tests covering TS2493 and TS2339 multi-element destructuring assignment)
- [x] `./scripts/conformance/conformance.sh run --filter "emitCapturingThisInTupleDestructuring"` (2/2 pass — was 1/2 before)
- [x] `./scripts/conformance/conformance.sh run --filter "destructuring"` (162/174 — same as before, no regressions)