### PR TITLE
fix(checker): suppress TS2322 cascade for bare generics in type literals

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -240,6 +240,10 @@ name = "type_arg_count_mismatch_tests"
 path = "tests/type_arg_count_mismatch_tests.rs"
 
 [[test]]
+name = "ts2314_in_type_literal_suppresses_ts2322_tests"
+path = "tests/ts2314_in_type_literal_suppresses_ts2322_tests.rs"
+
+[[test]]
 name = "commonjs_module_export_alias_tests"
 path = "tests/commonjs_module_export_alias_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -405,11 +405,23 @@ impl<'a> CheckerState<'a> {
                 }
                 // Resolve the symbol's structural body first
                 let _ = self.type_reference_symbol_type(sym_id);
+                let type_params = self.get_type_params_for_symbol(sym_id);
+                // Mirror `resolve_simple_type_reference`: when a bare type reference
+                // omits required type arguments, return ERROR so cascading TS2322
+                // checks against the naked-type-parameter form are suppressed.  The
+                // TS2314 diagnostic is emitted independently by
+                // `check_type_for_missing_names`, so we don't double-emit here.
+                let required_count = type_params
+                    .iter()
+                    .filter(|param| param.default.is_none())
+                    .count();
+                if required_count > 0 {
+                    return TypeId::ERROR;
+                }
                 // For generic types with all-default type parameters (e.g., Uint8Array<T = ArrayBufferLike>),
                 // wrap in Application(Lazy(DefId), defaults) to match resolve_simple_type_reference behavior.
                 // Without this, bare Lazy(DefId) misses the default instantiation and causes false
                 // TS2322 when compared against an explicit Application (e.g., Uint8Array<ArrayBuffer>).
-                let type_params = self.get_type_params_for_symbol(sym_id);
                 if !type_params.is_empty() && type_params.iter().all(|p| p.default.is_some()) {
                     let default_args: Vec<TypeId> =
                         crate::query_boundaries::common::resolve_default_type_args(

--- a/crates/tsz-checker/tests/ts2314_in_type_literal_suppresses_ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2314_in_type_literal_suppresses_ts2322_tests.rs
@@ -1,0 +1,107 @@
+//! Tests for type-literal-nested generic-without-args TS2314 behavior.
+//!
+//! When a generic class or interface is referenced without required type
+//! arguments inside a type literal (e.g. `var x: { a: C } = ...`), tsc:
+//!   1. Emits TS2314 ("Generic type 'C<T>' requires 1 type argument(s).")
+//!   2. Treats the reference as `errorType` so cascading TS2322 from a
+//!      structural mismatch against the naked-type-parameter form is
+//!      suppressed.
+//!
+//! Without (2), the in-type-literal resolution path leaves `C` as a bare
+//! `Lazy(DefId)` whose evaluation is `C<T>` (with naked `T`).  Comparing a
+//! concrete instance like `new C<number>()` against that produces a spurious
+//! TS2322 "Type 'C<number>' is not assignable to type 'C<T>'." that tsc
+//! never emits.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// Class type used without type arguments in a type literal property.
+/// Reproduces `genericsWithoutTypeParameters1.ts`: assigning `new C<number>()`
+/// to `{ a: C }` must emit TS2314 once, with no extra TS2322 from the
+/// `C<number>` ⇄ `C<T>` mismatch.
+#[test]
+fn test_class_in_type_literal_without_args_no_spurious_ts2322() {
+    let source = r#"
+class C<T> {
+    foo(): T { return null as any; }
+}
+var x: { a: C } = { a: new C<number>() };
+"#;
+    let codes = check_source_codes(source);
+
+    assert!(
+        codes.contains(&2314),
+        "Expected TS2314 for missing type arguments on C, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "Should not emit TS2322 when the target type is `errorType` from missing type args, got: {codes:?}"
+    );
+}
+
+/// Interface type used without type arguments in a type literal property.
+#[test]
+fn test_interface_in_type_literal_without_args_no_spurious_ts2322() {
+    let source = r#"
+interface I<T> {
+    bar(): T;
+}
+var x: { a: I } = { a: { bar() { return 1; } } };
+"#;
+    let codes = check_source_codes(source);
+
+    assert!(
+        codes.contains(&2314),
+        "Expected TS2314 for missing type arguments on I, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "Should not emit TS2322 when the target type is `errorType` from missing type args, got: {codes:?}"
+    );
+}
+
+/// Sanity check: when type arguments ARE supplied correctly, no TS2314 is
+/// emitted and a real type mismatch still produces TS2322.
+#[test]
+fn test_class_in_type_literal_with_args_still_emits_ts2322_on_real_mismatch() {
+    let source = r#"
+class C<T> {
+    foo(): T { return null as any; }
+}
+var x: { a: C<string> } = { a: new C<number>() };
+"#;
+    let codes = check_source_codes(source);
+
+    assert!(
+        !codes.contains(&2314),
+        "TS2314 should not be emitted when type arguments are supplied, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 for genuine string vs number mismatch, got: {codes:?}"
+    );
+}
+
+/// Default-typed generics used bare in a type literal must continue to
+/// resolve to `Application(base, [defaults])` so they remain assignable from
+/// matching concrete instantiations.
+#[test]
+fn test_all_defaults_in_type_literal_no_ts2314_no_ts2322() {
+    let source = r#"
+interface Box<T = string> {
+    value: T;
+}
+declare const b: Box<string>;
+var x: { a: Box } = { a: b };
+"#;
+    let codes = check_source_codes(source);
+
+    assert!(
+        !codes.contains(&2314),
+        "TS2314 should not fire for a generic with all-default type params, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "Default-typed generic should be assignable from explicit form, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- When a generic class/interface is referenced without required type arguments inside a type literal (e.g. `var x: { a: C } = ...` for a `class C<T>`), the in-type-literal resolution path left the reference as a bare `Lazy(DefId)`. Evaluating that lazy ref produces the class type with naked `T`, so a concrete `new C<number>()` failed structural compatibility against `C<T>` and emitted a spurious TS2322 ("Type 'C<number>' is not assignable to type 'C<T>'.") that tsc never emits.
- Mirror the behavior of `resolve_simple_type_reference`: when the referenced symbol has at least one type parameter without a default, return `TypeId::ERROR` so the assignability check sees `errorType` and skips cascade diagnostics. TS2314 is still emitted by the existing `check_type_for_missing_names` walker, so the user-facing diagnostic is unchanged — only the spurious TS2322 disappears.
- Fixes the conformance test `compiler/genericsWithoutTypeParameters1.ts` and ships unit-tested coverage for the class, interface, default-typed, and "real mismatch with explicit args" cases.

## Test plan

- [x] `cargo nextest run -p tsz-checker --test ts2314_in_type_literal_suppresses_ts2322_tests` (4/4 pass)
- [x] `cargo nextest run -p tsz-checker` (5436/5436 pass)
- [x] `cargo nextest run -p tsz-solver` (5524/5524 pass)
- [x] `./scripts/conformance/conformance.sh run --filter "genericsWithoutTypeParameters1"` (1/1 pass — was fingerprint-only failure)
- [x] `./scripts/conformance/conformance.sh run --filter "generic"` — no new regressions vs baseline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
