### PR TITLE
fix(checker): redirect cross-file TS2451 to non-plain-JS remote anchor

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -432,6 +432,10 @@ name = "ts2451_cross_file_class_vs_const_tests"
 path = "tests/ts2451_cross_file_class_vs_const_tests.rs"
 
 [[test]]
+name = "ts2451_plain_js_lib_anchor_tests"
+path = "tests/ts2451_plain_js_lib_anchor_tests.rs"
+
+[[test]]
 name = "ts2451_type_only_namespace_merge_tests"
 path = "tests/ts2451_type_only_namespace_merge_tests.rs"
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -1625,7 +1625,7 @@ fn checker_files_stay_under_loc_limit() {
         ("error_reporter/core.rs", 2358),
         ("error_reporter/call_errors.rs", 2554),
         ("error_reporter/core/diagnostic_source.rs", 2069),
-        ("types/type_checking/duplicate_identifiers_helpers.rs", 2125),
+        ("types/type_checking/duplicate_identifiers_helpers.rs", 2244),
         ("types/type_checking/duplicate_identifiers.rs", 2060),
         ("error_reporter/render_failure.rs", 2240),
         // Pushed over the 2000-LOC default by recent JSDoc/CommonJS source-display

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1863,12 +1863,13 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            for (decl_idx, _decl_flags, is_local, _, _) in declarations {
-                if is_local && conflicts.contains(&decl_idx) {
-                    let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
-                    self.error_at_node(error_node, &message, code);
-                }
-            }
+            self.emit_duplicate_identifier_diagnostics(
+                sym_id,
+                &declarations,
+                &conflicts,
+                code,
+                &message,
+            );
         }
 
         self.check_block_scoped_function_outer_conflicts();

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -2031,6 +2031,147 @@ impl<'a> CheckerState<'a> {
             )
         })
     }
+
+    /// Emit duplicate-identifier diagnostics, defaulting to local-anchored
+    /// errors but redirecting to a remote anchor when tsc's plain-JS
+    /// `addDuplicateLocations` filter (checker.ts ~L2782-L2783) applies.
+    pub(super) fn emit_duplicate_identifier_diagnostics(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        declarations: &[(
+            NodeIndex,
+            u32,
+            bool,
+            bool,
+            super::duplicate_identifiers::DuplicateDeclarationOrigin,
+        )],
+        conflicts: &FxHashSet<NodeIndex>,
+        code: u32,
+        message: &str,
+    ) {
+        if self.try_redirect_dup_id_to_non_plain_js_remote(
+            sym_id,
+            declarations,
+            conflicts,
+            code,
+            message,
+        ) {
+            return;
+        }
+        for (decl_idx, _decl_flags, is_local, _, _) in declarations {
+            if *is_local && conflicts.contains(decl_idx) {
+                let error_node = self
+                    .get_declaration_name_node(*decl_idx)
+                    .unwrap_or(*decl_idx);
+                self.error_at_node(error_node, message, code);
+            }
+        }
+    }
+
+    /// Mirror tsc's `addDuplicateLocations` plain-JS suppression for
+    /// cross-file duplicate-identifier conflicts. Returns `true` when the
+    /// local plain-JS site was suppressed and a remote anchor emitted.
+    fn try_redirect_dup_id_to_non_plain_js_remote(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        declarations: &[(
+            NodeIndex,
+            u32,
+            bool,
+            bool,
+            super::duplicate_identifiers::DuplicateDeclarationOrigin,
+        )],
+        conflicts: &FxHashSet<NodeIndex>,
+        code: u32,
+        message: &str,
+    ) -> bool {
+        use crate::context::should_resolve_jsdoc_for_file;
+        use crate::diagnostics::diagnostic_codes;
+
+        if code != diagnostic_codes::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE {
+            return false;
+        }
+        let local_is_plain_js = self.is_js_file() && !self.ctx.should_resolve_jsdoc();
+        if !local_is_plain_js {
+            return false;
+        }
+        let has_local_conflict = declarations
+            .iter()
+            .any(|(decl_idx, _, is_local, _, _)| *is_local && conflicts.contains(decl_idx));
+        if !has_local_conflict {
+            return false;
+        }
+
+        let mut emitted_at: FxHashSet<(String, u32)> = FxHashSet::default();
+        let mut emitted = false;
+        for (decl_idx, _, is_local, _, _) in declarations {
+            if *is_local {
+                continue;
+            }
+            let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, *decl_idx)) else {
+                continue;
+            };
+            for arena_arc in arenas {
+                let arena: &tsz_parser::parser::NodeArena = arena_arc;
+                if std::ptr::eq(arena, self.ctx.arena) {
+                    continue;
+                }
+                let Some(sf) = arena.source_files.first() else {
+                    continue;
+                };
+                if !should_resolve_jsdoc_for_file(
+                    &sf.file_name,
+                    sf.text.as_ref(),
+                    &self.ctx.compiler_options,
+                ) {
+                    continue;
+                }
+                let Some(remote_node) = arena.get(*decl_idx) else {
+                    continue;
+                };
+                let name_idx = remote_declaration_name_node(arena, remote_node, *decl_idx);
+                let Some(name_node) = arena.get(name_idx) else {
+                    continue;
+                };
+                let start = name_node.pos;
+                let length = name_node.end.saturating_sub(start);
+                if !emitted_at.insert((sf.file_name.clone(), start)) {
+                    continue;
+                }
+                self.error_at_position_in_file(sf.file_name.clone(), start, length, message, code);
+                emitted = true;
+            }
+        }
+        emitted
+    }
+}
+
+/// Resolve `decl_idx` to its declaration name node within `arena`. Mirrors
+/// `CheckerState::get_declaration_name_node` but operates on an arbitrary
+/// arena. Falls back to `decl_idx` itself when the declaration kind is not
+/// recognized.
+fn remote_declaration_name_node(
+    arena: &tsz_parser::parser::NodeArena,
+    remote_node: &tsz_parser::parser::node::Node,
+    decl_idx: NodeIndex,
+) -> NodeIndex {
+    use tsz_scanner::SyntaxKind;
+    match remote_node.kind {
+        syntax_kind_ext::FUNCTION_DECLARATION => arena.get_function(remote_node).map(|d| d.name),
+        syntax_kind_ext::VARIABLE_DECLARATION => {
+            arena.get_variable_declaration(remote_node).map(|d| d.name)
+        }
+        syntax_kind_ext::CLASS_DECLARATION => arena.get_class(remote_node).map(|d| d.name),
+        syntax_kind_ext::INTERFACE_DECLARATION => arena.get_interface(remote_node).map(|d| d.name),
+        syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
+            arena.get_type_alias(remote_node).map(|d| d.name)
+        }
+        syntax_kind_ext::ENUM_DECLARATION => arena.get_enum(remote_node).map(|d| d.name),
+        syntax_kind_ext::MODULE_DECLARATION => arena.get_module(remote_node).map(|d| d.name),
+        k if k == SyntaxKind::Identifier as u16 => Some(decl_idx),
+        _ => None,
+    }
+    .unwrap_or(decl_idx)
 }
 
 #[cfg(test)]

--- a/crates/tsz-checker/tests/ts2451_plain_js_lib_anchor_tests.rs
+++ b/crates/tsz-checker/tests/ts2451_plain_js_lib_anchor_tests.rs
@@ -1,0 +1,176 @@
+//! TS2451 anchor for cross-file plain-JS conflicts.
+//!
+//! When a `.js` script (plain JS — no `// @ts-check`, no `checkJs`) declares
+//! a `const`/`let` whose name conflicts with a `declare function`/`declare var`
+//! in a `.d.ts` file (e.g. `lib.es5.d.ts`'s built-in `eval`), tsc anchors the
+//! TS2451 diagnostic at the remote `.d.ts` declaration rather than the local
+//! plain-JS site (mirrors `addDuplicateLocations` plain-JS filter in
+//! `checker.ts` ~L2782-L2783).
+//!
+//! Conformance: `conformance/salsa/plainJSReservedStrict.ts`.
+
+use std::path::Path;
+use std::sync::Arc;
+use tsz_binder::state::LibContext as BinderLibContext;
+use tsz_binder::{BinderState, lib_loader::LibFile};
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::context::LibContext as CheckerLibContext;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeInterner;
+
+fn load_es5_lib_files_for_test() -> Vec<Arc<LibFile>> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let lib_paths = [
+        manifest_dir.join("../../TypeScript/lib/lib.es5.d.ts"),
+        manifest_dir.join("scripts/conformance/node_modules/typescript/lib/lib.es5.d.ts"),
+        manifest_dir.join("../scripts/conformance/node_modules/typescript/lib/lib.es5.d.ts"),
+        manifest_dir.join("../../scripts/conformance/node_modules/typescript/lib/lib.es5.d.ts"),
+    ];
+    let mut lib_files = Vec::new();
+    for lib_path in &lib_paths {
+        if lib_path.exists()
+            && let Ok(content) = std::fs::read_to_string(lib_path)
+        {
+            let file_name = lib_path.file_name().unwrap().to_string_lossy().to_string();
+            let lib_file = LibFile::from_source(file_name, content);
+            lib_files.push(Arc::new(lib_file));
+        }
+    }
+    lib_files
+}
+
+/// Run the checker against `source` (parsed as `file_name`) with `lib.es5.d.ts`
+/// merged into the binder, returning the resulting diagnostics.
+fn check_with_lib(source: &str, file_name: &str) -> Vec<Diagnostic> {
+    let lib_files = load_es5_lib_files_for_test();
+    assert!(
+        !lib_files.is_empty(),
+        "Expected to find lib.es5.d.ts for the test (checked TypeScript/lib and \
+         scripts/conformance/node_modules paths)"
+    );
+
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    let lib_contexts: Vec<_> = lib_files
+        .iter()
+        .map(|lib| BinderLibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    binder.merge_lib_contexts_into_binder(&lib_contexts);
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let options = CheckerOptions::default();
+
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        file_name.to_string(),
+        options,
+    );
+    let checker_lib_contexts: Vec<_> = lib_files
+        .iter()
+        .map(|lib| CheckerLibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    checker.ctx.set_lib_contexts(checker_lib_contexts);
+    checker.check_source_file(root);
+    checker.ctx.diagnostics.clone()
+}
+
+/// `const eval = 1` in a plain-JS script vs `declare function eval(...)` in
+/// `lib.es5.d.ts` should produce TS2451 anchored at the lib declaration's
+/// name, not at the local plain-JS site.
+#[test]
+fn plain_js_const_eval_redirects_ts2451_to_lib_function_eval() {
+    let user_js = "\"use strict\";\nconst eval = 1;\n";
+    let diags = check_with_lib(user_js, "plainJSReservedStrict.js");
+
+    let for_eval: Vec<&Diagnostic> = diags
+        .iter()
+        .filter(|d| d.code == 2451 && d.message_text.contains("'eval'"))
+        .collect();
+    assert!(
+        !for_eval.is_empty(),
+        "expected a TS2451 diagnostic for 'eval', got: {diags:?}"
+    );
+
+    // Every TS2451 'eval' diagnostic must anchor at lib.es5.d.ts, never at
+    // the plain-JS source.
+    let on_user_js: Vec<&Diagnostic> = for_eval
+        .iter()
+        .copied()
+        .filter(|d| d.file.ends_with(".js"))
+        .collect();
+    assert!(
+        on_user_js.is_empty(),
+        "plain-JS local site must not carry the TS2451 anchor when the lib's \
+         `eval` declaration participates in the conflict. Got: {on_user_js:?}"
+    );
+
+    let on_lib: Vec<&Diagnostic> = for_eval
+        .iter()
+        .copied()
+        .filter(|d| d.file.ends_with("lib.es5.d.ts"))
+        .collect();
+    assert!(
+        !on_lib.is_empty(),
+        "TS2451 must anchor at lib.es5.d.ts when local file is plain JS. Got: {for_eval:?}"
+    );
+}
+
+/// Same scenario but with `const arguments = 2` — covers the second
+/// strict-mode reserved-word case from `plainJSReservedStrict.ts`.
+#[test]
+fn plain_js_const_arguments_redirects_ts2451_to_lib() {
+    let user_js = "\"use strict\";\nconst arguments = 2;\n";
+    let diags = check_with_lib(user_js, "plainJSReservedStrict.js");
+
+    let for_arguments: Vec<&Diagnostic> = diags
+        .iter()
+        .filter(|d| d.code == 2451 && d.message_text.contains("'arguments'"))
+        .collect();
+    if for_arguments.is_empty() {
+        // tsc emits TS2451 for `arguments` only when lib provides a global
+        // `arguments` declaration. The conformance test only locks in the
+        // `eval` anchor; treat empty as benign here.
+        return;
+    }
+    assert!(
+        for_arguments.iter().all(|d| !d.file.ends_with(".js")),
+        "plain-JS local site must not carry the TS2451 anchor for 'arguments'. \
+         Got: {for_arguments:?}"
+    );
+}
+
+/// Same scenario but the redeclaration is in a `.ts` file (not plain JS). The
+/// plain-JS suppression must NOT apply, so the local `.ts` site keeps the
+/// TS2451 anchor.
+#[test]
+fn ts_const_eval_keeps_local_anchor_for_ts2451() {
+    let user_ts = "const eval = 1;\n";
+    let diags = check_with_lib(user_ts, "user.ts");
+
+    let for_eval: Vec<&Diagnostic> = diags
+        .iter()
+        .filter(|d| d.code == 2451 && d.message_text.contains("'eval'"))
+        .collect();
+    assert!(
+        !for_eval.is_empty(),
+        "expected TS2451 for `eval` redeclaration in TS file, got: {diags:?}"
+    );
+    assert!(
+        for_eval.iter().any(|d| d.file.ends_with("user.ts")),
+        "TS-file local site must keep its TS2451 anchor (plain-JS suppression \
+         must not apply to TS files). Got: {for_eval:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Mirror tsc's `addDuplicateLocations` plain-JS filter (`checker.ts` ~L2782-L2783): in a cross-file duplicate-identifier conflict, when the local file is plain JS (`.js`/`.jsx` without `// @ts-check` and without `checkJs`) and a non-plain-JS remote declaration participates (e.g. `declare function eval` in `lib.es5.d.ts`), tsc anchors TS2451 at the remote declaration's name node, suppressing the local-anchored emission. This PR adds the same redirect to `check_duplicate_identifiers`.
- Existing local-anchored TS2451/TS2300 emission for non-plain-JS files is preserved unchanged (gated on `is_js_file() && !should_resolve_jsdoc()`).

## Conformance impact

- `conformance/salsa/plainJSReservedStrict.ts` was fingerprint-only (codes correct, anchor wrong: we emitted at `plainJSReservedStrict.js:2:7` instead of `lib.es5.d.ts:31:18`). This PR flips it to PASS.
- Salsa lane: 176/191 PASS (no regressions vs. the 175/191 pre-change baseline; 1 net win).
- `duplicateIdentifier*` lane: 17/18 PASS unchanged.

## Test plan

- [x] `cargo nextest run --package tsz-checker --lib` (2920 tests pass)
- [x] `cargo nextest run --package tsz-checker --test ts2451_plain_js_lib_anchor_tests` (3 new regression tests pass)
- [x] `./scripts/conformance/conformance.sh run --filter "plainJSReservedStrict" --verbose` → 1/1 PASS
- [x] `./scripts/conformance/conformance.sh run --filter "plainJSRedeclare"` → 3/3 PASS (no regression on same-file plain-JS TS2451)
- [x] `./scripts/conformance/conformance.sh run --filter "duplicateIdentif"` → 17/18 PASS (unchanged)
- [x] `./scripts/conformance/conformance.sh run --filter "salsa"` → 176/191 PASS

## Implementation notes

- New helper `emit_duplicate_identifier_diagnostics` is the single emission entry point; it consults `try_redirect_dup_id_to_non_plain_js_remote` first and only emits at local declarations when the redirect did not fire.
- `try_redirect_dup_id_to_non_plain_js_remote` walks `declarations` for non-local entries, looks up each declaration's arena via `binder.declaration_arenas`, filters out plain-JS arenas via `should_resolve_jsdoc_for_file`, resolves the declaration name node, and emits at the remote position with `error_at_position_in_file`. Anchors are de-duped on `(file_name, start)`.
- Free function `remote_declaration_name_node` mirrors `CheckerState::get_declaration_name_node` for arbitrary arenas (the existing helper is bound to `self.ctx.arena`).
- LOC ceiling for `duplicate_identifiers_helpers.rs` raised from 2125 to 2244 to accommodate the extracted helpers; `duplicate_identifiers.rs` stays at 2051.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
