### PR TITLE
test(infra): bump nextest timeout for typebox structural display test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,7 +20,7 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.default.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation) | test(collect_diagnostics_reports_default_lib_breakage)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation) | test(collect_diagnostics_reports_default_lib_breakage) | test(typebox_static_array_return_diagnostics_use_structural_display)'
 slow-timeout = { period = "120s", terminate-after = 2 }
 
 [profile.default.junit]
@@ -35,7 +35,7 @@ retries = 0
 test-threads = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation) | test(collect_diagnostics_reports_default_lib_breakage)'
+filter = 'test(compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006) | test(compile_jsx_call_elaboration_check_no_crash1_react16_fixture_reports_ts2322) | test(compile_jsdoc_type_reference_to_ambient_value_keeps_construct_signature) | test(test_divergent_accessor_read_keeps_getter_surface_without_ts2339) | test(test_ts2536_with_lib_mismatched_keyof_source) | test(default_lib_validation) | test(collect_diagnostics_reports_default_lib_breakage) | test(typebox_static_array_return_diagnostics_use_structural_display)'
 slow-timeout = { period = "120s", terminate-after = 2 }
 
 # Quick profile for fast feedback during development


### PR DESCRIPTION
## Summary

`typebox_static_array_return_diagnostics_use_structural_display` runs ~13.5s on dev machines but pushes past the default 60s nextest cap on CI's slower self-hosted runners — verified on PRs #4392 and #4401, both of which had \`unit\` jobs fail with this exact `TIMEOUT` line:

```
TIMEOUT [ 60.015s] tsz-checker ...::typebox_static_array_return_diagnostics_use_structural_display
```

This adds the test to the existing 120s `slow-timeout` override list in both the `default` and `ci` profiles, alongside other known-slow checker tests (default-lib validation, react16 fixtures, etc.).

No behavior change.

## Verification

- `cargo nextest run -p tsz-checker -E 'test(typebox_static_array_return_diagnostics_use_structural_display)'` — passes in 13.5s with the new 120s budget
- Pre-commit hook: no Rust files changed, skipped

## Project Corpus Impact
- Row: n/a
- Bug family: test infrastructure timeout budget for slow TypeBox structural display fixture
- Evidence: nextest configuration-only change in .config/nextest.toml; no compiler behavior or project corpus row changes.

AgentName: M4Help
