### PR TITLE
fix(checker): skip JSDoc source-display rewrite for class property declarations

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -439,6 +439,10 @@ path = "tests/intersection_primitive_member_assignability_tests.rs"
 name = "union_origin_display_tests"
 path = "tests/union_origin_display_tests.rs"
 
+[[test]]
+name = "jsdoc_class_property_target_display"
+path = "tests/jsdoc_class_property_target_display.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -794,6 +794,13 @@ impl<'a> CheckerState<'a> {
 
         let mut current = expr_idx;
         loop {
+            // Skip JSDoc-derived source display when `current` is the name of a
+            // class property declaration whose leading JSDoc `@type` describes
+            // the declared (target) type, not an initializer/source expression.
+            // Without this guard the property name picks up the property's own
+            // `@type` annotation as the "source" string and produces tautological
+            // diagnostics like "Type 'boolean' is not assignable to type 'boolean'."
+            // for e.g. `/** @type {boolean} */ #foo = 3` where the source is `3`.
             if self
                 .ctx
                 .arena
@@ -807,6 +814,7 @@ impl<'a> CheckerState<'a> {
                             | syntax_kind_ext::METHOD_DECLARATION
                             | syntax_kind_ext::GET_ACCESSOR
                             | syntax_kind_ext::SET_ACCESSOR
+                            | syntax_kind_ext::PROPERTY_DECLARATION
                     )
                 })
             {

--- a/crates/tsz-checker/tests/jsdoc_class_property_target_display.rs
+++ b/crates/tsz-checker/tests/jsdoc_class_property_target_display.rs
@@ -1,0 +1,137 @@
+//! TS2322 source/target display for class property `/** @type {T} */ name = expr`.
+//!
+//! Regression for `jsdocPrivateName1.ts`: a JSDoc `@type` annotation on a
+//! class property declaration declares the property's type (the assignment
+//! target), not the initializer's source type. The TS2322 diagnostic must
+//! show the initializer's actual type as the source (e.g. `number` for `3`),
+//! not the JSDoc-declared property type (which would produce a tautological
+//! "Type 'boolean' is not assignable to type 'boolean'.").
+//!
+//! Same shape as the existing `module.exports = X` and `Foo.prototype = X`
+//! carve-outs in `jsdoc_annotated_expression_display`.
+
+use rustc_hash::FxHashSet;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn diagnostics_for_js(source: &str) -> Vec<(u32, String)> {
+    let mut parser = ParserState::new("test.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        no_implicit_any: false,
+        ..CheckerOptions::default()
+    };
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.js".to_string(),
+        options,
+    );
+    let _: FxHashSet<u32> = FxHashSet::default();
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// `class A { /** @type {boolean} */ #foo = 3 }` must emit
+/// `Type 'number' is not assignable to type 'boolean'.` — source uses the
+/// initializer's actual type (`number`), not the JSDoc-declared target type
+/// (`boolean`). Without the carve-out the property name node picks up the
+/// `@type {boolean}` annotation as the "source" string and the diagnostic
+/// degenerates into "Type 'boolean' is not assignable to type 'boolean'.".
+#[test]
+fn ts2322_for_private_class_property_jsdoc_uses_initializer_type_for_source() {
+    let diags = diagnostics_for_js(
+        r#"
+class A {
+    /** @type {boolean} some number value */
+    #foo = 3
+}
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got: {diags:?}"
+    );
+    let msg = &ts2322[0].1;
+    assert!(
+        msg.contains("'number'") && msg.contains("'boolean'"),
+        "TS2322 must show source as 'number' and target as 'boolean'; got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Type 'boolean' is not assignable to type 'boolean'"),
+        "TS2322 must not collapse both sides to the JSDoc-declared target type; got: {msg:?}"
+    );
+}
+
+/// Same bug, public (non-`#`) class property — verify the fix is not specific
+/// to private identifiers.
+#[test]
+fn ts2322_for_public_class_property_jsdoc_uses_initializer_type_for_source() {
+    let diags = diagnostics_for_js(
+        r#"
+class A {
+    /** @type {boolean} */
+    foo = 3
+}
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got: {diags:?}"
+    );
+    let msg = &ts2322[0].1;
+    assert!(
+        msg.contains("'number'") && msg.contains("'boolean'"),
+        "TS2322 must show source as 'number' and target as 'boolean'; got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Type 'boolean' is not assignable to type 'boolean'"),
+        "TS2322 must not collapse both sides to the JSDoc-declared target type; got: {msg:?}"
+    );
+}
+
+/// String initializer + JSDoc `@type {boolean}` — different source/target
+/// combo to confirm the source string is genuinely the initializer's type
+/// rather than just any other primitive.
+#[test]
+fn ts2322_for_string_initializer_class_property_jsdoc_uses_initializer_type_for_source() {
+    let diags = diagnostics_for_js(
+        r#"
+class A {
+    /** @type {boolean} */
+    foo = "hello"
+}
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got: {diags:?}"
+    );
+    let msg = &ts2322[0].1;
+    assert!(
+        msg.contains("'string'") && msg.contains("'boolean'"),
+        "TS2322 must show source as 'string' and target as 'boolean'; got: {msg:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Class properties with leading JSDoc `@type` annotations (e.g. `/** @type {boolean} */ #foo = 3` in a JS class) were producing tautological TS2322 diagnostics like "Type 'boolean' is not assignable to type 'boolean'."
- Root cause: `jsdoc_annotated_expression_display` walked from the diagnostic anchor (the property name) and used the property's own `@type` as the **source** display. The `@type` describes the target (declared) type, not the initializer's source type.
- Fix: add `PROPERTY_DECLARATION` to the parent-kind guard at the top of the helper, mirroring the existing carve-outs for `PROPERTY_ASSIGNMENT`, `METHOD_DECLARATION`, `GET_ACCESSOR`, `SET_ACCESSOR`, etc. and the runtime guard `is_jsdoc_declared_target_assignment` for `module.exports = X` / `Foo.prototype = X`.
- Fixes `jsdocPrivateName1.ts` fingerprint-only failure (one test from FAIL → PASS).

## Test plan
- [x] New unit tests in `crates/tsz-checker/tests/jsdoc_class_property_target_display.rs` covering private property, public property, and string-initializer variants
- [x] `cargo nextest run --package tsz-checker --test jsdoc_class_property_target_display` — 3/3 pass
- [x] `cargo nextest run --package tsz-checker` — 5428/5428 pass, no regressions
- [x] `./scripts/conformance/conformance.sh run --filter "jsdocPrivateName1"` — 1/1 pass (was 0/1)
- [x] `./scripts/conformance/conformance.sh run --filter "checkJsdoc"` — 39/41 pass (the 2 failures are pre-existing, unrelated `checkJsdocSatisfiesTag7/10`)
- [x] `./scripts/conformance/conformance.sh run --filter "typeTag"` — 7/7 pass (no regressions in adjacent JSDoc target-annotation paths)
- [x] `./scripts/conformance/conformance.sh run --filter "callbackTag"` — 7/7 pass
- [x] LOC ceiling test passes; the diff adds zero LOC to the grandfathered file (after the recent `chore(split)` extraction the file is well below 2000 LOC)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
