### PR TITLE
fix(emitter,enum-es5): inline namespace-qualified enum constants

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2365,7 +2365,10 @@ export default validate;
         "Expected `export default validate;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default validate;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     assert!(
         trimmed.contains("declare function validate(): void;"),
         "Expected the function declaration to follow: {trimmed}"
@@ -2395,7 +2398,10 @@ export default Test;
         "Expected `export default Test;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default Test;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     let default_pos = trimmed.find("export default Test;").unwrap();
     let decl_pos = trimmed
         .find("declare class Test")
@@ -2417,12 +2423,12 @@ export default validate;
 "#,
     );
     let trimmed = output.trim();
-    let default_pos = trimmed.find("export default validate;").expect(
-        "expected export default validate; in TS output",
-    );
-    let decl_pos = trimmed.find("declare function validate").expect(
-        "expected declare function validate in TS output",
-    );
+    let default_pos = trimmed
+        .find("export default validate;")
+        .expect("expected export default validate; in TS output");
+    let decl_pos = trimmed
+        .find("declare function validate")
+        .expect("expected declare function validate in TS output");
     assert!(
         decl_pos < default_pos,
         "TS files should preserve source order (declaration first): {trimmed}"

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -999,6 +999,25 @@ impl<'a> EnumES5Transformer<'a> {
         }
     }
 
+    /// Build a dotted path from a (possibly nested) property-access expression
+    /// or bare identifier. Used to resolve namespace-qualified enum references
+    /// like `M.N.E1` to a key in `prior_enum_values`.
+    fn build_dotted_path(&self, idx: NodeIndex) -> Option<String> {
+        let node = self.arena.get(idx)?;
+        if node.is_identifier() {
+            let id = self.arena.get_identifier(node)?;
+            return Some(id.escaped_text.to_string());
+        }
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(node)?;
+            let left = self.build_dotted_path(access.expression)?;
+            let right_node = self.arena.get(access.name_or_argument)?;
+            let right_id = self.arena.get_identifier(right_node)?;
+            return Some(format!("{left}.{}", right_id.escaped_text));
+        }
+        None
+    }
+
     /// Try to evaluate a constant expression to its numeric value.
     /// Handles numeric literals, binary/unary expressions, parenthesized expressions,
     /// and references to previously evaluated enum members (both bare identifiers and
@@ -1030,13 +1049,12 @@ impl<'a> EnumES5Transformer<'a> {
             k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 // Resolve E.Member references
                 let access = self.arena.get_access_expr(node)?;
+                let prop_node = self.arena.get(access.name_or_argument)?;
+                let prop_id = self.arena.get_identifier(prop_node)?;
                 let obj_node = self.arena.get(access.expression)?;
                 if obj_node.is_identifier()
                     && let Some(obj_id) = self.arena.get_identifier(obj_node)
                 {
-                    let prop_node = self.arena.get(access.name_or_argument)?;
-                    let prop_id = self.arena.get_identifier(prop_node)?;
-
                     // Same enum self-reference
                     if obj_id.escaped_text == self.current_enum_name
                         && let Some(&val) = self.member_values.get(prop_id.escaped_text.as_str())
@@ -1046,6 +1064,29 @@ impl<'a> EnumES5Transformer<'a> {
                     // Cross-enum reference (Foo.A from within enum Bar)
                     if let Some(enum_vals) =
                         self.prior_enum_values.get(obj_id.escaped_text.as_str())
+                        && let Some(&val) = enum_vals.get(prop_id.escaped_text.as_str())
+                    {
+                        return Some(val);
+                    }
+                    return None;
+                }
+                // Multi-level namespace-qualified reference (e.g. `M.N.E1.a`).
+                // tsc inlines the constant value at emit time so the JS output
+                // does not depend on the namespace IIFE having been evaluated.
+                if obj_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                    && let Some(qualified) = self.build_dotted_path(access.expression)
+                {
+                    // Try the full qualified name first (`M.N.E1`).
+                    if let Some(enum_vals) = self.prior_enum_values.get(&qualified)
+                        && let Some(&val) = enum_vals.get(prop_id.escaped_text.as_str())
+                    {
+                        return Some(val);
+                    }
+                    // Fall back to the trailing segment so simple-name keys
+                    // (`E1` in `prior_enum_values`) still resolve when the
+                    // emitter has not yet recorded a fully-qualified key.
+                    if let Some(last) = qualified.rsplit('.').next()
+                        && let Some(enum_vals) = self.prior_enum_values.get(last)
                         && let Some(&val) = enum_vals.get(prop_id.escaped_text.as_str())
                     {
                         return Some(val);


### PR DESCRIPTION
## Intent

\`enum E2 { b = M.N.E1.a }\` was emitting \`E2[E2[\"b\"] = M.N.E1.a] = \"b\"\`.
tsc inlines the resolved constant — \`E2[E2[\"b\"] = 1] = \"b\"\` — so the output
JS does not depend on the outer namespace IIFE having been initialized.

\`\`\`ts
namespace M {
  export namespace N {
    export enum E1 { a = 1 }
  }
}
namespace M {
  export namespace N {
    export enum E2 { b = M.N.E1.a }   // tsz: M.N.E1.a kept; tsc: 1
  }
}
\`\`\`

## Root cause

\`evaluate_constant_expression\`'s PROPERTY_ACCESS arm only handled
\`Identifier.Identifier\`. For nested namespace paths like \`M.N.E1.a\`, the LHS
of the property access is itself a PROPERTY_ACCESS_EXPRESSION, so the lookup
returned \`None\` and the emitter kept the unresolved expression.

## Fix

Adds \`build_dotted_path\` to walk nested PROPERTY_ACCESS_EXPRESSION chains.
The constant evaluator now tries:

1. Direct \`Identifier.Identifier\` (existing behaviour).
2. Full qualified key (\`M.N.E1\`) against \`prior_enum_values\`.
3. Trailing segment (\`E1\`) as a fallback so callers that record values under
   the bare enum name still resolve.

## Verification

Emit pass rate: 12335 → 12336 JS, 1285 → 1291 DTS (+7 net):

- \`enumBasics3\` (JS — namespace-qualified constant inlining)
- \`declarationEmitShadowingInferNotRenamed\` (DTS)
- \`declFileTypeofFunction\` (DTS)
- \`inferenceOptionalProperties\` / \`inferenceOptionalPropertiesStrict\` (DTS)
- \`jsDeclarationEmitDoesNotRenameImport\` (DTS)
- \`labeledStatementDeclarationListInLoopNoCrash3\` / \`4\` (es2015 DTS)

## Test plan

- [x] \`./scripts/emit/run.sh --filter=enumBasics3\` passes
- [x] Full emit run: +7 net, no regressions
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
