### PR TITLE
fix(parser): break out of arg list when ':' precedes statement-only keyword

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -2548,6 +2548,30 @@ impl ParserState {
                     self.error_comma_expected();
                     self.next_token();
 
+                    // After consuming the spurious `:`, if the next token is a
+                    // statement-only recovery boundary (e.g. `var`, `let`,
+                    // `return`), don't try to parse it as a type — emit TS1135
+                    // at the keyword and break out of the argument list so the
+                    // outer statement parser can recover. This matches tsc's
+                    // behaviour where `f(x: var ...)` produces TS1005 at `:`,
+                    // TS1135 at `var`, then re-parses `var ...` as a top-level
+                    // variable declaration.
+                    if self.is_argument_list_recovery_boundary() {
+                        if !self.is_token(SyntaxKind::EndOfFileToken) {
+                            // Bypass the distance-based suppression heuristic in
+                            // `should_report_error` because the previous TS1005
+                            // ',' expected emitted on the spurious `:` is only
+                            // a couple of columns away — we still want to flag
+                            // the keyword position with TS1135.
+                            use tsz_common::diagnostics::diagnostic_codes;
+                            self.parse_error_at_current_token(
+                                "Argument expression expected.",
+                                diagnostic_codes::ARGUMENT_EXPRESSION_EXPECTED,
+                            );
+                        }
+                        break;
+                    }
+
                     let recover_start = self.token_pos();
                     let _ = self.parse_type();
                     if self.token_pos() == recover_start

--- a/crates/tsz-parser/tests/parser_improvement_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tests.rs
@@ -2288,6 +2288,57 @@ const y = 1;
 }
 
 #[test]
+fn test_argument_list_colon_followed_by_var_keyword_emits_ts1135() {
+    // Regression for `f(x: var ...)` parser recovery.
+    //
+    // tsc emits:
+    //   - TS1005 ',' expected at the spurious `:`
+    //   - TS1135 "Argument expression expected." at `var`
+    //   - TS1134 "Variable declaration expected." at `(`
+    // The keyword should also break the argument list so the outer statement
+    // parser can keep recovering. This prevents earlier behaviour where the
+    // colon branch tried to parse `var` as a type, followed by another TS1005
+    // ',' expected at `(`.
+    let source = "f(x: var (--a)\n);";
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let _root = parser.parse_source_file();
+
+    let diagnostics = parser.get_diagnostics();
+    let ts1135 = diagnostics.iter().filter(|d| d.code == 1135).count();
+    let ts1134 = diagnostics.iter().filter(|d| d.code == 1134).count();
+    let ts1110 = diagnostics.iter().filter(|d| d.code == 1110).count();
+
+    assert!(
+        ts1135 >= 1,
+        "Expected TS1135 'Argument expression expected.' at `var`, got: {diagnostics:?}"
+    );
+    assert!(
+        ts1134 >= 1,
+        "Expected TS1134 'Variable declaration expected.' downstream of `var (`, got: {diagnostics:?}"
+    );
+    assert_eq!(
+        ts1110, 0,
+        "Expected no TS1110 'Type expected.' (the colon branch must not parse `var` as a type), got: {diagnostics:?}"
+    );
+
+    // Ensure we don't double-report `,` expected at `:` and at `(` of the
+    // call site (the previous bug emitted both).
+    let ts1005_at_paren = diagnostics
+        .iter()
+        .filter(|d| d.code == 1005)
+        .filter(|d| {
+            let pos = d.start as usize;
+            pos < source.len() && &source[pos..=pos] == "("
+        })
+        .count();
+    assert_eq!(
+        ts1005_at_paren, 0,
+        "TS1005 should not be emitted at `(` of `var (...)` after recovery, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_invalid_unicode_escape_in_var_no_extra_semicolon_error() {
     let source = r"var arg\uxxxx";
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());


### PR DESCRIPTION
## Summary

- Fix parser recovery when call argument list sees `:` followed by a statement-only keyword (e.g. `var`, `let`, `return`).
- Previously the colon branch consumed `:`, ran `parse_type()` on the keyword, and emitted a stray TS1005 at the next non-list-terminator token. Now we detect `is_argument_list_recovery_boundary()` after the spurious `:` and emit TS1135 + break, matching tsc.
- The TS1135 is emitted directly via `parse_error_at_current_token` to bypass the distance-based suppression heuristic, since the previous `:` error sits only two columns away.

## Conformance impact

- **4 tests flip FAIL -> PASS** (Net: 12205 -> 12209), including `labeledStatementDeclarationListInLoopNoCrash3.ts`, which exercises the same recovery path. No regressions.
- `labeledStatementDeclarationListInLoopNoCrash4.ts` (the original target) goes from `only-missing` (5 missing fingerprints + 1 extra fingerprint) to **fingerprint-only** with all four expected error codes (`TS1005`, `TS1134`, `TS1135`, `TS1160`) now present. The remaining diff is parser recovery on a different downstream construct (template literals on line 18 / final `}` position) and is outside this fix's scope.

## Test plan

- [x] `cargo nextest run -p tsz-parser` (683 tests pass)
- [x] `cargo nextest run -p tsz-checker --lib` (2922 tests pass)
- [x] New regression test `test_argument_list_colon_followed_by_var_keyword_emits_ts1135` covers the fix
- [x] Full conformance suite: +4, no regressions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
