### PR TITLE
fix(parser): recover JSX namespaced closing tails

### DIFF
--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -2014,23 +2014,27 @@ impl ParserState {
         self.parse_expected(SyntaxKind::LessThanSlashToken);
         let tag_name = self.parse_jsx_element_name();
         let end_pos = self.token_end();
-        if !self.parse_expected(SyntaxKind::GreaterThanToken)
-            && self.is_token(SyntaxKind::ColonToken)
-        {
-            // Match tsc's malformed namespaced-closing-tag recovery: report
-            // the missing `>` at the stray `:`, then consume the dangling
-            // namespace tail so outer expression recovery resumes at the real
-            // `>`/`;` tokens instead of the extra identifier segment.
-            self.next_token();
-            self.scanner.scan_jsx_identifier();
-            if self.is_identifier_or_keyword() {
-                self.parse_identifier_name();
-            }
-            if self.is_token(SyntaxKind::GreaterThanToken) {
-                self.parse_error_at_current_token(
-                    "',' expected.",
-                    tsz_common::diagnostics::diagnostic_codes::EXPECTED,
-                );
+        if !self.parse_expected(SyntaxKind::GreaterThanToken) {
+            if self.is_token(SyntaxKind::ColonToken) {
+                // Match tsc's malformed namespaced-closing-tag recovery: report
+                // the missing `>` at the stray `:`, then consume the dangling
+                // namespace tail so outer expression recovery resumes at the real
+                // `>`/`;` tokens instead of the extra identifier segment.
+                self.next_token();
+                self.scanner.scan_jsx_identifier();
+                if self.is_identifier_or_keyword() {
+                    self.parse_identifier_name();
+                }
+                if self.is_token(SyntaxKind::GreaterThanToken) {
+                    self.parse_error_at_current_token(
+                        "',' expected.",
+                        tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+                    );
+                }
+            } else if self.is_token(SyntaxKind::DotToken) {
+                // For a malformed namespaced close like `</b:c.x>`, tsc drops
+                // the stray `.` and lets `x >` recover as a following expression.
+                self.next_token();
             }
         }
         self.arena.add_jsx_closing(


### PR DESCRIPTION
## Summary
- recover malformed JSX namespaced closing tags with a stray dot by dropping only the dot
- let the remaining identifier/greater-than tail recover as the same expression TypeScript emits

## Validation
- scripts/safe-run.sh ./scripts/emit/run.sh --js-only --filter=checkJsxNamespaceNamesQuestionableForms --timeout=20000 --verbose
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter checkJsxNamespaceNamesQuestionableForms --verbose
- cargo clippy -p tsz-parser --all-targets -- -D warnings
- git diff --check
- cargo fmt --check
- pre-commit hook before restack: 21350 tests passed, 68 skipped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mohsen1/tsz/pull/2270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->