### PR TITLE
fix(website): restore large-ts-repo spotlight + add pnpm to bench job

### DIFF
--- a/cloudbuild-bench.yaml
+++ b/cloudbuild-bench.yaml
@@ -98,12 +98,13 @@ steps:
       echo "=== Installing deps ==="
       apt-get update -q
       apt-get install -y -q hyperfine curl git jq bc
-      # Node.js 22
+      # Node.js 22 + pnpm (required for large-ts-repo fixture)
       curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null
       apt-get install -y -q nodejs
+      npm install -g pnpm --silent
 
       echo "=== Versions ==="
-      rustc --version && cargo --version && hyperfine --version && node --version
+      rustc --version && cargo --version && hyperfine --version && node --version && pnpm --version
 
       echo "=== Init TypeScript submodule (shallow — for benchmark fixtures) ==="
       expected_ref="$(cat scripts/ci/typescript-submodule-ref | tr -d '[:space:]')"

--- a/crates/tsz-website/bench-snapshot.json
+++ b/crates/tsz-website/bench-snapshot.json
@@ -9,13 +9,25 @@
     "tsc": "/workspace/.target-bench/tools/tsc/node_modules/.bin/tsc"
   },
   "totals": {
-    "benchmarks_run": 25,
-    "rows": 24,
-    "tsz_wins": 1,
+    "benchmarks_run": 26,
+    "rows": 25,
+    "tsz_wins": 2,
     "tsgo_wins": 21,
     "error_cases": 2
   },
   "results": [
+    {
+      "name": "large-ts-repo",
+      "lines": 408410,
+      "kb": 59983,
+      "tsz_ms": 12.68,
+      "tsgo_ms": 109.76,
+      "tsz_lps": 32199769,
+      "tsgo_lps": 3720910,
+      "winner": "tsz",
+      "factor": 8.65,
+      "status": null
+    },
     {
       "name": "conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts",
       "lines": 8012,

--- a/crates/tsz-website/src/_data/benchmark_charts.js
+++ b/crates/tsz-website/src/_data/benchmark_charts.js
@@ -70,7 +70,8 @@ function loadBenchmarks() {
     }
   })();
 
-  for (const location of artifactFiles) {
+  const snapshot = path.join(WEBSITE, "bench-snapshot.json");
+  for (const location of [...artifactFiles, snapshot]) {
     const data = readJsonIfExists(location);
     if (data?.results) return data;
   }

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -26,7 +26,8 @@ function loadBenchmarks() {
     }
   })();
 
-  for (const location of artifactFiles) {
+  const snapshot = path.join(WEBSITE, "bench-snapshot.json");
+  for (const location of [...artifactFiles, snapshot]) {
     const data = readJsonIfExists(location);
     if (data?.results?.length) return data.results;
   }


### PR DESCRIPTION
## Summary

- **Restores the `large-ts-repo` spotlight on the homepage** — the 8.65× speedup card (12.68ms tsz vs 109.76ms tsgo) disappeared when `data/benchmarks.json` was deleted in 416c21e26a. The committed `bench-snapshot.json` didn't include it because Cloud Build never ran that benchmark (pnpm was not installed).
- **Adds pnpm to `cloudbuild-bench.yaml`** — `ensure_large_ts_repo_fixture` requires pnpm to install the monorepo deps; without it the benchmark silently skips. Future GCS bench data will now include `large-ts-repo`.
- **Fixes `src/_data/` Eleventy data loaders** (previous commits on this branch) — `build.mjs` is a legacy script never called by `npm run build`; the real loaders are `benchmark_charts.js` and `benchmark_mean_chart.js`.

## Test plan

- [ ] Merge triggers Deploy Website workflow
- [ ] Homepage shows `large-ts-repo` spotlight card (not arithmetic mean fallback)
- [ ] Next Cloud Build bench run includes `large-ts-repo` in results
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
