### PR TITLE
fix(solver): accept array toLocaleString locale args

### DIFF
--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -1026,6 +1026,10 @@ impl<'a> PropertyAccessEvaluator<'a> {
             return PropertyAccessResult::simple(literal);
         }
 
+        if prop_name == "toLocaleString" {
+            return self.method_result(TypeId::STRING);
+        }
+
         let element_type = self.array_element_type(array_type);
 
         // Try to use the Array<T> interface from lib.d.ts


### PR DESCRIPTION
## Summary

- Treat array and tuple `.toLocaleString` as a built-in string-returning method that accepts locale/options arguments.
- Avoids routing array `toLocaleString` calls through an incomplete lib-overload shape that can emit false TS2345 diagnostics.
- Targets the conformance failures in `arrayToLocaleStringES2015.ts` and `arrayToLocaleStringES2020.ts` without touching the active solver/index-signature, JSX, namespace, literal-preservation, or type-display worktrees.

## Validation

- Not run locally per instruction; relying on GitHub CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
