### PR TITLE
fix(checker): emit TS2451 for cross-file class collision with remote block-scoped variable

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -428,6 +428,10 @@ name = "ts2451_cross_file_augmentation_tests"
 path = "tests/ts2451_cross_file_augmentation_tests.rs"
 
 [[test]]
+name = "ts2451_cross_file_class_vs_const_tests"
+path = "tests/ts2451_cross_file_class_vs_const_tests.rs"
+
+[[test]]
 name = "ts2451_type_only_namespace_merge_tests"
 path = "tests/ts2451_type_only_namespace_merge_tests.rs"
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1626,7 +1626,7 @@ fn checker_files_stay_under_loc_limit() {
         ("error_reporter/call_errors.rs", 2554),
         ("error_reporter/core/diagnostic_source.rs", 2069),
         ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
-        ("types/type_checking/duplicate_identifiers.rs", 2051),
+        ("types/type_checking/duplicate_identifiers.rs", 2060),
         ("error_reporter/render_failure.rs", 2240),
         // Pushed over the 2000-LOC default by recent JSDoc/CommonJS source-display
         // changes (#679) and subsequent display-parity fixes (#682, #688, #690);

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1687,11 +1687,23 @@ impl<'a> CheckerState<'a> {
                         conflicts.contains(decl_idx)
                             && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
                     });
+                // For cross-file scenarios, the remote block-scoped declaration is
+                // not stored in `conflicts` (which only tracks local declarations),
+                // so check `declarations` directly for any remote block-scoped
+                // variable that could be triggering the redeclaration error. See
+                // duplicateIdentifierRelatedSpans1.ts: a local `class Bar` conflicts
+                // with a remote `const Bar` from another file — tsc emits TS2451.
+                let has_remote_block_scoped_conflict =
+                    declarations.iter().any(|(_, flags, is_local, _, _)| {
+                        !*is_local && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                    });
                 let has_function_conflict =
                     declarations.iter().any(|(decl_idx, flags, _, _, _)| {
                         conflicts.contains(decl_idx) && (flags & symbol_flags::FUNCTION) != 0
                     });
-                let use_ts2451 = if has_remote_declaration && has_block_scoped_conflict {
+                let use_ts2451 = if has_remote_declaration
+                    && (has_block_scoped_conflict || has_remote_block_scoped_conflict)
+                {
                     // Cross-file mixed conflicts generally use TS2451, except for
                     // synthetic default-import alias collisions where tsc reports
                     // TS2300 (for example impliedNodeFormatInterop1.ts).

--- a/crates/tsz-checker/tests/ts2451_cross_file_class_vs_const_tests.rs
+++ b/crates/tsz-checker/tests/ts2451_cross_file_class_vs_const_tests.rs
@@ -1,0 +1,146 @@
+//! TS2451 vs TS2300 selection for cross-file script-scope conflicts where a
+//! local non-block-scoped declaration (class/function) collides with a remote
+//! block-scoped variable (let/const).
+//!
+//! When two script files share global scope and one declares `const`/`let`
+//! while another declares `class`/`function` with the same name, tsc reports
+//! TS2451 ("Cannot redeclare block-scoped variable") on every conflicting
+//! declaration — not just on the block-scoped ones.
+//!
+//! Regression: `duplicateIdentifierRelatedSpans1.ts` was emitting TS2300 for
+//! the `class Bar {}` declaration in file2.ts when file1.ts had `const Bar`
+//! at script scope. The diagnostic chooser inspected only the conflicts set
+//! (which holds local declarations), so the remote `const Bar`'s
+//! `BLOCK_SCOPED_VARIABLE` flag was invisible to the cross-file branch.
+
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::module_resolution::build_module_resolution_maps;
+use tsz_checker::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn compile_script_files(files: &[(&str, &str)], entry_idx: usize) -> Vec<(u32, String, u32)> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        module: ModuleKind::CommonJS,
+        ..CheckerOptions::default()
+    };
+
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[entry_idx]);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone(), d.start))
+        .collect()
+}
+
+/// When a local `class Bar {}` in script file collides with a remote `const Bar`
+/// in another script file, tsc emits TS2451 ("Cannot redeclare block-scoped
+/// variable") on the class declaration — the redeclaration error subsumes the
+/// generic "duplicate identifier" diagnostic when ANY conflicting declaration
+/// (local or remote) is block-scoped.
+#[test]
+fn cross_file_class_vs_remote_const_uses_ts2451() {
+    let file1 = "class Foo { }\nconst Bar = 3;\n";
+    let file2 = "type Foo = number;\nclass Bar {}\n";
+    let file3 = "type Foo = 54;\nlet Bar = 42\n";
+
+    // Entry = file2.ts (where `class Bar {}` is local). The remote `const Bar`
+    // in file1 and `let Bar` in file3 are both block-scoped, so the local
+    // class redeclaration must surface as TS2451 — not TS2300.
+    let diags = compile_script_files(
+        &[
+            ("file1.ts", file1),
+            ("file2.ts", file2),
+            ("file3.ts", file3),
+        ],
+        1,
+    );
+    let bar_diags: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg, _)| matches!(*code, 2300 | 2451) && msg.contains("'Bar'"))
+        .collect();
+
+    assert!(
+        !bar_diags.is_empty(),
+        "expected duplicate-identifier diagnostic for 'Bar' in file2.ts, got: {diags:?}"
+    );
+    assert!(
+        bar_diags.iter().all(|(code, _, _)| *code == 2451),
+        "class-vs-remote-const conflict at script scope must emit TS2451 only; got: {bar_diags:?}"
+    );
+}
+
+/// Same scenario but entry = file3.ts where `let Bar` is local. The local
+/// `let` is itself block-scoped, so this branch was already correct, but we
+/// lock it in alongside the new file2 case to catch any regression that
+/// accidentally narrows the `BLOCK_SCOPED_VARIABLE` detection.
+#[test]
+fn cross_file_let_vs_remote_const_uses_ts2451() {
+    let file1 = "class Foo { }\nconst Bar = 3;\n";
+    let file2 = "type Foo = number;\nclass Bar {}\n";
+    let file3 = "type Foo = 54;\nlet Bar = 42\n";
+
+    let diags = compile_script_files(
+        &[
+            ("file1.ts", file1),
+            ("file2.ts", file2),
+            ("file3.ts", file3),
+        ],
+        2,
+    );
+    let bar_diags: Vec<_> = diags
+        .iter()
+        .filter(|(code, msg, _)| matches!(*code, 2300 | 2451) && msg.contains("'Bar'"))
+        .collect();
+
+    assert!(
+        !bar_diags.is_empty(),
+        "expected duplicate-identifier diagnostic for 'Bar' in file3.ts, got: {diags:?}"
+    );
+    assert!(
+        bar_diags.iter().all(|(code, _, _)| *code == 2451),
+        "let-vs-remote-const conflict at script scope must emit TS2451; got: {bar_diags:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `duplicateIdentifierRelatedSpans1.ts` was a fingerprint-only failure: tsc emits **TS2451** ("Cannot redeclare block-scoped variable") on `class Bar {}` in `file2.ts` because another script file declared `const Bar = 3;`. We were emitting TS2300 instead.
- The diagnostic chooser inferred `has_block_scoped_conflict` only by walking the local-only `conflicts` set, so a remote `BLOCK_SCOPED_VARIABLE` declaration was invisible to the cross-file branch. The fix adds a parallel `has_remote_block_scoped_conflict` probe that walks the full `declarations` list (which includes remote contributions from `same_name_top_level_script_declarations_for_current_file`).
- Net behavior: when any conflicting declaration — local or remote — is a `let`/`const`, the cross-file `has_remote_declaration` arm now correctly flips to TS2451 (gated on `!force2300`).

## Conformance impact
- `duplicateIdentifierRelatedSpans1.ts`: fingerprint-only → **PASS**.
- All 38 `Duplicate*` conformance tests, 18 `duplicateIdentifier*` tests, 7 `letDeclarations-scopes-duplicates*` tests, 26 `blockScoped*` tests, and the existing TS2451/TS2300 unit suites stay green.
- Pre-existing failures (`impliedNodeFormatInterop1`, `mergeSymbolRexportFunction`, etc.) are unchanged — they involve module augmentation paths that the new probe does not touch.

## Test plan
- [x] `cargo nextest run -p tsz-checker --test ts2451_cross_file_class_vs_const_tests` — new regression test covering class-vs-remote-const and let-vs-remote-const at script scope.
- [x] `cargo nextest run -p tsz-checker --test ts2451_cross_file_augmentation_tests --test ts2451_type_only_namespace_merge_tests --test ts2300_tests` — 54/54 pass.
- [x] `./scripts/conformance/conformance.sh run --filter duplicateIdentifierRelatedSpans1` — PASS.
- [x] `./scripts/conformance/conformance.sh run --filter Duplicate` — 38/38 PASS.
- [x] `./scripts/conformance/conformance.sh run --filter blockScoped` — 26/26 PASS.
- [x] Architecture LOC ceiling for `duplicate_identifiers.rs` bumped 2051 → 2060 to accommodate the +9 LOC (probe + comment).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
