### PR TITLE
fix(bench): use tsconfig.flat.bench.json for large-ts-repo to preserve path mappings

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1648,10 +1648,23 @@ ensure_large_ts_repo_fixture() {
     # `tsc/tsgo/tsz --noEmit -p tsconfig.json` exits almost immediately
     # without type-checking anything. Use a flat tsconfig that directly
     # includes all source files for an apples-to-apples measurement.
+    #
+    # Prefer tsconfig.flat.bench.json if the repo ships it: it already
+    # extends tsconfig.base.json which contains the 200+ `paths` mappings
+    # for cross-package @scope/pkg imports. Without those paths, tsc itself
+    # emits resolution errors and the benchmark is skipped.
+    if [ -f "$LARGE_TS_DIR/tsconfig.flat.bench.json" ]; then
+        return
+    fi
     local flat_tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
     if [ ! -f "$flat_tsconfig" ]; then
-        cat > "$flat_tsconfig" << 'FLATEOF'
+        local extends_base=""
+        if [ -f "$LARGE_TS_DIR/tsconfig.base.json" ]; then
+            extends_base='"extends": "./tsconfig.base.json",'
+        fi
+        cat > "$flat_tsconfig" << FLATEOF
 {
+  ${extends_base}
   "compilerOptions": {
     "target": "ES2023",
     "lib": ["ES2024", "esnext.disposable"],
@@ -1684,13 +1697,18 @@ run_large_ts_repo_benchmarks() {
     # Use the flat tsconfig so all source files are included in a single
     # compilation pass. The root tsconfig.json uses project references and
     # completes in milliseconds without actually checking any files.
-    local tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
-    local src_dir="$LARGE_TS_DIR/packages"
-
-    if [ ! -f "$tsconfig" ]; then
-        echo -e "${RED}✗ tsconfig.flat.json not found (ensure_large_ts_repo_fixture should have created it)${NC}"
+    # Prefer tsconfig.flat.bench.json (ships with the repo, extends base
+    # with full path mappings) over our generated tsconfig.flat.json.
+    local tsconfig
+    if [ -f "$LARGE_TS_DIR/tsconfig.flat.bench.json" ]; then
+        tsconfig="$LARGE_TS_DIR/tsconfig.flat.bench.json"
+    elif [ -f "$LARGE_TS_DIR/tsconfig.flat.json" ]; then
+        tsconfig="$LARGE_TS_DIR/tsconfig.flat.json"
+    else
+        echo -e "${RED}✗ No flat tsconfig found (ensure_large_ts_repo_fixture should have created one)${NC}"
         return
     fi
+    local src_dir="$LARGE_TS_DIR/packages"
 
     run_project_benchmark "large-ts-repo" "$tsconfig" "$src_dir"
     echo


### PR DESCRIPTION
## Problem

`ensure_large_ts_repo_fixture` generated `tsconfig.flat.json` with hardcoded compilerOptions but **no `paths` mappings**. large-ts-repo has 234 cross-package path entries like `@shared/core → ./packages/shared/core/src/index.ts` in `tsconfig.base.json`. Without them, tsc fails module resolution on every cross-package import → the benchmark validation step sees `tsc_check != 0` and skips large-ts-repo silently.

## Fix

- `ensure_large_ts_repo_fixture`: if `tsconfig.flat.bench.json` exists in the repo, return immediately (no generation needed).
- `run_large_ts_repo_benchmarks`: prefer `tsconfig.flat.bench.json` over `tsconfig.flat.json`. Fall back gracefully.
- Fallback generator: when creating `tsconfig.flat.json`, inherit `tsconfig.base.json` via `extends` when present.

`tsconfig.flat.bench.json` already ships in large-ts-repo and extends `tsconfig.base.json` with the full path table — tsc and tsgo both pass on it.

## Test plan
- [ ] Next Cloud Build bench run should include large-ts-repo in results
- [ ] Homepage spotlight for large-ts-repo should appear after next GCS publish + site redeploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
