### PR TITLE
fix(dts): preserve `new (...) => infer T` syntax in declaration emit

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -1216,11 +1216,7 @@ exports.K = NS.K;
     let output = emitter.emit(root);
 
     assert!(
-        output.contains("export var K: {"),
-        "Expected property-access CommonJS export to emit a synthetic declaration: {output}"
-    );
-    assert!(
-        output.contains("new (): any;"),
+        output.contains("export var K: new () => any;"),
         "Expected property-access CommonJS export to reuse the assigned initializer type: {output}"
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
@@ -1004,3 +1004,78 @@ var d = {
         "Did not expect enum member literal to leak into anonymous object type: {output}"
     );
 }
+
+/// Regression test for `declarationEmitShadowingInferNotRenamed`: a single
+/// non-abstract construct signature must render as `new (...) => T` (matching
+/// tsc), and an `Infer(T)` placeholder appearing inside the extends clause of
+/// a conditional must render as `infer T` (not `T`, and not collapsed to a
+/// `{ new(): { ... } }` object literal). Inside the conditional's true/false
+/// branches the same `Infer(T)` collapses to the bare name `T`.
+#[test]
+fn test_constructor_with_infer_in_extends_renders_as_arrow_with_infer() {
+    use tsz_solver::types::{ConditionalType, TypeParamInfo};
+
+    let interner = TypeInterner::new();
+    let t_atom = interner.intern_string("T");
+    let t_param = interner.type_param(TypeParamInfo {
+        name: t_atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let c_atom = interner.intern_string("C");
+    let c_param_info = TypeParamInfo {
+        name: c_atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let infer_c = interner.infer(c_param_info);
+
+    // Build a non-abstract constructor type whose return is `infer C`.
+    let ctor_type = interner.callable(CallableShape {
+        call_signatures: Vec::new(),
+        construct_signatures: vec![CallSignature::new(Vec::new(), infer_c)],
+        properties: Vec::new(),
+        string_index: None,
+        number_index: None,
+        symbol: None,
+        is_abstract: false,
+    });
+
+    // Build conditional `any extends (new () => infer C) ? C : never` and
+    // verify both:
+    //   - the extends clause renders as `new () => infer C`
+    //   - the true branch references `C` as a bare name (no `infer`).
+    let cond = interner.conditional(ConditionalType {
+        check_type: t_param,
+        extends_type: ctor_type,
+        true_type: infer_c,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+
+    let parser = ParserState::new("test.ts".to_string(), String::new());
+    let binder = BinderState::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let printed = emitter.print_type_id(cond);
+
+    assert!(
+        printed.contains("new () => infer C"),
+        "Expected non-abstract single-construct callable to render as `new () => infer C` \
+         when its return type is an Infer placeholder inside a conditional's extends clause: \
+         {printed}"
+    );
+    assert!(
+        !printed.contains("{\n    new (): infer C"),
+        "Did not expect a single-construct callable to fall through to the \
+         object-literal `{{ new (): T }}` form: {printed}"
+    );
+    // True branch references the same Infer placeholder; tsc prints just `C`.
+    assert!(
+        printed.contains("? C : "),
+        "Expected the true branch to reference the inferred placeholder by bare \
+         name `C`, not `infer C`: {printed}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/types/printer/mod.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/mod.rs
@@ -54,6 +54,12 @@ pub struct TypePrinter<'a> {
     strict_null_checks: bool,
     outer_type_param_names: Vec<Atom>,
     type_param_renames: Vec<(Atom, String)>,
+    /// True while printing types that lexically appear inside the `extends`
+    /// clause of a conditional type. Only inside this clause should an
+    /// `Infer(T)` placeholder render as `infer T`; references to the same
+    /// placeholder reused in the conditional's true/false branches (or anywhere
+    /// else, e.g. as a type argument) render as the bare name `T`.
+    in_extends_clause: bool,
 }
 
 impl<'a> TypePrinter<'a> {
@@ -74,7 +80,28 @@ impl<'a> TypePrinter<'a> {
             strict_null_checks: true,
             outer_type_param_names: Vec::new(),
             type_param_renames: Vec::new(),
+            in_extends_clause: false,
         }
+    }
+
+    /// Return a clone configured for printing the extends clause of a
+    /// conditional type, where `Infer(T)` should render as `infer T`.
+    pub(crate) fn entering_extends_clause(&self) -> Self {
+        let mut next = self.clone();
+        next.in_extends_clause = true;
+        next
+    }
+
+    /// Return a clone configured for printing positions outside any extends
+    /// clause, where `Infer(T)` collapses to the bare name `T`.
+    pub(crate) fn leaving_extends_clause(&self) -> Self {
+        let mut next = self.clone();
+        next.in_extends_clause = false;
+        next
+    }
+
+    pub(crate) const fn is_in_extends_clause(&self) -> bool {
+        self.in_extends_clause
     }
 
     /// Set the symbol arena for visibility checking.

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -565,6 +565,26 @@ impl<'a> TypePrinter<'a> {
             return self.print_callable(callable_id);
         }
         if let Some(param_info) = visitor::type_param_info(self.interner, type_id) {
+            // Distinguish `infer T` from a bare type parameter reference. tsc
+            // emits `infer T` (with constraint, if any) only when the
+            // placeholder appears inside the extends clause of a conditional
+            // type. References to the same `Infer(T)` reused elsewhere — true
+            // branch, false branch, or as a type argument — render as the
+            // bare name `T`. The `in_extends_clause` flag is propagated by
+            // `print_conditional` while it walks `cond.extends_type`.
+            if self.is_in_extends_clause() && visitor::is_infer_type(self.interner, type_id) {
+                let mut result = String::from("infer ");
+                result.push_str(&self.resolve_type_param_name(param_info.name));
+                if let Some(constraint) = param_info.constraint {
+                    // The constraint of an `infer T extends C` annotation is
+                    // not itself part of the extends clause for `infer`
+                    // purposes.
+                    let bare = self.leaving_extends_clause();
+                    result.push_str(" extends ");
+                    result.push_str(&bare.print_type(constraint));
+                }
+                return result;
+            }
             return self.print_type_parameter(&param_info);
         }
         if let Some(def_id) = visitor::lazy_def_id(self.interner, type_id) {

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -782,6 +782,29 @@ impl<'a> TypePrinter<'a> {
             return self.print_call_signature_arrow(&callable.call_signatures[0]);
         }
 
+        // Simple constructor callable: one construct signature, no other members
+        // → use `new (...) => T` (or `abstract new (...) => T`) syntax. This matches
+        // tsc's declaration-emit form for `new (...args) => T` written explicitly
+        // as a constructor type in source (e.g. `Record<string, new (...) => T>`
+        // or in the extends clause of a conditional). For anonymous and named
+        // class constructor types (which carry `symbol: Some(_)`), tsc keeps
+        // the structural `{ new (): T }` object-literal form, so we leave those
+        // to fall through to the multi-line rendering below.
+        if callable.symbol.is_none()
+            && callable.call_signatures.is_empty()
+            && callable.construct_signatures.len() == 1
+            && !has_properties
+            && callable.string_index.is_none()
+            && callable.number_index.is_none()
+        {
+            return self.print_construct_signature_arrow(
+                &callable.construct_signatures[0],
+                callable.is_abstract,
+            );
+        }
+        // Abstract constructor callables historically used the arrow form even
+        // when they carried a synthetic class symbol; preserve that to avoid
+        // regressing `abstract new () => { ... }` cases.
         if callable.is_abstract
             && callable.call_signatures.is_empty()
             && callable.construct_signatures.len() == 1
@@ -1721,10 +1744,16 @@ impl<'a> TypePrinter<'a> {
     ) -> String {
         let cond = self.interner.conditional_type(cond_id);
 
+        // The check type, true branch, and false branch are NOT in the extends
+        // clause. Only the extends_type subtree should render `Infer(T)` as
+        // `infer T`. Use scoped clones to avoid leaking the flag.
+        let bare = self.leaving_extends_clause();
+        let extends_scope = self.entering_extends_clause();
+
         // Check type needs parens when it's a conditional, function, constructor,
         // union, or intersection. Constructor/function types need parens because
         // their return type parsing greedily consumes the `extends` keyword.
-        let check_str = self.print_type(cond.check_type);
+        let check_str = bare.print_type(cond.check_type);
         let check_needs_parens = visitor::conditional_type_id(self.interner, cond.check_type)
             .is_some()
             || visitor::function_shape_id(self.interner, cond.check_type).is_some()
@@ -1736,7 +1765,7 @@ impl<'a> TypePrinter<'a> {
         // a function/constructor type whose return contains `extends` (i.e., a
         // conditional return type). Without parens the inner `extends` would be
         // mis-parsed as the outer conditional's extends clause.
-        let extends_str = self.print_type(cond.extends_type);
+        let extends_str = extends_scope.print_type(cond.extends_type);
         let extends_needs_parens = visitor::conditional_type_id(self.interner, cond.extends_type)
             .is_some()
             || self.function_like_has_conditional_return(cond.extends_type);
@@ -1756,8 +1785,8 @@ impl<'a> TypePrinter<'a> {
             "{} extends {} ? {} : {}",
             check,
             extends,
-            self.print_type(cond.true_type),
-            self.print_type(cond.false_type),
+            bare.print_type(cond.true_type),
+            bare.print_type(cond.false_type),
         )
     }
 

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -106,7 +106,7 @@ pub mod query {
         intersection_list_id, intrinsic_kind, is_array_type, is_conditional_type,
         is_empty_object_type, is_empty_object_type_through_type_constraints, is_enum_type,
         is_error_type, is_function_type, is_function_type_through_type_constraints,
-        is_generic_application, is_identity_comparable_type, is_index_access_type,
+        is_generic_application, is_identity_comparable_type, is_index_access_type, is_infer_type,
         is_intersection_type, is_lazy_type, is_literal_type,
         is_literal_type_through_type_constraints, is_mapped_type, is_module_namespace_type,
         is_object_like_type, is_object_like_type_through_type_constraints, is_primitive_type,

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -171,6 +171,20 @@ pub fn type_param_info(types: &dyn TypeDatabase, type_id: TypeId) -> Option<Type
     })
 }
 
+/// True when the type is a top-level `infer T` placeholder (`TypeData::Infer`).
+///
+/// Distinct from `type_param_info`, which collapses `TypeParameter` and `Infer`
+/// into the same `TypeParamInfo`. The declaration emitter needs the distinction
+/// to print `infer T` instead of just `T` for unbound infer placeholders that
+/// survive into emitted conditional types.
+pub fn is_infer_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    extract_type_data(types, type_id, |key| match key {
+        TypeData::Infer(_) => Some(true),
+        _ => None,
+    })
+    .unwrap_or(false)
+}
+
 /// Build default type arguments for a type parameter list, handling circular/forward
 /// references. In tsc, when a default references the same type parameter or a
 /// later-declared one (TS2744), the default is treated as `any`.


### PR DESCRIPTION
## Summary
- Render single-construct callables that have no nominal symbol (not a class) as `new (...) => T` instead of the multi-line `{ new (...): T; }` object-literal form. This matches tsc for constructor types written explicitly in source (e.g. inside `Record<string, new (...) => Client>` or in the extends clause of a conditional). Class constructor types (which carry a nominal `symbol`) keep the structural object-literal form.
- Render `Infer(T)` placeholders as `infer T` only while the printer is walking the extends clause of a conditional type. References to the same placeholder in the true/false branches or as a type argument continue to print as the bare name `T`, matching tsc.
- Add `is_infer_type` to `tsz-solver::query` to distinguish `TypeData::Infer` from `TypeData::TypeParameter` at the printer boundary (the existing `type_param_info` extractor collapses both).
- Thread an `in_extends_clause` flag through `TypePrinter` so the conditional emitter can scope `infer T` rendering to just the extends subtree.

Fixes the conformance test `declarationEmitShadowingInferNotRenamed`.

## Test plan
- [x] `cargo nextest run -p tsz-emitter --lib` (1608 passed, 2 skipped).
- [x] `cargo nextest run -p tsz-solver --lib` (5525 passed).
- [x] New regression test `test_constructor_with_infer_in_extends_renders_as_arrow_with_infer` exercises both invariants directly through `print_type_id`.
- [x] Full declaration-emit conformance: 1285 → 1286 passing (only `declarationEmitShadowingInferNotRenamed` flips, no regressions).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
