### PR TITLE
fix(checker): suppress TS2556 for array literal spreads in call resolution

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -1623,6 +1623,19 @@ impl<'a> CheckerState<'a> {
                 effective_index += elems.len();
                 continue;
             }
+            // An array literal spread (e.g. `...['a', 'x']`) is expanded element-by-element
+            // during argument collection, so each element is checked individually against
+            // the corresponding parameter. Treat it like a tuple-like spread here: advance
+            // by the literal's element count and skip the TS2556 emission. tsc behaves the
+            // same way — TS2556 is only reported for spreads of opaque arrays/iterables
+            // whose runtime length is unknown at the call site.
+            if array_element_type_for_type(self.ctx.types, spread_type).is_some()
+                && let Some(expr_node) = self.ctx.arena.get(spread_data.expression)
+                && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
+            {
+                effective_index += literal.elements.nodes.len();
+                continue;
+            }
             if is_type_parameter_type(self.ctx.types, spread_type)
                 && let Some(constraint) = crate::query_boundaries::common::type_parameter_constraint(
                     self.ctx.types,
@@ -1680,6 +1693,21 @@ impl<'a> CheckerState<'a> {
                     return prior_non_tuple_spread;
                 }
                 effective_index += elems.len();
+                continue;
+            }
+            // An array literal spread (e.g. `...['a', 'x']`) is expanded element-by-element
+            // during argument collection. A mismatch at one of those expanded indices is a
+            // per-element type error (TS2345/TS2322), not a TS2556. Skip past the literal's
+            // elements without setting `prior_non_tuple_spread`.
+            if array_element_type_for_type(self.ctx.types, spread_type).is_some()
+                && let Some(expr_node) = self.ctx.arena.get(spread_data.expression)
+                && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
+            {
+                let count = literal.elements.nodes.len();
+                if mismatch_index < effective_index + count {
+                    return prior_non_tuple_spread;
+                }
+                effective_index += count;
                 continue;
             }
             let is_non_tuple_spread = array_element_type_for_type(self.ctx.types, spread_type)

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -1630,7 +1630,10 @@ impl<'a> CheckerState<'a> {
             // same way — TS2556 is only reported for spreads of opaque arrays/iterables
             // whose runtime length is unknown at the call site.
             if array_element_type_for_type(self.ctx.types, spread_type).is_some()
-                && let Some(expr_node) = self.ctx.arena.get(spread_data.expression)
+                && let Some(expr_node) = self
+                    .ctx
+                    .arena
+                    .get(self.ctx.arena.skip_parenthesized(spread_data.expression))
                 && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
             {
                 effective_index += literal.elements.nodes.len();
@@ -1700,7 +1703,10 @@ impl<'a> CheckerState<'a> {
             // per-element type error (TS2345/TS2322), not a TS2556. Skip past the literal's
             // elements without setting `prior_non_tuple_spread`.
             if array_element_type_for_type(self.ctx.types, spread_type).is_some()
-                && let Some(expr_node) = self.ctx.arena.get(spread_data.expression)
+                && let Some(expr_node) = self
+                    .ctx
+                    .arena
+                    .get(self.ctx.arena.skip_parenthesized(spread_data.expression))
                 && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
             {
                 let count = literal.elements.nodes.len();

--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -1244,6 +1244,61 @@ nums(...strs);
     );
 }
 
+/// Spread of an array literal into a non-rest signature must NOT emit TS2556.
+/// The literal is statically expanded into individual arguments at the call
+/// site, so each element is checked against the matching parameter (this can
+/// produce TS2345 per element, but never TS2556 — the literal's length is
+/// known). See conformance/keyofAndIndexedAccess.ts: `path(thing, ...['a','x'])`.
+#[test]
+fn call_with_spread_array_literal_into_overload_does_not_emit_ts2556() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
+declare function path(obj: any, ...keys: (string | number)[]): any;
+
+function f1() {
+    let x = path({a: 1}, ...['a']);
+}
+"#,
+    );
+
+    let ts2556: Vec<_> = diags.iter().filter(|d| d.code == 2556).collect();
+    assert!(
+        ts2556.is_empty(),
+        "Expected no TS2556 for array literal spread (length is statically \
+         known and elements are checked individually), got: {:?}",
+        ts2556
+            .iter()
+            .map(|d| &d.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Spread of an opaque (non-literal) array into a non-rest-only signature
+/// MUST still emit TS2556 — the runtime length is unknown so the spread
+/// cannot be statically expanded.
+#[test]
+fn call_with_spread_opaque_array_into_non_rest_emits_ts2556() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
+
+function f1() {
+    const arr: string[] = ['a'];
+    let x = path({a: 1}, ...arr);
+}
+"#,
+    );
+
+    let ts2556: Vec<_> = diags.iter().filter(|d| d.code == 2556).collect();
+    assert!(
+        !ts2556.is_empty(),
+        "Expected TS2556 for opaque (non-literal) array spread into a \
+         signature with no rest parameter, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
 // === Property call regression tests ===
 // Tests for method invocation through property access expressions.
 


### PR DESCRIPTION
## Summary
- `validate_non_tuple_spreads_for_signature` and `find_prior_non_tuple_spread_for_mismatch` no longer flag array literal spreads (e.g. `...['a', 'x']`) as TS2556 violations. The argument collector already expands the literal into individual arguments and checks each element, so a TS2556 here is a false positive.
- Mirrors tsc behavior: TS2556 is only reported when the spread's runtime length is unknown at the call site (opaque arrays, iterables, generic spreads without tuple constraints).
- Conformance: removes the extra TS2556 fingerprint from `conformance/types/keyof/keyofAndIndexedAccess.ts` (`path(thing, ...['a','x'])` no longer rejects the rest-parameter overload via spurious TS2556).

## Root cause
For `path(thing, ...['a','x'])` with overloads `(obj, key1)`, `(obj, key1, key2)`, `(obj, key1, key2, key3)` and `(obj, ...keys)`, overload 0 succeeded; then the post-match `validate_non_tuple_spreads_for_signature` walked the spread, classified `['a','x']` (typed as `string[]`) as a non-tuple spread, and emitted TS2556 because position 1 was not a rest position. The validator failed to recognize that the matching argument-collection path expanded the literal element-by-element, so the spread's runtime arity is in fact statically known.

## Fix
In both helpers, when the spread expression is an array literal, treat it like a tuple spread: advance the `effective_index` by the literal's element count (no TS2556 emission, no `prior_non_tuple_spread` recording). Opaque-array spreads still go through the existing `allows_non_tuple_spread_position` gate.

## Test plan
- [x] `cargo nextest run -p tsz-checker --lib` — 2920 tests pass
- [x] Two regression tests added in `crates/tsz-checker/src/tests/call_architecture_tests.rs`:
  - `call_with_spread_array_literal_into_overload_does_not_emit_ts2556`
  - `call_with_spread_opaque_array_into_non_rest_emits_ts2556`
- [x] `./scripts/conformance/conformance.sh run --filter "keyofAndIndexedAccess"` — TS2556 extra is gone (test still has 2 unrelated extras: TS2322@308 indexed-access assignability, TS2538@630 deep solver issue, both out of scope).
- [x] `./scripts/conformance/conformance.sh run --filter "callWithSpread"` — 6/6 pass
- [x] `./scripts/conformance/conformance.sh run --filter "iteratorSpread"` — 23/23 pass
- [x] `./scripts/conformance/conformance.sh run --filter "readonlyRestParameters"` — 1/1 pass
- [x] Snapshot query confirms only 1 test currently has an extra TS2556 emission, so this fix is targeted at exactly that false-positive class.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
