### PR TITLE
fix(checker): guard named import aliases against SymbolId collision in cross-arena resolution

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1690,7 +1690,7 @@ impl<'a> CheckerState<'a> {
                     if let Some(alias_id) =
                         self.ctx.alias_partner_for(self.ctx.binder, export_sym_id)
                     {
-                        let ta_type = self.get_type_of_symbol(export_sym_id);
+                        let ta_type = self.get_type_of_symbol_for_cross_file_export(export_sym_id);
                         self.ctx.import_type_alias_types.insert(sym_id, ta_type);
                         self.record_cross_file_symbol_if_needed(alias_id, export_name, module_name);
                         let mut result = self.get_type_of_symbol(alias_id);
@@ -1698,8 +1698,17 @@ impl<'a> CheckerState<'a> {
                         if export_name == "default" {
                             result = self.widen_type_for_display(result);
                         }
-                        let should_cache_on_export_symbol =
-                            self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
+                        // Do not write to symbol_types[export_sym_id] when a local
+                        // non-alias symbol shares that SymbolId (SymbolId collision).
+                        let has_local_collision =
+                            self.ctx.binder.get_symbol(export_sym_id).is_some_and(|s| {
+                                s.flags & symbol_flags::ALIAS == 0
+                                    && s.declarations
+                                        .iter()
+                                        .any(|&d| d.is_some() && self.ctx.arena.get(d).is_some())
+                            });
+                        let should_cache_on_export_symbol = !has_local_collision
+                            && self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
                                 !sym.has_any_flags(symbol_flags::TYPE)
                                     || !sym.has_any_flags(symbol_flags::VALUE)
                             });
@@ -1738,7 +1747,9 @@ impl<'a> CheckerState<'a> {
                             };
                             if value_decl.is_none() {
                                 self.local_value_type_for_same_name_symbol(export_sym_id, &sym_name)
-                                    .unwrap_or_else(|| self.get_type_of_symbol(export_sym_id))
+                                    .unwrap_or_else(|| {
+                                        self.get_type_of_symbol_for_cross_file_export(export_sym_id)
+                                    })
                             } else {
                                 let vd_type = if self.ctx.arena.get(value_decl).is_some() {
                                     self.type_of_value_declaration_for_symbol(
@@ -1755,17 +1766,19 @@ impl<'a> CheckerState<'a> {
                                 if vd_type != TypeId::UNKNOWN && vd_type != TypeId::ERROR {
                                     vd_type
                                 } else {
-                                    self.get_type_of_symbol(export_sym_id)
+                                    self.get_type_of_symbol_for_cross_file_export(export_sym_id)
                                 }
                             }
                         } else if has_interface {
                             self.local_value_type_for_same_name_symbol(export_sym_id, &sym_name)
-                                .unwrap_or_else(|| self.get_type_of_symbol(export_sym_id))
+                                .unwrap_or_else(|| {
+                                    self.get_type_of_symbol_for_cross_file_export(export_sym_id)
+                                })
                         } else {
-                            self.get_type_of_symbol(export_sym_id)
+                            self.get_type_of_symbol_for_cross_file_export(export_sym_id)
                         }
                     } else {
-                        self.get_type_of_symbol(export_sym_id)
+                        self.get_type_of_symbol_for_cross_file_export(export_sym_id)
                     };
                     result = self.apply_module_augmentations(module_name, export_name, result);
                     if export_name == "default" {
@@ -1775,8 +1788,17 @@ impl<'a> CheckerState<'a> {
                         );
                         result = self.widen_fresh_object_literal_properties_for_display(result);
                     }
-                    let should_cache_on_export_symbol =
-                        self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
+                    // Do not write to symbol_types[export_sym_id] when a local non-alias
+                    // symbol shares that SymbolId (SymbolId collision across files).
+                    let has_local_collision =
+                        self.ctx.binder.get_symbol(export_sym_id).is_some_and(|s| {
+                            s.flags & symbol_flags::ALIAS == 0
+                                && s.declarations
+                                    .iter()
+                                    .any(|&d| d.is_some() && self.ctx.arena.get(d).is_some())
+                        });
+                    let should_cache_on_export_symbol = !has_local_collision
+                        && self.get_symbol_globally(export_sym_id).is_none_or(|sym| {
                             !sym.has_any_flags(symbol_flags::TYPE)
                                 || !sym.has_any_flags(symbol_flags::VALUE)
                         });

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -2276,7 +2276,23 @@ impl<'a> CheckerState<'a> {
         let cross_file_owner_idx = self
             .ctx
             .resolve_symbol_file_index(sym_id)
-            .filter(|&file_idx| file_idx != self.ctx.current_file_idx);
+            .filter(|&file_idx| file_idx != self.ctx.current_file_idx)
+            // SymbolId collision guard: per-file binders all start numbering at 0,
+            // so the same integer can appear as a locally-declared non-alias symbol
+            // HERE and as an exported symbol in another file recorded in
+            // cross_file_symbol_targets.  When the local binder owns a non-alias
+            // symbol at sym_id with a declaration in this arena, it holds that
+            // SymbolId — the cross_file_symbol_targets entry belongs to a different
+            // symbol and must not shadow local resolution or pollute the cross-file
+            // type cache for this checker context.
+            .filter(|_| {
+                !self.ctx.binder.get_symbol(sym_id).is_some_and(|s| {
+                    s.flags & tsz_binder::symbol_flags::ALIAS == 0
+                        && s.declarations
+                            .iter()
+                            .any(|&d| d.is_some() && self.ctx.arena.get(d).is_some())
+                })
+            });
         if let Some(file_idx) = cross_file_owner_idx
             && let Some((cached, _params)) = self
                 .ctx

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -431,9 +431,6 @@ impl<'a> CheckerState<'a> {
         // references whose target lives in another arena.
         if let Some(local_sym) = self.ctx.binder.get_symbol(sym_id) {
             let is_alias = local_sym.flags & symbol_flags::ALIAS != 0;
-            // The two branches are mutually exclusive on `is_alias`:
-            //   - non-alias: must own a declaration in the current arena
-            //   - alias:     must be a named import (has `import_module`)
             let must_stay_local = if is_alias {
                 local_sym.import_module.is_some()
             } else {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -104,11 +104,35 @@ impl<'a> CheckerState<'a> {
     /// Get a symbol from the current binder, lib binders, or other file binders.
     /// This ensures we can resolve symbols from lib.d.ts and other files.
     pub(crate) fn get_symbol_globally(&self, sym_id: SymbolId) -> Option<&tsz_binder::Symbol> {
+        // SymbolId collision guard. Each file's binder numbers symbols from 0,
+        // so a local symbol can share an integer with an exported symbol in
+        // another file. The local symbol must win in two cases:
+        //
+        //  1. Non-alias local symbols (functions, variables, classes,
+        //     interfaces, …) are uniquely owned by the current file.
+        //     Returning a cross-file collision would misidentify a local
+        //     `declare function` as an imported constant, producing spurious
+        //     TS2349/TS2345 errors.
+        //
+        //  2. Named import aliases (ALIAS + `import_module` set) are also
+        //     owned by the current file: the sym_id is the local alias
+        //     handle, not the target export. A cross-file lookup at a
+        //     colliding integer would return the wrong export symbol.
+        //
+        // Non-named alias symbols (ALIAS without `import_module`) are
+        // intentionally allowed to fall through to cross-file resolution.
+        let local_sym = self.ctx.binder.get_symbol(sym_id);
+        if let Some(sym) = local_sym {
+            let is_alias = sym.flags & symbol_flags::ALIAS != 0;
+            if !is_alias || sym.import_module.is_some() {
+                return Some(sym);
+            }
+        }
+
         // If the import/export resolver has already tied this raw SymbolId to a
-        // specific source file, use that binder before the current file. Raw
-        // SymbolIds are only file-local; checking the current binder first can
-        // accidentally pick an unrelated same-id symbol while resolving
-        // cross-file aliases.
+        // specific source file, use that binder (cross-file alias resolution).
+        // The guard above ensures we only reach here when the local lookup
+        // produced nothing or found an alias (whose target lives elsewhere).
         if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
             && file_idx != self.ctx.current_file_idx
             && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
@@ -117,8 +141,9 @@ impl<'a> CheckerState<'a> {
             return Some(sym);
         }
 
-        // 1. Check current file
-        if let Some(sym) = self.ctx.binder.get_symbol(sym_id) {
+        // 1. Return the local symbol if one was found above (a non-named alias
+        //    that fell through the guard but has no cross-file resolution).
+        if let Some(sym) = local_sym {
             return Some(sym);
         }
         // 2. Check lib files (lib.d.ts, etc.)
@@ -129,14 +154,11 @@ impl<'a> CheckerState<'a> {
         }
         // 3. O(1) fast-path: if this SymbolId was already resolved to a specific
         //    file via resolve_symbol_file_index, go directly to that binder.
+        if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
+            && let Some(sym) = binder.get_symbol(sym_id)
         {
-            let file_idx = self.ctx.resolve_symbol_file_index(sym_id);
-            if let Some(file_idx) = file_idx
-                && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
-                && let Some(sym) = binder.get_symbol(sym_id)
-            {
-                return Some(sym);
-            }
+            return Some(sym);
         }
         // 4. Fallback: O(N) scan over all binders
         if let Some(binders) = &self.ctx.all_binders {
@@ -384,6 +406,44 @@ impl<'a> CheckerState<'a> {
         &mut self,
         sym_id: SymbolId,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+        // SymbolId collision guard: per-file binders all start numbering at 0,
+        // so a local symbol can share a SymbolId integer with an exported
+        // symbol in another file recorded in cross_file_symbol_targets.
+        //
+        // Two kinds of local symbols must NOT be delegated cross-arena:
+        //
+        //  1. Non-alias symbols (function, variable, class, …) that have a
+        //     declaration in the current arena — they are exclusively owned
+        //     by this checker context.
+        //
+        //  2. Named import aliases (ALIAS + `import_module` set) — their
+        //     type is computed by following the import chain via
+        //     `compute_type_of_symbol_type_alias_variable_alias`, which
+        //     navigates to the source file itself. Delegating through a
+        //     colliding cross_file_symbol_targets entry would return the
+        //     wrong target symbol and bypass the import chain.
+        //
+        // Non-named alias symbols (ALIAS without `import_module`) are
+        // intentionally allowed through: they are genuine cross-file
+        // references whose target lives in another arena.
+        if let Some(local_sym) = self.ctx.binder.get_symbol(sym_id) {
+            let is_alias = local_sym.flags & symbol_flags::ALIAS != 0;
+            // The two branches are mutually exclusive on `is_alias`:
+            //   - non-alias: must own a declaration in the current arena
+            //   - alias:     must be a named import (has `import_module`)
+            let must_stay_local = if is_alias {
+                local_sym.import_module.is_some()
+            } else {
+                local_sym
+                    .declarations
+                    .iter()
+                    .any(|&d| d.is_some() && self.ctx.arena.get(d).is_some())
+            };
+            if must_stay_local {
+                return None;
+            }
+        }
+
         // Fast path: if this is a known cross-file symbol, skip the namespace guard
         // (which would check the wrong symbol in the current binder) and go straight
         // to cross-file delegation.
@@ -1145,6 +1205,219 @@ impl<'a> CheckerState<'a> {
         }
 
         None
+    }
+
+    /// Resolve the type of a known cross-file export symbol by creating a
+    /// child checker that uses the target file's arena and binder directly.
+    ///
+    /// Unlike `get_type_of_symbol`, which can be confused when the same SymbolId
+    /// integer names a locally-declared symbol in this file AND an exported
+    /// symbol in another file (per-file binders both start at 0), this function
+    /// explicitly delegates to `file_idx`'s context. The collision-guarded paths
+    /// in `delegate_cross_arena_symbol_resolution` and `get_type_of_symbol_inner`
+    /// can therefore remain conservative for local symbols without breaking alias
+    /// resolution.
+    ///
+    /// The result is cached in the cross-file symbol-type cache keyed by
+    /// `(sym_id, file_idx)` but is NOT written to the parent's `symbol_types[sym_id]`
+    /// cache, preventing a locally-declared symbol from inheriting the cross-file
+    /// export's type.
+    pub(crate) fn resolve_type_of_cross_file_export_symbol(
+        &mut self,
+        sym_id: SymbolId,
+        file_idx: usize,
+    ) -> TypeId {
+        // Cross-file cache hit: avoid re-creating the child checker.
+        if let Some((cached, _)) = self
+            .ctx
+            .cached_cross_file_symbol_type(sym_id, file_idx as u32)
+        {
+            return cached;
+        }
+
+        let Some(symbol_arena_arc) = self
+            .ctx
+            .all_arenas
+            .as_ref()
+            .and_then(|a| a.get(file_idx))
+            .cloned()
+        else {
+            return TypeId::UNKNOWN;
+        };
+        let symbol_arena = symbol_arena_arc.as_ref();
+
+        // Same arena — no delegation needed; caller should use get_type_of_symbol.
+        if std::ptr::eq(symbol_arena, self.ctx.arena) {
+            return self.get_type_of_symbol(sym_id);
+        }
+
+        if !Self::enter_cross_arena_delegation() {
+            return TypeId::UNKNOWN;
+        }
+        if !self.ctx.enter_recursion() {
+            Self::leave_cross_arena_delegation();
+            return TypeId::UNKNOWN;
+        }
+
+        let delegate_binder = self
+            .ctx
+            .get_binder_for_file(file_idx)
+            .unwrap_or(self.ctx.binder);
+        let file_name = symbol_arena
+            .source_files
+            .first()
+            .map(|sf| sf.file_name.clone())
+            .unwrap_or_else(|| self.ctx.file_name.clone());
+
+        let mut checker = Box::new(CheckerState::with_parent_cache_attributed(
+            symbol_arena,
+            delegate_binder,
+            self.ctx.types,
+            file_name,
+            self.ctx.compiler_options.clone(),
+            self,
+            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
+        ));
+        checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
+        checker.ctx.copy_cross_file_state_from(&self.ctx);
+        self.ctx.copy_symbol_file_targets_to_attributed(
+            &mut checker.ctx,
+            tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
+        );
+        checker.ctx.current_file_idx = file_idx;
+        // Remove any stale cache entry for sym_id so the child resolves it
+        // against the target file's binder rather than inheriting a colliding
+        // value from the parent context.
+        checker.ctx.symbol_types.remove(&sym_id);
+        checker.ctx.symbol_instance_types.remove(&sym_id);
+        for &id in &self.ctx.symbol_resolution_set {
+            if id != sym_id {
+                checker.ctx.symbol_resolution_set.insert(id);
+            }
+        }
+        for &id in &self.ctx.class_instance_resolution_set {
+            checker.ctx.class_instance_resolution_set.insert(id);
+        }
+        for &id in &self.ctx.class_constructor_resolution_set {
+            checker.ctx.class_constructor_resolution_set.insert(id);
+        }
+        checker.ctx.ensure_type_env_has_definition_store();
+
+        let result = checker.get_type_of_symbol(sym_id);
+
+        // Collect child data before dropping (child borrows self.ctx.types).
+        //
+        // Exclude sym_id from the symbol_types merge-back: writing the cross-file
+        // export's type under the same integer would overwrite (or pre-fill) the
+        // local symbol's cache entry, causing subsequent lookups for the local
+        // symbol to return the wrong type.
+        let child_symbol_types: Vec<(SymbolId, TypeId)> = checker
+            .ctx
+            .symbol_types
+            .iter()
+            .filter(|(k, _)| *k != sym_id)
+            .collect();
+        if let Ok(child_env) = checker.ctx.type_env.try_borrow() {
+            self.merge_child_type_env_snapshots(
+                &child_env,
+                "resolve_type_of_cross_file_export_symbol",
+            );
+        }
+        let child_lib_type_cache: Vec<(String, Option<TypeId>)> =
+            std::mem::take(&mut checker.ctx.lib_type_resolution_cache)
+                .into_iter()
+                .collect();
+        let child_instance_types: Vec<(SymbolId, TypeId)> = checker
+            .ctx
+            .symbol_instance_types
+            .iter()
+            .filter(|(k, _)| *k != sym_id)
+            .collect();
+        let child_namespace_names: rustc_hash::FxHashMap<TypeId, String> =
+            std::mem::take(&mut checker.ctx.namespace_module_names);
+        drop(checker);
+
+        // Merge collected data into the parent.
+        for (k, v) in child_symbol_types {
+            self.ctx.symbol_types.entry_or_insert(k, v);
+        }
+        for (name, type_id) in child_lib_type_cache {
+            self.ctx
+                .lib_type_resolution_cache
+                .entry(name)
+                .or_insert(type_id);
+        }
+        for (k, v) in child_instance_types {
+            self.ctx.symbol_instance_types.entry_or_insert(k, v);
+        }
+        self.ctx
+            .namespace_module_names
+            .extend(child_namespace_names);
+
+        // Cache in the cross-file cache (NOT in parent symbol_types[sym_id]).
+        self.ctx
+            .cache_cross_file_symbol_type(sym_id, file_idx as u32, result, Vec::new());
+
+        self.ctx.leave_recursion();
+        Self::leave_cross_arena_delegation();
+        result
+    }
+
+    /// Resolve the type of a cross-file export `SymbolId`, handling the case where
+    /// the same integer also names a locally-declared symbol in this file (SymbolId
+    /// collision).
+    ///
+    /// When no collision exists, delegates to `get_type_of_symbol`. When a collision
+    /// is detected, uses `resolve_type_of_cross_file_export_symbol` to create a
+    /// child checker for the owning file directly, bypassing the collision guards
+    /// in `delegate_cross_arena_symbol_resolution` that would otherwise force local
+    /// resolution and return the wrong type.
+    pub(crate) fn get_type_of_symbol_for_cross_file_export(
+        &mut self,
+        export_sym_id: SymbolId,
+    ) -> TypeId {
+        let has_collision = self.ctx.binder.get_symbol(export_sym_id).is_some_and(|s| {
+            s.flags & symbol_flags::ALIAS == 0
+                && s.declarations
+                    .iter()
+                    .any(|&d| d.is_some() && self.ctx.arena.get(d).is_some())
+        });
+
+        tracing::debug!(
+            sym_id = export_sym_id.0,
+            has_collision,
+            file = self.ctx.file_name.as_str(),
+            "get_type_of_symbol_for_cross_file_export"
+        );
+
+        if !has_collision {
+            let result = self.get_type_of_symbol(export_sym_id);
+            tracing::debug!(
+                sym_id = export_sym_id.0,
+                result = result.0,
+                "get_type_of_symbol_for_cross_file_export: no collision"
+            );
+            return result;
+        }
+
+        let Some(file_idx) = self.ctx.resolve_symbol_file_index(export_sym_id) else {
+            let result = self.get_type_of_symbol(export_sym_id);
+            tracing::debug!(
+                sym_id = export_sym_id.0,
+                result = result.0,
+                "get_type_of_symbol_for_cross_file_export: no file_idx"
+            );
+            return result;
+        };
+
+        let result = self.resolve_type_of_cross_file_export_symbol(export_sym_id, file_idx);
+        tracing::debug!(
+            sym_id = export_sym_id.0,
+            file_idx,
+            result = result.0,
+            "get_type_of_symbol_for_cross_file_export: resolved"
+        );
+        result
     }
 
     /// Delegate class instance type resolution to a child checker with the correct arena.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -129,10 +129,10 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // If the import/export resolver has already tied this raw SymbolId to a
-        // specific source file, use that binder (cross-file alias resolution).
-        // The guard above ensures we only reach here when the local lookup
-        // produced nothing or found an alias (whose target lives elsewhere).
+        // Cross-file resolver: if the resolver has tied this SymbolId to a
+        // non-current source file, use that binder. We only reach here when
+        // the local lookup produced nothing or found a non-named alias (whose
+        // target lives elsewhere).
         if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
             && file_idx != self.ctx.current_file_idx
             && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
@@ -141,26 +141,29 @@ impl<'a> CheckerState<'a> {
             return Some(sym);
         }
 
-        // 1. Return the local symbol if one was found above (a non-named alias
-        //    that fell through the guard but has no cross-file resolution).
+        // Non-named alias with no cross-file resolution: fall back to local.
         if let Some(sym) = local_sym {
             return Some(sym);
         }
-        // 2. Check lib files (lib.d.ts, etc.)
+
+        // Lib files (lib.d.ts, etc.).
         for lib in self.ctx.lib_contexts.iter() {
             if let Some(sym) = lib.binder.get_symbol(sym_id) {
                 return Some(sym);
             }
         }
-        // 3. O(1) fast-path: if this SymbolId was already resolved to a specific
-        //    file via resolve_symbol_file_index, go directly to that binder.
+
+        // Retry the resolver without the non-current-file filter, in case the
+        // resolver mapping points at the current file (e.g. local lookup found
+        // a fell-through alias).
         if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
             && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
             && let Some(sym) = binder.get_symbol(sym_id)
         {
             return Some(sym);
         }
-        // 4. Fallback: O(N) scan over all binders
+
+        // Last resort: O(N) scan over all known binders.
         if let Some(binders) = &self.ctx.all_binders {
             for binder in binders.iter() {
                 if let Some(sym) = binder.get_symbol(sym_id) {

--- a/crates/tsz-checker/tests/cross_file_lib_interface_identity_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_lib_interface_identity_tests.rs
@@ -161,9 +161,6 @@ const n: Node = bp;
     assert!(codes.is_empty(), "Diagnostics: {codes:?}");
 }
 
-// Known-failing cases tracked by issue #7690 — drop the `#[ignore]` when fixed.
-
-#[ignore = "tsz issue #7690: local `declare function` + cross-file import emits TS2345/TS2349 instead of resolving to lib Node"]
 #[test]
 fn local_declare_function_after_import_is_callable_with_cross_file_element() {
     let exporter = "export const blogPost: Element;";
@@ -180,7 +177,6 @@ takeNode(blogPost);
     assert!(codes.is_empty(), "Diagnostics: {codes:?}");
 }
 
-#[ignore = "tsz issue #7690: subclass of lib HTMLElement declared in another module loses heritage chain to Element/Node"]
 #[test]
 fn imported_element_class_extension_unifies_with_lib_html_element() {
     let leaf = r#"


### PR DESCRIPTION
Refs #8476. Complementary to #8550 (different symbol kind; covers the remaining class-extension case).

## Structural rule

> When a local symbol at `sym_id` is a named import alias (ALIAS flag + `import_module` set), tsz must resolve its type via the import chain rather than delegating to whatever `cross_file_symbol_targets[sym_id]` happens to map to. Per-file binders start numbering from 0, so the same integer can appear as a named import alias in `main.ts` and as an exported symbol in `component.d.ts`. The cross-file delegation must not be allowed to substitute one for the other.

## Root cause

Per-file binders all start numbering symbols from 0. After the N lib symbols, user symbols in each file get ids N, N+1, N+2 … Two files share integer space: `import { blogPost } from "./component"` in `main.ts` may produce alias `SymbolId(K)`, while the exported `const blogPost: Element` in `component.d.ts` also produces `SymbolId(K)`.

`resolve_import_alias_and_register` registers `cross_file_symbol_targets[K] = 0` (component.d.ts file index). Two code paths then treated the local alias as if it were the cross-file variable:

1. **`get_symbol_globally`**: when the local symbol is an ALIAS, the existing early-return was skipped, falling through to the cross-file binder lookup. This returned the export *variable* symbol from component.d.ts, making `flags` for the alias appear as VARIABLE flags — corrupting every downstream type decision.

2. **`delegate_cross_arena_symbol_resolution`**: the existing Fix B blocked non-alias local symbols from delegating, but ALIAS symbols passed through. The child checker then computed the type against the wrong arena, producing the wrong `TypeId` for the import alias.

## Fix

In both functions, named import aliases (ALIAS + `import_module.is_some()`) are now treated as exclusively owned by the current file — exactly like non-alias local symbols. This routes type resolution through `compute_type_of_symbol_type_alias_variable_alias`, which correctly navigates the import chain to the source file.

### `get_symbol_globally`

Consolidated the two separate guards into one:
```rust
if let Some(local_sym) = self.ctx.binder.get_symbol(sym_id) {
    let is_alias = local_sym.flags & symbol_flags::ALIAS != 0;
    if !is_alias || local_sym.import_module.is_some() {
        return Some(local_sym);  // local non-alias OR named import alias
    }
}
```

### `delegate_cross_arena_symbol_resolution`

Added a parallel guard alongside Fix B:
```rust
if let Some(local_sym) = self.ctx.binder.get_symbol(sym_id) {
    let is_alias = local_sym.flags & symbol_flags::ALIAS != 0;
    let must_stay_local = if is_alias {
        local_sym.import_module.is_some()  // named import alias
    } else {
        local_sym.declarations.iter().any(|&d| ...)  // local declaration
    };
    if must_stay_local { return None; }
}
```

## Owner layer

Checker — `state/type_analysis/cross_file.rs`. The rule is about which binder owns a raw `SymbolId`; solver type computation is unchanged.

## Relationship to PR #8550

PR #8550 fixes the **FUNCTION** symbol collision case (local `declare function` whose SymbolId collides with a value in another file) by adding a `function_has_local_decl` flag later in `delegate_cross_arena_symbol_resolution`. That guard and this guard are complementary:

- #8550 guard: non-alias, non-class, non-interface FUNCTION with local declaration node → stay local
- This PR's guard: ALIAS with `import_module` set → stay local (return early, before #8550's guard)

The two guards are at different code locations and guard different `symbol_flags`. This PR additionally fixes `imported_element_class_extension_unifies_with_lib_html_element` (the class extension heritage case that #8550 leaves as a follow-up).

## Adjacent-case test matrix

`crates/tsz-checker/tests/cross_file_lib_interface_identity_tests.rs` (9 tests, all passing):

| Test | What it proves |
|------|----------------|
| `imported_element_is_assignable_to_node` | Element lib heritage preserved across file boundary |
| `imported_element_keeps_lib_heritage_when_renamed_on_import` | Alias rename (`import { blogPost as post }`) doesn't lose lib identity |
| `imported_element_can_be_passed_as_node_argument_when_function_is_imported_too` | Both a value import and a function import coexist without collision |
| `imported_element_through_namespace_reexport_is_assignable_to_node` | Re-export path preserves lib heritage |
| `locally_declared_element_can_be_passed_as_node_element` | Baseline: local `Element` always works |
| `imported_html_element_is_assignable_to_element_and_node` | Full DOM hierarchy (`HTMLElement extends Element extends Node`) |
| `imported_div_element_is_assignable_to_html_element_and_node` | Deeper hierarchy |
| `local_declare_function_after_import_is_callable_with_cross_file_element` | `declare function takeNode(child: Node)` + `import { blogPost }` — collision with SymbolId K |
| `imported_element_class_extension_unifies_with_lib_html_element` | Class extension `MyElement extends HTMLElement` imported cross-file — previously left as a follow-up in #8550 |

Three invariants for §25 compliance: (a) renaming the import alias (`blogPost → post`) doesn't break the fix; (b) using a different DOM type (`HTMLElement`, `HTMLDivElement`) proves the fix isn't keyed on `Element`; (c) the class extension case proves `import_module.is_some()` guard is structural, not spelled.

## Known unsupported shapes / fallback

- Non-named alias symbols (ALIAS without `import_module`) continue to delegate cross-arena — they represent re-exports and need cross-file resolution.
- The `declarationFileForHtmlFileWithinDeclarationFile.ts` conformance test has a second fix (module resolution naming, PR #8453) that must land first before the accepted-regression entry can be cleared.

## Verification

```bash
cargo nextest run -p tsz-checker --test cross_file_lib_interface_identity_tests
# → 9 passed, 0 skipped
cargo clippy -p tsz-checker --all-targets -- -D warnings
# → clean
```

Full conformance, emit, fourslash, WASM to run on ready-for-review CI.

## Project Corpus Impact

- Row: n/a (conformance fixture still held back by module-resolution half in #8453)
- Bug family: cross-arena raw-SymbolId collision for named import aliases; downstream TS2345/TS2740 cascade
- Evidence: 9-test focused suite in `cross_file_lib_interface_identity_tests.rs` covering Element/HTMLElement/HTMLDivElement hierarchy and class extension patterns

AgentName: claude-sonnet-4-6 / keen-thompson-1owpR

https://claude.ai/code/session_01UCA5bN9Y3xZWp2QRMpnqpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCA5bN9Y3xZWp2QRMpnqpm)_