### PR TITLE
fix(checker): emit TS2786 for SFCs returning `undefined` with strictNullChecks

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -577,22 +577,26 @@ impl<'a> CheckerState<'a> {
                 if !is_unresolved(return_type) && !is_valid_null_like_return(return_type) {
                     any_checked = true;
                     if let Some(element_type) = jsx_element_type {
-                        // TSC allows null/undefined in SFC return types
-                        // (e.g., `() => Element | null` is valid).
                         // Strip null/undefined before checking against JSX.Element.
+                        // `() => Element | null` is valid; `() => undefined` is not.
                         let non_null_return = crate::query_boundaries::common::remove_nullish(
                             self.ctx.types,
                             return_type,
                         );
-                        // `never` after stripping nullish means the SFC only
-                        // returns nullish values (or unreachable). tsc treats
-                        // this as a valid JSX return type because `never` is
-                        // assignable to anything (e.g. `function F() { return null!; }`).
-                        // Mirrors the construct-signature handling below and
-                        // `check_jsx_sfc_return_type` (which also early-exits on never).
-                        if non_null_return != TypeId::NEVER
-                            && !self.is_assignable_to(non_null_return, element_type)
-                        {
+                        if non_null_return == TypeId::NEVER {
+                            // Stripping nullish left NEVER. Two cases:
+                            // 1. return_type IS never (unreachable bottom type) → valid.
+                            // 2. return_type was nullish-only (e.g. `undefined`,
+                            //    `null | undefined`) → the pure-null case was already
+                            //    handled by `is_valid_null_like_return` above, so
+                            //    `undefined` is present. With strictNullChecks,
+                            //    `undefined` is not valid JSX (not in JSX.Element | null).
+                            //    Without strictNullChecks, undefined is a subtype of
+                            //    everything, so it is valid JSX → no error.
+                            if return_type != TypeId::NEVER && self.ctx.strict_null_checks() {
+                                all_valid = false;
+                            }
+                        } else if !self.is_assignable_to(non_null_return, element_type) {
                             all_valid = false;
                         }
                     }
@@ -647,7 +651,14 @@ impl<'a> CheckerState<'a> {
                                     ret,
                                 );
                                 if stripped == TypeId::NEVER {
-                                    return true;
+                                    // Same logic as the function-shape path above:
+                                    // never itself is valid; nullish-only (undefined
+                                    // or null|undefined) is invalid with strictNullChecks,
+                                    // but valid without (undefined is a universal subtype).
+                                    if ret == TypeId::NEVER {
+                                        return true;
+                                    }
+                                    return !self.ctx.strict_null_checks();
                                 }
                                 stripped
                             } else {

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -16,6 +16,43 @@ fn check_jsx_codes(source: &str) -> Vec<u32> {
     check_jsx(source).iter().map(|d| d.code).collect()
 }
 
+fn check_jsx_strict(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    use crate::context::CheckerOptions;
+    use tsz_common::checker_options::JsxMode;
+    let opts = CheckerOptions {
+        jsx_mode: JsxMode::Preserve,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.tsx", opts)
+}
+
+fn check_jsx_strict_codes(source: &str) -> Vec<u32> {
+    check_jsx_strict(source).iter().map(|d| d.code).collect()
+}
+
+fn check_jsx_no_strict(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    use crate::context::CheckerOptions;
+    use tsz_common::checker_options::JsxMode;
+    let opts = CheckerOptions {
+        jsx_mode: JsxMode::Preserve,
+        strict: false,
+        strict_null_checks: false,
+        strict_function_types: false,
+        strict_property_initialization: false,
+        no_implicit_any: false,
+        no_implicit_this: false,
+        use_unknown_in_catch_variables: false,
+        strict_builtin_iterator_return: false,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.tsx", opts)
+}
+
+fn check_jsx_no_strict_codes(source: &str) -> Vec<u32> {
+    check_jsx_no_strict(source).iter().map(|d| d.code).collect()
+}
+
 /// JSX shorthand boolean attribute (`<Foo bar />`) typed as `true` for assignability.
 /// When prop expects literal `true`, shorthand must be assignable (no false positive).
 #[test]
@@ -404,6 +441,69 @@ fn jsx_sfc_returning_never_no_ts2786() {
     assert!(
         !diagnostics.contains(&2786),
         "SFC returning never (bottom type) should not emit TS2786, got: {diagnostics:?}"
+    );
+}
+
+/// TS2786 SHOULD fire with strictNullChecks for an SFC returning `undefined`
+/// (arrow function form). `undefined` is not assignable to `JSX.Element | null`.
+/// Mirrors `tsxSfcReturnUndefinedStrictNullChecks.tsx`.
+#[test]
+fn jsx_sfc_returning_undefined_strict_null_checks_emits_ts2786() {
+    let diagnostics = check_jsx_strict_codes(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface IntrinsicElements { }
+        }
+        const Foo = (props: any) => undefined;
+        <Foo />;
+        "#,
+    );
+    assert!(
+        diagnostics.contains(&2786),
+        "SFC returning undefined with strictNullChecks should emit TS2786, got: {diagnostics:?}"
+    );
+}
+
+/// TS2786 SHOULD fire with strictNullChecks for an SFC whose body returns `undefined`
+/// (function declaration form).
+#[test]
+fn jsx_sfc_function_body_returning_undefined_strict_null_checks_emits_ts2786() {
+    let diagnostics = check_jsx_strict_codes(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface IntrinsicElements { }
+        }
+        function Greet(x: { name?: string }) {
+            return undefined;
+        }
+        <Greet />;
+        "#,
+    );
+    assert!(
+        diagnostics.contains(&2786),
+        "SFC returning undefined (function body) with strictNullChecks should emit TS2786, got: {diagnostics:?}"
+    );
+}
+
+/// TS2786 should NOT fire without strictNullChecks for an SFC returning `undefined`
+/// (undefined is a subtype of every type without strict null checks).
+#[test]
+fn jsx_sfc_returning_undefined_no_strict_null_checks_no_ts2786() {
+    let diagnostics = check_jsx_no_strict_codes(
+        r#"
+        declare namespace JSX {
+            interface Element { }
+            interface IntrinsicElements { }
+        }
+        const Foo = (props: any) => undefined;
+        <Foo />;
+        "#,
+    );
+    assert!(
+        !diagnostics.contains(&2786),
+        "SFC returning undefined without strictNullChecks should not emit TS2786, got: {diagnostics:?}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -1267,10 +1267,7 @@ function f1() {
         ts2556.is_empty(),
         "Expected no TS2556 for array literal spread (length is statically \
          known and elements are checked individually), got: {:?}",
-        ts2556
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2556.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
 

--- a/docs/plan/claims/claude-exciting-keller-CLt8T.md
+++ b/docs/plan/claims/claude-exciting-keller-CLt8T.md
@@ -1,0 +1,30 @@
+# fix(checker): emit TS2786 for SFCs returning `undefined` with strictNullChecks
+
+- **Date**: 2026-04-26
+- **Branch**: `claude/exciting-keller-CLt8T`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+`check_jsx_component_return_type` in `crates/tsz-checker/src/checkers/jsx/extraction.rs`
+stripped null/undefined from the SFC return type before checking against `JSX.Element`.
+When the return type was purely nullish (e.g. `undefined`), stripping left `NEVER`, which
+was treated as "unreachable → valid". The fix distinguishes NEVER-from-stripping (invalid
+with strictNullChecks) from NEVER-as-the-actual-type (valid bottom type). Same fix applied
+to the call-signatures path.
+
+Root cause: `undefined` is not a valid JSX component return type with `strictNullChecks: true`.
+
+## Files Touched
+
+- `crates/tsz-checker/src/checkers/jsx/extraction.rs` (SFC and call-sig NEVER guard)
+- `crates/tsz-checker/src/checkers/jsx/tests.rs` (3 new tests + 2 helper fns)
+
+## Verification
+
+- `cargo test --package tsz-checker --lib -- jsx`: 204/204 pass
+- `cargo test --package tsz-checker --lib`: 2925/2925 pass
+- `./scripts/conformance/conformance.sh run --filter tsxSfcReturnUndefinedStrictNullChecks`: 1/1 PASS
+- Full conformance: 12210/12582 (97.0%) — net +5 vs baseline 12205, 8 improvements, 0 regressions


### PR DESCRIPTION
$(cat <<'EOF'
## Root cause

`check_jsx_component_return_type` in `crates/tsz-checker/src/checkers/jsx/extraction.rs` stripped `null | undefined` from the SFC return type before checking it against `JSX.Element`. When the return type was purely nullish (e.g. `undefined`), stripping left `NEVER`, which was then treated as "unreachable → valid" regardless of whether the original type was the bottom `never` type or `undefined`.

With `strictNullChecks: true`, returning `undefined` from a function component is invalid JSX — `undefined` is not assignable to `JSX.Element | null`.

## Fix

When `remove_nullish(return_type) == NEVER`, distinguish two cases:

1. `return_type IS never` (unreachable/bottom type) → valid JSX, skip  
2. `return_type was nullish-only` (`undefined` or `null | undefined`) →  
   - **With `strictNullChecks`**: invalid JSX — mark `all_valid = false`  
   - **Without `strictNullChecks`**: `undefined` is a universal subtype → valid, skip

Same fix applied to the call-signatures path (for component types without a function shape but with call signatures).

## Minimal repro

```ts
// @strictNullChecks: true
const Foo = (props: any) => undefined;
function Greet(x: {name?: string}) { return undefined; }

// Error
const foo = <Foo />;   // TS2786: 'Foo' cannot be used as a JSX component.
const G = <Greet />;   // TS2786: 'Greet' cannot be used as a JSX component.
```

## Tests added

Three new unit tests in `crates/tsz-checker/src/checkers/jsx/tests.rs`:

- `jsx_sfc_returning_undefined_strict_null_checks_emits_ts2786` — arrow-fn form
- `jsx_sfc_function_body_returning_undefined_strict_null_checks_emits_ts2786` — function-body form
- `jsx_sfc_returning_undefined_no_strict_null_checks_no_ts2786` — regression guard (no strict → no error)

## Verification

- `cargo test --package tsz-checker --lib -- jsx`: **204/204 pass**
- `cargo test --package tsz-checker --lib`: **2925/2925 pass**
- Targeted: `tsxSfcReturnUndefinedStrictNullChecks.tsx` flips **PASS**
- Full suite: **12210/12582 (97.0%)** — net **+5** vs baseline 12205, **8 improvements**, **0 regressions**

https://claude.ai/code/session_01W5Mw7yRvYfdqBhCW1SNSby
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5Mw7yRvYfdqBhCW1SNSby)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
