### PR TITLE
fix(solver/property): instrument hardcoded Function fallback

### DIFF
--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -1289,15 +1289,27 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
         // STEP 2: Hardcoded well-known Function members (no-lib / bootstrap path).
         // Reached when the boxed `Function` interface is unavailable (no lib loaded)
-        // or didn't resolve the property.
-        match prop_name {
-            "apply" | "call" | "bind" => return self.method_result(TypeId::ANY),
-            "toString" => return self.method_result(TypeId::STRING),
-            "name" => return PropertyAccessResult::simple(TypeId::STRING),
-            "length" => return PropertyAccessResult::simple(TypeId::NUMBER),
-            "prototype" | "arguments" => return PropertyAccessResult::simple(TypeId::ANY),
-            "caller" => return PropertyAccessResult::simple(self.any_args_function(TypeId::ANY)),
-            _ => {}
+        // or didn't resolve the property. We emit a structured trace event so
+        // drift (e.g. tests inadvertently bootstrapping with no-lib semantics)
+        // is visible at runtime — see robustness audit item 15 / PR #O.
+        let hardcoded_match = match prop_name {
+            "apply" | "call" | "bind" => Some(self.method_result(TypeId::ANY)),
+            "toString" => Some(self.method_result(TypeId::STRING)),
+            "name" => Some(PropertyAccessResult::simple(TypeId::STRING)),
+            "length" => Some(PropertyAccessResult::simple(TypeId::NUMBER)),
+            "prototype" | "arguments" => Some(PropertyAccessResult::simple(TypeId::ANY)),
+            "caller" => Some(PropertyAccessResult::simple(
+                self.any_args_function(TypeId::ANY),
+            )),
+            _ => None,
+        };
+        if let Some(result) = hardcoded_match {
+            tracing::trace!(
+                target: "tsz_solver::function_hardcoded_fallback",
+                prop_name = prop_name,
+                "Function property resolved via hardcoded no-lib fallback"
+            );
+            return result;
         }
 
         if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {


### PR DESCRIPTION
## Summary

- Mirror the canonical-lib-sym-id heuristic instrumentation (PR #1371) on `resolve_function_property`'s no-lib fallback. The boxed-`Function`-first ladder is unchanged; this only adds a structured `tracing::trace!` event when the hardcoded match (apply/call/bind/toString/name/length/prototype/arguments/caller) fires.
- Surfaces tests inadvertently bootstrapping with no-lib semantics or library augmentations that aren't taking effect — both indicate the lib resolver isn't covering this property and the user wouldn't see a TS2339 they should see.
- Robustness audit item 15 / PR #O — see `docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md`.

## Test plan

- [x] `cargo nextest run -p tsz-solver --lib` — all 5529 solver tests pass (no behaviour change)
- [x] `cargo check -p tsz-solver` — compiles cleanly

## Note

Behavior is preserved when the fallback fires; no conformance impact expected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
