### PR TITLE
fix(solver): drop SymbolId/DefId conflation fallback in this-receiver nominalization

### DIFF
--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -1336,6 +1336,54 @@ function test(r: Real | Fake) {
     );
 }
 
+#[test]
+fn ts2684_union_method_this_message_uses_interface_names_not_outer_function() {
+    // Regression for an ID-conflation bug in the property-access `this`
+    // binder: when the noop TypeResolver couldn't translate an interface's
+    // SymbolId to a DefId, `nominalize_object_receiver` fell back to
+    // `interner.reference(SymbolRef(sym_id.0))`, which created a
+    // `Lazy(DefId(sym_id.0))`. Because `SymbolId.0` and `DefId.0` are
+    // independent ID spaces, this produced a Lazy that pointed at an
+    // *unrelated* declaration (e.g., the enclosing `test` function), so the
+    // TS2684 message rendered as `Real & test` (or `Fake & test`) instead of
+    // `Real & Fake`. The fix: keep the original Object receiver when no
+    // DefId mapping exists, so the formatter can recover the interface name
+    // through `shape.symbol`.
+    let source = r#"
+interface Real {
+    method(this: this, n: number): void;
+    data: string;
+}
+interface Fake {
+    method(this: this, n: number): void;
+    data: number;
+}
+function test(r: Real | Fake) {
+    r.method(12);
+}
+"#;
+    let diags = relevant_diagnostics(source);
+    let ts2684 = diags
+        .iter()
+        .find(|(code, _)| *code == 2684)
+        .expect("expected TS2684 diagnostic");
+    let msg = &ts2684.1;
+    // The expected `this` should display as `Real & Fake` (interface names),
+    // not as `Fake & test` or `Lazy(N) & Lazy(M)`.
+    assert!(
+        msg.contains("'Real & Fake'") || msg.contains("'Fake & Real'"),
+        "TS2684 message should reference both interface names, not the outer function. Got: {msg}"
+    );
+    assert!(
+        !msg.contains("test'"),
+        "TS2684 message must not leak the enclosing function name `test`. Got: {msg}"
+    );
+    assert!(
+        !msg.contains("Lazy("),
+        "TS2684 message must not leak `Lazy(N)` placeholders. Got: {msg}"
+    );
+}
+
 // ─── Higher-order generic contextual types (compose/flip patterns) ──────
 
 #[test]

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -232,9 +232,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
         if self.skip_this_binding.get() {
             return type_id;
         }
-        let receiver = self.nominalize_object_receiver(receiver);
+        let new_receiver = self.nominalize_object_receiver(receiver);
         if crate::contains_this_type(self.interner(), type_id) {
-            crate::substitute_this_type(self.interner(), type_id, receiver)
+            crate::substitute_this_type(self.interner(), type_id, new_receiver)
         } else {
             type_id
         }
@@ -246,11 +246,16 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let shape = self.interner().object_shape(shape_id);
                 if let Some(sym_id) = shape.symbol {
                     let symbol_ref = crate::SymbolRef(sym_id.0);
-                    return self
-                        .resolver()
-                        .symbol_to_def_id(symbol_ref)
-                        .map(|def_id| self.interner().lazy(def_id))
-                        .unwrap_or_else(|| self.interner().reference(symbol_ref));
+                    // Only nominalize when the resolver can produce a real DefId.
+                    // Falling back to `interner().reference(symbol_ref)` here would
+                    // conflate `SymbolId.0` with `DefId.0` (independent ID spaces),
+                    // producing a Lazy(DefId) that points at a *different* declaration.
+                    // When no DefId mapping exists, keep the original object shape —
+                    // structural substitution is still correct, and the type formatter
+                    // can recover the interface name from `shape.symbol`.
+                    if let Some(def_id) = self.resolver().symbol_to_def_id(symbol_ref) {
+                        return self.interner().lazy(def_id);
+                    }
                 }
                 receiver
             }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -539,12 +539,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     fn receiver_type_from_shape_symbol(&self, shape: &ObjectShape) -> Option<TypeId> {
         let sym_id = shape.symbol?;
         let symbol_ref = crate::SymbolRef(sym_id.0);
-        Some(
-            self.resolver
-                .symbol_to_def_id(symbol_ref)
-                .map(|def_id| self.interner.lazy(def_id))
-                .unwrap_or_else(|| self.interner.reference(symbol_ref)),
-        )
+        // Only nominalize when the resolver can produce a real DefId.
+        // Falling back to `interner.reference(symbol_ref)` here would conflate
+        // `SymbolId.0` with `DefId.0` (independent ID spaces) and yield a
+        // Lazy(DefId) that points at an unrelated declaration.
+        self.resolver
+            .symbol_to_def_id(symbol_ref)
+            .map(|def_id| self.interner.lazy(def_id))
     }
 
     fn bind_property_receiver_this(&self, receiver: Option<TypeId>, type_id: TypeId) -> TypeId {
@@ -564,11 +565,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let shape = self.interner.object_shape(shape_id);
                 if let Some(sym_id) = shape.symbol {
                     let symbol_ref = crate::SymbolRef(sym_id.0);
-                    return self
-                        .resolver
-                        .symbol_to_def_id(symbol_ref)
-                        .map(|def_id| self.interner.lazy(def_id))
-                        .unwrap_or_else(|| self.interner.reference(symbol_ref));
+                    // Only nominalize when the resolver can produce a real DefId.
+                    // Falling back to `interner.reference(symbol_ref)` would conflate
+                    // `SymbolId.0` with `DefId.0` and produce a Lazy pointing at an
+                    // unrelated declaration. When no DefId mapping exists, keep the
+                    // original Object receiver — the structural shape is still a
+                    // sound `this` substitution target.
+                    if let Some(def_id) = self.resolver.symbol_to_def_id(symbol_ref) {
+                        return self.interner.lazy(def_id);
+                    }
                 }
                 receiver
             }


### PR DESCRIPTION
## Summary
- Fixes a SymbolId/DefId ID-space conflation in two solver paths that fall back to `interner.reference(SymbolRef(sym_id.0))` when the active resolver can't translate a `SymbolId` to a `DefId`. `interner.reference` reinterprets its arg as `DefId(sym_id.0)`, so the fallback fabricates a `Lazy(DefId)` that points at an *unrelated* declaration whenever the two ID spaces happen to share a raw u32 value.
- For the conformance test `unionThisTypeInFunctions.ts`, this leaked the enclosing `function test(...)` into the TS2684 message — `Real & test` (or `Lazy(2996) & Lazy(2997)` in the conformance run where the def-store path also failed) instead of `Real & Fake`.
- Fix: only nominalize when `symbol_to_def_id` returns a real `DefId`. When no mapping exists, keep the original `Object` receiver — `substitute_this_type` then binds `ThisType` to the structural shape (still sound), and the formatter recovers the interface name through `shape.symbol`.
- Applies the same shape to the two parallel paths in `SubtypeChecker` to remove the same trap.

## Files changed
- `crates/tsz-solver/src/operations/property.rs` — `nominalize_object_receiver` no longer falls back to the conflating `reference()`.
- `crates/tsz-solver/src/relations/subtype/rules/objects.rs` — same fix on `receiver_type_from_shape_symbol` and `normalize_receiver_type`.
- `crates/tsz-checker/tests/generic_call_inference_tests.rs` — adds `ts2684_union_method_this_message_uses_interface_names_not_outer_function` asserting the TS2684 message contains `Real & Fake`, never `test`, and never `Lazy(N)`.

## Conformance impact
- `TypeScript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts` flips PASS (was fingerprint-only — same TS2684 code, wrong message).

## Test plan
- [x] `cargo nextest run -p tsz-solver` (5525 pass)
- [x] `cargo nextest run -p tsz-checker` (5438 pass)
- [x] Targeted: `./scripts/conformance/conformance.sh run --filter "unionThisTypeInFunctions" --verbose` → 1/1 passes.
- [x] Smoke: `--filter "thisType"` (28/32, all 4 failures pre-existing per snapshot) and `--filter "this"` (89/95, all 6 failures pre-existing).

Pre-commit clippy hook flagged a pre-existing `match_same_arms` warning in `elaboration_array_mismatch.rs` (recently merged in #1470, not in scope). Bypassed with `TSZ_SKIP_HOOKS=1` per CLAUDE.md guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
