### PR TITLE
fix(bench): use flat tsconfig for large-ts-repo; remove invalid 12ms snapshot entry

### DIFF
--- a/crates/tsz-website/bench-snapshot.json
+++ b/crates/tsz-website/bench-snapshot.json
@@ -9,25 +9,13 @@
     "tsc": "/workspace/.target-bench/tools/tsc/node_modules/.bin/tsc"
   },
   "totals": {
-    "benchmarks_run": 26,
-    "rows": 25,
-    "tsz_wins": 2,
+    "benchmarks_run": 25,
+    "rows": 24,
+    "tsz_wins": 1,
     "tsgo_wins": 21,
     "error_cases": 2
   },
   "results": [
-    {
-      "name": "large-ts-repo",
-      "lines": 408410,
-      "kb": 59983,
-      "tsz_ms": 12.68,
-      "tsgo_ms": 109.76,
-      "tsz_lps": 32199769,
-      "tsgo_lps": 3720910,
-      "winner": "tsz",
-      "factor": 8.65,
-      "status": null
-    },
     {
       "name": "conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts",
       "lines": 8012,

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1644,12 +1644,10 @@ ensure_large_ts_repo_fixture() {
         pnpm --dir "$LARGE_TS_DIR" install --frozen-lockfile --silent
         touch "$deps_stamp"
     fi
-    # Use the repository's real tsconfig.json for large-ts-repo; skip synthetic
-    # flat-config generation used by previous benchmark iterations.
-    return
-
-    # Create flat tsconfig (includes all files directly) for consistent benchmarking.
-    # Note: tsz supports --build mode, but we use flat config for apples-to-apples comparison.
+    # The root tsconfig.json in large-ts-repo uses project references, so
+    # `tsc/tsgo/tsz --noEmit -p tsconfig.json` exits almost immediately
+    # without type-checking anything. Use a flat tsconfig that directly
+    # includes all source files for an apples-to-apples measurement.
     local flat_tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
     if [ ! -f "$flat_tsconfig" ]; then
         cat > "$flat_tsconfig" << 'FLATEOF'
@@ -1683,11 +1681,14 @@ run_large_ts_repo_benchmarks() {
     ensure_large_ts_repo_fixture
     echo -e "${GREEN}✓${NC} large-ts-repo pinned at $(git -C "$LARGE_TS_DIR" rev-parse --short HEAD)"
 
-    local tsconfig="$LARGE_TS_DIR/tsconfig.json"
+    # Use the flat tsconfig so all source files are included in a single
+    # compilation pass. The root tsconfig.json uses project references and
+    # completes in milliseconds without actually checking any files.
+    local tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
     local src_dir="$LARGE_TS_DIR/packages"
 
     if [ ! -f "$tsconfig" ]; then
-        echo -e "${RED}✗ tsconfig not found: $tsconfig${NC}"
+        echo -e "${RED}✗ tsconfig.flat.json not found (ensure_large_ts_repo_fixture should have created it)${NC}"
         return
     fi
 


### PR DESCRIPTION
## Problem

`large-ts-repo`'s root `tsconfig.json` uses **project references** — `tsc/tsgo/tsz --noEmit -p tsconfig.json` exits in milliseconds without type-checking any source files. The deleted `data/benchmarks.json` entry showing `tsz_ms: 12.68 / 8.65× win` was therefore measuring tsz doing essentially nothing, not a real full-project check.

## Fix

1. **`ensure_large_ts_repo_fixture`** now generates `tsconfig.flat.json` that directly `include`s `packages/**/src/**/*.ts`. This gives a real apples-to-apples single-pass measurement over all source files.
2. **`run_large_ts_repo_benchmarks`** uses `tsconfig.flat.json` instead of `tsconfig.json`.
3. **`bench-snapshot.json`** — removed the invalid large-ts-repo entry. The next Cloud Build bench run (which now has pnpm installed via #1498) will produce genuine timings.

## What to expect after next Cloud Build run

The real large-ts-repo timing will be much slower than 12ms — likely seconds for both tsz and tsgo, which is what makes it an interesting real-world stress test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
