### PR TITLE
fix(dts): preserve explicit | undefined in index-signature inference under exactOptionalPropertyTypes

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -751,6 +751,11 @@ pub(super) fn collect_diagnostics(
     program
         .type_interner
         .set_no_unchecked_indexed_access(options.checker.no_unchecked_indexed_access);
+    // Propagate exactOptionalPropertyTypes to the TypeInterner so that solver-side
+    // queries (e.g. index-signature inference) see the same flag as the checker.
+    program
+        .type_interner
+        .set_exact_optional_property_types(options.checker.exact_optional_property_types);
 
     // Create a shared QueryCache for memoized evaluate_type/is_subtype_of calls.
     let query_cache = QueryCache::new(&program.type_interner);
@@ -3641,6 +3646,9 @@ interface Constraint<A extends Runtype<any>> extends Runtype<A['witness']> {
         program
             .type_interner
             .set_no_unchecked_indexed_access(resolved.checker.no_unchecked_indexed_access);
+        program
+            .type_interner
+            .set_exact_optional_property_types(resolved.checker.exact_optional_property_types);
         let query_cache = tsz_solver::QueryCache::new(&program.type_interner);
         let mut checker = CheckerState::with_options(
             &program.files[0].arena,

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -2444,6 +2444,9 @@ pub fn apply_cli_overrides(options: &mut ResolvedCompilerOptions, args: &CliArgs
     if args.no_unchecked_indexed_access {
         options.checker.no_unchecked_indexed_access = true;
     }
+    if args.exact_optional_property_types {
+        options.checker.exact_optional_property_types = true;
+    }
     if args.no_property_access_from_index_signature {
         options.checker.no_property_access_from_index_signature = true;
     }

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -275,6 +275,17 @@ pub trait TypeDatabase {
     /// Record the result of `contains_this_type(type_id)` in the shared
     /// interner cache. Default impl is a no-op.
     fn set_contains_this_type_cache(&self, _type_id: TypeId, _result: bool) {}
+
+    /// Whether `exactOptionalPropertyTypes` is enabled.
+    ///
+    /// Exposed on `TypeDatabase` (in addition to `QueryDatabase`) so that
+    /// inference matching can distinguish synthetic `| undefined` from
+    /// optional markers vs. explicit `| undefined` in user-written types.
+    /// The default returns `false`; canonical implementations live on
+    /// `TypeInterner` and `QueryCache`.
+    fn exact_optional_property_types(&self) -> bool {
+        false
+    }
 }
 
 impl TypeDatabase for TypeInterner {
@@ -623,6 +634,10 @@ impl TypeDatabase for TypeInterner {
 
     fn set_contains_this_type_cache(&self, type_id: TypeId, result: bool) {
         self.contains_this_cache.insert(type_id, result);
+    }
+
+    fn exact_optional_property_types(&self) -> bool {
+        TypeInterner::exact_optional_property_types(self)
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1154,6 +1154,10 @@ impl TypeDatabase for QueryCache<'_> {
     fn set_contains_this_type_cache(&self, type_id: TypeId, result: bool) {
         self.interner.set_contains_this_type_cache(type_id, result);
     }
+
+    fn exact_optional_property_types(&self) -> bool {
+        self.exact_optional_property_types.get()
+    }
 }
 
 /// Implement `TypeResolver` for `QueryCache` with noop resolution.
@@ -1664,7 +1668,8 @@ impl QueryDatabase for QueryCache<'_> {
         // QueryCache doesn't have full TypeResolver capability, so use PropertyAccessEvaluator
         // with the current QueryDatabase.
         let prop_atom = self.interner.intern_string(prop_name);
-        let exact_optional_property_types = self.exact_optional_property_types();
+        let exact_optional_property_types =
+            crate::caches::db::QueryDatabase::exact_optional_property_types(self);
         let key = (
             object_type,
             prop_atom,

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -445,6 +445,16 @@ impl<'a> InferenceContext<'a> {
                 // e.g. `{ [sym]?: true }` should not contribute `true` when inferring
                 // T from `{ [s: string]: T }`.
                 if has_implicit_index && !source_shape.properties.is_empty() {
+                    // Under `exactOptionalPropertyTypes`, the `?` modifier does NOT
+                    // implicitly add `undefined` to a property's type. So any
+                    // `undefined` in `p.type_id` must have been explicitly written
+                    // by the user (e.g. `b?: number | undefined`) and should be
+                    // preserved during index-signature inference.
+                    //
+                    // Without EOPT, `b?: number` is equivalent to `b?: number | undefined`,
+                    // and tsc strips that synthetic `undefined` when inferring T from
+                    // `{ [k: string]: T }` to match its display behavior.
+                    let strip_optional_undefined = !self.interner.exact_optional_property_types();
                     for p in &source_shape.properties {
                         // Skip symbol-keyed properties — they are not reachable via
                         // a string index and must not pollute string-index inference.
@@ -452,10 +462,12 @@ impl<'a> InferenceContext<'a> {
                         if prop_name_str.starts_with("__unique_") {
                             continue;
                         }
-                        // For optional properties, strip `undefined` from optionality.
+                        // For optional properties, strip `undefined` from optionality
+                        // unless `exactOptionalPropertyTypes` preserves explicit undefined.
                         // tsc: `{ a: string, b?: number }` infers T as `string | number`
-                        // (not `string | number | undefined`).
-                        let prop_type = if p.optional {
+                        // (not `string | number | undefined`). With EOPT enabled,
+                        // `b?: number | undefined` infers T as `string | number | undefined`.
+                        let prop_type = if p.optional && strip_optional_undefined {
                             crate::narrowing::utils::remove_undefined(self.interner, p.type_id)
                         } else {
                             p.type_id

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -568,6 +568,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Without combination priority, common supertype picks only the first type.
         let idx_priority = crate::types::InferencePriority::MappedType;
 
+        // Under `exactOptionalPropertyTypes`, the `?` modifier does NOT implicitly
+        // add `undefined` to a property's stored type. Any `undefined` present must
+        // have been written explicitly (e.g. `b?: number | undefined`) and should
+        // be preserved during index-signature inference. Without EOPT, optional
+        // properties carry an implicit `| undefined` that tsc strips when inferring
+        // T from `{ [k: string]: T }`.
+        let strip_optional_undefined =
+            !crate::caches::db::QueryDatabase::exact_optional_property_types(self.interner);
+
         for (i, prop) in source_props.iter().enumerate() {
             // Skip symbol-keyed properties (stored with "__unique_" prefix).
             // Symbol-keyed properties are NOT accessible via string or numeric index
@@ -582,9 +591,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // For optional properties, strip `undefined` from the type before contributing
             // to index signature inference. When inferring T from `{ a: string, b?: number }`
             // against `{ [x: string]: T }`, tsc infers T = string | number (not
-            // string | number | undefined). The optionality of a property does not contribute
-            // `undefined` to the inferred index signature value type.
-            let prop_type = if prop.optional {
+            // string | number | undefined). With `exactOptionalPropertyTypes` enabled,
+            // `b?: number | undefined` preserves the explicit `| undefined` and infers
+            // T = string | number | undefined.
+            let prop_type = if prop.optional && strip_optional_undefined {
                 crate::narrowing::utils::remove_undefined(self.interner, prop.type_id)
             } else {
                 prop.type_id

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -183,7 +183,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
             db,
             resolver: None,
             no_unchecked_indexed_access: false,
-            exact_optional_property_types: db.exact_optional_property_types(),
+            exact_optional_property_types:
+                crate::caches::db::QueryDatabase::exact_optional_property_types(db),
             guard: RefCell::new(crate::recursion::RecursionGuard::with_profile(
                 crate::recursion::RecursionProfile::PropertyAccess,
             )),

--- a/crates/tsz-solver/tests/constraint_tests.rs
+++ b/crates/tsz-solver/tests/constraint_tests.rs
@@ -1219,3 +1219,162 @@ fn test_contra_candidate_wins_when_only_unknown_covariant() {
         "Expected T = number (contra-candidate wins over filtered unknown), got {result:?}"
     );
 }
+
+// =============================================================================
+// exactOptionalPropertyTypes + index-signature inference (regression tests)
+// =============================================================================
+
+/// `function f<T>(x: { [k: string]: T }): T;` called with
+/// `{ a?: string, b?: number | undefined }` (with `exactOptionalPropertyTypes`)
+/// should infer `T = string | number | undefined` because `b`'s explicit
+/// `| undefined` is preserved. Without EOPT (or under tsc's pre-EOPT semantics)
+/// the synthetic optional `| undefined` is stripped and `T = string | number`.
+///
+/// Regression for declaration-emit baseline `inferenceOptionalProperties.d.ts`
+/// where `declare const y2: string | number | undefined;` was previously
+/// emitted as `declare const y2: string | number;`.
+#[test]
+fn test_eopt_preserves_explicit_undefined_in_index_signature_inference() {
+    let interner = TypeInterner::new();
+    interner.set_exact_optional_property_types(true);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let t_name = interner.intern_string("T");
+    let t_type = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+
+    let param_obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: t_type,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let func = interner.function(FunctionShape {
+        type_params: vec![TypeParamInfo {
+            name: t_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        }],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("x")),
+            type_id: param_obj,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let a_name = interner.intern_string("a");
+    let b_name = interner.intern_string("b");
+    let number_or_undefined = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let arg = interner.object(vec![
+        PropertyInfo::opt(a_name, TypeId::STRING),
+        PropertyInfo::opt(b_name, number_or_undefined),
+    ]);
+
+    let result = evaluator.resolve_call(func, &[arg]);
+    let ret = match result {
+        CallResult::Success(ret) => ret,
+        other => panic!("Expected success, got {other:?}"),
+    };
+
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::UNDEFINED]);
+    assert_eq!(
+        ret, expected,
+        "Under exactOptionalPropertyTypes, explicit `| undefined` from `b?: number | undefined` \
+         must be preserved in the inferred index-signature value type. \
+         Expected `string | number | undefined`, got TypeId({ret:?})"
+    );
+}
+
+/// Without `exactOptionalPropertyTypes`, the same call should infer
+/// `T = string | number` (the synthetic optional `| undefined` is stripped),
+/// matching tsc's behavior under default settings.
+#[test]
+fn test_no_eopt_strips_optional_undefined_in_index_signature_inference() {
+    let interner = TypeInterner::new();
+    interner.set_exact_optional_property_types(false);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let t_name = interner.intern_string("T");
+    let t_type = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+
+    let param_obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: t_type,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let func = interner.function(FunctionShape {
+        type_params: vec![TypeParamInfo {
+            name: t_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        }],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("x")),
+            type_id: param_obj,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let a_name = interner.intern_string("a");
+    let b_name = interner.intern_string("b");
+    let number_or_undefined = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let arg = interner.object(vec![
+        PropertyInfo::opt(a_name, TypeId::STRING),
+        PropertyInfo::opt(b_name, number_or_undefined),
+    ]);
+
+    let result = evaluator.resolve_call(func, &[arg]);
+    let ret = match result {
+        CallResult::Success(ret) => ret,
+        other => panic!("Expected success, got {other:?}"),
+    };
+
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(
+        ret, expected,
+        "Without exactOptionalPropertyTypes, the synthetic optional `| undefined` is stripped. \
+         Expected `string | number`, got TypeId({ret:?})"
+    );
+}

--- a/scripts/emit/src/cli-transpiler.ts
+++ b/scripts/emit/src/cli-transpiler.ts
@@ -52,6 +52,7 @@ interface CompilerFlagOptions {
   experimentalDecorators?: boolean;
   emitDecoratorMetadata?: boolean;
   strictNullChecks?: boolean;
+  exactOptionalPropertyTypes?: boolean;
   jsx?: string;
   jsxFactory?: string;
   jsxFragmentFactory?: string;
@@ -88,6 +89,12 @@ function appendCompilerOptionFlags(args: string[], opts: CompilerFlagOptions): v
   if (opts.experimentalDecorators) args.push('--experimentalDecorators');
   if (opts.emitDecoratorMetadata) args.push('--emitDecoratorMetadata');
   if (opts.strictNullChecks !== undefined) args.push('--strictNullChecks', String(opts.strictNullChecks));
+  // tsz CLI defines `--exactOptionalPropertyTypes` as a presence-only flag.
+  // Passing the literal "true" turns into a positional input file, so only emit
+  // the flag when the option is enabled.
+  if (opts.exactOptionalPropertyTypes === true) {
+    args.push('--exactOptionalPropertyTypes');
+  }
   if (opts.jsx) args.push('--jsx', opts.jsx);
   if (opts.jsxFactory) args.push('--jsxFactory', opts.jsxFactory);
   if (opts.jsxFragmentFactory) args.push('--jsxFragmentFactory', opts.jsxFragmentFactory);
@@ -225,6 +232,7 @@ export class CliTranspiler {
       experimentalDecorators?: boolean;
       emitDecoratorMetadata?: boolean;
       strictNullChecks?: boolean;
+      exactOptionalPropertyTypes?: boolean;
       jsx?: string;
       jsxFactory?: string;
       jsxFragmentFactory?: string;
@@ -263,6 +271,7 @@ export class CliTranspiler {
       experimentalDecorators = false,
       emitDecoratorMetadata = false,
       strictNullChecks,
+      exactOptionalPropertyTypes,
       jsx,
       jsxFactory,
       jsxFragmentFactory,
@@ -373,6 +382,7 @@ export class CliTranspiler {
         experimentalDecorators,
         emitDecoratorMetadata,
         strictNullChecks,
+        exactOptionalPropertyTypes,
         jsx,
         jsxFactory,
         jsxFragmentFactory,
@@ -462,6 +472,7 @@ export class CliTranspiler {
             experimentalDecorators,
             emitDecoratorMetadata,
             strictNullChecks,
+            exactOptionalPropertyTypes,
             jsx,
             jsxFactory,
             jsxFragmentFactory,

--- a/scripts/emit/src/runner.ts
+++ b/scripts/emit/src/runner.ts
@@ -70,6 +70,7 @@ interface TestCase {
   experimentalDecorators: boolean;
   emitDecoratorMetadata: boolean;
   strictNullChecks?: boolean;
+  exactOptionalPropertyTypes?: boolean;
   jsx?: string;
   jsxFactory?: string;
   jsxFragmentFactory?: string;
@@ -164,6 +165,7 @@ function getCacheKey(
   experimentalDecorators: boolean = false,
   emitDecoratorMetadata: boolean = false,
   strictNullChecks: string = '',
+  exactOptionalPropertyTypes: string = '',
   jsx: string = '',
   jsxFactory: string = '',
   jsxFragmentFactory: string = '',
@@ -215,6 +217,7 @@ function getCacheKey(
     experimentalDecorators,
     emitDecoratorMetadata,
     strictNullChecks,
+    exactOptionalPropertyTypes,
     jsx,
     jsxFactory,
     jsxFragmentFactory,
@@ -566,6 +569,13 @@ async function findTestCases(filter: string, maxTests: number, dtsOnly: boolean)
         : directives.strict === false
           ? false
           : undefined;
+    const exactOptionalPropertyTypes = variant.exactoptionalpropertytypes !== undefined
+      ? variant.exactoptionalpropertytypes === 'true'
+      : typeof directives.exactoptionalpropertytypes === 'boolean'
+        ? directives.exactoptionalpropertytypes
+        : typeof tsconfigOptions.exactOptionalPropertyTypes === 'boolean'
+          ? (tsconfigOptions.exactOptionalPropertyTypes as boolean)
+          : undefined;
     const jsx = variant.jsx ?? (typeof directives.jsx === 'string' ? directives.jsx : undefined);
     const moduleDetection =
       variant.moduledetection ?? (typeof directives.moduledetection === 'string' ? directives.moduledetection : undefined);
@@ -640,6 +650,7 @@ async function findTestCases(filter: string, maxTests: number, dtsOnly: boolean)
       experimentalDecorators,
       emitDecoratorMetadata,
       strictNullChecks,
+      exactOptionalPropertyTypes,
       jsx,
       jsxFactory,
       jsxFragmentFactory,
@@ -749,6 +760,7 @@ async function runTest(transpiler: CliTranspiler, testCase: TestCase, config: Co
       testCase.experimentalDecorators,
       testCase.emitDecoratorMetadata,
       testCase.strictNullChecks === undefined ? '' : String(testCase.strictNullChecks),
+      testCase.exactOptionalPropertyTypes === undefined ? '' : String(testCase.exactOptionalPropertyTypes),
       testCase.jsx ?? '',
       testCase.jsxFactory ?? '',
       testCase.jsxFragmentFactory ?? '',
@@ -791,6 +803,7 @@ async function runTest(transpiler: CliTranspiler, testCase: TestCase, config: Co
         experimentalDecorators: testCase.experimentalDecorators,
         emitDecoratorMetadata: testCase.emitDecoratorMetadata,
         strictNullChecks: testCase.strictNullChecks,
+        exactOptionalPropertyTypes: testCase.exactOptionalPropertyTypes,
         jsx: testCase.jsx,
         jsxFactory: testCase.jsxFactory,
         jsxFragmentFactory: testCase.jsxFragmentFactory,


### PR DESCRIPTION
## Summary
- Fixes `inferenceOptionalProperties` (and `…Strict`) declaration-emit baselines: `declare const y2: string | number | undefined;` was being emitted as `declare const y2: string | number;` because the solver always stripped optional `| undefined` from index-signature inference contributions, regardless of `exactOptionalPropertyTypes`.
- Three coupled fixes ship together so EOPT actually reaches the solver-side inference walker:
  - **tsz-cli**: `--exactOptionalPropertyTypes` was a registered clap flag but `apply_cli_overrides` never copied it into `ResolvedCompilerOptions.checker`, and the `TypeInterner` was never told about EOPT (only `noUncheckedIndexedAccess` was being propagated).
  - **tsz-solver**: only strip the optional `| undefined` when EOPT is OFF. Patched the call-resolution walker (`constrain_properties_against_index_signatures`) and the parallel `infer_matching::infer_objects` path. Exposed `exact_optional_property_types` on `TypeDatabase` so `InferenceContext` (which only sees `&dyn TypeDatabase`) can read it.
  - **scripts/emit**: runner now reads `@exactOptionalPropertyTypes` / `tsconfig.compilerOptions.exactOptionalPropertyTypes` from baselines and forwards as a presence-only flag (passing `true` as a separate token was being eaten as a positional input file).
- Two regression tests in `crates/tsz-solver/tests/constraint_tests.rs` cover both EOPT-on (preserves explicit `| undefined`) and EOPT-off (strips synthetic optional `| undefined`) paths.

## Test plan
- [x] `cargo nextest run -p tsz-solver --lib -E 'test(eopt) | test(no_eopt)'` — new regression tests pass
- [x] `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib` — 5528 / 5528 pass
- [x] `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib` — 2922 / 2922 pass
- [x] `./scripts/emit/run.sh --skip-build --filter=inferenceOptionalProperties --dts-only` — 2 / 2 pass (was 0 / 2)
- [ ] Full emit suite via `./scripts/emit/run.sh --skip-build` to confirm declaration-emit pass rate moves up by 2 with no regressions
- [ ] Full conformance via `scripts/safe-run.sh ./scripts/conformance/conformance.sh run`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
