### PR TITLE
docs(architecture): mark audit item 12 (#L) as already addressed (7/17)

### DIFF
--- a/docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md
+++ b/docs/architecture/ROBUSTNESS_AUDIT_2026-04-26.md
@@ -331,7 +331,7 @@ control-flow-heavy tests.
 
 ---
 
-### 12. ⏳ Parser recovery placeholders are indistinguishable from real empty identifiers
+### 12. ✅ Parser recovery placeholders are indistinguishable from real empty identifiers
 
 **Files**
 
@@ -530,3 +530,8 @@ invariant.
   no-lib hardcoded ladder fires (`apply`/`call`/`bind`/`toString`/`name`/
   `length`/`prototype`/`arguments`/`caller`). Behaviour preserved; surfaces
   drift when the boxed `Function` interface fails to provide the property.
+- ✅ #12 (#L) parser recovery placeholders distinguishable from real empty
+  identifiers — already addressed by `NodeArena::is_missing_recovery_identifier`
+  (see `crates/tsz-parser/src/parser/node_access.rs:169`). Codifies the
+  `escaped_text.is_empty() && atom == Atom::NONE` invariant into a stable
+  API. Inline call-site migration is incremental and tracked separately.


### PR DESCRIPTION
## Summary

`NodeArena::is_missing_recovery_identifier` (`crates/tsz-parser/src/parser/node_access.rs:169`) already codifies the `escaped_text.is_empty() && atom == Atom::NONE` invariant into a stable API, with the audit reference in its docstring. Updating the audit doc to reflect that the helper exists.

Inline call-site migration to use the helper is a separate ongoing cleanup.

## Test plan

- [x] No code changes; pre-commit skipped Rust gates appropriately.

## Audit progress

7/17 items now ✅ (1, 4, 5, 12, 13, 15, 16).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
