### PR TITLE
fix(checker): select TC39 decorator first-arg shape by member kind (TS1240)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -158,6 +158,10 @@ name = "ts1240_tests"
 path = "tests/ts1240_tests.rs"
 
 [[test]]
+name = "ts1240_accessor_decorator_tests"
+path = "tests/ts1240_accessor_decorator_tests.rs"
+
+[[test]]
 name = "ts2802_downlevel_iteration_tests"
 path = "tests/ts2802_downlevel_iteration_tests.rs"
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -1,38 +1,54 @@
 //! Class-member decorator signature validation helpers.
 
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
+/// Decorator-type sentinels that short-circuit signature validation. `ERROR`
+/// is an unresolved type (we have already reported it elsewhere); `ANY` and
+/// `UNKNOWN` are explicitly permissive and tsc does not emit a follow-on
+/// TS1239/TS1240 for them.
+#[inline]
+const fn decorator_type_is_unchecked(t: TypeId) -> bool {
+    matches!(t, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN)
+}
+
 impl<'a> CheckerState<'a> {
-    /// TS1240 for ES field decorators: the runtime invokes field decorators as
-    /// `decorator(undefined, context)`. Resolve the decorator expression against
-    /// that value argument so signatures that require the field value itself are
-    /// rejected like tsc.
-    pub(crate) fn check_es_property_decorator_call_signature(
+    /// TS1240 for ES class-member decorators (TC39 stage 3).
+    ///
+    /// The runtime calling convention for the first argument varies by member kind:
+    ///
+    /// - Plain field (`x = …`): `undefined`
+    /// - Auto-accessor (`accessor x = …`): a `ClassAccessorDecoratorTarget<This, V>`
+    ///   object — `{ get(this: This): V; set(this: This, value: V): void }`
+    ///
+    /// Callers select the first-arg type per member kind; this helper resolves
+    /// the decorator type and verifies it is callable with `(first_arg, ANY)`,
+    /// emitting TS1240 otherwise. The second argument (the decorator context)
+    /// is `ANY` because the calling convention is distinguished by the first
+    /// argument shape alone — the context object differs by kind but tsc
+    /// reports the same TS1240 either way.
+    pub(crate) fn check_es_member_decorator_call_signature(
         &mut self,
         decorator_node: NodeIndex,
         decorator_type: TypeId,
+        first_arg: TypeId,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use crate::query_boundaries::common::CallResult;
-
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
+        if decorator_type_is_unchecked(decorator_type) {
             return;
         }
 
         self.ensure_relation_input_ready(decorator_type);
         let resolved = self.evaluate_type_for_assignability(decorator_type);
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
+        if decorator_type_is_unchecked(resolved) {
             return;
         }
 
         let (result, _, _) = self.resolve_call_with_checker_adapter(
             resolved,
-            &[TypeId::UNDEFINED, TypeId::ANY],
+            &[first_arg, TypeId::ANY],
             false,
             None,
             None,
@@ -47,6 +63,26 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Resolve `ClassAccessorDecoratorTarget<any, any>` from the lib globals.
+    ///
+    /// Returns `None` if the lib is not available (e.g. `--noLib`); callers
+    /// fall back to a permissive shape so absent libs do not cause false
+    /// positives.
+    pub(crate) fn resolve_class_accessor_decorator_target_any(&mut self) -> Option<TypeId> {
+        let lib_binders = self.get_lib_binders();
+        let sym_id = self
+            .ctx
+            .binder
+            .get_global_type_with_libs("ClassAccessorDecoratorTarget", &lib_binders)?;
+        let base = self.ctx.create_lazy_type_ref(sym_id);
+        Some(
+            self.ctx
+                .types
+                .factory()
+                .application(base, vec![TypeId::ANY, TypeId::ANY]),
+        )
+    }
+
     /// TS1329: Check if a method/accessor decorator accepts too few arguments.
     ///
     /// For experimental decorators, method/accessor decorators are called as
@@ -59,12 +95,7 @@ impl<'a> CheckerState<'a> {
         decorator_type: TypeId,
         decorator_node: NodeIndex,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
+        if decorator_type_is_unchecked(decorator_type) {
             return;
         }
 
@@ -127,19 +158,13 @@ impl<'a> CheckerState<'a> {
         decorator_type: TypeId,
         is_constructor_parameter: bool,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use crate::query_boundaries::common::CallResult;
-
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
+        if decorator_type_is_unchecked(decorator_type) {
             return;
         }
 
         self.ensure_relation_input_ready(decorator_type);
         let resolved = self.evaluate_type_for_assignability(decorator_type);
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
+        if decorator_type_is_unchecked(resolved) {
             return;
         }
 

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1548,6 +1548,35 @@ impl<'a> CheckerState<'a> {
         let legacy_decorator_not_valid = self.ctx.compiler_options.experimental_decorators
             && (is_private_member || is_class_expression_member);
 
+        // ES (TC39) decorator first-argument shape per member kind. Computed once
+        // before the per-decorator loop because the member kind and modifiers do
+        // not vary across decorators on the same declaration.
+        //
+        // - Plain field: runtime invokes `decorator(undefined, context)`.
+        // - Auto-accessor (`accessor x = …`): runtime invokes
+        //   `decorator(target, context)` where `target` is a
+        //   `ClassAccessorDecoratorTarget<This, Value>` object. We resolve the
+        //   global type and instantiate it with `<any, any>`; the decorator's
+        //   `This`/`Value` type parameters are inferred from this shape.
+        //
+        // If `ClassAccessorDecoratorTarget` is unavailable (e.g. `--noLib`) we
+        // fall back to `ANY` so the absence of the lib type cannot itself
+        // produce a TS1240 false positive.
+        let es_member_first_arg: Option<TypeId> =
+            if !self.ctx.compiler_options.experimental_decorators
+                && node.kind == syntax_kind_ext::PROPERTY_DECLARATION
+                && !is_ambient_field
+            {
+                Some(if self.has_accessor_modifier_ref(modifiers) {
+                    self.resolve_class_accessor_decorator_target_any()
+                        .unwrap_or(TypeId::ANY)
+                } else {
+                    TypeId::UNDEFINED
+                })
+            } else {
+                None
+            };
+
         if let Some(modifiers) = modifiers {
             for &modifier_idx in &modifiers.nodes {
                 let Some(modifier_node) = self.ctx.arena.get(modifier_idx) else {
@@ -1586,11 +1615,12 @@ impl<'a> CheckerState<'a> {
 
                 let decorator_type = self.compute_type_of_node(decorator.expression);
 
-                if !self.ctx.compiler_options.experimental_decorators
-                    && node.kind == syntax_kind_ext::PROPERTY_DECLARATION
-                    && !is_ambient_field
-                {
-                    self.check_es_property_decorator_call_signature(modifier_idx, decorator_type);
+                if let Some(first_arg) = es_member_first_arg {
+                    self.check_es_member_decorator_call_signature(
+                        modifier_idx,
+                        decorator_type,
+                        first_arg,
+                    );
                 }
 
                 // TS1329: Check if the decorator accepts too few arguments for this position.

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -231,6 +231,18 @@ impl<'a> CheckerState<'a> {
         self.has_modifier_kind(modifiers, SyntaxKind::AccessorKeyword)
     }
 
+    /// Like [`Self::has_accessor_modifier`] but accepts a borrowed
+    /// `Option<&NodeList>` — used at call sites that already hold the
+    /// modifier list as a reference.
+    pub(crate) fn has_accessor_modifier_ref(
+        &self,
+        modifiers: Option<&tsz_parser::parser::NodeList>,
+    ) -> bool {
+        self.ctx
+            .arena
+            .has_modifier_ref(modifiers, SyntaxKind::AccessorKeyword)
+    }
+
     /// Check if modifiers include the 'override' keyword.
     pub(crate) fn has_override_modifier(
         &self,

--- a/crates/tsz-checker/tests/ts1240_accessor_decorator_tests.rs
+++ b/crates/tsz-checker/tests/ts1240_accessor_decorator_tests.rs
@@ -1,0 +1,322 @@
+//! Tests for TS1240 on TC39 auto-accessor decorators.
+//!
+//! Structural rule: when `experimentalDecorators` is off and a class
+//! member declaration carries one or more decorators, the checker selects
+//! the first-arg type from the member kind — `ClassAccessorDecoratorTarget<This, V>`
+//! for `accessor` fields, `undefined` for plain fields — and rejects (TS1240)
+//! decorators whose resolved signature cannot accept `(first_arg, ANY)`.
+//!
+//! These tests intentionally vary type-parameter and identifier names to
+//! confirm the fix is not keyed on user-chosen spellings (anti-hardcoding
+//! per CLAUDE.md §25 / §26).
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// The reported repro from #6652: a TC39 accessor decorator that takes a
+/// generic `ClassAccessorDecoratorTarget<This, Value>` must not produce
+/// TS1240. The interface is declared locally; the checker resolves it from
+/// `file_locals` just like a globally-scoped lib declaration.
+#[test]
+fn ts1240_accessor_decorator_with_class_accessor_decorator_target_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+interface ClassAccessorDecoratorContext<This, Value> {}
+interface ClassAccessorDecoratorResult<This, Value> {}
+
+function bound<T, V>(
+    target: ClassAccessorDecoratorTarget<T, V>,
+    context: ClassAccessorDecoratorContext<T, V>
+): ClassAccessorDecoratorResult<T, V> | void {
+    return {} as any;
+}
+
+class WithAccessor {
+    @bound
+    accessor value: number = 0;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for accessor decorator typed against ClassAccessorDecoratorTarget, got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding: rename the decorator's type parameters from `T/V` to
+/// `A/B` and the field identifier from `value` to `field` — the fix must
+/// rest on the structural rule (accessor modifier + decorator first-arg
+/// shape), not on the spelling.
+#[test]
+fn ts1240_accessor_decorator_renamed_type_parameters_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function deco<A, B>(
+    target: ClassAccessorDecoratorTarget<A, B>,
+    context: any
+): void {}
+
+class Renamed {
+    @deco
+    accessor field: string = "";
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 with renamed type parameters, got: {codes:?}"
+    );
+}
+
+/// The fix must not depend on the field being instance-level. Static
+/// auto-accessors share the same TC39 calling convention.
+#[test]
+fn ts1240_static_accessor_decorator_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function bound<T, V>(
+    target: ClassAccessorDecoratorTarget<T, V>,
+    context: any
+): void {}
+
+class WithStaticAccessor {
+    @bound
+    static accessor flag: boolean = false;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for static auto-accessor decorator, got: {codes:?}"
+    );
+}
+
+/// A decorator that accepts `any` (or no annotation) for the first
+/// argument must remain compatible with the accessor calling convention.
+#[test]
+fn ts1240_accessor_decorator_with_any_first_param_accepted() {
+    let codes = check_source_codes(
+        r#"
+function loose(_target: any, _context: any): void {}
+
+class C {
+    @loose
+    accessor x = 0;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for accessor decorator with `any` first param, got: {codes:?}"
+    );
+}
+
+/// Structural rule check: a decorator whose first parameter has a shape
+/// genuinely incompatible with `ClassAccessorDecoratorTarget` must still
+/// be rejected. The first arg here is `string`, which cannot accept an
+/// object with `get`/`set` methods, so TS1240 is correct.
+#[test]
+fn ts1240_accessor_decorator_with_incompatible_first_arg_still_rejected() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function bad(_target: string, _context: any): void {}
+
+class C {
+    @bad
+    accessor x = 0;
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1240),
+        "Expected TS1240 for accessor decorator with incompatible first arg, got: {codes:?}"
+    );
+}
+
+/// Non-callable decorator value (a number literal) is still rejected:
+/// the fix narrows the first-arg shape, it does not soften the basic
+/// callable check.
+#[test]
+fn ts1240_non_callable_accessor_decorator_rejected() {
+    let codes = check_source_codes(
+        r#"
+const dec = 42;
+
+class C {
+    @dec
+    accessor x = 0;
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1240),
+        "Expected TS1240 for non-callable accessor decorator, got: {codes:?}"
+    );
+}
+
+/// Plain-field regression guard: the existing TS1240 behavior for plain
+/// fields (decorator first arg must accept `undefined`) must be
+/// unchanged. A decorator whose first arg is `string` is still rejected
+/// on a plain field.
+#[test]
+fn ts1240_plain_field_with_non_undefined_first_arg_still_rejected() {
+    let codes = check_source_codes(
+        r#"
+function dec(_target: string, _context: any): void {}
+
+class C {
+    @dec
+    x = 0;
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1240),
+        "Expected TS1240 for plain field with non-undefined first arg, got: {codes:?}"
+    );
+}
+
+/// Plain-field acceptance regression guard: a decorator typed against
+/// `ClassFieldDecoratorContext` (and `undefined` first arg) must continue
+/// to be accepted on a plain field.
+#[test]
+fn ts1240_plain_field_with_undefined_first_arg_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassFieldDecoratorContext<T, V> {}
+
+function fieldDec<T, V>(
+    _target: undefined,
+    _context: ClassFieldDecoratorContext<T, V>
+): void {}
+
+class C {
+    @fieldDec
+    x = 0;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for plain field with undefined first arg, got: {codes:?}"
+    );
+}
+
+/// Stacking decorators: the first-arg shape is loop-invariant per member,
+/// so multiple decorators on the same accessor must each see the
+/// `ClassAccessorDecoratorTarget` shape (not have the gate fall back to a
+/// per-decorator computation).
+#[test]
+fn ts1240_multiple_accessor_decorators_all_typed_against_target_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function a<T, V>(_t: ClassAccessorDecoratorTarget<T, V>, _c: any): void {}
+function b<T, V>(_t: ClassAccessorDecoratorTarget<T, V>, _c: any): void {}
+
+class Stacked {
+    @a
+    @b
+    accessor x = 0;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for stacked accessor decorators, got: {codes:?}"
+    );
+}
+
+/// Decorator-factory form (`@bound()` rather than `@bound`): the check
+/// resolves the call expression's return type as the decorator value, so
+/// a factory returning a compatible decorator must also be accepted.
+#[test]
+fn ts1240_accessor_decorator_factory_call_accepted() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function make<T, V>(): (
+    target: ClassAccessorDecoratorTarget<T, V>,
+    context: any
+) => void {
+    return (_t, _c) => {};
+}
+
+class C {
+    @make()
+    accessor x = 0;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1240),
+        "Expected no TS1240 for accessor decorator factory call, got: {codes:?}"
+    );
+}
+
+/// The accessor decorator's first-arg shape must NOT be required on
+/// plain-field decorators. A decorator typed against
+/// `ClassAccessorDecoratorTarget` applied to a plain field is correctly
+/// rejected (the runtime would pass `undefined`, not a target object).
+#[test]
+fn ts1240_accessor_typed_decorator_on_plain_field_rejected() {
+    let codes = check_source_codes(
+        r#"
+interface ClassAccessorDecoratorTarget<This, Value> {
+    get(this: This): Value;
+    set(this: This, value: Value): void;
+}
+
+function accessorOnly<T, V>(
+    _target: ClassAccessorDecoratorTarget<T, V>,
+    _context: any
+): void {}
+
+class C {
+    @accessorOnly
+    x = 0;
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1240),
+        "Expected TS1240 for accessor-typed decorator on plain field, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #6652.

## Structural rule

> When `experimentalDecorators` is off and a class member declaration carries one or more decorators, the checker selects the runtime first argument shape from the member kind — `ClassAccessorDecoratorTarget<This, V>` for auto-accessor (`accessor x = …`) fields, `undefined` for plain fields — and rejects (TS1240) decorators whose resolved signature cannot accept `(first_arg, ANY)`.

## Owner layer

Checker (member-declaration walker chooses the calling convention). Solver validates callability via the existing `resolve_call_with_checker_adapter` path. No solver semantics change.

## What was wrong

Previously the TS1240 check always passed `[UNDEFINED, ANY]`, so any decorator typed against `ClassAccessorDecoratorTarget` (the standard TC39 auto-accessor first-arg type) was rejected the moment the user wrote `accessor x = 0`. That covers every idiomatic auto-accessor decorator in the wild.

## Fix breadth

- `check_es_property_decorator_call_signature` → renamed to `check_es_member_decorator_call_signature(node, ty, first_arg)`, generalizing over member kind. Both the field and accessor calling conventions now flow through one helper.
- `resolve_class_accessor_decorator_target_any` resolves `ClassAccessorDecoratorTarget<any, any>` from the lib globals and falls back to `TypeId::ANY` when the lib is unavailable (e.g. `--noLib`) so the lib's absence cannot itself produce a TS1240 false positive.
- `es_member_first_arg: Option<TypeId>` is computed once before the per-decorator loop using a new `has_accessor_modifier_ref` helper (sibling to the existing `has_accessor_modifier`).
- Deduped the `ERROR | ANY | UNKNOWN` early-return triplet across all three decorator-signature checkers via a file-local `const fn decorator_type_is_unchecked`.

## Anti-hardcoding (CLAUDE.md §25 / §26)

- No user-chosen identifier or rendered type-display string drives the decision; the only string literal is the built-in lib global name `"ClassAccessorDecoratorTarget"` (the §25 carve-out for well-known names).
- One unit test renames the decorator's type parameters (`T/V → A/B`) to verify the fix is not keyed on the spelling.

## Test matrix (11 unit tests, `tests/ts1240_accessor_decorator_tests.rs`)

| # | Validates |
|---|---|
| reported repro | basic accessor + `ClassAccessorDecoratorTarget<T, V>` |
| renamed type params | fix is not keyed on the spelling (`T/V → A/B`) |
| static accessor | static and instance auto-accessors share the convention |
| `any` first param | permissive accessor decorator is accepted |
| structurally incompatible first arg | `target: string` accessor decorator is **still rejected** — the key test the prior all-`ANY` approach would miss |
| non-callable decorator | `@42 accessor x` is still rejected |
| stacked decorators | `@a @b accessor x` — invariance across the per-decorator loop |
| decorator factory call | `@make() accessor x` — call expression as decorator value |
| plain-field regression (accept) | `undefined` first arg still accepted on plain fields |
| plain-field regression (reject) | `target: string` still rejected on plain fields |
| accessor-typed decorator on plain field | rejected — runtime passes `undefined`, not a target object |

## Conformance

```text
- passed: unchanged (no conformance tests expect TS1240 today; fix removes a false positive that is not in the corpus snapshot)
- fixed: 0
- new failures: 0
- changed failures: 0
- category delta: false_positive 0, all_missing 0, wrong_code 0, fingerprint_only 0, close_to_passing 0
```

## Test plan

- [x] `cargo test -p tsz-checker --test ts1240_accessor_decorator_tests` — 11/11 pass
- [x] `cargo test -p tsz-checker --test ts1240_tests --test ts1239_parameter_decorator_tests --test ts1238_tests` — 23/23 pass (no decorator regressions)
- [x] `cargo test -p tsz-checker --lib` — 4057/4057 pass (5 ignored)
- [x] `cargo clippy -p tsz-checker --lib --tests -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] rebased on top of `origin/main`

https://claude.ai/code/session_01QVP5gdyLCXaCCmsCv1ejo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVP5gdyLCXaCCmsCv1ejo7)_