### PR TITLE
fix(checker): suppress TS9006 when JSDoc `typeof import("/...")` is unresolvable

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -318,15 +318,17 @@ impl<'a> CheckerState<'a> {
 
             if let Some(shape) = query::object_shape(self.ctx.types, type_id)
                 && let Some(sym_id) = shape.symbol
-                && let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
-                    return Some(info);
-                }
+                && let Some(info) = self.private_external_module_nameability_info(sym_id, None)
+            {
+                return Some(info);
+            }
 
             if let Some(shape) = query::callable_shape(self.ctx.types, type_id)
                 && let Some(sym_id) = shape.symbol
-                && let Some(info) = self.private_external_module_nameability_info(sym_id, None) {
-                    return Some(info);
-                }
+                && let Some(info) = self.private_external_module_nameability_info(sym_id, None)
+            {
+                return Some(info);
+            }
         }
 
         None
@@ -547,8 +549,100 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // If the current file references this target file via a JSDoc
+        // `typeof import(<spec>)` whose `<spec>` is rejected by tsc as
+        // unresolvable (e.g. an absolute `/...` path that has no matching
+        // ambient module), the program-level error is the resolution failure
+        // (TS2307/TS2792). Stacking a TS9006 about a "private name from
+        // <module>" on top of that just contradicts the prior error — tsc
+        // does not emit it. Detect this case by re-running the same
+        // unresolvable-specifier predicate the JSDoc diagnostic check uses.
+        if self.current_file_jsdoc_typeof_import_unresolvable_for_target(file_idx) {
+            return None;
+        }
+
         let module_specifier = self.module_specifier_for_file(file_idx)?;
         Some((referenced_name, module_specifier))
+    }
+
+    /// Returns true if the current file contains a JSDoc `@type {typeof
+    /// import("<spec>")}` whose `<spec>` is rejected by tsc as unresolvable
+    /// (rooted/absolute paths with no ambient module fallback) and that
+    /// specifier — via our resolver's basename probing — still happens to
+    /// land on `target_file_idx`. tsc emits TS2307/TS2792 for such
+    /// specifiers and intentionally suppresses follow-on diagnostics that
+    /// walk the (technically resolved) target file's private symbols.
+    fn current_file_jsdoc_typeof_import_unresolvable_for_target(
+        &self,
+        target_file_idx: u32,
+    ) -> bool {
+        let arena = self.ctx.arena;
+        let Some(sf) = arena.source_files.first() else {
+            return false;
+        };
+        let source_text = sf.text.as_ref();
+        // Cheap text scan first — most files have no JSDoc `import(` at all.
+        if !source_text.contains("import(") {
+            return false;
+        }
+
+        let mut search_start = 0usize;
+        while let Some(rel) = source_text[search_start..].find("import(") {
+            let abs = search_start + rel + "import(".len();
+            // Skip optional whitespace
+            let bytes = source_text.as_bytes();
+            let mut cursor = abs;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            // Expect a quoted specifier; skip non-string forms (unsupported here).
+            if cursor >= bytes.len() {
+                break;
+            }
+            let quote = bytes[cursor];
+            if quote != b'"' && quote != b'\'' {
+                search_start = abs;
+                continue;
+            }
+            cursor += 1;
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != quote {
+                cursor += 1;
+            }
+            if cursor >= bytes.len() {
+                break;
+            }
+            let specifier = &source_text[start..cursor];
+            search_start = cursor + 1;
+
+            // Match the JSDoc TS2307 check: rooted specifiers (starting with
+            // `/`) are unresolvable per tsc unless an ambient module declares
+            // them. Plain relative/non-rooted forms are out of scope here —
+            // they go through the standard resolution-error pipeline.
+            if !specifier.starts_with('/') {
+                continue;
+            }
+            let has_ambient_module = self
+                .ctx
+                .declared_modules_contains(self.ctx.binder, specifier)
+                || self
+                    .ctx
+                    .binder
+                    .shorthand_ambient_modules
+                    .contains(specifier);
+            if has_ambient_module {
+                continue;
+            }
+            let resolved = self
+                .ctx
+                .resolve_import_target_from_file(self.ctx.current_file_idx, specifier)
+                .or_else(|| self.ctx.resolve_import_target(specifier));
+            if resolved.map(|idx| idx as u32) == Some(target_file_idx) {
+                return true;
+            }
+        }
+
+        false
     }
 
     fn find_external_private_symbol_owner_file(&self, symbol_name: &str) -> Option<u32> {

--- a/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
@@ -317,6 +317,52 @@ module.exports = ns;
     );
 }
 
+/// Regression for `jsDeclarationsTypeReassignmentFromDeclaration.ts`: when a
+/// JSDoc `@type {typeof import("/some-mod")}` references an unresolvable
+/// module specifier (here an absolute path `/some-mod` that tsc rejects),
+/// tsc emits only TS2307. The follow-on TS9006 about `Item` being a private
+/// name from `"some-mod"` would be misleading because the module never
+/// resolved to begin with — `Item` cannot become "private" from a module
+/// the program cannot find.
+#[test]
+fn checked_js_jsdoc_type_with_unresolvable_module_does_not_emit_ts9006() {
+    let diagnostics = compile_named_files(
+        &[
+            (
+                "/some-mod.d.ts",
+                r#"
+interface Item {
+    x: string;
+}
+declare const items: Item[];
+export = items;
+                "#,
+            ),
+            (
+                "index.js",
+                r#"
+/** @type {typeof import("/some-mod")} */
+const items = [];
+module.exports = items;
+                "#,
+            ),
+        ],
+        "index.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            emit_declarations: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !has_error(&diagnostics, 9006),
+        "TS9006 must not be emitted when the JSDoc `typeof import(...)` module specifier is unresolvable (TS2307 already covers the failure). Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
 #[test]
 fn checked_js_optional_nested_jsdoc_param_flows_into_destructured_binding() {
     let diagnostics = compile_named_files(

--- a/docs/plan/claims/fix-ts9006-suppress-when-import-resolution-failed.md
+++ b/docs/plan/claims/fix-ts9006-suppress-when-import-resolution-failed.md
@@ -1,0 +1,37 @@
+# fix(checker): suppress TS9006 when JSDoc `typeof import("/...")` is unresolvable
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/ts9006-suppress-when-import-resolution-failed`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (conformance)
+
+## Intent
+
+`jsDeclarationsTypeReassignmentFromDeclaration.ts` expects only TS2307 for an
+unresolvable absolute-path JSDoc import (`/** @type {typeof import("/some-mod")} */`)
+but tsz also fired TS9006 ("Declaration emit for this file requires using
+private name 'Item' from module 'some-mod'"). tsz's resolver still finds the
+file via basename probing even though tsc considers `/some-mod` unresolvable,
+so the type carries `Item` and the private-name walk in
+`first_private_name_from_external_module_reference` reports it.
+
+The fix is to suppress the TS9006 path when the current file references the
+target file via a JSDoc `typeof import(<spec>)` whose `<spec>` matches the
+same unresolvable predicate the JSDoc diagnostic check uses (rooted/absolute
+paths with no ambient module fallback). Stacking TS9006 on top of TS2307 for
+the same module just contradicts the prior error.
+
+## Files Touched
+
+- `crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs`
+  (~75 LOC: new helper `current_file_jsdoc_typeof_import_unresolvable_for_target`,
+  one-line guard inside `private_external_module_nameability_info`)
+- `crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs`
+  (~40 LOC: regression test `checked_js_jsdoc_type_with_unresolvable_module_does_not_emit_ts9006`)
+
+## Verification
+
+- `cargo nextest run -p tsz-checker --test js_jsdoc_diagnostics_tests` (8/8 pass)
+- `./scripts/conformance/conformance.sh run --filter "jsDeclarations"` (96/96 pass)
+- `./scripts/conformance/conformance.sh run --filter "jsDeclarationsTypeReassignmentFromDeclaration"` (2/2 pass)

--- a/docs/plan/claims/fix-ts9006-suppress-when-import-resolution-failed.md
+++ b/docs/plan/claims/fix-ts9006-suppress-when-import-resolution-failed.md
@@ -2,8 +2,8 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `fix/ts9006-suppress-when-import-resolution-failed`
-- **PR**: TBD
-- **Status**: claim
+- **PR**: #1472
+- **Status**: ready
 - **Workstream**: 1 (conformance)
 
 ## Intent


### PR DESCRIPTION
## Summary

- Fix `jsDeclarationsTypeReassignmentFromDeclaration.ts` (a Workstream-1 conformance failure): tsc emits only TS2307 for an unresolvable absolute-path JSDoc import (`@type {typeof import("/some-mod")}`), but tsz also fired TS9006 ("private name 'Item' from module 'some-mod'").
- Root cause: tsz's resolver finds `/some-mod.d.ts` by basename probing even though tsc considers `/some-mod` unresolvable. The inferred type carries `Item`, and the private-name walk in `first_private_name_from_external_module_reference` reports it on top of the TS2307.
- Fix: in `private_external_module_nameability_info`, suppress when the current file references the target file via a JSDoc `typeof import(<spec>)` whose `<spec>` matches the same unresolvable predicate the JSDoc diagnostic check uses (rooted/absolute paths with no ambient module fallback).

## Test plan

- [x] `cargo nextest run -p tsz-checker --test js_jsdoc_diagnostics_tests` — 8/8 pass (includes new `checked_js_jsdoc_type_with_unresolvable_module_does_not_emit_ts9006` regression and existing positive `checked_js_declaration_emit_private_name_from_module_reports_ts9006`)
- [x] `./scripts/conformance/conformance.sh run --filter "jsDeclarationsTypeReassignmentFromDeclaration"` — 2/2 pass (was 1/2)
- [x] `./scripts/conformance/conformance.sh run --filter "jsDeclarations"` — 96/96 pass
- [x] `cargo nextest run -p tsz-checker --lib` — 2918/2918 pass

## Notes

- Pre-commit clippy failure in `tsz-solver` is **pre-existing** (unrelated to this change); used `TSZ_SKIP_HOOKS=1` per CLAUDE.md.
- One LOC change actually inside the existing function (the `if … return None;` guard); the rest is the new helper `current_file_jsdoc_typeof_import_unresolvable_for_target` and its regression test.