### PR TITLE
fix(solver,checker): emit TS2344 for JSDoc @extends incompat prop type

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -167,7 +167,21 @@ impl<'a> CheckerState<'a> {
             }
 
             let arg_display = self.format_type_diagnostic(arg_type);
-            let constraint_display = self.format_type_diagnostic(constraint);
+            // Prefer the original constraint expression text — when the user
+            // wrote `@template {Foo} T` we want to display `Foo`, not the
+            // expanded structural shape of the typedef. tsc keeps the alias
+            // name. Fall back to the formatter when the source text is a
+            // structural form (contains `<`, `|`, `&`, `(`, `[`, `{`, `?`).
+            let trimmed_constraint_expr = constraint_expr.trim();
+            let constraint_display = if !trimmed_constraint_expr.is_empty()
+                && !trimmed_constraint_expr
+                    .chars()
+                    .any(|c| matches!(c, '<' | '|' | '&' | '(' | ')' | '[' | ']' | '{' | '}' | '?'))
+            {
+                trimmed_constraint_expr.to_string()
+            } else {
+                self.format_type_diagnostic(constraint)
+            };
             let message = format!(
                 "Type '{arg_display}' does not satisfy the constraint '{constraint_display}'."
             );

--- a/crates/tsz-checker/tests/jsdoc_extends_constraint_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_extends_constraint_tests.rs
@@ -95,6 +95,136 @@ class D extends A {}
 }
 
 #[test]
+fn jsdoc_string_not_assignable_to_boolean_or_string_array_minimization() {
+    // Pre-fix `string` was reported as a subtype of `boolean | string[]` via a
+    // String/iterable shortcut that misclassified arrays as "purely iterable".
+    // This minimization keeps that bug visible at the JSDoc-assignability layer
+    // without depending on @extends/@template plumbing.
+    let source = r#"
+/**
+ * @typedef {{ b: boolean | string[]; }} Foo
+ */
+/** @type {Foo} */
+const x = { b: "hello" };
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let codes: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 (string not assignable to boolean | string[]), got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_extends_incompatible_property_type_emits_ts2344() {
+    // Constraint `b: boolean | string[]`; arg supplies `b: string`. All required
+    // props are present but `string` is not assignable to `boolean | string[]`,
+    // so tsc emits TS2344. Mirrors `extendsTag5.ts` class E.
+    let source = r#"
+/**
+ * @typedef {{
+*     a: number | string;
+*     b: boolean | string[];
+* }} Foo
+*/
+
+/**
+* @template {Foo} T
+*/
+class A {
+   /**
+    * @param {T} a
+    */
+   constructor(a) { return a }
+}
+
+/**
+ * @extends {A<{a: string, b: string}>}
+ */
+class E extends A {}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let ts2344: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(
+        !ts2344.is_empty(),
+        "Expected TS2344 for @extends incompatible property type, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_extends_multi_line_incompatible_property_type_emits_ts2344() {
+    // Same shape but `@extends` type spans multiple JSDoc lines. Mirrors
+    // `extendsTag5.ts` class C.
+    let source = r#"
+/**
+ * @typedef {{
+*     a: number | string;
+*     b: boolean | string[];
+* }} Foo
+*/
+
+/**
+* @template {Foo} T
+*/
+class A {
+   /**
+    * @param {T} a
+    */
+   constructor(a) { return a }
+}
+
+/**
+ * @extends {A<{
+ *     a: string,
+ *     b: string
+ * }>}
+ */
+class C extends A {}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let ts2344: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(
+        !ts2344.is_empty(),
+        "Expected TS2344 for multi-line @extends incompatible property type, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_extends_constraint_display_uses_typedef_alias_name() {
+    // tsc displays the typedef alias `Foo` in the TS2344 message instead of
+    // the structural expansion `{ a: ...; b: ...; }`.
+    let source = r#"
+/**
+ * @typedef {{
+*     a: number | string;
+*     b: boolean | string[];
+* }} Foo
+*/
+
+/**
+* @template {Foo} T
+*/
+class A {
+   /** @param {T} a */
+   constructor(a) { return a }
+}
+
+/**
+ * @extends {A<{a: string, b: string}>}
+ */
+class E extends A {}
+"#;
+    let diags = check_js_with_jsdoc(source);
+    let ts2344: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2344).collect();
+    assert!(!ts2344.is_empty(), "Expected TS2344, got: {diags:?}");
+    let messages: Vec<&str> = ts2344.iter().map(|(_, m)| m.as_str()).collect();
+    assert!(
+        messages.iter().any(|m| m.contains("constraint 'Foo'")),
+        "TS2344 should display the typedef alias 'Foo'; got: {messages:?}"
+    );
+}
+
+#[test]
 fn jsdoc_extends_multi_line_missing_property_emits_ts2344() {
     // Multi-line `@extends {A<{...}>}` with a missing required property
     // exercises both the balanced-brace extraction and the line-continuation

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -417,7 +417,28 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if a target type has named properties beyond `[Symbol.iterator]`
     /// and `__@iterator` (the iterable protocol). Properties like `length` and
     /// numeric index signatures that `String` naturally has are also excluded.
-    fn target_has_non_iterable_properties(&self, target: TypeId) -> bool {
+    fn target_has_non_iterable_properties(&mut self, target: TypeId) -> bool {
+        // Arrays/tuples carry methods like `push`/`pop`/`slice` that `String`
+        // does not provide, so they must NOT slip through the iterable
+        // shortcut. Catch all three forms a target can take:
+        //   - `TypeData::Array` / `TypeData::Tuple` (no lib loaded)
+        //   - `ReadonlyType<Array|Tuple>` wrappers
+        //   - `Application(Array, [T])` (the global `Array<T>` interface)
+        // The probe `evaluate_type(target)` covers the Application form by
+        // resolving it to its structural array body. Without this guard,
+        // `string <: string[]` (and via `boolean | string[]` etc.) leaked
+        // through and silently suppressed downstream constraint diagnostics.
+        for probe in [
+            target,
+            readonly_inner_type(self.interner, target).unwrap_or(target),
+            self.evaluate_type(target),
+        ] {
+            if array_element_type(self.interner, probe).is_some()
+                || tuple_list_id(self.interner, probe).is_some()
+            {
+                return true;
+            }
+        }
         let shape = object_shape_id(self.interner, target)
             .or_else(|| object_with_index_shape_id(self.interner, target))
             .map(|id| self.interner.object_shape(id));

--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -615,6 +615,34 @@ fn subtype_checker_with_query_db_uses_cache() {
     assert!(checker2.is_subtype_of(wider, narrow));
 }
 
+/// `string` is NOT a subtype of `string[]` — even when the `SubtypeChecker` is
+/// configured with a `QueryDatabase`. The String/iterable shortcut in
+/// `is_boxed_primitive_subtype` previously misclassified arrays as
+/// "purely iterable" because `target_has_non_iterable_properties` only
+/// inspected `ObjectShape` and missed `TypeData::Array`. Regression for
+/// `conformance/jsdoc/extendsTag5.ts` (TS2344 was being suppressed by
+/// `string <: boolean | string[]` returning true via this path).
+#[test]
+fn string_is_not_subtype_of_array_string_with_query_db() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let array_string = interner.array(TypeId::STRING);
+
+    let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(
+        !checker.is_subtype_of(TypeId::STRING, array_string),
+        "string must not be a subtype of string[] (with query_db)"
+    );
+
+    let union = interner.union(vec![TypeId::BOOLEAN, array_string]);
+    let mut checker2 = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(
+        !checker2.is_subtype_of(TypeId::STRING, union),
+        "string must not be a subtype of boolean | string[] (with query_db)"
+    );
+}
+
 // =============================================================================
 // Fast Path Tests (identity, any, unknown, never, error)
 // =============================================================================

--- a/docs/plan/claims/fix-checker-jsdoc-extends-incompat-prop-ts2344.md
+++ b/docs/plan/claims/fix-checker-jsdoc-extends-incompat-prop-ts2344.md
@@ -1,0 +1,72 @@
+# fix(solver,checker): emit TS2344 for JSDoc @extends incompat property type
+
+- **Date**: 2026-04-26
+- **Branch**: `fix/checker-jsdoc-extends-incompat-prop-ts2344`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+`conformance/jsdoc/extendsTag5.ts` was wrong-code: tsc emits TS2344 when a JSDoc
+`@extends {A<{...}>}` type-argument violates the target's `@template {Foo} T`
+constraint via an incompatible property type (e.g. `b: string` vs constraint
+`b: boolean | string[]`). tsz missed TS2344 entirely and instead emitted
+spurious TS2322/TS2409 on the constructor body.
+
+## Root Cause
+
+Two stacked bugs:
+
+1. **Solver — String/iterable shortcut leak**: `is_boxed_primitive_subtype`
+   (`crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs`) had a
+   String/iterable shortcut that returned true when the target was iterable
+   yielding string AND `target_has_non_iterable_properties` reported "no
+   extras". The helper only inspected `ObjectShape` / `ObjectWithIndex`, so it
+   missed `TypeData::Array(T)` (no lib loaded) and `Application(Array, [T])`
+   (lib loaded). Net: `string <: string[]` returned true, which dragged
+   `string <: boolean | string[]` to true, and the JSDoc constraint check
+   silently passed.
+2. **Checker — Constraint display lost typedef alias**: TS2344 message
+   formatted the constraint by structurally expanding the resolved typedef,
+   producing `'{ a: ...; b: ...; }'` instead of tsc's `'Foo'`.
+
+## Fix
+
+- **Solver**: `target_has_non_iterable_properties` now returns `true` when
+  the target (raw, readonly-unwrapped, or `evaluate_type`-resolved) is
+  `TypeData::Array` or `TypeData::Tuple` — catching all three shapes
+  `Array<T>` can take depending on lib state. Helper now takes `&mut self`
+  to allow `evaluate_type`.
+- **Checker**: `check_jsdoc_extends_tag_type_argument_constraints` now uses
+  the original `constraint_expr` text as the display name when the source
+  is a single identifier (no `<`, `|`, `&`, `(`, `[`, `{`, `?`), falling
+  back to `format_type_diagnostic` only for structural constraints.
+
+## Files Touched
+
+- `crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs`
+- `crates/tsz-solver/tests/subtype_cache_tests.rs` (1 new lock)
+- `crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs`
+- `crates/tsz-checker/tests/jsdoc_extends_constraint_tests.rs` (4 new locks)
+
+## Verification
+
+- `cargo nextest run -p tsz-solver subtype_cache_tests` — 31/31 pass
+- `cargo nextest run -p tsz-solver --tests` — 5522/5522 pass
+- `cargo nextest run -p tsz-checker --test jsdoc_extends_constraint_tests`
+  — 7/7 pass (3 pre-existing + 4 new)
+- `cargo nextest run -p tsz-checker --lib` — 2918/2918 pass
+- `./scripts/conformance/conformance.sh run --filter "extendsTag5" --verbose`:
+  before: missing TS2344 ×2 + extra TS2322/TS2409 (wrong-code)
+  after: TS2344 ×2 emit at correct positions with `'Foo'` display; only
+  spurious TS2322/TS2409 from the constructor body remain (separate bug,
+  tracked in memory).
+
+## Remaining Gap (Separate)
+
+`extendsTag5.ts` still fails as fingerprint-only on the constructor-body
+`return a` pattern: `class A` (no own props) with `constructor(a: T)
+{ return a }` produces tsz TS2322 + TS2409 ("Type 'T' is not assignable to
+type 'A<T>'"). tsc accepts because A's instance type has no required
+members. Saved as a separate memory item for follow-up.


### PR DESCRIPTION
## Intent

Fix the TS2344 wrong-code conformance failure on
`conformance/jsdoc/extendsTag5.ts` (and the wider class of JSDoc
`@extends {A<...>}` constraint violations on incompatible property types).

## Root Cause

Two stacked bugs:

1. **Solver String/iterable shortcut leak** (`tsz-solver`):
   `target_has_non_iterable_properties` (in
   `crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs`) only
   inspected `ObjectShape` / `ObjectWithIndex`, so it missed
   `TypeData::Array(T)` (no lib loaded) and `Application(Array, [T])`
   (lib loaded). The String/iterable shortcut therefore returned true
   for `string <: string[]`, which dragged
   `string <: boolean | string[]` to true and silently passed the JSDoc
   `@extends` constraint check. Fixed by probing the raw,
   readonly-unwrapped, and `evaluate_type`-resolved forms for
   array/tuple kinds before the shape probe.

2. **Constraint display lost typedef alias** (`tsz-checker`):
   `check_jsdoc_extends_tag_type_argument_constraints` (in
   `crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs`)
   formatted the constraint by structurally expanding the resolved
   typedef, producing `'{ a: ...; b: ...; }'` instead of tsc's `'Foo'`.
   Fixed by using the original `constraint_expr` text when it's a
   single identifier (no `<`, `|`, `&`, `(`, `[`, `{`, `?`); falls back
   to `format_type_diagnostic` for structural constraints.

## Tests

- New solver lock in `subtype_cache_tests.rs` for `string` not subtype
  of `string[]` or `boolean | string[]` with `query_db` set.
- 4 new checker locks in `jsdoc_extends_constraint_tests.rs`:
  incompatible property type single-line + multi-line, alias-name
  display, and a minimization without @extends machinery.

## Verification

- `cargo nextest run -p tsz-solver --tests` — 5522/5522 pass
- `cargo nextest run -p tsz-checker --lib` — 2918/2918 pass
- `cargo nextest run -p tsz-checker --test jsdoc_extends_constraint_tests` — 7/7
- Conformance `extendsTag5.ts`: TS2344 now emits at correct positions
  with `'Foo'` display matching tsc; remaining gap is spurious
  TS2322/TS2409 from `class A {} constructor(a: T) { return a }` body
  (separate bug, tracked in memory as
  `project_extendsTag5_constructor_return_T_to_A_of_T.md`).

## Roadmap Claim

`docs/plan/claims/fix-checker-jsdoc-extends-incompat-prop-ts2344.md`
(Workstream 1 — Diagnostic Conformance).