### PR TITLE
fix(parser): accept `_` as numeric separator inside regex `\x`/`\u` escapes

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -94,17 +94,12 @@ impl<'a> CheckerState<'a> {
                 );
                 true
             }
-            Some(SubtypeFailureReason::TupleElementMismatch { .. }) => {
-                // Tuple arity mismatch (source has too many or too few elements
-                // for the target tuple). tsc reports this as the outer
-                // "Source has N element(s) but target requires/allows-only M."
-                // sub-message under the call-site TS2345/TS2322 — it does not
-                // drill into a specific source element (even when one of them
-                // would also fail an element-by-element assignability check).
-                // Returning false here lets the outer caller render the
-                // arity-aware TS2345 with related information directly.
-                false
-            }
+            // Tuple arity mismatch (`SubtypeFailureReason::TupleElementMismatch`)
+            // intentionally falls through to the wildcard `=> false`. tsc reports
+            // it as the outer "Source has N element(s) but target requires …"
+            // sub-message under TS2345/TS2322 and does not drill into a specific
+            // source element, so the outer caller renders the arity-aware
+            // diagnostic directly.
             Some(SubtypeFailureReason::ArrayElementMismatch {
                 source_element: _,
                 target_element,

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -177,7 +177,8 @@ declare let c: any;
     );
     let ts2493_count = diagnostics.iter().filter(|d| d.code == 2493).count();
     assert_eq!(
-        ts2493_count, 2,
+        ts2493_count,
+        2,
         "Expected TS2493 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2493_count,
         diagnostics
@@ -219,7 +220,8 @@ declare let c: any;
     );
     let ts2339_count = diagnostics.iter().filter(|d| d.code == 2339).count();
     assert_eq!(
-        ts2339_count, 2,
+        ts2339_count,
+        2,
         "Expected TS2339 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2339_count,
         diagnostics

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -1500,16 +1500,23 @@ impl ParserState {
     ) -> usize {
         use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 
+        // tsc accepts `_` in regex `\x` escape positions (numericSeparators
+        // proposal extended into regex contexts) and defers strict validation
+        // to the regex runtime. Mirror that: `_` does not trigger TS1125 here.
+        // See `parser.numericSeparators.unicodeEscape.ts` regex files (8, 12,
+        // 20, …) where tsc emits no diagnostic for `\xf_f`/`\u_ffff`/etc.
+        let is_hex_or_separator = |b: u8| Self::is_hex_digit(b) || b == b'_';
+
         let first = j + 2;
         let second = j + 3;
-        if first >= raw.len() || !Self::is_hex_digit(raw[first]) {
+        if first >= raw.len() || !is_hex_or_separator(raw[first]) {
             self.parse_error_at(
                 self.u32_from_usize(body_start + first),
                 u32::from(first < raw.len()),
                 diagnostic_messages::HEXADECIMAL_DIGIT_EXPECTED,
                 diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED,
             );
-        } else if second >= raw.len() || !Self::is_hex_digit(raw[second]) {
+        } else if second >= raw.len() || !is_hex_or_separator(raw[second]) {
             self.parse_error_at(
                 self.u32_from_usize(body_start + second),
                 u32::from(second < raw.len()),
@@ -1538,32 +1545,38 @@ impl ParserState {
             }
             Some(close + 1)
         } else {
+            // tsc accepts `_` as a numeric separator inside regex `\u` escapes
+            // (see `parser.numericSeparators.unicodeEscape.ts` regex files); the
+            // strict hex grammar is enforced by the regex runtime, not the
+            // parser. Treat `_` as a valid char in any of the four positions.
+            let is_hex_or_separator = |b: u8| Self::is_hex_digit(b) || b == b'_';
+
             let first = j + 2;
             let second = j + 3;
             let third = j + 4;
             let fourth = j + 5;
-            if first >= raw.len() || !Self::is_hex_digit(raw[first]) {
+            if first >= raw.len() || !is_hex_or_separator(raw[first]) {
                 self.parse_error_at(
                     self.u32_from_usize(body_start + first),
                     u32::from(first < raw.len()),
                     diagnostic_messages::HEXADECIMAL_DIGIT_EXPECTED,
                     diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED,
                 );
-            } else if second >= raw.len() || !Self::is_hex_digit(raw[second]) {
+            } else if second >= raw.len() || !is_hex_or_separator(raw[second]) {
                 self.parse_error_at(
                     self.u32_from_usize(body_start + second),
                     u32::from(second < raw.len()),
                     diagnostic_messages::HEXADECIMAL_DIGIT_EXPECTED,
                     diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED,
                 );
-            } else if third >= raw.len() || !Self::is_hex_digit(raw[third]) {
+            } else if third >= raw.len() || !is_hex_or_separator(raw[third]) {
                 self.parse_error_at(
                     self.u32_from_usize(body_start + third),
                     u32::from(third < raw.len()),
                     diagnostic_messages::HEXADECIMAL_DIGIT_EXPECTED,
                     diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED,
                 );
-            } else if fourth >= raw.len() || !Self::is_hex_digit(raw[fourth]) {
+            } else if fourth >= raw.len() || !is_hex_or_separator(raw[fourth]) {
                 self.parse_error_at(
                     self.u32_from_usize(body_start + fourth),
                     u32::from(fourth < raw.len()),

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -4026,3 +4026,42 @@ fn test_object_literal_comma_recovery_after_short_distance_colon_error() {
         "expected TS1005 `',' expected.` at `{{` after `C4`, got {diagnostics:?}"
     );
 }
+
+#[test]
+fn test_regex_hex_escape_with_numeric_separator_no_ts1125() {
+    // Regression for conformance test
+    // `conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.unicodeEscape.ts`:
+    // tsc accepts `_` as a numeric-separator placeholder inside regex `\x` and
+    // `\u` escapes (deferring strict hex grammar to the regex runtime), and
+    // emits NO TS1125 for `/\xf_f/u` or `/\u_ffff/u`. We previously rejected
+    // `_` at every hex-digit slot in the parser-level regex escape validator.
+    let source = "/\\xf_f/u\n/\\uff_ff/u\n/\\u_ffff/u\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+        "regex `\\x`/`\\u` escapes with `_` separator must not emit TS1125, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_regex_hex_escape_keeps_real_hex_digit_validation() {
+    // Sanity guard: `_` relaxation must not silence genuine non-hex chars.
+    // For `/\u\i\c/` the `\u` is followed by `\` (not hex, not `_`), so TS1125
+    // must still fire — matching tsc's `regularExpressionAnnexB.ts`.
+    let source = "/\\u\\i\\c/\n";
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+        "regex `\\u\\i...` must still emit TS1125 for non-hex non-separator chars, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- tsc accepts `_` as a numeric-separator placeholder inside regex `\x` and `\u` escapes (e.g. `/\xf_f/u`, `/\u_ffff/u`) and emits NO TS1125, deferring strict hex grammar to the regex runtime.
- Our parser-level regex escape validators rejected `_` at every hex-digit slot, producing 6 false-positive TS1125 fingerprints in `parser.numericSeparators.unicodeEscape.ts`.
- Relax the validator to treat `_` as a valid placeholder. Genuine non-hex chars (e.g. `/\u\i\c/`) still emit TS1125 — matching `regularExpressionAnnexB.ts`.
- String/template `\x`/`\u` escapes are NOT affected — they keep strict hex validation, so file 9 `"\xf_f"` continues to emit TS1125.
- Drive-by: collapse a `match_same_arms` warning in `elaboration_array_mismatch.rs`; pick up `cargo fmt` reflow on `tuple_index_access_tests.rs` from the pre-commit hook.

Flips conformance fingerprint-only failure `parser.numericSeparators.unicodeEscape.ts` to PASS.

## Test plan

- [x] `cargo nextest run -p tsz-parser` — all 684 parser tests pass (including 2 new regression tests)
- [x] `./scripts/conformance/conformance.sh run --filter "numericSeparators.unicodeEscape"` — flips to PASS (1/1)
- [x] `./scripts/conformance/conformance.sh run --filter "regularExpression"` — 6/7 (no regression vs pre-fix baseline)
- [x] `./scripts/conformance/conformance.sh run --filter "numericSeparator"` — 8/9 (no regression)

## Note

Pre-commit nextest was skipped via `TSZ_SKIP_TESTS=1` because an unrelated `tsz-checker` test (`test_module_exports_object_literal_member_conflicts_with_module_augmentation`) fails on `origin/main` HEAD; verified parser changes in isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
