### PR TITLE
chore(lint): fix 4 clippy errors blocking CI on main

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -1449,12 +1449,12 @@ function f() {
 /// Regression: TS2322 must fire when a bare type parameter is assigned to a
 /// template-literal pattern referencing the same type parameter.
 ///
-/// `tsc` reports TS2322 here because `\`${T}\`` is an opaque pattern type;
+/// `tsc` reports TS2322 here because the template-literal pattern is opaque;
 /// `T`'s instantiation could be a literal subtype that does not structurally
 /// match the template, so the assignment is not statically sound. Without the
 /// template-literal carve-out in `should_suppress_assignability_diagnostic`,
-/// the generic "complex type" suppression would silently accept it because
-/// `\`${T}\`` "contains" T but is not itself a type parameter.
+/// the generic "complex type" suppression would silently accept it because the
+/// template-literal "contains" T but is not itself a type parameter.
 ///
 /// Repros the missing fingerprint at
 /// `templateLiteralTypes5.ts(14,11)`.
@@ -1487,11 +1487,11 @@ function f<T extends "a" | "b">(x: T) {
 }
 
 /// Companion check: template-literal vs template-literal assignments where
-/// both sides share a type parameter (e.g. `\`${Uppercase<T>}\``) must keep
-/// their existing suppression. This locks in the narrowness of the
+/// both sides share a type parameter (e.g. an `Uppercase<T>` template) must
+/// keep their existing suppression. This locks in the narrowness of the
 /// template-literal carve-out so it does not regress
 /// `templateLiteralTypes3.ts` (where tsc accepts the spread of values typed
-/// `Uppercase<\`1.${T}.4\`>` against an inferred `Uppercase<\`1.${T}.3\`>`).
+/// as `Uppercase` of one template against an inferred `Uppercase` of another).
 #[test]
 fn template_literal_to_template_literal_with_generic_intrinsic_does_not_emit_ts2345() {
     let source = r#"
@@ -1544,8 +1544,7 @@ function h({ prop = "baz" }: StringUnion) {}
          not the initializer `\"baz\"` (offset {baz_offset}); got: {diag:?}"
     );
     assert!(
-        diag.message_text.contains("\"baz\"")
-            && diag.message_text.contains("\"foo\" | \"bar\""),
+        diag.message_text.contains("\"baz\"") && diag.message_text.contains("\"foo\" | \"bar\""),
         "TS2322 message should still describe the actual mismatch (\"baz\" vs literal union), \
          got: {:?}",
         diag.message_text

--- a/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
+++ b/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
@@ -853,7 +853,7 @@ const obj = {
 /// parameter name, not at the enclosing arrow function's `(` token.
 ///
 /// Before the fix, `assignment_anchor_node` walked up from the Parameter to
-/// the ArrowFunction and returned the function's start position (`(`), which
+/// the `ArrowFunction` and returned the function's start position (`(`), which
 /// shifted the diagnostic column one to the left of tsc's anchor.
 #[test]
 fn jsdoc_type_function_param_default_anchors_at_parameter_name() {

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1322,8 +1322,8 @@ var z = { ...x };
 /// element-vs-element TS2322 anchored on the spread expression instead of
 /// the whole-array TS2322 at the assignment.
 ///
-/// Regression for TypeScript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts:
-///   var array: number[] = [0, 1, ...new SymbolIterator];
+/// Regression for `TypeScript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts`:
+///   `var array: number[] = [0, 1, ...new SymbolIterator];`
 /// Expected message at the spread expression:
 ///   `Type 'symbol' is not assignable to type 'number'`.
 ///

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1411,15 +1411,14 @@ impl TypeInterner {
         }
         let mut has_anon_object = false;
         for &id in current {
-            match self.lookup(id) {
-                Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                    let shape = self.object_shape(shape_id);
-                    if shape.symbol.is_none() {
-                        has_anon_object = true;
-                        break;
-                    }
+            if let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
+                self.lookup(id)
+            {
+                let shape = self.object_shape(shape_id);
+                if shape.symbol.is_none() {
+                    has_anon_object = true;
+                    break;
                 }
-                _ => {}
             }
         }
         if !has_anon_object {


### PR DESCRIPTION
## Summary
Main has 4 clippy errors causing the `lint` job to fail across **all** queued PRs (#1458, #1460, #1463, #1464, #1465, #1466 today). Per `wait-for-CI` policy nothing can merge until lint is green.

| Fix | File | Lint |
|-----|------|------|
| `match` → `if let` | `tsz-solver/src/intern/core/interner.rs:1414` | `clippy::single_match` |
| add backticks around `SymbolIterator` | `tsz-checker/tests/spread_rest_tests.rs:1326` | `clippy::doc_markdown` |
| rewrite backtick template-literal example | `tsz-checker/src/assignability/assignment_checker_tests.rs:1452,1489` | `clippy::doc_markdown` (unbalanced backticks) |
| backtick `ArrowFunction` | `tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs:856` | `clippy::doc_markdown` |

## Test plan
- [x] `cargo clippy --all-targets --workspace -- -D warnings` passes locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
