### PR TITLE
fix(solver): reverse-mapped inference drills into finite recursive-alias sources

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -366,3 +366,56 @@ const checked_ = checkType_<{x: number, y: string}>()({
         "expected target type to match tsc baseline `{{ x: number; y: \"y\"; }}`, got message: {msg}"
     );
 }
+
+#[test]
+fn reverse_mapped_finite_recursive_alias_drills_to_leaf() {
+    // Regression test for reverseMappedTypeDeepDeclarationEmit.ts.
+    //
+    // When a homomorphic mapped type's template recursively references itself
+    // via a type alias indirection (here through `Validator<T>`), reverse
+    // inference must continue drilling into nested object sources until a
+    // non-recursive leaf (e.g. a function type) is reached. The previous
+    // recursion guard short-circuited on ANY re-entry of Case 6, returning
+    // the source unchanged and producing
+    //   `V = { Test: { Test1: { Test2: NativeTypeValidator<string> } } }`
+    // when the correct inferred T is
+    //   `V = { Test: { Test1: { Test2: string } } }`.
+    //
+    // The fix tracks `(template, source_value)` pairs in the recursion chain
+    // and only converges to the source when the SAME pair re-occurs (true
+    // structural recursion like `interface A { a: A }`). Distinct sub-objects
+    // are still allowed to recurse, so finite sources reverse-map all the way
+    // down. We assert the correct inference by writing a `string`-typed leaf
+    // back into the inferred shape: if T collapsed early to
+    // `NativeTypeValidator<string>`, the assignment would emit TS2322.
+    let code = r#"
+type Validator<T> = NativeTypeValidator<T> | ObjectValidator<T>
+type NativeTypeValidator<T> = (n: any) => T | undefined
+type ObjectValidator<O> = {
+  [K in keyof O]: Validator<O[K]>
+}
+declare const SimpleStringValidator: NativeTypeValidator<string>;
+declare const ObjValidator: <V>(validatorObj: ObjectValidator<V>) => (o: any) => V;
+const test = {
+  Test: {
+    Test1: {
+      Test2: SimpleStringValidator
+    },
+  }
+}
+const validatorFunc = ObjValidator(test);
+const outputExample: { Test: { Test1: { Test2: string } } } = validatorFunc({
+  Test: {
+    Test1: {
+      Test2: "hi"
+    },
+  }
+});
+"#;
+    let codes = check_and_get_codes(code);
+    assert!(
+        !codes.contains(&2322),
+        "Expected no TS2322 (V should reverse-infer all the way to leaf `string`, \
+         not stop at `NativeTypeValidator<string>`), got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -719,13 +719,30 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     TypeData::Object(source_shape_id) | TypeData::ObjectWithIndex(source_shape_id),
                 ) = self.interner.lookup(source_value)
             {
-                // Detect recursive mapped type patterns (e.g., Deep<T> = { [K in keyof T]: Deep<T[K]> }).
-                // When we re-enter this case from an inner reverse_infer_through_template call,
-                // we're in a recursive expansion chain that would loop infinitely.
-                // Follow tsc's inferReversedType: for object sources against recursive homomorphic
-                // mapped types, the reversed type converges to the source itself.
+                // Detect recursive mapped type patterns (e.g., `Deep<T> = { [K in keyof T]: Deep<T[K]> }`
+                // against a self-referential source like `interface A { a: A }`).
+                //
+                // We track `(mapped_template_id, source_value_id)` pairs currently in the recursion
+                // chain. Re-entering with the SAME pair means the source is genuinely recursive and
+                // expanding further would loop forever. In that case we follow tsc's
+                // `inferReversedType` and converge to the source itself.
+                //
+                // Distinct pairs (e.g., the same mapped template against a strictly smaller source
+                // sub-object) ARE allowed to recurse so that finite sources reverse-map through every
+                // level. This matters for patterns like:
+                //   type Validator<T> = NativeTypeValidator<T> | ObjectValidator<T>
+                //   type ObjectValidator<O> = { [K in keyof O]: Validator<O[K]> }
+                // where the source `{ Test: { Test1: { Test2: leaf } } }` is finite and we need
+                // to drill all the way to `leaf` to extract the inferred type.
+                //
+                // We also keep a hard depth cap as a safety net for pathological inputs.
+                let pair = (template, source_value);
+                if self.reverse_mapped_visited.borrow().contains(&pair) {
+                    return Some(source_value);
+                }
                 let depth = self.reverse_mapped_depth.get();
-                if depth > 0 {
+                const REVERSE_MAPPED_DEPTH_CAP: u32 = 64;
+                if depth >= REVERSE_MAPPED_DEPTH_CAP {
                     return Some(source_value);
                 }
 
@@ -737,6 +754,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let mut any_reversed = false;
 
                 self.reverse_mapped_depth.set(depth + 1);
+                self.reverse_mapped_visited.borrow_mut().insert(pair);
 
                 for prop in &source_props {
                     // Instantiate the mapped template with the concrete key
@@ -837,6 +855,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 }
 
                 self.reverse_mapped_depth.set(depth);
+                self.reverse_mapped_visited.borrow_mut().remove(&pair);
 
                 if any_reversed {
                     if reverse_string_index.is_some() || reverse_number_index.is_some() {

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -205,9 +205,17 @@ pub struct CallEvaluator<'a, C: AssignabilityChecker> {
     /// where each Application type references the previous one multiple times).
     pub(crate) contextual_sensitivity_cache: RefCell<FxHashMap<TypeId, bool>>,
     /// Recursion depth for reverse mapped type inference through mapped type templates.
-    /// Used to detect recursive type alias patterns (e.g., `Deep<T> = { [K in keyof T]: Deep<T[K]> }`)
-    /// and short-circuit infinite expansion, matching tsc's lazy `ReverseMappedType` convergence.
+    /// Used as a hard cap to prevent runaway recursion (in addition to the
+    /// `reverse_mapped_visited` set which short-circuits true recursive patterns).
     pub(crate) reverse_mapped_depth: Cell<u32>,
+    /// Set of `(mapped_template_id, source_value_id)` pairs currently being reverse-inferred.
+    /// When we re-enter `reverse_infer_through_template` Case 6 with a pair we've already seen
+    /// in the current chain, we've hit a true recursive type pattern (e.g., `Deep<T>` against
+    /// a self-referential interface like `interface A { a: A }`). In that case we short-circuit
+    /// to the source value itself, matching tsc's lazy `ReverseMappedType` convergence.
+    /// Distinct pairs (different source sub-objects) are still allowed to recurse so that
+    /// finite sources like `{Test: {Test1: {Test2: leaf}}}` reverse-map through every level.
+    pub(crate) reverse_mapped_visited: RefCell<FxHashSet<(TypeId, TypeId)>>,
 }
 
 #[derive(Clone, Copy)]
@@ -259,6 +267,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             last_instantiated_params: None,
             contextual_sensitivity_cache: RefCell::new(FxHashMap::default()),
             reverse_mapped_depth: Cell::new(0),
+            reverse_mapped_visited: RefCell::new(FxHashSet::default()),
         }
     }
 


### PR DESCRIPTION
## Summary

- Reverse-mapped inference for recursive type aliases (e.g. `Validator<T> = NativeTypeValidator<T> | ObjectValidator<T>` where `ObjectValidator<O> = { [K in keyof O]: Validator<O[K]> }`) used a `depth > 0` short-circuit that returned the source value as-is on any re-entry of Case 6. That collapsed finite sources like `{ Test: { Test1: { Test2: leaf } } }`, producing `V = …NativeTypeValidator<string>` instead of `V = …string`, which manifested as a wrong-type declaration emit for `reverseMappedTypeDeepDeclarationEmit`.
- Replaced the depth gate with a visited-pair set: `(template_id, source_value_id)` pairs currently in the recursion chain. Re-entry with the SAME pair (true structural recursion like `interface A { a: A }` against `Deep<T>`) still converges to the source, but distinct sub-objects are allowed to recurse so finite sources reverse-map all the way down to leaves. A hard depth cap of 64 stays as a safety net.
- Adds a regression unit test in `crates/tsz-checker/tests/reverse_mapped_inference_tests.rs::reverse_mapped_finite_recursive_alias_drills_to_leaf`.

## Impact

- Declaration emit conformance: 1285 -> 1286 (+1) for `reverseMappedTypeDeepDeclarationEmit`.
- All previously-passing reverse-mapped tests still pass (13/13 reverse-mapped checker tests, 5525/5525 solver lib tests, 2923/2923 checker lib tests).

## Test plan

- [x] `cargo nextest run -p tsz-checker -E 'test(reverse_mapped)'` — all pass
- [x] `cargo nextest run -p tsz-solver --lib` — all pass
- [x] `cargo nextest run -p tsz-checker --lib` — all pass
- [x] `./scripts/emit/run.sh --filter reverseMappedTypeDeepDeclarationEmit --dts-only` — target now passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
