### PR TITLE
fix(dts): emit recursive elided form for anonymous self-returning functions

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -129,7 +129,7 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(&type_text);
             } else if has_initializer
                 && (self.function_initializer_has_inline_parameter_comments(initializer)
-                    || self.function_initializer_is_self_returning(initializer)
+                    || self.function_initializer_is_self_returning_for(initializer, decl_name)
                     || self.function_initializer_returns_unique_identifier(initializer)
                     || self.function_initializer_has_typeof_in_param_annotations(initializer))
                 && {
@@ -735,7 +735,7 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         let is_self_returning = func.type_annotation.is_none()
-            && self.function_initializer_is_self_returning(initializer);
+            && self.function_initializer_is_self_returning_for(initializer, decl_name);
 
         self.write(": ");
         if is_self_returning {
@@ -1048,23 +1048,41 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
-    pub(in crate::declaration_emitter) fn function_initializer_is_self_returning(
+    /// Returns `true` when the initializer is a function expression / arrow whose
+    /// body returns either the function's own name or the binding it is being
+    /// assigned to. Both cases produce a recursive type that declaration emit
+    /// cannot spell directly, so tsc represents them as
+    /// `(...args) => (...args) => /*elided*/ any`.
+    pub(in crate::declaration_emitter) fn function_initializer_is_self_returning_for(
         &self,
         initializer: NodeIndex,
+        decl_name: NodeIndex,
     ) -> bool {
         let Some(init_node) = self.arena.get(initializer) else {
             return false;
         };
-        if init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION {
+        if init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+            && init_node.kind != syntax_kind_ext::ARROW_FUNCTION
+        {
             return false;
         }
         let Some(func) = self.arena.get_function(init_node) else {
             return false;
         };
-        let Some(name) = self.get_identifier_text(func.name) else {
-            return false;
-        };
-        self.function_body_returns_identifier(func.body, &name)
+
+        if let Some(name) = self.get_identifier_text(func.name)
+            && self.function_body_returns_identifier(func.body, &name)
+        {
+            return true;
+        }
+
+        if let Some(name) = self.get_identifier_text(decl_name)
+            && self.function_body_returns_identifier(func.body, &name)
+        {
+            return true;
+        }
+
+        false
     }
 
     /// True when the initializer is an arrow/function expression whose

--- a/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/comprehensive_parity.rs
@@ -1094,3 +1094,32 @@ const printFn = (action: typeof foo) => { action(1); };
         "arrow parameter `typeof X` must be preserved in dts: {output}"
     );
 }
+
+#[test]
+fn test_anonymous_function_returning_outer_var_emits_elided_recursive_type() {
+    // Regression for declFileTypeofFunction: a `var foo3 = function () { return foo3; }`
+    // (anonymous function expression returning the binding it's assigned to)
+    // and the matching arrow form `var x = () => { return x; }` must be emitted
+    // as `() => () => /*elided*/ any`, matching tsc. Previously these emitted
+    // `() => any` because the self-returning detector only inspected the
+    // function's own name (which is None for anonymous expressions and
+    // arrows).
+    let output = emit_dts_with_binding(
+        r#"
+var foo3 = function () {
+    return foo3;
+}
+var x = () => {
+    return x;
+}
+"#,
+    );
+    assert!(
+        output.contains("foo3: () => () => /*elided*/ any"),
+        "anonymous function returning outer var should emit recursive elided form: {output}"
+    );
+    assert!(
+        output.contains("x: () => () => /*elided*/ any"),
+        "arrow returning outer var should emit recursive elided form: {output}"
+    );
+}


### PR DESCRIPTION
## Summary
- `var foo = function () { return foo; }` and the matching arrow `var x = () => { return x; }` were emitted as `() => any` because `function_initializer_is_self_returning` only checked the function expression's own name (always `None` for anonymous fns and arrows). The variable being assigned to was never consulted.
- Extend the detector to also check the surrounding variable's name, and accept arrow functions in addition to function expressions, so dts emit produces tsc's recursive `() => () => /*elided*/ any` form.
- Adds a unit test in `tsz-emitter` covering both shapes.

## Test plan
- [x] `./scripts/emit/run.sh --skip-build --filter=declFileTypeofFunction --dts-only --verbose` — now passes (was the target failure).
- [x] `./scripts/emit/run.sh --skip-build --filter=declFile --dts-only` — 108/118 (was 107/118), no regressions.
- [x] `./scripts/emit/run.sh --skip-build --filter=typeof --dts-only` — 17/20 (was 16/20), no regressions.
- [x] `cargo nextest run -p tsz-emitter --lib` — 1608/1608 pass.
- [x] Pre-commit hook ran 4652 tests across 14 binaries, all passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
