### PR TITLE
ci(project): guard clean subset evidence paths

### DIFF
--- a/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
+++ b/scripts/ci/test-project-compile-guard-readiness-artifacts.mjs
@@ -466,22 +466,14 @@ withTempDir((dir) => {
   });
 
   assert.equal(result.status, 1, result.stdout || result.stderr);
-  assert.match(result.stderr, /type-challenges-assertions-tsc-clean failed the tsc oracle check/);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsc status \(fail\) must be pass/,
+  );
 
   const rows = readJsonl(path.join(fixtureRoot, "project-compatibility.jsonl"));
   const cleanRow = rows.find((row) => row.name === "type-challenges-assertions-tsc-clean");
-  assert.ok(cleanRow, "expected tsc-clean assertion project row");
-  assertRequiredCompatibilityFields(cleanRow);
-  assert.equal(cleanRow.state, "yellow");
-  assert.equal(cleanRow.exit_class, "fixture invalid");
-  assert.equal(cleanRow.phase, "fixture setup");
-  assert.equal(cleanRow.diagnostic_status, "tsc clean subset failed");
-  assert.deepEqual(cleanRow.exit_codes.tsc, [1]);
-  assert.deepEqual(cleanRow.exit_codes.tsz, []);
-  assert.equal(cleanRow.assertion_clean_subset.total_candidates, 1);
-  assert.equal(cleanRow.assertion_clean_subset.generated_assertions, 1);
-  assert.equal(cleanRow.assertion_clean_subset.tsc_status, "fail");
-  assert.equal(cleanRow.assertion_clean_subset.tsz_status, "pass");
+  assert.equal(cleanRow, undefined);
 });
 
 withTempDir((dir) => {

--- a/scripts/ci/test-type-challenges-assertion-candidates.mjs
+++ b/scripts/ci/test-type-challenges-assertion-candidates.mjs
@@ -148,7 +148,14 @@ withTempDir((dir) => {
     "import type { Equal, Expect } from '@type-challenges/utils'\ntype cases = [Expect<Equal<MyAwaited<Promise<string>>, string>>]\n",
   );
 
-  writeJson(pairingPath, basePairingReport());
+  const report = basePairingReport();
+  report.pairedSolutions[0].solution.output = ".\\solutions\\easy-first.ts";
+  report.pairedSolutions[0].solution.source = ".\\en\\easy-first.md";
+  report.pairedSolutions[0].template.output = "./questions/00014-easy-first/template.ts";
+  report.pairedSolutions[0].template.source = ".\\questions\\00014-easy-first\\template.ts";
+  report.pairedSolutions[0].testCase.output = ".\\questions\\00014-easy-first\\test-cases.ts";
+  report.pairedSolutions[0].testCase.source = "./questions/00014-easy-first/test-cases.ts";
+  writeJson(pairingPath, report);
 
   const result = spawnSync(
     process.execPath,
@@ -172,12 +179,34 @@ withTempDir((dir) => {
     manifest.entries.map((entry) => [
       entry.id,
       entry.output,
+      entry.solution.output,
+      entry.solution.source,
+      entry.template.output,
+      entry.testCase.output,
       entry.assertion.referencedSolutionDeclarations,
       entry.assertion.hasReferencedSolutionDeclaration,
     ]),
     [
-      ["14", "assertions/14-easy-first.ts", ["First"], true],
-      ["189", "assertions/189-easy-awaited.ts", [], false],
+      [
+        "14",
+        "assertions/14-easy-first.ts",
+        "solutions/easy-first.ts",
+        "en/easy-first.md",
+        "questions/00014-easy-first/template.ts",
+        "questions/00014-easy-first/test-cases.ts",
+        ["First"],
+        true,
+      ],
+      [
+        "189",
+        "assertions/189-easy-awaited.ts",
+        "solutions/easy-awaited.ts",
+        "en/easy-awaited.md",
+        "questions/00189-easy-awaited/template.ts",
+        "questions/00189-easy-awaited/test-cases.ts",
+        [],
+        false,
+      ],
     ],
   );
 
@@ -434,6 +463,55 @@ withTempDir((dir) => {
           id: "14",
           solution: {
             output: "../solutions/easy-first.ts",
+            source: "en/easy-first.md",
+            challenge: { id: "14", level: "easy", slug: "first" },
+            declarations: ["First"],
+          },
+          template: {
+            output: "questions/00014-easy-first/template.ts",
+            source: "questions/00014-easy-first/template.ts",
+            challenge: { id: "14", level: "easy", slug: "first" },
+          },
+          testCase: {
+            output: "questions/00014-easy-first/test-cases.ts",
+            source: "questions/00014-easy-first/test-cases.ts",
+            challenge: { id: "14", level: "easy", slug: "first" },
+          },
+        },
+      ],
+      counts: {
+        pairedSolutions: 1,
+        solutionsMissingTemplates: 0,
+        solutionsMissingTestCases: 0,
+      },
+    }),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, pairingPath, dir, dir, outputDir, manifestPath],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /solution\.output must be a relative path/);
+  assert.equal(fs.existsSync(manifestPath), false);
+});
+
+withTempDir((dir) => {
+  const pairingPath = path.join(dir, "pairing.json");
+  const outputDir = path.join(dir, "assertions");
+  const manifestPath = path.join(outputDir, "type-challenges-assertions-manifest.json");
+  writeJson(
+    pairingPath,
+    basePairingReport({
+      pairedSolutions: [
+        {
+          id: "14",
+          solution: {
+            output: "C:\\solutions\\easy-first.ts",
             source: "en/easy-first.md",
             challenge: { id: "14", level: "easy", slug: "first" },
             declarations: ["First"],

--- a/scripts/ci/test-type-challenges-assertion-clean-subset.mjs
+++ b/scripts/ci/test-type-challenges-assertion-clean-subset.mjs
@@ -664,6 +664,134 @@ withTempDir((dir) => {
   const subsetManifestPath = path.join(outputDir, "type-challenges-assertions-tsc-clean-manifest.json");
 
   writeFile(path.join(candidateDir, "utils", "index.d.ts"), "export {};\n");
+  writeFile(path.join(candidateDir, "assertions", "14-easy-first.ts"), "export {};\n");
+  writeJson(candidateManifestPath, {
+    fixture: "type-challenges-assertion-candidates",
+    counts: { generatedAssertions: 1 },
+    entries: [
+      {
+        id: "14",
+        output: "assertions/14-easy-first.ts",
+        solution: { output: "C:\\solutions\\easy-first.ts", source: "en/easy-first.md" },
+        template: {
+          output: "questions/00014-easy-first/template.ts",
+          source: "questions/00014-easy-first/template.ts",
+        },
+        testCase: {
+          output: "questions/00014-easy-first/test-cases.ts",
+          source: "questions/00014-easy-first/test-cases.ts",
+        },
+        assertion: {
+          hasReferencedSolutionDeclaration: true,
+          referencedSolutionDeclarations: ["First"],
+        },
+      },
+    ],
+  });
+  writeJson(classificationPath, {
+    fixture: "type-challenges-assertion-classification",
+    candidateManifest: {
+      fixture: "type-challenges-assertion-candidates",
+      counts: { generatedAssertions: 1 },
+    },
+    compilers: {
+      tsc: {
+        status: "pass",
+        candidateDiagnostics: {
+          filesWithoutDiagnostics: ["assertions/14-easy-first.ts"],
+          filesWithDiagnostics: [],
+        },
+      },
+      tsz: { status: "pass" },
+    },
+    comparison: { status: "both-pass" },
+  });
+
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, candidateDir, candidateManifestPath, classificationPath, outputDir, subsetManifestPath],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /selected entries\[0\]\.solution\.output/);
+  assert.equal(fs.existsSync(subsetManifestPath), false);
+});
+
+withTempDir((dir) => {
+  const candidateDir = path.join(dir, "candidates");
+  const outputDir = path.join(dir, "clean");
+  const candidateManifestPath = path.join(candidateDir, "type-challenges-assertions-manifest.json");
+  const classificationPath = path.join(candidateDir, "type-challenges-assertions-classification.json");
+  const subsetManifestPath = path.join(outputDir, "type-challenges-assertions-tsc-clean-manifest.json");
+
+  writeFile(path.join(candidateDir, "utils", "index.d.ts"), "export {};\n");
+  writeFile(path.join(candidateDir, "assertions", "14-easy-first.ts"), "export {};\n");
+  writeJson(candidateManifestPath, {
+    fixture: "type-challenges-assertion-candidates",
+    counts: { generatedAssertions: 1 },
+    entries: [
+      {
+        id: "14",
+        output: "assertions/14-easy-first.ts",
+        solution: { output: "solutions/easy-first.ts", source: "en/easy-first.md" },
+        template: {
+          output: "questions/00014-easy-first/template.ts",
+          source: "questions/./00014-easy-first/template.ts",
+        },
+        testCase: {
+          output: "questions/00014-easy-first/test-cases.ts",
+          source: "questions/00014-easy-first/test-cases.ts",
+        },
+        assertion: {
+          hasReferencedSolutionDeclaration: true,
+          referencedSolutionDeclarations: ["First"],
+        },
+      },
+    ],
+  });
+  writeJson(classificationPath, {
+    fixture: "type-challenges-assertion-classification",
+    candidateManifest: {
+      fixture: "type-challenges-assertion-candidates",
+      counts: { generatedAssertions: 1 },
+    },
+    compilers: {
+      tsc: {
+        status: "pass",
+        candidateDiagnostics: {
+          filesWithoutDiagnostics: ["assertions/14-easy-first.ts"],
+          filesWithDiagnostics: [],
+        },
+      },
+      tsz: { status: "pass" },
+    },
+    comparison: { status: "both-pass" },
+  });
+
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, candidateDir, candidateManifestPath, classificationPath, outputDir, subsetManifestPath],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /selected entries\[0\]\.template\.source/);
+  assert.equal(fs.existsSync(subsetManifestPath), false);
+});
+
+withTempDir((dir) => {
+  const candidateDir = path.join(dir, "candidates");
+  const outputDir = path.join(dir, "clean");
+  const candidateManifestPath = path.join(candidateDir, "type-challenges-assertions-manifest.json");
+  const classificationPath = path.join(candidateDir, "type-challenges-assertions-classification.json");
+  const subsetManifestPath = path.join(outputDir, "type-challenges-assertions-tsc-clean-manifest.json");
+
+  writeFile(path.join(candidateDir, "utils", "index.d.ts"), "export {};\n");
   writeJson(candidateManifestPath, {
     fixture: "type-challenges-assertion-candidates",
     counts: { generatedAssertions: 1 },

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -715,6 +715,62 @@ withTempDir((dir) => {
     dir,
     classification: {
       fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(2),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 2,
+            candidatesWithDiagnostics: 1,
+            candidatesWithoutDiagnostics: 1,
+            filesWithDiagnostics: ["assertions/two.ts"],
+            filesWithoutDiagnostics: ["assertions/one.ts"],
+          },
+        },
+        tsz: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 2,
+            candidatesWithDiagnostics: 1,
+            candidatesWithoutDiagnostics: 1,
+            filesWithDiagnostics: ["assertions/one.ts"],
+            filesWithoutDiagnostics: ["assertions/two.ts"],
+          },
+        },
+      },
+      comparison: {
+        status: "both-pass",
+        diagnosticFreeCandidateDelta: 0,
+        candidateFileComparison: {
+          totalCandidates: 2,
+          counts: {
+            bothAccepted: 1,
+            bothRejected: 1,
+            tscAcceptedTszRejected: 0,
+            tscRejectedTszAccepted: 0,
+          },
+          bothAccepted: ["assertions/one.ts"],
+          bothRejected: ["assertions/two.ts"],
+          tscAcceptedTszRejected: [],
+          tscRejectedTszAccepted: [],
+        },
+      },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /candidateFileComparison\.bothAccepted does not match compiler candidate diagnostic file lists: expected <none>, actual assertions\/one\.ts/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
       candidateManifest: candidateManifest(1),
       compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
       comparison: { status: "both-pass" },

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -45,12 +45,42 @@ function withComparisonCompilerStatuses(report) {
     return report;
   }
 
+  const compilers = Object.fromEntries(
+    Object.entries(report.compilers ?? {}).map(([compiler, result]) => [
+      compiler,
+      withDiagnosticFreeFileList(result),
+    ]),
+  );
+
   return {
     ...report,
+    compilers,
     comparison: {
-      tscStatus: report.compilers?.tsc?.status,
-      tszStatus: report.compilers?.tsz?.status,
+      tscStatus: compilers.tsc?.status,
+      tszStatus: compilers.tsz?.status,
       ...report.comparison,
+    },
+  };
+}
+
+function withDiagnosticFreeFileList(result) {
+  const diagnostics = result?.candidateDiagnostics;
+  if (
+    !diagnostics ||
+    Object.prototype.hasOwnProperty.call(diagnostics, "filesWithoutDiagnostics") ||
+    !Number.isInteger(diagnostics.candidatesWithoutDiagnostics)
+  ) {
+    return result;
+  }
+
+  return {
+    ...result,
+    candidateDiagnostics: {
+      ...diagnostics,
+      filesWithoutDiagnostics: Array.from(
+        { length: diagnostics.candidatesWithoutDiagnostics },
+        (_, index) => `assertions/diagnostic-free-${index + 1}.ts`,
+      ),
     },
   };
 }
@@ -1492,6 +1522,37 @@ withTempDir((dir) => {
   assert.match(
     result.stderr,
     /tsc candidateDiagnostics files overlap between diagnostic and diagnostic-free lists: assertions\/one\.ts/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(2),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 2,
+            candidatesWithDiagnostics: 1,
+            candidatesWithoutDiagnostics: 1,
+            filesWithDiagnostics: ["assertions/one.ts"],
+            filesWithoutDiagnostics: null,
+          },
+        },
+        tsz: { status: "pass" },
+      },
+      comparison: { status: "both-pass" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc candidateDiagnostics\.filesWithoutDiagnostics must be an array when candidatesWithoutDiagnostics is nonzero/,
   );
   assert.equal(fs.existsSync(outFile), false);
 });

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -45,25 +45,51 @@ function withComparisonCompilerStatuses(report) {
     return report;
   }
 
+  const candidateUniverse = candidateFileUniverse(report);
   const compilers = Object.fromEntries(
     Object.entries(report.compilers ?? {}).map(([compiler, result]) => [
       compiler,
-      withDiagnosticFreeFileList(result),
+      withDiagnosticFreeFileList(result, candidateUniverse),
     ]),
   );
 
   return {
     ...report,
     compilers,
-    comparison: {
+    comparison: withCandidateFileComparison(compilers, {
       tscStatus: compilers.tsc?.status,
       tszStatus: compilers.tsz?.status,
       ...report.comparison,
-    },
+    }),
   };
 }
 
-function withDiagnosticFreeFileList(result) {
+function candidateFileUniverse(report) {
+  const files = [];
+  for (const result of Object.values(report.compilers ?? {})) {
+    const diagnostics = result?.candidateDiagnostics;
+    for (const field of ["filesWithDiagnostics", "filesWithoutDiagnostics"]) {
+      for (const file of diagnostics?.[field] ?? []) {
+        if (!files.includes(file)) {
+          files.push(file);
+        }
+      }
+    }
+  }
+
+  const totalCandidates = Math.max(
+    0,
+    ...Object.values(report.compilers ?? {})
+      .map((result) => result?.candidateDiagnostics?.totalCandidates)
+      .filter(Number.isInteger),
+  );
+  while (files.length < totalCandidates) {
+    files.push(`assertions/diagnostic-free-${files.length + 1}.ts`);
+  }
+  return files;
+}
+
+function withDiagnosticFreeFileList(result, candidateUniverse) {
   const diagnostics = result?.candidateDiagnostics;
   if (
     !diagnostics ||
@@ -77,12 +103,76 @@ function withDiagnosticFreeFileList(result) {
     ...result,
     candidateDiagnostics: {
       ...diagnostics,
-      filesWithoutDiagnostics: Array.from(
-        { length: diagnostics.candidatesWithoutDiagnostics },
-        (_, index) => `assertions/diagnostic-free-${index + 1}.ts`,
-      ),
+      filesWithoutDiagnostics: candidateUniverse
+        .filter((file) => !(diagnostics.filesWithDiagnostics || []).includes(file))
+        .slice(0, diagnostics.candidatesWithoutDiagnostics),
     },
   };
+}
+
+function withCandidateFileComparison(compilers, comparison) {
+  if (
+    Object.prototype.hasOwnProperty.call(comparison, "candidateFileComparison") ||
+    !hasConcreteCandidateFileLists(compilers.tsc) ||
+    !hasConcreteCandidateFileLists(compilers.tsz)
+  ) {
+    return comparison;
+  }
+
+  const tscDiagnostics = compilers.tsc.candidateDiagnostics;
+  const tszDiagnostics = compilers.tsz.candidateDiagnostics;
+  const bothAccepted = intersectSorted(
+    tscDiagnostics.filesWithoutDiagnostics,
+    tszDiagnostics.filesWithoutDiagnostics,
+  );
+  const bothRejected = intersectSorted(
+    tscDiagnostics.filesWithDiagnostics || [],
+    tszDiagnostics.filesWithDiagnostics || [],
+  );
+  const tscAcceptedTszRejected = intersectSorted(
+    tscDiagnostics.filesWithoutDiagnostics,
+    tszDiagnostics.filesWithDiagnostics || [],
+  );
+  const tscRejectedTszAccepted = intersectSorted(
+    tscDiagnostics.filesWithDiagnostics || [],
+    tszDiagnostics.filesWithoutDiagnostics,
+  );
+
+  return {
+    ...comparison,
+    candidateFileComparison: {
+      totalCandidates: tscDiagnostics.totalCandidates,
+      counts: {
+        bothAccepted: bothAccepted.length,
+        bothRejected: bothRejected.length,
+        tscAcceptedTszRejected: tscAcceptedTszRejected.length,
+        tscRejectedTszAccepted: tscRejectedTszAccepted.length,
+      },
+      bothAccepted,
+      bothRejected,
+      tscAcceptedTszRejected,
+      tscRejectedTszAccepted,
+    },
+  };
+}
+
+function hasConcreteCandidateFileLists(result) {
+  const diagnostics = result?.candidateDiagnostics;
+  return (
+    diagnostics &&
+    Number.isInteger(diagnostics.totalCandidates) &&
+    Number.isInteger(diagnostics.candidatesWithDiagnostics) &&
+    Number.isInteger(diagnostics.candidatesWithoutDiagnostics) &&
+    (diagnostics.candidatesWithDiagnostics === 0 ||
+      Array.isArray(diagnostics.filesWithDiagnostics)) &&
+    (diagnostics.candidatesWithoutDiagnostics === 0 ||
+      Array.isArray(diagnostics.filesWithoutDiagnostics))
+  );
+}
+
+function intersectSorted(left, right) {
+  const rightSet = new Set(right);
+  return left.filter((file) => rightSet.has(file)).sort();
 }
 
 function assertRequiredCompatibilityFields(row) {
@@ -460,6 +550,7 @@ withTempDir((dir) => {
             candidatesWithDiagnostics: 0,
             candidatesWithoutDiagnostics: 1,
             filesWithDiagnostics: [],
+            filesWithoutDiagnostics: ["assertions/two.ts"],
           },
         },
         tsz: {
@@ -571,6 +662,50 @@ withTempDir((dir) => {
   assert.match(
     result.stderr,
     /assertion classification comparison\.status must be a non-empty string/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(2),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 2,
+            candidatesWithDiagnostics: 1,
+            candidatesWithoutDiagnostics: 1,
+            filesWithDiagnostics: ["assertions/one.ts"],
+            filesWithoutDiagnostics: ["assertions/two.ts"],
+          },
+        },
+        tsz: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 2,
+            candidatesWithDiagnostics: 0,
+            candidatesWithoutDiagnostics: 2,
+            filesWithDiagnostics: [],
+            filesWithoutDiagnostics: ["assertions/one.ts", "assertions/two.ts"],
+          },
+        },
+      },
+      comparison: {
+        status: "both-pass",
+        diagnosticFreeCandidateDelta: 1,
+        candidateFileComparison: null,
+      },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /comparison\.candidateFileComparison is required when both compiler candidate file lists are concrete/,
   );
   assert.equal(fs.existsSync(outFile), false);
 });

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -92,19 +92,37 @@ function withDiagnosticFreeFileList(result, candidateUniverse) {
   const diagnostics = result?.candidateDiagnostics;
   if (
     !diagnostics ||
-    Object.prototype.hasOwnProperty.call(diagnostics, "filesWithoutDiagnostics") ||
     !Number.isInteger(diagnostics.candidatesWithoutDiagnostics)
   ) {
     return result;
   }
 
+  const candidateDiagnostics = { ...diagnostics };
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      candidateDiagnostics,
+      "candidatesWithDiagnostics",
+    ) &&
+    Number.isInteger(candidateDiagnostics.totalCandidates)
+  ) {
+    candidateDiagnostics.candidatesWithDiagnostics =
+      candidateDiagnostics.totalCandidates -
+      candidateDiagnostics.candidatesWithoutDiagnostics;
+  }
+  if (Object.prototype.hasOwnProperty.call(candidateDiagnostics, "filesWithoutDiagnostics")) {
+    return {
+      ...result,
+      candidateDiagnostics,
+    };
+  }
+
   return {
     ...result,
     candidateDiagnostics: {
-      ...diagnostics,
+      ...candidateDiagnostics,
       filesWithoutDiagnostics: candidateUniverse
-        .filter((file) => !(diagnostics.filesWithDiagnostics || []).includes(file))
-        .slice(0, diagnostics.candidatesWithoutDiagnostics),
+        .filter((file) => !(candidateDiagnostics.filesWithDiagnostics || []).includes(file))
+        .slice(0, candidateDiagnostics.candidatesWithoutDiagnostics),
     },
   };
 }
@@ -767,6 +785,118 @@ withTempDir((dir) => {
   assert.match(
     result.stderr,
     /candidateFileComparison\.bothAccepted does not match compiler candidate diagnostic file lists: expected <none>, actual assertions\/one\.ts/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 1,
+      },
+      entries: [{ output: "assertions/00001-easy-pick.ts" }],
+    },
+    cleanSubsetClassification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: cleanCandidateManifest({
+        totalCandidates: 2,
+        rejected: 1,
+      }),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithDiagnostics: null,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+        tsz: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+      },
+      comparison: { status: "both-pass" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsc candidateDiagnostics\.candidatesWithDiagnostics must be an integer/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 1,
+      },
+      entries: [{ output: "assertions/00001-easy-pick.ts" }],
+    },
+    cleanSubsetClassification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: cleanCandidateManifest({
+        totalCandidates: 2,
+        rejected: 1,
+      }),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+        tsz: {
+          status: "fail",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithDiagnostics: 1,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+      },
+      comparison: { status: "tsz-rejects-tsc-accepted" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsz candidate diagnostic counts \(1 \+ 1\) do not match totalCandidates \(1\)/,
   );
   assert.equal(fs.existsSync(outFile), false);
 });

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -679,6 +679,71 @@ withTempDir((dir) => {
       fixture: "type-challenges-assertions-tsc-clean",
       sources: candidateSources(),
       counts: {
+        totalCandidates: 1,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 0,
+      },
+      entries: [{ output: "../outside.ts" }],
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion manifest entries\[0\]\.output must stay inside the assertion candidate directory/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 2,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 2,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 0,
+      },
+      entries: [
+        { output: "assertions/00001-easy-pick.ts" },
+        { output: "./assertions/00001-easy-pick.ts" },
+      ],
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion manifest entries contain duplicate outputs: assertions\/00001-easy-pick\.ts/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
         totalCandidates: 2,
         tscAcceptedAssertions: 1,
         tscAcceptedAssertionsReferencingSolutionDeclaration: 1,

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -671,6 +671,116 @@ withTempDir((dir) => {
     dir,
     classification: {
       fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 1,
+      },
+      entries: [{ output: "assertions/00001-easy-pick.ts" }],
+    },
+    cleanSubsetClassification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: cleanCandidateManifest({
+        totalCandidates: 2,
+        rejected: 1,
+      }),
+      compilers: {
+        tsc: {
+          status: "fail",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 0,
+          },
+        },
+        tsz: {
+          status: "fail",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 0,
+          },
+        },
+      },
+      comparison: { status: "both-nonpassing" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsc status \(fail\) must be pass/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 1,
+      },
+      entries: [{ output: "assertions/00001-easy-pick.ts" }],
+    },
+    cleanSubsetClassification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: cleanCandidateManifest({
+        totalCandidates: 2,
+        rejected: 1,
+      }),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 0,
+          },
+        },
+        tsz: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+      },
+      comparison: { status: "both-pass" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsc candidatesWithoutDiagnostics \(0\) must match manifest tscAcceptedAssertions \(1\)/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
       candidateManifest: candidateManifest(2),
       compilers: {
         tsc: {

--- a/scripts/ci/test-type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/test-type-challenges-assertion-compatibility.mjs
@@ -40,12 +40,11 @@ function readRows(file) {
     .map((line) => JSON.parse(line));
 }
 
-function withComparisonCompilerStatuses(report) {
+function withComparisonCompilerStatuses(report, candidateUniverse = candidateFileUniverse(report)) {
   if (!report?.comparison || typeof report.comparison !== "object") {
     return report;
   }
 
-  const candidateUniverse = candidateFileUniverse(report);
   const compilers = Object.fromEntries(
     Object.entries(report.compilers ?? {}).map(([compiler, result]) => [
       compiler,
@@ -240,9 +239,12 @@ function runCompatibility({ dir, classification, cleanSubsetManifest = null, cle
     writeJson(cleanSubsetManifestPath, cleanSubsetManifest);
   }
   if (cleanSubsetClassification) {
+    const cleanSubsetCandidateUniverse = Array.isArray(cleanSubsetManifest?.entries)
+      ? cleanSubsetManifest.entries.map((entry) => entry.output).filter(Boolean)
+      : undefined;
     writeJson(
       cleanSubsetClassificationPath,
-      withComparisonCompilerStatuses(cleanSubsetClassification),
+      withComparisonCompilerStatuses(cleanSubsetClassification, cleanSubsetCandidateUniverse),
     );
   }
 
@@ -284,9 +286,12 @@ function runCompatibilityRaw({
     writeJson(cleanSubsetManifestPath, cleanSubsetManifest);
   }
   if (cleanSubsetClassification) {
+    const cleanSubsetCandidateUniverse = Array.isArray(cleanSubsetManifest?.entries)
+      ? cleanSubsetManifest.entries.map((entry) => entry.output).filter(Boolean)
+      : undefined;
     writeJson(
       cleanSubsetClassificationPath,
-      withComparisonCompilerStatuses(cleanSubsetClassification),
+      withComparisonCompilerStatuses(cleanSubsetClassification, cleanSubsetCandidateUniverse),
     );
   }
 
@@ -662,6 +667,62 @@ withTempDir((dir) => {
   assert.match(
     result.stderr,
     /assertion classification comparison\.status must be a non-empty string/,
+  );
+  assert.equal(fs.existsSync(outFile), false);
+});
+
+withTempDir((dir) => {
+  const { result, outFile } = runCompatibilityRaw({
+    dir,
+    classification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: candidateManifest(1),
+      compilers: { tsc: { status: "pass" }, tsz: { status: "pass" } },
+      comparison: { status: "both-pass" },
+    },
+    cleanSubsetManifest: {
+      fixture: "type-challenges-assertions-tsc-clean",
+      sources: candidateSources(),
+      counts: {
+        totalCandidates: 2,
+        tscAcceptedAssertions: 1,
+        tscAcceptedAssertionsReferencingSolutionDeclaration: 1,
+        tscAcceptedAssertionsMissingSolutionDeclarationReference: 0,
+        tscRejectedAssertions: 1,
+      },
+      entries: [{ output: "assertions/00001-easy-pick.ts" }],
+    },
+    cleanSubsetClassification: {
+      fixture: "type-challenges-assertion-classification",
+      candidateManifest: cleanCandidateManifest({
+        totalCandidates: 2,
+        rejected: 1,
+      }),
+      compilers: {
+        tsc: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 1,
+            filesWithoutDiagnostics: ["assertions/00002-medium-return-type.ts"],
+          },
+        },
+        tsz: {
+          status: "pass",
+          candidateDiagnostics: {
+            totalCandidates: 1,
+            candidatesWithoutDiagnostics: 1,
+          },
+        },
+      },
+      comparison: { status: "both-pass" },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /tsc-clean assertion classification tsc candidateDiagnostics\.filesWithoutDiagnostics does not match tsc-clean assertion manifest entries: expected assertions\/00001-easy-pick\.ts, actual assertions\/00002-medium-return-type\.ts/,
   );
   assert.equal(fs.existsSync(outFile), false);
 });

--- a/scripts/ci/test-type-challenges-pairing-report.mjs
+++ b/scripts/ci/test-type-challenges-pairing-report.mjs
@@ -221,6 +221,44 @@ withTempDir((dir) => {
     manifest(
       "questions/**/template.ts",
       [{ id: "13", source: "questions/00013-warm-hello-world/template.ts" }],
+      ({ level, slug }) => ({ challenge: { id: "", level, slug } }),
+    ),
+  );
+  writeJson(
+    testCases,
+    manifest("questions/**/test-cases.ts", [
+      { id: "13", source: "questions/00013-warm-hello-world/test-cases.ts" },
+    ]),
+  );
+  writeJson(
+    solutions,
+    manifest("en/*.md", [{ id: "13", source: "en/hello-world.md" }]),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [REPORT_SCRIPT, templates, testCases, solutions, output],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /template manifest entry 1 has no challenge id/);
+  assert.ok(!fs.existsSync(output));
+});
+
+withTempDir((dir) => {
+  const templates = path.join(dir, "templates.json");
+  const testCases = path.join(dir, "test-cases.json");
+  const solutions = path.join(dir, "solutions.json");
+  const output = path.join(dir, "pairing.json");
+
+  writeJson(
+    templates,
+    manifest(
+      "questions/**/template.ts",
+      [{ id: "13", source: "questions/00013-warm-hello-world/template.ts" }],
       () => ({}),
       { ref: "" },
     ),
@@ -246,6 +284,46 @@ withTempDir((dir) => {
   );
   assert.equal(result.status, 1);
   assert.match(result.stderr, /<missing ref>/);
+  assert.ok(!fs.existsSync(output));
+});
+
+withTempDir((dir) => {
+  const templates = path.join(dir, "templates.json");
+  const testCases = path.join(dir, "test-cases.json");
+  const solutions = path.join(dir, "solutions.json");
+  const output = path.join(dir, "pairing.json");
+
+  writeJson(
+    templates,
+    manifest("questions/**/template.ts", [
+      { id: "13", source: "questions/00013-warm-hello-world/template.ts" },
+    ]),
+  );
+  writeJson(
+    testCases,
+    manifest("questions/**/test-cases.ts", [
+      { id: "13", source: "questions/00013-warm-hello-world/test-cases.ts" },
+    ]),
+  );
+  writeJson(
+    solutions,
+    manifest(
+      "en/*.md",
+      [{ id: "13", source: "en/hello-world.md" }],
+      ({ level, slug }) => ({ challenge: { level, title: slug } }),
+    ),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [REPORT_SCRIPT, templates, testCases, solutions, output],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /solution manifest entry 1 has no challenge id/);
   assert.ok(!fs.existsSync(output));
 });
 

--- a/scripts/ci/test-type-challenges-pairing-report.mjs
+++ b/scripts/ci/test-type-challenges-pairing-report.mjs
@@ -472,6 +472,47 @@ withTempDir((dir) => {
     manifest(
       "questions/**/template.ts",
       [{ id: "13", source: "questions/00013-warm-hello-world/template.ts" }],
+      () => ({ output: "../outside.ts" }),
+    ),
+  );
+  writeJson(
+    testCases,
+    manifest("questions/**/test-cases.ts", [
+      { id: "13", source: "questions/00013-warm-hello-world/test-cases.ts" },
+    ]),
+  );
+  writeJson(
+    solutions,
+    manifest("en/*.md", [{ id: "13", source: "en/hello-world.md" }]),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [REPORT_SCRIPT, templates, testCases, solutions, output],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /template manifest entry 1 output path must stay inside the manifest root/,
+  );
+  assert.ok(!fs.existsSync(output));
+});
+
+withTempDir((dir) => {
+  const templates = path.join(dir, "templates.json");
+  const testCases = path.join(dir, "test-cases.json");
+  const solutions = path.join(dir, "solutions.json");
+  const output = path.join(dir, "pairing.json");
+
+  writeJson(
+    templates,
+    manifest(
+      "questions/**/template.ts",
+      [{ id: "13", source: "questions/00013-warm-hello-world/template.ts" }],
       () => ({ source: "" }),
     ),
   );
@@ -496,6 +537,47 @@ withTempDir((dir) => {
   );
   assert.equal(result.status, 1);
   assert.match(result.stderr, /template manifest entry 1 has no source path/);
+  assert.ok(!fs.existsSync(output));
+});
+
+withTempDir((dir) => {
+  const templates = path.join(dir, "templates.json");
+  const testCases = path.join(dir, "test-cases.json");
+  const solutions = path.join(dir, "solutions.json");
+  const output = path.join(dir, "pairing.json");
+
+  writeJson(
+    templates,
+    manifest(
+      "questions/**/template.ts",
+      [{ id: "13", source: "questions/00013-warm-hello-world/template.ts" }],
+      () => ({ source: "/tmp/template.ts" }),
+    ),
+  );
+  writeJson(
+    testCases,
+    manifest("questions/**/test-cases.ts", [
+      { id: "13", source: "questions/00013-warm-hello-world/test-cases.ts" },
+    ]),
+  );
+  writeJson(
+    solutions,
+    manifest("en/*.md", [{ id: "13", source: "en/hello-world.md" }]),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [REPORT_SCRIPT, templates, testCases, solutions, output],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /template manifest entry 1 source path must stay inside the manifest root/,
+  );
   assert.ok(!fs.existsSync(output));
 });
 

--- a/scripts/ci/type-challenges-assertion-candidates.mjs
+++ b/scripts/ci/type-challenges-assertion-candidates.mjs
@@ -126,13 +126,20 @@ function requiredString(value, label) {
 
 function ensureRelativePath(value, label) {
   const text = requiredString(value, label);
-  const segments = text.split(/[\\/]+/);
-  if (!path.isAbsolute(text) && !segments.includes("..")) {
-    return text;
+  const normalized = text.replace(/\\/g, "/").replace(/^(?:\.\/)+/, "");
+  const segments = normalized.split("/");
+  if (
+    !path.isAbsolute(text) &&
+    !/^[A-Za-z]:\//.test(normalized) &&
+    normalized !== "" &&
+    normalized !== "." &&
+    segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..")
+  ) {
+    return normalized;
   }
 
   console.error(
-    `error: Type Challenges pairing report ${label} must be a relative path: ${text}`,
+    `error: Type Challenges pairing report ${label} must be a relative path inside the pairing root: ${text}`,
   );
   process.exit(1);
 }

--- a/scripts/ci/type-challenges-assertion-clean-subset.mjs
+++ b/scripts/ci/type-challenges-assertion-clean-subset.mjs
@@ -56,11 +56,13 @@ function validateEvidencePath(value, label) {
     fail(`${label} must be a non-empty relative path`);
   }
   const normalized = value.split(/[\\/]+/).join("/").replace(/^\.\//, "");
+  const segments = normalized.split("/");
   if (
     path.isAbsolute(value) ||
+    /^[A-Za-z]:\//.test(normalized) ||
     normalized === "" ||
     normalized === "." ||
-    normalized.split("/").includes("..")
+    segments.some((segment) => segment === "." || segment === "..")
   ) {
     fail(`${label} must be a relative source path: ${value}`);
   }

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -308,6 +308,18 @@ if (cleanSubsetManifest) {
   if (!Array.isArray(cleanSubsetEntries)) {
     fail("tsc-clean assertion manifest entries must be an array");
   }
+  const cleanSubsetOutputs = cleanSubsetEntries.map((entry, index) =>
+    validateCandidateOutputPath(
+      entry?.output,
+      `tsc-clean assertion manifest entries[${index}].output`,
+    ),
+  );
+  const duplicateCleanSubsetOutputs = duplicatedValues(cleanSubsetOutputs);
+  if (duplicateCleanSubsetOutputs.length > 0) {
+    fail(
+      `tsc-clean assertion manifest entries contain duplicate outputs: ${duplicateCleanSubsetOutputs.join(", ")}`,
+    );
+  }
   const cleanSubsetCounts = cleanSubsetManifest.counts;
   const acceptedAssertions = cleanSubsetCounts.tscAcceptedAssertions;
   const acceptedReferencingSolutionDeclaration =

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -494,6 +494,24 @@ if (cleanSubsetManifest && cleanSubsetClassification) {
         `tsc-clean assertion classification ${compiler} candidatesWithoutDiagnostics (${candidatesWithoutDiagnostics}) must be between 0 and totalCandidates (${totalCandidates})`,
       );
     }
+    const candidatesWithDiagnostics =
+      cleanSubsetClassification.compilers?.[compiler]?.candidateDiagnostics
+        ?.candidatesWithDiagnostics;
+    if (!Number.isInteger(candidatesWithDiagnostics)) {
+      fail(
+        `tsc-clean assertion classification ${compiler} candidateDiagnostics.candidatesWithDiagnostics must be an integer`,
+      );
+    }
+    if (candidatesWithDiagnostics < 0 || candidatesWithDiagnostics > totalCandidates) {
+      fail(
+        `tsc-clean assertion classification ${compiler} candidatesWithDiagnostics (${candidatesWithDiagnostics}) must be between 0 and totalCandidates (${totalCandidates})`,
+      );
+    }
+    if (candidatesWithDiagnostics + candidatesWithoutDiagnostics !== totalCandidates) {
+      fail(
+        `tsc-clean assertion classification ${compiler} candidate diagnostic counts (${candidatesWithDiagnostics} + ${candidatesWithoutDiagnostics}) do not match totalCandidates (${totalCandidates})`,
+      );
+    }
   }
   validateComparisonCompilerStatuses(
     cleanSubsetClassification.comparison,

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -817,6 +817,13 @@ if (comparison.bySemanticFamilyDelta !== null && comparison.bySemanticFamilyDelt
 }
 const candidateFileComparisonCounts = comparison.candidateFileComparison?.counts || {};
 const normalizedCandidateFileComparison = {};
+if (
+  Number.isInteger(tscCandidateDiagnostics.candidatesWithDiagnostics) &&
+  Number.isInteger(tszCandidateDiagnostics.candidatesWithDiagnostics) &&
+  !comparison.candidateFileComparison
+) {
+  fail("assertion classification comparison.candidateFileComparison is required when both compiler candidate file lists are concrete");
+}
 if (comparison.candidateFileComparison) {
   const candidateFileComparisonTotal = comparison.candidateFileComparison.totalCandidates;
   const bucketEntries = [];

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -488,6 +488,19 @@ if (cleanSubsetManifest && cleanSubsetClassification) {
     cleanSubsetClassification.compilers,
     "tsc-clean assertion classification",
   );
+  const cleanTsc = cleanSubsetClassification.compilers?.tsc || {};
+  if (cleanTsc.status !== "pass") {
+    fail(
+      `tsc-clean assertion classification tsc status (${cleanTsc.status}) must be pass`,
+    );
+  }
+  const cleanTscDiagnosticFree =
+    cleanTsc.candidateDiagnostics?.candidatesWithoutDiagnostics;
+  if (cleanTscDiagnosticFree !== acceptedAssertions) {
+    fail(
+      `tsc-clean assertion classification tsc candidatesWithoutDiagnostics (${cleanTscDiagnosticFree}) must match manifest tscAcceptedAssertions (${acceptedAssertions})`,
+    );
+  }
 }
 const tsc = report.compilers?.tsc || {};
 const tsz = report.compilers?.tsz || {};

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -633,7 +633,6 @@ for (const [compiler, diagnostics] of [
     if (files === null || files === undefined) {
       diagnosticFiles[field] = [];
       if (
-        field === "filesWithDiagnostics" &&
         Number.isInteger(diagnostics[countField]) &&
         diagnostics[countField] > 0
       ) {

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -142,6 +142,36 @@ function duplicatedValues(values) {
   return [...duplicates].sort();
 }
 
+function intersectSorted(left, right) {
+  const rightSet = new Set(right);
+  return left.filter((value) => rightSet.has(value)).sort();
+}
+
+function hasConcreteCandidateDiagnosticFiles(diagnostics) {
+  return (
+    Number.isInteger(diagnostics.totalCandidates) &&
+    Number.isInteger(diagnostics.candidatesWithDiagnostics) &&
+    Number.isInteger(diagnostics.candidatesWithoutDiagnostics) &&
+    (diagnostics.candidatesWithDiagnostics === 0 ||
+      Array.isArray(diagnostics.filesWithDiagnostics)) &&
+    (diagnostics.candidatesWithoutDiagnostics === 0 ||
+      Array.isArray(diagnostics.filesWithoutDiagnostics))
+  );
+}
+
+function assertSameFileSet(actual, expected, label) {
+  const sortedActual = [...actual].sort();
+  const sortedExpected = [...expected].sort();
+  if (
+    sortedActual.length !== sortedExpected.length ||
+    sortedActual.some((file, index) => file !== sortedExpected[index])
+  ) {
+    fail(
+      `${label} does not match compiler candidate diagnostic file lists: expected ${sortedExpected.join(", ") || "<none>"}, actual ${sortedActual.join(", ") || "<none>"}`,
+    );
+  }
+}
+
 function validateCompilerStatus(status, label) {
   if (typeof status !== "string" || status.trim() === "") {
     fail(`${label} status must be a non-empty string`);
@@ -894,6 +924,43 @@ if (comparison.candidateFileComparison) {
   if (bucketTotal !== candidateFileComparisonTotal) {
     fail(
       `assertion classification candidateFileComparison bucket counts (${bucketTotal}) do not match totalCandidates (${candidateFileComparisonTotal})`,
+    );
+  }
+  if (
+    hasConcreteCandidateDiagnosticFiles(tscCandidateDiagnostics) &&
+    hasConcreteCandidateDiagnosticFiles(tszCandidateDiagnostics)
+  ) {
+    assertSameFileSet(
+      normalizedCandidateFileComparison.bothAccepted,
+      intersectSorted(
+        normalizedCandidateDiagnosticFiles.tsc.filesWithoutDiagnostics,
+        normalizedCandidateDiagnosticFiles.tsz.filesWithoutDiagnostics,
+      ),
+      "assertion classification candidateFileComparison.bothAccepted",
+    );
+    assertSameFileSet(
+      normalizedCandidateFileComparison.bothRejected,
+      intersectSorted(
+        normalizedCandidateDiagnosticFiles.tsc.filesWithDiagnostics,
+        normalizedCandidateDiagnosticFiles.tsz.filesWithDiagnostics,
+      ),
+      "assertion classification candidateFileComparison.bothRejected",
+    );
+    assertSameFileSet(
+      normalizedCandidateFileComparison.tscAcceptedTszRejected,
+      intersectSorted(
+        normalizedCandidateDiagnosticFiles.tsc.filesWithoutDiagnostics,
+        normalizedCandidateDiagnosticFiles.tsz.filesWithDiagnostics,
+      ),
+      "assertion classification candidateFileComparison.tscAcceptedTszRejected",
+    );
+    assertSameFileSet(
+      normalizedCandidateFileComparison.tscRejectedTszAccepted,
+      intersectSorted(
+        normalizedCandidateDiagnosticFiles.tsc.filesWithDiagnostics,
+        normalizedCandidateDiagnosticFiles.tsz.filesWithoutDiagnostics,
+      ),
+      "assertion classification candidateFileComparison.tscRejectedTszAccepted",
     );
   }
 }

--- a/scripts/ci/type-challenges-assertion-compatibility.mjs
+++ b/scripts/ci/type-challenges-assertion-compatibility.mjs
@@ -159,7 +159,12 @@ function hasConcreteCandidateDiagnosticFiles(diagnostics) {
   );
 }
 
-function assertSameFileSet(actual, expected, label) {
+function assertSameFileSet(
+  actual,
+  expected,
+  label,
+  expectedDescription = "compiler candidate diagnostic file lists",
+) {
   const sortedActual = [...actual].sort();
   const sortedExpected = [...expected].sort();
   if (
@@ -167,7 +172,7 @@ function assertSameFileSet(actual, expected, label) {
     sortedActual.some((file, index) => file !== sortedExpected[index])
   ) {
     fail(
-      `${label} does not match compiler candidate diagnostic file lists: expected ${sortedExpected.join(", ") || "<none>"}, actual ${sortedActual.join(", ") || "<none>"}`,
+      `${label} does not match ${expectedDescription}: expected ${sortedExpected.join(", ") || "<none>"}, actual ${sortedActual.join(", ") || "<none>"}`,
     );
   }
 }
@@ -513,6 +518,32 @@ if (cleanSubsetManifest && cleanSubsetClassification) {
       `tsc-clean assertion classification tsc candidatesWithoutDiagnostics (${cleanTscDiagnosticFree}) must match manifest tscAcceptedAssertions (${acceptedAssertions})`,
     );
   }
+  const cleanTscDiagnosticFreeFiles =
+    cleanTsc.candidateDiagnostics?.filesWithoutDiagnostics;
+  if (!Array.isArray(cleanTscDiagnosticFreeFiles)) {
+    fail(
+      "tsc-clean assertion classification tsc candidateDiagnostics.filesWithoutDiagnostics must be an array",
+    );
+  }
+  const normalizedCleanTscDiagnosticFreeFiles = cleanTscDiagnosticFreeFiles.map(
+    (file, index) =>
+      validateCandidateOutputPath(
+        file,
+        `tsc-clean assertion classification tsc candidateDiagnostics.filesWithoutDiagnostics[${index}]`,
+      ),
+  );
+  const cleanSubsetOutputs = cleanSubsetManifest.entries.map((entry, index) =>
+    validateCandidateOutputPath(
+      entry?.output,
+      `tsc-clean assertion manifest entries[${index}].output`,
+    ),
+  );
+  assertSameFileSet(
+    normalizedCleanTscDiagnosticFreeFiles,
+    cleanSubsetOutputs,
+    "tsc-clean assertion classification tsc candidateDiagnostics.filesWithoutDiagnostics",
+    "tsc-clean assertion manifest entries",
+  );
 }
 const tsc = report.compilers?.tsc || {};
 const tsz = report.compilers?.tsz || {};

--- a/scripts/ci/type-challenges-pairing-report.mjs
+++ b/scripts/ci/type-challenges-pairing-report.mjs
@@ -154,8 +154,8 @@ function ensureManifestEntries(label, manifest) {
   const generated = Number(manifest?.generated);
   const expectedGenerated = Number(manifest?.expectedGenerated);
   const requiredChallengeFields = label === "solution"
-    ? ["level", "title"]
-    : ["level", "slug"];
+    ? ["id", "level", "title"]
+    : ["id", "level", "slug"];
 
   if (!Array.isArray(entries) || entries.length === 0) {
     console.error(`error: Type Challenges ${label} manifest has no entries`);

--- a/scripts/ci/type-challenges-pairing-report.mjs
+++ b/scripts/ci/type-challenges-pairing-report.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import path from "node:path";
 
 const [templateManifestPath, testCasesManifestPath, solutionsManifestPath, outputPath] =
   process.argv.slice(2);
@@ -131,6 +132,23 @@ function normalizeManifestPath(value) {
   return String(value).replace(/\\/g, "/").replace(/^(?:\.\/)+/, "");
 }
 
+function validateRelativeManifestPath(value, label) {
+  const normalized = normalizeManifestPath(value);
+  if (
+    path.isAbsolute(value) ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized === "" ||
+    normalized === "." ||
+    normalized
+      .split("/")
+      .some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    console.error(`error: Type Challenges ${label} must stay inside the manifest root: ${value}`);
+    process.exit(1);
+  }
+  return normalized;
+}
+
 function ensureManifestEntries(label, manifest) {
   const entries = manifest?.entries;
   const generated = Number(manifest?.generated);
@@ -172,7 +190,10 @@ function ensureManifestEntries(label, manifest) {
       );
       process.exit(1);
     }
-    const normalizedOutput = normalizeManifestPath(output);
+    const normalizedOutput = validateRelativeManifestPath(
+      output,
+      `${label} manifest entry ${index + 1} output path`,
+    );
     if (outputs.has(normalizedOutput)) {
       console.error(
         `error: Type Challenges ${label} manifest contains duplicate output path ${normalizedOutput}`,
@@ -187,7 +208,10 @@ function ensureManifestEntries(label, manifest) {
       );
       process.exit(1);
     }
-    const normalizedSource = normalizeManifestPath(source);
+    const normalizedSource = validateRelativeManifestPath(
+      source,
+      `${label} manifest entry ${index + 1} source path`,
+    );
     if (sources.has(normalizedSource)) {
       console.error(
         `error: Type Challenges ${label} manifest contains duplicate source path ${normalizedSource}`,


### PR DESCRIPTION
## Agent
AgentName: M1PD1

## Track
Type Challenges readiness / Project Direction #7731

## Invariant
When the Type Challenges tsc-clean subset generator preserves solution/template/test-case evidence paths from accepted assertion candidates, those evidence paths must remain relative source paths without drive-letter roots or dot/parent segments before the clean subset manifest is written.

## Scope
- Reject drive-letter roots and dot segments in `scripts/ci/type-challenges-assertion-clean-subset.mjs` selected-entry evidence paths.
- Add focused tests for a drive-letter solution output and a dot-segment template source.

## Project Corpus Impact
- Row: type-challenges-assertions-tsc-clean
- Bug family: Artifact consistency / clean-subset evidence path validation
- Evidence: The clean subset manifest now rejects unsafe selected-entry source evidence before downstream compatibility rows consume it.

## Verification
- `node --check scripts/ci/type-challenges-assertion-clean-subset.mjs`
- `node --check scripts/ci/test-type-challenges-assertion-clean-subset.mjs`
- `node scripts/ci/test-type-challenges-assertion-clean-subset.mjs`
- `git diff --check -- scripts/ci/type-challenges-assertion-clean-subset.mjs scripts/ci/test-type-challenges-assertion-clean-subset.mjs`

## Coordination Notes
- Stacked on #8147 (`codex/m1pd1-assertion-pair-path-normalization-2-20260518`).
- This is an artifact-boundary guard and does not touch #7731 ReplaceKeys compiler semantics.
