### PR TITLE
fix(checker): preserve mapped diagnostic display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -287,7 +287,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.types.factory().object_with_index(widened_shape)
     }
 
-    pub(crate) fn normalize_property_receiver_application_display_type(
+    pub(in crate::error_reporter) fn normalize_property_receiver_application_display_type(
         &mut self,
         ty: TypeId,
     ) -> TypeId {

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -378,6 +378,27 @@ impl<'a> CheckerState<'a> {
             return alias_name;
         }
 
+        let application_display =
+            crate::query_boundaries::common::type_application(self.ctx.types, display_ty)
+                .map(|_| display_ty)
+                .or_else(|| {
+                    self.ctx
+                        .types
+                        .get_display_alias(display_ty)
+                        .or_else(|| self.ctx.types.get_display_alias(ty))
+                        .filter(|&alias| {
+                            crate::query_boundaries::common::type_application(self.ctx.types, alias)
+                                .is_some()
+                        })
+                });
+        if let Some(application_display) = application_display {
+            let normalized =
+                self.normalize_property_receiver_application_display_type(application_display);
+            if normalized != application_display {
+                return self.format_type_diagnostic_widened_for_assignability_display(normalized);
+            }
+        }
+
         // Application-backed primitive Intersection: when an Application (e.g.
         // `Brand<T>`) evaluates to an Intersection that contains at least one
         // primitive member (number/string/boolean), tsc always shows the structural

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -342,6 +342,18 @@ impl<'a> CheckerState<'a> {
         if let Some(name) = self.js_constructor_receiver_display_for_node(idx) {
             return name;
         }
+        if let Some(receiver) = self.access_receiver_for_diagnostic_node(idx)
+            && let Some(annotation) = self.declared_type_annotation_text_for_expression(receiver)
+            && annotation.contains('<')
+            && annotation
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+            && (crate::query_boundaries::common::is_generic_application(self.ctx.types, type_id)
+                || self.ctx.types.get_display_alias(type_id).is_some())
+        {
+            return self.format_annotation_like_type(&annotation);
+        }
         // When the receiver is a type alias whose body resolves to an Enum
         // (e.g. `type C1 = Color` where `Color` is an enum), tsc displays the
         // underlying enum's nominal name in TS2339 messages, not the alias.

--- a/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
@@ -340,6 +340,70 @@ x.b;
 }
 
 #[test]
+fn test_property_receiver_display_preserves_annotated_mapped_type_params() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyPick<T, K extends keyof T> = { [P in K]: T[P] };
+type MyRecord<K extends keyof any, T> = { [P in K]: T };
+
+function pickAccess<T, K extends keyof T>(obj: MyPick<T, K>) {
+    obj.foo;
+}
+
+function recordAccess<T, K extends keyof T>(obj: MyRecord<K, number>) {
+    obj.foo;
+}
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2339 && message == "Property 'foo' does not exist on type 'MyPick<T, K>'."
+        }),
+        "Expected TS2339 to preserve annotated MyPick<T, K> receiver.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2339
+                && message == "Property 'foo' does not exist on type 'MyRecord<K, number>'."
+        }),
+        "Expected TS2339 to preserve annotated MyRecord<K, number> receiver.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_assignability_display_widens_fresh_application_args() {
+    let diagnostics = compile_and_get_diagnostics_named(
+        "test.ts",
+        r#"
+type MyReadonly<T> = { readonly [P in keyof T]: T[P] };
+declare function objAndReadonly<T>(primary: T, secondary: MyReadonly<T>): T;
+
+objAndReadonly({ x: 0, y: 0 }, { x: 1 });
+        "#,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    );
+
+    let message = diagnostic_message(&diagnostics, 2345).expect("expected TS2345");
+    assert!(
+        message.contains("MyReadonly<{ x: number; y: number; }>"),
+        "Expected mapped application target display to widen fresh object args.\nActual diagnostics: {diagnostics:#?}"
+    );
+    assert!(
+        !message.contains("MyReadonly<{ x: 0; y: 0; }>"),
+        "Mapped application target display must not preserve fresh literal args.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_cross_binder_symbol_id_collision_emits_ts2322_for_this_return() {
     let passport_dts = r#"
 declare module 'passport' {


### PR DESCRIPTION
## Summary
- Preserve explicit generic mapped receiver annotations in TS2339 display, matching cases like Pick<T, K> and Record<K, number>.
- Reuse mapped application argument normalization for assignability display so fresh object literal args widen inside generic mapped targets.
- Add focused conformance regression coverage for both display paths.

## Verification
- cargo test -p tsz-checker test_property_receiver_display_preserves_annotated_mapped_type_params
- cargo test -p tsz-checker test_assignability_display_widens_fresh_application_args
- ./scripts/conformance/conformance.sh run --filter "mappedTypeErrors" --verbose --workers 1

Note: cargo fmt --check still reports unrelated pre-existing formatting drift in import/declaration.rs and isolated_modules_export_default_tests.rs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/1533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
