### PR TITLE
refactor(checker): carry call relation evidence explicitly

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1110,16 +1110,6 @@ impl<'a> CheckerState<'a> {
             use crate::query_boundaries::assignability::RelationRequest;
             let (prepared_source, prepared_target) =
                 self.prepare_assignability_inputs(source, target);
-            let cached_outcome = self
-                .ctx
-                .call_relation_outcomes
-                .borrow()
-                .get(&(prepared_source, prepared_target))
-                .cloned();
-            if let Some(outcome) = cached_outcome {
-                return self
-                    .report_argument_assignability_with_outcome(source, target, arg_idx, outcome);
-            }
             RelationRequest::call_arg(prepared_source, prepared_target)
                 .with_property_classification()
         };
@@ -1127,7 +1117,7 @@ impl<'a> CheckerState<'a> {
         self.report_argument_assignability_with_outcome(source, target, arg_idx, outcome)
     }
 
-    fn report_argument_assignability_with_outcome(
+    pub(crate) fn report_argument_assignability_with_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -1,6 +1,6 @@
 //! Adapter methods for routing call/new resolution through the solver.
 
-use super::CheckerCallAssignabilityAdapter;
+use super::{CheckerCallAssignabilityAdapter, CheckerCallResolution};
 use crate::query_boundaries::checkers::call::{
     resolve_call, resolve_call_with_arg_sources, resolve_new,
 };
@@ -119,12 +119,33 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
     ) -> tsz_solver::operations::CallWithCheckerResult {
+        self.resolve_call_with_checker_adapter_evidence(
+            func_type,
+            arg_types,
+            force_bivariant_callbacks,
+            contextual_type,
+            actual_this_type,
+        )
+        .into_solver_tuple()
+    }
+
+    pub(crate) fn resolve_call_with_checker_adapter_evidence(
+        &mut self,
+        func_type: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+    ) -> CheckerCallResolution {
         self.ensure_relation_input_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
-        resolve_call(
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
+        let (result, selected_type_predicate, instantiated_params) = resolve_call(
             db,
             &mut checker,
             func_type,
@@ -132,7 +153,13 @@ impl<'a> CheckerState<'a> {
             force_bivariant_callbacks,
             contextual_type,
             actual_this_type,
-        )
+        );
+        CheckerCallResolution {
+            result,
+            selected_type_predicate,
+            instantiated_params,
+            relation_evidence: checker.relation_evidence,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -145,12 +172,36 @@ impl<'a> CheckerState<'a> {
         actual_this_type: Option<TypeId>,
         arg_source_is_type_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
+        self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+            func_type,
+            arg_types,
+            force_bivariant_callbacks,
+            contextual_type,
+            actual_this_type,
+            arg_source_is_type_annotation,
+        )
+        .into_solver_tuple()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn resolve_call_with_checker_adapter_and_arg_sources_evidence(
+        &mut self,
+        func_type: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+        arg_source_is_type_annotation: &[bool],
+    ) -> CheckerCallResolution {
         self.ensure_relation_input_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
-        resolve_call_with_arg_sources(
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
+        let (result, selected_type_predicate, instantiated_params) = resolve_call_with_arg_sources(
             db,
             &mut checker,
             func_type,
@@ -159,7 +210,13 @@ impl<'a> CheckerState<'a> {
             contextual_type,
             actual_this_type,
             arg_source_is_type_annotation,
-        )
+        );
+        CheckerCallResolution {
+            result,
+            selected_type_predicate,
+            instantiated_params,
+            relation_evidence: checker.relation_evidence,
+        }
     }
 
     pub(crate) fn resolve_new_with_checker_adapter(
@@ -173,7 +230,10 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
         resolve_new(
             db,
             &mut checker,

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -50,8 +50,34 @@ pub(crate) struct OverloadResolution {
     pub(crate) selected_type_predicate: SelectedTypePredicate,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct CallRelationEvidence {
+    pub(crate) source: TypeId,
+    pub(crate) target: TypeId,
+    pub(crate) outcome: crate::query_boundaries::assignability::RelationOutcome,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CheckerCallResolution {
+    pub(crate) result: CallResult,
+    pub(crate) selected_type_predicate: SelectedTypePredicate,
+    pub(crate) instantiated_params: Option<Vec<tsz_solver::ParamInfo>>,
+    pub(crate) relation_evidence: Vec<CallRelationEvidence>,
+}
+
+impl CheckerCallResolution {
+    pub(crate) fn into_solver_tuple(self) -> tsz_solver::operations::CallWithCheckerResult {
+        (
+            self.result,
+            self.selected_type_predicate,
+            self.instantiated_params,
+        )
+    }
+}
+
 pub(super) struct CheckerCallAssignabilityAdapter<'s, 'ctx> {
     pub(super) state: &'s mut CheckerState<'ctx>,
+    pub(super) relation_evidence: Vec<CallRelationEvidence>,
 }
 
 impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
@@ -76,11 +102,11 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         let outcome = self.state.execute_relation_request(&request);
         let related = outcome.related;
         if related {
-            self.state
-                .ctx
-                .call_relation_outcomes
-                .borrow_mut()
-                .insert((prepared_source, prepared_target), outcome);
+            self.relation_evidence.push(CallRelationEvidence {
+                source: prepared_source,
+                target: prepared_target,
+                outcome,
+            });
             return true;
         }
         let target_display = self.state.format_type_diagnostic(target);
@@ -90,11 +116,11 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
                 return true;
             }
         }
-        self.state
-            .ctx
-            .call_relation_outcomes
-            .borrow_mut()
-            .insert((prepared_source, prepared_target), outcome);
+        self.relation_evidence.push(CallRelationEvidence {
+            source: prepared_source,
+            target: prepared_target,
+            outcome,
+        });
         false
     }
     fn is_assignable_to_strict(&mut self, source: TypeId, target: TypeId) -> bool {

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -84,7 +84,6 @@ impl<'a> CheckerContext<'a> {
             lib_heritage_in_progress: FxHashSet::default(),
             node_types: crate::context::NodeTypeCache::with_capacity(arena.nodes.len()),
             request_node_types: FxHashMap::default(),
-            call_relation_outcomes: RefCell::new(FxHashMap::default()),
             object_literal_tracking: crate::context::ObjectLiteralTracking::default(),
             request_cache_counters: crate::context::RequestCacheCounters::default(),
             type_environment: RefCell::new(TypeEnvironment::new()),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -78,9 +78,6 @@ use tsz_parser::parser::node::NodeArena;
 pub type CrossFileTypeParamsCache =
     Arc<dashmap::DashMap<(u32, NodeIndex), Vec<tsz_solver::TypeParamInfo>>>;
 
-pub(crate) type CallRelationOutcomeCache =
-    RefCell<FxHashMap<(TypeId, TypeId), crate::query_boundaries::assignability::RelationOutcome>>;
-
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.
 ///
 /// Prevents stack overflow when resolving deeply recursive or circular
@@ -442,11 +439,6 @@ pub struct CheckerContext<'a> {
 
     /// Request-aware cache for audited non-empty request paths only.
     pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
-
-    /// Transient relation evidence produced while solver call resolution checks
-    /// argument compatibility. Diagnostic reporting can reuse it for TS2345
-    /// instead of issuing a second relation request for the same prepared pair.
-    pub(crate) call_relation_outcomes: CallRelationOutcomeCache,
 
     /// Object-literal diagnostic recovery and active initializer state.
     pub object_literal_tracking: ObjectLiteralTracking,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -1,3 +1,5 @@
+mod callee_helpers;
+
 use crate::call_checker::CallableContext;
 use crate::context::TypingRequest;
 use crate::query_boundaries::assignability as assign_query;
@@ -21,104 +23,6 @@ use super::super::complex::is_contextually_sensitive;
 use super::post_generic::PostGenericCallDiagnostics;
 
 impl<'a> CheckerState<'a> {
-    fn fresh_direct_function_call_signature(
-        &mut self,
-        callee_expression: NodeIndex,
-    ) -> Option<tsz_solver::CallSignature> {
-        let callee_node = self.ctx.arena.get(callee_expression)?;
-        if callee_node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
-            return None;
-        }
-
-        let sym_id = self.resolve_identifier_symbol(callee_expression)?;
-        let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        let function_decl_count = symbol
-            .all_declarations()
-            .into_iter()
-            .filter(|&decl_idx| {
-                self.ctx
-                    .arena
-                    .get(decl_idx)
-                    .is_some_and(|node| node.kind == syntax_kind_ext::FUNCTION_DECLARATION)
-            })
-            .count();
-        if function_decl_count > 1 {
-            return None;
-        }
-        let decl_idx = symbol.value_declaration.into_option()?;
-        let decl_node = self.ctx.arena.get(decl_idx)?;
-        if decl_node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
-            return None;
-        }
-        let func = self.ctx.arena.get_function(decl_node).cloned()?;
-
-        let diagnostics_before = self.ctx.snapshot_diagnostics();
-        let fresh_signature = self.call_signature_from_function(&func, decl_idx);
-        self.ctx.rollback_diagnostics(&diagnostics_before);
-
-        Some(fresh_signature)
-    }
-
-    fn direct_function_call_type_for_type_argument_validation(
-        &mut self,
-        callee_expression: NodeIndex,
-    ) -> Option<TypeId> {
-        let fresh_signature = self.fresh_direct_function_call_signature(callee_expression)?;
-        if fresh_signature.type_params.is_empty() {
-            return None;
-        }
-
-        Some(self.ctx.types.factory().function(FunctionShape {
-            type_params: fresh_signature.type_params,
-            params: fresh_signature.params,
-            this_type: fresh_signature.this_type,
-            return_type: fresh_signature.return_type,
-            type_predicate: fresh_signature.type_predicate,
-            is_constructor: false,
-            is_method: fresh_signature.is_method,
-        }))
-    }
-
-    fn refresh_callee_shape_type_param_constraints(
-        &mut self,
-        callee_expression: NodeIndex,
-        mut shape: FunctionShape,
-    ) -> FunctionShape {
-        if shape.type_params.is_empty() {
-            return shape;
-        }
-
-        let Some(fresh_signature) = self.fresh_direct_function_call_signature(callee_expression)
-        else {
-            return shape;
-        };
-        if fresh_signature.type_params.len() != shape.type_params.len() {
-            return shape;
-        }
-
-        for (existing, fresh) in shape
-            .type_params
-            .iter_mut()
-            .zip(fresh_signature.type_params.iter())
-        {
-            let existing_unresolved = existing.constraint.is_none_or(|constraint| {
-                constraint == TypeId::UNKNOWN || constraint == TypeId::ERROR
-            });
-            let fresh_resolved = fresh.constraint.is_some_and(|constraint| {
-                constraint != TypeId::UNKNOWN && constraint != TypeId::ERROR
-            });
-            if existing_unresolved && fresh_resolved {
-                existing.constraint = fresh.constraint;
-            }
-
-            if existing.default.is_none() && fresh.default.is_some() {
-                existing.default = fresh.default;
-            }
-        }
-
-        shape
-    }
-
     fn setup_higher_order_callee_contextual_type(
         &mut self,
         callee_expression: NodeIndex,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -715,6 +715,7 @@ impl<'a> CheckerState<'a> {
                     is_super_call: false,
                     is_optional_chain: nullish_cause.is_some(),
                     allow_contextual_mismatch_deferral: false,
+                    relation_evidence: &[],
                 },
             );
         }
@@ -2470,36 +2471,53 @@ impl<'a> CheckerState<'a> {
             contextual_type
         };
 
-        let (mut result, mut instantiated_predicate, mut generic_instantiated_params) =
-            if is_super_call {
-                (
-                    self.resolve_new_with_checker_adapter(
-                        callee_type_for_call,
-                        &generic_inference_arg_types,
-                        force_bivariant_callbacks,
-                        call_resolution_contextual_type,
-                    ),
-                    None,
-                    None,
-                )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+        let (
+            mut result,
+            mut instantiated_predicate,
+            mut generic_instantiated_params,
+            mut relation_evidence,
+        ) = if is_super_call {
+            (
+                self.resolve_new_with_checker_adapter(
                     callee_type_for_call,
                     &generic_inference_arg_types,
                     force_bivariant_callbacks,
                     call_resolution_contextual_type,
-                    actual_this_type,
-                    &generic_inference_arg_source_markers,
-                )
-            } else {
-                self.resolve_call_with_checker_adapter(
-                    callee_type_for_call,
-                    &generic_inference_arg_types,
-                    force_bivariant_callbacks,
-                    call_resolution_contextual_type,
-                    actual_this_type,
-                )
-            };
+                ),
+                None,
+                None,
+                Vec::new(),
+            )
+        } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+                &generic_inference_arg_source_markers,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        } else {
+            let resolution = self.resolve_call_with_checker_adapter_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        };
         // When the checker's intra-expression Round 2 produced a substitution that
         // pins type parameters the solver could not (the solver's single-pass
         // inference dropped the binding because the same parameter appears in a
@@ -2697,23 +2715,36 @@ impl<'a> CheckerState<'a> {
                     ),
                     None,
                     None,
+                    Vec::new(),
                 )
             } else if retry_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+                let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             } else {
-                self.resolve_call_with_checker_adapter(
+                let resolution = self.resolve_call_with_checker_adapter_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             };
             // Apply the same checker-side substitution refinement to the retry's
@@ -2758,6 +2789,7 @@ impl<'a> CheckerState<'a> {
             };
             instantiated_predicate = retry.1;
             generic_instantiated_params = retry.2;
+            relation_evidence = retry.3;
         }
 
         if is_generic_call
@@ -3127,6 +3159,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain: nullish_cause.is_some(),
             allow_contextual_mismatch_deferral,
+            relation_evidence: &relation_evidence,
         };
         // Pop the shape_this_type that was kept on the stack since the
         // argument collection phase.

--- a/crates/tsz-checker/src/types/computation/call/inner/callee_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner/callee_helpers.rs
@@ -1,0 +1,106 @@
+//! Callee-shape helpers for call expression checking.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::{FunctionShape, TypeId};
+
+impl<'a> CheckerState<'a> {
+    fn fresh_direct_function_call_signature(
+        &mut self,
+        callee_expression: NodeIndex,
+    ) -> Option<tsz_solver::CallSignature> {
+        let callee_node = self.ctx.arena.get(callee_expression)?;
+        if callee_node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(callee_expression)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        let function_decl_count = symbol
+            .all_declarations()
+            .into_iter()
+            .filter(|&decl_idx| {
+                self.ctx
+                    .arena
+                    .get(decl_idx)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::FUNCTION_DECLARATION)
+            })
+            .count();
+        if function_decl_count > 1 {
+            return None;
+        }
+        let decl_idx = symbol.value_declaration.into_option()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        if decl_node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+            return None;
+        }
+        let func = self.ctx.arena.get_function(decl_node).cloned()?;
+
+        let diagnostics_before = self.ctx.snapshot_diagnostics();
+        let fresh_signature = self.call_signature_from_function(&func, decl_idx);
+        self.ctx.rollback_diagnostics(&diagnostics_before);
+
+        Some(fresh_signature)
+    }
+
+    pub(super) fn direct_function_call_type_for_type_argument_validation(
+        &mut self,
+        callee_expression: NodeIndex,
+    ) -> Option<TypeId> {
+        let fresh_signature = self.fresh_direct_function_call_signature(callee_expression)?;
+        if fresh_signature.type_params.is_empty() {
+            return None;
+        }
+
+        Some(self.ctx.types.factory().function(FunctionShape {
+            type_params: fresh_signature.type_params,
+            params: fresh_signature.params,
+            this_type: fresh_signature.this_type,
+            return_type: fresh_signature.return_type,
+            type_predicate: fresh_signature.type_predicate,
+            is_constructor: false,
+            is_method: fresh_signature.is_method,
+        }))
+    }
+
+    pub(super) fn refresh_callee_shape_type_param_constraints(
+        &mut self,
+        callee_expression: NodeIndex,
+        mut shape: FunctionShape,
+    ) -> FunctionShape {
+        if shape.type_params.is_empty() {
+            return shape;
+        }
+
+        let Some(fresh_signature) = self.fresh_direct_function_call_signature(callee_expression)
+        else {
+            return shape;
+        };
+        if fresh_signature.type_params.len() != shape.type_params.len() {
+            return shape;
+        }
+
+        for (existing, fresh) in shape
+            .type_params
+            .iter_mut()
+            .zip(fresh_signature.type_params.iter())
+        {
+            let existing_unresolved = existing.constraint.is_none_or(|constraint| {
+                constraint == TypeId::UNKNOWN || constraint == TypeId::ERROR
+            });
+            let fresh_resolved = fresh.constraint.is_some_and(|constraint| {
+                constraint != TypeId::UNKNOWN && constraint != TypeId::ERROR
+            });
+            if existing_unresolved && fresh_resolved {
+                existing.constraint = fresh.constraint;
+            }
+
+            if existing.default.is_none() && fresh.default.is_some() {
+                existing.default = fresh.default;
+            }
+        }
+
+        shape
+    }
+}

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -895,36 +895,53 @@ impl<'a> CheckerState<'a> {
         };
         let call_resolution_contextual_type = contextual_type;
 
-        let (mut result, mut instantiated_predicate, mut generic_instantiated_params) =
-            if is_super_call {
-                (
-                    self.resolve_new_with_checker_adapter(
-                        callee_type_for_call,
-                        &generic_inference_arg_types,
-                        force_bivariant_callbacks,
-                        call_resolution_contextual_type,
-                    ),
-                    None,
-                    None,
-                )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+        let (
+            mut result,
+            mut instantiated_predicate,
+            mut generic_instantiated_params,
+            mut relation_evidence,
+        ) = if is_super_call {
+            (
+                self.resolve_new_with_checker_adapter(
                     callee_type_for_call,
                     &generic_inference_arg_types,
                     force_bivariant_callbacks,
                     call_resolution_contextual_type,
-                    actual_this_type,
-                    &generic_inference_arg_source_markers,
-                )
-            } else {
-                self.resolve_call_with_checker_adapter(
-                    callee_type_for_call,
-                    &generic_inference_arg_types,
-                    force_bivariant_callbacks,
-                    call_resolution_contextual_type,
-                    actual_this_type,
-                )
-            };
+                ),
+                None,
+                None,
+                Vec::new(),
+            )
+        } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+                &generic_inference_arg_source_markers,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        } else {
+            let resolution = self.resolve_call_with_checker_adapter_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        };
         let needs_real_type_recheck = is_generic_call
             && args.iter().enumerate().any(|(i, &arg_idx)| {
                 self.argument_needs_refresh_for_contextual_call(
@@ -1067,23 +1084,36 @@ impl<'a> CheckerState<'a> {
                     ),
                     None,
                     None,
+                    Vec::new(),
                 )
             } else if retry_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+                let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             } else {
-                self.resolve_call_with_checker_adapter(
+                let resolution = self.resolve_call_with_checker_adapter_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             };
             result = if retry_sanitized || needs_real_type_recheck {
@@ -1102,6 +1132,7 @@ impl<'a> CheckerState<'a> {
             };
             instantiated_predicate = retry.1;
             generic_instantiated_params = retry.2;
+            relation_evidence = retry.3;
         }
 
         if is_generic_call
@@ -1287,6 +1318,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,
+            relation_evidence: &relation_evidence,
         };
         if pushed_this_type_from_shape {
             self.ctx.this_type_stack.pop();

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1,5 +1,7 @@
 //! Call-result handling helpers shared by call expression computation.
 
+mod args;
+
 use crate::checkers_domain::call_checker::CallRelationEvidence;
 use crate::query_boundaries::assignability as assign_query;
 use crate::query_boundaries::common;
@@ -1899,42 +1901,6 @@ impl<'a> CheckerState<'a> {
                 .any(|&(start, end)| diag.start >= start && diag.start < end)
         });
         self.ctx.rebuild_emitted_diagnostics_from_current();
-    }
-
-    pub(crate) fn build_expanded_args_for_error(&mut self, args: &[NodeIndex]) -> Vec<NodeIndex> {
-        let mut expanded = Vec::with_capacity(args.len());
-        for &arg_idx in args {
-            if let Some(n) = self.ctx.arena.get(arg_idx)
-                && n.kind == syntax_kind_ext::SPREAD_ELEMENT
-                && let Some(spread_expression) = self
-                    .ctx
-                    .arena
-                    .get_spread(n)
-                    .map(|spread| spread.expression)
-                    .or_else(|| self.ctx.arena.get_children(arg_idx).first().copied())
-            {
-                let spread_type = self.get_type_of_node(spread_expression);
-                let spread_type = self.resolve_type_for_property_access(spread_type);
-                let spread_type = self.resolve_lazy_type(spread_type);
-                if let Some(elems) =
-                    crate::query_boundaries::common::tuple_elements(self.ctx.types, spread_type)
-                {
-                    expanded.extend(std::iter::repeat_n(arg_idx, elems.len()));
-                    continue;
-                }
-                // Array literal spreads have known element count — expand them
-                let inner_idx = self.ctx.arena.skip_parenthesized(spread_expression);
-                if let Some(expr_node) = self.ctx.arena.get(inner_idx)
-                    && expr_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-                    && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
-                {
-                    expanded.extend(std::iter::repeat_n(arg_idx, literal.elements.nodes.len()));
-                    continue;
-                }
-            }
-            expanded.push(arg_idx);
-        }
-        expanded
     }
 
     /// Check if TS2769 (no overload matches) should be suppressed due to structural

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1,5 +1,6 @@
 //! Call-result handling helpers shared by call expression computation.
 
+use crate::checkers_domain::call_checker::CallRelationEvidence;
 use crate::query_boundaries::assignability as assign_query;
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::CallResult;
@@ -22,9 +23,22 @@ pub(super) struct CallResultContext<'a> {
     pub(super) is_super_call: bool,
     pub(super) is_optional_chain: bool,
     pub(super) allow_contextual_mismatch_deferral: bool,
+    pub(super) relation_evidence: &'a [CallRelationEvidence],
 }
 
 impl<'a> CheckerState<'a> {
+    fn relation_evidence_for_pair<'e>(
+        relation_evidence: &'e [CallRelationEvidence],
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<&'e crate::query_boundaries::assignability::RelationOutcome> {
+        relation_evidence
+            .iter()
+            .rev()
+            .find(|evidence| evidence.source == source && evidence.target == target)
+            .map(|evidence| &evidence.outcome)
+    }
+
     fn is_generic_indexed_access_surface(&self, type_id: TypeId) -> bool {
         self.generic_indexed_access_surface_inner(type_id)
             || self
@@ -833,6 +847,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,
+            relation_evidence,
             ..
         } = context;
         match result {
@@ -1320,6 +1335,17 @@ impl<'a> CheckerState<'a> {
                                 reported_actual,
                                 reported_expected,
                                 arg_idx,
+                            );
+                        } else if let Some(outcome) = Self::relation_evidence_for_pair(
+                            relation_evidence,
+                            reported_actual,
+                            reported_expected,
+                        ) {
+                            let _ = self.report_argument_assignability_with_outcome(
+                                reported_actual,
+                                reported_expected,
+                                arg_idx,
+                                outcome.clone(),
                             );
                         } else {
                             let _ = self.check_argument_assignable_or_report(

--- a/crates/tsz-checker/src/types/computation/call_result/args.rs
+++ b/crates/tsz-checker/src/types/computation/call_result/args.rs
@@ -1,0 +1,44 @@
+//! Argument helpers for call-result diagnostics.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn build_expanded_args_for_error(&mut self, args: &[NodeIndex]) -> Vec<NodeIndex> {
+        let mut expanded = Vec::with_capacity(args.len());
+        for &arg_idx in args {
+            if let Some(n) = self.ctx.arena.get(arg_idx)
+                && n.kind == syntax_kind_ext::SPREAD_ELEMENT
+                && let Some(spread_expression) = self
+                    .ctx
+                    .arena
+                    .get_spread(n)
+                    .map(|spread| spread.expression)
+                    .or_else(|| self.ctx.arena.get_children(arg_idx).first().copied())
+            {
+                let spread_type = self.get_type_of_node(spread_expression);
+                let spread_type = self.resolve_type_for_property_access(spread_type);
+                let spread_type = self.resolve_lazy_type(spread_type);
+                if let Some(elems) =
+                    crate::query_boundaries::common::tuple_elements(self.ctx.types, spread_type)
+                {
+                    expanded.extend(std::iter::repeat_n(arg_idx, elems.len()));
+                    continue;
+                }
+                // Array literal spreads have known element count; expand them.
+                let inner_idx = self.ctx.arena.skip_parenthesized(spread_expression);
+                if let Some(expr_node) = self.ctx.arena.get(inner_idx)
+                    && expr_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                    && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
+                {
+                    expanded.extend(std::iter::repeat_n(arg_idx, literal.elements.nodes.len()));
+                    continue;
+                }
+            }
+            expanded.push(arg_idx);
+        }
+        expanded
+    }
+}

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -498,6 +498,7 @@ impl<'a> CheckerState<'a> {
                 is_super_call: false,
                 is_optional_chain: false,
                 allow_contextual_mismatch_deferral: true,
+                relation_evidence: &[],
             },
         );
 


### PR DESCRIPTION
## Summary
- Replace the transient `CheckerContext` TS2345 relation-outcome cache from the parent PR with explicit call-resolution evidence.
- Add a checker-owned `CheckerCallResolution` wrapper that preserves solver `CallResult` while carrying relation outcomes collected by `CheckerCallAssignabilityAdapter`.
- Thread call relation evidence through active call-result handling so TS2345 diagnostics can consume the already-collected `RelationOutcome` directly.

## Structural Rule
When solver call resolution detects an argument mismatch through the checker assignability adapter, checker call handling should carry that relation evidence as part of the call-resolution result instead of hiding it in ambient checker state.

## Owner Layer
- Solver `CallResult` remains unchanged and does not depend on checker diagnostic evidence.
- Checker call adapter owns the relation evidence collected while answering solver assignability requests.
- Call-result diagnostics consume that checker-owned evidence only at the TS2345 reporting edge.

## Verification
- `cargo check -p tsz-checker`
- Focused `tsz --ignoreConfig --noEmit` probes for primitive TS2345, missing-property TS2345, TS2322 object property mismatch, callback mismatch, and weak/excess-property argument diagnostics.
- Trace probes with `TSZ_LOG="tsz_checker::query_boundaries::assignability=trace,tsz_solver::relations=trace" TSZ_LOG_FORMAT=tree` still show one `execute_relation` / solver `query_relation` for the basic TS2345 prepared pair after removing the context cache.

## Stacking
- Stacked on #7323 / `refactor/relation-outcome-diagnostics-20260515`.

AgentName: m3-max-64g-gpt55