### PR TITLE
fix(checker): report TS2367 for explicit unknown intersections

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -1288,7 +1288,33 @@ impl<'a> CheckerState<'a> {
                 // For same-family comparisons (e.g., `"foo"` vs `"bar"`), literal
                 // types are preserved in the error message.
                 let (left_display, right_display) =
-                    self.widen_for_ts2367_cross_family_display(left_narrow, right_narrow);
+                    if let Some(type_param) = self
+                        .ts2367_explicit_unknown_like_intersection_type_param_display(
+                            left_narrow,
+                            right_narrow,
+                        ) {
+                        (
+                            type_param,
+                            crate::query_boundaries::common::widen_literal_type(
+                                self.ctx.types,
+                                right_narrow,
+                            ),
+                        )
+                    } else if let Some(type_param) = self
+                        .ts2367_explicit_unknown_like_intersection_type_param_display(
+                            right_narrow,
+                            left_narrow,
+                        ) {
+                        (
+                            crate::query_boundaries::common::widen_literal_type(
+                                self.ctx.types,
+                                left_narrow,
+                            ),
+                            type_param,
+                        )
+                    } else {
+                        self.widen_for_ts2367_cross_family_display(left_narrow, right_narrow)
+                    };
                 // tsc shows unique symbols as `typeof varName` in comparison overlap errors
                 // (distinct from index-type errors like TS2538/TS7053 where it uses `unique symbol`).
                 let left_str = self.format_type_for_ts2367_display(left_display);

--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -824,6 +824,43 @@ fn ts2367_preserves_literal_types_in_display() {
 }
 
 #[test]
+fn ts2367_for_explicit_unknown_intersection_compared_to_primitive() {
+    let diags = check_source_diagnostics(
+        r#"function f<T extends unknown>(value: T & ({} | null)) {
+    if (value === 42) {}
+}
+
+function g<T extends {} | undefined>(value: T & ({} | null)) {
+    if (value === 42) {}
+}
+
+function unconstrained<T>(value: T & ({} | null)) {
+    if (value === 42) {}
+}
+
+function object_constrained<T extends {}>(value: T & ({} | null)) {
+    if (value === 42) {}
+}"#,
+    );
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        2,
+        "Expected TS2367 only for explicit unknown/undefined-bearing constraints, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        relevant
+            .iter()
+            .all(|diag| diag.message_text.contains("types 'T' and 'number'")),
+        "Expected tsc-style `T` vs `number` display, got: {relevant:?}"
+    );
+}
+
+#[test]
 fn no_ts2367_for_three_member_union_narrowed_in_loop() {
     // Three-member union `0 | 1 | 2` narrowed by control flow in a for-of loop.
     // This matches the f1() case from controlFlowNoIntermediateErrors.

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1096,6 +1096,13 @@ impl<'a> CheckerState<'a> {
         //    overlap just because `I1` is assignable from `I2`.
         if let Some(left_members) = query::get_intersection_members(self.ctx.types, effective_left)
         {
+            if self.intersection_with_explicit_unknown_like_constraint_excludes_primitive(
+                &left_members,
+                effective_right,
+            ) {
+                return true;
+            }
+
             let has_type_param = left_members
                 .iter()
                 .any(|m| is_type_parameter_like(self.ctx.types, *m));
@@ -1141,6 +1148,13 @@ impl<'a> CheckerState<'a> {
         if let Some(right_members) =
             query::get_intersection_members(self.ctx.types, effective_right)
         {
+            if self.intersection_with_explicit_unknown_like_constraint_excludes_primitive(
+                &right_members,
+                effective_left,
+            ) {
+                return true;
+            }
+
             let has_type_param = right_members
                 .iter()
                 .any(|m| is_type_parameter_like(self.ctx.types, *m));
@@ -1253,6 +1267,112 @@ impl<'a> CheckerState<'a> {
         tracing::trace!("no overlap detected");
         // No other overlap detected
         true
+    }
+
+    pub(crate) fn ts2367_explicit_unknown_like_intersection_type_param_display(
+        &self,
+        type_id: TypeId,
+        other: TypeId,
+    ) -> Option<TypeId> {
+        let members = query::get_intersection_members(self.ctx.types, type_id)?;
+        if !self.is_non_nullish_primitive_or_literal(other) {
+            return None;
+        }
+
+        let type_param = members.iter().copied().find(|&member| {
+            is_type_parameter_like(self.ctx.types, member)
+                && self.type_param_has_explicit_unknown_or_undefined_constraint(member)
+        })?;
+        let has_object_nullish_member = members.iter().any(|&member| {
+            !is_type_parameter_like(self.ctx.types, member)
+                && self.is_object_or_nullish_only_type(member)
+        });
+
+        has_object_nullish_member.then_some(type_param)
+    }
+
+    fn intersection_with_explicit_unknown_like_constraint_excludes_primitive(
+        &self,
+        members: &[TypeId],
+        other: TypeId,
+    ) -> bool {
+        if !self.is_non_nullish_primitive_or_literal(other) {
+            return false;
+        }
+
+        let mut has_matching_type_param = false;
+        let mut has_object_nullish_member = false;
+
+        for &member in members {
+            if is_type_parameter_like(self.ctx.types, member) {
+                has_matching_type_param |=
+                    self.type_param_has_explicit_unknown_or_undefined_constraint(member);
+            } else if self.is_object_or_nullish_only_type(member) {
+                has_object_nullish_member = true;
+            }
+        }
+
+        has_matching_type_param && has_object_nullish_member
+    }
+
+    fn type_param_has_explicit_unknown_or_undefined_constraint(&self, type_id: TypeId) -> bool {
+        let Some(info) = crate::query_boundaries::common::type_param_info(self.ctx.types, type_id)
+        else {
+            return false;
+        };
+        let Some(constraint) = info.constraint else {
+            return false;
+        };
+
+        constraint == TypeId::UNKNOWN
+            || (self.type_contains_exact(constraint, TypeId::UNDEFINED)
+                && !self.type_contains_exact(constraint, TypeId::NULL))
+    }
+
+    fn is_object_or_nullish_only_type(&self, type_id: TypeId) -> bool {
+        if type_id == TypeId::OBJECT
+            || type_id == TypeId::NULL
+            || type_id == TypeId::UNDEFINED
+            || crate::query_boundaries::common::is_empty_object_type(self.ctx.types, type_id)
+        {
+            return true;
+        }
+
+        crate::query_boundaries::common::union_members(self.ctx.types, type_id).is_some_and(
+            |members| {
+                !members.is_empty()
+                    && members
+                        .iter()
+                        .all(|&member| self.is_object_or_nullish_only_type(member))
+            },
+        )
+    }
+
+    fn type_contains_exact(&self, type_id: TypeId, needle: TypeId) -> bool {
+        type_id == needle
+            || crate::query_boundaries::common::union_members(self.ctx.types, type_id).is_some_and(
+                |members| {
+                    members
+                        .iter()
+                        .any(|&member| self.type_contains_exact(member, needle))
+                },
+            )
+    }
+
+    fn is_non_nullish_primitive_or_literal(&self, type_id: TypeId) -> bool {
+        use crate::query_boundaries::common::{classify_literal_type, LiteralTypeKind};
+
+        if matches!(
+            type_id,
+            TypeId::STRING | TypeId::NUMBER | TypeId::BOOLEAN | TypeId::BIGINT | TypeId::SYMBOL
+        ) {
+            return true;
+        }
+
+        !matches!(
+            classify_literal_type(self.ctx.types, type_id),
+            LiteralTypeKind::NotLiteral
+        ) || crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, type_id)
     }
 
     pub(crate) fn are_pure_signature_objects(&mut self, left: TypeId, right: TypeId) -> bool {

--- a/docs/plan/claims/fix-checker-ts2367-explicit-unknown-intersection.md
+++ b/docs/plan/claims/fix-checker-ts2367-explicit-unknown-intersection.md
@@ -1,0 +1,36 @@
+# fix(checker): emit TS2367 for explicit unknown intersection comparisons
+
+- **Date**: 2026-04-27
+- **Time**: 2026-04-27 01:35:05 UTC
+- **Branch**: `codex/conformance-ts2367-unknown-controlflow`
+- **PR**: pending
+- **Status**: ready
+- **Workstream**: 1 (Diagnostic Conformance)
+
+## Intent
+
+Fix the missing TS2367 diagnostics in
+`TypeScript/tests/cases/conformance/types/unknown/unknownControlFlow.ts` for
+comparisons like:
+
+```ts
+function f<T extends unknown>(value: T & ({} | null)) {
+    if (value === 42) {}
+}
+
+function g<T extends {} | undefined>(value: T & ({} | null)) {
+    if (value === 42) {}
+}
+```
+
+tsc reports these as no-overlap comparisons between `T` and `number`. tsz
+currently treats the explicit `unknown`/undefined-bearing type-parameter
+constraint as overlap-permissive and misses TS2367.
+
+This is distinct from the active decorator, array `toLocaleString`, type-display,
+index-signature, JSX, overload, namespace/import, and parser-recovery lanes.
+
+## Verification Plan
+
+CI only per request. Add focused checker regression coverage and rely on PR CI
+for build, unit, and conformance validation.


### PR DESCRIPTION
## What changed

Adds TS2367 no-overlap handling for explicit unknown-like type-parameter intersections, matching the `unknownControlFlow.ts` cases where tsc reports `T` vs `number`:

```ts
function f<T extends unknown>(value: T & ({} | null)) {
    if (value === 42) {}
}

function g<T extends {} | undefined>(value: T & ({} | null)) {
    if (value === 42) {}
}
```

The checker now recognizes that these explicit constraints exclude primitive equality overlap through the object/nullish intersection member, while leaving truly unconstrained `T` and `T extends {}` alone.

## Why

`unknownControlFlow.ts` was missing TS2367 even though tsc emits two no-overlap comparison diagnostics. The previous overlap path treated explicit `unknown` constraints like unconstrained type parameters and therefore considered the comparison overlap-permissive.

## Roadmap claim

- Added `docs/plan/claims/fix-checker-ts2367-explicit-unknown-intersection.md` before publishing this PR.

## Validation

- CI only, per request. Local test/conformance runs were intentionally skipped.
- `git diff --check` after commit produced no output.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
