### PR TITLE
fix(dts): preserve jsdoc function overload order

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -329,13 +329,20 @@ impl<'a> DeclarationEmitter<'a> {
                     continue;
                 }
                 let should_hoist = if stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
-                    self.arena.get_function(stmt_node).is_some_and(|func| {
-                        self.arena
-                            .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
-                            || self.get_identifier_text(func.name).is_some_and(|name| {
-                                js_hoistable_function_export_names.contains(&name)
-                            })
-                    })
+                    let is_exported_or_named_export =
+                        self.arena.get_function(stmt_node).is_some_and(|func| {
+                            self.arena
+                                .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
+                                || self.get_identifier_text(func.name).is_some_and(|name| {
+                                    js_hoistable_function_export_names.contains(&name)
+                                })
+                        });
+                    if is_exported_or_named_export {
+                        true
+                    } else {
+                        let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(stmt_node.pos);
+                        !Self::jsdoc_overload_signatures_from_chain(&jsdoc_chain).is_empty()
+                    }
                 } else if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
                     self.arena
                         .get_export_decl(stmt_node)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2078,6 +2078,59 @@ export function convert(value) {
 }
 
 #[test]
+fn test_jsdoc_overload_function_declaration_hoists_before_variables() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @template T
+ * @param {T} x
+ * @returns {T}
+ */
+const identity = x => x;
+
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ */
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
+/**
+ * @param {unknown[]} array
+ * @param {(x: unknown) => unknown} iterable
+ * @returns {unknown[]}
+ */
+function flatMap(array, iterable = identity) {
+    return array;
+}
+"#,
+    );
+
+    let flat_map_pos = output
+        .find("declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];")
+        .expect("expected first flatMap overload");
+    let identity_pos = output
+        .find("declare function identity<T>(x: T): T;")
+        .expect("expected identity helper declaration");
+
+    assert!(
+        flat_map_pos < identity_pos,
+        "Expected JSDoc overload function declarations before variables: {output}"
+    );
+    assert!(
+        output.contains("declare function flatMap<T>(array: T[][]): T[];"),
+        "Expected second flatMap overload: {output}"
+    );
+}
+
+#[test]
 fn test_jsdoc_constructor_overload_tags_emit_constructor_signatures() {
     let output = emit_js_dts_with_usage_analysis(
         r#"


### PR DESCRIPTION
## Summary

- Hoist JS function declarations with parsed JSDoc `@overload` signatures even when they are not exported.
- Add a regression test for overloaded JS function declarations appearing before intervening variable declarations.

## Why

TypeScript declaration emit orders JSDoc overload function declarations ahead of top-level variable declarations. `jsFileFunctionOverloads` and `jsFileFunctionOverloads2` were failing only because the overloaded `flatMap` declaration was emitted after the earlier `identity` variable declaration.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p tsz-emitter --lib test_jsdoc_ -- --nocapture`
- `CARGO_TARGET_DIR=.target cargo build -p tsz-cli --bin tsz`
- focused DTS: `jsFileFunctionOverloads` and `jsFileFunctionOverloads2` pass
- fresh-cache full DTS at 20s timeout: `1565/1669`; fixed target tests, with 4 extra timeout-only cases versus previous snapshot
- regenerated-cache full DTS at 60s timeout: `1570/1669`, no new failures versus previous snapshot; fixed `jsFileFunctionOverloads`, `jsFileFunctionOverloads2`, and one unrelated previous timeout completed
