### PR TITLE
fix(parser): suppress spurious TS1124 when exponent has misplaced separator with digit

### DIFF
--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -1267,10 +1267,7 @@ function f1() {
         ts2556.is_empty(),
         "Expected no TS2556 for array literal spread (length is statically \
          known and elements are checked individually), got: {:?}",
-        ts2556
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2556.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
 

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -177,7 +177,8 @@ declare let c: any;
     );
     let ts2493_count = diagnostics.iter().filter(|d| d.code == 2493).count();
     assert_eq!(
-        ts2493_count, 2,
+        ts2493_count,
+        2,
         "Expected TS2493 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2493_count,
         diagnostics
@@ -219,7 +220,8 @@ declare let c: any;
     );
     let ts2339_count = diagnostics.iter().filter(|d| d.code == 2339).count();
     assert_eq!(
-        ts2339_count, 2,
+        ts2339_count,
+        2,
         "Expected TS2339 once per out-of-bounds element (indexes 1 and 2), got {}: {:?}",
         ts2339_count,
         diagnostics

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -79,6 +79,10 @@ mod jsx_unclosed_tag_tests;
 mod jsx_namespace_recovery_tests;
 
 #[cfg(test)]
+#[path = "../../tests/numeric_literal_exponent_tests.rs"]
+mod numeric_literal_exponent_tests;
+
+#[cfg(test)]
 #[path = "../../tests/state_expression_tests.rs"]
 mod state_expression_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -478,25 +478,27 @@ impl ParserState {
         }
 
         // Check for missing exponent digits (e.g., 1e+, 1e-, 1e) - TS1124
-        // If there's a Scientific flag but the text ends without valid digits after e/E
+        // If there's a Scientific flag but the exponent has no actual digits.
+        //
+        // Note: a misplaced separator like `0e_0` or `0e_` is NOT a missing
+        // digit — the scanner emits TS6188 for the underscore, and tsc does
+        // not also emit TS1124 when at least one digit is present in the
+        // exponent. We only emit TS1124 when the exponent is genuinely empty
+        // of digits (e.g. `1e+`, `1e_`, `1e+_`).
         if (token_flags & TokenFlags::Scientific as u32) != 0 {
             let bytes = text.as_bytes();
-            let len = bytes.len();
             let missing_digit = if let Some(exp_offset) = bytes
                 .iter()
                 .rposition(|byte| *byte == b'e' || *byte == b'E')
             {
-                if exp_offset + 1 >= len {
-                    true
-                } else {
-                    let after = &bytes[exp_offset + 1..];
-                    let first = after[0];
-                    if first == b'+' || first == b'-' {
-                        after.len() == 1 || after[1] == b'_'
-                    } else {
-                        first == b'_'
-                    }
+                let mut after_idx = exp_offset + 1;
+                if after_idx < bytes.len() && (bytes[after_idx] == b'+' || bytes[after_idx] == b'-')
+                {
+                    after_idx += 1;
                 }
+                // Genuine missing-digit only when no digit appears after the
+                // exponent prefix (`e`/`E` and an optional sign).
+                !bytes[after_idx..].iter().any(|b| b.is_ascii_digit())
             } else {
                 false
             };

--- a/crates/tsz-parser/tests/numeric_literal_exponent_tests.rs
+++ b/crates/tsz-parser/tests/numeric_literal_exponent_tests.rs
@@ -1,0 +1,88 @@
+//! Locks in TS1124 ("Digit expected") emission for numeric-literal exponents.
+//! tsc only emits TS1124 when the exponent has no actual digits (e.g. `1e+`,
+//! `1e_`, `1e+_`). When a digit is present but a separator is misplaced
+//! (e.g. `0e_0`), the scanner emits TS6188 alone — TS1124 is **not** also
+//! emitted, since the exponent is well-formed except for the rejected `_`.
+//!
+//! Regression: `parser.numericSeparators.decmialNegative.ts` files 9.ts,
+//! 15.ts, 22.ts, 28.ts, 35.ts, 41.ts. Before the fix, tsz emitted both
+//! TS6188 (at the underscore) and TS1124 (at end-of-literal); tsc emits
+//! only TS6188.
+
+use crate::parser::state::ParserState;
+
+fn parse_codes(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+    parser
+        .scanner
+        .get_scanner_diagnostics()
+        .iter()
+        .map(|d| d.code)
+        .chain(parser.parse_diagnostics.iter().map(|d| d.code))
+        .collect()
+}
+
+#[test]
+fn underscore_after_e_with_digit_emits_only_ts6188() {
+    // `0e_0` — separator misplaced after `e`, but a digit follows. tsc
+    // emits only TS6188 at the `_`, not TS1124 at end-of-literal.
+    let codes = parse_codes("0e_0");
+    assert!(
+        codes.contains(&6188),
+        "expected TS6188 for misplaced underscore in exponent, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1124),
+        "TS1124 should NOT fire when an exponent digit is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn underscore_after_signed_exponent_with_digit_emits_only_ts6188() {
+    // `0e+_0` — sign present, then misplaced underscore, then digit.
+    let codes = parse_codes("0e+_0");
+    assert!(
+        codes.contains(&6188),
+        "expected TS6188 for misplaced underscore after `+`, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1124),
+        "TS1124 should NOT fire when an exponent digit is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn empty_exponent_still_emits_ts1124() {
+    // `1e+` — genuinely missing digit, must still emit TS1124.
+    let codes = parse_codes("1e+");
+    assert!(
+        codes.contains(&1124),
+        "TS1124 should fire when exponent has no digits, got: {codes:?}"
+    );
+}
+
+#[test]
+fn underscore_only_exponent_emits_both() {
+    // `1e_` — separator at start of exponent and no digit after. tsc emits
+    // TS6188 (separator not allowed) and TS1124 (digit expected).
+    let codes = parse_codes("1e_");
+    assert!(
+        codes.contains(&6188),
+        "expected TS6188 for misplaced underscore in empty exponent, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1124),
+        "TS1124 should fire when exponent ends with no digit, got: {codes:?}"
+    );
+}
+
+#[test]
+fn well_formed_decimal_with_exponent_emits_no_diagnostics() {
+    // Sanity: `1.5e+10` is fully well-formed.
+    let codes = parse_codes("let x = 1.5e+10;");
+    assert!(
+        !codes.contains(&1124) && !codes.contains(&6188) && !codes.contains(&6189),
+        "well-formed numeric literal should produce no separator/digit diagnostics, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Intent

\`0e_0\` was emitting both TS6188 ("Numeric separators are not allowed here")
and a stray TS1124 ("Digit expected") at end-of-literal. tsc only emits TS6188 —
the \`0\` after \`_\` is a digit, so the exponent is well-formed except for the
rejected separator, which the scanner already flags.

\`\`\`ts
const a = 0e_0;
// tsc: 1 diagnostic — TS6188 at the underscore
// tsz (before): TS6188 at the underscore + TS1124 at end-of-literal
// tsz (after):  TS6188 at the underscore (matches tsc)
\`\`\`

## Root cause

The parser's missing-exponent-digit check (\`state_expressions_literals.rs\`)
classified any \`_\` immediately after \`e\`/\`E\`/\`+\`/\`-\` as a missing-digit
case, even when a real digit followed it. The scanner already pushes TS6188
for the misplaced \`_\` — the parser was layering an additional false-positive
TS1124.

Fix: walk past the optional sign and check whether *any* digit appears in the
exponent run. Only emit TS1124 when the exponent is genuinely empty of digits.

## Conformance impact

Net 0 against the snapshot baseline. The originally-targeted file
\`parser.numericSeparators.decmialNegative.ts\` still fails — it expects a
TS6188 + TS6189 pair on the separate \`0__0\` integer-part case (file 18.ts /
31.ts / 44.ts), which is a different scanner issue tracked separately.

The fix is correctness-preserving: it removes false-positive TS1124 emissions
in any source that misplaces a separator inside an otherwise valid exponent.

## Tests

\`crates/tsz-parser/tests/numeric_literal_exponent_tests.rs\` (5 cases):

| Input | Expected codes |
|-------|----------------|
| \`0e_0\` | TS6188 only |
| \`0e+_0\` | TS6188 only |
| \`1e+\` | TS1124 (genuine missing digit) |
| \`1e_\` | TS6188 + TS1124 (misplaced AND no digit) |
| \`1.5e+10\` | none |

## Test plan

- [x] \`cargo nextest run -p tsz-parser -- numeric_literal_exponent\` passes (5/5)
- [x] \`cargo nextest run -p tsz-parser\` passes (full suite)
- [x] \`cargo nextest run -p tsz-checker --lib\` passes
- [x] \`scripts/safe-run.sh ./scripts/conformance/conformance.sh run\` — net 0 (no regressions)
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
