### PR TITLE
refactor(checker): use relation outcomes for satisfies fallback

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -558,13 +558,17 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // Check assignability using the actual types (return types)
-        if self.is_assignable_to(source, target) {
+        let outcome = {
+            use crate::query_boundaries::assignability::RelationRequest;
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source, target);
+            let request = RelationRequest::assign(prepared_source, prepared_target);
+            self.execute_relation_request(&request)
+        };
+
+        if outcome.related {
             return true;
         }
-
-        // Get the failure reason using the check types
-        let analysis = self.analyze_assignability_failure(source, target);
 
         // Try to elaborate the source error first
         if self.try_elaborate_assignment_source_error(source_idx, target) {
@@ -572,11 +576,12 @@ impl<'a> CheckerState<'a> {
         }
 
         // Report the error using the display types (full function types)
-        if let Some(ref reason) = analysis.failure_reason {
+        if let Some(ref failure) = outcome.failure {
+            let reason = failure.to_solver_failure_reason();
             // For simple type mismatches (TypeMismatch, IntrinsicTypeMismatch, LiteralTypeMismatch),
             // use the error_reporter method to render with display types
             if matches!(
-                reason,
+                &reason,
                 tsz_solver::SubtypeFailureReason::TypeMismatch { .. }
                     | tsz_solver::SubtypeFailureReason::IntrinsicTypeMismatch { .. }
                     | tsz_solver::SubtypeFailureReason::LiteralTypeMismatch { .. }
@@ -592,7 +597,7 @@ impl<'a> CheckerState<'a> {
                 self.error_type_not_assignable_with_reason_and_display(
                     source_for_display,
                     target_for_display,
-                    reason,
+                    &reason,
                     diag_idx,
                 );
             }

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -2124,8 +2124,11 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn is_weak_union_violation(&mut self, source: TypeId, target: TypeId) -> bool {
-        self.analyze_assignability_failure(source, target)
-            .weak_union_violation
+        use crate::query_boundaries::assignability::RelationRequest;
+
+        let (prepared_source, prepared_target) = self.prepare_assignability_inputs(source, target);
+        let request = RelationRequest::assign(prepared_source, prepared_target);
+        self.execute_relation_request(&request).weak_union_violation
     }
 
     /// Emit TS2559 ("Type 'X' has no properties in common with type 'Y'")

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -253,21 +253,20 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if self.is_assignable_to(source, target) {
-            return true;
-        }
-        if self.is_nested_same_wrapper_application_assignment(source, target) {
-            return true;
-        }
-
         // Build a RelationRequest so the weak-union hint is collected alongside
         // the failure reason, avoiding a redundant solver round-trip in
         // should_skip_weak_union_error's fallback path.
-        {
+        let relation_outcome = {
             use crate::query_boundaries::assignability::RelationRequest;
             let (ps, pt) = self.prepare_assignability_inputs(source, target);
             let request = RelationRequest::assign(ps, pt).with_property_classification();
             let outcome = self.execute_relation_request(&request);
+            if outcome.related {
+                return true;
+            }
+            if self.is_nested_same_wrapper_application_assignment(source, target) {
+                return true;
+            }
             if self.should_skip_weak_union_error_with_outcome(
                 source,
                 target,
@@ -280,7 +279,8 @@ impl<'a> CheckerState<'a> {
                 self.error_no_common_properties(source, target, diag_idx);
                 return false;
             }
-        }
+            outcome
+        };
 
         // tsc 6.0: `satisfies` ignores readonly-to-mutable mismatches.
         // `[1,2,3] as const satisfies unknown[]` is accepted because `satisfies`
@@ -327,7 +327,13 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        self.error_type_does_not_satisfy_the_expected_type(source, target, diag_idx, keyword_pos);
+        self.error_type_does_not_satisfy_the_expected_type_with_outcome(
+            source,
+            target,
+            diag_idx,
+            keyword_pos,
+            Some(&relation_outcome),
+        );
         false
     }
 

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -165,7 +165,9 @@ impl<'a> CheckerState<'a> {
         // boundary so we never fall back to checker-local property enumeration.
         use crate::query_boundaries::assignability::RelationRequest;
         let (ps, pt) = self.prepare_assignability_inputs(source, target);
-        let built_outcome = self.execute_relation_request(&RelationRequest::assign(ps, pt));
+        let built_outcome = self.execute_relation_request(
+            &RelationRequest::assign(ps, pt).with_property_classification(),
+        );
         if let Some(ref cls) = built_outcome.property_classification {
             if cls.excess_properties.is_empty() {
                 return false;
@@ -264,7 +266,7 @@ impl<'a> CheckerState<'a> {
         {
             use crate::query_boundaries::assignability::RelationRequest;
             let (ps, pt) = self.prepare_assignability_inputs(source, target);
-            let request = RelationRequest::assign(ps, pt);
+            let request = RelationRequest::assign(ps, pt).with_property_classification();
             let outcome = self.execute_relation_request(&request);
             if self.should_skip_weak_union_error_with_outcome(
                 source,
@@ -704,13 +706,18 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // Canonical relation path: execute a RelationRequest to get both the
-        // assignability result and structured failure info in one boundary call.
-
-        // Reset the relation depth flag before the assignability check so we
-        // can detect fresh depth exceedance from this particular relation.
+        // Canonical relation path: execute one RelationRequest and use both its
+        // boolean projection and structured failure info. This keeps diagnostic
+        // paths from doing a boolean relation pass and then repeating the same
+        // relation as failure analysis setup.
         self.ctx.relation_depth_exceeded.set(false);
-        let assignable = self.is_assignable_to(source, target);
+        let request = {
+            use crate::query_boundaries::assignability::RelationRequest;
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source, target);
+            RelationRequest::assign(prepared_source, prepared_target).with_property_classification()
+        };
+        let outcome = self.execute_relation_request(&request);
         // TS2859: if the solver hit its recursion/complexity limit during the check
         // (including the constituent-count overflow guard in check_subtype_inner),
         // emit "Excessive complexity comparing types" regardless of whether the
@@ -733,7 +740,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if assignable {
+        if outcome.related {
             if self.has_explicit_any_generic_variable_annotation(diag_idx)
                 && self.emit_polymorphic_this_property_assignment_error(source, target, diag_idx)
             {
@@ -744,15 +751,6 @@ impl<'a> CheckerState<'a> {
             }
             return true;
         }
-        // Build a RelationRequest for the Assign kind so the weak-union hint
-        // can be collected alongside the failure reason.
-        let request = {
-            use crate::query_boundaries::assignability::RelationRequest;
-            let (prepared_source, prepared_target) =
-                self.prepare_assignability_inputs(source, target);
-            RelationRequest::assign(prepared_source, prepared_target)
-        };
-        let outcome = self.execute_relation_request(&request);
 
         // Use the pre-computed RelationOutcome to avoid re-enumerating
         // properties and re-checking assignability inside the skip logic.
@@ -791,7 +789,7 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
-        self.error_type_not_assignable_with_reason_at(source, target, diag_idx);
+        self.diagnose_assignment_failure_with_relation_outcome(source, target, diag_idx, &outcome);
         false
     }
 
@@ -963,7 +961,7 @@ impl<'a> CheckerState<'a> {
         let request = {
             use crate::query_boundaries::assignability::RelationRequest;
             let (ps, pt) = self.prepare_assignability_inputs(source, target);
-            RelationRequest::assign(ps, pt)
+            RelationRequest::assign(ps, pt).with_property_classification()
         };
         let outcome = self.execute_relation_request(&request);
         if self.should_skip_weak_union_error_with_outcome(
@@ -1013,7 +1011,7 @@ impl<'a> CheckerState<'a> {
         let request = {
             use crate::query_boundaries::assignability::RelationRequest;
             let (ps, pt) = self.prepare_assignability_inputs(source, target);
-            RelationRequest::assign(ps, pt)
+            RelationRequest::assign(ps, pt).with_property_classification()
         };
         let outcome = self.execute_relation_request(&request);
         if self.should_skip_weak_union_error_with_outcome(
@@ -1061,7 +1059,7 @@ impl<'a> CheckerState<'a> {
         let request = {
             use crate::query_boundaries::assignability::RelationRequest;
             let (ps, pt) = self.prepare_assignability_inputs(source, target);
-            RelationRequest::assign(ps, pt)
+            RelationRequest::assign(ps, pt).with_property_classification()
         };
         let outcome = self.execute_relation_request(&request);
         if self.should_skip_weak_union_error_with_outcome(
@@ -1104,10 +1102,35 @@ impl<'a> CheckerState<'a> {
         if target == TypeId::NEVER && self.generic_indexed_access_argument_surface(source) {
             return true;
         }
-        let checker_only_mismatch = self
-            .checker_only_assignability_failure_reason(source, target)
-            .is_some();
-        if self.is_assignable_to(source, target) && !checker_only_mismatch {
+        let request = {
+            use crate::query_boundaries::assignability::RelationRequest;
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source, target);
+            let cached_outcome = self
+                .ctx
+                .call_relation_outcomes
+                .borrow()
+                .get(&(prepared_source, prepared_target))
+                .cloned();
+            if let Some(outcome) = cached_outcome {
+                return self
+                    .report_argument_assignability_with_outcome(source, target, arg_idx, outcome);
+            }
+            RelationRequest::call_arg(prepared_source, prepared_target)
+                .with_property_classification()
+        };
+        let outcome = self.execute_relation_request(&request);
+        self.report_argument_assignability_with_outcome(source, target, arg_idx, outcome)
+    }
+
+    fn report_argument_assignability_with_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        arg_idx: NodeIndex,
+        outcome: crate::query_boundaries::assignability::RelationOutcome,
+    ) -> bool {
+        if outcome.related {
             return true;
         }
         if self.should_suppress_partial_self_argument_mismatch(source, target) {
@@ -1121,16 +1144,6 @@ impl<'a> CheckerState<'a> {
         ) {
             return true;
         }
-
-        // Build a CallArg relation request to collect the weak-union hint
-        // without a separate solver call.
-        let request = {
-            use crate::query_boundaries::assignability::RelationRequest;
-            let (prepared_source, prepared_target) =
-                self.prepare_assignability_inputs(source, target);
-            RelationRequest::call_arg(prepared_source, prepared_target)
-        };
-        let outcome = self.execute_relation_request(&request);
 
         if self.should_skip_weak_union_error_with_outcome(source, target, arg_idx, Some(&outcome)) {
             return true;
@@ -1174,7 +1187,7 @@ impl<'a> CheckerState<'a> {
         // parameter), contextual typing cannot supply types for the extra
         // source parameters, and the parameter-count mismatch ("Target
         // signature provides too few arguments") must surface as TS2345.
-        if !checker_only_mismatch
+        if outcome.failure.is_none()
             && self.arg_is_callback_with_unannotated_params(arg_idx)
             && self.target_can_contextually_type_callback_params(arg_idx, target)
         {
@@ -1190,7 +1203,12 @@ impl<'a> CheckerState<'a> {
         if self.try_elaborate_callback_body_diagnostics(arg_idx, target) {
             return false;
         }
-        self.error_argument_not_assignable_at(source, target, arg_idx);
+        self.error_argument_not_assignable_at_with_relation_failure(
+            source,
+            target,
+            arg_idx,
+            outcome.failure.as_ref(),
+        );
         false
     }
 

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1106,16 +1106,6 @@ impl<'a> CheckerState<'a> {
             use crate::query_boundaries::assignability::RelationRequest;
             let (prepared_source, prepared_target) =
                 self.prepare_assignability_inputs(source, target);
-            let cached_outcome = self
-                .ctx
-                .call_relation_outcomes
-                .borrow()
-                .get(&(prepared_source, prepared_target))
-                .cloned();
-            if let Some(outcome) = cached_outcome {
-                return self
-                    .report_argument_assignability_with_outcome(source, target, arg_idx, outcome);
-            }
             RelationRequest::call_arg(prepared_source, prepared_target)
                 .with_property_classification()
         };
@@ -1123,7 +1113,7 @@ impl<'a> CheckerState<'a> {
         self.report_argument_assignability_with_outcome(source, target, arg_idx, outcome)
     }
 
-    fn report_argument_assignability_with_outcome(
+    pub(crate) fn report_argument_assignability_with_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -226,6 +226,22 @@ impl<'a> CheckerState<'a> {
         force_bivariant_callbacks: bool,
         contextual_type: Option<TypeId>,
     ) -> CallResult {
+        self.resolve_new_with_checker_adapter_evidence(
+            type_id,
+            arg_types,
+            force_bivariant_callbacks,
+            contextual_type,
+        )
+        .result
+    }
+
+    pub(crate) fn resolve_new_with_checker_adapter_evidence(
+        &mut self,
+        type_id: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+    ) -> CheckerCallResolution {
         self.ensure_relation_input_ready(type_id);
         self.ensure_relation_inputs_ready(arg_types);
 
@@ -234,13 +250,19 @@ impl<'a> CheckerState<'a> {
             state: self,
             relation_evidence: Vec::new(),
         };
-        resolve_new(
+        let result = resolve_new(
             db,
             &mut checker,
             type_id,
             arg_types,
             force_bivariant_callbacks,
             contextual_type,
-        )
+        );
+        CheckerCallResolution {
+            result,
+            selected_type_predicate: None,
+            instantiated_params: None,
+            relation_evidence: checker.relation_evidence,
+        }
     }
 }

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -1,6 +1,6 @@
 //! Adapter methods for routing call/new resolution through the solver.
 
-use super::CheckerCallAssignabilityAdapter;
+use super::{CheckerCallAssignabilityAdapter, CheckerCallResolution};
 use crate::query_boundaries::checkers::call::{
     resolve_call, resolve_call_with_arg_sources, resolve_new,
 };
@@ -119,12 +119,33 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
     ) -> tsz_solver::operations::CallWithCheckerResult {
+        self.resolve_call_with_checker_adapter_evidence(
+            func_type,
+            arg_types,
+            force_bivariant_callbacks,
+            contextual_type,
+            actual_this_type,
+        )
+        .into_solver_tuple()
+    }
+
+    pub(crate) fn resolve_call_with_checker_adapter_evidence(
+        &mut self,
+        func_type: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+    ) -> CheckerCallResolution {
         self.ensure_relation_input_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
-        resolve_call(
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
+        let (result, selected_type_predicate, instantiated_params) = resolve_call(
             db,
             &mut checker,
             func_type,
@@ -132,7 +153,13 @@ impl<'a> CheckerState<'a> {
             force_bivariant_callbacks,
             contextual_type,
             actual_this_type,
-        )
+        );
+        CheckerCallResolution {
+            result,
+            selected_type_predicate,
+            instantiated_params,
+            relation_evidence: checker.relation_evidence,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -145,12 +172,36 @@ impl<'a> CheckerState<'a> {
         actual_this_type: Option<TypeId>,
         arg_source_is_type_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
+        self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+            func_type,
+            arg_types,
+            force_bivariant_callbacks,
+            contextual_type,
+            actual_this_type,
+            arg_source_is_type_annotation,
+        )
+        .into_solver_tuple()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn resolve_call_with_checker_adapter_and_arg_sources_evidence(
+        &mut self,
+        func_type: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+        arg_source_is_type_annotation: &[bool],
+    ) -> CheckerCallResolution {
         self.ensure_relation_input_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
-        resolve_call_with_arg_sources(
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
+        let (result, selected_type_predicate, instantiated_params) = resolve_call_with_arg_sources(
             db,
             &mut checker,
             func_type,
@@ -159,7 +210,13 @@ impl<'a> CheckerState<'a> {
             contextual_type,
             actual_this_type,
             arg_source_is_type_annotation,
-        )
+        );
+        CheckerCallResolution {
+            result,
+            selected_type_predicate,
+            instantiated_params,
+            relation_evidence: checker.relation_evidence,
+        }
     }
 
     pub(crate) fn resolve_new_with_checker_adapter(
@@ -173,7 +230,10 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            relation_evidence: Vec::new(),
+        };
         resolve_new(
             db,
             &mut checker,

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -66,15 +66,35 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         {
             return false;
         }
-        if self.state.is_assignable_to(source, target) {
+        let (prepared_source, prepared_target) =
+            self.state.prepare_assignability_inputs(source, target);
+        let request = crate::query_boundaries::assignability::RelationRequest::call_arg(
+            prepared_source,
+            prepared_target,
+        )
+        .with_property_classification();
+        let outcome = self.state.execute_relation_request(&request);
+        let related = outcome.related;
+        if related {
+            self.state
+                .ctx
+                .call_relation_outcomes
+                .borrow_mut()
+                .insert((prepared_source, prepared_target), outcome);
             return true;
         }
         let target_display = self.state.format_type_diagnostic(target);
         if target_display.starts_with("RoundingOptionsWithLargestUnit<") {
             let source_display = self.state.format_type_for_assignability_message(source);
-            return source_display.contains("largestUnit")
-                && source_display.contains("smallestUnit");
+            if source_display.contains("largestUnit") && source_display.contains("smallestUnit") {
+                return true;
+            }
         }
+        self.state
+            .ctx
+            .call_relation_outcomes
+            .borrow_mut()
+            .insert((prepared_source, prepared_target), outcome);
         false
     }
     fn is_assignable_to_strict(&mut self, source: TypeId, target: TypeId) -> bool {

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -50,8 +50,34 @@ pub(crate) struct OverloadResolution {
     pub(crate) selected_type_predicate: SelectedTypePredicate,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct CallRelationEvidence {
+    pub(crate) source: TypeId,
+    pub(crate) target: TypeId,
+    pub(crate) outcome: crate::query_boundaries::assignability::RelationOutcome,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CheckerCallResolution {
+    pub(crate) result: CallResult,
+    pub(crate) selected_type_predicate: SelectedTypePredicate,
+    pub(crate) instantiated_params: Option<Vec<tsz_solver::ParamInfo>>,
+    pub(crate) relation_evidence: Vec<CallRelationEvidence>,
+}
+
+impl CheckerCallResolution {
+    pub(crate) fn into_solver_tuple(self) -> tsz_solver::operations::CallWithCheckerResult {
+        (
+            self.result,
+            self.selected_type_predicate,
+            self.instantiated_params,
+        )
+    }
+}
+
 pub(super) struct CheckerCallAssignabilityAdapter<'s, 'ctx> {
     pub(super) state: &'s mut CheckerState<'ctx>,
+    pub(super) relation_evidence: Vec<CallRelationEvidence>,
 }
 
 impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
@@ -76,11 +102,11 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         let outcome = self.state.execute_relation_request(&request);
         let related = outcome.related;
         if related {
-            self.state
-                .ctx
-                .call_relation_outcomes
-                .borrow_mut()
-                .insert((prepared_source, prepared_target), outcome);
+            self.relation_evidence.push(CallRelationEvidence {
+                source: prepared_source,
+                target: prepared_target,
+                outcome,
+            });
             return true;
         }
         let target_display = self.state.format_type_diagnostic(target);
@@ -90,11 +116,11 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
                 return true;
             }
         }
-        self.state
-            .ctx
-            .call_relation_outcomes
-            .borrow_mut()
-            .insert((prepared_source, prepared_target), outcome);
+        self.relation_evidence.push(CallRelationEvidence {
+            source: prepared_source,
+            target: prepared_target,
+            outcome,
+        });
         false
     }
     fn is_assignable_to_strict(&mut self, source: TypeId, target: TypeId) -> bool {

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1598,17 +1598,18 @@ impl<'a> CheckerState<'a> {
                     // and the type argument shares no common properties, tsc emits TS2559
                     // instead of TS2344. However, primitive types satisfy weak type
                     // constraints in tsc (e.g., `bigint extends {t?: string}` is valid).
-                    let weak_constraint_violation =
-                        if let Some(outcome) = constraint_relation_outcome.as_ref() {
-                            outcome.weak_union_violation
-                        } else {
-                            let analysis = self
-                                .analyze_assignability_failure(type_arg, instantiated_constraint);
-                            matches!(
-                                analysis.failure_reason,
-                                Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
-                            )
-                        };
+                    let weak_constraint_violation = if let Some(outcome) =
+                        constraint_relation_outcome.as_ref()
+                    {
+                        outcome.weak_union_violation
+                    } else {
+                        use crate::query_boundaries::assignability::RelationRequest;
+                        let (prepared_arg, prepared_constraint) =
+                            self.prepare_assignability_inputs(type_arg, instantiated_constraint);
+                        let request = RelationRequest::assign(prepared_arg, prepared_constraint);
+                        let outcome = self.execute_relation_request(&request);
+                        outcome.weak_union_violation
+                    };
                     if weak_constraint_violation {
                         // Primitives satisfy weak type constraints — skip TS2559
                         if !query::is_primitive_type(self.ctx.types.as_type_database(), type_arg) {

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1494,16 +1494,22 @@ impl<'a> CheckerState<'a> {
                             )
                             .is_some_and(|sigs| !sigs.is_empty())
                     });
+                let all_optional_non_primitive = constraint_is_all_optional
+                    && !query::is_primitive_type(self.ctx.types.as_type_database(), type_arg);
+                let mut constraint_relation_outcome = None;
                 let mut is_satisfied = !callable_arity_failure
                     && !constructor_accessibility_failure
                     && (primitive_satisfies_weak
-                        || if constraint_is_all_optional
-                            && !query::is_primitive_type(
-                                self.ctx.types.as_type_database(),
-                                type_arg,
-                            )
-                        {
-                            self.is_assignable_to(type_arg, instantiated_constraint)
+                        || if all_optional_non_primitive {
+                            use crate::query_boundaries::assignability::RelationRequest;
+                            let (prepared_arg, prepared_constraint) = self
+                                .prepare_assignability_inputs(type_arg, instantiated_constraint);
+                            let request =
+                                RelationRequest::assign(prepared_arg, prepared_constraint);
+                            let outcome = self.execute_relation_request(&request);
+                            let related = outcome.related;
+                            constraint_relation_outcome = Some(outcome);
+                            related
                         } else {
                             self.is_assignable_to_no_weak_checks(type_arg, instantiated_constraint)
                         });
@@ -1513,15 +1519,13 @@ impl<'a> CheckerState<'a> {
                 // separately check for weak type violation (TS2559).
                 // Non-primitive type arguments with NO common properties should
                 // fail, e.g., MyObjA {x: string} vs ObjA {y?: string}.
-                if is_satisfied && constraint_is_all_optional && !primitive_satisfies_weak {
-                    let analysis =
-                        self.analyze_assignability_failure(type_arg, instantiated_constraint);
-                    if matches!(
-                        analysis.failure_reason,
-                        Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
-                    ) {
-                        is_satisfied = false;
-                    }
+                if is_satisfied
+                    && !primitive_satisfies_weak
+                    && constraint_relation_outcome
+                        .as_ref()
+                        .is_some_and(|outcome| outcome.weak_union_violation)
+                {
+                    is_satisfied = false;
                 }
 
                 // Fallback for recursive generic constraints (coinductive semantics).
@@ -1594,12 +1598,18 @@ impl<'a> CheckerState<'a> {
                     // and the type argument shares no common properties, tsc emits TS2559
                     // instead of TS2344. However, primitive types satisfy weak type
                     // constraints in tsc (e.g., `bigint extends {t?: string}` is valid).
-                    let analysis =
-                        self.analyze_assignability_failure(type_arg, instantiated_constraint);
-                    if matches!(
-                        analysis.failure_reason,
-                        Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
-                    ) {
+                    let weak_constraint_violation =
+                        if let Some(outcome) = constraint_relation_outcome.as_ref() {
+                            outcome.weak_union_violation
+                        } else {
+                            let analysis = self
+                                .analyze_assignability_failure(type_arg, instantiated_constraint);
+                            matches!(
+                                analysis.failure_reason,
+                                Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
+                            )
+                        };
+                    if weak_constraint_violation {
                         // Primitives satisfy weak type constraints — skip TS2559
                         if !query::is_primitive_type(self.ctx.types.as_type_database(), type_arg) {
                             self.error_no_common_properties_constraint(

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -3,6 +3,7 @@
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::query_boundaries::assignability::RelationOutcome;
 use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
@@ -435,7 +436,8 @@ impl<'a> CheckerState<'a> {
         let mut named_attr_nodes: rustc_hash::FxHashMap<String, NodeIndex> =
             rustc_hash::FxHashMap::default();
 
-        let mut spread_entries: Vec<(TypeId, TypeId, NodeIndex, usize)> = Vec::new();
+        let mut spread_entries: Vec<(TypeId, TypeId, NodeIndex, usize, Option<RelationOutcome>)> =
+            Vec::new();
 
         let attr_nodes = &attrs.properties.nodes;
         let any_spread_present = attr_nodes.iter().any(|&attr_idx| {
@@ -1159,12 +1161,26 @@ impl<'a> CheckerState<'a> {
                 // where `props: T`), we can't enumerate the properties it provides.
                 // Mark spread_covers_all so missing-required-property checks (TS2741)
                 // don't fire — the generic spread could provide any property.
-                if crate::query_boundaries::common::contains_type_parameters(
-                    self.ctx.types,
-                    spread_type,
-                ) {
+                let spread_has_type_parameters =
+                    crate::query_boundaries::common::contains_type_parameters(
+                        self.ctx.types,
+                        spread_type,
+                    );
+                let concrete_spread_outcome = if !spread_has_type_parameters && !skip_prop_checks {
+                    use crate::query_boundaries::assignability::RelationRequest;
+                    let (prepared_spread, prepared_props) =
+                        self.prepare_assignability_inputs(spread_type, props_type);
+                    let request = RelationRequest::assign(prepared_spread, prepared_props);
+                    Some(self.execute_relation_request(&request))
+                } else {
+                    None
+                };
+                if spread_has_type_parameters {
                     spread_covers_all = true;
-                } else if !skip_prop_checks && self.is_assignable_to(spread_type, props_type) {
+                } else if concrete_spread_outcome
+                    .as_ref()
+                    .is_some_and(|outcome| outcome.related)
+                {
                     // The solver reports the spread is structurally assignable to the
                     // whole props type, so all required members are satisfied — including
                     // ones inherited from Object.prototype (toString, valueOf, …) that
@@ -1198,6 +1214,7 @@ impl<'a> CheckerState<'a> {
                         display_spread_type,
                         spread_expr_idx,
                         attr_i,
+                        concrete_spread_outcome,
                     ));
                 }
             }
@@ -1229,9 +1246,12 @@ impl<'a> CheckerState<'a> {
                 );
             let mut earlier_spread_props: rustc_hash::FxHashSet<String> =
                 rustc_hash::FxHashSet::default();
-            for (i, &(spread_type, raw_spread_type, _spread_expr_idx, spread_pos)) in
+            for (i, (spread_type, raw_spread_type, _spread_expr_idx, spread_pos, outcome)) in
                 spread_entries.iter().enumerate()
             {
+                let spread_type = *spread_type;
+                let raw_spread_type = *raw_spread_type;
+                let spread_pos = *spread_pos;
                 // Only later explicit attributes override the current spread.
                 let mut overridden: rustc_hash::FxHashSet<&str> = explicit_attr_entries
                     .iter()
@@ -1324,6 +1344,7 @@ impl<'a> CheckerState<'a> {
                     &display_target,
                     preferred_target_display,
                     merged_attrs_display.as_deref(),
+                    outcome.as_ref(),
                 );
                 suppress_missing_props_from_spread |= had_error || suppress_missing_props;
 
@@ -1532,7 +1553,7 @@ impl<'a> CheckerState<'a> {
         let spread_satisfies_type_param = props_is_type_param
             && spread_entries
                 .iter()
-                .any(|&(spread_type, _, _, _)| self.is_assignable_to(spread_type, props_type));
+                .any(|(spread_type, _, _, _, _)| self.is_assignable_to(*spread_type, props_type));
         let reported_type_param_assignability = if !reported_custom_children_assignability
             && !reported_special_attr_assignability
             && !reported_class_missing_props_assignability

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -72,6 +72,7 @@ impl<'a> CheckerState<'a> {
         display_target: &str,
         preferred_target_display: Option<&str>,
         merged_attrs_display: Option<&str>,
+        concrete_spread_outcome: Option<&crate::query_boundaries::assignability::RelationOutcome>,
     ) -> bool {
         use crate::query_boundaries::common::PropertyAccessResult;
 
@@ -88,24 +89,34 @@ impl<'a> CheckerState<'a> {
                 spread_source_type,
             );
 
+        let built_concrete_spread_outcome;
+        let concrete_spread_outcome = if let Some(outcome) = concrete_spread_outcome {
+            Some(outcome)
+        } else if !spread_has_type_params {
+            use crate::query_boundaries::assignability::RelationRequest;
+            let (prepared_spread, prepared_props) =
+                self.prepare_assignability_inputs(spread_type, props_type);
+            let request = RelationRequest::assign(prepared_spread, prepared_props);
+            built_concrete_spread_outcome = self.execute_relation_request(&request);
+            Some(&built_concrete_spread_outcome)
+        } else {
+            None
+        };
+
         // For concrete spread types, whole-type assignability is the fast path and
         // also prevents false positives from imprecise per-property extraction.
         // For generic spreads, the relation can be too optimistic; keep them on the
         // normalized JSX spread path below so we can classify TS2322 vs TS2741 from
         // the apparent/object shape first.
-        if !spread_has_type_params && self.is_assignable_to(spread_type, props_type) {
+        if concrete_spread_outcome.is_some_and(|outcome| outcome.related) {
             return false;
         }
 
         // TS2559: When the spread type has no properties in common with the target
         // props type (a "weak type" violation), tsc emits TS2559 instead of proceeding
         // with per-property TS2322 checks.
-        if !spread_has_type_params {
-            let analysis = self.analyze_assignability_failure(spread_type, props_type);
-            if matches!(
-                &analysis.failure_reason,
-                Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
-            ) {
+        if let Some(outcome) = concrete_spread_outcome {
+            if outcome.weak_union_violation {
                 let resolved_spread = self.evaluate_type_with_env(spread_type);
                 let resolved_spread = self.resolve_type_for_property_access(resolved_spread);
                 let has_jsx_managed_prop = crate::query_boundaries::common::object_shape_for_type(

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1506,43 +1506,48 @@ impl<'a> CheckerState<'a> {
                         } else {
                             interface_type
                         };
-                        if !self.is_assignable_to(class_instance_type, target_type) {
-                            let analysis = self
-                                .analyze_assignability_failure(class_instance_type, target_type);
+                        let outcome = {
+                            use crate::query_boundaries::assignability::RelationRequest;
+                            let (prepared_source, prepared_target) =
+                                self.prepare_assignability_inputs(class_instance_type, target_type);
+                            let request = RelationRequest::assign(prepared_source, prepared_target);
+                            self.execute_relation_request(&request)
+                        };
+                        if !outcome.related {
                             let suppress_index_member_duplicate = !is_class
                                 && interface_has_index_signature
                                 && self.class_index_signatures_satisfy_interface(
                                     class_instance_type,
                                     target_type,
                                 )
-                                && matches!(
-                                    analysis.failure_reason,
-                                    Some(
+                                && outcome.failure.as_ref().is_some_and(|failure| {
+                                    matches!(
+                                        failure.to_solver_failure_reason(),
                                         tsz_solver::SubtypeFailureReason::IndexSignatureMismatch {
                                             ..
                                         } | tsz_solver::SubtypeFailureReason::PropertyTypeMismatch {
                                             ..
                                         }
                                     )
-                                );
+                                });
                             if !is_class
                                 && let Some(
-                                    tsz_solver::SubtypeFailureReason::PropertyTypeMismatch {
+                                    crate::query_boundaries::relation_types::RelationFailure::IncompatiblePropertyValue {
                                         property_name,
                                         source_property_type,
                                         target_property_type,
                                         ..
                                     },
-                                ) = analysis.failure_reason
+                                ) = outcome.failure.as_ref()
                             {
                                 let member_name =
-                                    self.ctx.types.resolve_atom(property_name).to_string();
+                                    self.ctx.types.resolve_atom(*property_name).to_string();
                                 let class_member_idx = class_members
                                     .get(&member_name)
                                     .copied()
                                     .unwrap_or(class_error_idx);
-                                let expected_str = self.format_type(target_property_type);
-                                let actual_str = self.format_type(source_property_type);
+                                let expected_str = self.format_type(*target_property_type);
+                                let actual_str = self.format_type(*source_property_type);
                                 incompatible_members.push((
                                     class_member_idx,
                                     member_name,

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1448,12 +1448,18 @@ impl<'a> CheckerState<'a> {
                         if is_weak {
                             let class_instance_type =
                                 self.get_class_instance_type(class_idx, class_data);
-                            let analysis = self
-                                .analyze_assignability_failure(class_instance_type, interface_type);
-                            if matches!(
-                                analysis.failure_reason,
-                                Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
-                            ) {
+                            let outcome = {
+                                use crate::query_boundaries::assignability::RelationRequest;
+                                let (prepared_source, prepared_target) = self
+                                    .prepare_assignability_inputs(
+                                        class_instance_type,
+                                        interface_type,
+                                    );
+                                let request =
+                                    RelationRequest::assign(prepared_source, prepared_target);
+                                self.execute_relation_request(&request)
+                            };
+                            if outcome.weak_union_violation {
                                 let class_str = self.format_type(class_instance_type);
                                 let iface_str = self.format_type(interface_type);
                                 let message = crate::diagnostics::format_message(

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -84,7 +84,6 @@ impl<'a> CheckerContext<'a> {
             lib_heritage_in_progress: FxHashSet::default(),
             node_types: crate::context::NodeTypeCache::with_capacity(arena.nodes.len()),
             request_node_types: FxHashMap::default(),
-            call_relation_outcomes: RefCell::new(FxHashMap::default()),
             object_literal_tracking: crate::context::ObjectLiteralTracking::default(),
             request_cache_counters: crate::context::RequestCacheCounters::default(),
             type_environment: RefCell::new(TypeEnvironment::new()),

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -84,6 +84,7 @@ impl<'a> CheckerContext<'a> {
             lib_heritage_in_progress: FxHashSet::default(),
             node_types: crate::context::NodeTypeCache::with_capacity(arena.nodes.len()),
             request_node_types: FxHashMap::default(),
+            call_relation_outcomes: RefCell::new(FxHashMap::default()),
             object_literal_tracking: crate::context::ObjectLiteralTracking::default(),
             request_cache_counters: crate::context::RequestCacheCounters::default(),
             type_environment: RefCell::new(TypeEnvironment::new()),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -78,6 +78,9 @@ use tsz_parser::parser::node::NodeArena;
 pub type CrossFileTypeParamsCache =
     Arc<dashmap::DashMap<(u32, NodeIndex), Vec<tsz_solver::TypeParamInfo>>>;
 
+pub(crate) type CallRelationOutcomeCache =
+    RefCell<FxHashMap<(TypeId, TypeId), crate::query_boundaries::assignability::RelationOutcome>>;
+
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.
 ///
 /// Prevents stack overflow when resolving deeply recursive or circular
@@ -439,6 +442,11 @@ pub struct CheckerContext<'a> {
 
     /// Request-aware cache for audited non-empty request paths only.
     pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
+
+    /// Transient relation evidence produced while solver call resolution checks
+    /// argument compatibility. Diagnostic reporting can reuse it for TS2345
+    /// instead of issuing a second relation request for the same prepared pair.
+    pub(crate) call_relation_outcomes: CallRelationOutcomeCache,
 
     /// Object-literal diagnostic recovery and active initializer state.
     pub object_literal_tracking: ObjectLiteralTracking,

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -78,9 +78,6 @@ use tsz_parser::parser::node::NodeArena;
 pub type CrossFileTypeParamsCache =
     Arc<dashmap::DashMap<(u32, NodeIndex), Vec<tsz_solver::TypeParamInfo>>>;
 
-pub(crate) type CallRelationOutcomeCache =
-    RefCell<FxHashMap<(TypeId, TypeId), crate::query_boundaries::assignability::RelationOutcome>>;
-
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.
 ///
 /// Prevents stack overflow when resolving deeply recursive or circular
@@ -442,11 +439,6 @@ pub struct CheckerContext<'a> {
 
     /// Request-aware cache for audited non-empty request paths only.
     pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
-
-    /// Transient relation evidence produced while solver call resolution checks
-    /// argument compatibility. Diagnostic reporting can reuse it for TS2345
-    /// instead of issuing a second relation request for the same prepared pair.
-    pub(crate) call_relation_outcomes: CallRelationOutcomeCache,
 
     /// Object-literal diagnostic recovery and active initializer state.
     pub object_literal_tracking: ObjectLiteralTracking,

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -529,6 +529,86 @@ impl<'a> CheckerState<'a> {
         self.diagnose_assignment_failure_with_anchor(source, target, anchor_idx);
     }
 
+    /// Diagnose an assignment failure using failure evidence already collected
+    /// by `execute_relation_request`.
+    pub(crate) fn diagnose_assignment_failure_with_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        idx: NodeIndex,
+        outcome: &crate::query_boundaries::assignability::RelationOutcome,
+    ) {
+        let anchor_idx =
+            self.resolve_diagnostic_anchor_node(idx, DiagnosticAnchorKind::RewriteAssignment);
+        if let Some(reason) = outcome.failure.as_ref() {
+            self.diagnose_assignment_failure_with_reason(source, target, anchor_idx, reason);
+        } else {
+            self.diagnose_assignment_failure_with_anchor(source, target, anchor_idx);
+        }
+    }
+
+    fn diagnose_assignment_failure_with_reason(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        anchor_idx: NodeIndex,
+        failure_reason: &crate::query_boundaries::relation_types::RelationFailure,
+    ) {
+        use crate::query_boundaries::relation_types::RelationFailure;
+
+        if matches!(failure_reason, RelationFailure::ExcessProperty { .. }) {
+            let start_idx = if let Some(node) = self.ctx.arena.get(anchor_idx) {
+                if node.kind == syntax_kind_ext::RETURN_STATEMENT {
+                    self.ctx
+                        .arena
+                        .get_return_statement(node)
+                        .map(|ret| ret.expression)
+                        .unwrap_or(anchor_idx)
+                } else {
+                    anchor_idx
+                }
+            } else {
+                anchor_idx
+            };
+            if let Some(obj_idx) = self.find_rhs_object_literal(start_idx) {
+                self.check_object_literal_excess_properties(source, target, obj_idx);
+            }
+            return;
+        }
+        if let RelationFailure::MissingProperty {
+            property_name,
+            source_type,
+            target_type,
+        } = failure_reason
+        {
+            let pn = self.ctx.types.resolve_atom_ref(*property_name);
+            if pn.starts_with("[Symbol.") || pn.starts_with("__js_ctor_brand_") {
+                return;
+            }
+            if self.missing_property_is_satisfied_by_source(
+                &[source, *source_type],
+                &[target, *target_type],
+                *property_name,
+            ) {
+                return;
+            }
+        }
+        if is_callable_application_type(self.ctx.types, source)
+            && is_callable_application_type(self.ctx.types, target)
+            && self.should_suppress_outer_callback_return_assignability(target, anchor_idx)
+        {
+            return;
+        }
+        let mut diag = self.render_relation_failure(failure_reason, source, target, anchor_idx, 0);
+        if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+            diag.message_text = self.rewrite_declared_generic_alias_source_in_ts2322_message(
+                anchor_idx,
+                diag.message_text,
+            );
+        }
+        self.ctx.push_diagnostic(diag);
+    }
+
     /// Internal helper that reports a detailed assignability failure using an
     /// already-resolved diagnostic anchor.
     pub(super) fn diagnose_assignment_failure_with_anchor(

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -466,14 +466,21 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let fallback_analysis;
+        let fallback_outcome;
         let reason = if let Some(outcome) = outcome {
             outcome.failure.as_ref().map(
                 crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
             )
         } else {
-            fallback_analysis = self.analyze_assignability_failure(source, target);
-            fallback_analysis.failure_reason
+            use crate::query_boundaries::assignability::RelationRequest;
+
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source, target);
+            let request = RelationRequest::assign(prepared_source, prepared_target);
+            fallback_outcome = self.execute_relation_request(&request);
+            fallback_outcome.failure.as_ref().map(
+                crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
+            )
         };
 
         // For TS1360, point the diagnostic at the `satisfies` keyword position

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -815,16 +815,18 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Use one solver-boundary analysis path for TS2322 metadata.
-        let analysis = self.analyze_assignability_failure(source, target);
-        let reason = analysis.failure_reason;
+        use crate::query_boundaries::assignability::RelationRequest;
+
+        let (prepared_source, prepared_target) = self.prepare_assignability_inputs(source, target);
+        let request = RelationRequest::assign(prepared_source, prepared_target);
+        let outcome = self.execute_relation_request(&request);
 
         // Trace what's happening with contextualTyping33
         if self.ctx.file_name.contains("contextualTyping33") {
             let _src_str = self.format_type_diagnostic(source);
             let _tgt_str = self.format_type_diagnostic(target);
             tracing::trace!(
-                source = %_src_str, target = %_tgt_str, ?reason,
+                source = %_src_str, target = %_tgt_str, reason = ?outcome.failure,
                 "diagnose_assignment"
             );
         }
@@ -832,186 +834,108 @@ impl<'a> CheckerState<'a> {
         if tracing::enabled!(Level::TRACE) {
             let source_type = self.format_type_diagnostic(source);
             let target_type = self.format_type_diagnostic(target);
-            let reason_ref = reason.as_ref();
             trace!(
                 source = %source_type,
                 target = %target_type,
-                reason = ?reason_ref,
+                reason = ?outcome.failure,
                 node_idx = anchor_idx.0,
                 file = %self.ctx.file_name,
                 "assignability failure diagnostics"
             );
         }
-        match reason {
-            Some(ref failure_reason) => {
-                // ExcessProperty errors need special handling: emit at the property position,
-                // not the statement position. Find the object literal and call the excess
-                // property checker to emit at the correct position.
-                if matches!(
-                    failure_reason,
-                    tsz_solver::SubtypeFailureReason::ExcessProperty { .. }
-                ) {
-                    // Walk through statements and binary expressions to find the object literal
-                    let start_idx = if let Some(node) = self.ctx.arena.get(anchor_idx) {
-                        // If anchor is a return statement, start from its expression
-                        if node.kind == syntax_kind_ext::RETURN_STATEMENT {
-                            self.ctx
-                                .arena
-                                .get_return_statement(node)
-                                .and_then(|ret| {
-                                    if ret.expression.is_some() {
-                                        Some(ret.expression)
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .unwrap_or(anchor_idx)
-                        } else {
-                            anchor_idx
-                        }
-                    } else {
-                        anchor_idx
-                    };
-                    let literal_idx = self.find_rhs_object_literal(start_idx);
-                    if let Some(obj_idx) = literal_idx {
-                        self.check_object_literal_excess_properties(source, target, obj_idx);
-                    }
-                    // If we can't find an object literal, the solver's excess property
-                    // check may be from a non-literal fresh type (shouldn't happen in
-                    // typical code, but fallback to avoid silent suppression).
+        if let Some(reason) = outcome.failure.as_ref() {
+            self.diagnose_assignment_failure_with_reason(source, target, anchor_idx, reason);
+            return;
+        }
+
+        // Before falling back to generic TS2322, check if there are missing
+        // properties from index signature source. If so, emit TS2741 instead.
+        if let Some(anchor) =
+            self.resolve_diagnostic_anchor(anchor_idx, DiagnosticAnchorKind::Exact)
+            && let Some(missing_props) =
+                self.missing_required_properties_from_index_signature_source(source, target)
+        {
+            // For TS2739, when the source is a non-generic type alias
+            // whose body is a generic Application (`type B = A<X1, X2, ...>`),
+            // tsc unfolds one level to display the application form
+            // `A<X1, X2, ...>` rather than the wrapper alias name `B`.
+            // See `compiler/objectTypeWithStringAndNumberIndexSignatureToAny.ts`
+            // line 91, which expects `Type 'NumberTo<number>'` for
+            // `type NumberToNumber = NumberTo<number>` source. The unfold
+            // is scoped to the missing-properties source only — TS2322
+            // target context and TS2339 receiver keep the alias name.
+            let src_str = if let Some(display) =
+                self.ts2739_alias_of_application_source_display_text(source)
+            {
+                display
+            } else {
+                self.format_type_for_diagnostic_role(
+                    source,
+                    DiagnosticTypeDisplayRole::AssignmentSource { target, anchor_idx },
+                )
+            };
+            let tgt_str = self.format_type_for_diagnostic_role(
+                target,
+                DiagnosticTypeDisplayRole::AssignmentTarget { source, anchor_idx },
+            );
+            let (message, code) = if missing_props.len() == 1 {
+                let prop_name = self
+                    .ctx
+                    .types
+                    .resolve_atom_ref(missing_props[0])
+                    .to_string();
+                if prop_name.starts_with("__js_ctor_brand_") {
+                    // Synthetic brand from JS constructor functions — TSC
+                    // doesn't report these as missing properties.
+                    self.error_type_not_assignable_generic_with_anchor(source, target, anchor_idx);
                     return;
                 }
-                // Skip MissingProperty for computed symbol expressions (TS2339 emitted separately).
-                if let tsz_solver::SubtypeFailureReason::MissingProperty {
-                    property_name,
-                    source_type,
-                    target_type,
-                } = &failure_reason
-                {
-                    let pn = self.ctx.types.resolve_atom_ref(*property_name);
-                    if pn.starts_with("[Symbol.") || pn.starts_with("__js_ctor_brand_") {
-                        return;
-                    }
-                    if self.missing_property_is_satisfied_by_source(
-                        &[source, *source_type],
-                        &[target, *target_type],
-                        *property_name,
-                    ) {
-                        return;
-                    }
-                }
-                if is_callable_application_type(self.ctx.types, source)
-                    && is_callable_application_type(self.ctx.types, target)
-                    && self.should_suppress_outer_callback_return_assignability(target, anchor_idx)
-                {
+                if tsz_solver::utils::is_synthetic_private_brand_name(&prop_name) {
+                    // Private brand mismatch
+                    self.error_type_not_assignable_generic_with_anchor(source, target, anchor_idx);
                     return;
                 }
-                let mut diag =
-                    self.render_failure_reason(failure_reason, source, target, anchor_idx, 0);
-                if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
-                    diag.message_text = self
-                        .rewrite_declared_generic_alias_source_in_ts2322_message(
-                            anchor_idx,
-                            diag.message_text,
-                        );
-                }
-                self.ctx.push_diagnostic(diag);
-            }
-            None => {
-                // Before falling back to generic TS2322, check if there are missing
-                // properties from index signature source. If so, emit TS2741 instead.
-                if let Some(anchor) =
-                    self.resolve_diagnostic_anchor(anchor_idx, DiagnosticAnchorKind::Exact)
-                    && let Some(missing_props) =
-                        self.missing_required_properties_from_index_signature_source(source, target)
-                {
-                    // For TS2739, when the source is a non-generic type alias
-                    // whose body is a generic Application (`type B = A<X1, X2, ...>`),
-                    // tsc unfolds one level to display the application form
-                    // `A<X1, X2, ...>` rather than the wrapper alias name `B`.
-                    // See `compiler/objectTypeWithStringAndNumberIndexSignatureToAny.ts`
-                    // line 91, which expects `Type 'NumberTo<number>'` for
-                    // `type NumberToNumber = NumberTo<number>` source. The unfold
-                    // is scoped to the missing-properties source only — TS2322
-                    // target context and TS2339 receiver keep the alias name.
-                    let src_str = if let Some(display) =
-                        self.ts2739_alias_of_application_source_display_text(source)
-                    {
-                        display
-                    } else {
-                        self.format_type_for_diagnostic_role(
-                            source,
-                            DiagnosticTypeDisplayRole::AssignmentSource { target, anchor_idx },
-                        )
-                    };
-                    let tgt_str = self.format_type_for_diagnostic_role(
-                        target,
-                        DiagnosticTypeDisplayRole::AssignmentTarget { source, anchor_idx },
-                    );
-                    let (message, code) = if missing_props.len() == 1 {
-                        let prop_name = self
-                            .ctx
-                            .types
-                            .resolve_atom_ref(missing_props[0])
-                            .to_string();
-                        if prop_name.starts_with("__js_ctor_brand_") {
-                            // Synthetic brand from JS constructor functions — TSC
-                            // doesn't report these as missing properties.
-                            self.error_type_not_assignable_generic_with_anchor(
-                                source, target, anchor_idx,
-                            );
-                            return;
-                        }
-                        if tsz_solver::utils::is_synthetic_private_brand_name(&prop_name) {
-                            // Private brand mismatch
-                            self.error_type_not_assignable_generic_with_anchor(
-                                source, target, anchor_idx,
-                            );
-                            return;
-                        }
-                        (
-                                format_message(
-                                    diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                                    &[&prop_name, &src_str, &tgt_str],
-                                ),
-                                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                            )
-                    } else {
-                        let prop_list: Vec<String> = missing_props
-                            .iter()
-                            .take(4)
-                            .map(|name| self.ctx.types.resolve_atom_ref(*name).to_string())
-                            .collect();
-                        let props_joined = prop_list.join(", ");
-                        if missing_props.len() > 4 {
-                            let more_count = (missing_props.len() - 4).to_string();
-                            (
+                (
+                    format_message(
+                        diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                        &[&prop_name, &src_str, &tgt_str],
+                    ),
+                    diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+                )
+            } else {
+                let prop_list: Vec<String> = missing_props
+                    .iter()
+                    .take(4)
+                    .map(|name| self.ctx.types.resolve_atom_ref(*name).to_string())
+                    .collect();
+                let props_joined = prop_list.join(", ");
+                if missing_props.len() > 4 {
+                    let more_count = (missing_props.len() - 4).to_string();
+                    (
                                     format_message(
                                         diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
                                         &[&src_str, &tgt_str, &props_joined, &more_count],
                                     ),
                                     diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE,
                                 )
-                        } else {
-                            (
-                                    format_message(
-                                        diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
-                                        &[&src_str, &tgt_str, &props_joined],
-                                    ),
-                                    diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
-                                )
-                        }
-                    };
-                    self.emit_render_request_at_anchor(
-                        anchor,
-                        DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message),
-                    );
-                    return;
+                } else {
+                    (
+                        format_message(
+                            diagnostic_messages::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
+                            &[&src_str, &tgt_str, &props_joined],
+                        ),
+                        diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE,
+                    )
                 }
-                // Fallback to generic message
-                self.error_type_not_assignable_generic_with_anchor(source, target, anchor_idx);
-            }
+            };
+            self.emit_render_request_at_anchor(
+                anchor,
+                DiagnosticRenderRequest::simple(DiagnosticAnchorKind::Exact, code, message),
+            );
+            return;
         }
+        // Fallback to generic message
+        self.error_type_not_assignable_generic_with_anchor(source, target, anchor_idx);
     }
 
     /// Narrow the TS2412 source display to the offending member when the

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -443,15 +443,38 @@ impl<'a> CheckerState<'a> {
         idx: NodeIndex,
         keyword_pos: Option<u32>,
     ) {
+        self.error_type_does_not_satisfy_the_expected_type_with_outcome(
+            source,
+            target,
+            idx,
+            keyword_pos,
+            None,
+        );
+    }
+
+    pub(crate) fn error_type_does_not_satisfy_the_expected_type_with_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        idx: NodeIndex,
+        keyword_pos: Option<u32>,
+        outcome: Option<&crate::query_boundaries::assignability::RelationOutcome>,
+    ) {
         if !self.has_exact_optional_property_mismatch(source, target)
             && self.should_suppress_assignability_diagnostic(source, target)
         {
             return;
         }
 
-        let reason = self
-            .analyze_assignability_failure(source, target)
-            .failure_reason;
+        let fallback_analysis;
+        let reason = if let Some(outcome) = outcome {
+            outcome.failure.as_ref().map(
+                crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
+            )
+        } else {
+            fallback_analysis = self.analyze_assignability_failure(source, target);
+            fallback_analysis.failure_reason
+        };
 
         // For TS1360, point the diagnostic at the `satisfies` keyword position
         // when available, rather than walking up to the enclosing statement.

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -40,7 +40,21 @@ impl<'a> CheckerState<'a> {
         source_type: TypeId,
         target_type: TypeId,
     ) -> bool {
-        use crate::query_boundaries::common::SubtypeFailureReason;
+        self.try_elaborate_array_literal_mismatch_with_relation_failure(
+            arg_idx,
+            source_type,
+            target_type,
+            None,
+        )
+    }
+
+    pub(in crate::error_reporter::call_errors) fn try_elaborate_array_literal_mismatch_with_relation_failure(
+        &mut self,
+        arg_idx: NodeIndex,
+        source_type: TypeId,
+        target_type: TypeId,
+        relation_failure: Option<&crate::query_boundaries::relation_types::RelationFailure>,
+    ) -> bool {
         use tsz_parser::parser::syntax_kind_ext;
 
         if source_type.is_any_unknown_or_error() || target_type.is_any_unknown_or_error() {
@@ -77,10 +91,21 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let analysis = self.analyze_assignability_failure(source_type, target_type);
+        let fallback_analysis;
+        let fallback_reason;
+        let failure = if let Some(failure) = relation_failure {
+            Some(failure)
+        } else {
+            fallback_analysis = self.analyze_assignability_failure(source_type, target_type);
+            fallback_reason = fallback_analysis
+                .failure_reason
+                .map(crate::query_boundaries::relation_types::RelationFailure::from_solver_reason);
+            fallback_reason.as_ref()
+        };
         #[allow(clippy::match_same_arms)] // explicit TupleElementMismatch arm carries rationale
-        match analysis.failure_reason {
-            Some(SubtypeFailureReason::TupleElementTypeMismatch {
+        match failure {
+            Some(
+                crate::query_boundaries::relation_types::RelationFailure::TupleElementTypeMismatch {
                 index,
                 source_element,
                 target_element,
@@ -96,11 +121,11 @@ impl<'a> CheckerState<'a> {
                         crate::query_boundaries::common::tuple_leading_fixed_count_before_trailing(
                             &target_elements,
                         )
-                    && index >= n_leading
+                    && *index >= n_leading
                 {
                     return false;
                 }
-                let Some(&elem_idx) = arr.elements.nodes.get(index) else {
+                let Some(&elem_idx) = arr.elements.nodes.get(*index) else {
                     return false;
                 };
                 let is_spread = self
@@ -112,17 +137,17 @@ impl<'a> CheckerState<'a> {
                     return false;
                 }
                 if self
-                    .array_elaboration_widening_required_for_display(source_element, target_element)
+                    .array_elaboration_widening_required_for_display(*source_element, *target_element)
                 {
                     self.error_type_not_assignable_at_with_widened_source_display(
-                        source_element,
-                        target_element,
+                        *source_element,
+                        *target_element,
                         elem_idx,
                     );
                 } else {
                     self.error_type_not_assignable_at_with_anchor(
-                        source_element,
-                        target_element,
+                        *source_element,
+                        *target_element,
                         elem_idx,
                     );
                 }
@@ -134,7 +159,8 @@ impl<'a> CheckerState<'a> {
             // sub-message under TS2345/TS2322 and does not drill into a specific
             // source element, so the outer caller renders the arity-aware
             // diagnostic directly.
-            Some(SubtypeFailureReason::ArrayElementMismatch {
+            Some(
+                crate::query_boundaries::relation_types::RelationFailure::ArrayElementMismatch {
                 source_element: _,
                 target_element,
             }) => {
@@ -151,20 +177,20 @@ impl<'a> CheckerState<'a> {
                     if elem_type.is_any_unknown_or_error() {
                         continue;
                     }
-                    if !self.is_assignable_to(elem_type, target_element) {
+                    if !self.is_assignable_to(elem_type, *target_element) {
                         if self.array_elaboration_widening_required_for_display(
                             elem_type,
-                            target_element,
+                            *target_element,
                         ) {
                             self.error_type_not_assignable_at_with_widened_source_display(
                                 elem_type,
-                                target_element,
+                                *target_element,
                                 elem_idx,
                             );
                         } else {
                             self.error_type_not_assignable_at_with_anchor(
                                 elem_type,
-                                target_element,
+                                *target_element,
                                 elem_idx,
                             );
                         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_array_mismatch.rs
@@ -91,16 +91,17 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let fallback_analysis;
-        let fallback_reason;
+        let fallback_outcome;
         let failure = if let Some(failure) = relation_failure {
             Some(failure)
         } else {
-            fallback_analysis = self.analyze_assignability_failure(source_type, target_type);
-            fallback_reason = fallback_analysis
-                .failure_reason
-                .map(crate::query_boundaries::relation_types::RelationFailure::from_solver_reason);
-            fallback_reason.as_ref()
+            use crate::query_boundaries::assignability::RelationRequest;
+
+            let (prepared_source, prepared_target) =
+                self.prepare_assignability_inputs(source_type, target_type);
+            let request = RelationRequest::assign(prepared_source, prepared_target);
+            fallback_outcome = self.execute_relation_request(&request);
+            fallback_outcome.failure.as_ref()
         };
         #[allow(clippy::match_same_arms)] // explicit TupleElementMismatch arm carries rationale
         match failure {

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -96,6 +96,18 @@ impl<'a> CheckerState<'a> {
         param_type: TypeId,
         idx: NodeIndex,
     ) {
+        self.error_argument_not_assignable_at_with_relation_failure(
+            arg_type, param_type, idx, None,
+        );
+    }
+
+    pub(crate) fn error_argument_not_assignable_at_with_relation_failure(
+        &mut self,
+        arg_type: TypeId,
+        param_type: TypeId,
+        idx: NodeIndex,
+        relation_failure: Option<&crate::query_boundaries::relation_types::RelationFailure>,
+    ) {
         if self.should_suppress_argument_not_assignable_diagnostic(arg_type, param_type) {
             return;
         }
@@ -160,10 +172,16 @@ impl<'a> CheckerState<'a> {
         if self.try_elaborate_callback_body_diagnostics(idx, param_type) {
             return;
         }
-        // Run failure analysis to produce elaboration as related information,
-        // matching tsc's behavior of emitting TS2741/TS2739/TS2740 etc. as
-        // related diagnostics under the primary TS2345.
-        let analysis = self.analyze_assignability_failure(arg_type, param_type);
+        // Use relation evidence from the caller when available. Legacy callers
+        // still fall back to failure analysis until their paths build
+        // `RelationRequest`s.
+        let fallback_analysis;
+        let failure_reason = if let Some(reason) = relation_failure {
+            Some(reason.to_solver_failure_reason())
+        } else {
+            fallback_analysis = self.analyze_assignability_failure(arg_type, param_type);
+            fallback_analysis.failure_reason
+        };
 
         // When the failure reason is NoCommonProperties (weak types with no
         // properties in common), tsc emits TS2559 directly instead of TS2345.
@@ -173,7 +191,7 @@ impl<'a> CheckerState<'a> {
         // literal types (e.g., "12" not "number", "false" not "boolean") in
         // "has no properties in common" messages.
         if matches!(
-            &analysis.failure_reason,
+            &failure_reason,
             Some(tsz_solver::SubtypeFailureReason::NoCommonProperties { .. })
         ) {
             // Try to get the literal expression display (unwidened) from the AST
@@ -237,10 +255,9 @@ impl<'a> CheckerState<'a> {
                 argument_idx: idx,
             },
         );
-        if let Some(display) = self.mapped_property_mismatch_parameter_display(
-            &param_str,
-            analysis.failure_reason.as_ref(),
-        ) {
+        if let Some(display) =
+            self.mapped_property_mismatch_parameter_display(&param_str, failure_reason.as_ref())
+        {
             param_str = display;
         }
         if let Some(display) =
@@ -275,7 +292,7 @@ impl<'a> CheckerState<'a> {
             &[&arg_str, &param_str],
         );
 
-        let request = if let Some(reason) = analysis.failure_reason {
+        let request = if let Some(reason) = failure_reason {
             DiagnosticRenderRequest::with_failure_reason(
                 DiagnosticAnchorKind::Exact,
                 diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -165,8 +165,12 @@ impl<'a> CheckerState<'a> {
         {
             return;
         }
-        if self.try_elaborate_array_literal_mismatch_from_failure_reason(idx, arg_type, param_type)
-        {
+        if self.try_elaborate_array_literal_mismatch_with_relation_failure(
+            idx,
+            arg_type,
+            param_type,
+            relation_failure,
+        ) {
             return;
         }
         if self.try_elaborate_callback_body_diagnostics(idx, param_type) {

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -173,14 +173,20 @@ impl<'a> CheckerState<'a> {
             return;
         }
         // Use relation evidence from the caller when available. Legacy callers
-        // still fall back to failure analysis until their paths build
-        // `RelationRequest`s.
-        let fallback_analysis;
+        // build a boundary request here so TS2345 fallback rendering still goes
+        // through the same relation/failure path.
+        let fallback_outcome;
         let failure_reason = if let Some(reason) = relation_failure {
             Some(reason.to_solver_failure_reason())
         } else {
-            fallback_analysis = self.analyze_assignability_failure(arg_type, param_type);
-            fallback_analysis.failure_reason
+            use crate::query_boundaries::assignability::RelationRequest;
+            let (prepared_arg, prepared_param) =
+                self.prepare_assignability_inputs(arg_type, param_type);
+            let request = RelationRequest::call_arg(prepared_arg, prepared_param);
+            fallback_outcome = self.execute_relation_request(&request);
+            fallback_outcome.failure.as_ref().map(
+                crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason,
+            )
         };
 
         // When the failure reason is NoCommonProperties (weak types with no

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -874,10 +874,17 @@ impl<'a> CheckerState<'a> {
                     all_same = false;
                     break;
                 };
-                let analysis = self.analyze_assignability_failure(*arg_type, *param_type);
+                use crate::query_boundaries::assignability::RelationRequest;
+                let (prepared_arg, prepared_param) =
+                    self.prepare_assignability_inputs(*arg_type, *param_type);
+                let request = RelationRequest::call_arg(prepared_arg, prepared_param);
+                let outcome = self.execute_relation_request(&request);
                 let Some(tsz_solver::SubtypeFailureReason::ExcessProperty {
                     property_name, ..
-                }) = analysis.failure_reason
+                }) = outcome
+                    .failure
+                    .as_ref()
+                    .map(crate::query_boundaries::relation_types::RelationFailure::to_solver_failure_reason)
                 else {
                     all_same = false;
                     break;

--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -388,7 +388,10 @@ impl<'a> CheckerState<'a> {
             Some(
                 RelationFailure::MissingProperty { .. }
                 | RelationFailure::MissingProperties { .. }
-                | RelationFailure::PropertyModifierMismatch { .. },
+                | RelationFailure::OptionalPropertyRequired { .. }
+                | RelationFailure::ReadonlyPropertyMismatch { .. }
+                | RelationFailure::PropertyVisibilityMismatch { .. }
+                | RelationFailure::PropertyNominalMismatch { .. },
             ) => Some(arg_idx),
             _ => None,
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -320,7 +320,8 @@ impl<'a> CheckerState<'a> {
         arg_idx: NodeIndex,
         param_type: TypeId,
     ) -> Option<NodeIndex> {
-        use crate::query_boundaries::common::SubtypeFailureReason;
+        use crate::query_boundaries::assignability::RelationRequest;
+        use crate::query_boundaries::relation_types::RelationFailure;
         use tsz_parser::parser::syntax_kind_ext;
 
         let source_type = self.get_type_of_node(arg_idx);
@@ -379,12 +380,15 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let analysis = self.analyze_assignability_failure(source_type, effective_param_type);
-        match analysis.failure_reason.as_ref() {
+        let (prepared_source, prepared_target) =
+            self.prepare_assignability_inputs(source_type, effective_param_type);
+        let request = RelationRequest::assign(prepared_source, prepared_target);
+        let outcome = self.execute_relation_request(&request);
+        match outcome.failure.as_ref() {
             Some(
-                SubtypeFailureReason::MissingProperty { .. }
-                | SubtypeFailureReason::MissingProperties { .. }
-                | SubtypeFailureReason::OptionalPropertyRequired { .. },
+                RelationFailure::MissingProperty { .. }
+                | RelationFailure::MissingProperties { .. }
+                | RelationFailure::PropertyModifierMismatch { .. },
             ) => Some(arg_idx),
             _ => None,
         }

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -807,19 +807,23 @@ impl<'a> CheckerState<'a> {
         source_type: TypeId,
         target_type: TypeId,
     ) -> bool {
-        use crate::query_boundaries::common::SubtypeFailureReason;
+        use crate::query_boundaries::assignability::RelationRequest;
+        use crate::query_boundaries::relation_types::RelationFailure;
 
-        let analysis = self.analyze_assignability_failure(source_type, target_type);
-        let Some(reason) = analysis.failure_reason else {
+        let (prepared_source, prepared_target) =
+            self.prepare_assignability_inputs(source_type, target_type);
+        let request = RelationRequest::assign(prepared_source, prepared_target);
+        let outcome = self.execute_relation_request(&request);
+        let Some(reason) = outcome.failure.as_ref() else {
             return false;
         };
 
         match reason {
-            SubtypeFailureReason::MissingProperty { property_name, .. } => {
-                let prop_name = self.ctx.types.resolve_atom_ref(property_name);
+            RelationFailure::MissingProperty { property_name, .. } => {
+                let prop_name = self.ctx.types.resolve_atom_ref(*property_name);
                 is_object_prototype_method(&prop_name)
             }
-            SubtypeFailureReason::MissingProperties { property_names, .. } => {
+            RelationFailure::MissingProperties { property_names, .. } => {
                 !property_names.is_empty()
                     && property_names.iter().all(|property_name| {
                         let prop_name = self.ctx.types.resolve_atom_ref(*property_name);

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1053,6 +1053,26 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Render the checker-facing relation failure shape produced by
+    /// `query_boundaries`.
+    ///
+    /// This is intentionally parallel to `render_failure_reason` during the
+    /// migration: diagnostic paths can consume boundary-owned evidence without
+    /// re-running solver failure analysis, while specialized renderer logic can
+    /// move over variant by variant.
+    pub(crate) fn render_relation_failure(
+        &mut self,
+        reason: &crate::query_boundaries::relation_types::RelationFailure,
+        source: TypeId,
+        target: TypeId,
+        idx: NodeIndex,
+        depth: u32,
+    ) -> Diagnostic {
+        let solver_reason = reason.to_solver_failure_reason();
+
+        self.render_failure_reason(&solver_reason, source, target, idx, depth)
+    }
+
     fn object_literal_property_literal_union_alias_target_display(
         &mut self,
         target: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -115,6 +115,13 @@ pub(crate) struct RelationRequest {
     /// erased signatures. This is a targeted interface property compatibility
     /// mode, not the default assignment relation.
     pub allow_erased_generic_signature_retry: bool,
+    /// Whether the caller needs object property classification in the outcome.
+    ///
+    /// Property classification can perform additional relation checks for
+    /// matching properties and trimmed object shapes. Keep it opt-in so a
+    /// diagnostic relation request can be cheap when it only needs the boolean
+    /// result and structured failure reason.
+    pub collect_property_classification: bool,
 }
 
 impl RelationRequest {
@@ -127,6 +134,7 @@ impl RelationRequest {
             missing_property_mode: MissingPropertyMode::Report,
             source_is_fresh: false,
             allow_erased_generic_signature_retry: false,
+            collect_property_classification: false,
         }
     }
 
@@ -178,6 +186,12 @@ impl RelationRequest {
     /// Allow a failed generic-signature inference to retry with erased signatures.
     pub(crate) fn with_erased_generic_signature_retry(mut self) -> Self {
         self.allow_erased_generic_signature_retry = true;
+        self
+    }
+
+    /// Request property-level evidence for EPC/weak-union prioritization.
+    pub(crate) fn with_property_classification(mut self) -> Self {
+        self.collect_property_classification = true;
         self
     }
 }
@@ -612,6 +626,18 @@ pub(crate) struct RelationOutcome {
     pub property_classification: Option<super::relation_types::PropertyClassification>,
 }
 
+impl Clone for RelationOutcome {
+    fn clone(&self) -> Self {
+        Self {
+            related: self.related,
+            depth_exceeded: self.depth_exceeded,
+            failure: self.failure.clone(),
+            weak_union_violation: self.weak_union_violation,
+            property_classification: self.property_classification.clone(),
+        }
+    }
+}
+
 /// Execute a `RelationRequest` through the canonical boundary.
 ///
 /// This is the single authoritative entry point for relation queries that
@@ -685,19 +711,23 @@ pub(crate) fn execute_relation<R: tsz_solver::TypeResolver>(
     });
 
     let (weak_union_violation, failure) = match analysis {
-        Some(a) => (
-            a.weak_union_violation,
-            a.failure_reason
-                .map(super::relation_types::RelationFailure::from_solver_reason),
-        ),
+        Some(a) => {
+            let failure = a
+                .failure_reason
+                .map(super::relation_types::RelationFailure::from_solver_reason);
+            (a.weak_union_violation, failure)
+        }
         None => (false, None),
     };
 
-    // Always populate property classification when the relation fails.
-    // This provides the canonical property-level analysis that callers like
-    // `should_skip_weak_union_error` need without re-enumerating properties.
-    let property_classification =
-        classify_object_properties(db.as_type_database(), request.source, request.target);
+    // Property classification is useful for EPC/weak-union prioritization, but
+    // it is not free: it may perform additional subtype checks for matching
+    // properties and trimmed object shapes. Collect it only when the caller
+    // asks for that diagnostic evidence.
+    let property_classification = request
+        .collect_property_classification
+        .then(|| classify_object_properties(db.as_type_database(), request.source, request.target))
+        .flatten();
 
     // Suppress ExcessProperty failure when the target has structural features
     // that make EPC inapplicable.

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -5,7 +5,7 @@
 //! the relation.
 
 use tsz_common::interner::Atom;
-use tsz_solver::{SubtypeFailureReason, TypeId};
+use tsz_solver::{SubtypeFailureReason, TypeId, Visibility};
 
 // ---------------------------------------------------------------------------
 // PropertyClassification: structured property-level analysis for EPC/missing
@@ -120,8 +120,18 @@ pub(crate) enum RelationFailure {
         source_count: usize,
         target_count: usize,
     },
-    /// Property modifier mismatch (optional/readonly/visibility/nominal).
-    PropertyModifierMismatch { property_name: Atom },
+    /// Optional source property cannot satisfy a required target property.
+    OptionalPropertyRequired { property_name: Atom },
+    /// Readonly property cannot satisfy a mutable property.
+    ReadonlyPropertyMismatch { property_name: Atom },
+    /// Property visibility mismatch.
+    PropertyVisibilityMismatch {
+        property_name: Atom,
+        source_visibility: Visibility,
+        target_visibility: Visibility,
+    },
+    /// Private/protected property declarations are nominally distinct.
+    PropertyNominalMismatch { property_name: Atom },
     /// Weak union violation (no common properties).
     WeakUnionViolation {
         source_type: TypeId,
@@ -239,7 +249,26 @@ impl RelationFailure {
                 source_count: *source_count,
                 target_count: *target_count,
             },
-            Self::PropertyModifierMismatch { property_name } => {
+            Self::OptionalPropertyRequired { property_name } => {
+                SubtypeFailureReason::OptionalPropertyRequired {
+                    property_name: *property_name,
+                }
+            }
+            Self::ReadonlyPropertyMismatch { property_name } => {
+                SubtypeFailureReason::ReadonlyPropertyMismatch {
+                    property_name: *property_name,
+                }
+            }
+            Self::PropertyVisibilityMismatch {
+                property_name,
+                source_visibility,
+                target_visibility,
+            } => SubtypeFailureReason::PropertyVisibilityMismatch {
+                property_name: *property_name,
+                source_visibility: *source_visibility,
+                target_visibility: *target_visibility,
+            },
+            Self::PropertyNominalMismatch { property_name } => {
                 SubtypeFailureReason::PropertyNominalMismatch {
                     property_name: *property_name,
                 }
@@ -391,13 +420,23 @@ impl RelationFailure {
                 source_count,
                 target_count,
             },
-            SubtypeFailureReason::OptionalPropertyRequired { property_name }
-            | SubtypeFailureReason::ReadonlyPropertyMismatch { property_name }
-            | SubtypeFailureReason::PropertyNominalMismatch { property_name } => {
-                Self::PropertyModifierMismatch { property_name }
+            SubtypeFailureReason::OptionalPropertyRequired { property_name } => {
+                Self::OptionalPropertyRequired { property_name }
             }
-            SubtypeFailureReason::PropertyVisibilityMismatch { property_name, .. } => {
-                Self::PropertyModifierMismatch { property_name }
+            SubtypeFailureReason::ReadonlyPropertyMismatch { property_name } => {
+                Self::ReadonlyPropertyMismatch { property_name }
+            }
+            SubtypeFailureReason::PropertyVisibilityMismatch {
+                property_name,
+                source_visibility,
+                target_visibility,
+            } => Self::PropertyVisibilityMismatch {
+                property_name,
+                source_visibility,
+                target_visibility,
+            },
+            SubtypeFailureReason::PropertyNominalMismatch { property_name } => {
+                Self::PropertyNominalMismatch { property_name }
             }
             SubtypeFailureReason::TupleElementTypeMismatch {
                 index,

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -125,6 +125,115 @@ pub(crate) enum RelationFailure {
 }
 
 impl RelationFailure {
+    /// Convert this checker-facing failure back to the legacy solver reason
+    /// shape while renderers are still migrating variant by variant.
+    pub(crate) fn to_solver_failure_reason(&self) -> SubtypeFailureReason {
+        match self {
+            Self::MissingProperty {
+                property_name,
+                source_type,
+                target_type,
+            } => SubtypeFailureReason::MissingProperty {
+                property_name: *property_name,
+                source_type: *source_type,
+                target_type: *target_type,
+            },
+            Self::MissingProperties {
+                property_names,
+                source_type,
+                target_type,
+            } => SubtypeFailureReason::MissingProperties {
+                property_names: property_names.clone(),
+                source_type: *source_type,
+                target_type: *target_type,
+            },
+            Self::ExcessProperty {
+                property_name,
+                target_type,
+            } => SubtypeFailureReason::ExcessProperty {
+                property_name: *property_name,
+                target_type: *target_type,
+            },
+            Self::IncompatiblePropertyValue {
+                property_name,
+                source_property_type,
+                target_property_type,
+                nested,
+            } => SubtypeFailureReason::PropertyTypeMismatch {
+                property_name: *property_name,
+                source_property_type: *source_property_type,
+                target_property_type: *target_property_type,
+                nested_reason: nested
+                    .as_ref()
+                    .map(|nested| Box::new(nested.to_solver_failure_reason())),
+            },
+            Self::NoApplicableSignature {
+                source_type,
+                target_type,
+            } => SubtypeFailureReason::TypeMismatch {
+                source_type: *source_type,
+                target_type: *target_type,
+            },
+            Self::TupleArityMismatch {
+                source_count,
+                target_count,
+            } => SubtypeFailureReason::TupleElementMismatch {
+                source_count: *source_count,
+                target_count: *target_count,
+            },
+            Self::ReturnTypeMismatch {
+                source_return,
+                target_return,
+                nested,
+            } => SubtypeFailureReason::ReturnTypeMismatch {
+                source_return: *source_return,
+                target_return: *target_return,
+                nested_reason: nested
+                    .as_ref()
+                    .map(|nested| Box::new(nested.to_solver_failure_reason())),
+            },
+            Self::ParameterTypeMismatch {
+                param_index,
+                source_param,
+                target_param,
+                inner,
+            } => SubtypeFailureReason::ParameterTypeMismatch {
+                param_index: *param_index,
+                source_param: *source_param,
+                target_param: *target_param,
+                inner_reason: inner
+                    .as_ref()
+                    .map(|inner| Box::new(inner.to_solver_failure_reason())),
+            },
+            Self::ParameterCountMismatch {
+                source_count,
+                target_count,
+            } => SubtypeFailureReason::ParameterCountMismatch {
+                source_count: *source_count,
+                target_count: *target_count,
+            },
+            Self::PropertyModifierMismatch { property_name } => {
+                SubtypeFailureReason::PropertyNominalMismatch {
+                    property_name: *property_name,
+                }
+            }
+            Self::WeakUnionViolation {
+                source_type,
+                target_type,
+            } => SubtypeFailureReason::NoCommonProperties {
+                source_type: *source_type,
+                target_type: *target_type,
+            },
+            Self::TypeMismatch {
+                source_type,
+                target_type,
+            } => SubtypeFailureReason::TypeMismatch {
+                source_type: *source_type,
+                target_type: *target_type,
+            },
+        }
+    }
+
     /// Convert a solver `SubtypeFailureReason` into checker-facing `RelationFailure`.
     pub(crate) fn from_solver_reason(reason: SubtypeFailureReason) -> Self {
         match reason {

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -87,6 +87,17 @@ pub(crate) enum RelationFailure {
         source_count: usize,
         target_count: usize,
     },
+    /// Tuple element type mismatch at a specific element index.
+    TupleElementTypeMismatch {
+        index: usize,
+        source_element: TypeId,
+        target_element: TypeId,
+    },
+    /// Array element type mismatch.
+    ArrayElementMismatch {
+        source_element: TypeId,
+        target_element: TypeId,
+    },
     /// Return type incompatibility.
     ReturnTypeMismatch {
         source_return: TypeId,
@@ -180,6 +191,22 @@ impl RelationFailure {
             } => SubtypeFailureReason::TupleElementMismatch {
                 source_count: *source_count,
                 target_count: *target_count,
+            },
+            Self::TupleElementTypeMismatch {
+                index,
+                source_element,
+                target_element,
+            } => SubtypeFailureReason::TupleElementTypeMismatch {
+                index: *index,
+                source_element: *source_element,
+                target_element: *target_element,
+            },
+            Self::ArrayElementMismatch {
+                source_element,
+                target_element,
+            } => SubtypeFailureReason::ArrayElementMismatch {
+                source_element: *source_element,
+                target_element: *target_element,
             },
             Self::ReturnTypeMismatch {
                 source_return,
@@ -341,9 +368,9 @@ impl RelationFailure {
             SubtypeFailureReason::ArrayElementMismatch {
                 source_element,
                 target_element,
-            } => Self::TypeMismatch {
-                source_type: source_element,
-                target_type: target_element,
+            } => Self::ArrayElementMismatch {
+                source_element,
+                target_element,
             },
             SubtypeFailureReason::IndexSignatureMismatch {
                 source_value_type,
@@ -373,12 +400,13 @@ impl RelationFailure {
                 Self::PropertyModifierMismatch { property_name }
             }
             SubtypeFailureReason::TupleElementTypeMismatch {
+                index,
                 source_element,
                 target_element,
-                ..
-            } => Self::TypeMismatch {
-                source_type: source_element,
-                target_type: target_element,
+            } => Self::TupleElementTypeMismatch {
+                index,
+                source_element,
+                target_element,
             },
             SubtypeFailureReason::MissingIndexSignature { .. }
             | SubtypeFailureReason::RecursionLimitExceeded => Self::TypeMismatch {

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -3404,7 +3404,10 @@ fn test_relation_failure_covers_semantic_families() {
         "ReturnTypeMismatch",
         "ParameterTypeMismatch",
         "ParameterCountMismatch",
-        "PropertyModifierMismatch",
+        "OptionalPropertyRequired",
+        "ReadonlyPropertyMismatch",
+        "PropertyVisibilityMismatch",
+        "PropertyNominalMismatch",
         "WeakUnionViolation",
         "TypeMismatch",
     ] {
@@ -3429,8 +3432,14 @@ fn test_relation_failure_preserves_canonical_solver_mapping() {
     );
     assert!(
         source.contains("SubtypeFailureReason::OptionalPropertyRequired { property_name }")
-            && source.contains("Self::PropertyModifierMismatch { property_name }"),
-        "OptionalPropertyRequired must normalize to PropertyModifierMismatch"
+            && source.contains("Self::OptionalPropertyRequired { property_name }")
+            && source.contains("SubtypeFailureReason::ReadonlyPropertyMismatch { property_name }")
+            && source.contains("Self::ReadonlyPropertyMismatch { property_name }")
+            && source.contains("SubtypeFailureReason::PropertyVisibilityMismatch")
+            && source.contains("Self::PropertyVisibilityMismatch")
+            && source.contains("SubtypeFailureReason::PropertyNominalMismatch { property_name }")
+            && source.contains("Self::PropertyNominalMismatch { property_name }"),
+        "property modifier solver reasons must preserve their specific modifier kind"
     );
     assert!(
         source.contains("SubtypeFailureReason::PropertyTypeMismatch")

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -3399,6 +3399,8 @@ fn test_relation_failure_covers_semantic_families() {
         "IncompatiblePropertyValue",
         "NoApplicableSignature",
         "TupleArityMismatch",
+        "TupleElementTypeMismatch",
+        "ArrayElementMismatch",
         "ReturnTypeMismatch",
         "ParameterTypeMismatch",
         "ParameterCountMismatch",
@@ -3466,15 +3468,13 @@ fn test_relation_failure_preserves_canonical_solver_mapping() {
     );
     assert!(
         source.contains("SubtypeFailureReason::ArrayElementMismatch {")
-            && source.contains("source_type: source_element,")
-            && source.contains("target_type: target_element,")
+            && source.contains("=> Self::ArrayElementMismatch")
+            && source.contains("SubtypeFailureReason::TupleElementTypeMismatch {")
+            && source.contains("=> Self::TupleElementTypeMismatch")
             && source.contains("SubtypeFailureReason::IndexSignatureMismatch {")
             && source.contains("source_type: source_value_type,")
-            && source.contains("target_type: target_value_type,")
-            && source.contains("SubtypeFailureReason::TupleElementTypeMismatch {")
-            && source.contains("source_type: source_element,")
-            && source.contains("target_type: target_element,"),
-        "element/index-specific solver mismatches must normalize through TypeMismatch using the concrete element/value types"
+            && source.contains("target_type: target_value_type,"),
+        "array/tuple element mismatches must retain element detail, while index-signature mismatches normalize through TypeMismatch"
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -715,6 +715,7 @@ impl<'a> CheckerState<'a> {
                     is_super_call: false,
                     is_optional_chain: nullish_cause.is_some(),
                     allow_contextual_mismatch_deferral: false,
+                    relation_evidence: &[],
                 },
             );
         }
@@ -2470,36 +2471,53 @@ impl<'a> CheckerState<'a> {
             contextual_type
         };
 
-        let (mut result, mut instantiated_predicate, mut generic_instantiated_params) =
-            if is_super_call {
-                (
-                    self.resolve_new_with_checker_adapter(
-                        callee_type_for_call,
-                        &generic_inference_arg_types,
-                        force_bivariant_callbacks,
-                        call_resolution_contextual_type,
-                    ),
-                    None,
-                    None,
-                )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+        let (
+            mut result,
+            mut instantiated_predicate,
+            mut generic_instantiated_params,
+            mut relation_evidence,
+        ) = if is_super_call {
+            (
+                self.resolve_new_with_checker_adapter(
                     callee_type_for_call,
                     &generic_inference_arg_types,
                     force_bivariant_callbacks,
                     call_resolution_contextual_type,
-                    actual_this_type,
-                    &generic_inference_arg_source_markers,
-                )
-            } else {
-                self.resolve_call_with_checker_adapter(
-                    callee_type_for_call,
-                    &generic_inference_arg_types,
-                    force_bivariant_callbacks,
-                    call_resolution_contextual_type,
-                    actual_this_type,
-                )
-            };
+                ),
+                None,
+                None,
+                Vec::new(),
+            )
+        } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+                &generic_inference_arg_source_markers,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        } else {
+            let resolution = self.resolve_call_with_checker_adapter_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        };
         // When the checker's intra-expression Round 2 produced a substitution that
         // pins type parameters the solver could not (the solver's single-pass
         // inference dropped the binding because the same parameter appears in a
@@ -2697,23 +2715,36 @@ impl<'a> CheckerState<'a> {
                     ),
                     None,
                     None,
+                    Vec::new(),
                 )
             } else if retry_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+                let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             } else {
-                self.resolve_call_with_checker_adapter(
+                let resolution = self.resolve_call_with_checker_adapter_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             };
             // Apply the same checker-side substitution refinement to the retry's
@@ -2758,6 +2789,7 @@ impl<'a> CheckerState<'a> {
             };
             instantiated_predicate = retry.1;
             generic_instantiated_params = retry.2;
+            relation_evidence = retry.3;
         }
 
         if is_generic_call
@@ -3127,6 +3159,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain: nullish_cause.is_some(),
             allow_contextual_mismatch_deferral,
+            relation_evidence: &relation_evidence,
         };
         // Pop the shape_this_type that was kept on the stack since the
         // argument collection phase.

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -895,36 +895,53 @@ impl<'a> CheckerState<'a> {
         };
         let call_resolution_contextual_type = contextual_type;
 
-        let (mut result, mut instantiated_predicate, mut generic_instantiated_params) =
-            if is_super_call {
-                (
-                    self.resolve_new_with_checker_adapter(
-                        callee_type_for_call,
-                        &generic_inference_arg_types,
-                        force_bivariant_callbacks,
-                        call_resolution_contextual_type,
-                    ),
-                    None,
-                    None,
-                )
-            } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+        let (
+            mut result,
+            mut instantiated_predicate,
+            mut generic_instantiated_params,
+            mut relation_evidence,
+        ) = if is_super_call {
+            (
+                self.resolve_new_with_checker_adapter(
                     callee_type_for_call,
                     &generic_inference_arg_types,
                     force_bivariant_callbacks,
                     call_resolution_contextual_type,
-                    actual_this_type,
-                    &generic_inference_arg_source_markers,
-                )
-            } else {
-                self.resolve_call_with_checker_adapter(
-                    callee_type_for_call,
-                    &generic_inference_arg_types,
-                    force_bivariant_callbacks,
-                    call_resolution_contextual_type,
-                    actual_this_type,
-                )
-            };
+                ),
+                None,
+                None,
+                Vec::new(),
+            )
+        } else if generic_inference_arg_source_markers.iter().any(|&m| m) {
+            let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+                &generic_inference_arg_source_markers,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        } else {
+            let resolution = self.resolve_call_with_checker_adapter_evidence(
+                callee_type_for_call,
+                &generic_inference_arg_types,
+                force_bivariant_callbacks,
+                call_resolution_contextual_type,
+                actual_this_type,
+            );
+            (
+                resolution.result,
+                resolution.selected_type_predicate,
+                resolution.instantiated_params,
+                resolution.relation_evidence,
+            )
+        };
         let needs_real_type_recheck = is_generic_call
             && args.iter().enumerate().any(|(i, &arg_idx)| {
                 self.argument_needs_refresh_for_contextual_call(
@@ -1067,23 +1084,36 @@ impl<'a> CheckerState<'a> {
                     ),
                     None,
                     None,
+                    Vec::new(),
                 )
             } else if retry_arg_source_markers.iter().any(|&m| m) {
-                self.resolve_call_with_checker_adapter_and_arg_sources(
+                let resolution = self.resolve_call_with_checker_adapter_and_arg_sources_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
                     &retry_arg_source_markers,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             } else {
-                self.resolve_call_with_checker_adapter(
+                let resolution = self.resolve_call_with_checker_adapter_evidence(
                     callee_type_for_call,
                     &retry_generic_arg_types,
                     force_bivariant_callbacks,
                     contextual_type,
                     actual_this_type,
+                );
+                (
+                    resolution.result,
+                    resolution.selected_type_predicate,
+                    resolution.instantiated_params,
+                    resolution.relation_evidence,
                 )
             };
             result = if retry_sanitized || needs_real_type_recheck {
@@ -1102,6 +1132,7 @@ impl<'a> CheckerState<'a> {
             };
             instantiated_predicate = retry.1;
             generic_instantiated_params = retry.2;
+            relation_evidence = retry.3;
         }
 
         if is_generic_call
@@ -1287,6 +1318,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,
+            relation_evidence: &relation_evidence,
         };
         if pushed_this_type_from_shape {
             self.ctx.this_type_stack.pop();

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -39,6 +39,25 @@ impl<'a> CheckerState<'a> {
             .map(|evidence| &evidence.outcome)
     }
 
+    fn report_argument_assignability_with_evidence(
+        &mut self,
+        relation_evidence: &[CallRelationEvidence],
+        source: TypeId,
+        target: TypeId,
+        arg_idx: NodeIndex,
+    ) -> bool {
+        if let Some(outcome) = Self::relation_evidence_for_pair(relation_evidence, source, target) {
+            self.report_argument_assignability_with_outcome(
+                source,
+                target,
+                arg_idx,
+                outcome.clone(),
+            )
+        } else {
+            self.check_argument_assignable_or_report(source, target, arg_idx)
+        }
+    }
+
     fn is_generic_indexed_access_surface(&self, type_id: TypeId) -> bool {
         self.generic_indexed_access_surface_inner(type_id)
             || self
@@ -1336,19 +1355,9 @@ impl<'a> CheckerState<'a> {
                                 reported_expected,
                                 arg_idx,
                             );
-                        } else if let Some(outcome) = Self::relation_evidence_for_pair(
-                            relation_evidence,
-                            reported_actual,
-                            reported_expected,
-                        ) {
-                            let _ = self.report_argument_assignability_with_outcome(
-                                reported_actual,
-                                reported_expected,
-                                arg_idx,
-                                outcome.clone(),
-                            );
                         } else {
-                            let _ = self.check_argument_assignable_or_report(
+                            let _ = self.report_argument_assignability_with_evidence(
+                                relation_evidence,
                                 reported_actual,
                                 reported_expected,
                                 arg_idx,
@@ -1391,7 +1400,8 @@ impl<'a> CheckerState<'a> {
                                 aggregate_anchor_override.unwrap_or(call_idx),
                             );
                         } else {
-                            let _ = self.check_argument_assignable_or_report(
+                            let _ = self.report_argument_assignability_with_evidence(
+                                relation_evidence,
                                 reported_actual,
                                 reported_expected,
                                 call_idx,
@@ -1434,7 +1444,8 @@ impl<'a> CheckerState<'a> {
                                 aggregate_anchor_override.unwrap_or(last_arg),
                             );
                         } else {
-                            let _ = self.check_argument_assignable_or_report(
+                            let _ = self.report_argument_assignability_with_evidence(
+                                relation_evidence,
                                 reported_actual,
                                 reported_expected,
                                 last_arg,
@@ -1458,7 +1469,8 @@ impl<'a> CheckerState<'a> {
                             aggregate_anchor_override.unwrap_or(call_idx),
                         );
                     } else {
-                        let _ = self.check_argument_assignable_or_report(
+                        let _ = self.report_argument_assignability_with_evidence(
+                            relation_evidence,
                             reported_actual,
                             reported_expected,
                             call_idx,

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -39,7 +39,7 @@ impl<'a> CheckerState<'a> {
             .map(|evidence| &evidence.outcome)
     }
 
-    fn report_argument_assignability_with_evidence(
+    pub(crate) fn report_argument_assignability_with_evidence(
         &mut self,
         relation_evidence: &[CallRelationEvidence],
         source: TypeId,

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1,5 +1,6 @@
 //! Call-result handling helpers shared by call expression computation.
 
+use crate::checkers_domain::call_checker::CallRelationEvidence;
 use crate::query_boundaries::assignability as assign_query;
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::CallResult;
@@ -22,9 +23,22 @@ pub(super) struct CallResultContext<'a> {
     pub(super) is_super_call: bool,
     pub(super) is_optional_chain: bool,
     pub(super) allow_contextual_mismatch_deferral: bool,
+    pub(super) relation_evidence: &'a [CallRelationEvidence],
 }
 
 impl<'a> CheckerState<'a> {
+    fn relation_evidence_for_pair<'e>(
+        relation_evidence: &'e [CallRelationEvidence],
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<&'e crate::query_boundaries::assignability::RelationOutcome> {
+        relation_evidence
+            .iter()
+            .rev()
+            .find(|evidence| evidence.source == source && evidence.target == target)
+            .map(|evidence| &evidence.outcome)
+    }
+
     fn is_generic_indexed_access_surface(&self, type_id: TypeId) -> bool {
         self.generic_indexed_access_surface_inner(type_id)
             || self
@@ -833,6 +847,7 @@ impl<'a> CheckerState<'a> {
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,
+            relation_evidence,
             ..
         } = context;
         match result {
@@ -1320,6 +1335,17 @@ impl<'a> CheckerState<'a> {
                                 reported_actual,
                                 reported_expected,
                                 arg_idx,
+                            );
+                        } else if let Some(outcome) = Self::relation_evidence_for_pair(
+                            relation_evidence,
+                            reported_actual,
+                            reported_expected,
+                        ) {
+                            let _ = self.report_argument_assignability_with_outcome(
+                                reported_actual,
+                                reported_expected,
+                                arg_idx,
+                                outcome.clone(),
                             );
                         } else {
                             let _ = self.check_argument_assignable_or_report(

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1504,12 +1504,14 @@ impl<'a> CheckerState<'a> {
         // Delegate to Solver for constructor resolution, passing contextual type
         // so generic constructors like `new Promise(...)` can infer type parameters
         // from the expected type (e.g., `const x: Obj = new Promise(...)` infers T=Obj).
-        let result = self.resolve_new_with_checker_adapter(
+        let new_resolution = self.resolve_new_with_checker_adapter_evidence(
             constructor_type,
             &arg_types,
             false,
             contextual_type,
         );
+        let result = new_resolution.result;
+        let relation_evidence = new_resolution.relation_evidence;
 
         match result {
             CallResult::Success(mut return_type) => {
@@ -1819,8 +1821,12 @@ impl<'a> CheckerState<'a> {
                             false
                         };
                         if !elaborated {
-                            let _ =
-                                self.check_argument_assignable_or_report(actual, expected, arg_idx);
+                            let _ = self.report_argument_assignability_with_evidence(
+                                &relation_evidence,
+                                actual,
+                                expected,
+                                arg_idx,
+                            );
                         }
                     }
                 }

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -498,6 +498,7 @@ impl<'a> CheckerState<'a> {
                 is_super_call: false,
                 is_optional_chain: false,
                 allow_contextual_mismatch_deferral: true,
+                relation_evidence: &[],
             },
         );
 


### PR DESCRIPTION
AgentName: M5Manager

## Summary
Replacement draft PR for closed #7350 after restoring deleted head branch `refactor/satisfies-fallback-relation-outcome-20260516` at `4de8288e43c5790d4a24a41c72deee673cb82fb0`. The original PR could not be reopened directly.

The restored branch is a full-closed-PR audit candidate with a non-empty/unverified diff against `main` (21 files changed, 1090 insertions(+), 435 deletions(-)), so this keeps the work visible for owner refresh instead of leaving it stranded as a closed PR with a deleted branch.

## Current State
WIP/help-wanted. Next owner must rebase/deduplicate against current `main`, confirm whether the diff should still land, and run appropriate verification before marking ready.

## Project Corpus Impact
- Row: unknown pending owner refresh
- Bug family: carried over from closed #7350
- Evidence: branch-management preservation only; no management-pass verification.

## Verification
- Not run in this management pass.