### PR TITLE
fix(scanner,parser): dedup TS1124/TS1351/TS1005 at empty-exponent literals

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2365,7 +2365,10 @@ export default validate;
         "Expected `export default validate;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default validate;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     assert!(
         trimmed.contains("declare function validate(): void;"),
         "Expected the function declaration to follow: {trimmed}"
@@ -2395,7 +2398,10 @@ export default Test;
         "Expected `export default Test;` to be hoisted to the top: {trimmed}"
     );
     let count = trimmed.matches("export default Test;").count();
-    assert_eq!(count, 1, "Expected exactly one export-default emission: {trimmed}");
+    assert_eq!(
+        count, 1,
+        "Expected exactly one export-default emission: {trimmed}"
+    );
     let default_pos = trimmed.find("export default Test;").unwrap();
     let decl_pos = trimmed
         .find("declare class Test")
@@ -2417,12 +2423,12 @@ export default validate;
 "#,
     );
     let trimmed = output.trim();
-    let default_pos = trimmed.find("export default validate;").expect(
-        "expected export default validate; in TS output",
-    );
-    let decl_pos = trimmed.find("declare function validate").expect(
-        "expected declare function validate in TS output",
-    );
+    let default_pos = trimmed
+        .find("export default validate;")
+        .expect("expected export default validate; in TS output");
+    let decl_pos = trimmed
+        .find("declare function validate")
+        .expect("expected declare function validate in TS output");
     assert!(
         decl_pos < default_pos,
         "TS files should preserve source order (declaration first): {trimmed}"

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -308,6 +308,18 @@ impl ParserState {
         self.pending_jsx_missing_close_brace_in_expression_statement = 0;
         self.jsx_missing_brace_semicolon_window_start = None;
         self.namespace_import_yielded_to_statement = false;
+        // The high-water mark tracks the count of scanner diagnostics that
+        // have been considered by the parser-side dedup at `parse_error_at`.
+        // When the parser is reused via `reset()` the caller passes a fresh
+        // source text. Without clearing the mark AND the scanner's diagnostic
+        // vec, the dedup check at line 1080 (`scanner_diags.len() > HWM`) could
+        // see a stale `last()` whose `pos` accidentally matches a new-parse
+        // error and wrongly suppress it. The Scanner's `set_text` (called
+        // above) intentionally does NOT clear the diagnostics for callers
+        // outside ParserState, so we explicitly clear them here. (Devin
+        // review on PR #1521.)
+        self.scanner.clear_scanner_diagnostics();
+        self.scanner_diagnostics_high_water_mark = 0;
     }
 
     /// Check recursion limit - returns true if we can continue, false if limit exceeded

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -136,6 +136,15 @@ pub struct ParserState {
     pub(crate) recursion_depth: u32,
     /// Position of last error (to prevent cascading errors at same position)
     pub(crate) last_error_pos: u32,
+    /// Number of scanner diagnostics observed at the time the most recent
+    /// parser-side diagnostic was pushed. `scanner_diagnostics[idx..]` for
+    /// any `idx >= this` represents scanner emissions that happened *after*
+    /// our last parser push and therefore are the effective "lastError" tail
+    /// for tsc's `parseErrorAtPosition` `lastError.start` dedup. Without
+    /// this, a TS1124 emitted by the scanner (`1ee`'s empty exponent) would
+    /// not suppress a follow-up TS1005 the parser emits at the same position
+    /// the way tsc's single `parseDiagnostics` vec does.
+    pub(crate) scanner_diagnostics_high_water_mark: usize,
     /// Stack of label scopes for duplicate label detection (TS1114)
     /// Each scope is a map from label name to the position where it was first defined
     pub(crate) label_scopes: Vec<FxHashMap<String, u32>>,
@@ -242,6 +251,7 @@ impl ParserState {
             node_count: 0,
             recursion_depth: 0,
             last_error_pos: 0,
+            scanner_diagnostics_high_water_mark: 0,
             label_scopes: vec![FxHashMap::default()],
             seen_module_indicator: false,
             last_named_imports_consumed_closing_brace: false,
@@ -1055,6 +1065,23 @@ impl ParserState {
         if let Some(last) = self.parse_diagnostics.last()
             && last.start == start
         {
+            self.scanner_diagnostics_high_water_mark = self.scanner.get_scanner_diagnostics().len();
+            return;
+        }
+        // tsc routes scanner errors through the same `parseErrorAtPosition`
+        // path via `scanError`, so they share the same `lastError` slot. We
+        // mirror that here: any scanner diagnostics emitted *after* our most
+        // recent parser push are the effective "lastError" tail. If the very
+        // last such scanner diagnostic shares this start, dedup applies.
+        // (Earlier scanner diagnostics are not relevant: a parser push or
+        // a later scanner push past their position has already moved the
+        // effective `lastError` past them.)
+        let scanner_diags = self.scanner.get_scanner_diagnostics();
+        if scanner_diags.len() > self.scanner_diagnostics_high_water_mark
+            && let Some(last_scanner) = scanner_diags.last()
+            && self.u32_from_usize(last_scanner.pos) == start
+        {
+            self.scanner_diagnostics_high_water_mark = scanner_diags.len();
             return;
         }
         // Track the position of this error to prevent cascading errors at same position
@@ -1065,6 +1092,9 @@ impl ParserState {
             message: message.to_string(),
             code,
         });
+        // After pushing a parser diagnostic, the effective "lastError" is
+        // ours; subsequent scanner emissions reset the comparison frame.
+        self.scanner_diagnostics_high_water_mark = self.scanner.get_scanner_diagnostics().len();
     }
 
     /// Report parse error at current token with specific error code

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -477,42 +477,12 @@ impl ParserState {
             }
         }
 
-        // Check for missing exponent digits (e.g., 1e+, 1e-, 1e) - TS1124
-        // If there's a Scientific flag but the exponent has no actual digits.
-        //
-        // Note: a misplaced separator like `0e_0` or `0e_` is NOT a missing
-        // digit — the scanner emits TS6188 for the underscore, and tsc does
-        // not also emit TS1124 when at least one digit is present in the
-        // exponent. We only emit TS1124 when the exponent is genuinely empty
-        // of digits (e.g. `1e+`, `1e_`, `1e+_`).
-        if (token_flags & TokenFlags::Scientific as u32) != 0 {
-            let bytes = text.as_bytes();
-            let missing_digit = if let Some(exp_offset) = bytes
-                .iter()
-                .rposition(|byte| *byte == b'e' || *byte == b'E')
-            {
-                let mut after_idx = exp_offset + 1;
-                if after_idx < bytes.len() && (bytes[after_idx] == b'+' || bytes[after_idx] == b'-')
-                {
-                    after_idx += 1;
-                }
-                // Genuine missing-digit only when no digit appears after the
-                // exponent prefix (`e`/`E` and an optional sign).
-                !bytes[after_idx..].iter().any(|b| b.is_ascii_digit())
-            } else {
-                false
-            };
-            if missing_digit {
-                use tsz_common::diagnostics::diagnostic_codes;
-                // Find position of the missing digit (at the end)
-                self.parse_error_at(
-                    end_pos,
-                    0,
-                    "Digit expected.",
-                    diagnostic_codes::DIGIT_EXPECTED,
-                );
-            }
-        }
+        // TS1124 ("Digit expected") for empty exponents (`1e+`, `1e`, `1ee`,
+        // `3en`, etc.) is emitted by the scanner inline during
+        // `scan_decimal_number` so the position matches tsc (right after the
+        // `e`/sign) and the same-start dedup in
+        // `check_for_identifier_start_after_numeric_literal` can suppress a
+        // colliding TS1351 the same way tsc's `parseErrorAtPosition` does.
 
         // Check for missing hex digits (e.g., 0x, 0X) - TS1125
         if (token_flags & TokenFlags::HexSpecifier as u32) != 0 {

--- a/crates/tsz-parser/tests/numeric_literal_exponent_tests.rs
+++ b/crates/tsz-parser/tests/numeric_literal_exponent_tests.rs
@@ -78,6 +78,51 @@ fn underscore_only_exponent_emits_both() {
 }
 
 #[test]
+fn parser_state_reset_clears_scanner_diagnostics_and_high_water_mark() {
+    // Devin review on PR #1521: ParserState::reset must clear both the
+    // scanner's accumulated diagnostics vec AND the high-water mark used by
+    // parse_error_at's dedup. Otherwise a reused parser (LSP `update_source`
+    // path) carries stale entries; if a new-parse parser error happens to
+    // share a `start` with the LAST stale scanner diagnostic, dedup wrongly
+    // suppresses the new error.
+
+    // Parse 1 — produce some scanner diagnostics (e.g. TS1124 on `1e+`).
+    let mut parser = ParserState::new("first.ts".to_string(), "1e+".to_string());
+    let _ = parser.parse_source_file();
+    let scan_count_after_first = parser.scanner.get_scanner_diagnostics().len();
+    assert!(
+        scan_count_after_first > 0,
+        "first parse must produce at least one scanner diagnostic"
+    );
+
+    // Reset for parse 2 — must wipe scanner diagnostics and HWM.
+    parser.reset("second.ts".to_string(), "let x = 1.5e+10;".to_string());
+    assert_eq!(
+        parser.scanner.get_scanner_diagnostics().len(),
+        0,
+        "reset must clear scanner_diagnostics so reused-parser callers don't see stale entries"
+    );
+    assert_eq!(
+        parser.scanner_diagnostics_high_water_mark, 0,
+        "reset must clear the high-water mark (otherwise the parser-side dedup at parse_error_at sees a non-zero floor)"
+    );
+
+    // Parse 2 — well-formed source, must produce zero scanner diagnostics.
+    let _ = parser.parse_source_file();
+    let codes: Vec<u32> = parser
+        .scanner
+        .get_scanner_diagnostics()
+        .iter()
+        .map(|d| d.code)
+        .chain(parser.parse_diagnostics.iter().map(|d| d.code))
+        .collect();
+    assert!(
+        !codes.contains(&1124) && !codes.contains(&6188),
+        "second parse of clean source must not surface stale-scanner-diagnostic codes, got: {codes:?}"
+    );
+}
+
+#[test]
 fn well_formed_decimal_with_exponent_emits_no_diagnostics() {
     // Sanity: `1.5e+10` is fully well-formed.
     let codes = parse_codes("let x = 1.5e+10;");

--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -1446,7 +1446,22 @@ impl ScannerState {
                         self.pos += 1;
                     }
                 }
-                self.scan_digits_with_separators(is_digit);
+                // Mirror tsc's `scanNumber` exponent branch: if the exponent has
+                // no digits (e.g. `1e`, `1e+`, `1ee`, `3en`), emit TS1124
+                // "Digit expected" at the current position. Emitting here (before
+                // `check_for_identifier_start_after_numeric_literal`) lets us
+                // mirror tsc's `parseErrorAtPosition` same-start dedup: a later
+                // TS1351 at the same position is suppressed by the helper below.
+                let saw_exp_digit = self.scan_digits_with_separators(is_digit);
+                if !saw_exp_digit {
+                    self.scanner_diagnostics.push(ScannerDiagnostic {
+                        pos: self.pos,
+                        length: 0,
+                        args: Vec::new(),
+                        message: diagnostic_messages::DIGIT_EXPECTED,
+                        code: diagnostic_codes::DIGIT_EXPECTED,
+                    });
+                }
             }
         }
 
@@ -1518,13 +1533,26 @@ impl ScannerState {
             });
             true
         } else {
-            self.scanner_diagnostics.push(ScannerDiagnostic {
-                pos: identifier_start,
-                length: identifier_end - identifier_start,
-                message: diagnostic_messages::AN_IDENTIFIER_OR_KEYWORD_CANNOT_IMMEDIATELY_FOLLOW_A_NUMERIC_LITERAL,
-                code: diagnostic_codes::AN_IDENTIFIER_OR_KEYWORD_CANNOT_IMMEDIATELY_FOLLOW_A_NUMERIC_LITERAL,
-                args: Vec::new(),
-            });
+            // Mirror tsc's `parseErrorAtPosition` same-start dedup: if a prior
+            // scanner diagnostic was already pushed at `identifier_start`
+            // (e.g. TS1124 "Digit expected" emitted by the empty-exponent
+            // branch in `scan_decimal_number` for `1ee`/`123ee`), tsc's parser
+            // would suppress this TS1351 because its `lastError.start` matches.
+            // We mirror that suppression here so the merged diagnostics match
+            // tsc fingerprint-for-fingerprint.
+            let already_diag_at_pos = self
+                .scanner_diagnostics
+                .last()
+                .is_some_and(|d| d.pos == identifier_start);
+            if !already_diag_at_pos {
+                self.scanner_diagnostics.push(ScannerDiagnostic {
+                    pos: identifier_start,
+                    length: identifier_end - identifier_start,
+                    message: diagnostic_messages::AN_IDENTIFIER_OR_KEYWORD_CANNOT_IMMEDIATELY_FOLLOW_A_NUMERIC_LITERAL,
+                    code: diagnostic_codes::AN_IDENTIFIER_OR_KEYWORD_CANNOT_IMMEDIATELY_FOLLOW_A_NUMERIC_LITERAL,
+                    args: Vec::new(),
+                });
+            }
             self.pos = identifier_start;
             false
         }

--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -3035,6 +3035,15 @@ impl ScannerState {
         &self.scanner_diagnostics
     }
 
+    /// Clear accumulated scanner diagnostics. Used by `ParserState::reset` so a
+    /// reused parser doesn't carry stale scanner-side errors into a new parse.
+    /// `set_text` does NOT clear them — callers like the LSP that re-text the
+    /// scanner across edits without going through ParserState may want the
+    /// previous diagnostics to remain accessible.
+    pub fn clear_scanner_diagnostics(&mut self) {
+        self.scanner_diagnostics.clear();
+    }
+
     /// Merge conflict marker length (7 characters: `<<<<<<<`, `=======`, etc.)
     const MERGE_CONFLICT_MARKER_LENGTH: usize = 7;
 

--- a/crates/tsz-scanner/tests/scanner_impl_tests.rs
+++ b/crates/tsz-scanner/tests/scanner_impl_tests.rs
@@ -372,3 +372,100 @@ fn test_template_rescan_invalid_hex_escape() {
         scanner.get_token_text_ref()
     );
 }
+
+// --- Empty-exponent / identifier-after-numeric scanner diagnostics --------
+//
+// Mirrors tsc's `scanNumber` exponent branch: a numeric literal whose
+// exponent has no digits (`1e+`, `1ee`, `3en`, ...) emits TS1124 right after
+// the `e` (or sign), and tsc's `parseErrorAtPosition` same-start dedup
+// suppresses any TS1351 that would fire at the same position. We verify the
+// scanner emits those diagnostics in the same shape so the merged
+// fingerprint matches tsc on `identifierStartAfterNumericLiteral.ts`.
+
+fn scan_first_token(source: &str) -> Vec<(usize, u32)> {
+    let mut scanner = ScannerState::new(source.to_string(), true);
+    let _ = scanner.scan();
+    scanner
+        .get_scanner_diagnostics()
+        .iter()
+        .map(|d| (d.pos, d.code))
+        .collect()
+}
+
+#[test]
+fn scan_number_empty_exponent_emits_ts1124_after_e() {
+    // `1e` — exponent has no digit. tsc emits TS1124 at pos=2 (right after
+    // the `e`, before EOF). No TS1351 because there is no following
+    // identifier.
+    let diags = scan_first_token("1e");
+    assert!(
+        diags.iter().any(|(pos, code)| *pos == 2 && *code == 1124),
+        "expected TS1124 at pos=2 for `1e`, got {diags:?}",
+    );
+    assert!(
+        !diags.iter().any(|(_, code)| *code == 1351),
+        "should not emit TS1351 for `1e`, got {diags:?}",
+    );
+}
+
+#[test]
+fn scan_number_exponent_with_sign_no_digit_emits_ts1124_after_sign() {
+    // `1e+` — sign consumed, no digit. tsc fires TS1124 at the position
+    // right after the sign (pos=3).
+    let diags = scan_first_token("1e+");
+    assert!(
+        diags.iter().any(|(pos, code)| *pos == 3 && *code == 1124),
+        "expected TS1124 at pos=3 for `1e+`, got {diags:?}",
+    );
+}
+
+#[test]
+fn scan_number_double_e_keeps_only_ts1124_dedup_ts1351() {
+    // `1ee` — exponent has no digit, but the trailing char is an identifier
+    // start. tsc's lastError-by-start dedup drops the TS1351 that would fire
+    // at the same position as the TS1124 emitted by the empty exponent.
+    let diags = scan_first_token("1ee");
+    assert!(
+        diags.iter().any(|(pos, code)| *pos == 2 && *code == 1124),
+        "expected TS1124 at pos=2 for `1ee`, got {diags:?}",
+    );
+    assert!(
+        !diags.iter().any(|(_, code)| *code == 1351),
+        "TS1351 must be deduped at same position as TS1124 for `1ee`, got {diags:?}",
+    );
+}
+
+#[test]
+fn scan_number_exponent_followed_by_n_keeps_ts1124_and_ts1352() {
+    // `3en` — exponent has no digit, then bigint suffix `n`. tsc emits both
+    // TS1124 (after `e`) and TS1352 (bigint with exponential), at distinct
+    // positions, so no dedup applies.
+    let diags = scan_first_token("3en");
+    assert!(
+        diags.iter().any(|(pos, code)| *pos == 2 && *code == 1124),
+        "expected TS1124 at pos=2 for `3en`, got {diags:?}",
+    );
+    assert!(
+        diags.iter().any(|(_, code)| *code == 1352),
+        "expected TS1352 (bigint exponential) for `3en`, got {diags:?}",
+    );
+    assert!(
+        !diags.iter().any(|(_, code)| *code == 1351),
+        "should not emit TS1351 for `3en` (bigint branch wins), got {diags:?}",
+    );
+}
+
+#[test]
+fn scan_number_well_formed_decimal_with_exponent_emits_no_diagnostic() {
+    // Sanity: `1e9` is fully valid; no diagnostics expected from the
+    // scanner's empty-exponent path.
+    let diags = scan_first_token("1e9");
+    assert!(
+        !diags.iter().any(|(_, code)| *code == 1124),
+        "well-formed `1e9` must not emit TS1124, got {diags:?}",
+    );
+    assert!(
+        !diags.iter().any(|(_, code)| *code == 1351),
+        "well-formed `1e9` must not emit TS1351, got {diags:?}",
+    );
+}

--- a/docs/plan/claims/fix-scanner-exp-digit-dedup-20260427.md
+++ b/docs/plan/claims/fix-scanner-exp-digit-dedup-20260427.md
@@ -1,0 +1,47 @@
+# fix(scanner,parser): dedup TS1124/TS1351/TS1005 at empty-exponent literals
+
+- **Date**: 2026-04-27
+- **Time**: 2026-04-27 02:10:00
+- **Branch**: `fix/scanner-exp-digit-dedup-20260427-0210`
+- **PR**: pending
+- **Status**: WIP
+- **Workstream**: conformance / fingerprint parity
+
+## Intent
+
+`identifierStartAfterNumericLiteral.ts` was a fingerprint-only failure
+because the scanner emitted TS1351 ("identifier cannot follow a numeric
+literal") at the same position as the parser-emitted TS1124 ("Digit
+expected") for `1ee`/`123ee`, and tsz then also emitted a stray TS1005 at
+the same position. tsc's `parseErrorAtPosition` deduplicates by
+`lastError.start`, so a follow-up error at the same position is suppressed.
+
+## Root cause
+
+- `scan_decimal_number` did not emit TS1124 inline when the exponent had no
+  digits, so the position came from the parser at end-of-token (`3en` ->
+  col 4 instead of col 3).
+- Scanner-emitted diagnostics never participated in the parser's
+  `parse_error_at` same-position dedup because they live in a separate
+  vec drained at end-of-parse.
+
+## Fix shape
+
+1. Scanner-side: emit TS1124 inline in `scan_decimal_number`'s exponent
+   branch when no digits are consumed; suppress the colliding TS1351 in
+   `check_for_identifier_start_after_numeric_literal` when a scanner
+   diagnostic at the same start was just pushed.
+2. Parser-side: `parse_error_at` consults the most recent scanner
+   diagnostic emitted *after* our last parser push (tracked via a
+   high-water mark). Mirrors tsc's single-vec `lastError` semantics
+   without changing diagnostic ordering or merge-time sort.
+3. Removed the duplicated parser-level missing-exponent-digit emission
+   that fired at the wrong position.
+
+## Tests
+
+- New scanner unit tests in `tsz-scanner/tests/scanner_impl_tests.rs`
+  pinning the exact diagnostics for `1e`, `1e+`, `1ee`, `3en`, `1e9`.
+- Existing `numeric_literal_exponent_tests.rs` coverage retained.
+- `identifierStartAfterNumericLiteral.ts` flips from fingerprint-only
+  failure to pass.


### PR DESCRIPTION
## Summary

- `identifierStartAfterNumericLiteral.ts` was a fingerprint-only failure because tsz emitted TS1351 ("identifier cannot follow a numeric literal") and a stray TS1005 at the same position as TS1124 ("Digit expected") for inputs like `1ee`/`123ee`/`3en`. tsc's `parseErrorAtPosition` deduplicates by `lastError.start`, so follow-up errors at the same position are suppressed.
- Scanner now emits TS1124 inline in `scan_decimal_number`'s exponent branch when no digits follow `e`/`E`/sign, and `check_for_identifier_start_after_numeric_literal` suppresses a colliding TS1351 at the same start.
- Parser's `parse_error_at` consults the most recent scanner diagnostic emitted *after* its last push (high-water mark) and applies the same `lastError.start` dedup, mirroring tsc's single-vec semantics. Removed the parser-level missing-exponent emission that fired at the wrong end-of-token position.

## Test plan

- [x] `cargo nextest run -p tsz-scanner --lib` (60/60 pass, including 5 new empty-exponent test cases for `1e`, `1e+`, `1ee`, `3en`, `1e9`).
- [x] `cargo nextest run -p tsz-parser --lib` (690/690 pass).
- [x] `./scripts/conformance/conformance.sh run --filter "identifierStartAfterNumericLiteral" --verbose` flips from fingerprint-only failure to PASS.
- [ ] CI conformance suite (full run on PR).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
