### PR TITLE
fix(solver): canonicalize non-string primitives in string-intrinsic templates

### DIFF
--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -177,7 +177,8 @@ declare let c: any;
     );
     let ts2493_count = diagnostics.iter().filter(|d| d.code == 2493).count();
     assert_eq!(
-        ts2493_count, 2,
+        ts2493_count,
+        2,
         "Expected TS2493 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2493_count,
         diagnostics
@@ -219,7 +220,8 @@ declare let c: any;
     );
     let ts2339_count = diagnostics.iter().filter(|d| d.code == 2339).count();
     assert_eq!(
-        ts2339_count, 2,
+        ts2339_count,
+        2,
         "Expected TS2339 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2339_count,
         diagnostics

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
@@ -153,13 +153,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Apply a string intrinsic to a template literal type
     ///
-    /// This handles cases like `Uppercase<hello-${string}>`, which should produce
-    /// a template literal with uppercase text spans: `HELLO-${string}`
+    /// This handles cases like an `Uppercase` over a template literal with
+    /// `${string}` placeholders: text spans are uppercased and the type
+    /// placeholders are wrapped in `Uppercase<...>`.
     ///
     /// For template literals with type interpolations:
     /// - Text spans are transformed (uppercased, lowercased, etc.)
     /// - Type spans are wrapped in the same string intrinsic
     /// - For Capitalize/Uncapitalize, special handling for the first span
+    /// - Non-string primitive type spans (`number`, `bigint`, `boolean`) are
+    ///   first stringified by wrapping in a single-placeholder template
+    ///   literal to mirror tsc's `getStringMappingType` canonicalization.
+    ///   This keeps templates produced by applying the intrinsic structurally
+    ///   aligned with the hand-written equivalents tsc uses, and prevents
+    ///   spurious TS2322 between equivalent pattern-literal forms.
     pub(crate) fn apply_string_intrinsic_to_template_literal(
         &self,
         kind: StringIntrinsicKind,
@@ -217,17 +224,28 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     }
                 }
                 TemplateSpan::Type(type_id) => {
+                    // Canonicalize non-string primitive type spans (number, bigint,
+                    // boolean) into the `${T}` template-literal form before applying
+                    // the intrinsic. tsc's `getStringMappingType` does this via
+                    // `isPatternLiteralPlaceholderType`: the placeholder is wrapped in
+                    // a single-span template literal, so `Uppercase<number>` and
+                    // `Uppercase<\`${number}\`>` collapse to the same canonical
+                    // representation. For boolean, this also triggers expansion to
+                    // `"true" | "false"` via the template-literal interner, matching
+                    // tsc's `${boolean}` -> `"false" | "true"` behavior.
+                    let canonical_arg =
+                        canonicalize_string_intrinsic_arg(self.interner(), *type_id);
                     // For type interpolations, wrap in the appropriate string intrinsic
                     // For Capitalize/Uncapitalize on non-first position, we don't wrap
                     // since those only affect the first character
                     let wrapped_type = if is_first_span {
                         // First position type: apply the intrinsic
-                        self.interner().string_intrinsic(kind, *type_id)
+                        self.interner().string_intrinsic(kind, canonical_arg)
                     } else {
                         // Non-first position: only Uppercase/Lowercase apply
                         match kind {
                             StringIntrinsicKind::Uppercase | StringIntrinsicKind::Lowercase => {
-                                self.interner().string_intrinsic(kind, *type_id)
+                                self.interner().string_intrinsic(kind, canonical_arg)
                             }
                             StringIntrinsicKind::Capitalize | StringIntrinsicKind::Uncapitalize => {
                                 // Capitalize/Uncapitalize don't affect non-first positions
@@ -279,5 +297,40 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
             }
         }
+    }
+}
+
+/// Canonicalize a `StringIntrinsic` type argument so that non-string primitive
+/// placeholders (`number`, `bigint`, `boolean`) are wrapped in template
+/// literal form, mirroring tsc's `getStringMappingType` /
+/// `isPatternLiteralPlaceholderType` normalization.
+///
+/// Without this, the result of applying a string mapping to a template such
+/// as `Uppercase<aA-then-number>` would keep the bare `number` placeholder,
+/// while a hand-written `Uppercase<just-number>` produced via the
+/// template-literal canonical form keeps the `${number}` wrapping, leaving
+/// the two equivalent pattern-literal types structurally different and
+/// emitting spurious TS2322 mismatches between them.
+///
+/// For boolean specifically, wrapping in a template literal triggers the
+/// template-literal interner expansion to `"false" | "true"`, matching tsc's
+/// `${boolean}` cross-product behaviour.
+pub(crate) fn canonicalize_string_intrinsic_arg(
+    interner: &dyn crate::TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    use crate::types::{IntrinsicKind, TemplateSpan};
+    match interner.lookup(type_id) {
+        Some(TypeData::Intrinsic(IntrinsicKind::Number))
+        | Some(TypeData::Intrinsic(IntrinsicKind::Bigint))
+        | Some(TypeData::Intrinsic(IntrinsicKind::Boolean)) => {
+            let empty_atom = interner.intern_string("");
+            interner.template_literal(vec![
+                TemplateSpan::Text(empty_atom),
+                TemplateSpan::Type(type_id),
+                TemplateSpan::Text(empty_atom),
+            ])
+        }
+        _ => type_id,
     }
 }

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -422,8 +422,68 @@ impl TypeInterner {
             }
         }
 
+        // Mirror tsc's `getTemplateLiteralType` collapse: a template literal
+        // whose only span is a single pattern-literal type (e.g.
+        // `Uppercase<\`${number}\`>`) is structurally identical to that span
+        // itself. Collapsing avoids wrapping pattern-literal placeholders in
+        // an extra `${...}` layer when callers re-construct templates around
+        // already-canonical pattern types (see
+        // `apply_string_intrinsic_to_template_literal`). See checker.ts
+        // `getTemplateLiteralType` "Normalize `${Mapping<xxx>}` into Mapping<xxx>".
+        if let [TemplateSpan::Type(only_type)] = normalized.as_slice() {
+            let only_type = *only_type;
+            if self.is_pattern_literal_type(only_type) {
+                return only_type;
+            }
+        }
+
         let list_id = self.intern_template_list(normalized);
         self.intern(TypeData::TemplateLiteral(list_id))
+    }
+
+    /// Check if a type is a "pattern literal type": a `TemplateLiteral` whose
+    /// every type span is a pattern-literal placeholder, or a `StringIntrinsic`
+    /// over a pattern-literal placeholder.
+    ///
+    /// Mirrors tsc's `isPatternLiteralType`.
+    fn is_pattern_literal_type(&self, type_id: TypeId) -> bool {
+        match self.lookup(type_id) {
+            Some(TypeData::TemplateLiteral(list_id)) => {
+                let spans = self.template_list(list_id);
+                spans.iter().all(|span| match span {
+                    TemplateSpan::Text(_) => true,
+                    TemplateSpan::Type(t) => self.is_pattern_literal_placeholder_type(*t),
+                })
+            }
+            Some(TypeData::StringIntrinsic { type_arg, .. }) => {
+                self.is_pattern_literal_placeholder_type(type_arg)
+            }
+            _ => false,
+        }
+    }
+
+    /// Check if a type is a "pattern literal placeholder": one of the
+    /// non-string primitives that can stand in for a stringified value in a
+    /// template literal pattern (`number`, `bigint`, `string`, `any`), or
+    /// itself a pattern literal type.
+    ///
+    /// Mirrors tsc's `isPatternLiteralPlaceholderType` (minus intersection
+    /// handling, which is not needed for the current
+    /// `getTemplateLiteralType`-style collapse).
+    fn is_pattern_literal_placeholder_type(&self, type_id: TypeId) -> bool {
+        match self.lookup(type_id) {
+            Some(TypeData::Intrinsic(kind)) => matches!(
+                kind,
+                crate::types::IntrinsicKind::Any
+                    | crate::types::IntrinsicKind::String
+                    | crate::types::IntrinsicKind::Number
+                    | crate::types::IntrinsicKind::Bigint
+            ),
+            Some(TypeData::TemplateLiteral(_)) | Some(TypeData::StringIntrinsic { .. }) => {
+                self.is_pattern_literal_type(type_id)
+            }
+            _ => false,
+        }
     }
 
     /// Get the interpolation positions from a template literal type

--- a/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
+++ b/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
@@ -427,3 +427,200 @@ fn assignability_query_normalizes_nested_uppercase_intrinsics() {
         "Assignable relation should treat Uppercase<string> as compatible with Uppercase<Uppercase<string>>"
     );
 }
+
+// =============================================================================
+// Regression: Uppercase<`aA${number}${bigint}${boolean}`> should be equivalent
+// to `AA${Uppercase<`${number}`>}${Uppercase<`${bigint}`>}${Uppercase<`${boolean}`>}`.
+//
+// tsc canonicalizes `Uppercase<number>` to `Uppercase<\`${number}\`>` via
+// `getStringMappingType`'s `isPatternLiteralPlaceholderType` path (checker.ts
+// line 19124), so applying a string mapping to a template literal whose type
+// spans are non-string primitives (number, bigint, boolean) yields the same
+// canonical form as a hand-written equivalent that already wraps the
+// primitives in `${T}` template literals.
+// =============================================================================
+
+#[test]
+fn uppercase_over_pattern_with_number_canonicalizes_inner_to_template_literal() {
+    use crate::types::IntrinsicKind;
+
+    let interner = TypeInterner::new();
+
+    // Build `\`aA${number}\`` and apply Uppercase<...>.
+    let empty = interner.intern_string("");
+    let prefix = interner.intern_string("aA");
+    let pattern = interner.template_literal(vec![
+        TemplateSpan::Text(prefix),
+        TemplateSpan::Type(TypeId::NUMBER),
+        TemplateSpan::Text(empty),
+    ]);
+    let upper_pattern = interner.string_intrinsic(StringIntrinsicKind::Uppercase, pattern);
+    let evaluated = evaluate_type(&interner, upper_pattern);
+
+    // Expect `\`AA${Uppercase<\`${number}\`>}\``: the type span must be a
+    // StringIntrinsic whose inner type is a TemplateLiteral wrapping `number`,
+    // mirroring tsc's canonicalization.
+    let Some(TypeData::TemplateLiteral(spans_id)) = interner.lookup(evaluated) else {
+        panic!(
+            "expected TemplateLiteral, got {:?}",
+            interner.lookup(evaluated)
+        );
+    };
+    let spans = interner.template_list(spans_id);
+    let mut found_canonical_inner = false;
+    for span in spans.iter() {
+        if let TemplateSpan::Type(t) = span
+            && let Some(TypeData::StringIntrinsic { kind, type_arg }) = interner.lookup(*t)
+        {
+            assert_eq!(kind, StringIntrinsicKind::Uppercase);
+            // The canonicalized form is `Uppercase<\`${number}\`>`, where the
+            // inner is a TemplateLiteral over `number` (not `number` itself).
+            match interner.lookup(type_arg) {
+                Some(TypeData::TemplateLiteral(inner_id)) => {
+                    let inner = interner.template_list(inner_id);
+                    let has_number = inner.iter().any(|s| {
+                        matches!(s, TemplateSpan::Type(t)
+                            if matches!(interner.lookup(*t),
+                                Some(TypeData::Intrinsic(IntrinsicKind::Number))))
+                    });
+                    assert!(
+                        has_number,
+                        "inner template literal should wrap `number`, got spans {:?}",
+                        inner.iter().collect::<Vec<_>>()
+                    );
+                    found_canonical_inner = true;
+                }
+                other => {
+                    panic!("expected StringIntrinsic inner to be TemplateLiteral, got {other:?}")
+                }
+            }
+        }
+    }
+    assert!(
+        found_canonical_inner,
+        "Uppercase<\\`aA${{number}}\\`> should canonicalize the number type span to `${{number}}`"
+    );
+}
+
+#[test]
+fn uppercase_over_template_with_non_string_primitives_matches_hand_written_equivalent() {
+    let interner = TypeInterner::new();
+
+    // NonStringPat = Uppercase<`aA${number}${bigint}${boolean}`>
+    let empty = interner.intern_string("");
+    let lower_prefix = interner.intern_string("aA");
+    let pattern = interner.template_literal(vec![
+        TemplateSpan::Text(lower_prefix),
+        TemplateSpan::Type(TypeId::NUMBER),
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::BIGINT),
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::BOOLEAN),
+        TemplateSpan::Text(empty),
+    ]);
+    let upper_pattern = interner.string_intrinsic(StringIntrinsicKind::Uppercase, pattern);
+
+    // EquivalentNonStringPat = `AA${Uppercase<`${number}`>}${Uppercase<`${bigint}`>}${Uppercase<`${boolean}`>}`
+    let upper_prefix = interner.intern_string("AA");
+    let number_template = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::NUMBER),
+        TemplateSpan::Text(empty),
+    ]);
+    let bigint_template = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::BIGINT),
+        TemplateSpan::Text(empty),
+    ]);
+    let boolean_template = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::BOOLEAN),
+        TemplateSpan::Text(empty),
+    ]);
+    let upper_number = interner.string_intrinsic(StringIntrinsicKind::Uppercase, number_template);
+    let upper_bigint = interner.string_intrinsic(StringIntrinsicKind::Uppercase, bigint_template);
+    let upper_boolean = interner.string_intrinsic(StringIntrinsicKind::Uppercase, boolean_template);
+    let equivalent_pat = interner.template_literal(vec![
+        TemplateSpan::Text(upper_prefix),
+        TemplateSpan::Type(upper_number),
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(upper_bigint),
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(upper_boolean),
+        TemplateSpan::Text(empty),
+    ]);
+
+    // After evaluating both, they should be mutually assignable.
+    let lhs = evaluate_type(&interner, upper_pattern);
+    let rhs = evaluate_type(&interner, equivalent_pat);
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(lhs, rhs),
+        "Uppercase<`aA${{number}}${{bigint}}${{boolean}}`> should be assignable to its hand-written equivalent"
+    );
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(rhs, lhs),
+        "Hand-written equivalent should be assignable back to Uppercase<`aA${{number}}${{bigint}}${{boolean}}`>"
+    );
+}
+
+#[test]
+fn template_literal_collapses_single_pattern_type_span() {
+    use crate::types::IntrinsicKind;
+
+    let interner = TypeInterner::new();
+
+    // `\`${Uppercase<\`${number}\`>}\`` should collapse to `Uppercase<\`${number}\`>`
+    // mirroring tsc's `Normalize ${Mapping<xxx>} into Mapping<xxx>` rule
+    // (checker.ts `getTemplateLiteralType`).
+    let empty = interner.intern_string("");
+    let number_template = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::NUMBER),
+        TemplateSpan::Text(empty),
+    ]);
+    let upper_number_template =
+        interner.string_intrinsic(StringIntrinsicKind::Uppercase, number_template);
+
+    // Wrap the pattern-literal type back in a single-span template literal.
+    let wrapped = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(upper_number_template),
+        TemplateSpan::Text(empty),
+    ]);
+
+    assert_eq!(
+        wrapped, upper_number_template,
+        "`\\`${{Uppercase<\\`${{number}}\\`>}}\\`` should collapse to `Uppercase<\\`${{number}}\\`>`"
+    );
+
+    // Sanity: the collapse must not happen for non-pattern-literal types
+    // (e.g. a literal string), since wrapping `\`${\"abc\"}\`` is just `\"abc\"` via
+    // the existing literal-collapse path, but a non-pattern type span is not
+    // a candidate for the new collapse rule.
+    let abc = interner.literal_string("abc");
+    let _ = abc; // touch to silence unused; fix below uses it via lookup.
+    // Pattern check sanity: pure number is NOT a pattern-literal type by itself
+    // (only TemplateLiteral or StringIntrinsic over a placeholder qualify).
+    let bare_wrapped_number = interner.template_literal(vec![
+        TemplateSpan::Text(empty),
+        TemplateSpan::Type(TypeId::NUMBER),
+        TemplateSpan::Text(empty),
+    ]);
+    let Some(TypeData::TemplateLiteral(_)) = interner.lookup(bare_wrapped_number) else {
+        // If the bare `${number}` collapsed, that would be a regression: only
+        // pattern-literal *types* (TemplateLiteral / StringIntrinsic over
+        // placeholders) should collapse, not raw placeholders.
+        panic!(
+            "`${{number}}` must remain a TemplateLiteral wrapping `number`; got {:?}",
+            interner.lookup(bare_wrapped_number)
+        );
+    };
+    // And `number` itself must not be a TemplateLiteral after the lookup chain.
+    assert!(matches!(
+        interner.lookup(TypeId::NUMBER),
+        Some(TypeData::Intrinsic(IntrinsicKind::Number))
+    ));
+}


### PR DESCRIPTION
## Summary
- `Uppercase` over a template literal containing `${number}`, `${bigint}`, or `${boolean}` previously produced a different structural form than the equivalent hand-written `Uppercase<` over `${number}` / `${bigint}` / `${boolean}` `>` interpolations, causing spurious TS2322 between two equivalent pattern-literal types (test: `stringMappingOverPatternLiterals`).
- Mirror tsc's `getStringMappingType` canonicalization: when applying a string mapping to a template literal type span that is a non-string primitive, wrap the placeholder in a single-span template literal first. For `boolean`, this also triggers the existing template-literal interner expansion to a `"true" | "false"` literal union.
- Add tsc's `getTemplateLiteralType` "Normalize template-of-mapping into mapping" collapse to the template-literal interner so re-wrapping a canonical pattern-literal type in a single-span template literal does not introduce an extra layer.

## Test plan
- [x] New solver unit tests in `string_intrinsic_subtype_tests.rs` cover canonicalization, hand-written equivalence, and the single-pattern-type collapse.
- [x] `cargo nextest run --package tsz-solver --lib` (5526 passed)
- [x] `cargo nextest run --package tsz-checker --lib` (2920 passed)
- [x] `./scripts/conformance/conformance.sh run --filter "stringMappingOverPatternLiterals" --verbose` (1/1 passing; was fingerprint-only before)
- [x] No regressions on `--filter "Mapping|literal|templateLiteral|boolean|Conditional"` runs (existing fingerprint-only failures unchanged).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
