### PR TITLE
[WIP] fix(solver): combined-signature approach for union construct signatures

### DIFF
--- a/crates/tsz-checker/src/tests/call_architecture_tests.rs
+++ b/crates/tsz-checker/src/tests/call_architecture_tests.rs
@@ -1267,10 +1267,7 @@ function f1() {
         ts2556.is_empty(),
         "Expected no TS2556 for array literal spread (length is statically \
          known and elements are checked individually), got: {:?}",
-        ts2556
-            .iter()
-            .map(|d| &d.message_text)
-            .collect::<Vec<_>>()
+        ts2556.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
 

--- a/crates/tsz-solver/src/operations/constructors.rs
+++ b/crates/tsz-solver/src/operations/constructors.rs
@@ -306,11 +306,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
     /// Resolve a `new` expression on a union type.
     ///
-    /// For unions, ALL members must be constructable (stricter than function calls).
-    /// If all members succeed, returns a union of their instance types.
+    /// Uses the same three-phase approach as `resolve_union_call`:
     ///
-    /// Example: `typeof A | typeof B` where both A and B are concrete classes
-    /// - `new (typeof A | typeof B)()` succeeds and returns `A | B`
+    /// Phase 1: Arity check against the combined signature (max of all members'
+    ///          required counts, intersection of param types, union of return types).
+    /// Phase 2: Per-member resolution to collect actual return types.
+    /// Phase 3: Validate arg types against the combined (intersected) param types.
+    ///
+    /// When no combined signature exists (any member has multiple/generic construct
+    /// signatures), falls back to strict per-member semantics: ALL members must
+    /// succeed for the union to succeed.
     fn resolve_union_new(
         &mut self,
         union_type: TypeId,
@@ -319,12 +324,32 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     ) -> CallResult {
         let members = self.interner.type_list(list_id);
 
-        // Pre-compute the combined construct return type from union members'
-        // construct signatures (mirrors try_compute_combined_union_signature
-        // for the call path). This is used as fallback_return when all members
-        // fail with ArgumentTypeMismatch but have identical param types.
-        let combined_construct_return = self.compute_combined_construct_return(&members);
+        // Compute a combined construct signature when all members have exactly one
+        // non-generic construct signature. Intersects param types (contravariant)
+        // and unions return types.
+        let combined = self.try_compute_combined_union_construct_signature(&members);
 
+        // Phase 1: Argument count validation using combined signature.
+        if let Some(ref combined) = combined {
+            if arg_types.len() < combined.min_required {
+                return CallResult::ArgumentCountMismatch {
+                    expected_min: combined.min_required,
+                    expected_max: combined.max_allowed,
+                    actual: arg_types.len(),
+                };
+            }
+            if let Some(max) = combined.max_allowed
+                && arg_types.len() > max
+            {
+                return CallResult::ArgumentCountMismatch {
+                    expected_min: combined.min_required,
+                    expected_max: combined.max_allowed,
+                    actual: arg_types.len(),
+                };
+            }
+        }
+
+        // Phase 2: Per-member resolution to collect return types and failures.
         let mut return_types = Vec::new();
         let mut failures = Vec::new();
 
@@ -334,11 +359,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     return_types.push(ret);
                 }
                 CallResult::NotCallable { .. } => {
-                    // Skip non-constructable union members. tsc filters union
-                    // members to those with construct signatures rather than
-                    // failing the entire `new` expression when any member lacks one.
-                    // e.g. `new x` where `x: { a: string } | (new (a: string) => void)`
-                    // should succeed using the constructable member.
+                    if combined.is_some() {
+                        // Combined signature guarantees each member has a construct
+                        // signature; NotCallable is unexpected — treat as full failure.
+                        return CallResult::NotCallable {
+                            type_id: union_type,
+                        };
+                    }
+                    // When no combined signature, skip non-constructable members.
                 }
                 err => {
                     failures.push(err);
@@ -346,104 +374,90 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
-        // If any members succeeded, return a union of their return types
+        // Phase 3 (combined path): validate arg types against intersected param types.
+        if let Some(ref combined) = combined {
+            // When all members succeeded, return the union of their return types.
+            if failures.is_empty() {
+                let return_type = if return_types.len() == 1 {
+                    return_types[0]
+                } else {
+                    self.interner.union(return_types)
+                };
+                return CallResult::Success(return_type);
+            }
+
+            // Validate each arg against the combined (intersected) parameter type.
+            for (i, &arg_type) in arg_types.iter().enumerate() {
+                if i < combined.param_types.len() {
+                    let param_type = combined.param_types[i];
+                    if !self.checker.is_assignable_to(arg_type, param_type) {
+                        return CallResult::ArgumentTypeMismatch {
+                            index: i,
+                            expected: param_type,
+                            actual: arg_type,
+                            fallback_return: combined.return_type,
+                        };
+                    }
+                }
+            }
+
+            // All arg types passed; handle arity-only failures from per-member resolution.
+            // (Can happen when a member has fewer params than the combined max allows.)
+            let all_failures_are_arity = !failures.is_empty()
+                && failures
+                    .iter()
+                    .all(|f| matches!(f, CallResult::ArgumentCountMismatch { .. }));
+
+            if all_failures_are_arity && !return_types.is_empty() {
+                // Some members succeeded, some failed on arity alone — combined
+                // arity check passed, so the call is valid.
+                return CallResult::Success(combined.return_type);
+            }
+
+            if all_failures_are_arity || failures.is_empty() {
+                return CallResult::Success(combined.return_type);
+            }
+
+            // Mixed failures — propagate first failure.
+            return failures
+                .into_iter()
+                .next()
+                .unwrap_or(CallResult::NotCallable {
+                    type_id: union_type,
+                });
+        }
+
+        // No combined signature — strict per-member semantics: ALL members must succeed.
         if !return_types.is_empty() {
-            if return_types.len() == 1 {
-                return CallResult::Success(return_types[0]);
-            }
-            // Return a union of all return types
-            let union_result = self.interner.union(return_types);
-            CallResult::Success(union_result)
-        } else if !failures.is_empty() {
-            // If all failures are ArgumentTypeMismatch, aggregate like build_union_call_result:
-            // intersect parameter types and use the combined construct return.
-            let all_arg_mismatches = failures
-                .iter()
-                .all(|f| matches!(f, CallResult::ArgumentTypeMismatch { .. }));
-
-            if all_arg_mismatches {
-                let mut param_types = Vec::new();
-                let mut actual_arg = TypeId::ERROR;
-                for failure in &failures {
-                    if let CallResult::ArgumentTypeMismatch {
-                        expected, actual, ..
-                    } = failure
-                    {
-                        param_types.push(*expected);
-                        actual_arg = *actual;
-                    }
-                }
-                let intersected_param = if param_types.len() == 1 {
-                    param_types[0]
+            if failures.is_empty() {
+                let return_type = if return_types.len() == 1 {
+                    return_types[0]
                 } else {
-                    let mut result = param_types[0];
-                    for &pt in &param_types[1..] {
-                        result = self.interner.intersection2(result, pt);
-                    }
-                    result
+                    self.interner.union(return_types)
                 };
-                // Only use the combined return when all union members expected
-                // the same parameter type (same guard as build_union_call_result).
-                let all_same_param = param_types.windows(2).all(|w| w[0] == w[1]);
-                let combined_return = if all_same_param {
-                    combined_construct_return.unwrap_or(TypeId::ERROR)
-                } else {
-                    TypeId::ERROR
-                };
-                CallResult::ArgumentTypeMismatch {
-                    index: 0,
-                    expected: intersected_param,
-                    actual: actual_arg,
-                    fallback_return: combined_return,
-                }
-            } else {
-                failures
-                    .into_iter()
-                    .next()
-                    .expect("failures is non-empty when no constituent is callable")
+                return CallResult::Success(return_type);
             }
-        } else {
-            CallResult::NotCallable {
-                type_id: union_type,
-            }
+            // Some members failed — propagate first failure.
+            return failures
+                .into_iter()
+                .next()
+                .unwrap_or(CallResult::NotCallable {
+                    type_id: union_type,
+                });
         }
-    }
 
-    /// Compute the combined construct return type for a union of constructors.
-    ///
-    /// Extracts construct signatures from each union member and returns the
-    /// union of their return types. This mirrors `try_compute_combined_union_signature`
-    /// for the call path but only computes the return type (not params/arity).
-    fn compute_combined_construct_return(&self, members: &[TypeId]) -> Option<TypeId> {
-        let mut return_types = Vec::new();
-        for &member in members {
-            match self.interner.lookup(member) {
-                Some(TypeData::Callable(callable_id)) => {
-                    let callable = self.interner.callable_shape(callable_id);
-                    if callable.construct_signatures.len() == 1 {
-                        return_types.push(callable.construct_signatures[0].return_type);
-                    } else if !callable.construct_signatures.is_empty() {
-                        // Multiple construct overloads — use first (conservative)
-                        return_types.push(callable.construct_signatures[0].return_type);
-                    } else {
-                        return None; // member has no construct signature
-                    }
-                }
-                Some(TypeData::Function(func_id)) => {
-                    let func = self.interner.function_shape(func_id);
-                    if func.is_constructor {
-                        return_types.push(func.return_type);
-                    } else {
-                        return None;
-                    }
-                }
-                _ => return None,
-            }
+        if !failures.is_empty() {
+            return failures
+                .into_iter()
+                .next()
+                .unwrap_or(CallResult::NotCallable {
+                    type_id: union_type,
+                });
         }
-        if return_types.is_empty() {
-            return None;
+
+        CallResult::NotCallable {
+            type_id: union_type,
         }
-        Some(self.interner.union(return_types))
     }
 
     /// Resolve a `new` expression on an intersection type.

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -231,15 +231,15 @@ pub(super) enum UnionCallSignatureCompatibility {
 ///   → combined: (a: number & boolean): string | Date
 ///              = (a: never): string | Date
 /// ```
-pub(super) struct CombinedUnionSignature {
+pub(crate) struct CombinedUnionSignature {
     /// Intersected parameter types at each position
-    pub(super) param_types: Vec<TypeId>,
+    pub(crate) param_types: Vec<TypeId>,
     /// Minimum required arguments (max of all members' required counts)
-    pub(super) min_required: usize,
+    pub(crate) min_required: usize,
     /// Maximum allowed arguments (None if unbounded / has rest)
-    pub(super) max_allowed: Option<usize>,
+    pub(crate) max_allowed: Option<usize>,
     /// Unioned return type from all members
-    pub(super) return_type: TypeId,
+    pub(crate) return_type: TypeId,
 }
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -518,6 +518,163 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         })
     }
 
+    /// Compute the combined union signature for a union of construct signatures.
+    ///
+    /// Mirrors `try_compute_combined_union_signature` but uses `construct_signatures`
+    /// instead of `call_signatures`. Returns `None` if any member has no (or multiple)
+    /// construct signatures or if any is generic.
+    pub(crate) fn try_compute_combined_union_construct_signature(
+        &mut self,
+        members: &[TypeId],
+    ) -> Option<CombinedUnionSignature> {
+        if members.is_empty() {
+            return None;
+        }
+
+        // Collect single construct signatures from each member: (params, return_type, has_rest)
+        let mut all_signatures: Vec<(Vec<ParamInfo>, TypeId, bool)> = Vec::new();
+
+        for &member in members {
+            let member = self.normalize_union_member(member);
+            match self.interner.lookup(member) {
+                Some(TypeData::Callable(callable_id)) => {
+                    let callable = self.interner.callable_shape(callable_id);
+                    if callable.construct_signatures.len() != 1 {
+                        return None; // 0 or multiple overloads — no combined
+                    }
+                    let sig = &callable.construct_signatures[0];
+                    if !sig.type_params.is_empty() {
+                        return None;
+                    }
+                    let params = self.normalize_union_signature_params(&sig.params);
+                    let has_rest = params.iter().any(|p| p.rest);
+                    all_signatures.push((params, sig.return_type, has_rest));
+                }
+                _ => return None, // not a constructable type with a single signature
+            }
+        }
+
+        if all_signatures.is_empty() {
+            return None;
+        }
+
+        let max_param_count = all_signatures
+            .iter()
+            .map(|(params, _, _)| params.len())
+            .max()
+            .unwrap_or(0);
+
+        let mut combined_params = Vec::new();
+        let mut min_required = 0;
+
+        for i in 0..max_param_count {
+            let mut param_types_at_pos = Vec::new();
+            let mut any_required = false;
+
+            for (params, _, has_rest) in &all_signatures {
+                if i < params.len() {
+                    let param = &params[i];
+                    if param.rest {
+                        if let Some(elem) = crate::type_queries::get_array_element_type(
+                            self.interner,
+                            param.type_id,
+                        ) {
+                            param_types_at_pos.push(elem);
+                        } else {
+                            return None;
+                        }
+                    } else {
+                        // Strip `| undefined` that the binder may add for optional
+                        // params (`b?: number` → type_id = `number | undefined`).
+                        // The combined param type should be the raw type (`number`)
+                        // so that error messages say "not assignable to 'number'"
+                        // rather than "not assignable to 'number | undefined'".
+                        let type_id = if param.optional {
+                            crate::narrowing::utils::remove_undefined(self.interner, param.type_id)
+                        } else {
+                            param.type_id
+                        };
+                        param_types_at_pos.push(type_id);
+                    }
+                    if param.is_required() {
+                        any_required = true;
+                    }
+                } else if *has_rest
+                    && let Some(rest_param) = params.last().filter(|p| p.rest)
+                    && let Some(elem) = crate::type_queries::get_array_element_type(
+                        self.interner,
+                        rest_param.type_id,
+                    )
+                {
+                    param_types_at_pos.push(elem);
+                }
+            }
+
+            let combined_type = if param_types_at_pos.len() == 1 {
+                param_types_at_pos[0]
+            } else if param_types_at_pos.is_empty() {
+                continue;
+            } else {
+                let mut result = param_types_at_pos[0];
+                for &pt in &param_types_at_pos[1..] {
+                    result = self.interner.intersection2(result, pt);
+                }
+                result
+            };
+
+            combined_params.push(combined_type);
+
+            if any_required {
+                min_required = i + 1;
+            }
+        }
+
+        let max_allowed = {
+            let member_mins: Vec<usize> = all_signatures
+                .iter()
+                .map(|(params, _, _)| {
+                    params
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, p)| p.is_required() && !p.rest)
+                        .map(|(i, _)| i + 1)
+                        .max()
+                        .unwrap_or(0)
+                })
+                .collect();
+
+            let max_min = *member_mins.iter().max().unwrap_or(&0);
+
+            let base_has_rest = all_signatures
+                .iter()
+                .zip(member_mins.iter())
+                .any(|((_, _, has_rest), &m_min)| m_min == max_min && *has_rest);
+            let base_max_params = all_signatures
+                .iter()
+                .zip(member_mins.iter())
+                .filter(|&(_, &m_min)| m_min == max_min)
+                .map(|((params, _, _), _)| params.len())
+                .max()
+                .unwrap_or(0);
+
+            if base_has_rest {
+                None
+            } else {
+                Some(base_max_params)
+            }
+        };
+
+        let return_types: Vec<TypeId> = all_signatures.iter().map(|(_, ret, _)| *ret).collect();
+        let return_type = self.interner.union(return_types);
+
+        Some(CombinedUnionSignature {
+            param_types: combined_params,
+            min_required,
+            max_allowed,
+            return_type,
+        })
+    }
+
     fn build_union_call_result(
         &self,
         union_type: TypeId,

--- a/crates/tsz-solver/tests/operations_tests.rs
+++ b/crates/tsz-solver/tests/operations_tests.rs
@@ -11817,3 +11817,237 @@ fn test_union_call_mixed_overloads_compatible_this_callable() {
          should be callable when `this` types match. Got: {result:?}"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// resolve_union_new — combined construct-signature tests
+// These lock the Phase 1/2/3 algorithm used by resolve_union_new.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Helper: build a one-construct-signature Callable type.
+#[cfg(test)]
+fn make_construct_callable(
+    interner: &TypeInterner,
+    params: Vec<ParamInfo>,
+    return_type: TypeId,
+) -> TypeId {
+    interner.callable(CallableShape {
+        construct_signatures: vec![CallSignature {
+            type_params: vec![],
+            params,
+            this_type: None,
+            return_type,
+            type_predicate: None,
+            is_method: false,
+        }],
+        ..Default::default()
+    })
+}
+
+#[test]
+fn test_union_new_different_param_types_rejects_any_arg() {
+    // { new(a: number): number } | { new(a: string): Date }
+    // Combined param type = number & string = never → every arg fails.
+    let interner = TypeInterner::new();
+    let num_param = ParamInfo {
+        name: None,
+        type_id: TypeId::NUMBER,
+        optional: false,
+        rest: false,
+    };
+    let str_param = ParamInfo {
+        name: None,
+        type_id: TypeId::STRING,
+        optional: false,
+        rest: false,
+    };
+    let m1 = make_construct_callable(&interner, vec![num_param], TypeId::NUMBER);
+    let m2 = make_construct_callable(&interner, vec![str_param], TypeId::STRING);
+    let union_type = interner.union(vec![m1, m2]);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    // Passing `10` (number) should fail with AtM { expected: never }
+    let result = evaluator.resolve_new(union_type, &[TypeId::NUMBER]);
+    assert!(
+        matches!(
+            result,
+            CallResult::ArgumentTypeMismatch {
+                index: 0,
+                expected,
+                ..
+            } if expected == TypeId::NEVER
+        ),
+        "union new with incompatible param types should report AtM(never). Got: {result:?}"
+    );
+
+    // Passing `"hello"` (string) should also fail with AtM { expected: never }
+    let result2 = evaluator.resolve_new(union_type, &[TypeId::STRING]);
+    assert!(
+        matches!(
+            result2,
+            CallResult::ArgumentTypeMismatch {
+                index: 0,
+                expected,
+                ..
+            } if expected == TypeId::NEVER
+        ),
+        "union new with incompatible param types should report AtM(never). Got: {result2:?}"
+    );
+}
+
+#[test]
+fn test_union_new_different_param_counts_requires_max_args() {
+    // { new(a: string): string } | { new(a: string, b: number): number }
+    // Combined min_required = 2 (max of 1 and 2).
+    let interner = TypeInterner::new();
+    let str_param = || ParamInfo {
+        name: None,
+        type_id: TypeId::STRING,
+        optional: false,
+        rest: false,
+    };
+    let num_param = ParamInfo {
+        name: None,
+        type_id: TypeId::NUMBER,
+        optional: false,
+        rest: false,
+    };
+    let m1 = make_construct_callable(&interner, vec![str_param()], TypeId::STRING);
+    let m2 = make_construct_callable(&interner, vec![str_param(), num_param], TypeId::NUMBER);
+    let union_type = interner.union(vec![m1, m2]);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    // 0 args → arity error: expected_min = 2
+    let result = evaluator.resolve_new(union_type, &[]);
+    assert!(
+        matches!(
+            result,
+            CallResult::ArgumentCountMismatch {
+                expected_min: 2,
+                expected_max: Some(2),
+                actual: 0
+            }
+        ),
+        "0 args should require expected_min=2. Got: {result:?}"
+    );
+
+    // 1 arg → arity error: expected_min = 2
+    let result = evaluator.resolve_new(union_type, &[TypeId::STRING]);
+    assert!(
+        matches!(
+            result,
+            CallResult::ArgumentCountMismatch {
+                expected_min: 2,
+                ..
+            }
+        ),
+        "1 arg should still fail (min=2). Got: {result:?}"
+    );
+
+    // 2 args → success
+    let result = evaluator.resolve_new(union_type, &[TypeId::STRING, TypeId::NUMBER]);
+    assert!(
+        matches!(result, CallResult::Success(_)),
+        "2 args should succeed. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_union_new_same_return_types_correct_union() {
+    // { new(a: number): string } | { new(a: number): number }
+    // Combined: param = number, return = string | number.
+    let interner = TypeInterner::new();
+    let num_param = || ParamInfo {
+        name: None,
+        type_id: TypeId::NUMBER,
+        optional: false,
+        rest: false,
+    };
+    let m1 = make_construct_callable(&interner, vec![num_param()], TypeId::STRING);
+    let m2 = make_construct_callable(&interner, vec![num_param()], TypeId::NUMBER);
+    let union_type = interner.union(vec![m1, m2]);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let result = evaluator.resolve_new(union_type, &[TypeId::NUMBER]);
+    assert!(
+        matches!(result, CallResult::Success(_)),
+        "compatible construct sigs should succeed. Got: {result:?}"
+    );
+
+    // Wrong arg type → AtM at index 0
+    let result = evaluator.resolve_new(union_type, &[TypeId::STRING]);
+    assert!(
+        matches!(result, CallResult::ArgumentTypeMismatch { index: 0, .. }),
+        "wrong arg type should give AtM at index 0. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_union_new_all_fail_requires_all_member_success() {
+    // { new(a: number): number } | { new(a: number): Date; new(a: string): boolean }
+    // Member 2 has multiple construct sigs → combined = None → strict per-member.
+    // If member 1 fails (string arg), whole union fails.
+    let interner = TypeInterner::new();
+    let num_param = || ParamInfo {
+        name: None,
+        type_id: TypeId::NUMBER,
+        optional: false,
+        rest: false,
+    };
+    let str_param = ParamInfo {
+        name: None,
+        type_id: TypeId::STRING,
+        optional: false,
+        rest: false,
+    };
+
+    let m1 = make_construct_callable(&interner, vec![num_param()], TypeId::NUMBER);
+
+    // member2 has TWO construct signatures
+    let m2 = interner.callable(CallableShape {
+        construct_signatures: vec![
+            CallSignature {
+                type_params: vec![],
+                params: vec![num_param()],
+                this_type: None,
+                return_type: TypeId::NUMBER,
+                type_predicate: None,
+                is_method: false,
+            },
+            CallSignature {
+                type_params: vec![],
+                params: vec![str_param],
+                this_type: None,
+                return_type: TypeId::BOOLEAN,
+                type_predicate: None,
+                is_method: false,
+            },
+        ],
+        ..Default::default()
+    });
+
+    let union_type = interner.union(vec![m1, m2]);
+
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    // `10` (number) → member1 succeeds, member2 succeeds (first overload) → union succeeds
+    let result = evaluator.resolve_new(union_type, &[TypeId::NUMBER]);
+    assert!(
+        matches!(result, CallResult::Success(_)),
+        "number arg where both members can construct should succeed. Got: {result:?}"
+    );
+
+    // `"hello"` (string) → member1 fails, member2 succeeds (second overload)
+    // Strict semantics: member1 fails → whole union fails.
+    let result = evaluator.resolve_new(union_type, &[TypeId::STRING]);
+    assert!(
+        !matches!(result, CallResult::Success(_)),
+        "string arg where member1 fails should fail the union. Got: {result:?}"
+    );
+}

--- a/docs/plan/claims/claude-exciting-keller-6PLSu.md
+++ b/docs/plan/claims/claude-exciting-keller-6PLSu.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-04-26
 - **Branch**: `claude/exciting-keller-6PLSu`
-- **PR**: TBD
+- **PR**: #1520
 - **Status**: ready
 - **Workstream**: Conformance — fingerprint parity
 

--- a/docs/plan/claims/claude-exciting-keller-6PLSu.md
+++ b/docs/plan/claims/claude-exciting-keller-6PLSu.md
@@ -1,0 +1,49 @@
+# fix(solver): combined-signature approach for union construct signatures
+
+- **Date**: 2026-04-26
+- **Branch**: `claude/exciting-keller-6PLSu`
+- **PR**: TBD
+- **Status**: ready
+- **Workstream**: Conformance — fingerprint parity
+
+## Intent
+
+`resolve_union_new` previously returned Success if ANY union member's construct
+signature accepted the arguments. TypeScript requires ALL members to succeed
+(strict semantics), validated through a "combined union signature" that
+intersects parameter types (contravariant) and unions return types.
+
+The fix mirrors the Phase 1/2/3 approach already used by `resolve_union_call`:
+
+- Phase 1: arity check against combined.min\_required / combined.max\_allowed
+  (max of all members' required arg counts, respecting rest params)
+- Phase 2: per-member resolution to collect return types
+- Phase 3: validate each arg against combined.param\_types (intersected across
+  members), reporting the correct arg index and raw expected type
+
+Also adds `try_compute_combined_union_construct_signature` (mirrors the call
+version) and strips `| undefined` from optional params before intersection so
+error messages show the raw type (`number`, not `number | undefined`).
+
+Fixes `unionTypeConstructSignatures.ts` from fingerprint-only failure to 100%
+pass, resolving 15 missing fingerprints and 8 spurious extra fingerprints
+(wrong arg index, wrong expected type, wrong arg count messages).
+
+## Files Touched
+
+- `crates/tsz-solver/src/operations/core/call_evaluator.rs` — promote
+  `CombinedUnionSignature` from `pub(super)` to `pub(crate)`
+- `crates/tsz-solver/src/operations/core/call_resolution.rs` — add
+  `try_compute_combined_union_construct_signature` (~130 LOC)
+- `crates/tsz-solver/src/operations/constructors.rs` — rewrite
+  `resolve_union_new` with Phase 1/2/3 approach; remove
+  `compute_combined_construct_return` helper (~120 LOC change)
+- `crates/tsz-solver/tests/operations_tests.rs` — 4 new unit tests
+
+## Verification
+
+- `cargo test -p tsz-solver --lib -- test_union_new` (4 tests pass)
+- `cargo test -p tsz-solver --lib` (5529 tests pass)
+- `conformance --filter unionTypeConstructSignatures`: 1/1 pass (was 0/1)
+- `conformance --filter unionType`: 26/30 (was 25/30)
+- `conformance --filter construct`: 112/113 (no regression)


### PR DESCRIPTION
## Summary

- `resolve_union_new` previously returned Success if ANY union member's construct signature accepted the arguments. TypeScript requires ALL members to succeed, validated through a combined union signature that intersects parameter types (contravariant) and unions return types.
- Mirrors the Phase 1/2/3 approach already used by `resolve_union_call`: arity check → per-member resolution → arg type validation against combined param types.
- Strips `| undefined` from optional params before intersection so error messages show the raw type (`number`, not `number | undefined`).

## Files changed

- `crates/tsz-solver/src/operations/core/call_evaluator.rs` — promote `CombinedUnionSignature` to `pub(crate)`
- `crates/tsz-solver/src/operations/core/call_resolution.rs` — add `try_compute_combined_union_construct_signature`
- `crates/tsz-solver/src/operations/constructors.rs` — rewrite `resolve_union_new` with Phase 1/2/3
- `crates/tsz-solver/tests/operations_tests.rs` — 4 new unit tests

## Verification

- `cargo nextest run -p tsz-solver --lib` — 5529 tests pass (4 new)
- `conformance --filter unionTypeConstructSignatures`: 1/1 pass (was 0/1)
- `conformance --filter unionType`: 26/30 (was 25/30)
- `conformance --filter construct`: 112/113 (no regression)

https://claude.ai/code/session_01Nti47PKw93oURXdQ8qpB5e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nti47PKw93oURXdQ8qpB5e)_