### PR TITLE
fix(solver,checker): prefer tuple arity mismatch over inner element drill-down

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -69,18 +69,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let effective_target_type = self.evaluate_type_with_env(target_type);
-        let effective_target_type = self.resolve_type_for_property_access(effective_target_type);
-        let effective_target_type = self.resolve_lazy_type(effective_target_type);
-        let effective_target_type = self.evaluate_application_type(effective_target_type);
-        let ctx_helper = tsz_solver::ContextualTypeContext::with_expected_and_options(
-            self.ctx.types,
-            effective_target_type,
-            self.ctx.compiler_options.no_implicit_any,
-        );
-        let tuple_target_elements =
-            crate::query_boundaries::common::tuple_elements(self.ctx.types, effective_target_type);
-
         let analysis = self.analyze_assignability_failure(source_type, target_type);
         match analysis.failure_reason {
             Some(SubtypeFailureReason::TupleElementTypeMismatch {
@@ -107,52 +95,14 @@ impl<'a> CheckerState<'a> {
                 true
             }
             Some(SubtypeFailureReason::TupleElementMismatch { .. }) => {
-                for (index, &elem_idx) in arr.elements.nodes.iter().enumerate() {
-                    let is_spread = self
-                        .ctx
-                        .arena
-                        .get(elem_idx)
-                        .is_some_and(|node| node.kind == syntax_kind_ext::SPREAD_ELEMENT);
-                    if is_spread {
-                        continue;
-                    }
-
-                    let target_element_type =
-                        if let Some(elements) = tuple_target_elements.as_deref() {
-                            let Some(t) = self.elaboration_tuple_element_type_at(elements, index)
-                            else {
-                                continue;
-                            };
-                            t
-                        } else if let Some(t) = ctx_helper.get_tuple_element_type(index) {
-                            t
-                        } else if let Some(t) = ctx_helper.get_array_element_type() {
-                            t
-                        } else if let Some(t) = crate::query_boundaries::common::array_element_type(
-                            self.ctx.types,
-                            effective_target_type,
-                        ) {
-                            t
-                        } else {
-                            continue;
-                        };
-
-                    let elem_type = self.elaboration_source_expression_type(elem_idx);
-                    if elem_type.is_any_unknown_or_error()
-                        || target_element_type.is_any_unknown_or_error()
-                    {
-                        continue;
-                    }
-
-                    if !self.is_assignable_to(elem_type, target_element_type) {
-                        self.error_type_not_assignable_at_with_anchor(
-                            elem_type,
-                            target_element_type,
-                            elem_idx,
-                        );
-                        return true;
-                    }
-                }
+                // Tuple arity mismatch (source has too many or too few elements
+                // for the target tuple). tsc reports this as the outer
+                // "Source has N element(s) but target requires/allows-only M."
+                // sub-message under the call-site TS2345/TS2322 — it does not
+                // drill into a specific source element (even when one of them
+                // would also fail an element-by-element assignability check).
+                // Returning false here lets the outer caller render the
+                // arity-aware TS2345 with related information directly.
                 false
             }
             Some(SubtypeFailureReason::ArrayElementMismatch {

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1441,6 +1441,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             });
         }
 
+        // When both source and target are closed tuples (no rest elements) and
+        // source has more elements than target allows, prefer the arity-mismatch
+        // reason over an element-level type mismatch. This matches tsc, which
+        // reports the outer "Source has N element(s) but target allows only M"
+        // diagnostic instead of drilling into a specific element when the
+        // length already disqualifies the relation.
+        let target_has_rest = target.iter().any(|e| e.rest);
+        let source_has_rest = source.iter().any(|e| e.rest);
+        if !target_has_rest && !source_has_rest && source.len() > target.len() {
+            return Some(SubtypeFailureReason::TupleElementMismatch {
+                source_count: source.len(),
+                target_count: target.len(),
+            });
+        }
+
         for (i, t_elem) in target.iter().enumerate() {
             if t_elem.rest {
                 let expansion = self.expand_tuple_rest(t_elem.type_id);

--- a/crates/tsz-solver/tests/compat_tests.rs
+++ b/crates/tsz-solver/tests/compat_tests.rs
@@ -6060,3 +6060,120 @@ fn test_explain_function_to_callable_with_properties_produces_missing_properties
         }
     }
 }
+
+/// Regression: when a closed source tuple has more elements than a closed
+/// target tuple, the failure reason must be the arity mismatch — not an
+/// element-level type mismatch — even if some interior element would also
+/// fail to assign. tsc reports
+/// "Source has N element(s) but target allows only M." in this case and
+/// stops there; tsz must do the same so that the call-site diagnostic is the
+/// outer TS2345 (with the correct `Source has ...` sub-message) instead of a
+/// drilled-in TS2322 at a single tuple element. Without this rule, the
+/// conformance test
+/// `destructuringParameterDeclaration3ES5.ts` fingerprints differently from
+/// tsc on the call `a9([1, 2, [["string"]], false, true])` because the inner
+/// `[["string"]]` vs `[[any]]` element comparison fires before the length
+/// check.
+#[test]
+fn test_explain_tuple_arity_takes_priority_over_element_mismatch() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+
+    // Inner tuple types so the element-level check would otherwise drill in.
+    let inner_string = interner.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let nested_string = interner.tuple(vec![TupleElement {
+        type_id: inner_string,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let inner_any = interner.tuple(vec![TupleElement {
+        type_id: TypeId::ANY,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let nested_any = interner.tuple(vec![TupleElement {
+        type_id: inner_any,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+
+    // Source: [number, number, [[string]], boolean, boolean] — length 5.
+    let source = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: nested_string,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::BOOLEAN,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::BOOLEAN,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+
+    // Target: [any, any, [[any]]] — length 3.
+    let target = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::ANY,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::ANY,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: nested_any,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+
+    assert!(!checker.is_assignable(source, target));
+
+    match checker.explain_failure(source, target) {
+        Some(SubtypeFailureReason::TupleElementMismatch {
+            source_count,
+            target_count,
+        }) => {
+            assert_eq!(source_count, 5);
+            assert_eq!(target_count, 3);
+        }
+        other => panic!(
+            "Expected TupleElementMismatch (arity) to take priority over an inner \
+             TupleElementTypeMismatch, got: {other:?}"
+        ),
+    }
+}

--- a/docs/plan/claims/fix-solver-tuple-arity-mismatch-priority.md
+++ b/docs/plan/claims/fix-solver-tuple-arity-mismatch-priority.md
@@ -1,0 +1,50 @@
+# fix(solver,checker): tuple-arity mismatch takes priority over inner element mismatch
+
+- **Date**: 2026-04-26 20:16:50
+- **Branch**: `fix/solver-tuple-arity-mismatch-priority`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Conformance — fingerprint parity, Big3 / TS2322 / TS2345)
+
+## Intent
+
+When a closed source tuple has more elements than a closed target tuple,
+the solver was returning a `TupleElementTypeMismatch` for the first
+type-incompatible element instead of the `TupleElementMismatch` arity
+failure. The checker's array-literal elaboration then anchored a TS2322
+on the inner element with a misleading message. `tsc` instead reports
+the call-site TS2345 with the outer `Source has N element(s) but target
+allows only M.` sub-message and does not drill into individual source
+elements.
+
+This change:
+
+1. Makes `SubtypeChecker::explain_tuple_failure` short-circuit to
+   `TupleElementMismatch` when both source and target are closed and
+   source has strictly more elements than target. The returned reason
+   then reflects what the relation actually rejected.
+2. Drops the symptom-side iteration in
+   `try_elaborate_array_literal_mismatch_from_failure_reason` for the
+   `TupleElementMismatch` branch. tsc never drills into a specific
+   source element on tuple arity failures — the arity sub-message is
+   the diagnostic. Returning `false` here lets the outer call-error
+   path render the proper TS2345 with related info.
+
+## Files Touched
+
+- `crates/tsz-solver/src/relations/subtype/explain.rs` (+15 LOC)
+- `crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs` (-54 LOC)
+- `crates/tsz-solver/tests/compat_tests.rs` (+125 LOC, regression test)
+
+## Verification
+
+- `cargo nextest run --package tsz-solver --lib -E 'test(test_explain) | test(test_tuple) | test(tuple_subtype) | test(tuple_assignability)'`
+  → 154 passed
+- `cargo nextest run --package tsz-checker --lib` → 2918 passed
+- `cargo nextest run --package tsz-solver --lib` → 5521 passed
+- Conformance: `destructuringParameterDeclaration3ES5.ts` flips from
+  `TS2322 test.ts:27:11 ...string[][]...` to the correct
+  `TS2345 test.ts:27:4 Argument of type ...` (only remaining delta is
+  a literal vs widened-boolean display — separate fingerprint issue).
+- Full conformance: net +1 (3 PASS improvements, 2 unrelated stale-baseline
+  drift entries already failing on plain main).

--- a/docs/plan/claims/fix-solver-tuple-arity-mismatch-priority.md
+++ b/docs/plan/claims/fix-solver-tuple-arity-mismatch-priority.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26 20:16:50
 - **Branch**: `fix/solver-tuple-arity-mismatch-priority`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1470
+- **Status**: ready
 - **Workstream**: 1 (Conformance — fingerprint parity, Big3 / TS2322 / TS2345)
 
 ## Intent


### PR DESCRIPTION
## Summary
- When a closed source tuple has more elements than a closed target tuple, `explain_tuple_failure` now short-circuits to `TupleElementMismatch` (arity) instead of returning `TupleElementTypeMismatch` for the first type-incompatible element.
- `try_elaborate_array_literal_mismatch_from_failure_reason` no longer drills into individual source elements on the `TupleElementMismatch` branch; the outer call-error path renders the arity-aware TS2345 with related info, matching tsc.

## Why
On `destructuringParameterDeclaration3ES5.ts`, the call `a9([1, 2, [["string"]], false, true])` against parameter `[any, any, [[any]]]` was producing a misleading `TS2322 test.ts:27:11 Type 'string[][]' is not assignable to type '[[any]]'` instead of tsc's outer `TS2345 test.ts:27:4 Argument of type '[number, number, [[string]], boolean, boolean]' is not assignable to parameter of type '[any, any, [[any]]]'. Source has 5 element(s) but target allows only 3.`

Root cause analysis followed the architecture rule: solver owns relation reasoning. The fix lives in the solver's explain layer, with a small follow-on in the checker's array-literal elaboration that previously second-guessed the solver and reported individual elements even when the relation rejected the tuple on arity.

## Test plan
- [x] `cargo nextest run --package tsz-solver --lib -E 'test(test_explain) | test(test_tuple) | test(tuple_subtype) | test(tuple_assignability)'` (154 tests, all pass)
- [x] `cargo nextest run --package tsz-solver --lib` (5521 tests, all pass)
- [x] `cargo nextest run --package tsz-checker --lib` (2918 tests, all pass)
- [x] Added regression test `test_explain_tuple_arity_takes_priority_over_element_mismatch` in `crates/tsz-solver/tests/compat_tests.rs` covering the exact `[number, number, [[string]], boolean, boolean] → [any, any, [[any]]]` shape.
- [x] Targeted conformance: `destructuringParameterDeclaration3ES5.ts` flips from extra TS2322 at column 11 to correct TS2345 at column 4 (only remaining delta is literal vs widened-boolean display, a separate fingerprint issue).
- [x] Full conformance: net +1 (3 PASS improvements: `subclassThisTypeAssignable01.ts`, `generatorYieldContextualType.ts`, `optionalTupleElements1.ts`). Two flagged "regressions" (`checkJsdocSatisfiesTag7.ts`, `checkJsdocSatisfiesTag10.ts`) were already failing on plain main with the same `Record<Keys, ...>` vs `Record<"a"|"b"|"c"|"d", ...>` fingerprint diff — stale baseline drift, not caused by this PR.

## Architecture compliance (§22 / §23)
1. Change is in the solver's relation explain logic (WHAT) and the checker's diagnostic anchoring (WHERE) — not in any ad-hoc checker type algorithm.
2. Goes through `analyze_assignability_failure` → `explain_failure` (the sanctioned compatibility gateway).
3. Preserves weak-union/excess-property/any-propagation behavior — change only affects the order in which arity vs element-type mismatches are reported.
4. No new `TypeKey`/raw interner usage in the checker.
5. Visitor-style traversal preserved; no checker recursion into solver internals.