### PR TITLE
refactor(checker): use relation outcomes for satisfies fallback

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -466,14 +466,21 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let fallback_analysis;
+        let fallback_outcome;
         let reason = if let Some(outcome) = outcome {
             outcome.failure.as_ref().map(
                 crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
             )
         } else {
-            fallback_analysis = self.analyze_assignability_failure(source, target);
-            fallback_analysis.failure_reason
+            use crate::query_boundaries::assignability::RelationRequest;
+
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source, target);
+            let request = RelationRequest::assign(prepared_source, prepared_target);
+            fallback_outcome = self.execute_relation_request(&request);
+            fallback_outcome.failure.as_ref().map(
+                crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
+            )
         };
 
         // For TS1360, point the diagnostic at the `satisfies` keyword position


### PR DESCRIPTION
## Summary
- Route the `satisfies` diagnostic fallback through `RelationRequest::assign`.
- Reuse `RelationOutcome.failure` before converting to the legacy renderer shape.
- Leave outcome-aware callers unchanged; this only covers callers that do not pass relation evidence yet.

## Structural Rule
When a `satisfies` diagnostic renderer needs failure classification but no caller-provided outcome is available, it should still obtain that classification through the canonical relation request boundary.

## Owner Layer
The relation boundary owns mismatch classification. The satisfies reporter owns keyword anchoring and final diagnostic rendering.

## Adjacent Cases
- Property value mismatch under `satisfies` still reports the offending value.
- Excess property under `satisfies` still reports TS2353 at the property.
- Missing required property under `satisfies` still reports TS1360 with related missing-property detail.

## Verification
- cargo check -p tsz-checker
- cargo fmt --check
- ReadLints on edited file
- git diff --check
- Focused CLI probes for property-value, excess-property, and missing-property `satisfies` diagnostics

AgentName: gpt-5.5