### PR TITLE
fix(checker): report self-indexed property circularity

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -136,6 +136,25 @@ impl<'a> CheckerState<'a> {
             self.check_type_annotation_for_implicit_any_params(prop.type_annotation);
         }
 
+        if prop.type_annotation.is_some()
+            && let Some(class_info) = self.ctx.enclosing_class.as_ref()
+            && let Some(property_name) =
+                crate::types_domain::queries::core::get_literal_property_name(
+                    self.ctx.arena,
+                    prop.name,
+                )
+            && self.indexed_access_references_owner_property(
+                prop.type_annotation,
+                &class_info.name,
+                &property_name,
+            )
+        {
+            let message = format!(
+                "'{property_name}' is referenced directly or indirectly in its own type annotation."
+            );
+            self.error_at_node(prop.name, &message, 2502);
+        }
+
         // Track static property initializer context for TS17011
         let is_static = self.has_static_modifier(&prop.modifiers);
         let prev_static_prop_init = self

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -276,6 +276,27 @@ impl<'a> CheckerState<'a> {
                 {
                     self.check_nested_this_types_for_ts2526(sig.type_annotation);
                 }
+
+                if member_node.kind == syntax_kind_ext::PROPERTY_SIGNATURE
+                    && let Some(owner_name) = iface_name.as_deref()
+                    && let Some(sig) = self.ctx.arena.get_signature(member_node)
+                    && sig.type_annotation.is_some()
+                    && let Some(property_name) =
+                        crate::types_domain::queries::core::get_literal_property_name(
+                            self.ctx.arena,
+                            sig.name,
+                        )
+                    && self.indexed_access_references_owner_property(
+                        sig.type_annotation,
+                        owner_name,
+                        &property_name,
+                    )
+                {
+                    let message = format!(
+                        "'{property_name}' is referenced directly or indirectly in its own type annotation."
+                    );
+                    self.error_at_node(sig.name, &message, 2502);
+                }
             }
             // TS2502 + TS2615: Check if property type annotation circularly
             // references itself through a mapped type applied to the enclosing interface.

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -602,6 +602,55 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    pub(crate) fn indexed_access_references_owner_property(
+        &self,
+        type_node_idx: NodeIndex,
+        owner_name: &str,
+        property_name: &str,
+    ) -> bool {
+        let Some(type_node) = self.ctx.arena.get(type_node_idx) else {
+            return false;
+        };
+        if type_node.kind != syntax_kind_ext::INDEXED_ACCESS_TYPE {
+            return false;
+        }
+        let Some(indexed) = self.ctx.arena.get_indexed_access_type(type_node) else {
+            return false;
+        };
+        let Some(object_type_node) = self.ctx.arena.get(indexed.object_type) else {
+            return false;
+        };
+        if object_type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(object_type_node) else {
+            return false;
+        };
+        let object_name = self
+            .ctx
+            .arena
+            .get_identifier_at(type_ref.type_name)
+            .map(|ident| ident.escaped_text.as_str());
+        if object_name != Some(owner_name) {
+            return false;
+        }
+
+        let Some(index_node) = self.ctx.arena.get(indexed.index_type) else {
+            return false;
+        };
+        if let Some(lit) = self.ctx.arena.get_literal(index_node) {
+            return lit.text == property_name;
+        }
+        if let Some(lit_type) = self.ctx.arena.get_literal_type(index_node)
+            && let Some(inner) = self.ctx.arena.get(lit_type.literal)
+            && let Some(lit) = self.ctx.arena.get_literal(inner)
+        {
+            return lit.text == property_name;
+        }
+
+        false
+    }
+
     pub(crate) fn type_literal_has_circular_accessor_reference(
         &self,
         type_node_idx: NodeIndex,
@@ -861,7 +910,21 @@ impl<'a> CheckerState<'a> {
                             }
                             entry.push((call_sig, optional, readonly));
                         } else {
-                            let type_id = if sig.type_annotation.is_some() {
+                            let circular_self_reference = sig.type_annotation.is_some()
+                                && owner_name.as_deref().is_some_and(|owner_name| {
+                                    self.indexed_access_references_owner_property(
+                                        sig.type_annotation,
+                                        owner_name,
+                                        &name,
+                                    )
+                                });
+                            let type_id = if circular_self_reference {
+                                let message = format!(
+                                    "'{name}' is referenced directly or indirectly in its own type annotation."
+                                );
+                                self.error_at_node(sig.name, &message, 2502);
+                                TypeId::ANY
+                            } else if sig.type_annotation.is_some() {
                                 self.get_type_from_type_node_in_type_literal(sig.type_annotation)
                             } else {
                                 TypeId::ANY

--- a/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
@@ -114,6 +114,31 @@ type T00 = { [P in P]: string };
 }
 
 #[test]
+fn test_self_indexed_property_annotations_emit_ts2502() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+type T1 = {
+    x: T1["x"];
+};
+
+interface I1 {
+    x: I1["x"];
+}
+
+class C1 {
+    x: C1["x"];
+}
+"#,
+    );
+
+    let ts2502_count = diagnostics.iter().filter(|d| d.code == 2502).count();
+    assert_eq!(
+        ts2502_count, 3,
+        "Expected TS2502 for self-indexed type literal, interface, and class properties.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_mapped_type_invalid_key_constraint_emits_ts2536() {
     let diagnostics = compile_and_get_diagnostics(
         r"

--- a/docs/plan/claims/fix-checker-self-indexed-property-ts2502.md
+++ b/docs/plan/claims/fix-checker-self-indexed-property-ts2502.md
@@ -1,0 +1,30 @@
+# fix(checker): emit TS2502 for self-indexed property annotations
+
+- **Date**: 2026-04-27
+- **Time**: 2026-04-27 01:29:38 UTC
+- **Branch**: `codex/conformance-roadmap`
+- **PR**: pending
+- **Status**: ready
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the missing TS2502 diagnostics in
+`TypeScript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts`
+for property declarations whose annotation indexes the containing type by the
+same property name:
+
+```ts
+type T = { x: T["x"] };
+interface I { x: I["x"] }
+class C { x: C["x"] }
+```
+
+This is separate from the active type-display, JSX, index-signature, overload,
+namespace/import-qualification, and parser-recovery worktrees. The change belongs
+in checker circularity detection around member declarations and type literals.
+
+## Verification Plan
+
+CI only per request. Add focused checker regression coverage and rely on the PR
+checks/full conformance to validate behavior.


### PR DESCRIPTION
## What changed

Adds checker circularity detection for property annotations that index the containing type by the same property name, matching tsc's TS2502 behavior for shapes like:

```ts
type T = { x: T["x"] };
interface I { x: I["x"] }
class C { x: C["x"] }
```

## Why

`circularIndexedAccessErrors.ts` expected TS2502 for these self-indexed property annotations, but tsz only reported the surrounding indexed-access/deep-instantiation diagnostics. This PR recognizes the direct `Owner["property"]` circularity at the checker member/type-literal layer.

## Roadmap claim

- Added `docs/plan/claims/fix-checker-self-indexed-property-ts2502.md` and marked it ready.

## Validation

- CI only, per request. Local conformance/tests were not run.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
