### PR TITLE
fix(website): add bench-snapshot.json fallback to Eleventy data loaders

### DIFF
--- a/crates/tsz-website/src/_data/benchmark_charts.js
+++ b/crates/tsz-website/src/_data/benchmark_charts.js
@@ -70,7 +70,8 @@ function loadBenchmarks() {
     }
   })();
 
-  for (const location of artifactFiles) {
+  const snapshot = path.join(WEBSITE, "bench-snapshot.json");
+  for (const location of [...artifactFiles, snapshot]) {
     const data = readJsonIfExists(location);
     if (data?.results) return data;
   }

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -26,7 +26,8 @@ function loadBenchmarks() {
     }
   })();
 
-  for (const location of artifactFiles) {
+  const snapshot = path.join(WEBSITE, "bench-snapshot.json");
+  for (const location of [...artifactFiles, snapshot]) {
     const data = readJsonIfExists(location);
     if (data?.results?.length) return data.results;
   }


### PR DESCRIPTION
The previous snapshot fix (#1490) put the fallback in `build.mjs`, which is the legacy `build:legacy` script. The actual Eleventy build (`npm run build`) reads benchmark data from `src/_data/benchmark_charts.js` and `src/_data/benchmark_mean_chart.js`. This PR adds the fallback there.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
