### PR TITLE
fix(solver): reduce `T & undefined` to `never` for union/intersection constraints

### DIFF
--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -361,13 +361,23 @@ impl TypeInterner {
     /// - The `object` intrinsic
     /// - Structural object types, arrays, tuples, functions, callables
     /// - Literal types (string/number/boolean/bigint literals)
+    /// - Unions where every member is clearly non-nullable (e.g., `"A" | "B"`)
+    /// - Intersections containing at least one clearly non-nullable member
     ///
     /// Returns false for:
     /// - null, undefined, void, any, unknown, never
-    /// - Union types (might contain nullable members)
     /// - Type parameters (constraint may be nullable)
     /// - Lazy/Application/Mapped (unresolved, can't determine)
     fn is_clearly_non_nullable_constraint(&self, id: TypeId) -> bool {
+        self.is_clearly_non_nullable_constraint_with_depth(id, 0)
+    }
+
+    /// Recursive helper for `is_clearly_non_nullable_constraint`.
+    ///
+    /// `depth` guards against pathological/cyclic structures by capping recursion
+    /// at a small constant. Union/Intersection bodies are still typically shallow.
+    fn is_clearly_non_nullable_constraint_with_depth(&self, id: TypeId, depth: u32) -> bool {
+        const MAX_DEPTH: u32 = 4;
         match id {
             TypeId::STRING
             | TypeId::NUMBER
@@ -382,20 +392,37 @@ impl TypeInterner {
             | TypeId::UNKNOWN
             | TypeId::NEVER
             | TypeId::ERROR => false,
-            _ => matches!(
-                self.lookup(id),
+            _ => match self.lookup(id) {
                 Some(
                     TypeData::Literal(_)
-                        | TypeData::Object(_)
-                        | TypeData::ObjectWithIndex(_)
-                        | TypeData::Array(_)
-                        | TypeData::Tuple(_)
-                        | TypeData::Function(_)
-                        | TypeData::Callable(_)
-                        | TypeData::TemplateLiteral(_)
-                        | TypeData::UniqueSymbol(_)
-                )
-            ),
+                    | TypeData::Object(_)
+                    | TypeData::ObjectWithIndex(_)
+                    | TypeData::Array(_)
+                    | TypeData::Tuple(_)
+                    | TypeData::Function(_)
+                    | TypeData::Callable(_)
+                    | TypeData::TemplateLiteral(_)
+                    | TypeData::UniqueSymbol(_),
+                ) => true,
+                Some(TypeData::Union(list_id)) if depth < MAX_DEPTH => {
+                    // A union is clearly non-nullable iff every member is.
+                    // E.g., `"A" | "B"` is non-nullable; `string | undefined` is not.
+                    let members = self.type_list(list_id);
+                    !members.is_empty()
+                        && members.iter().all(|&m| {
+                            self.is_clearly_non_nullable_constraint_with_depth(m, depth + 1)
+                        })
+                }
+                Some(TypeData::Intersection(list_id)) if depth < MAX_DEPTH => {
+                    // An intersection is clearly non-nullable if ANY member is non-nullable
+                    // (the non-nullable member forces the result to exclude null/undefined).
+                    let members = self.type_list(list_id);
+                    members
+                        .iter()
+                        .any(|&m| self.is_clearly_non_nullable_constraint_with_depth(m, depth + 1))
+                }
+                _ => false,
+            },
         }
     }
 

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -372,6 +372,65 @@ fn test_interner_intersection_optional_object_literals_not_reduced() {
     assert_ne!(intersection, TypeId::NEVER);
 }
 
+/// Regression: `T extends "A" | "B"` intersected with `undefined` reduces to `never`.
+///
+/// Previously, `is_clearly_non_nullable_constraint` only recognized single
+/// primitive/structural types, so a union constraint of string literals
+/// (`"A" | "B"`) was conservatively treated as possibly nullable and the
+/// intersection was *not* reduced. This produced a false TS2719 in
+/// `unknownControlFlow.ts` where `T_AB & undefined` was assigned to `never`.
+#[test]
+fn test_interner_intersection_type_param_with_string_literal_union_constraint_and_undefined_is_never()
+ {
+    let interner = TypeInterner::new();
+    let constraint = interner.union(vec![
+        interner.literal_string("A"),
+        interner.literal_string("B"),
+    ]);
+    let t = TypeParamInfo {
+        name: interner.intern_string("T_AB"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    };
+    let type_param = interner.type_param(t);
+    let intersection = interner.intersection(vec![type_param, TypeId::UNDEFINED]);
+    assert_eq!(intersection, TypeId::NEVER);
+}
+
+/// `T extends string | number` intersected with `null` reduces to `never`.
+#[test]
+fn test_interner_intersection_type_param_with_primitive_union_constraint_and_null_is_never() {
+    let interner = TypeInterner::new();
+    let constraint = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let t = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    };
+    let type_param = interner.type_param(t);
+    let intersection = interner.intersection(vec![type_param, TypeId::NULL]);
+    assert_eq!(intersection, TypeId::NEVER);
+}
+
+/// Negative: `T extends string | undefined` intersected with `undefined` is NOT `never`.
+/// The constraint allows the undefined component, so the intersection must remain unreduced.
+#[test]
+fn test_interner_intersection_type_param_with_nullable_union_constraint_and_undefined_not_never() {
+    let interner = TypeInterner::new();
+    let constraint = interner.union(vec![TypeId::STRING, TypeId::UNDEFINED]);
+    let t = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+    };
+    let type_param = interner.type_param(t);
+    let intersection = interner.intersection(vec![type_param, TypeId::UNDEFINED]);
+    assert_ne!(intersection, TypeId::NEVER);
+}
+
 #[test]
 fn test_interner_object_sorting() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
## Summary

- Extend `is_clearly_non_nullable_constraint` to recursively recognize unions and intersections, so a constraint like `T extends "A" | "B"` is correctly treated as non-nullable and `T & undefined` reduces to `never` at intersection construction time.
- Three new unit tests in `crates/tsz-solver/tests/intern_tests.rs` lock positive (`"A" | "B"`, `string | number`) and negative (`string | undefined` — must NOT reduce) cases.

## Why

`unknownControlFlow.ts` was emitting a false `TS2719`:

```ts
type AB = "A" | "B";
function x<T_AB extends AB>(x: T_AB & undefined, y: any) {
    let r2: never = y as T_AB & undefined;  // <- "Type 'never' is not assignable to type 'never'..."
}
```

The TS2719 message is only synthesized when source and target display identically — and both displayed as `never`. The root cause was upstream: we were emitting an assignability error at all because `T_AB & undefined` did not reduce to `TypeId::NEVER`. `is_clearly_non_nullable_constraint` only handled single primitive/structural types, and rejected union constraints conservatively.

`tsc` reports nothing for the same source — `never` is assignable to `never`.

## Conformance impact

- `unknownControlFlow.ts`: drops the false `TS2719`. Test still has unrelated fingerprint mismatches (TS2367 missing, etc.).
- Full suite: 12198 -> 12199 PASS, +3 improvements (`subclassThisTypeAssignable01`, `generatorYieldContextualType`, `optionalTupleElements1`), 2 reported "regressions" are pre-existing baseline drift on `checkJsdocSatisfiesTag7/10` (they fail on `main` too with the same fingerprint mismatch — not caused by this PR).

## Test plan

- [x] `cargo nextest run -p tsz-solver --lib -- 'test_interner_intersection_type_param'` (3/3 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "unknownControlFlow" --verbose` (TS2719 false positive removed)
- [x] Full conformance: net +1 PASS