### PR TITLE
fix(checker): preserve keyof T in property-receiver application display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -327,9 +327,17 @@ impl<'a> CheckerState<'a> {
     }
 
     fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
-        let evaluated = self.evaluate_type_with_env(ty);
-        if evaluated != ty {
-            return self.normalize_property_receiver_application_display_arg(evaluated);
+        // Only resolve `Lazy(DefId)` references via the type environment.
+        // Calling `evaluate_type_with_env` on richer shapes (e.g. `keyof T`,
+        // `T[K]`, conditional types) eagerly expands them to their evaluated
+        // structural form and loses the original syntactic identity that tsc
+        // preserves in property-receiver diagnostics. Structural recursion
+        // below already handles applications/unions/intersections/objects.
+        if crate::query_boundaries::common::is_lazy_type(self.ctx.types.as_type_database(), ty) {
+            let evaluated = self.evaluate_type_with_env(ty);
+            if evaluated != ty {
+                return self.normalize_property_receiver_application_display_arg(evaluated);
+            }
         }
 
         if let Some(app) = query::type_application(self.ctx.types, ty) {

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -304,6 +304,18 @@ function test<Shape extends Record<string, string>>(shape: Shape, key: keyof Sha
         "Expected TS2551 for unknown literal property on generic mapped type.\nActual diagnostics: {diagnostics:#?}"
     );
 
+    // Property-receiver display in TS2551 must preserve the original generic
+    // type-argument shape. Earlier behaviour eagerly evaluated `keyof Shape`
+    // through the type environment, expanding it to its constraint and
+    // collapsing the union to `string | number`, breaking conformance parity
+    // with tsc on tests like mappedTypeGenericWithKnownKeys.
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2551 && message.contains("Record<keyof Shape | \"knownLiteralKey\", number>")
+        }),
+        "Expected TS2551 to preserve `Record<keyof Shape | \"knownLiteralKey\", number>` in the property-receiver display.\nActual diagnostics: {diagnostics:#?}"
+    );
+
     assert!(
         diagnostics.iter().any(|(code, message)| {
             *code == 2862 && message.contains("Record<keyof Shape | \"knownLiteralKey\", number>")

--- a/docs/plan/claims/fix-ts2551-property-receiver-preserves-keyof-arg-display.md
+++ b/docs/plan/claims/fix-ts2551-property-receiver-preserves-keyof-arg-display.md
@@ -1,0 +1,35 @@
+# fix(checker): preserve keyof T in property-receiver type-application display
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/ts2551-property-receiver-preserves-keyof-arg-display`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance fingerprint parity)
+
+## Intent
+
+`normalize_property_receiver_application_display_arg` was eagerly calling
+`evaluate_type_with_env` on every type-argument node before recursing
+structurally. For arguments containing generic operator types like
+`keyof Shape`, evaluation expanded the operator into its evaluated structural
+form (e.g. `keyof Record<string, string>` → `string | number`), erasing the
+syntactic identity tsc preserves in property-receiver diagnostics. Restrict
+the evaluation step to `Lazy(DefId)` references so the structural recursion
+below handles applications/unions/intersections/objects directly while
+keyof/index-access/conditional types stay intact in the printed message.
+
+Fixes the `mappedTypeGenericWithKnownKeys.ts` fingerprint-only failure where
+TS2551 currently reads
+`Record<string | number, number>` instead of
+`Record<keyof Shape | "knownLiteralKey", number>`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/error_reporter/core/type_display.rs` (~14 LOC change)
+- `crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs` (+15 LOC test)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --lib` (2918/2918 pass)
+- `cargo nextest run -p tsz-checker --test conformance_issues` (791/791 pass)
+- `./scripts/conformance/conformance.sh run --filter "mappedTypeGenericWithKnownKeys"` (1/1 pass)

--- a/docs/plan/claims/fix-ts2551-property-receiver-preserves-keyof-arg-display.md
+++ b/docs/plan/claims/fix-ts2551-property-receiver-preserves-keyof-arg-display.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/ts2551-property-receiver-preserves-keyof-arg-display`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1469
+- **Status**: ready
 - **Workstream**: 1 (conformance fingerprint parity)
 
 ## Intent


### PR DESCRIPTION
## Summary

- Restrict `evaluate_type_with_env` in `normalize_property_receiver_application_display_arg` to `Lazy(DefId)` references so generic operator types (`keyof T`, `T[K]`, conditionals) keep their syntactic identity in property-receiver diagnostics.
- Fixes `mappedTypeGenericWithKnownKeys.ts` fingerprint-only failure where TS2551 read `Record<string | number, number>` instead of `Record<keyof Shape | "knownLiteralKey", number>`.

## Root cause

`normalize_property_receiver_application_display_arg` ran `evaluate_type_with_env` on every argument before recursing structurally. For args containing `keyof Shape`, evaluation expanded the operator into the constraint form, collapsing `keyof Shape | "knownLiteralKey"` into `string | number` and losing the syntactic shape tsc preserves in property-receiver diagnostics. Now we only evaluate if the arg is itself `Lazy(DefId)` — the structural recursion below already handles applications/unions/intersections/objects natively.

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib` (2918/2918 pass)
- [x] `cargo nextest run -p tsz-checker --test conformance_issues` (791/791 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "mappedTypeGenericWithKnownKeys"` (1/1 pass — now passes, previously fingerprint-only)
- [x] Existing `test_generic_mapped_type_known_keys_emit_ts2551_and_ts2862` extended with TS2551 type-display assertion