### PR TITLE
fix(emitter): treat instantiated declare-namespace as runtime for export=

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2365,7 +2365,10 @@ export default validate;
         "Expected `export default validate;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default validate;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     assert!(
         trimmed.contains("declare function validate(): void;"),
         "Expected the function declaration to follow: {trimmed}"
@@ -2395,7 +2398,10 @@ export default Test;
         "Expected `export default Test;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default Test;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     let default_pos = trimmed.find("export default Test;").unwrap();
     let decl_pos = trimmed
         .find("declare class Test")
@@ -2417,12 +2423,12 @@ export default validate;
 "#,
     );
     let trimmed = output.trim();
-    let default_pos = trimmed.find("export default validate;").expect(
-        "expected export default validate; in TS output",
-    );
-    let decl_pos = trimmed.find("declare function validate").expect(
-        "expected declare function validate in TS output",
-    );
+    let default_pos = trimmed
+        .find("export default validate;")
+        .expect("expected export default validate; in TS output");
+    let decl_pos = trimmed
+        .find("declare function validate")
+        .expect("expected declare function validate in TS output");
     assert!(
         decl_pos < default_pos,
         "TS files should preserve source order (declaration first): {trimmed}"

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1355,15 +1355,15 @@ impl<'a> Printer<'a> {
                     }) =>
                 {
                     // Namespace `X` matches the export-equals identifier.
-                    // Distinguish runtime vs type-only:
-                    // - `declare namespace X` is always type-only at JS emit (ambient).
-                    // - `namespace X { ...types only... }` is type-only (non-instantiated).
-                    // - `namespace X { ...values... }` is runtime (instantiated IIFE).
+                    // Distinguish runtime vs type-only by inspecting the body:
+                    // - `namespace X { ...values... }` (with or without `declare`) is
+                    //   runtime — `declare namespace X { var a }` declares X as a
+                    //   value reference, so `export = X` must lower to
+                    //   `module.exports = X` like any other value export.
+                    // - `namespace X { ...types only... }` and empty namespaces are
+                    //   type-only.
                     if let Some(module_decl) = self.arena.get_module(stmt_node) {
-                        let is_declare = self
-                            .arena
-                            .has_modifier(&module_decl.modifiers, SyntaxKind::DeclareKeyword);
-                        if !is_declare && self.is_instantiated_module(module_decl.body) {
+                        if self.is_instantiated_module(module_decl.body) {
                             matched_runtime = true;
                         } else {
                             matched_type = true;


### PR DESCRIPTION
## Intent

\`declare namespace M1 { export var a; export function b(); }\` declares M1 as
a runtime value — \`export = M1\` should lower to \`module.exports = M1\` like
any other runtime export. tsz was treating *any* \`declare\` namespace as
type-only and eliding the export.

\`\`\`ts
// foo1.ts
declare namespace M1 {
    export var a: string;
    export function b(): number;
}
export = M1;
// tsc:  module.exports = M1;
// tsz (before): Object.defineProperty(exports, \"__esModule\", { value: true });
// tsz (after):  module.exports = M1;
\`\`\`

## Fix

\`export_assignment_identifier_is_type_only\` now decides purely from
\`is_instantiated_module(body)\` for namespaces — the body's runtime
declarations (var, function, class, instantiated nested namespace) make
M1 a runtime value, regardless of whether M1 itself was declared \`declare\`.

## Verification

Emit pass rate: 12335 → 12337 JS (+2):

- \`exportDeclaredModule\` (was +1/-1)
- \`declarationFileNoCrashOnExtraExportModifier\` (was +2/-1)

DTS unchanged. No JS-emit regressions; no unit-test regressions.

## Test plan

- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
