### PR TITLE
bench: increase large-ts-repo tsz validation timeout to 20× BENCH_TIMEOUT

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -674,7 +674,7 @@ run_project_benchmark() {
     # Very large fixtures (6000+ files) need an even longer timeout.
     local project_timeout
     if [ "$name" = "large-ts-repo" ]; then
-        project_timeout=$((BENCH_TIMEOUT * 5))
+        project_timeout=$((BENCH_TIMEOUT * 20))
     else
         project_timeout=$((BENCH_TIMEOUT * 2))
     fi


### PR DESCRIPTION
## Summary

- Raises the `project_timeout` for `large-ts-repo` from `BENCH_TIMEOUT * 5` (300s) to `BENCH_TIMEOUT * 20` (1200s)
- Previous timeout killed the tsz pre-validation on large-ts-repo (6000+ files), leaving `tsz_ms = null` in the JSON result
- `benchmark_mean_chart.js` requires both `tsz_ms` and `tsgo_ms` to be finite numbers before rendering the homepage spotlight — null tsz_ms means the spotlight silently disappears
- Local testing shows tsz takes > 480s on `tsconfig.flat.bench.json` (still running after 8 min), well above the 300s limit
- The tsc pre-validation timeout stays at 6× (360s) — tsc is significantly faster

## Test plan

- [ ] Cloud Build c3-88 run reaches large-ts-repo and produces valid `tsz_ms` timing
- [ ] `latest.json` in GCS contains `"name": "large-ts-repo"` with finite `tsz_ms` and `tsgo_ms`
- [ ] Homepage spotlight renders at tsz.dev after the next gh-pages deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
