### PR TITLE
ci(gh-pages): switch GCS download to curl to expose real errors

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -163,20 +163,36 @@ jobs:
 
       - name: Download latest benchmark data from GCS
         run: |
-          LATEST=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache/bench-runs/latest.json
-          if gsutil -q stat "$LATEST" 2>/dev/null; then
-            gsutil cp "$LATEST" /tmp/bench-latest.json
-            # Reject data where bc was missing and all timings are zero.
-            nonzero=$(jq '[.results[]? | select(.tsz_ms > 0)] | length' /tmp/bench-latest.json 2>/dev/null || echo "0")
-            if [ "${nonzero}" -gt 0 ]; then
-              mkdir -p artifacts
-              cp /tmp/bench-latest.json artifacts/bench-vs-tsgo-latest.json
-              echo "Downloaded fresh benchmark data from GCS (${nonzero} valid results, $(date -u))"
-            else
-              echo "GCS data has no valid timing results — skipping bench charts"
-            fi
+          BUCKET="thirdface-ai-oauth_cloudbuild"
+          OBJECT="tsz-ci-cache/bench-runs/latest.json"
+          URL="https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/${OBJECT//\//%2F}?alt=media"
+
+          # Get OAuth token from credentials wired by google-github-actions/auth above.
+          TOKEN=$(gcloud auth print-access-token 2>/dev/null || echo "")
+
+          if [[ -z "$TOKEN" ]]; then
+            echo "No OAuth token — GCP auth step may have failed or secret is missing"
           else
-            echo "No latest.json in GCS yet — bench charts will show placeholder"
+            HTTP=$(curl -s -w "\n%{http_code}" -o /tmp/bench-latest.json \
+              -H "Authorization: Bearer ${TOKEN}" "$URL")
+            STATUS=$(echo "$HTTP" | tail -1)
+            echo "GCS fetch HTTP ${STATUS}"
+            if [[ "$STATUS" == "200" ]]; then
+              nonzero=$(jq '[.results[]? | select(.tsz_ms > 0)] | length' /tmp/bench-latest.json 2>/dev/null || echo "0")
+              if [ "${nonzero}" -gt 0 ]; then
+                mkdir -p artifacts
+                cp /tmp/bench-latest.json artifacts/bench-vs-tsgo-latest.json
+                echo "Downloaded ${nonzero} valid results from GCS ($(date -u))"
+              else
+                echo "GCS data has no valid timing results — skipping bench charts"
+              fi
+            elif [[ "$STATUS" == "404" ]]; then
+              echo "latest.json not found in GCS — bench job has not written results yet"
+            elif [[ "$STATUS" == "401" || "$STATUS" == "403" ]]; then
+              echo "GCS access denied HTTP ${STATUS} — service account in SCCACHE_GCS_KEY_JSON lacks read on ${BUCKET}"
+            else
+              echo "GCS fetch failed HTTP ${STATUS}"
+            fi
           fi
         continue-on-error: true
 


### PR DESCRIPTION
## Problem

`gsutil -q stat ... 2>/dev/null` swallows all errors — both "file not found" and "permission denied" produce the same "No latest.json in GCS yet" log line. We can't tell whether:

- The bench job has never written `latest.json` (404 — Cloud Build hasn't run successfully)
- The `SCCACHE_GCS_KEY_JSON` service account lacks read permission on `thirdface-ai-oauth_cloudbuild` (403)

## Change

Replace gsutil with `curl` + explicit Bearer token from `gcloud auth print-access-token`. The log now shows the actual HTTP status:

- **200** — downloaded successfully, site will show fresh bench data
- **404** — bench job hasn't written results yet
- **401/403** — service account needs `roles/storage.objectViewer` on `thirdface-ai-oauth_cloudbuild`

## Next steps after merge

Trigger a deploy and look at the "Download latest benchmark data from GCS" step to see which HTTP code we get, then fix accordingly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
