### PR TITLE
fix(ci): use google-github-actions/auth for GCS bench download

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -121,18 +121,15 @@ jobs:
       # Benchmarks now run on Cloud Build (c3-88, 88 vCPU) via cloudbuild-bench.yaml
       # and publish results to GCS. We download the latest result here so the site
       # always deploys immediately without waiting for a benchmark run.
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
+        continue-on-error: true
+
       - name: Download latest benchmark data from GCS
-        env:
-          SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
         run: |
-          set -euo pipefail
-          if [[ -z "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
-            echo "No GCS credentials — bench charts will show placeholder"
-            exit 0
-          fi
-          printf '%s' "$SCCACHE_GCS_KEY_JSON" > /tmp/gcs-key.json
-          trap 'rm -f /tmp/gcs-key.json' EXIT
-          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcs-key.json
           LATEST=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/latest.json
           if gsutil -q stat "$LATEST" 2>/dev/null; then
             gsutil cp "$LATEST" /tmp/bench-latest.json


### PR DESCRIPTION
## Problem

The bench download step in `gh-pages.yml` was failing silently with "No latest.json in GCS yet" even though `latest.json` is clearly present in GCS (`generated_at: 2026-04-26T21:39:41`).

Root cause: the step manually wrote `SCCACHE_GCS_KEY_JSON` to `/tmp/gcs-key.json` and exported `GOOGLE_APPLICATION_CREDENTIALS`, but gsutil on Ubuntu 24.04 runners resolves Application Default Credentials through its own layered lookup that doesn't pick up env vars set within the same script's `export`. The `gsutil -q stat` was failing (silently due to `2>/dev/null`), dropping into the else branch.

## Fix

Replace the manual credential wiring with `google-github-actions/auth@v2`, which correctly configures the runner's ADC layer so all subsequent `gcloud`/`gsutil` calls use the right service account key.

The download script is simplified: no more inline JSON-to-file writing, no `set -euo pipefail` guard, no credential cleanup trap.

## Test plan

- [ ] Merge → gh-pages run picks up `SCCACHE_GCS_KEY_JSON` via auth action
- [ ] "Download latest benchmark data from GCS" step prints "Downloaded fresh benchmark data from GCS (N valid results)"
- [ ] Bench charts render on tsz.dev
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
