### PR TITLE
fix(dts): keep cjs typedef aliases local

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -909,6 +909,27 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         }
 
+        let js_export_equals_root_name = if self.source_is_js_file {
+            match kind {
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION => self
+                    .arena
+                    .get_function(stmt_node)
+                    .map(|func| func.name)
+                    .filter(|&name| self.is_js_export_equals_name(name)),
+                k if k == syntax_kind_ext::CLASS_DECLARATION => self
+                    .arena
+                    .get_class(stmt_node)
+                    .map(|class| class.name)
+                    .filter(|&name| self.is_js_export_equals_name(name)),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if let Some(name_idx) = js_export_equals_root_name {
+            self.emit_pending_js_export_equals_for_name(name_idx);
+        }
+
         let is_variable_like_export = kind == syntax_kind_ext::VARIABLE_STATEMENT
             || (kind == syntax_kind_ext::EXPORT_DECLARATION
                 && self
@@ -916,7 +937,7 @@ impl<'a> DeclarationEmitter<'a> {
                     .get_export_decl(stmt_node)
                     .and_then(|export| self.arena.get(export.export_clause))
                     .is_some_and(|clause| clause.kind == syntax_kind_ext::VARIABLE_STATEMENT));
-        if !is_variable_like_export {
+        if !is_variable_like_export && js_export_equals_root_name.is_none() {
             self.emit_leading_jsdoc_type_aliases_for_pos(stmt_node.pos);
         }
 
@@ -957,6 +978,13 @@ impl<'a> DeclarationEmitter<'a> {
                     }
                 }
             }
+        } else if js_export_equals_root_name.is_some()
+            && has_jsdoc_type_alias
+            && !has_jsdoc_type_function_signature
+        {
+            let styled_chain = self.leading_jsdoc_comment_chain_for_pos_with_style(stmt_node.pos);
+            self.emit_jsdoc_comment_chain_preserving_multiline_style(&styled_chain);
+            self.mark_leading_comments_emitted_before(stmt_node.pos);
         } else if has_jsdoc_type_function_signature || has_jsdoc_type_alias {
             self.emit_leading_jsdoc_comments(stmt_node.pos);
             self.writer.truncate(before_jsdoc_len);

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -1291,6 +1291,42 @@ const value = 1;
 }
 
 #[test]
+fn test_js_export_equals_class_keeps_leading_typedef_local() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @typedef {string | number} Whatever
+ */
+class Conn {
+    constructor() {}
+    item = 3;
+    method() {}
+}
+module.exports = Conn;
+"#,
+    );
+
+    let expected = r#"export = Conn;
+/**
+ * @typedef {string | number} Whatever
+ */
+declare class Conn {
+    item: number;
+    method(): void;
+}
+declare namespace Conn {
+    export { Whatever };
+}
+type Whatever = string | number;
+"#;
+
+    assert_eq!(
+        output, expected,
+        "Expected export= class typedef to remain local and follow the namespace: {output}"
+    );
+}
+
+#[test]
 fn test_js_multiline_typedef_before_function_variable_is_emitted() {
     let source = r#"
 /**


### PR DESCRIPTION
## Summary

- Emit pending `export =` before leading typedef comments on JS export-equals root classes/functions.
- Keep typedef aliases attached to those root declarations local instead of emitting them early as `export type` aliases.
- Preserve multiline JSDoc comment style while allowing the namespace export plus trailing local alias emission to match TypeScript.

Fixes DTS baseline `jsDeclarationsTypedefAndImportTypes`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tsz-emitter --lib test_js_export_equals_class_keeps_leading_typedef_local -- --nocapture`
- `cargo test -p tsz-emitter --lib 'typedef' -- --nocapture`
- `CARGO_TARGET_DIR=.target cargo build -p tsz-cli --bin tsz`
- Focused DTS: `scripts/emit/run.sh --dts-only --verbose --skip-build --timeout=20000 --filter=jsDeclarationsTypedefAndImportTypes --json-out=/tmp/dts-focused-jsDeclarationsTypedefAndImportTypes-after.json` passed 1/1.
- Regenerated-cache full DTS: removed `scripts/emit/.cache/emit-cache.json` and `scripts/emit/.cache/dts-baseline-index.json`, then ran `scripts/emit/run.sh --dts-only --verbose --skip-build --timeout=60000 --json-out=/tmp/dts-current-after-jsdoc-typedef-export-equals-local.json`; result `1571/1669`, no new failures, fixed `jsDeclarationsTypedefAndImportTypes`.
