### PR TITLE
ci(gh-pages): cache WASM build output across deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,16 @@ jobs:
           fetch-depth: 1
       - name: Run wasm suite
         run: scripts/ci/github-suite.sh wasm
+      - name: Build web WASM for website playground
+        run: |
+          cp LICENSE.txt crates/tsz-wasm/LICENSE.txt
+          wasm-pack build crates/tsz-wasm --target web --out-dir ../../pkg/web --no-opt
+      - name: Upload web WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-web
+          path: pkg/web/
+          retention-days: 30
 
   conformance:
     name: conformance-${{ matrix.shard }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -81,31 +81,52 @@ jobs:
         with:
           submodules: true
 
+      # Try to reuse the web WASM artifact already built by the CI wasm job
+      # for the same commit. Falls back to the local cache, then a full build.
+      - name: Download web WASM from CI
+        id: wasm-ci-download
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CI_RUN=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?status=success&branch=main&per_page=5" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"${{ github.sha }}\")][0].id" 2>/dev/null || echo "")
+          if [[ -n "$CI_RUN" && "$CI_RUN" != "null" ]]; then
+            echo "Found CI run $CI_RUN for this SHA, downloading wasm-web artifact..."
+            gh run download "$CI_RUN" -n wasm-web -D pkg/web/ 2>/dev/null \
+              && echo "downloaded=true" >> "$GITHUB_OUTPUT" \
+              || echo "Artifact download failed, will build locally."
+          else
+            echo "No matching CI run found for ${{ github.sha }}, will build locally."
+          fi
+        continue-on-error: true
+
       - name: Cache built WASM output
         id: wasm-cache
+        if: steps.wasm-ci-download.outputs.downloaded != 'true'
         uses: actions/cache@v4
         with:
           path: pkg/web/
           key: wasm-web-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'crates/*/src/**', 'crates/*/build.rs') }}
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-ci-download.outputs.downloaded != 'true' && steps.wasm-cache.outputs.cache-hit != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-ci-download.outputs.downloaded != 'true' && steps.wasm-cache.outputs.cache-hit != 'true'
         with:
           cache-on-failure: true
 
       - name: Install wasm-pack
-        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-ci-download.outputs.downloaded != 'true' && steps.wasm-cache.outputs.cache-hit != 'true'
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install wasm-opt (via binaryen)
-        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-ci-download.outputs.downloaded != 'true' && steps.wasm-cache.outputs.cache-hit != 'true'
         run: sudo apt-get install -y binaryen
 
       - name: Build WASM (web target)
-        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        if: steps.wasm-ci-download.outputs.downloaded != 'true' && steps.wasm-cache.outputs.cache-hit != 'true'
         run: |
           cp LICENSE.txt crates/tsz-wasm/LICENSE.txt
           # wasm-opt currently produces a web build that fails during

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -81,19 +81,31 @@ jobs:
         with:
           submodules: true
 
+      - name: Cache built WASM output
+        id: wasm-cache
+        uses: actions/cache@v4
+        with:
+          path: pkg/web/
+          key: wasm-web-${{ hashFiles('Cargo.lock', 'crates/*/src/**') }}
+
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         with:
           cache-on-failure: true
 
       - name: Install wasm-pack
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install wasm-opt (via binaryen)
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: sudo apt-get install -y binaryen
 
       - name: Build WASM (web target)
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: |
           cp LICENSE.txt crates/tsz-wasm/LICENSE.txt
           # wasm-opt currently produces a web build that fails during

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: pkg/web/
-          key: wasm-web-${{ hashFiles('Cargo.lock', 'crates/*/src/**') }}
+          key: wasm-web-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'crates/*/src/**', 'crates/*/build.rs') }}
 
       - uses: dtolnay/rust-toolchain@stable
         if: steps.wasm-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Problem

The `wasm` job rebuilds from scratch on every website deploy — installing Rust toolchain, wasm-pack, binaryen, and recompiling — even when no Rust source changed. For docs/website-only pushes this wastes 5-10 min.

## Fix

Add an `actions/cache@v4` step for `pkg/web/` keyed on:
```
wasm-web-${{ hashFiles('Cargo.lock', 'crates/*/src/**') }}
```

All build steps (toolchain, Swatinem cache, wasm-pack install, binaryen, compile) are gated on `cache-hit != 'true'`. The upload step always runs so the artifact is available for the build job regardless.

**On cache hit**: checkout + cache restore + upload only (~30s)
**On cache miss**: full build as before (~5-10 min), result saved for next run

The key correctly covers all crate sources so any Rust change (in `tsz-solver`, `tsz-wasm`, anywhere) busts the cache.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
