### PR TITLE
fix(bench): survive project-benchmark failures — don't abort before large-ts-repo

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -2887,14 +2887,14 @@ main() {
     run_ts_toolbelt_benchmarks
     run_ts_essentials_benchmarks
     run_utility_types_project_benchmarks
-    run_ts_toolbelt_project_benchmarks
-    run_ts_essentials_project_benchmarks
-    run_rxjs_project_benchmarks
-    run_type_fest_project_benchmarks
-    run_zod_project_benchmarks
-    run_kysely_project_benchmarks
-    run_nextjs_benchmarks
-    run_large_ts_repo_benchmarks
+    run_ts_toolbelt_project_benchmarks || true
+    run_ts_essentials_project_benchmarks || true
+    run_rxjs_project_benchmarks || true
+    run_type_fest_project_benchmarks || true
+    run_zod_project_benchmarks || true
+    run_kysely_project_benchmarks || true
+    run_nextjs_benchmarks || true
+    run_large_ts_repo_benchmarks || true
 
     print_header "Synthetic Benchmarks - Scaling Test"
     


### PR DESCRIPTION
## Problem

The bench suite was terminating after `run_ts_toolbelt_project_benchmarks` crashed (tsc likely OOM on 242 type-level files). With `set -euo pipefail`, the first failure halts the script via EXIT trap before reaching `run_large_ts_repo_benchmarks`. Results for ts-essentials-project, rxjs, type-fest, zod, kysely, and especially **large-ts-repo** were never collected.

## Fix

Wrap each external project runner call in `|| true` at the call site in the main loop. This prevents one fixture's crash from aborting the entire suite.

## Test plan
- [ ] Next Cloud Build bench run survives ts-toolbelt-project crash and continues to large-ts-repo
- [ ] large-ts-repo timing data appears in GCS `latest.json`
- [ ] Homepage spotlight for large-ts-repo appears after next site redeploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
