### PR TITLE
refactor(solver): drop root operations core exports

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -206,7 +206,7 @@ impl<'a> CheckerContext<'a> {
             depth_exceeded: Cell::new(false),
             relation_depth_exceeded: Cell::new(false),
             skip_callable_type_param_suppression: Cell::new(false),
-            eval_session: Rc::new(tsz_solver::EvaluationSession::new()),
+            eval_session: Rc::new(tsz_solver::evaluation::session::EvaluationSession::new()),
             recursion_depth: RefCell::new(tsz_solver::recursion::DepthCounter::with_profile(
                 tsz_solver::recursion::RecursionProfile::CheckerRecursion,
             )),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -940,7 +940,7 @@ pub struct CheckerContext<'a> {
     /// Explicit evaluation session state (replaces thread-local depth/fuel guards).
     /// Shared via `Rc` across parent/child contexts so counters survive cross-arena
     /// delegation without implicit global state.
-    pub eval_session: Rc<tsz_solver::EvaluationSession>,
+    pub eval_session: Rc<tsz_solver::evaluation::session::EvaluationSession>,
 
     /// General recursion depth counter for type checking.
     /// Prevents stack overflow by bailing out when depth exceeds the limit.

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -1,7 +1,7 @@
-use tsz_solver::operations::CallResult;
+use tsz_solver::operations::{AssignabilityChecker, CallResult};
 use tsz_solver::{
-    AssignabilityChecker, ContextualTypeContext, FunctionShape, QueryDatabase, TypeDatabase,
-    TypeEnvironment, TypeId, TypeResolver, TypeSubstitution,
+    ContextualTypeContext, FunctionShape, QueryDatabase, TypeDatabase, TypeEnvironment, TypeId,
+    TypeResolver, TypeSubstitution,
 };
 
 pub(crate) use super::super::common::array_element_type as array_element_type_for_type;
@@ -20,7 +20,7 @@ pub(crate) fn get_contextual_signature(
     db: &dyn QueryDatabase,
     type_id: TypeId,
 ) -> Option<FunctionShape> {
-    tsz_solver::get_contextual_signature_cached_with_compat_checker(db, type_id)
+    tsz_solver::operations::get_contextual_signature_cached_with_compat_checker(db, type_id)
 }
 
 pub(crate) fn get_contextual_signature_for_arity(
@@ -28,7 +28,7 @@ pub(crate) fn get_contextual_signature_for_arity(
     type_id: TypeId,
     arg_count: usize,
 ) -> Option<FunctionShape> {
-    tsz_solver::get_contextual_signature_for_arity_cached_with_compat_checker(
+    tsz_solver::operations::get_contextual_signature_for_arity_cached_with_compat_checker(
         db, type_id, arg_count,
     )
 }

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1,6 +1,6 @@
 use tsz_solver::{
     CallSignature, CallableShape, ObjectShape, TupleElement, TypeApplication, TypeDatabase, TypeId,
-    TypePredicate,
+    TypePredicate, operations::widening,
 };
 
 // Re-export solver value types used by checker call computation.
@@ -444,7 +444,7 @@ pub(crate) fn widen_function_literal_return_type(db: &dyn TypeDatabase, type_id:
     let Some(shape) = tsz_solver::type_queries::get_function_shape(db, type_id) else {
         return type_id;
     };
-    let widened_return = tsz_solver::widen_literal_type(db, shape.return_type);
+    let widened_return = widening::widen_literal_type(db, shape.return_type);
     if widened_return != shape.return_type {
         tsz_solver::type_queries::replace_function_return_type(db, type_id, widened_return)
     } else {
@@ -474,7 +474,7 @@ pub(crate) fn widen_callable_literal_return_types(
         .call_signatures
         .iter()
         .map(|sig| {
-            let widened = tsz_solver::widen_literal_type(db, sig.return_type);
+            let widened = widening::widen_literal_type(db, sig.return_type);
             if widened != sig.return_type {
                 any_changed = true;
                 let mut new_sig = sig.clone();
@@ -528,7 +528,7 @@ pub(crate) fn unwrap_readonly_or_noinfer(db: &dyn TypeDatabase, type_id: TypeId)
 
 /// Widen a literal type to its base primitive (e.g. `"hello"` → `string`).
 pub(crate) fn widen_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_type(db, type_id)
+    widening::widen_type(db, type_id)
 }
 
 /// Widen a type for diagnostic display, preserving boolean literal intrinsics.
@@ -536,7 +536,7 @@ pub(crate) fn widen_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
 /// Like `widen_type` but keeps `true`/`false` literals so narrowed types
 /// display correctly (e.g., `string | false` instead of `string | boolean`).
 pub(crate) fn widen_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_type_for_display(db, type_id)
+    widening::widen_type_for_display(db, type_id)
 }
 
 /// Widen a type for call-argument diagnostic display: widens boolean
@@ -544,7 +544,7 @@ pub(crate) fn widen_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> 
 /// renders match tsc, e.g. `[number, number, boolean, boolean]` instead of
 /// `[number, number, false, true]`. Function param types are still skipped.
 pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_argument_type_for_display(db, type_id)
+    widening::widen_argument_type_for_display(db, type_id)
 }
 
 /// Extract the element type from a rest-argument array/tuple type.
@@ -749,7 +749,7 @@ pub(crate) fn literal_value(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Li
 
 /// Widen a literal type to its base type (e.g., `3` → `number`).
 pub(crate) fn widen_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_literal_type(db, type_id)
+    widening::widen_literal_type(db, type_id)
 }
 
 /// Check if a type is a template literal type.
@@ -1801,17 +1801,17 @@ pub(crate) fn evaluate_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
 }
 
 pub(crate) fn widen_type_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_type_deep(db, type_id)
+    widening::widen_type_deep(db, type_id)
 }
 
 /// Display-widen a type for TS2403 redeclaration messages.
 ///
-/// Thin boundary wrapper over `tsz_solver::display_widen_for_redeclaration`.
+/// Thin boundary wrapper over `tsz_solver::operations::widening::display_widen_for_redeclaration`.
 /// See the solver definition for semantics — preserves top-level literal /
 /// literal-union types while deep-widening fresh literals nested inside
 /// compound shapes.
 pub(crate) fn display_widen_for_redeclaration(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::display_widen_for_redeclaration(db, type_id)
+    widening::display_widen_for_redeclaration(db, type_id)
 }
 
 pub(crate) fn string_intrinsic_components(
@@ -1884,7 +1884,7 @@ pub(crate) fn instantiate_type_preserving_meta(
 }
 
 pub(crate) fn get_base_type_for_comparison(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::get_base_type_for_comparison(db, type_id)
+    widening::get_base_type_for_comparison(db, type_id)
 }
 
 pub(crate) fn apply_contextual_type(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -6,19 +6,19 @@ use tsz_solver::{
 // Re-export solver value types used by checker call computation.
 pub(crate) use tsz_solver::judge::{DefaultJudge, Judge, JudgeConfig};
 pub(crate) use tsz_solver::operations::property::PropertyAccessResult;
+pub(crate) use tsz_solver::operations::{AssignabilityChecker, CallResult};
 pub(crate) use tsz_solver::type_queries::{
     RemappedMappedIndexAccessResult, TypeTraversalKind, constraint_allows_mutable_array_like,
     is_remapped_mapped_index_access, remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
-    AssignabilityChecker, CallResult, ContextualTypeContext, FunctionShape, IndexKind,
-    IndexSignatureResolver, IntrinsicKind, MappedType, ObjectFlags, OptionalPropertyChainKey,
-    ParamInfo, PendingDiagnostic, PendingDiagnosticBuilder, QueryDatabase, SourceLocation,
-    SubtypeFailureReason, TypeEnvironment, TypeFormatter, TypeResolver, TypeSubstitution,
-    fill_application_defaults, instantiate_generic,
+    ContextualTypeContext, FunctionShape, IndexKind, IndexSignatureResolver, IntrinsicKind,
+    MappedType, ObjectFlags, OptionalPropertyChainKey, ParamInfo, PendingDiagnostic,
+    PendingDiagnosticBuilder, QueryDatabase, SourceLocation, SubtypeFailureReason, TypeEnvironment,
+    TypeFormatter, TypeResolver, TypeSubstitution, fill_application_defaults, instantiate_generic,
 };
 #[allow(unused_imports)]
-pub(crate) use tsz_solver::{BinaryOpEvaluator, TypeInstantiator, TypeInterner};
+pub(crate) use tsz_solver::{TypeInstantiator, TypeInterner};
 
 pub(crate) use super::construct_signatures::construct_signatures_for_type;
 pub(crate) use super::type_rewrite::replace_type_queries_and_lazies_with;
@@ -1103,7 +1103,7 @@ pub(crate) fn is_valid_mapped_type_key_type(
     db: &dyn tsz_solver::QueryDatabase,
     type_id: TypeId,
 ) -> bool {
-    let evaluator = tsz_solver::BinaryOpEvaluator::new(db);
+    let evaluator = tsz_solver::operations::BinaryOpEvaluator::new(db);
     evaluator.is_valid_mapped_type_key_type(type_id)
 }
 
@@ -1672,8 +1672,8 @@ pub(crate) fn union_list_id(
 /// through this function instead of calling `BinaryOpEvaluator::new()` directly.
 pub(crate) fn new_binary_op_evaluator(
     db: &dyn tsz_solver::QueryDatabase,
-) -> tsz_solver::BinaryOpEvaluator<'_> {
-    tsz_solver::BinaryOpEvaluator::new(db)
+) -> tsz_solver::operations::BinaryOpEvaluator<'_> {
+    tsz_solver::operations::BinaryOpEvaluator::new(db)
 }
 
 // ── Visitor aliases (same-name wrappers for inline-call migration) ─────────

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -2,9 +2,9 @@ use tsz_solver::{NullishFilter, PropertyInfo, TypeDatabase, TypeId, TypeResolver
 
 /// Re-export of the solver's binary operation result type.
 ///
-/// Wraps `tsz_solver::BinaryOpResult`.
+/// Wraps `tsz_solver::operations::BinaryOpResult`.
 /// This is the result enum returned by binary operation evaluation.
-pub(crate) use tsz_solver::BinaryOpResult;
+pub(crate) use tsz_solver::operations::BinaryOpResult;
 
 pub(crate) fn evaluate_contextual_structure_with(
     db: &dyn tsz_solver::QueryDatabase,
@@ -18,15 +18,15 @@ pub(crate) fn evaluate_plus_chain(
     db: &dyn tsz_solver::QueryDatabase,
     operand_types: &[TypeId],
 ) -> Option<TypeId> {
-    tsz_solver::BinaryOpEvaluator::new(db).evaluate_plus_chain(operand_types)
+    tsz_solver::operations::BinaryOpEvaluator::new(db).evaluate_plus_chain(operand_types)
 }
 
 pub(crate) fn is_arithmetic_operand(db: &dyn tsz_solver::QueryDatabase, type_id: TypeId) -> bool {
-    tsz_solver::BinaryOpEvaluator::new(db).is_arithmetic_operand(type_id)
+    tsz_solver::operations::BinaryOpEvaluator::new(db).is_arithmetic_operand(type_id)
 }
 
 pub(crate) fn is_bigint_like(db: &dyn tsz_solver::QueryDatabase, type_id: TypeId) -> bool {
-    tsz_solver::BinaryOpEvaluator::new(db).is_bigint_like(type_id)
+    tsz_solver::operations::BinaryOpEvaluator::new(db).is_bigint_like(type_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/tsz-checker/src/query_boundaries/widening.rs
+++ b/crates/tsz-checker/src/query_boundaries/widening.rs
@@ -14,7 +14,7 @@ use tsz_solver::{TypeDatabase, TypeId};
 /// types would produce types incompatible with the original argument under
 /// strict-function-types.
 pub(crate) fn widen_type_for_inference(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::widen_type_for_inference(db, type_id)
+    tsz_solver::operations::widening::widen_type_for_inference(db, type_id)
 }
 
 /// Apply a `const` assertion to a type, recursively converting mutable literals

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -23,7 +23,7 @@ impl<'a> CheckerState<'a> {
         import_module: &Option<String>,
         import_name: &Option<String>,
         escaped_name: &str,
-        factory: &tsz_solver::TypeFactory<'_>,
+        factory: &tsz_solver::construction::TypeFactory<'_>,
     ) -> (TypeId, Vec<tsz_solver::TypeParamInfo>) {
         if flags & symbol_flags::TYPE_ALIAS != 0 {
             if escaped_name == "BuiltinIteratorReturn"

--- a/crates/tsz-checker/src/types/computation/call/callee_context.rs
+++ b/crates/tsz-checker/src/types/computation/call/callee_context.rs
@@ -1,4 +1,4 @@
-use crate::context::TypingRequest;
+use crate::context::{TypingRequest, speculation::DiagnosticSpeculationSnapshot};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -38,9 +38,9 @@ impl<'a> CheckerState<'a> {
         }
         let func = self.ctx.arena.get_function(decl_node).cloned()?;
 
-        let diagnostics_before = self.ctx.snapshot_diagnostics();
+        let diagnostics_before = DiagnosticSpeculationSnapshot::new(&self.ctx);
         let fresh_signature = self.call_signature_from_function(&func, decl_idx);
-        self.ctx.rollback_diagnostics(&diagnostics_before);
+        diagnostics_before.rollback(&mut self.ctx.diagnostic_state());
 
         Some(fresh_signature)
     }
@@ -137,7 +137,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let snap = self.ctx.snapshot_diagnostics();
+        let snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
         let params = args
             .iter()
             .copied()
@@ -148,7 +148,7 @@ impl<'a> CheckerState<'a> {
                 rest: false,
             })
             .collect();
-        self.ctx.rollback_diagnostics(&snap);
+        snap.rollback(&mut self.ctx.diagnostic_state());
 
         Some(
             self.ctx

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -7,7 +7,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_solver::{PropertyInfo, TypeId};
 
 fn order_preserving_union(
-    factory: tsz_solver::TypeFactory<'_>,
+    factory: tsz_solver::construction::TypeFactory<'_>,
     mut members: Vec<TypeId>,
 ) -> TypeId {
     let mut seen = rustc_hash::FxHashSet::default();

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -66,7 +66,7 @@ fn dedup_call_signatures_keep_last(sigs: &mut Vec<tsz_solver::CallSignature>) {
 pub(crate) fn merge_string_index_by_union(
     existing: &mut IndexSignature,
     extra: IndexSignature,
-    factory: tsz_solver::TypeFactory<'_>,
+    factory: tsz_solver::construction::TypeFactory<'_>,
 ) {
     if existing.key_type != extra.key_type {
         existing.key_type = factory.union2(existing.key_type, extra.key_type);

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -840,7 +840,7 @@ impl<'a> CheckerState<'a> {
         }
 
         fn signature_params_as_tuple(
-            factory: tsz_solver::TypeFactory<'_>,
+            factory: tsz_solver::construction::TypeFactory<'_>,
             params: &[tsz_solver::ParamInfo],
         ) -> TypeId {
             let tuple_elements: Vec<tsz_solver::TupleElement> = params
@@ -856,7 +856,7 @@ impl<'a> CheckerState<'a> {
         }
 
         fn bound_callable_return_type(
-            factory: tsz_solver::TypeFactory<'_>,
+            factory: tsz_solver::construction::TypeFactory<'_>,
             sig: &tsz_solver::CallSignature,
             remaining_params: Vec<tsz_solver::ParamInfo>,
             is_constructor: bool,

--- a/crates/tsz-checker/tests/stability_validation_tests.rs
+++ b/crates/tsz-checker/tests/stability_validation_tests.rs
@@ -110,7 +110,7 @@ fn test_type_lowering_operation_limit() {
 #[test]
 fn test_constraint_recursion_depth_limit() {
     // Validates that constraint collection has recursion limits
-    use tsz_solver::MAX_CONSTRAINT_RECURSION_DEPTH;
+    use tsz_solver::operations::MAX_CONSTRAINT_RECURSION_DEPTH;
 
     assert_in_range(
         "Constraint recursion depth",

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -515,11 +515,13 @@ impl<'a> ContextualTypeContext<'a> {
         // discards instantiated parameter types like `Iterable<readonly [K, V]>`,
         // which in turn breaks nested generic call contextual typing.
         if let Some(TypeData::Application(app_id)) = self.interner.lookup(expected) {
-            if let Some(shape) = crate::get_contextual_signature_for_arity_with_compat_checker(
-                self.interner,
-                expected,
-                arg_count,
-            ) {
+            if let Some(shape) =
+                crate::operations::get_contextual_signature_for_arity_with_compat_checker(
+                    self.interner,
+                    expected,
+                    arg_count,
+                )
+            {
                 return extract_param_type_at_for_call(
                     self.interner,
                     &shape.params,
@@ -889,9 +891,10 @@ impl<'a> ContextualTypeContext<'a> {
 
         // Handle Application explicitly - unwrap to base type
         if let Some(TypeData::Application(app_id)) = self.interner.lookup(expected) {
-            if let Some(shape) =
-                crate::get_contextual_signature_with_compat_checker(self.interner, expected)
-            {
+            if let Some(shape) = crate::operations::get_contextual_signature_with_compat_checker(
+                self.interner,
+                expected,
+            ) {
                 return Some(shape.return_type);
             }
             let app = self.interner.type_application(app_id);

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -230,7 +230,6 @@ pub use evaluation::evaluate::{
     TypeEvaluator, evaluate_conditional, evaluate_index_access, evaluate_index_access_with_options,
     evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_with_request,
 };
-pub use evaluation::session::EvaluationSession;
 pub use instantiation::application::{ApplicationEvaluator, ApplicationResult};
 pub use instantiation::instantiate::{
     MAX_INSTANTIATION_DEPTH, TypeInstantiator, TypeSubstitution, fill_application_defaults,
@@ -241,7 +240,6 @@ pub use instantiation::instantiate::{
     instantiate_type_with_infer, instantiate_type_with_infer_cached, substitute_this_type,
     substitute_this_type_at_return_position, substitute_this_type_cached,
 };
-pub use intern::type_factory::TypeFactory;
 pub use narrowing::{
     CachedPropertyType, DiscriminantInfo, GuardSense, NarrowingCache, NarrowingContext,
     NarrowingResult, NullishFilter, OptionalPropertyChainKey, TypeGuard, TypeofKind,
@@ -294,11 +292,6 @@ pub use types::{
     TypeListId, Visibility, is_compiler_managed_type, normalize_display_property_order,
 };
 // unsoundness_audit: accessed via tsz_solver::unsoundness_audit module path
-pub use operations::widening::{
-    display_widen_for_redeclaration, get_base_type_for_comparison, widen_argument_type_for_display,
-    widen_literal_type, widen_type, widen_type_deep, widen_type_for_display,
-    widen_type_for_inference,
-};
 
 // Test modules: Most are loaded by their source files via #[path = "tests/..."] declarations.
 // Only include modules here that aren't loaded elsewhere to avoid duplicate_mod warnings.

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -261,12 +261,9 @@ pub(crate) use operations::compound_assignment::{
     fallback_compound_assignment_result, is_compound_assignment_operator,
     is_logical_compound_assignment_operator, map_compound_assignment_to_binary,
 };
-pub use operations::{
+#[cfg(test)]
+pub(crate) use operations::{
     AssignabilityChecker, BinaryOpEvaluator, BinaryOpResult, CallEvaluator, CallResult,
-    MAX_CONSTRAINT_RECURSION_DEPTH, get_contextual_signature_cached_with_compat_checker,
-    get_contextual_signature_for_arity_cached_with_compat_checker,
-    get_contextual_signature_for_arity_with_compat_checker,
-    get_contextual_signature_with_compat_checker,
 };
 pub use relations::compat::{AssignabilityOverrideProvider, CompatChecker, NoopOverrideProvider};
 pub use relations::judge::{

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -2272,13 +2272,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                             || infer_ctx.all_candidates_from_array_elements(var))
                                         || crate::visitor::is_union_of_fresh_literals(db, result);
                                     if should_widen {
-                                        crate::widen_literal_type(db, result)
+                                        widening::widen_literal_type(db, result)
                                     } else {
                                         result
                                     }
                                 }
                             } else {
-                                crate::widen_literal_type(self.interner.as_type_database(), ty)
+                                widening::widen_literal_type(self.interner.as_type_database(), ty)
                             }
                         } else if self.inference_type_contains_fresh_object_or_array(ty)
                             && !infer_ctx.has_type_annotation_candidates(var)

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -2,6 +2,7 @@
 
 use crate::caches::db::QueryDatabase;
 use crate::diagnostics::SubtypeFailureReason;
+use crate::operations::AssignabilityChecker;
 use crate::relations::subtype::{NoopResolver, SubtypeChecker, TypeResolver};
 use crate::types::{
     IntrinsicKind, LiteralValue, MappedModifier, MappedType, PropertyInfo, TypeData, TypeId,
@@ -11,7 +12,7 @@ use crate::visitor::{
     is_empty_object_type_through_type_constraints, is_error_type, keyof_inner_type, lazy_def_id,
     mapped_type_id, type_param_info, union_list_id,
 };
-use crate::{AnyPropagationRules, AssignabilityChecker, TypeDatabase};
+use crate::{AnyPropagationRules, TypeDatabase};
 use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -12,12 +12,12 @@
 
 use std::sync::Arc;
 
-use crate::AssignabilityChecker;
 use crate::TypeDatabase;
 use crate::caches::db::QueryDatabase;
 use crate::def::DefId;
 use crate::diagnostics::{DynSubtypeTracer, SubtypeFailureReason};
 use crate::objects::{PropertyCollectionResult, collect_properties};
+use crate::operations::AssignabilityChecker;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -494,7 +494,7 @@ ROOT_SOLVER_EXPLICIT_REEXPORT_COUNT_CHECKS = [
             "relations",
             "widening",
         ),
-        124,
+        115,
     ),
 ]
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -494,7 +494,7 @@ ROOT_SOLVER_EXPLICIT_REEXPORT_COUNT_CHECKS = [
             "relations",
             "widening",
         ),
-        115,
+        111,
     ),
 ]
 


### PR DESCRIPTION
AgentName: M1PD1

## Summary

- Stack this solver root-export cleanup on #9059 so it no longer carries the unrelated snapshot-rollback cap bump that review rejected.
- Remove the flat root `tsz_solver` operation-core exports for `AssignabilityChecker`, binary/call evaluator result types, constraint recursion depth, and contextual signature helpers.
- Route internal/checker callers through the named `tsz_solver::operations` facade instead.
- Ratchet the #8204 flat root explicit computation re-export cap from 124 to 115 on the stacked base.

## Structural Rule

When callers need operation-core solver APIs, they should use the domain-owned `tsz_solver::operations` facade instead of the crate-root compatibility surface; this keeps the root API from teaching downstream callers broad computation internals.

## Owner Layer

Solver API boundary. The semantic implementations remain in solver operations; checker query-boundary callers keep orchestration wrappers and now import from the named solver facade. No relation, evaluation, inference, or emit behavior is intended to change.

## Adjacent Cases

- Checker call query-boundary contextual signature helpers still call the same solver operations through `tsz_solver::operations`.
- Binary operation query-boundary helpers still construct the same `BinaryOpEvaluator`, now via the operations facade.
- Solver-internal relation/contextual modules still use `AssignabilityChecker` through the operations module instead of the root export.

## Unsupported Shapes / Fallback

No runtime fallback behavior changes. Existing compatibility APIs remain available from their domain modules; only the flat root compatibility re-export is retired.

## Project Corpus Impact

- Row: n/a
- Bug family: architecture-only solver root API boundary cleanup
- Evidence: import/export routing and arch-ratchet only; no checker, solver, parser, binder, emitter, LSP, WASM, benchmark fixture, or project-corpus row behavior is intended to change.

## Verification

On stacked base #9059:
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRootSolverComputationImportCountTests`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --check`
- `cargo check -p tsz-solver -p tsz-checker`
- `git diff --check origin/codex/m1pd1-next-project-direction-ratchet-20260520...HEAD`

## Coordination Notes

Ready-review state: WIP label removed and PR marked ready at user request after clean mergeability and passing draft CI. Heavy ready-review CI is now the merge gate.
