### PR TITLE
fix(checker): recover contextual generic new returns

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -80,6 +80,213 @@ impl<'a> CheckerState<'a> {
         true
     }
 
+    fn type_parameter_default_syntactically_satisfies_constraint(
+        &self,
+        param_idx: NodeIndex,
+    ) -> bool {
+        let Some(param_node) = self.ctx.arena.get(param_idx) else {
+            return false;
+        };
+        let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
+            return false;
+        };
+        if param.default == NodeIndex::NONE || param.constraint == NodeIndex::NONE {
+            return false;
+        }
+        self.type_node_syntactically_in_constraint(param.default, param.constraint, 0)
+    }
+
+    fn type_node_syntactically_in_constraint(
+        &self,
+        default_node: NodeIndex,
+        constraint_node: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        if depth > 32 {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(constraint_node) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::UNION_TYPE
+            && let Some(union) = self.ctx.arena.get_composite_type(node)
+        {
+            return union.types.nodes.iter().any(|&member| {
+                self.type_nodes_syntactically_equal(default_node, member, depth + 1)
+            });
+        }
+        self.type_nodes_syntactically_equal(default_node, constraint_node, depth + 1)
+    }
+
+    fn type_nodes_syntactically_equal(&self, left: NodeIndex, right: NodeIndex, depth: u8) -> bool {
+        if depth > 32 || left == NodeIndex::NONE || right == NodeIndex::NONE {
+            return false;
+        }
+
+        let left = self.unwrap_syntactic_type_node(left, depth);
+        let right = self.unwrap_syntactic_type_node(right, depth);
+        if left == right {
+            return true;
+        }
+
+        let Some(left_node) = self.ctx.arena.get(left) else {
+            return false;
+        };
+        let Some(right_node) = self.ctx.arena.get(right) else {
+            return false;
+        };
+        if left_node.kind != right_node.kind {
+            return false;
+        }
+
+        if let (Some(left_ident), Some(right_ident)) = (
+            self.ctx.arena.get_identifier(left_node),
+            self.ctx.arena.get_identifier(right_node),
+        ) {
+            return left_ident.escaped_text == right_ident.escaped_text;
+        }
+
+        if let (Some(left_name), Some(right_name)) = (
+            self.ctx.arena.get_qualified_name(left_node),
+            self.ctx.arena.get_qualified_name(right_node),
+        ) {
+            return self.type_nodes_syntactically_equal(left_name.left, right_name.left, depth + 1)
+                && self.type_nodes_syntactically_equal(
+                    left_name.right,
+                    right_name.right,
+                    depth + 1,
+                );
+        }
+
+        if let (Some(left_ref), Some(right_ref)) = (
+            self.ctx.arena.get_type_ref(left_node),
+            self.ctx.arena.get_type_ref(right_node),
+        ) {
+            if !self.type_nodes_syntactically_equal(
+                left_ref.type_name,
+                right_ref.type_name,
+                depth + 1,
+            ) {
+                return false;
+            }
+            return match (&left_ref.type_arguments, &right_ref.type_arguments) {
+                (None, None) => true,
+                (Some(left_args), Some(right_args)) => {
+                    left_args.nodes.len() == right_args.nodes.len()
+                        && left_args.nodes.iter().zip(right_args.nodes.iter()).all(
+                            |(&left_arg, &right_arg)| {
+                                self.type_nodes_syntactically_equal(left_arg, right_arg, depth + 1)
+                            },
+                        )
+                }
+                _ => false,
+            };
+        }
+
+        if let (Some(left_wrapped), Some(right_wrapped)) = (
+            self.ctx.arena.get_wrapped_type(left_node),
+            self.ctx.arena.get_wrapped_type(right_node),
+        ) {
+            return self.type_nodes_syntactically_equal(
+                left_wrapped.type_node,
+                right_wrapped.type_node,
+                depth + 1,
+            );
+        }
+
+        if let (Some(left_literal_type), Some(right_literal_type)) = (
+            self.ctx.arena.get_literal_type(left_node),
+            self.ctx.arena.get_literal_type(right_node),
+        ) {
+            return self.type_nodes_syntactically_equal(
+                left_literal_type.literal,
+                right_literal_type.literal,
+                depth + 1,
+            );
+        }
+
+        if let (Some(left_literal), Some(right_literal)) = (
+            self.ctx.arena.get_literal(left_node),
+            self.ctx.arena.get_literal(right_node),
+        ) {
+            return left_literal.text == right_literal.text;
+        }
+
+        if let (Some(left_array), Some(right_array)) = (
+            self.ctx.arena.get_array_type(left_node),
+            self.ctx.arena.get_array_type(right_node),
+        ) {
+            return self.type_nodes_syntactically_equal(
+                left_array.element_type,
+                right_array.element_type,
+                depth + 1,
+            );
+        }
+
+        if let (Some(left_tuple), Some(right_tuple)) = (
+            self.ctx.arena.get_tuple_type(left_node),
+            self.ctx.arena.get_tuple_type(right_node),
+        ) {
+            return left_tuple.elements.nodes.len() == right_tuple.elements.nodes.len()
+                && left_tuple
+                    .elements
+                    .nodes
+                    .iter()
+                    .zip(right_tuple.elements.nodes.iter())
+                    .all(|(&left_elem, &right_elem)| {
+                        self.type_nodes_syntactically_equal(left_elem, right_elem, depth + 1)
+                    });
+        }
+
+        if let (Some(left_composite), Some(right_composite)) = (
+            self.ctx.arena.get_composite_type(left_node),
+            self.ctx.arena.get_composite_type(right_node),
+        ) {
+            return left_composite.types.nodes.len() == right_composite.types.nodes.len()
+                && left_composite
+                    .types
+                    .nodes
+                    .iter()
+                    .zip(right_composite.types.nodes.iter())
+                    .all(|(&left_type, &right_type)| {
+                        self.type_nodes_syntactically_equal(left_type, right_type, depth + 1)
+                    });
+        }
+
+        matches!(
+            left_node.kind,
+            k if k == SyntaxKind::AnyKeyword as u16
+                || k == SyntaxKind::UnknownKeyword as u16
+                || k == SyntaxKind::NeverKeyword as u16
+                || k == SyntaxKind::StringKeyword as u16
+                || k == SyntaxKind::NumberKeyword as u16
+                || k == SyntaxKind::BooleanKeyword as u16
+                || k == SyntaxKind::BigIntKeyword as u16
+                || k == SyntaxKind::SymbolKeyword as u16
+                || k == SyntaxKind::VoidKeyword as u16
+                || k == SyntaxKind::UndefinedKeyword as u16
+                || k == SyntaxKind::ObjectKeyword as u16
+                || k == SyntaxKind::ThisKeyword as u16
+        )
+    }
+
+    fn unwrap_syntactic_type_node(&self, mut node_idx: NodeIndex, mut depth: u8) -> NodeIndex {
+        while depth <= 32 {
+            let Some(node) = self.ctx.arena.get(node_idx) else {
+                return node_idx;
+            };
+            if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+                && let Some(wrapped) = self.ctx.arena.get_wrapped_type(node)
+            {
+                node_idx = wrapped.type_node;
+                depth += 1;
+                continue;
+            }
+            return node_idx;
+        }
+        node_idx
+    }
+
     // Nested generic declarations can be re-evaluated out of context (for example during
     // application-type expansion), so recover the nearest enclosing generic scope when the
     // current type-parameter list is missing its outer captures.
@@ -1810,6 +2017,13 @@ impl<'a> CheckerState<'a> {
             if self
                 .empty_type_literal_satisfies_optional_mapped_constraint(param_idx, constraint_type)
             {
+                continue;
+            }
+            // A default that is syntactically one branch of its constraint union
+            // satisfies the constraint by construction. This keeps default
+            // validation from depending on an early semantic copy of the same
+            // branch that may not have all lazy aliases stabilized yet.
+            if self.type_parameter_default_syntactically_satisfies_constraint(param_idx) {
                 continue;
             }
             if !self.is_assignable_to(default_type, constraint_type) {

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1498,7 +1498,16 @@ impl<'a> CheckerState<'a> {
                         });
                     let contextual_app =
                         query::get_application_info(self.ctx.types, contextual_type);
-                    if let (Some((result_base, result_args)), Some((ctx_base, ctx_args))) =
+                    if constructor_shape.as_ref().is_some_and(|shape| {
+                        self.contextual_application_recovers_unresolved_constructor_result(
+                            new_expr.expression,
+                            return_type,
+                            contextual_type,
+                            &shape.type_params,
+                        )
+                    }) {
+                        return_type = contextual_type;
+                    } else if let (Some((result_base, result_args)), Some((ctx_base, ctx_args))) =
                         (result_app, contextual_app)
                         && result_base == ctx_base
                         && result_args.len() == ctx_args.len()
@@ -1848,7 +1857,7 @@ impl<'a> CheckerState<'a> {
             CallResult::TypeParameterConstraintViolation {
                 inferred_type,
                 constraint_type,
-                return_type,
+                mut return_type,
             } => {
                 // Type parameter constraint violations are argument-level
                 // mismatches. tsc reports TS2345 at the argument.
@@ -1858,6 +1867,18 @@ impl<'a> CheckerState<'a> {
                     constraint_type,
                     anchor,
                 );
+                if let Some(contextual_type) = contextual_type
+                    && constructor_shape.as_ref().is_some_and(|shape| {
+                        self.contextual_application_recovers_unresolved_constructor_result(
+                            new_expr.expression,
+                            return_type,
+                            contextual_type,
+                            &shape.type_params,
+                        )
+                    })
+                {
+                    return_type = contextual_type;
+                }
                 return_type
             }
             CallResult::NoOverloadMatch {

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -115,6 +115,49 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    fn generic_new_argument_accepts_contextual_parameter(
+        &mut self,
+        arg_idx: NodeIndex,
+        expected: TypeId,
+    ) -> bool {
+        if expected == TypeId::ANY || expected == TypeId::ERROR || expected == TypeId::UNKNOWN {
+            return false;
+        }
+
+        let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
+            return false;
+        };
+        if !matches!(
+            arg_node.kind,
+            tsz_parser::parser::syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                | tsz_parser::parser::syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+        ) {
+            return false;
+        }
+
+        let snap = self.ctx.snapshot_diagnostics();
+        let request = TypingRequest::with_contextual_type(expected);
+        let contextual_actual = self.get_type_of_node_with_request(arg_idx, &request);
+        self.ctx.rollback_diagnostics(&snap);
+
+        contextual_actual != TypeId::ANY
+            && contextual_actual != TypeId::ERROR
+            && self.is_assignable_to(contextual_actual, expected)
+    }
+
+    fn recover_new_expression_return_type_after_contextual_argument_match(
+        &mut self,
+        constructor_type: TypeId,
+        fallback_return: TypeId,
+    ) -> TypeId {
+        if fallback_return != TypeId::ERROR {
+            fallback_return
+        } else {
+            self.instance_type_from_constructor_type(constructor_type)
+                .unwrap_or(TypeId::ERROR)
+        }
+    }
+
     ///
     /// This keeps general alias typing unchanged (important for type-position behavior)
     /// while ensuring constructor resolution sees the direct constructable type.
@@ -1729,6 +1772,15 @@ impl<'a> CheckerState<'a> {
                 }
                 if index < args.len() {
                     let arg_idx = args[index];
+                    if is_generic_new
+                        && self.generic_new_argument_accepts_contextual_parameter(arg_idx, expected)
+                    {
+                        return self
+                            .recover_new_expression_return_type_after_contextual_argument_match(
+                                constructor_type,
+                                fallback_return,
+                            );
+                    }
                     // Check if this is a weak union violation or excess property case
                     // In these cases, TypeScript shows TS2353 (excess property) instead of TS2322
                     // We should skip the TS2322 error regardless of check_excess_properties flag

--- a/crates/tsz-checker/src/types/computation/complex_contextual_application.rs
+++ b/crates/tsz-checker/src/types/computation/complex_contextual_application.rs
@@ -1,7 +1,8 @@
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::TypeId;
+use tsz_solver::{TypeId, TypeParamInfo};
 
 impl<'a> CheckerState<'a> {
     fn application_bases_are_same_nominal_type(&self, left: TypeId, right: TypeId) -> bool {
@@ -108,6 +109,186 @@ impl<'a> CheckerState<'a> {
                     || arg == TypeId::ERROR
                     || query::type_parameter_info(self.ctx.types, arg).is_some()
             })
+    }
+
+    pub(crate) fn contextual_application_recovers_unresolved_constructor_result(
+        &self,
+        callee_expr: NodeIndex,
+        result_type: TypeId,
+        contextual_type: TypeId,
+        constructor_type_params: &[TypeParamInfo],
+    ) -> bool {
+        if constructor_type_params.is_empty() {
+            return false;
+        }
+
+        let constructor_param_names: FxHashSet<_> = constructor_type_params
+            .iter()
+            .map(|type_param| type_param.name)
+            .collect();
+
+        let context_supplies_specific_args = |ctx_args: &[TypeId]| {
+            ctx_args
+                .iter()
+                .any(|&arg| arg != TypeId::ANY && arg != TypeId::UNKNOWN && arg != TypeId::ERROR)
+        };
+
+        let result_matches_context = self
+            .application_infos_for_type(result_type)
+            .into_iter()
+            .any(|(result_base, result_args)| {
+                !result_args.is_empty()
+                    && result_args.iter().all(|&arg| {
+                        arg == TypeId::UNKNOWN
+                            || query::type_parameter_info(self.ctx.types, arg)
+                                .is_some_and(|info| constructor_param_names.contains(&info.name))
+                    })
+                    && self
+                        .application_infos_for_type(contextual_type)
+                        .into_iter()
+                        .any(|(ctx_base, ctx_args)| {
+                            self.application_bases_are_same_nominal_type(result_base, ctx_base)
+                                && result_args.len() == ctx_args.len()
+                                && context_supplies_specific_args(&ctx_args)
+                        })
+            });
+        if result_matches_context {
+            return true;
+        }
+
+        let Some(target_sym) = self
+            .ctx
+            .binder
+            .resolve_identifier(self.ctx.arena, callee_expr)
+            .or_else(|| self.ctx.binder.get_node_symbol(callee_expr))
+            .or_else(|| self.resolve_qualified_symbol(callee_expr))
+        else {
+            return false;
+        };
+
+        self.application_infos_for_type(contextual_type)
+            .into_iter()
+            .any(|(ctx_base, ctx_args)| {
+                self.contextual_application_base_matches_target(
+                    target_sym,
+                    ctx_base,
+                    &ctx_args,
+                    Some(constructor_type_params.len()),
+                )
+            })
+    }
+
+    pub(crate) fn contextual_application_matches_new_target(
+        &self,
+        callee_expr: NodeIndex,
+        contextual_type: TypeId,
+    ) -> bool {
+        let Some(target_sym) = self
+            .ctx
+            .binder
+            .resolve_identifier(self.ctx.arena, callee_expr)
+            .or_else(|| self.ctx.binder.get_node_symbol(callee_expr))
+            .or_else(|| self.resolve_qualified_symbol(callee_expr))
+        else {
+            return false;
+        };
+
+        self.application_infos_for_type(contextual_type)
+            .into_iter()
+            .any(|(ctx_base, ctx_args)| {
+                self.contextual_application_base_matches_target(
+                    target_sym, ctx_base, &ctx_args, None,
+                )
+            })
+    }
+
+    fn contextual_application_base_matches_target(
+        &self,
+        target_sym: tsz_binder::SymbolId,
+        ctx_base: TypeId,
+        ctx_args: &[TypeId],
+        max_arg_count: Option<usize>,
+    ) -> bool {
+        self.application_base_symbol_id(ctx_base) == Some(target_sym)
+            && max_arg_count.is_none_or(|max| ctx_args.len() <= max)
+            && !ctx_args.is_empty()
+            && ctx_args
+                .iter()
+                .any(|&arg| arg != TypeId::ANY && arg != TypeId::UNKNOWN && arg != TypeId::ERROR)
+    }
+
+    pub(crate) fn contextual_application_recovers_unknown_result(
+        &self,
+        result_type: TypeId,
+        contextual_type: TypeId,
+    ) -> bool {
+        self.contextual_application_recovers_unresolved_result_by_base(
+            result_type,
+            contextual_type,
+            |arg| arg == TypeId::UNKNOWN,
+        )
+    }
+
+    pub(crate) fn contextual_application_recovers_type_param_result(
+        &self,
+        result_type: TypeId,
+        contextual_type: TypeId,
+    ) -> bool {
+        self.contextual_application_recovers_unresolved_result_by_base(
+            result_type,
+            contextual_type,
+            |arg| {
+                arg == TypeId::UNKNOWN
+                    || query::type_parameter_info(self.ctx.types, arg).is_some()
+                    || crate::query_boundaries::common::contains_type_parameters(
+                        self.ctx.types,
+                        arg,
+                    )
+            },
+        )
+    }
+
+    fn contextual_application_recovers_unresolved_result_by_base(
+        &self,
+        result_type: TypeId,
+        contextual_type: TypeId,
+        unresolved: impl Fn(TypeId) -> bool,
+    ) -> bool {
+        self.application_infos_for_type(result_type)
+            .into_iter()
+            .any(|(result_base, result_args)| {
+                !result_args.is_empty()
+                    && result_args.iter().all(|&arg| unresolved(arg))
+                    && self
+                        .application_infos_for_type(contextual_type)
+                        .into_iter()
+                        .any(|(ctx_base, ctx_args)| {
+                            self.application_bases_are_same_nominal_type(result_base, ctx_base)
+                                && result_args.len() == ctx_args.len()
+                                && ctx_args.iter().any(|&arg| {
+                                    arg != TypeId::ANY
+                                        && arg != TypeId::UNKNOWN
+                                        && arg != TypeId::ERROR
+                                })
+                        })
+            })
+    }
+
+    fn application_infos_for_type(&self, type_id: TypeId) -> Vec<(TypeId, Vec<TypeId>)> {
+        let mut applications = Vec::with_capacity(2);
+        if let Some(app) = query::get_application_info(self.ctx.types, type_id) {
+            applications.push(app);
+        }
+        if let Some(alias_app) = self
+            .ctx
+            .types
+            .get_display_alias(type_id)
+            .and_then(|alias| query::get_application_info(self.ctx.types, alias))
+            && !applications.contains(&alias_app)
+        {
+            applications.push(alias_app);
+        }
+        applications
     }
 
     fn is_in_static_class_method_context(&self, idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
+++ b/crates/tsz-checker/src/types/property_access_type/class_recovery.rs
@@ -175,6 +175,77 @@ impl<'a> CheckerState<'a> {
             .map(|member| member.type_id)
     }
 
+    pub(super) fn recover_direct_this_class_chain_member(
+        &mut self,
+        direct_class_this_receiver: bool,
+        used_class_chain_method_type: bool,
+        receiver_expr: NodeIndex,
+        property_name: &str,
+        prop_type: TypeId,
+        object_type_for_access: TypeId,
+        original_object_type: TypeId,
+    ) -> Option<(TypeId, bool)> {
+        if used_class_chain_method_type
+            || !direct_class_this_receiver
+            || object_type_for_access != original_object_type
+            || self.enclosing_class_declares_member(property_name)
+        {
+            return None;
+        }
+
+        let summary = self.summarize_class_chain(self.nearest_enclosing_class(receiver_expr)?);
+        let member = summary.member_info(property_name, false, true)?;
+        if member.from_interface
+            || matches!(
+                member.type_id,
+                TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
+            )
+            || member.type_id == prop_type
+        {
+            return None;
+        }
+
+        Some((member.type_id, member.is_method || member.is_accessor))
+    }
+
+    fn enclosing_class_declares_member(&self, property_name: &str) -> bool {
+        self.ctx.enclosing_class.as_ref().is_some_and(|class_info| {
+            class_info.member_nodes.iter().any(|&member_idx| {
+                self.get_member_name(member_idx).as_deref() == Some(property_name)
+            })
+        })
+    }
+
+    pub(super) fn substitute_direct_this_property_shape_type(
+        &self,
+        direct_class_this_receiver: bool,
+        used_class_chain_method_type: bool,
+        object_type_for_access: TypeId,
+        property_name: &str,
+    ) -> Option<TypeId> {
+        if used_class_chain_method_type || !direct_class_this_receiver {
+            return None;
+        }
+
+        let shape = crate::query_boundaries::common::object_shape_for_type(
+            self.ctx.types,
+            object_type_for_access,
+        )?;
+        let raw_prop = shape
+            .properties
+            .iter()
+            .find(|prop| self.ctx.types.resolve_atom_ref(prop.name).as_ref() == property_name)?;
+        crate::query_boundaries::common::contains_this_type(self.ctx.types, raw_prop.type_id).then(
+            || {
+                crate::query_boundaries::common::substitute_this_type(
+                    self.ctx.types,
+                    raw_prop.type_id,
+                    self.ctx.types.this_type(),
+                )
+            },
+        )
+    }
+
     pub(super) fn has_recoverable_current_class_member(
         &mut self,
         is_current_class_member_initializer_receiver: bool,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1847,45 +1847,28 @@ impl<'a> CheckerState<'a> {
                         return TypeId::ERROR;
                     }
 
-                    if !used_class_chain_method_type
-                        && direct_class_this_receiver
-                        && let Some(class_idx) = self.nearest_enclosing_class(access.expression)
+                    if let Some((recovered_type, recovered_method)) = self
+                        .recover_direct_this_class_chain_member(
+                            direct_class_this_receiver,
+                            used_class_chain_method_type,
+                            access.expression,
+                            property_name,
+                            prop_type,
+                            object_type_for_access,
+                            original_object_type,
+                        )
                     {
-                        let summary = self.summarize_class_chain(class_idx);
-                        if let Some(member_info) = summary.member_info(property_name, false, true)
-                            && !matches!(
-                                member_info.type_id,
-                                TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
-                            )
-                            && member_info.type_id != prop_type
-                        {
-                            prop_type = member_info.type_id;
-                            used_class_chain_method_type =
-                                summary.member_kind(property_name, false, true)
-                                    == Some(ClassMemberKind::MethodLike);
-                        }
+                        prop_type = recovered_type;
+                        used_class_chain_method_type = recovered_method;
                     }
 
-                    if !used_class_chain_method_type
-                        && direct_class_this_receiver
-                        && let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
-                            self.ctx.types,
-                            object_type_for_access,
-                        )
-                        && let Some(raw_prop) = shape.properties.iter().find(|prop| {
-                            self.ctx.types.resolve_atom_ref(prop.name).as_ref()
-                                == property_name.as_str()
-                        })
-                        && crate::query_boundaries::common::contains_this_type(
-                            self.ctx.types,
-                            raw_prop.type_id,
-                        )
-                    {
-                        prop_type = crate::query_boundaries::common::substitute_this_type(
-                            self.ctx.types,
-                            raw_prop.type_id,
-                            self.ctx.types.this_type(),
-                        );
+                    if let Some(recovered_type) = self.substitute_direct_this_property_shape_type(
+                        direct_class_this_receiver,
+                        used_class_chain_method_type,
+                        object_type_for_access,
+                        property_name,
+                    ) {
+                        prop_type = recovered_type;
                     }
 
                     // Substitute polymorphic `this` type with the receiver type.

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1849,6 +1849,25 @@ impl<'a> CheckerState<'a> {
 
                     if !used_class_chain_method_type
                         && direct_class_this_receiver
+                        && let Some(class_idx) = self.nearest_enclosing_class(access.expression)
+                    {
+                        let summary = self.summarize_class_chain(class_idx);
+                        if let Some(member_info) = summary.member_info(property_name, false, true)
+                            && !matches!(
+                                member_info.type_id,
+                                TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR
+                            )
+                            && member_info.type_id != prop_type
+                        {
+                            prop_type = member_info.type_id;
+                            used_class_chain_method_type =
+                                summary.member_kind(property_name, false, true)
+                                    == Some(ClassMemberKind::MethodLike);
+                        }
+                    }
+
+                    if !used_class_chain_method_type
+                        && direct_class_this_receiver
                         && let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
                             self.ctx.types,
                             object_type_for_access,

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -178,6 +178,35 @@ impl<'a> CheckerState<'a> {
             }
             let mut return_type =
                 self.get_type_of_node_with_request(return_data.expression, &request);
+            if let Some(contextual_type) = request.contextual_type
+                && self
+                    .ctx
+                    .arena
+                    .get(return_data.expression)
+                    .is_some_and(|expr_node| expr_node.kind == syntax_kind_ext::NEW_EXPRESSION)
+                && (self
+                    .contextual_application_recovers_unknown_result(return_type, contextual_type)
+                    || self.contextual_application_recovers_type_param_result(
+                        return_type,
+                        contextual_type,
+                    )
+                    || (crate::query_boundaries::common::contains_type_parameters(
+                        self.ctx.types,
+                        return_type,
+                    ) && self
+                        .ctx
+                        .arena
+                        .get_call_expr_at(return_data.expression)
+                        .is_some_and(|new_expr| {
+                            self.contextual_application_matches_new_target(
+                                new_expr.expression,
+                                contextual_type,
+                            )
+                        })))
+                && self.is_assignable_to(contextual_type, expected_type)
+            {
+                return_type = contextual_type;
+            }
             self.ctx.preserve_literal_types = prev_preserve_literals;
             if self.ctx.in_async_context() {
                 // Use unwrap_async_return_type_for_body which handles unions

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -865,7 +865,34 @@ impl<'a> CheckerState<'a> {
         {
             self.ctx.in_const_assertion = true;
         }
-        let return_type = self.get_type_of_node_with_request(expr_idx, &request);
+        let mut return_type = self.get_type_of_node_with_request(expr_idx, &request);
+        if let Some(contextual_type) = effective_return_context
+            && self
+                .ctx
+                .arena
+                .get(expr_idx)
+                .is_some_and(|expr_node| expr_node.kind == syntax_kind_ext::NEW_EXPRESSION)
+            && (self.contextual_application_recovers_unknown_result(return_type, contextual_type)
+                || self.contextual_application_recovers_type_param_result(
+                    return_type,
+                    contextual_type,
+                )
+                || (crate::query_boundaries::common::contains_type_parameters(
+                    self.ctx.types,
+                    return_type,
+                ) && self
+                    .ctx
+                    .arena
+                    .get_call_expr_at(expr_idx)
+                    .is_some_and(|new_expr| {
+                        self.contextual_application_matches_new_target(
+                            new_expr.expression,
+                            contextual_type,
+                        )
+                    })))
+        {
+            return_type = contextual_type;
+        }
         self.ctx.in_const_assertion = prev_const_assertion;
         self.ctx.preserve_literal_types = prev_preserve_literals;
         return_type

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -3371,6 +3371,147 @@ class ZodEffects<
 }
 
 #[test]
+fn contextual_generic_new_return_recovers_unresolved_constructor_type_params() {
+    let source = r#"
+type ParseReturnType<T> = { ok: true; value: T } | { ok: false };
+interface BaseDef {}
+
+abstract class Schema<Out, Def extends BaseDef = BaseDef, In = Out> {
+    readonly _output!: Out;
+    readonly _input!: In;
+    readonly _def!: Def;
+    abstract _parse(): ParseReturnType<Out>;
+    constructor(def: Def) {}
+}
+
+type AnySchema = Schema<any, any, any>;
+type Effect<T> = { type: "refinement"; refine: (arg: T) => unknown };
+
+interface WrapperDef<S extends AnySchema = AnySchema> extends BaseDef {
+    schema: S;
+    effect: Effect<any>;
+}
+
+class Wrapper<
+    S extends AnySchema,
+    Out = S["_output"],
+    In = S["_input"]
+> extends Schema<Out, WrapperDef<S>, In> {
+    _parse(): ParseReturnType<Out> {
+        return null as never;
+    }
+
+    static make = <Source extends AnySchema>(
+        schema: Source,
+        effect: Effect<Source["_output"]>
+    ): Wrapper<Source, Source["_output"]> => {
+        return new Wrapper({ schema, effect });
+    };
+}
+
+interface DecoratedDef<Item extends AnyCarrier = AnyCarrier> extends BaseDef {
+    item: Item;
+    hook: Hook<any>;
+}
+
+abstract class Carrier<Value, Def extends BaseDef = BaseDef, Raw = Value> {
+    readonly value!: Value;
+    readonly raw!: Raw;
+    readonly def!: Def;
+    abstract parse(): ParseReturnType<Value>;
+    constructor(def: Def) {}
+}
+
+type AnyCarrier = Carrier<any, any, any>;
+type Hook<T> = { run: (value: T) => unknown };
+
+class Decorated<
+    Item extends AnyCarrier,
+    Value = Item["value"],
+    Raw = Item["raw"]
+> extends Carrier<Value, DecoratedDef<Item>, Raw> {
+    parse(): ParseReturnType<Value> {
+        return null as never;
+    }
+
+    static build = <Entity extends AnyCarrier>(
+        item: Entity,
+        hook: Hook<Entity["value"]>
+    ): Decorated<Entity, Entity["value"]> => {
+        return new Decorated({ item, hook });
+    };
+}
+"#;
+    let diags = relevant_strict_diagnostics(source);
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2322 && *code != 2739),
+        "contextual generic new returns should recover the enclosing application when constructor args leave class params unresolved. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn contextual_generic_new_return_keeps_different_constructor_base_mismatch() {
+    let source = r#"
+type ParseReturnType<T> = { ok: true; value: T } | { ok: false };
+interface BaseDef {}
+
+abstract class Schema<Out, Def extends BaseDef = BaseDef, In = Out> {
+    readonly _output!: Out;
+    readonly _input!: In;
+    readonly _def!: Def;
+    abstract _parse(): ParseReturnType<Out>;
+    constructor(def: Def) {}
+}
+
+type AnySchema = Schema<any, any, any>;
+type Effect<T> = { type: "refinement"; refine: (arg: T) => unknown };
+
+interface WrapperDef<S extends AnySchema = AnySchema> extends BaseDef {
+    schema: S;
+    marker: "wrapper";
+    effect: Effect<any>;
+}
+
+interface OtherDef<S extends AnySchema = AnySchema> extends BaseDef {
+    other: S;
+    marker: "other";
+}
+
+class Wrapper<
+    S extends AnySchema,
+    Out = S["_output"],
+    In = S["_input"]
+> extends Schema<Out, WrapperDef<S>, In> {
+    _parse(): ParseReturnType<Out> {
+        return null as never;
+    }
+}
+
+class Other<
+    S extends AnySchema,
+    Out = S["_output"],
+    In = S["_input"]
+> extends Schema<Out, OtherDef<S>, In> {
+    _parse(): ParseReturnType<Out> {
+        return null as never;
+    }
+}
+
+function wrong<Source extends AnySchema>(
+    schema: Source,
+    effect: Effect<Source["_output"]>
+): Other<Source, Source["_output"]> {
+    return new Wrapper({ schema, marker: "wrapper", effect });
+}
+"#;
+    let diags = relevant_strict_diagnostics(source);
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "contextual recovery must not hide a different constructor application base. Got: {diags:#?}"
+    );
+}
+
+#[test]
 fn conflicting_contextual_instantiation_keeps_enclosing_return_type_param() {
     let source = r#"
 declare function accept<R>(fn: (a: string, b: number) => R): R;

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -3297,6 +3297,80 @@ const keep: Pending<Connection> = pool.acquire();
 }
 
 #[test]
+fn generic_constructor_argument_contextualizes_nested_discriminated_object_property() {
+    let source = r#"
+type RefinementCtx = { addIssue(message: string): void };
+interface ZodTypeDef {}
+type ZodTypeAny = ZodType<any, any, any>;
+type input<T extends ZodType<any, any, any>> = T["_input"];
+type output<T extends ZodType<any, any, any>> = T["_output"];
+type ParseReturnType<T> =
+    | { status: "valid"; value: T }
+    | { status: "dirty"; value: T }
+    | { status: "aborted" };
+
+type RefinementEffect<T> = {
+    type: "refinement";
+    refinement: (arg: T, ctx: RefinementCtx) => any;
+};
+type TransformEffect<T> = {
+    type: "transform";
+    transform: (arg: T) => any;
+};
+type PreprocessEffect<T> = {
+    type: "preprocess";
+    transform: (arg: T) => any;
+};
+type Effect<T> = RefinementEffect<T> | TransformEffect<T> | PreprocessEffect<T>;
+
+enum ZodFirstPartyTypeKind {
+    ZodEffects = "ZodEffects",
+}
+
+interface ZodEffectsDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    schema: T;
+    typeName: ZodFirstPartyTypeKind.ZodEffects;
+    effect: Effect<any>;
+}
+
+abstract class ZodType<Output, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
+    _output!: Output;
+    _input!: Input;
+    _def!: Def;
+
+    abstract _parse(): ParseReturnType<Output>;
+
+    constructor(def: Def) {}
+
+    _refinement(refinement: RefinementEffect<Output>["refinement"]): ZodEffects<this> {
+        return new ZodEffects({
+            schema: this,
+            typeName: ZodFirstPartyTypeKind.ZodEffects,
+            effect: { type: "refinement", refinement },
+        });
+    }
+}
+
+class ZodEffects<
+    T extends ZodTypeAny,
+    Output = output<T>,
+    Input = input<T>
+> extends ZodType<Output, ZodEffectsDef<T>, Input> {
+    _parse(): ParseReturnType<Output> {
+        return null as any;
+    }
+}
+"#;
+    let diags = relevant_strict_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Effect<any>") && message.contains("type: string")
+        }),
+        "nested discriminated object literal in a constructor argument should inherit the Effect<any> context. Got: {diags:#?}"
+    );
+}
+
+#[test]
 fn conflicting_contextual_instantiation_keeps_enclosing_return_type_param() {
     let source = r#"
 declare function accept<R>(fn: (a: string, b: number) => R): R;

--- a/crates/tsz-checker/tests/generic_tests.rs
+++ b/crates/tsz-checker/tests/generic_tests.rs
@@ -778,6 +778,36 @@ interface ITest<P extends Prefixes, E extends AllPrefixData = PrefixData<P>> { }
     );
 }
 
+#[test]
+fn test_tuple_default_matching_constraint_union_member_no_ts2344() {
+    let source = r#"
+export {};
+interface Schema { readonly _output: unknown; }
+type SchemaAny = Schema;
+type TupleItems = [SchemaAny, ...SchemaAny[]];
+interface TupleDef<T extends TupleItems | [] = TupleItems> {
+    items: T;
+}
+class Tuple<
+    T extends [SchemaAny, ...SchemaAny[]] | [] = [SchemaAny, ...SchemaAny[]]
+> {
+    readonly def!: TupleDef<T>;
+}
+"#;
+
+    let diagnostics = crate::test_utils::check_source_diagnostics(source);
+    let ts2344_messages = diagnostics
+        .iter()
+        .filter(|d| d.code == 2344)
+        .map(|d| d.message_text.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        ts2344_messages.is_empty(),
+        "tuple defaults that syntactically match a constraint union member should not emit TS2344; got {ts2344_messages:?}"
+    );
+}
+
 /// TS2744 position must anchor at the offending forward-referenced identifier
 /// inside the type-parameter default, not at the start of the entire default
 /// expression. tsc points at the identifier itself.

--- a/crates/tsz-checker/tests/ts2322_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_tests.rs
@@ -1716,6 +1716,74 @@ interface Buzz { id: number; buzz: string }
         "union of built-in array methods should contextually type callback params, got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn inherited_generic_class_field_array_methods_preserve_callback_context() {
+    let source = r#"
+export {};
+type StringCheck =
+  | { kind: "email"; pattern: string }
+  | { kind: "regex"; regex: RegExp };
+interface StringDef extends BaseDef {
+  checks: StringCheck[];
+}
+interface BoxDef<Item> extends BaseDef {
+  values: Item[];
+}
+interface BaseDef {
+  errorMap?: (issue: unknown) => string;
+}
+declare abstract class Base<
+  Output,
+  Def extends BaseDef = BaseDef,
+  Input = Output
+> {
+  readonly _type: Output;
+  readonly _output: Output;
+  readonly _input: Input;
+  readonly _def: Def;
+  abstract parse(input: unknown): Output;
+}
+class StringSchema extends Base<string, StringDef> {
+  parse(input: unknown): string {
+    return String(input);
+  }
+  get isEmail() {
+    return !!this._def.checks.find(ch => ch.kind === "email");
+  }
+  get usesRegex() {
+    return !!this._def.checks.find(entry => entry.kind === "regex");
+  }
+}
+class BoxSchema<T> extends Base<T, BoxDef<T>> {
+  parse(input: unknown): T {
+    return input as T;
+  }
+  has(value: T) {
+    return this._def.values.find(item => item === value);
+  }
+}
+"#;
+
+    let diagnostics = compile_with_libs_for_ts(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_implicit_any: true,
+            strict_null_checks: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::PARAMETER_IMPLICITLY_HAS_AN_TYPE),
+        "array methods reached through inherited generic class fields should contextually type callback params, got: {diagnostics:?}"
+    );
+}
 // =============================================================================
 // Assignment Expression Tests (TS2322)
 // =============================================================================


### PR DESCRIPTION
AgentName: M4-P

Stacked on #7368 (`codex/m4p-zod-tuple-constraint-20260516`).

## Structural Rule
When a contextually typed `new C(...)` expression successfully resolves but leaves the constructed result as the same class application with unresolved constructor/class type parameters, tsc uses the contextual return application for the expression result. This change lets tsz recover that contextual application by matching the constructor target/application base and preserving normal argument diagnostics.

## Owner Layer
Checker new-expression orchestration and return-type collection. The solver still owns relation checks; this patch only prevents checker cache/inference passes from keeping an unresolved constructor application after a contextual return type already supplied the same nominal application.

## Adjacent Cases Covered
- `Wrapper<Source, Source["_output"]>` factory returning `new Wrapper(...)` with class defaults.
- Renamed `Decorated<Entity, Entity["value"]>` factory using different class/type-parameter names.
- Negative `Other<Source>` return target for `new Wrapper(...)` still reports TS2322 because the application base differs.
- Full Zod `ZodEffects.create` / `createWithPreprocess` path where the raw constructed result displays as `ZodEffects<T, Output, Input>` but the contextual return is `ZodEffects<I, I["_output"], I["_input"]>`.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests contextual_generic_new_return_recovers_unresolved_constructor_type_params --no-fail-fast`
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests contextual_generic_new_return_keeps_different_constructor_base_mismatch --no-fail-fast`
- `scripts/safe-run.sh --limit 75% -- cargo run -p tsz-cli --bin tsz -- --noEmit -p /Users/mohsen/code/tsz-m4p-zod-effect-discriminant-20260516/.target-bench/external/zod/tsconfig.flat.json`

## Notes
The Zod smoke is clean on this stack. This PR remains draft because it is stacked on draft predecessors (#7361, #7366, #7368).
