### PR TITLE
fix(emitter,ir-printer): drop disambiguating parens around _a.sent() in assignment RHS

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -2393,10 +2393,7 @@ impl<'a> CheckerState<'a> {
         // Look at merged decls on the import's own symbol.
         if let Some(sym) = self.ctx.binder.get_symbol(sym_id) {
             for &decl_idx in &sym.declarations {
-                if decl_idx == binding_node_idx
-                    || decl_idx == clause_idx
-                    || decl_idx == stmt_idx
-                {
+                if decl_idx == binding_node_idx || decl_idx == clause_idx || decl_idx == stmt_idx {
                     continue;
                 }
                 if !self.ctx.binder.node_symbols.contains_key(&decl_idx.0) {
@@ -2439,19 +2436,20 @@ impl<'a> CheckerState<'a> {
                             .find_enclosing_scope(self.ctx.arena, decl_idx)
                     }
                 });
-                let in_same_scope = match (import_scope, decl_containing_scope) {
-                    (Some(a), Some(b)) if a == b => true,
-                    (Some(a), Some(b)) => {
-                        let sym_a = self.ctx.binder.scopes.get(a.0 as usize).and_then(|s| {
-                            self.ctx.binder.node_symbols.get(&s.container_node.0)
-                        });
-                        let sym_b = self.ctx.binder.scopes.get(b.0 as usize).and_then(|s| {
-                            self.ctx.binder.node_symbols.get(&s.container_node.0)
-                        });
-                        sym_a.is_some() && sym_a == sym_b
-                    }
-                    _ => true,
-                };
+                let in_same_scope =
+                    match (import_scope, decl_containing_scope) {
+                        (Some(a), Some(b)) if a == b => true,
+                        (Some(a), Some(b)) => {
+                            let sym_a = self.ctx.binder.scopes.get(a.0 as usize).and_then(|s| {
+                                self.ctx.binder.node_symbols.get(&s.container_node.0)
+                            });
+                            let sym_b = self.ctx.binder.scopes.get(b.0 as usize).and_then(|s| {
+                                self.ctx.binder.node_symbols.get(&s.container_node.0)
+                            });
+                            sym_a.is_some() && sym_a == sym_b
+                        }
+                        _ => true,
+                    };
                 if !in_same_scope {
                     continue;
                 }
@@ -2480,14 +2478,8 @@ impl<'a> CheckerState<'a> {
         // Look at separate same-name symbols (binder may keep them split
         // across imports vs locals via alias_partners).
         if !local_has_value || !local_has_pure_type {
-            let all_symbols: Vec<tsz_binder::SymbolId> = self
-                .ctx
-                .binder
-                .symbols
-                .find_all_by_name(name)
-                .iter()
-                .copied()
-                .collect();
+            let all_symbols: Vec<tsz_binder::SymbolId> =
+                self.ctx.binder.symbols.find_all_by_name(name).to_vec();
             for other_sym_id in all_symbols {
                 if other_sym_id == sym_id {
                     continue;
@@ -2503,17 +2495,16 @@ impl<'a> CheckerState<'a> {
                 }
                 // Same-scope filter.
                 let other_in_same_scope = other_sym.declarations.iter().any(|&decl_idx| {
-                    let decl_containing =
-                        self.ctx.arena.get_extended(decl_idx).and_then(|ext| {
-                            let parent = ext.parent;
-                            if parent.is_some() {
-                                self.ctx.binder.find_enclosing_scope(self.ctx.arena, parent)
-                            } else {
-                                self.ctx
-                                    .binder
-                                    .find_enclosing_scope(self.ctx.arena, decl_idx)
-                            }
-                        });
+                    let decl_containing = self.ctx.arena.get_extended(decl_idx).and_then(|ext| {
+                        let parent = ext.parent;
+                        if parent.is_some() {
+                            self.ctx.binder.find_enclosing_scope(self.ctx.arena, parent)
+                        } else {
+                            self.ctx
+                                .binder
+                                .find_enclosing_scope(self.ctx.arena, decl_idx)
+                        }
+                    });
                     match (import_scope, decl_containing) {
                         (Some(a), Some(b)) => a == b,
                         _ => true,

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -521,7 +521,7 @@ impl<'a> CheckerState<'a> {
                 .as_ref()
                 .and_then(|idx| idx.get(module_spec));
             let scan_indices: Vec<usize> = match candidate_indices {
-                Some(indices) => indices.iter().copied().collect(),
+                Some(indices) => indices.to_vec(),
                 None => (0..binders.len()).collect(),
             };
             for binder_idx in scan_indices {

--- a/crates/tsz-checker/tests/isolated_modules_export_default_tests.rs
+++ b/crates/tsz-checker/tests/isolated_modules_export_default_tests.rs
@@ -84,10 +84,7 @@ fn export_default_of_type_only_alias_emits_ts1292() {
     let type_ts = "export type T = number;\n";
     let test3_ts = "import { T } from \"./type\";\nexport default T;\n";
 
-    let diags = compile_with_isolated_modules(
-        &[("/type.ts", type_ts), ("/test3.ts", test3_ts)],
-        1,
-    );
+    let diags = compile_with_isolated_modules(&[("/type.ts", type_ts), ("/test3.ts", test3_ts)], 1);
 
     assert!(
         diags.iter().any(|(code, _, _)| *code == 1292),
@@ -105,10 +102,7 @@ fn import_type_clashing_with_local_type_alias_emits_ts2440_and_ts1292() {
     let type_ts = "export type T = number;\n";
     let test2_ts = "import { T } from \"./type\";\ntype T = number;\nexport default T;\n";
 
-    let diags = compile_with_isolated_modules(
-        &[("/type.ts", type_ts), ("/test2.ts", test2_ts)],
-        1,
-    );
+    let diags = compile_with_isolated_modules(&[("/type.ts", type_ts), ("/test2.ts", test2_ts)], 1);
 
     assert!(
         diags.iter().any(|(code, _, _)| *code == 2440),
@@ -132,10 +126,7 @@ fn import_type_clashing_with_local_const_emits_ts2865() {
     let type_ts = "export type T = number;\n";
     let test1_ts = "import { T } from \"./type\";\nconst T = 0;\nexport default T;\n";
 
-    let diags = compile_with_isolated_modules(
-        &[("/type.ts", type_ts), ("/test1.ts", test1_ts)],
-        1,
-    );
+    let diags = compile_with_isolated_modules(&[("/type.ts", type_ts), ("/test1.ts", test1_ts)], 1);
 
     assert!(
         diags.iter().any(|(code, _, _)| *code == 2865),
@@ -156,13 +147,13 @@ fn type_only_import_with_no_local_conflict_is_clean() {
     let type_ts = "export type T = number;\n";
     let consumer_ts = "import { T } from \"./type\";\nexport type Alias = T;\n";
 
-    let diags = compile_with_isolated_modules(
-        &[("/type.ts", type_ts), ("/consumer.ts", consumer_ts)],
-        1,
-    );
+    let diags =
+        compile_with_isolated_modules(&[("/type.ts", type_ts), ("/consumer.ts", consumer_ts)], 1);
 
     assert!(
-        diags.iter().all(|(code, _, _)| *code != 2440 && *code != 2865),
+        diags
+            .iter()
+            .all(|(code, _, _)| *code != 2440 && *code != 2865),
         "Expected no TS2440/TS2865 for a clean type-only import. Got: {diags:?}"
     );
 }
@@ -175,10 +166,8 @@ fn type_only_import_modifier_suppresses_ts2865() {
     let type_ts = "export type T = number;\n";
     let consumer_ts = "import type { T } from \"./type\";\nconst T = 0;\nexport { T };\n";
 
-    let diags = compile_with_isolated_modules(
-        &[("/type.ts", type_ts), ("/consumer.ts", consumer_ts)],
-        1,
-    );
+    let diags =
+        compile_with_isolated_modules(&[("/type.ts", type_ts), ("/consumer.ts", consumer_ts)], 1);
 
     assert!(
         diags.iter().all(|(code, _, _)| *code != 2865),

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -469,7 +469,33 @@ impl<'a> IRPrinter<'a> {
                     self.write(" ");
                     self.write(operator);
                     self.write(" ");
-                    self.emit_sent_aware(right);
+                    // Plain assignment operators (`=`, `+=`, etc.) don't need
+                    // disambiguating parens around `_a.sent()` on the RHS — the
+                    // call-expression precedence is unambiguous in that
+                    // position. tsc emits `y = _a.sent();` without parens.
+                    let is_assign = matches!(
+                        operator.as_ref(),
+                        "=" | "+="
+                            | "-="
+                            | "*="
+                            | "/="
+                            | "%="
+                            | "**="
+                            | "<<="
+                            | ">>="
+                            | ">>>="
+                            | "&="
+                            | "|="
+                            | "^="
+                            | "&&="
+                            | "||="
+                            | "??="
+                    );
+                    if is_assign {
+                        self.emit_node(right);
+                    } else {
+                        self.emit_sent_aware(right);
+                    }
                 }
             }
             IRNode::PrefixUnaryExpr { operator, operand } => {


### PR DESCRIPTION
## Intent

\`var y = await foo();\` was lowering to \`y = (_a.sent());\` instead of
\`y = _a.sent();\`. The \`emit_sent_aware\` helper added parens unconditionally
on the right operand of any binary expression, but plain assignment operators
don't need disambiguating parens — call-expression precedence is unambiguous
in that position. tsc emits no parens here.

\`\`\`ts
async function f() {
  var y = await foo();
  // tsc:    y = _a.sent();
  // tsz (before): y = (_a.sent());
  // tsz (after):  y = _a.sent();
}
\`\`\`

## Fix

In \`ir_printer.rs\`, the binary-expression arm now skips \`emit_sent_aware\`
on the RHS for assignment operators (\`=\`, \`+=\`, \`-=\`, ..., \`??=\`).
Other operators (\`**\`, \`<<\`, \`||\`, etc.) keep the existing wrapping —
those genuinely need parens around \`_a.sent()\` for correct precedence.

## Verification

Emit pass rate: 12338 → 12344 JS (+6 net):

- \`doNotElaborateAssignabilityToTypeParameters(target=es5)\`
- \`es5-asyncFunctionPropertyAccess(target=es5)\`
- \`awaitUnion_es5(target=es5)\`
- \`importMeta(module=commonjs,target=es5)\`
- \`importMeta(module=es2020,target=es5)\`
- \`importMeta(module=esnext,target=es5)\`
- diff shrink in \`es5-asyncFunctionBinaryExpressions\` and
  \`es5-asyncFunctionElementAccess\`

DTS unchanged. No JS-emit regressions.

## Companion commit

The branch ships with one chore commit replacing two pre-existing
\`iter().copied().collect()\` slice-to-vec patterns with \`to_vec()\` — needed
to pass the precommit clippy gate.

## Test plan

- [x] Targeted: \`./scripts/emit/run.sh --filter=es5-asyncFunctionPropertyAccess\` passes (1/2 → 2/2)
- [x] Targeted: \`./scripts/emit/run.sh --filter=doNotElaborateAssignabilityToTypeParameters\` passes
- [x] Full emit run: 12338 → 12344 JS, no regressions
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
