### PR TITLE
Fix experimental class decorator TS1238 timing

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -107,6 +107,8 @@ impl<'a> CheckerState<'a> {
         // TS1042: async modifier cannot be used on class declarations
         self.check_async_modifier_on_declaration(&class.modifiers);
 
+        let mut experimental_class_decorators = Vec::new();
+
         // Evaluate class-level decorator expressions to trigger definite-assignment
         // checks (TS2454) and other diagnostics. tsc evaluates decorator expressions
         // even if the class has other errors.
@@ -123,13 +125,12 @@ impl<'a> CheckerState<'a> {
 
                     // TS1238: Validate class decorator call signature.
                     if self.ctx.compiler_options.experimental_decorators {
-                        // Experimental decorators: tsc anchors TS1238 at the expression (after @).
-                        self.check_class_decorator_call_signature(
-                            decorator.expression,
-                            decorator_type,
-                            stmt_idx,
-                            class,
-                        );
+                        // Experimental class decorators receive the class constructor
+                        // value. Save the expression type and validate it after the
+                        // class value side has been refreshed; doing it here can see a
+                        // provisional/re-entrant constructor shape and miss TS1238.
+                        experimental_class_decorators
+                            .push((decorator.expression, decorator_type));
                     } else {
                         // ES decorators: tsc anchors TS1238 at the whole decorator
                         // (including `@`) when the factory requires too many args, but
@@ -832,6 +833,16 @@ impl<'a> CheckerState<'a> {
         for sym_id in refresh_symbols {
             self.ctx.symbol_types.remove(&sym_id);
             let _ = self.get_type_of_symbol(sym_id);
+        }
+
+        for (decorator_expression, decorator_type) in experimental_class_decorators {
+            // Experimental decorators: tsc anchors TS1238 at the expression (after @).
+            self.check_class_decorator_call_signature(
+                decorator_expression,
+                decorator_type,
+                stmt_idx,
+                class,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- defer experimental class decorator signature validation until after the class value-side constructor shape is refreshed
- keep early decorator expression evaluation so grammar and definite-assignment diagnostics still run in source order
- fixes the hard conformance shape behind `decorators/decoratorCallGeneric.ts`, where validating against a provisional constructor can miss TS1238

## Validation

- Not run locally, per request. Relying on CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
