### PR TITLE
fix(dts): preserve jsdoc function overload order

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -254,6 +254,7 @@ impl<'a> DeclarationEmitter<'a> {
             self.js_deferred_function_export_statements.remove(stmt_idx);
             self.js_deferred_value_export_statements.remove(stmt_idx);
         }
+        let js_commonjs_closure_export = self.js_commonjs_export_assignment_closure(source_file);
 
         debug!(
             "[DEBUG] source_file has {} comments",
@@ -297,6 +298,9 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 self.emit_js_anonymous_export_equals_value_declaration(initializer);
             }
+        }
+        if let Some((_, root_initializer, ref secondary_members)) = js_commonjs_closure_export {
+            self.emit_js_commonjs_closure_export_assignment(root_initializer, secondary_members);
         }
 
         // For JS source files, hoist `export default <Identifier>` statements that
@@ -375,6 +379,15 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
             if skipped_nested_module_export_namespace_stmts.contains(&stmt_idx) {
+                continue;
+            }
+            if js_commonjs_closure_export
+                .as_ref()
+                .is_some_and(|(closure_stmt_idx, _, _)| *closure_stmt_idx == stmt_idx)
+            {
+                if let Some(stmt_node) = self.arena.get(stmt_idx) {
+                    self.skip_comments_in_node(stmt_node.pos, stmt_node.end);
+                }
                 continue;
             }
             if deferred_js_namespace_objects.contains(&stmt_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -719,7 +719,7 @@ impl<'a> DeclarationEmitter<'a> {
             || text.contains(&format!("export async function {name}"))
     }
 
-    fn emit_jsdoc_overload_comment(&mut self, jsdoc: &str) {
+    pub(in crate::declaration_emitter) fn emit_jsdoc_overload_comment(&mut self, jsdoc: &str) {
         self.write_indent();
         self.write("/**");
         self.write_line();
@@ -1873,8 +1873,12 @@ impl<'a> DeclarationEmitter<'a> {
         // Emit parameter properties from constructor first (before other members)
         self.emit_parameter_properties(&class.members);
 
-        // Emit `#private;` if any member has a private identifier name (e.g., #foo)
-        if self.class_has_private_identifier_member(&class.members) {
+        // Emit `#private;` if any member has a private identifier name (e.g., #foo).
+        // JSDoc constructor overloads in JS are emitted before the private marker,
+        // so that path defers this marker into the ordered member pass.
+        if self.class_has_private_identifier_member(&class.members)
+            && !self.class_has_jsdoc_overload_constructor(&class.members)
+        {
             self.write_indent();
             self.write("#private;");
             self.write_line();

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1,8 +1,8 @@
 use rustc_hash::FxHashSet;
 use tracing::debug;
 use tsz_common::comments::is_jsdoc_comment;
-use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::type_queries;
 
@@ -461,6 +461,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
 
+        self.emit_deferred_js_export_equals_dependency_classes(source_file);
         self.emit_pending_top_level_jsdoc_type_aliases(source_file);
         self.emit_pending_jsdoc_callback_type_aliases(source_file);
         self.emit_trailing_top_level_jsdoc_type_aliases(source_file);
@@ -562,6 +563,70 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         found_in_ambient_module
+    }
+
+    fn emit_deferred_js_export_equals_dependency_classes(
+        &mut self,
+        source_file: &tsz_parser::parser::node::SourceFileData,
+    ) {
+        if !self.source_is_js_file || self.js_export_equals_names.is_empty() {
+            return;
+        }
+
+        let deferred = source_file
+            .statements
+            .nodes
+            .iter()
+            .copied()
+            .filter(|&stmt_idx| {
+                let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                    return false;
+                };
+                if stmt_node.kind != syntax_kind_ext::CLASS_DECLARATION {
+                    return false;
+                }
+                let Some(class) = self.arena.get_class(stmt_node) else {
+                    return false;
+                };
+                self.should_defer_js_export_equals_dependency_class(class.name, &class.modifiers)
+            })
+            .collect::<Vec<_>>();
+        if deferred.is_empty() {
+            return;
+        }
+
+        let export_equals_names = std::mem::take(&mut self.js_export_equals_names);
+        for class_idx in deferred {
+            self.emit_class_declaration(class_idx);
+        }
+        self.js_export_equals_names = export_equals_names;
+    }
+
+    fn should_defer_js_export_equals_dependency_class(
+        &self,
+        name_idx: NodeIndex,
+        modifiers: &Option<NodeList>,
+    ) -> bool {
+        self.source_is_js_file
+            && !self.js_export_equals_names.is_empty()
+            && !self
+                .arena
+                .has_modifier(modifiers, SyntaxKind::ExportKeyword)
+            && !self.is_js_named_exported_name(name_idx)
+            && !self.is_js_export_equals_name(name_idx)
+            && self.is_js_export_equals_namespace_alias_local(name_idx)
+    }
+
+    fn is_js_export_equals_namespace_alias_local(&self, name_idx: NodeIndex) -> bool {
+        let Some(name) = self.get_identifier_text(name_idx) else {
+            return false;
+        };
+
+        self.js_export_equals_names.iter().any(|root_name| {
+            self.js_namespace_export_aliases
+                .get(root_name)
+                .is_some_and(|aliases| aliases.iter().any(|alias| alias.local_name == name))
+        })
     }
 
     fn prune_unused_named_import_specifiers_from_output(output: &str) -> String {
@@ -1494,6 +1559,9 @@ impl<'a> DeclarationEmitter<'a> {
             .arena
             .has_modifier(&class.modifiers, SyntaxKind::ExportKeyword)
             || self.is_js_named_exported_name(class.name);
+        if self.should_defer_js_export_equals_dependency_class(class.name, &class.modifiers) {
+            return;
+        }
         if !is_exported
             && !self.should_emit_public_api_member(&class.modifiers)
             && !self.is_js_export_equals_name(class.name)

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -329,13 +329,20 @@ impl<'a> DeclarationEmitter<'a> {
                     continue;
                 }
                 let should_hoist = if stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
-                    self.arena.get_function(stmt_node).is_some_and(|func| {
-                        self.arena
-                            .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
-                            || self.get_identifier_text(func.name).is_some_and(|name| {
-                                js_hoistable_function_export_names.contains(&name)
-                            })
-                    })
+                    let is_exported_or_named_export =
+                        self.arena.get_function(stmt_node).is_some_and(|func| {
+                            self.arena
+                                .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
+                                || self.get_identifier_text(func.name).is_some_and(|name| {
+                                    js_hoistable_function_export_names.contains(&name)
+                                })
+                        });
+                    if is_exported_or_named_export {
+                        true
+                    } else {
+                        let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(stmt_node.pos);
+                        !Self::jsdoc_overload_signatures_from_chain(&jsdoc_chain).is_empty()
+                    }
                 } else if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
                     self.arena
                         .get_export_decl(stmt_node)

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -737,6 +737,8 @@ impl<'a> DeclarationEmitter<'a> {
             .current_statement_jsdoc_chain
             .iter()
             .any(|jsdoc| Self::jsdoc_contains_type_alias_tag(jsdoc));
+        let suppress_jsdoc_type_alias_comments =
+            has_jsdoc_type_alias && self.statement_emits_js_object_literal_namespace(stmt_idx);
         let has_jsdoc_type_function_signature = self
             .statement_jsdoc_type_function_signature_node(stmt_idx)
             .is_some();
@@ -745,7 +747,7 @@ impl<'a> DeclarationEmitter<'a> {
             self.writer.truncate(before_jsdoc_len);
             let mut filtered =
                 Self::jsdoc_chain_without_type_tags(&self.current_statement_jsdoc_chain);
-            if has_jsdoc_type_alias {
+            if suppress_jsdoc_type_alias_comments {
                 filtered.retain(|jsdoc| !Self::jsdoc_contains_type_alias_tag(jsdoc));
             }
             self.emit_jsdoc_comment_chain(&filtered);
@@ -888,6 +890,50 @@ impl<'a> DeclarationEmitter<'a> {
         }
         self.suppress_current_statement_jsdoc_comments = false;
         self.current_statement_jsdoc_chain.clear();
+    }
+
+    fn statement_emits_js_object_literal_namespace(&self, stmt_idx: NodeIndex) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return false;
+        };
+        if stmt_node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
+            return false;
+        }
+        let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
+            return false;
+        };
+
+        for &decl_list_idx in &var_stmt.declarations.nodes {
+            let Some(decl_list_node) = self.arena.get(decl_list_idx) else {
+                continue;
+            };
+            if decl_list_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+                continue;
+            }
+            let Some(decl_list) = self.arena.get_variable(decl_list_node) else {
+                continue;
+            };
+            if decl_list.declarations.nodes.len() != 1 {
+                continue;
+            }
+            let Some(&decl_idx) = decl_list.declarations.nodes.first() else {
+                continue;
+            };
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            if self.is_js_object_literal_namespace_candidate(decl.name, decl.initializer) {
+                return true;
+            }
+        }
+
+        false
     }
 
     fn emit_hoisted_js_function_statement(&mut self, stmt_idx: NodeIndex) {

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1145,7 +1145,8 @@ impl<'a> DeclarationEmitter<'a> {
                 let solver_undefined_or_any = effective_return_type_id
                     == tsz_solver::types::TypeId::ANY
                     || effective_return_type_id == tsz_solver::types::TypeId::UNDEFINED;
-                if solver_undefined_or_any
+                if (solver_undefined_or_any
+                    || effective_return_type_id == tsz_solver::types::TypeId::NEVER)
                     && func_body.is_some()
                     && self.body_returns_void(func_body)
                 {

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -629,6 +629,134 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
+    fn emit_jsdoc_overload_function_declarations(
+        &mut self,
+        func_idx: NodeIndex,
+        is_exported: bool,
+    ) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(func_node) = self.arena.get(func_idx) else {
+            return false;
+        };
+        let Some(func) = self.arena.get_function(func_node) else {
+            return false;
+        };
+
+        let overloads =
+            Self::jsdoc_overload_signatures_from_chain(&self.current_statement_jsdoc_chain);
+        if overloads.is_empty() {
+            return false;
+        }
+
+        for overload in overloads {
+            self.emit_jsdoc_overload_comment(&overload.comment);
+            self.write_indent();
+            if is_exported {
+                self.write("export ");
+            }
+            if self.should_emit_declare_keyword(is_exported) {
+                self.write("declare ");
+            }
+            self.write("function ");
+            self.emit_node(func.name);
+            self.emit_jsdoc_template_parameters(&overload.type_params);
+            self.write("(");
+            for (idx, param) in overload.params.iter().enumerate() {
+                if idx > 0 {
+                    self.write(", ");
+                }
+                if param.rest {
+                    self.write("...");
+                }
+                self.write(&param.name);
+                if param.optional && !param.rest {
+                    self.write("?");
+                }
+                self.write(": ");
+                self.write(&param.type_text);
+            }
+            self.write(")");
+            self.write(": ");
+            self.write(overload.return_type.as_deref().unwrap_or("any"));
+            self.write(";");
+            self.write_line();
+        }
+
+        true
+    }
+
+    fn statement_is_jsdoc_overload_signature(&self, stmt_idx: NodeIndex) -> bool {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return false;
+        };
+        if stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            return self
+                .arena
+                .get_function(stmt_node)
+                .is_some_and(|func| func.body.is_none());
+        }
+        if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+            return self
+                .arena
+                .get_export_decl(stmt_node)
+                .and_then(|export| self.arena.get(export.export_clause))
+                .and_then(|clause| self.arena.get_function(clause))
+                .is_some_and(|func| func.body.is_none());
+        }
+        false
+    }
+
+    fn source_text_has_export_function(&self, name_idx: NodeIndex) -> bool {
+        let Some(name) = self.get_identifier_text(name_idx) else {
+            return false;
+        };
+        let Some(text) = self.source_file_text.as_deref() else {
+            return false;
+        };
+        text.contains(&format!("export function {name}"))
+            || text.contains(&format!("export async function {name}"))
+    }
+
+    fn emit_jsdoc_overload_comment(&mut self, jsdoc: &str) {
+        self.write_indent();
+        self.write("/**");
+        self.write_line();
+        for line in jsdoc.trim().lines() {
+            self.write_indent();
+            if line.trim().is_empty() {
+                self.write(" *");
+            } else {
+                self.write(" * ");
+                self.write(line.trim());
+            }
+            self.write_line();
+        }
+        self.write_indent();
+        self.write(" */");
+        self.write_line();
+    }
+
+    fn mark_leading_comments_emitted_before(&mut self, pos: u32) {
+        let Some(text) = self.source_file_text.as_deref() else {
+            return;
+        };
+        let bytes = text.as_bytes();
+        let mut actual_start = pos as usize;
+        while actual_start < bytes.len()
+            && matches!(bytes[actual_start], b' ' | b'\t' | b'\r' | b'\n')
+        {
+            actual_start += 1;
+        }
+
+        while self.comment_emit_idx < self.all_comments.len()
+            && self.all_comments[self.comment_emit_idx].end as usize <= actual_start
+        {
+            self.comment_emit_idx += 1;
+        }
+    }
+
     fn prune_unused_named_import_specifiers_from_output(output: &str) -> String {
         let lines = output.lines().collect::<Vec<_>>();
         let mut changed = false;
@@ -807,7 +935,22 @@ impl<'a> DeclarationEmitter<'a> {
         let has_jsdoc_type_function_signature = self
             .statement_jsdoc_type_function_signature_node(stmt_idx)
             .is_some();
-        if has_jsdoc_type_function_signature || has_jsdoc_type_alias {
+        let has_jsdoc_overload_tags = self.source_is_js_file
+            && self
+                .current_statement_jsdoc_chain
+                .iter()
+                .any(|jsdoc| Self::jsdoc_has_overload_tag(jsdoc));
+        if has_jsdoc_overload_tags {
+            // JS @overload tags emit one declaration per overload.  Do not bulk
+            // emit the whole leading comment chain before a single signature.
+            if self.statement_is_jsdoc_overload_signature(stmt_idx) {
+                for jsdoc in self.current_statement_jsdoc_chain.clone() {
+                    if Self::jsdoc_has_overload_tag(&jsdoc) {
+                        self.emit_jsdoc_overload_comment(&jsdoc);
+                    }
+                }
+            }
+        } else if has_jsdoc_type_function_signature || has_jsdoc_type_alias {
             self.emit_leading_jsdoc_comments(stmt_node.pos);
             self.writer.truncate(before_jsdoc_len);
             let mut filtered =
@@ -1009,10 +1152,47 @@ impl<'a> DeclarationEmitter<'a> {
         self.current_statement_jsdoc_chain =
             self.leading_jsdoc_comment_chain_for_pos(stmt_node.pos);
         let jsdoc_chain = self.current_statement_jsdoc_chain.clone();
+        let hoisted_func_idx = if stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            Some(stmt_idx)
+        } else if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+            self.arena
+                .get_export_decl(stmt_node)
+                .and_then(|export| self.arena.get(export.export_clause))
+                .and_then(|clause| {
+                    (clause.kind == syntax_kind_ext::FUNCTION_DECLARATION)
+                        .then_some(self.arena.get_export_decl(stmt_node)?.export_clause)
+                })
+        } else {
+            None
+        };
+        if let Some(func_idx) = hoisted_func_idx
+            && !Self::jsdoc_overload_signatures_from_chain(&jsdoc_chain).is_empty()
+        {
+            let is_exported = self
+                .arena
+                .get(func_idx)
+                .and_then(|func_node| self.arena.get_function(func_node))
+                .is_some_and(|func| {
+                    self.arena
+                        .has_modifier(&func.modifiers, SyntaxKind::ExportKeyword)
+                        || self.is_js_named_exported_name(func.name)
+                        || self.source_text_has_export_function(func.name)
+                })
+                || self.statement_has_effective_export(stmt_idx);
+            self.emit_jsdoc_overload_function_declarations(func_idx, is_exported);
+            self.emitted_module_indicator = true;
+            self.current_statement_jsdoc_chain.clear();
+            return;
+        }
         let has_jsdoc_type_function_signature = self
             .statement_jsdoc_type_function_signature_node(stmt_idx)
             .is_some();
-        if has_jsdoc_type_function_signature {
+        let has_jsdoc_overload_tags = jsdoc_chain
+            .iter()
+            .any(|jsdoc| Self::jsdoc_has_overload_tag(jsdoc));
+        if has_jsdoc_overload_tags {
+            self.emit_jsdoc_comment_chain(&jsdoc_chain);
+        } else if has_jsdoc_type_function_signature {
             let filtered = Self::jsdoc_chain_without_type_tags(&jsdoc_chain);
             self.emit_jsdoc_comment_chain(&filtered);
         } else if jsdoc_chain.len() == 1
@@ -1131,6 +1311,29 @@ impl<'a> DeclarationEmitter<'a> {
                 self.skip_comments_in_node(func_node.pos, func_node.end);
                 return;
             }
+        }
+
+        if self.emit_jsdoc_overload_function_declarations(func_idx, is_exported) {
+            if should_emit_late_bound_namespace {
+                self.emit_ts_late_bound_function_namespace_from_members(
+                    func.name,
+                    is_exported,
+                    &late_bound_members,
+                );
+            }
+            if !self.emit_js_function_like_class_if_needed(
+                func.name,
+                &func.parameters,
+                func.body,
+                is_exported,
+                func_idx,
+            ) {
+                self.emit_js_synthetic_prototype_class_if_needed(func.name, is_exported);
+            }
+            self.emit_js_namespace_export_aliases_for_name(func.name, is_exported);
+            self.mark_leading_comments_emitted_before(func_node.pos);
+            self.skip_comments_in_node(func_node.pos, func_node.end);
+            return;
         }
 
         self.emit_pending_js_export_equals_for_name(func.name);

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -733,13 +733,21 @@ impl<'a> DeclarationEmitter<'a> {
         let saved_comment_idx = self.comment_emit_idx;
         self.current_statement_jsdoc_chain =
             self.emittable_jsdoc_comment_chain_for_pos(stmt_node.pos);
+        let has_jsdoc_type_alias = self
+            .current_statement_jsdoc_chain
+            .iter()
+            .any(|jsdoc| Self::jsdoc_contains_type_alias_tag(jsdoc));
         let has_jsdoc_type_function_signature = self
             .statement_jsdoc_type_function_signature_node(stmt_idx)
             .is_some();
-        if has_jsdoc_type_function_signature {
+        if has_jsdoc_type_function_signature || has_jsdoc_type_alias {
             self.emit_leading_jsdoc_comments(stmt_node.pos);
             self.writer.truncate(before_jsdoc_len);
-            let filtered = Self::jsdoc_chain_without_type_tags(&self.current_statement_jsdoc_chain);
+            let mut filtered =
+                Self::jsdoc_chain_without_type_tags(&self.current_statement_jsdoc_chain);
+            if has_jsdoc_type_alias {
+                filtered.retain(|jsdoc| !Self::jsdoc_contains_type_alias_tag(jsdoc));
+            }
             self.emit_jsdoc_comment_chain(&filtered);
         } else {
             self.emit_leading_jsdoc_comments(stmt_node.pos);

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -252,7 +252,8 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(return_type_id) =
                     type_queries::get_return_type(*interner, method_type_id)
             {
-                if return_type_id == tsz_solver::types::TypeId::ANY
+                if (return_type_id == tsz_solver::types::TypeId::ANY
+                    || return_type_id == tsz_solver::types::TypeId::NEVER)
                     && method_body.is_some()
                     && self.body_returns_void(method_body)
                 {
@@ -274,7 +275,8 @@ impl<'a> DeclarationEmitter<'a> {
                     self.write(&self.print_type_id(return_type_id));
                 }
             } else if let Some(method_type_id) = method_type_id {
-                if method_type_id == tsz_solver::types::TypeId::ANY
+                if (method_type_id == tsz_solver::types::TypeId::ANY
+                    || method_type_id == tsz_solver::types::TypeId::NEVER)
                     && method_body.is_some()
                     && self.body_returns_void(method_body)
                 {
@@ -354,7 +356,8 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(return_type_id) =
                     type_queries::get_return_type(*interner, method_type_id)
             {
-                if return_type_id == tsz_solver::types::TypeId::ANY
+                if (return_type_id == tsz_solver::types::TypeId::ANY
+                    || return_type_id == tsz_solver::types::TypeId::NEVER)
                     && method_body.is_some()
                     && self.body_returns_void(method_body)
                 {
@@ -369,7 +372,8 @@ impl<'a> DeclarationEmitter<'a> {
                     self.write_type_text_with_current_indent(&type_text);
                 }
             } else if let Some(method_type_id) = method_type_id {
-                if method_type_id == tsz_solver::types::TypeId::ANY
+                if (method_type_id == tsz_solver::types::TypeId::ANY
+                    || method_type_id == tsz_solver::types::TypeId::NEVER)
                     && method_body.is_some()
                     && self.body_returns_void(method_body)
                 {

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -993,6 +993,11 @@ impl<'a> DeclarationEmitter<'a> {
             self.emit_setter_parameters_with_type_text(&accessor.parameters, &type_text);
         } else if !is_getter
             && !is_private
+            && let Some(type_text) = self.js_setter_param_declared_type_text(&accessor.parameters)
+        {
+            self.emit_setter_parameters_with_type_text(&accessor.parameters, &type_text);
+        } else if !is_getter
+            && !is_private
             && let Some(type_text) =
                 self.paired_getter_type_predicate_text(accessor_idx, &accessor.parameters)
         {
@@ -1015,6 +1020,9 @@ impl<'a> DeclarationEmitter<'a> {
             self.emit_type(accessor.type_annotation);
         } else if is_getter && !is_private {
             if let Some(type_text) = self.jsdoc_return_type_text_for_node(accessor_idx) {
+                self.write(": ");
+                self.write(&type_text);
+            } else if let Some(type_text) = self.jsdoc_type_text_for_node(accessor_idx) {
                 self.write(": ");
                 self.write(&type_text);
             } else if let Some(type_text) = self.matching_setter_parameter_type_text(accessor_idx) {
@@ -1482,6 +1490,23 @@ impl<'a> DeclarationEmitter<'a> {
             self.write(": ");
             self.write(type_text);
         }
+    }
+
+    fn js_setter_param_declared_type_text(
+        &self,
+        params: &tsz_parser::parser::NodeList,
+    ) -> Option<String> {
+        if !self.source_is_js_file {
+            return None;
+        }
+
+        let param_idx = *params.nodes.first()?;
+        let decl = self.jsdoc_param_decl_for_parameter(param_idx, 0)?;
+        let mut type_text = decl.type_text;
+        if decl.optional && !Self::type_text_has_undefined_branch(&type_text) {
+            type_text.push_str(" | undefined");
+        }
+        Some(type_text)
     }
 
     pub(in crate::declaration_emitter) fn emit_index_signature(&mut self, sig_idx: NodeIndex) {

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -686,6 +686,10 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         };
 
+        if self.emit_jsdoc_overload_constructor_declarations(ctor_idx) {
+            return;
+        }
+
         // Check if this is an overload (no body) or implementation (has body)
         let is_overload = ctor.body.is_none();
         let is_implementation = !is_overload;
@@ -764,6 +768,96 @@ impl<'a> DeclarationEmitter<'a> {
         if let Some(body_node) = self.arena.get(ctor_body) {
             self.skip_comments_in_node(body_node.pos, body_node.end);
         }
+    }
+
+    pub(in crate::declaration_emitter) fn class_has_jsdoc_overload_constructor(
+        &self,
+        members: &NodeList,
+    ) -> bool {
+        self.source_is_js_file
+            && members
+                .nodes
+                .iter()
+                .copied()
+                .any(|member_idx| self.member_is_jsdoc_overload_constructor(member_idx))
+    }
+
+    pub(in crate::declaration_emitter) fn member_is_jsdoc_overload_constructor(
+        &self,
+        member_idx: NodeIndex,
+    ) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(member_node) = self.arena.get(member_idx) else {
+            return false;
+        };
+        if member_node.kind != syntax_kind_ext::CONSTRUCTOR {
+            return false;
+        }
+
+        self.leading_jsdoc_comment_chain_for_pos(member_node.pos)
+            .iter()
+            .any(|jsdoc| Self::jsdoc_has_overload_tag(jsdoc))
+    }
+
+    fn emit_jsdoc_overload_constructor_declarations(&mut self, ctor_idx: NodeIndex) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(ctor_node) = self.arena.get(ctor_idx) else {
+            return false;
+        };
+        let Some(ctor) = self.arena.get_constructor(ctor_node) else {
+            return false;
+        };
+
+        let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(ctor_node.pos);
+        let overloads = Self::jsdoc_overload_signatures_from_chain(&jsdoc_chain);
+        if overloads.is_empty() {
+            return false;
+        }
+
+        self.class_has_constructor_overloads = true;
+        for overload in overloads {
+            self.emit_jsdoc_overload_comment(&overload.comment);
+            self.write_indent();
+
+            if let Some(ref mods) = ctor.modifiers {
+                for &mod_idx in &mods.nodes {
+                    if let Some(mod_node) = self.arena.get(mod_idx) {
+                        match mod_node.kind {
+                            k if k == SyntaxKind::PrivateKeyword as u16 => self.write("private "),
+                            k if k == SyntaxKind::ProtectedKeyword as u16 => {
+                                self.write("protected ");
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            self.write("constructor(");
+            for (idx, param) in overload.params.iter().enumerate() {
+                if idx > 0 {
+                    self.write(", ");
+                }
+                if param.rest {
+                    self.write("...");
+                }
+                self.write(&param.name);
+                if param.optional && !param.rest {
+                    self.write("?");
+                }
+                self.write(": ");
+                self.write(&param.type_text);
+            }
+            self.write(");");
+            self.write_line();
+        }
+
+        self.skip_comments_in_node(ctor_node.pos, ctor_node.end);
+        true
     }
 
     pub(in crate::declaration_emitter) fn emit_js_array_subclass_constructor_overloads_if_needed(

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -24,6 +24,10 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         }
 
+        if self.emit_jsdoc_overload_method_declarations(method_idx, method) {
+            return;
+        }
+
         // Get method name as string for overload tracking
         let method_name = self.get_function_name(method_idx);
 
@@ -768,6 +772,89 @@ impl<'a> DeclarationEmitter<'a> {
         if let Some(body_node) = self.arena.get(ctor_body) {
             self.skip_comments_in_node(body_node.pos, body_node.end);
         }
+    }
+
+    pub(in crate::declaration_emitter) fn member_is_jsdoc_overload_method(
+        &self,
+        member_idx: NodeIndex,
+    ) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(member_node) = self.arena.get(member_idx) else {
+            return false;
+        };
+        if member_node.kind != syntax_kind_ext::METHOD_DECLARATION {
+            return false;
+        }
+
+        self.leading_jsdoc_comment_chain_for_pos(member_node.pos)
+            .iter()
+            .any(|jsdoc| Self::jsdoc_has_overload_tag(jsdoc))
+    }
+
+    pub(in crate::declaration_emitter) fn member_is_jsdoc_overload_signature(
+        &self,
+        member_idx: NodeIndex,
+    ) -> bool {
+        self.member_is_jsdoc_overload_constructor(member_idx)
+            || self.member_is_jsdoc_overload_method(member_idx)
+    }
+
+    fn emit_jsdoc_overload_method_declarations(
+        &mut self,
+        method_idx: NodeIndex,
+        method: &MethodDeclData,
+    ) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(method_node) = self.arena.get(method_idx) else {
+            return false;
+        };
+
+        let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(method_node.pos);
+        let overloads = Self::jsdoc_overload_signatures_from_chain(&jsdoc_chain);
+        if overloads.is_empty() {
+            return false;
+        }
+
+        if let Some(method_name) = self.get_function_name(method_idx) {
+            self.method_names_with_overloads.insert(method_name);
+        }
+
+        for overload in overloads {
+            self.emit_jsdoc_overload_comment(&overload.comment);
+            self.write_indent();
+            self.emit_member_modifiers(&method.modifiers);
+            self.emit_node(method.name);
+            if method.question_token {
+                self.write("?");
+            }
+            self.emit_jsdoc_template_parameters(&overload.type_params);
+            self.write("(");
+            for (idx, param) in overload.params.iter().enumerate() {
+                if idx > 0 {
+                    self.write(", ");
+                }
+                if param.rest {
+                    self.write("...");
+                }
+                self.write(&param.name);
+                if param.optional && !param.rest {
+                    self.write("?");
+                }
+                self.write(": ");
+                self.write(&param.type_text);
+            }
+            self.write("): ");
+            self.write(overload.return_type.as_deref().unwrap_or("any"));
+            self.write(";");
+            self.write_line();
+        }
+
+        self.skip_comments_in_node(method_node.pos, method_node.end);
+        true
     }
 
     pub(in crate::declaration_emitter) fn class_has_jsdoc_overload_constructor(

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -1415,7 +1415,13 @@ impl<'a> DeclarationEmitter<'a> {
         self.method_names_with_overloads = FxHashSet::default();
 
         self.emit_parameter_properties(&class.members);
-        if self.class_has_private_identifier_member(&class.members) {
+        let mut emitted_deferred_private_marker = false;
+        let emit_private_marker_after_jsdoc_constructor = self
+            .class_has_private_identifier_member(&class.members)
+            && self.class_has_jsdoc_overload_constructor(&class.members);
+        if self.class_has_private_identifier_member(&class.members)
+            && !emit_private_marker_after_jsdoc_constructor
+        {
             self.write_indent();
             self.write("#private;");
             self.write_line();
@@ -1429,7 +1435,9 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                self.emit_leading_jsdoc_comments(member_node.pos);
+                if !self.member_is_jsdoc_overload_constructor(member_idx) {
+                    self.emit_leading_jsdoc_comments(member_node.pos);
+                }
             }
             let before_member_len = self.writer.len();
             self.emit_class_member(member_idx);
@@ -1439,6 +1447,18 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(member_node) = self.arena.get(member_idx) {
                     self.skip_comments_in_node(member_node.pos, member_node.end);
                 }
+            }
+            if emit_private_marker_after_jsdoc_constructor
+                && !emitted_deferred_private_marker
+                && self
+                    .arena
+                    .get(member_idx)
+                    .is_some_and(|member_node| member_node.kind == syntax_kind_ext::CONSTRUCTOR)
+            {
+                self.write_indent();
+                self.write("#private;");
+                self.write_line();
+                emitted_deferred_private_marker = true;
             }
         }
         self.emit_js_inferred_constructor_assignment_properties(&class.members);
@@ -1510,7 +1530,13 @@ impl<'a> DeclarationEmitter<'a> {
         self.method_names_with_overloads = FxHashSet::default();
 
         self.emit_parameter_properties(&class.members);
-        if self.class_has_private_identifier_member(&class.members) {
+        let mut emitted_deferred_private_marker = false;
+        let emit_private_marker_after_jsdoc_constructor = self
+            .class_has_private_identifier_member(&class.members)
+            && self.class_has_jsdoc_overload_constructor(&class.members);
+        if self.class_has_private_identifier_member(&class.members)
+            && !emit_private_marker_after_jsdoc_constructor
+        {
             self.write_indent();
             self.write("#private;");
             self.write_line();
@@ -1524,7 +1550,9 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                self.emit_leading_jsdoc_comments(member_node.pos);
+                if !self.member_is_jsdoc_overload_constructor(member_idx) {
+                    self.emit_leading_jsdoc_comments(member_node.pos);
+                }
             }
             let before_member_len = self.writer.len();
             self.emit_class_member(member_idx);
@@ -1534,6 +1562,18 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(member_node) = self.arena.get(member_idx) {
                     self.skip_comments_in_node(member_node.pos, member_node.end);
                 }
+            }
+            if emit_private_marker_after_jsdoc_constructor
+                && !emitted_deferred_private_marker
+                && self
+                    .arena
+                    .get(member_idx)
+                    .is_some_and(|member_node| member_node.kind == syntax_kind_ext::CONSTRUCTOR)
+            {
+                self.write_indent();
+                self.write("#private;");
+                self.write_line();
+                emitted_deferred_private_marker = true;
             }
         }
         self.emit_js_inferred_constructor_assignment_properties(&class.members);
@@ -2367,6 +2407,10 @@ impl<'a> DeclarationEmitter<'a> {
         members: &NodeList,
     ) {
         let mut emitted_js_constructor_assignment_properties = false;
+        let mut emitted_deferred_private_marker = false;
+        let emit_private_marker_after_jsdoc_constructor = self
+            .class_has_private_identifier_member(members)
+            && self.class_has_jsdoc_overload_constructor(members);
         let member_order = self.class_member_emit_order(members);
         let uses_reordered_js_member_comments =
             self.source_is_js_file && member_order != members.nodes;
@@ -2374,7 +2418,11 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                if uses_reordered_js_member_comments {
+                if self.member_is_jsdoc_overload_constructor(member_idx) {
+                    // The constructor overload path emits one comment per overload
+                    // signature; emitting the whole chain here would attach the
+                    // implementation comment to the reconstructed signature.
+                } else if uses_reordered_js_member_comments {
                     let jsdoc_chain =
                         self.leading_jsdoc_comment_chain_for_pos_with_style(member_node.pos);
                     self.emit_jsdoc_comment_chain_preserving_multiline_style(&jsdoc_chain);
@@ -2394,6 +2442,18 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(member_node) = self.arena.get(member_idx)
             {
                 self.skip_comments_in_node(member_node.pos, member_node.end);
+            }
+            if emit_private_marker_after_jsdoc_constructor
+                && !emitted_deferred_private_marker
+                && self
+                    .arena
+                    .get(member_idx)
+                    .is_some_and(|member_node| member_node.kind == syntax_kind_ext::CONSTRUCTOR)
+            {
+                self.write_indent();
+                self.write("#private;");
+                self.write_line();
+                emitted_deferred_private_marker = true;
             }
             if !emitted_js_constructor_assignment_properties
                 && self.source_is_js_file

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -3072,6 +3072,62 @@ impl<'a> DeclarationEmitter<'a> {
         bindings
     }
 
+    fn collect_flattened_binding_type_texts_from_annotation(
+        &mut self,
+        pattern_idx: NodeIndex,
+        type_annotation: NodeIndex,
+    ) -> Vec<(NodeIndex, String)> {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return Vec::new();
+        };
+        if pattern_node.kind != syntax_kind_ext::ARRAY_BINDING_PATTERN {
+            return Vec::new();
+        }
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return Vec::new();
+        };
+        let pattern_elements = pattern.elements.nodes.clone();
+
+        let Some(type_node) = self.arena.get(type_annotation) else {
+            return Vec::new();
+        };
+        let Some(tuple) = self.arena.get_tuple_type(type_node) else {
+            return Vec::new();
+        };
+        let tuple_elements = tuple.elements.nodes.clone();
+
+        let mut type_texts = Vec::new();
+        let mut tuple_index = 0usize;
+        for element_idx in pattern_elements {
+            let Some(element_node) = self.arena.get(element_idx) else {
+                continue;
+            };
+            if element_node.kind == syntax_kind_ext::OMITTED_EXPRESSION {
+                tuple_index += 1;
+                continue;
+            }
+            if element_node.kind != syntax_kind_ext::BINDING_ELEMENT {
+                continue;
+            }
+            let Some(element) = self.arena.get_binding_element(element_node) else {
+                continue;
+            };
+            let Some(name_node) = self.arena.get(element.name) else {
+                continue;
+            };
+            if name_node.kind == SyntaxKind::Identifier as u16
+                && let Some(&tuple_element_idx) = tuple_elements.get(tuple_index)
+                && let Some(type_text) = self.type_node_text(tuple_element_idx)
+            {
+                type_texts.push((element.name, type_text));
+            }
+            if !element.dot_dot_dot_token {
+                tuple_index += 1;
+            }
+        }
+        type_texts
+    }
+
     pub(in crate::declaration_emitter) fn emit_flattened_binding_type_annotation(
         &mut self,
         ident_idx: NodeIndex,
@@ -3115,6 +3171,8 @@ impl<'a> DeclarationEmitter<'a> {
                 &[decl_idx, decl.name, decl.initializer],
             ),
         );
+        let annotation_type_texts = self
+            .collect_flattened_binding_type_texts_from_annotation(decl.name, decl.type_annotation);
         if bindings.is_empty() {
             return;
         }
@@ -3143,7 +3201,15 @@ impl<'a> DeclarationEmitter<'a> {
                 self.emit_leading_jsdoc_comments(node.pos);
             }
             self.emit_node(ident_idx);
-            self.emit_flattened_binding_type_annotation(ident_idx, type_id);
+            if let Some(type_text) = annotation_type_texts
+                .iter()
+                .find_map(|(idx, text)| (*idx == ident_idx).then(|| text.clone()))
+            {
+                self.write(": ");
+                self.write(&type_text);
+            } else {
+                self.emit_flattened_binding_type_annotation(ident_idx, type_id);
+            }
         }
         self.write(";");
         self.write_line();

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -381,11 +381,10 @@ impl<'a> DeclarationEmitter<'a> {
         true
     }
 
-    pub(in crate::declaration_emitter) fn emit_js_object_literal_namespace_if_possible(
-        &mut self,
+    pub(in crate::declaration_emitter) fn is_js_object_literal_namespace_candidate(
+        &self,
         decl_name: NodeIndex,
         initializer: NodeIndex,
-        is_exported: bool,
     ) -> bool {
         if !self.source_is_js_file || !initializer.is_some() {
             return false;
@@ -444,6 +443,25 @@ impl<'a> DeclarationEmitter<'a> {
                 _ => return false,
             }
         }
+
+        true
+    }
+
+    pub(in crate::declaration_emitter) fn emit_js_object_literal_namespace_if_possible(
+        &mut self,
+        decl_name: NodeIndex,
+        initializer: NodeIndex,
+        is_exported: bool,
+    ) -> bool {
+        if !self.is_js_object_literal_namespace_candidate(decl_name, initializer) {
+            return false;
+        }
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        let Some(object) = self.arena.get_literal_expr(init_node) else {
+            return false;
+        };
 
         self.write_indent();
         if is_exported {

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -2357,9 +2357,8 @@ impl<'a> DeclarationEmitter<'a> {
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
                 if uses_reordered_js_member_comments {
-                    for jsdoc in self.leading_jsdoc_comment_chain_for_pos(member_node.pos) {
-                        self.emit_multiline_jsdoc_comment(&jsdoc);
-                    }
+                    let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(member_node.pos);
+                    self.emit_jsdoc_comment_chain(&jsdoc_chain);
                 } else {
                     self.emit_leading_jsdoc_comments(member_node.pos);
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -983,6 +983,16 @@ impl<'a> DeclarationEmitter<'a> {
         initializer: NodeIndex,
         is_exported: bool,
     ) {
+        if is_exported {
+            let object_initializer = self
+                .get_identifier_text(initializer)
+                .and_then(|local_name| self.js_top_level_variable_initializer(&local_name))
+                .unwrap_or(initializer);
+            if self.emit_js_object_literal_namespace(name_idx, object_initializer, true, false) {
+                return;
+            }
+        }
+
         if self.emit_js_synthetic_class_expression_declaration(name_idx, initializer, is_exported) {
             return;
         }
@@ -2547,6 +2557,11 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::FalseKeyword as u16 => Some("boolean".to_string()),
             k if k == SyntaxKind::NullKeyword as u16 => Some("null".to_string()),
             k if k == SyntaxKind::UndefinedKeyword as u16 => Some("undefined".to_string()),
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                && self.js_empty_object_literal_initializer(initializer) =>
+            {
+                Some("{}".to_string())
+            }
             k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
                 self.infer_fallback_type_text(initializer)
             }

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -2375,8 +2375,9 @@ impl<'a> DeclarationEmitter<'a> {
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
                 if uses_reordered_js_member_comments {
-                    let jsdoc_chain = self.leading_jsdoc_comment_chain_for_pos(member_node.pos);
-                    self.emit_jsdoc_comment_chain(&jsdoc_chain);
+                    let jsdoc_chain =
+                        self.leading_jsdoc_comment_chain_for_pos_with_style(member_node.pos);
+                    self.emit_jsdoc_comment_chain_preserving_multiline_style(&jsdoc_chain);
                 } else {
                     self.emit_leading_jsdoc_comments(member_node.pos);
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -1429,7 +1429,7 @@ impl<'a> DeclarationEmitter<'a> {
         // collector) and would be emitted a second time when the statement
         // visitor reaches it. Remove those stmt indices from the deferred
         // maps before emitting here, so the statement visitor skips them.
-        for (stmt_idx, _) in
+        for (stmt_idx, _, _) in
             self.js_module_exports_secondary_member_stmt_assignments(root_initializer)
         {
             self.js_deferred_value_export_statements.remove(&stmt_idx);
@@ -1486,7 +1486,7 @@ impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn js_module_exports_secondary_member_stmt_assignments(
         &self,
         root_initializer: NodeIndex,
-    ) -> Vec<(NodeIndex, NodeIndex)> {
+    ) -> Vec<(NodeIndex, NodeIndex, NodeIndex)> {
         let Some(source_file_idx) = self.current_source_file_idx else {
             return Vec::new();
         };
@@ -1533,9 +1533,9 @@ impl<'a> DeclarationEmitter<'a> {
                 if !self.is_module_exports_reference(receiver) {
                     return None;
                 }
-                let (name_idx, _) =
+                let (name_idx, initializer) =
                     self.js_commonjs_named_export_for_statement_with_options(stmt_idx, true)?;
-                Some((stmt_idx, name_idx))
+                Some((stmt_idx, name_idx, initializer))
             })
             .collect()
     }
@@ -1600,14 +1600,22 @@ impl<'a> DeclarationEmitter<'a> {
         &mut self,
         root_initializer: NodeIndex,
     ) {
-        let secondary_classes: Vec<_> = self
-            .js_module_exports_secondary_member_assignments(root_initializer)
+        let secondary_class_stmts: Vec<_> = self
+            .js_module_exports_secondary_member_stmt_assignments(root_initializer)
             .into_iter()
-            .filter(|(_, initializer)| {
+            .filter(|(_, _, initializer)| {
                 self.arena
                     .get(*initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::CLASS_EXPRESSION)
             })
+            .collect();
+        for (stmt_idx, _, _) in &secondary_class_stmts {
+            self.js_deferred_value_export_statements.remove(stmt_idx);
+            self.js_deferred_function_export_statements.remove(stmt_idx);
+        }
+        let secondary_classes: Vec<_> = secondary_class_stmts
+            .into_iter()
+            .map(|(_, name_idx, initializer)| (name_idx, initializer))
             .collect();
         if secondary_classes.is_empty() {
             return;

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -781,6 +781,256 @@ impl<'a> DeclarationEmitter<'a> {
         true
     }
 
+    pub(in crate::declaration_emitter) fn js_commonjs_export_assignment_closure(
+        &self,
+        source_file: &tsz_parser::parser::node::SourceFileData,
+    ) -> Option<(NodeIndex, NodeIndex, Vec<(NodeIndex, NodeIndex, NodeIndex)>)> {
+        if !self.source_file_is_js(source_file) {
+            return None;
+        }
+
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                continue;
+            }
+            let Some(func) = self.arena.get_function(stmt_node) else {
+                continue;
+            };
+            let Some(block_node) = self.arena.get(func.body) else {
+                continue;
+            };
+            let Some(block) = self.arena.get_block(block_node) else {
+                continue;
+            };
+            let Some(root_initializer) =
+                block
+                    .statements
+                    .nodes
+                    .iter()
+                    .copied()
+                    .find_map(|inner_stmt_idx| {
+                        self.js_module_exports_exports_assignment_initializer(inner_stmt_idx)
+                    })
+            else {
+                continue;
+            };
+
+            let mut secondary_members = Vec::new();
+            for &inner_stmt_idx in &block.statements.nodes {
+                let Some((export_name_idx, local_name_idx, local_initializer)) =
+                    self.js_exports_closure_secondary_member(inner_stmt_idx, &block.statements)
+                else {
+                    continue;
+                };
+                secondary_members.push((export_name_idx, local_name_idx, local_initializer));
+            }
+
+            return Some((stmt_idx, root_initializer, secondary_members));
+        }
+        None
+    }
+
+    fn js_module_exports_exports_assignment_initializer(
+        &self,
+        stmt_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let stmt_node = self.arena.get(stmt_idx)?;
+        if stmt_node.kind != syntax_kind_ext::EXPRESSION_STATEMENT {
+            return None;
+        }
+        let expr_stmt = self.arena.get_expression_statement(stmt_node)?;
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_stmt.expression);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return None;
+        }
+        let binary = self.arena.get_binary_expr(expr_node)?;
+        if binary.operator_token != SyntaxKind::EqualsToken as u16
+            || !self.is_module_exports_reference(binary.left)
+        {
+            return None;
+        }
+
+        let rhs = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.right);
+        let rhs_node = self.arena.get(rhs)?;
+        if rhs_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return None;
+        }
+        let rhs_binary = self.arena.get_binary_expr(rhs_node)?;
+        if rhs_binary.operator_token != SyntaxKind::EqualsToken as u16
+            || !self.is_exports_identifier_reference(rhs_binary.left)
+        {
+            return None;
+        }
+        let initializer = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(rhs_binary.right);
+        if self.is_js_function_initializer(initializer) {
+            Some(initializer)
+        } else {
+            None
+        }
+    }
+
+    fn js_exports_closure_secondary_member(
+        &self,
+        stmt_idx: NodeIndex,
+        statements: &NodeList,
+    ) -> Option<(NodeIndex, NodeIndex, NodeIndex)> {
+        let (export_name_idx, initializer) =
+            self.js_commonjs_named_export_for_statement_with_options(stmt_idx, false)?;
+        let local_name = self.get_identifier_text(initializer)?;
+        let (local_name_idx, local_initializer) =
+            self.js_closure_local_function_initializer(statements, &local_name)?;
+        Some((export_name_idx, local_name_idx, local_initializer))
+    }
+
+    fn js_closure_local_function_initializer(
+        &self,
+        statements: &NodeList,
+        name: &str,
+    ) -> Option<(NodeIndex, NodeIndex)> {
+        for &stmt_idx in &statements.nodes {
+            let stmt_node = self.arena.get(stmt_idx)?;
+            if stmt_node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
+                continue;
+            }
+            let var_stmt = self.arena.get_variable(stmt_node)?;
+            for &decl_list_idx in &var_stmt.declarations.nodes {
+                let decl_list_node = self.arena.get(decl_list_idx)?;
+                let decl_list = self.arena.get_variable(decl_list_node)?;
+                for &decl_idx in &decl_list.declarations.nodes {
+                    let decl_node = self.arena.get(decl_idx)?;
+                    let decl = self.arena.get_variable_declaration(decl_node)?;
+                    if self.get_identifier_text(decl.name).as_deref() == Some(name)
+                        && self.is_js_function_initializer(decl.initializer)
+                    {
+                        return Some((decl.name, decl.initializer));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub(in crate::declaration_emitter) fn emit_js_commonjs_closure_export_assignment(
+        &mut self,
+        root_initializer: NodeIndex,
+        secondary_members: &[(NodeIndex, NodeIndex, NodeIndex)],
+    ) {
+        let export_name = if self.reserved_names.contains("_exports") {
+            self.generate_unique_name("_exports")
+        } else {
+            "_exports".to_string()
+        };
+        self.reserved_names.insert(export_name.clone());
+
+        self.emit_js_commonjs_closure_export_function(root_initializer, &export_name);
+        if !secondary_members.is_empty() {
+            self.write_indent();
+            self.write("declare namespace ");
+            self.write(&export_name);
+            self.write(" {");
+            self.write_line();
+            self.increase_indent();
+            self.write_indent();
+            self.write("export { ");
+            for (idx, (export_name_idx, local_name_idx, _)) in secondary_members.iter().enumerate()
+            {
+                if idx > 0 {
+                    self.write(", ");
+                }
+                self.emit_node(*local_name_idx);
+                self.write(" as ");
+                self.emit_node(*export_name_idx);
+            }
+            self.write(" };");
+            self.write_line();
+            self.decrease_indent();
+            self.write_indent();
+            self.write("}");
+            self.write_line();
+        }
+
+        self.write_indent();
+        self.write("export = ");
+        self.write(&export_name);
+        self.write(";");
+        self.write_line();
+
+        for (_, local_name_idx, local_initializer) in secondary_members {
+            self.emit_js_synthetic_function_declaration(*local_name_idx, *local_initializer, false);
+        }
+        self.emitted_scope_marker = true;
+        self.emitted_module_indicator = true;
+    }
+
+    fn emit_js_commonjs_closure_export_function(
+        &mut self,
+        initializer: NodeIndex,
+        export_name: &str,
+    ) {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return;
+        };
+        let Some(func) = self.arena.get_function(init_node) else {
+            return;
+        };
+
+        let jsdoc = self.function_like_jsdoc_for_node(initializer);
+        self.write_indent();
+        self.write("declare function ");
+        self.write(export_name);
+        self.write("(");
+        let saved_comment_idx = self.comment_emit_idx;
+        self.comment_emit_idx = self
+            .all_comments
+            .iter()
+            .position(|comment| comment.end > init_node.pos)
+            .unwrap_or(self.all_comments.len());
+        self.emit_parameters_with_body(&func.parameters, func.body);
+        self.comment_emit_idx = saved_comment_idx;
+        self.write(")");
+
+        if func.type_annotation.is_some() {
+            self.write(": ");
+            self.emit_type(func.type_annotation);
+        } else if let Some(return_type_text) = jsdoc
+            .as_deref()
+            .and_then(Self::parse_jsdoc_return_type_text)
+        {
+            self.write(": ");
+            self.write(&return_type_text);
+        } else if let (Some(return_type_text), true) =
+            self.function_body_return_hint(func, func.body)
+        {
+            self.write(": ");
+            self.write(&return_type_text);
+        } else if let Some(return_type_text) = self
+            .js_function_body_preferred_return_text_for_declaration(
+                func.body,
+                initializer,
+                &func.parameters,
+            )
+        {
+            self.write(": ");
+            self.write(&return_type_text);
+        } else if func.body.is_some() && self.body_returns_void(func.body) {
+            self.write(": void");
+        } else {
+            self.write(": any");
+        }
+        self.write(";");
+        self.write_line();
+    }
+
     pub(in crate::declaration_emitter) fn emit_js_synthetic_function_declaration(
         &mut self,
         name_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -1435,7 +1435,7 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                if !self.member_is_jsdoc_overload_constructor(member_idx) {
+                if !self.member_is_jsdoc_overload_signature(member_idx) {
                     self.emit_leading_jsdoc_comments(member_node.pos);
                 }
             }
@@ -1550,7 +1550,7 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                if !self.member_is_jsdoc_overload_constructor(member_idx) {
+                if !self.member_is_jsdoc_overload_signature(member_idx) {
                     self.emit_leading_jsdoc_comments(member_node.pos);
                 }
             }
@@ -2418,8 +2418,8 @@ impl<'a> DeclarationEmitter<'a> {
             let before_jsdoc_len = self.writer.len();
             let saved_comment_idx = self.comment_emit_idx;
             if let Some(member_node) = self.arena.get(member_idx) {
-                if self.member_is_jsdoc_overload_constructor(member_idx) {
-                    // The constructor overload path emits one comment per overload
+                if self.member_is_jsdoc_overload_signature(member_idx) {
+                    // The JSDoc overload path emits one comment per overload
                     // signature; emitting the whole chain here would attach the
                     // implementation comment to the reconstructed signature.
                 } else if uses_reordered_js_member_comments {

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit.rs
@@ -798,6 +798,14 @@ impl<'a> DeclarationEmitter<'a> {
         };
 
         let jsdoc = self.function_like_jsdoc_for_node(initializer);
+        if is_exported
+            && jsdoc
+                .as_deref()
+                .is_some_and(|jsdoc| jsdoc.contains("@constructor"))
+            && self.emit_js_commonjs_constructor_prototype_class(name_idx)
+        {
+            return;
+        }
         let reserved_export_alias = if is_exported {
             self.js_reserved_export_local_name(name_idx)
         } else {
@@ -3604,6 +3612,70 @@ impl<'a> DeclarationEmitter<'a> {
         true
     }
 
+    fn emit_js_commonjs_constructor_prototype_class(&mut self, name_idx: NodeIndex) -> bool {
+        let Some(export_name) = self.js_commonjs_export_name_text(name_idx) else {
+            return false;
+        };
+        let prototype_members = self.js_prototype_object_members_for_export_name(&export_name);
+        if prototype_members.is_empty() {
+            return false;
+        }
+
+        self.write_indent();
+        self.write("export class ");
+        self.write(&export_name);
+        self.write(" {");
+        self.write_line();
+        self.increase_indent();
+
+        for member_idx in prototype_members {
+            self.emit_js_commonjs_constructor_prototype_member(member_idx);
+        }
+
+        self.decrease_indent();
+        self.write_indent();
+        self.write("}");
+        self.write_line();
+        self.emitted_module_indicator = true;
+        true
+    }
+
+    fn emit_js_commonjs_constructor_prototype_member(&mut self, member_idx: NodeIndex) {
+        let Some(member_node) = self.arena.get(member_idx) else {
+            return;
+        };
+        let before_jsdoc_len = self.writer.len();
+        let saved_comment_idx = self.comment_emit_idx;
+        self.emit_leading_jsdoc_comments(member_node.pos);
+        let before_member_len = self.writer.len();
+
+        if let Some(prop) = self.arena.get_property_assignment(member_node) {
+            if let Some(type_text) = self
+                .function_expression_type_text_from_ast(prop.initializer)
+                .or_else(|| {
+                    self.resolve_declaration_type_text(&[prop.initializer], Some(prop.initializer))
+                        .map(|resolved| resolved.emitted_type_text)
+                })
+                .or_else(|| self.allowlisted_initializer_type_text(prop.initializer))
+            {
+                self.write_indent();
+                self.emit_node(prop.name);
+                self.write(": ");
+                self.write(&type_text);
+                self.write(";");
+                self.write_line();
+            }
+        } else {
+            self.emit_class_member(member_idx);
+        }
+
+        if self.writer.len() == before_member_len {
+            self.writer.truncate(before_jsdoc_len);
+            self.comment_emit_idx = saved_comment_idx;
+            self.skip_comments_in_node(member_node.pos, member_node.end);
+        }
+    }
+
     fn js_proto_property_assignment_type_text(&self, member_idx: NodeIndex) -> Option<String> {
         let member_node = self.arena.get(member_idx)?;
         let prop = self.arena.get_property_assignment(member_node)?;
@@ -3684,6 +3756,10 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(name) = self.get_identifier_text(name_idx) else {
             return Vec::new();
         };
+        self.js_prototype_object_members_for_export_name(&name)
+    }
+
+    fn js_prototype_object_members_for_export_name(&self, name: &str) -> Vec<NodeIndex> {
         let Some(source_file_idx) = self.current_source_file_idx else {
             return Vec::new();
         };
@@ -3734,8 +3810,13 @@ impl<'a> DeclarationEmitter<'a> {
                 .get_identifier_text(lhs_access.name_or_argument)
                 .as_deref()
                 != Some("prototype")
-                || self.get_identifier_text(lhs_access.expression).as_deref() != Some(&name)
             {
+                continue;
+            }
+            let receiver_name = self
+                .get_identifier_text(lhs_access.expression)
+                .or_else(|| self.module_exports_property_reference_name(lhs_access.expression));
+            if receiver_name.as_deref() != Some(name) {
                 continue;
             }
             let rhs = self

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -1102,8 +1102,12 @@ impl<'a> DeclarationEmitter<'a> {
         // Emit parameter properties from constructor first (before other members)
         self.emit_parameter_properties(&class.members);
 
-        // Emit `#private;` if any member has a private identifier name
-        if self.class_has_private_identifier_member(&class.members) {
+        // Emit `#private;` if any member has a private identifier name.
+        // JS constructor overload declarations are reconstructed before the
+        // private marker, so that path defers to the ordered member pass.
+        if self.class_has_private_identifier_member(&class.members)
+            && !self.class_has_jsdoc_overload_constructor(&class.members)
+        {
             self.write_indent();
             self.write("#private;");
             self.write_line();
@@ -1558,8 +1562,12 @@ impl<'a> DeclarationEmitter<'a> {
         // Emit parameter properties from constructor first (before other members)
         self.emit_parameter_properties(&class.members);
 
-        // Emit `#private;` if any member has a private identifier name (e.g., #foo)
-        if self.class_has_private_identifier_member(&class.members) {
+        // Emit `#private;` if any member has a private identifier name (e.g., #foo).
+        // JS constructor overload declarations are reconstructed before the
+        // private marker, so that path defers to the ordered member pass.
+        if self.class_has_private_identifier_member(&class.members)
+            && !self.class_has_jsdoc_overload_constructor(&class.members)
+        {
             self.write_indent();
             self.write("#private;");
             self.write_line();

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/comments_source.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/comments_source.rs
@@ -34,32 +34,49 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         for jsdoc in chain {
-            self.write_indent();
-            let trimmed = jsdoc.trim();
-            if !trimmed.contains('\n') {
-                self.write("/** ");
-                self.write(trimmed);
-                self.write(" */");
-                self.write_line();
-                continue;
-            }
+            self.emit_jsdoc_comment(jsdoc, false);
+        }
+    }
 
-            self.write("/**");
-            self.write_line();
-            for line in trimmed.lines() {
-                self.write_indent();
-                if line.trim().is_empty() {
-                    self.write(" *");
-                } else {
-                    self.write(" * ");
-                    self.write(line.trim());
-                }
-                self.write_line();
-            }
-            self.write_indent();
+    pub(crate) fn emit_jsdoc_comment_chain_preserving_multiline_style(
+        &mut self,
+        chain: &[(String, bool)],
+    ) {
+        if self.remove_comments {
+            return;
+        }
+
+        for (jsdoc, force_multiline) in chain {
+            self.emit_jsdoc_comment(jsdoc, *force_multiline);
+        }
+    }
+
+    fn emit_jsdoc_comment(&mut self, jsdoc: &str, force_multiline: bool) {
+        self.write_indent();
+        let trimmed = jsdoc.trim();
+        if !force_multiline && !trimmed.contains('\n') {
+            self.write("/** ");
+            self.write(trimmed);
             self.write(" */");
             self.write_line();
+            return;
         }
+
+        self.write("/**");
+        self.write_line();
+        for line in trimmed.lines() {
+            self.write_indent();
+            if line.trim().is_empty() {
+                self.write(" *");
+            } else {
+                self.write(" * ");
+                self.write(line.trim());
+            }
+            self.write_line();
+        }
+        self.write_indent();
+        self.write(" */");
+        self.write_line();
     }
 
     pub(crate) fn emit_multiline_jsdoc_comment(&mut self, jsdoc: &str) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -452,6 +452,20 @@ impl<'a> DeclarationEmitter<'a> {
             else {
                 continue;
             };
+            if let Some((param_name, value_text)) = self
+                .infer_constrained_identity_callback_substitution(
+                    &source_function_type,
+                    arg_idx,
+                    type_param_names,
+                    type_param_constraints,
+                )
+                && !substitutions
+                    .iter()
+                    .any(|(name, _)| name.as_str() == param_name)
+            {
+                substitutions.push((param_name, value_text));
+                continue;
+            }
             let Some(argument_function_type) = self.function_type_parts_for_expression(arg_idx)
             else {
                 continue;
@@ -465,6 +479,55 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         substitutions
+    }
+
+    pub(super) fn infer_constrained_identity_callback_substitution(
+        &self,
+        source_function_type: &super::type_inference_function_text::FunctionTypeTextParts,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        type_param_constraints: &[(String, String)],
+    ) -> Option<(String, String)> {
+        if source_function_type.parameters.len() != 1 {
+            return None;
+        }
+        let source_param = source_function_type.parameters.first()?;
+        let param_type = source_param.type_text.trim();
+        if source_param.rest
+            || !type_param_names.iter().any(|name| name == param_type)
+            || source_function_type.return_type.trim() != param_type
+        {
+            return None;
+        }
+        let constraint = Self::type_param_constraint_text(type_param_constraints, param_type)?;
+
+        let arg_idx = self.skip_parenthesized_non_null_and_comma(arg_idx);
+        let arg_node = self.arena.get(arg_idx)?;
+        if arg_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && arg_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return None;
+        }
+        let func = self.arena.get_function(arg_node)?;
+        if func.type_annotation.is_some() || func.parameters.nodes.len() != 1 {
+            return None;
+        }
+        let arg_param_idx = *func.parameters.nodes.first()?;
+        let arg_param_node = self.arena.get(arg_param_idx)?;
+        let arg_param = self.arena.get_parameter(arg_param_node)?;
+        if arg_param.type_annotation.is_some() {
+            return None;
+        }
+        let arg_param_name = self.get_identifier_text(arg_param.name)?;
+        let body_idx = self.skip_parenthesized_expression(func.body)?;
+        let body_node = self.arena.get(body_idx)?;
+        if body_node.kind != SyntaxKind::Identifier as u16
+            || self.get_identifier_text(body_idx).as_deref() != Some(arg_param_name.as_str())
+        {
+            return None;
+        }
+
+        Some((param_type.to_string(), constraint.to_string()))
     }
 
     fn single_generic_type_argument_text(type_text: &str) -> Option<(&str, &str)> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -976,12 +976,71 @@ impl<'a> DeclarationEmitter<'a> {
         if !needs_typeof {
             return None;
         }
+        if self.namespace_import_alias_targets_json_module(expr_idx, sym_id, binder) {
+            return None;
+        }
 
         let reference_text = self
             .nameable_constructor_expression_text(expr_idx)
             .or_else(|| self.get_identifier_text(expr_idx))?;
         let reference_text = self.relative_value_reference_text(&reference_text);
         Some(format!("typeof {reference_text}"))
+    }
+
+    fn namespace_import_alias_targets_json_module(
+        &self,
+        expr_idx: NodeIndex,
+        sym_id: SymbolId,
+        binder: &tsz_binder::BinderState,
+    ) -> bool {
+        let module_specifier = self
+            .namespace_import_module_specifier_from_syntax(expr_idx)
+            .or_else(|| self.imported_value_module_specifier_from_syntax(expr_idx))
+            .or_else(|| {
+                self.is_namespace_import_alias_symbol(sym_id)
+                    .then(|| self.imported_value_module_specifier(sym_id, binder))
+                    .flatten()
+            });
+
+        module_specifier.is_some_and(|module_specifier| module_specifier.ends_with(".json"))
+    }
+
+    pub(in crate::declaration_emitter) fn namespace_import_module_specifier_from_syntax(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let local_name = self.get_identifier_text(expr_idx)?;
+        let source_file = self
+            .current_source_file_idx
+            .and_then(|source_file_idx| self.arena.get(source_file_idx))
+            .and_then(|node| self.arena.get_source_file(node))
+            .or_else(|| self.arena_source_file(self.arena))?;
+
+        for &stmt_idx in &source_file.statements.nodes {
+            let stmt_node = self.arena.get(stmt_idx)?;
+            let import = self.arena.get_import_decl(stmt_node)?;
+            let module_lit = self
+                .arena
+                .get(import.module_specifier)
+                .and_then(|node| self.arena.get_literal(node))?;
+            let clause = self
+                .arena
+                .get(import.import_clause)
+                .and_then(|node| self.arena.get_import_clause(node))?;
+            let bindings = self
+                .arena
+                .get(clause.named_bindings)
+                .and_then(|node| self.arena.get_named_imports(node))?;
+
+            if bindings.name.is_some()
+                && bindings.elements.nodes.is_empty()
+                && self.get_identifier_text(bindings.name).as_deref() == Some(local_name.as_str())
+            {
+                return Some(module_lit.text.clone());
+            }
+        }
+
+        None
     }
 
     pub(in crate::declaration_emitter) fn relative_value_reference_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -15,6 +15,8 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| self.call_expression_returned_local_class_constructor_text(expr_idx, false))
             .or_else(|| {
                 self.super_method_call_return_type_text(expr_idx)
+                    .or_else(|| self.call_expression_function_variable_return_type_text(expr_idx))
+                    .or_else(|| self.generic_call_returned_identity_callback_type_text(expr_idx))
                     .or_else(|| self.call_expression_source_return_type_text(expr_idx))
                     .or_else(|| self.bind_call_remaining_function_type_text(expr_idx))
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
@@ -24,6 +26,126 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|type_text| {
                 self.expand_rest_tuple_parameters_in_function_type_text(expr_idx, &type_text)
                     .unwrap_or(type_text)
+            })
+    }
+
+    fn call_expression_function_variable_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let callee_idx = self.skip_parenthesized_expression(call.expression)?;
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let parts = self.function_type_parts_for_expression(callee_idx)?;
+        let return_type = parts.return_type.trim();
+        if return_type == "any" || return_type == "unknown" || !return_type.contains('"') {
+            return None;
+        }
+        Some(return_type.to_string())
+    }
+
+    fn generic_call_returned_identity_callback_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let arguments = call.arguments.as_ref()?;
+        let binder = self.binder?;
+        let sym_id = self.value_reference_symbol(call.expression).or_else(|| {
+            let callee_idx = self.skip_parenthesized_expression(call.expression)?;
+            let callee_name = self.get_identifier_text(callee_idx)?;
+            binder.file_locals.get(&callee_name)
+        })?;
+        let sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(sym_id, binder));
+
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let func = callable_function_from_symbol_decl(source_arena, decl_idx)?;
+            let returned_param_index =
+                self.returned_parameter_index_from_function_body(source_arena, func)?;
+            let returned_param_node =
+                source_arena.get(*func.parameters.nodes.get(returned_param_index)?)?;
+            let returned_param = source_arena.get_parameter(returned_param_node)?;
+            let param_type_text = self
+                .emit_type_node_text_from_arena(source_arena, returned_param.type_annotation)
+                .or_else(|| {
+                    self.source_slice_from_arena(source_arena, returned_param.type_annotation)
+                })?;
+            let source_function_type = Self::parse_function_type_text(param_type_text.trim())?;
+
+            let mut type_param_constraints = Vec::new();
+            let type_param_names = func
+                .type_parameters
+                .as_ref()?
+                .nodes
+                .iter()
+                .copied()
+                .filter_map(|param_idx| {
+                    let param_node = source_arena.get(param_idx)?;
+                    let param = source_arena.get_type_parameter(param_node)?;
+                    let name = identifier_text(source_arena, param.name)?;
+                    if param.constraint.is_some()
+                        && let Some(constraint) = self
+                            .emit_type_node_text_from_arena(source_arena, param.constraint)
+                            .or_else(|| {
+                                self.source_slice_from_arena(source_arena, param.constraint)
+                            })
+                    {
+                        type_param_constraints.push((name.clone(), constraint));
+                    }
+                    Some(name)
+                })
+                .collect::<Vec<_>>();
+            let arg_idx = *arguments.nodes.get(returned_param_index)?;
+            let (param_name, value_text) = self.infer_constrained_identity_callback_substitution(
+                &source_function_type,
+                arg_idx,
+                &type_param_names,
+                &type_param_constraints,
+            )?;
+            Some(Self::replace_whole_words_in_text(
+                param_type_text.trim(),
+                &[(param_name, value_text)],
+            ))
+        })
+    }
+
+    fn returned_parameter_index_from_function_body(
+        &self,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+    ) -> Option<usize> {
+        let body_node = source_arena.get(func.body)?;
+        let block = source_arena.get_block(body_node)?;
+        if block.statements.nodes.len() != 1 {
+            return None;
+        }
+        let stmt_node = source_arena.get(*block.statements.nodes.first()?)?;
+        let ret = source_arena.get_return_statement(stmt_node)?;
+        let returned_name = identifier_text(source_arena, ret.expression)?;
+        func.parameters
+            .nodes
+            .iter()
+            .copied()
+            .enumerate()
+            .find_map(|(index, param_idx)| {
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_parameter(param_node)?;
+                (identifier_text(source_arena, param.name).as_deref()
+                    == Some(returned_name.as_str()))
+                .then_some(index)
             })
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -18,6 +18,8 @@ impl<'a> DeclarationEmitter<'a> {
                     .or_else(|| self.call_expression_function_variable_return_type_text(expr_idx))
                     .or_else(|| self.generic_call_returned_identity_callback_type_text(expr_idx))
                     .or_else(|| self.call_expression_local_overload_return_type_text(expr_idx))
+                    .or_else(|| self.generic_rest_identity_parameters_tuple_type_text(expr_idx))
+                    .or_else(|| self.call_expression_parameters_return_tuple_type_text(expr_idx))
                     .or_else(|| self.call_expression_source_return_type_text(expr_idx))
                     .or_else(|| self.bind_call_remaining_function_type_text(expr_idx))
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
@@ -28,6 +30,223 @@ impl<'a> DeclarationEmitter<'a> {
                 self.expand_rest_tuple_parameters_in_function_type_text(expr_idx, &type_text)
                     .unwrap_or(type_text)
             })
+    }
+
+    fn generic_rest_identity_parameters_tuple_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        self.generic_rest_identity_return_type_param_name(call.expression)?;
+
+        let args = call.arguments.as_ref()?;
+        let [arg_idx] = args.nodes.as_slice() else {
+            return None;
+        };
+
+        let arg_node = self.arena.get(*arg_idx)?;
+        if arg_node.kind == syntax_kind_ext::SPREAD_ELEMENT {
+            let spread = self.arena.get_spread(arg_node)?;
+            return self.call_expression_parameters_return_tuple_type_text(spread.expression);
+        }
+
+        let tuple_text = self.call_expression_parameters_return_tuple_type_text(*arg_idx)?;
+        Some(format!("[{tuple_text}]"))
+    }
+
+    fn generic_rest_identity_return_type_param_name(
+        &self,
+        callee_idx: NodeIndex,
+    ) -> Option<String> {
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(callee_idx)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(callable) = Self::callable_decl_parts_from_node(self.arena, decl_node) else {
+                continue;
+            };
+            let [param_idx] = callable.parameters.nodes.as_slice() else {
+                continue;
+            };
+            let Some(param_node) = self.arena.get(*param_idx) else {
+                continue;
+            };
+            let Some(param) = self.arena.get_parameter(param_node) else {
+                continue;
+            };
+            if !param.dot_dot_dot_token || callable.type_annotation.is_none() {
+                continue;
+            }
+            let Some(return_type_text) = self
+                .emit_type_node_text_from_arena(self.arena, callable.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, callable.type_annotation))
+            else {
+                continue;
+            };
+            let Some(rest_type_text) = self
+                .emit_type_node_text_from_arena(self.arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
+            else {
+                continue;
+            };
+            let rest_type_text = rest_type_text.trim();
+            if rest_type_text.is_empty() || return_type_text.trim() != rest_type_text {
+                continue;
+            }
+            if callable.type_parameters.is_some_and(|type_params| {
+                type_params.nodes.iter().copied().any(|type_param_idx| {
+                    self.arena
+                        .get(type_param_idx)
+                        .and_then(|node| self.arena.get_type_parameter(node))
+                        .and_then(|type_param| self.get_identifier_text(type_param.name))
+                        .as_deref()
+                        == Some(rest_type_text)
+                })
+            }) {
+                return Some(rest_type_text.to_string());
+            }
+        }
+
+        None
+    }
+
+    fn call_expression_parameters_return_tuple_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let args = call.arguments.as_ref()?;
+        let [arg_idx] = args.nodes.as_slice() else {
+            return None;
+        };
+        let return_type_param = self.parameters_return_type_param_name(call.expression)?;
+        let parameter_type_text = self.callable_parameter_type_text(call.expression)?;
+        if parameter_type_text.trim() != return_type_param {
+            return None;
+        }
+        self.callable_parameter_tuple_type_text_for_value(*arg_idx)
+    }
+
+    fn parameters_return_type_param_name(&self, callee_idx: NodeIndex) -> Option<String> {
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(callee_idx)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(callable) = Self::callable_decl_parts_from_node(self.arena, decl_node) else {
+                continue;
+            };
+            let return_type_text = self
+                .emit_type_node_text_from_arena(self.arena, callable.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, callable.type_annotation))?;
+            let return_type_text = return_type_text.trim();
+            let Some(inner) = return_type_text
+                .strip_prefix("Parameters<")
+                .and_then(|text| text.strip_suffix('>'))
+                .map(str::trim)
+            else {
+                continue;
+            };
+            if Self::simple_type_reference_name(inner).is_none() {
+                continue;
+            }
+            return Some(inner.to_string());
+        }
+
+        None
+    }
+
+    fn callable_parameter_type_text(&self, callee_idx: NodeIndex) -> Option<String> {
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(callee_idx)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(callable) = Self::callable_decl_parts_from_node(self.arena, decl_node) else {
+                continue;
+            };
+            let [param_idx] = callable.parameters.nodes.as_slice() else {
+                continue;
+            };
+            let Some(param_node) = self.arena.get(*param_idx) else {
+                continue;
+            };
+            let Some(param) = self.arena.get_parameter(param_node) else {
+                continue;
+            };
+            if let Some(type_text) = self
+                .emit_type_node_text_from_arena(self.arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
+            {
+                return Some(type_text);
+            }
+        }
+
+        None
+    }
+
+    fn callable_parameter_tuple_type_text_for_value(&self, expr_idx: NodeIndex) -> Option<String> {
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(expr_idx)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(callable) = Self::callable_decl_parts_from_node(self.arena, decl_node) else {
+                continue;
+            };
+            let mut elements = Vec::new();
+            for &param_idx in &callable.parameters.nodes {
+                let param_node = self.arena.get(param_idx)?;
+                let param = self.arena.get_parameter(param_node)?;
+                let name = self.get_identifier_text(param.name)?;
+                let type_text = self
+                    .emit_type_node_text_from_arena(self.arena, param.type_annotation)
+                    .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
+                    .unwrap_or_else(|| "any".to_string());
+                let optional = if param.question_token { "?" } else { "" };
+                if param.dot_dot_dot_token {
+                    elements.push(format!("...{name}{optional}: {}", type_text.trim()));
+                } else {
+                    elements.push(format!("{name}{optional}: {}", type_text.trim()));
+                }
+            }
+            return Some(format!("[{}]", elements.join(", ")));
+        }
+
+        None
     }
 
     fn call_expression_local_overload_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -17,6 +17,7 @@ impl<'a> DeclarationEmitter<'a> {
                 self.super_method_call_return_type_text(expr_idx)
                     .or_else(|| self.call_expression_function_variable_return_type_text(expr_idx))
                     .or_else(|| self.generic_call_returned_identity_callback_type_text(expr_idx))
+                    .or_else(|| self.call_expression_local_overload_return_type_text(expr_idx))
                     .or_else(|| self.call_expression_source_return_type_text(expr_idx))
                     .or_else(|| self.bind_call_remaining_function_type_text(expr_idx))
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
@@ -27,6 +28,164 @@ impl<'a> DeclarationEmitter<'a> {
                 self.expand_rest_tuple_parameters_in_function_type_text(expr_idx, &type_text)
                     .unwrap_or(type_text)
             })
+    }
+
+    fn call_expression_local_overload_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let args = call.arguments.as_ref()?;
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(call.expression)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+
+        let mut candidates = Vec::new();
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(callable) = Self::callable_decl_parts_from_node(self.arena, decl_node) else {
+                continue;
+            };
+            if callable.body.is_some()
+                || callable
+                    .type_parameters
+                    .is_some_and(|params| !params.nodes.is_empty())
+                || callable.type_annotation.is_none()
+                || !self.function_signature_accepts_call_arguments(
+                    self.arena,
+                    callable.parameters,
+                    call,
+                )
+            {
+                continue;
+            }
+            let Some(return_type) = self
+                .emit_type_node_text_from_arena(self.arena, callable.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, callable.type_annotation))
+            else {
+                continue;
+            };
+            let exact =
+                self.overload_signature_exact_literal_match(callable.parameters, &args.nodes);
+            if exact || self.overload_signature_accepts_arguments(callable.parameters, &args.nodes)
+            {
+                candidates.push((exact, return_type.trim().to_string()));
+            }
+        }
+
+        candidates
+            .iter()
+            .find_map(|(exact, return_type)| exact.then(|| return_type.clone()))
+            .or_else(|| {
+                candidates
+                    .into_iter()
+                    .next()
+                    .map(|(_, return_type)| return_type)
+            })
+    }
+
+    fn overload_signature_exact_literal_match(
+        &self,
+        parameters: &NodeList,
+        arg_nodes: &[NodeIndex],
+    ) -> bool {
+        !arg_nodes.is_empty()
+            && parameters
+                .nodes
+                .iter()
+                .zip(arg_nodes.iter())
+                .all(|(&param_idx, &arg_idx)| {
+                    let Some(param_type) = self.overload_parameter_type_text(param_idx) else {
+                        return false;
+                    };
+                    let Some(arg_type) = self.overload_argument_type_text(arg_idx) else {
+                        return false;
+                    };
+                    Self::overload_type_text_is_single_literal(&arg_type)
+                        && param_type.trim() == arg_type.trim()
+                })
+    }
+
+    fn overload_signature_accepts_arguments(
+        &self,
+        parameters: &NodeList,
+        arg_nodes: &[NodeIndex],
+    ) -> bool {
+        parameters
+            .nodes
+            .iter()
+            .zip(arg_nodes.iter())
+            .all(|(&param_idx, &arg_idx)| {
+                let Some(param_type) = self.overload_parameter_type_text(param_idx) else {
+                    return false;
+                };
+                let Some(arg_type) = self.overload_argument_type_text(arg_idx) else {
+                    return false;
+                };
+                Self::overload_type_accepts_argument_type(&param_type, &arg_type)
+            })
+    }
+
+    fn overload_parameter_type_text(&self, param_idx: NodeIndex) -> Option<String> {
+        let param_node = self.arena.get(param_idx)?;
+        let param = self.arena.get_parameter(param_node)?;
+        self.emit_type_node_text_from_arena(self.arena, param.type_annotation)
+            .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
+            .map(|text| text.trim().to_string())
+    }
+
+    fn overload_argument_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        self.reference_declared_type_annotation_text(arg_idx)
+            .or_else(|| self.const_literal_initializer_text(arg_idx))
+            .or_else(|| self.preferred_expression_type_text(arg_idx))
+            .filter(|text| text != "any" && text != "unknown")
+            .map(|text| text.trim().to_string())
+    }
+
+    fn overload_type_accepts_argument_type(param_type: &str, arg_type: &str) -> bool {
+        let param_parts = Self::split_top_level_union_type_parts(param_type);
+        let arg_parts = Self::split_top_level_union_type_parts(arg_type);
+        !arg_parts.is_empty()
+            && arg_parts.iter().all(|arg_part| {
+                param_parts.iter().any(|param_part| {
+                    Self::overload_type_part_accepts_argument(param_part, arg_part)
+                })
+            })
+    }
+
+    fn overload_type_part_accepts_argument(param_part: &str, arg_part: &str) -> bool {
+        let param_part = param_part.trim();
+        let arg_part = arg_part.trim();
+        param_part == arg_part
+            || Self::overload_literal_primitive_name(arg_part)
+                .is_some_and(|primitive| primitive == param_part)
+    }
+
+    fn overload_type_text_is_single_literal(type_text: &str) -> bool {
+        let parts = Self::split_top_level_union_type_parts(type_text);
+        parts.len() == 1 && Self::overload_literal_primitive_name(&parts[0]).is_some()
+    }
+
+    fn overload_literal_primitive_name(type_text: &str) -> Option<&'static str> {
+        let trimmed = type_text.trim();
+        if (trimmed.starts_with('"') && trimmed.ends_with('"'))
+            || (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+        {
+            return Some("string");
+        }
+        if matches!(trimmed, "true" | "false") {
+            return Some("boolean");
+        }
+        trimmed.parse::<f64>().ok().map(|_| "number")
     }
 
     fn call_expression_function_variable_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
@@ -2334,6 +2334,9 @@ impl<'a> DeclarationEmitter<'a> {
             k if k == SyntaxKind::FalseKeyword as u16 => true,
             k if k == SyntaxKind::NullKeyword as u16 => true,
             k if k == SyntaxKind::UndefinedKeyword as u16 => true,
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
+                self.js_empty_object_literal_initializer(initializer)
+            }
             k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => true,
             k if k == syntax_kind_ext::NEW_EXPRESSION => true,
             k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
@@ -2341,6 +2344,18 @@ impl<'a> DeclarationEmitter<'a> {
             }
             _ => false,
         }
+    }
+
+    pub(crate) fn js_empty_object_literal_initializer(&self, initializer: NodeIndex) -> bool {
+        let Some(init_node) = self.arena.get(initializer) else {
+            return false;
+        };
+        if init_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return false;
+        }
+        self.arena
+            .get_literal_expr(init_node)
+            .is_some_and(|object| object.elements.nodes.is_empty())
     }
 
     pub(in crate::declaration_emitter) fn groupable_js_reexport_info(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -478,6 +478,9 @@ impl<'a> DeclarationEmitter<'a> {
         if trimmed.is_empty() {
             return "any".to_string();
         }
+        if let Some(index_signature) = Self::normalize_jsdoc_object_index_type(trimmed) {
+            return index_signature;
+        }
         if trimmed == "?" {
             return Self::normalize_jsdoc_type_atom(trimmed);
         }
@@ -489,6 +492,12 @@ impl<'a> DeclarationEmitter<'a> {
         }
         if let Some(inner) = trimmed.strip_suffix('=') {
             return format!("{} | undefined", Self::normalize_jsdoc_type_expr(inner));
+        }
+        if let Some(inner) = trimmed.strip_prefix('!') {
+            return Self::normalize_jsdoc_type_expr(inner);
+        }
+        if let Some(inner) = trimmed.strip_suffix('!') {
+            return Self::normalize_jsdoc_type_expr(inner);
         }
         if let Some(inner) = Self::strip_balanced_parens(trimmed) {
             let normalized = Self::normalize_jsdoc_type_expr(inner);
@@ -510,6 +519,24 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
         Self::normalize_jsdoc_type_atom(trimmed)
+    }
+
+    fn normalize_jsdoc_object_index_type(type_expr: &str) -> Option<String> {
+        let args = type_expr
+            .strip_prefix("Object<")
+            .or_else(|| type_expr.strip_prefix("Object.<"))?
+            .strip_suffix('>')?;
+        let parts = Self::split_jsdoc_params(args);
+        if parts.len() != 2 {
+            return None;
+        }
+        let key = Self::normalize_jsdoc_type_expr(parts[0]);
+        let value = Self::normalize_jsdoc_type_expr(parts[1]);
+        let key = match key.as_str() {
+            "string" | "number" | "symbol" => key,
+            _ => "string".to_string(),
+        };
+        Some(format!("{{\n    [x: {key}]: {value};\n}}"))
     }
 
     fn strip_balanced_parens(text: &str) -> Option<&str> {
@@ -593,6 +620,7 @@ impl<'a> DeclarationEmitter<'a> {
 
         // Parse parameters
         let mut ts_params = Vec::new();
+        let mut construct_return_type = None;
         if !params_str.trim().is_empty() {
             let raw_params = Self::split_jsdoc_params(params_str);
             let mut unnamed_idx = 0u32;
@@ -611,6 +639,11 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(colon) = Self::find_param_colon(raw) {
                     let name = raw[..colon].trim();
                     let ptype = Self::normalize_jsdoc_type_atom(raw[colon + 1..].trim());
+                    if name == "new" {
+                        construct_return_type = Some(ptype);
+                        unnamed_idx = unnamed_idx.max(1);
+                        continue;
+                    }
                     if is_rest {
                         ts_params.push(format!("...args: {ptype}[]"));
                     } else {
@@ -629,7 +662,15 @@ impl<'a> DeclarationEmitter<'a> {
             }
         }
 
-        Some(format!("({}) => {}", ts_params.join(", "), return_type))
+        if let Some(construct_return_type) = construct_return_type {
+            Some(format!(
+                "new ({}) => {}",
+                ts_params.join(", "),
+                construct_return_type
+            ))
+        } else {
+            Some(format!("({}) => {}", ts_params.join(", "), return_type))
+        }
     }
 
     /// Normalize a single JSDoc type atom: `*` -> `any`, otherwise pass through.
@@ -1092,7 +1133,11 @@ impl<'a> DeclarationEmitter<'a> {
             }
             let rest = rest.trim();
             let (type_expr, _) = Self::parse_jsdoc_braced_type_and_name(rest)?;
-            let text = Self::normalize_jsdoc_type_text(type_expr, false);
+            let text = if type_expr.trim() == "?" {
+                "unknown".to_string()
+            } else {
+                Self::normalize_jsdoc_type_text(type_expr, false)
+            };
             if Self::jsdoc_type_needs_checker_resolution(&text) {
                 return Self::convert_jsdoc_function_type(&text);
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -311,6 +311,16 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         pos: u32,
     ) -> Vec<String> {
+        self.leading_jsdoc_comment_chain_for_pos_with_style(pos)
+            .into_iter()
+            .map(|(jsdoc, _)| jsdoc)
+            .collect()
+    }
+
+    pub(in crate::declaration_emitter) fn leading_jsdoc_comment_chain_for_pos_with_style(
+        &self,
+        pos: u32,
+    ) -> Vec<(String, bool)> {
         let Some(text) = self.source_file_text.as_deref() else {
             return Vec::new();
         };
@@ -336,7 +346,12 @@ impl<'a> DeclarationEmitter<'a> {
             return Vec::new();
         };
 
-        let mut chain = vec![get_jsdoc_content(nearest, text)];
+        let styled_comment = |comment: &tsz_common::comments::CommentRange| {
+            let raw = &text[comment.pos as usize..comment.end as usize];
+            (get_jsdoc_content(comment, text), raw.contains('\n'))
+        };
+
+        let mut chain = vec![styled_comment(nearest)];
         let mut current_start = nearest.pos as usize;
         for comment in self
             .all_comments
@@ -354,7 +369,7 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 break;
             }
-            chain.push(get_jsdoc_content(comment, text));
+            chain.push(styled_comment(comment));
             current_start = comment.pos as usize;
         }
         chain.reverse();

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -1362,6 +1362,10 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
+    pub(in crate::declaration_emitter) fn jsdoc_contains_type_alias_tag(jsdoc: &str) -> bool {
+        Self::jsdoc_has_property_tags(jsdoc) || Self::parse_jsdoc_typedef_alias(jsdoc).is_some()
+    }
+
     pub(in crate::declaration_emitter) fn jsdoc_chain_without_type_tags(
         chain: &[String],
     ) -> Vec<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -533,7 +533,38 @@ impl<'a> DeclarationEmitter<'a> {
                     .join(" | ");
             }
         }
+        if let Some(generic) = Self::normalize_jsdoc_generic_type_reference(trimmed) {
+            return generic;
+        }
         Self::normalize_jsdoc_type_atom(trimmed)
+    }
+
+    fn normalize_jsdoc_generic_type_reference(type_expr: &str) -> Option<String> {
+        let open = type_expr.find('<')?;
+        if !type_expr.ends_with('>') {
+            return None;
+        }
+
+        let base = type_expr[..open].trim();
+        if base.is_empty()
+            || !base
+                .chars()
+                .all(|ch| ch == '_' || ch == '$' || ch == '.' || ch.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+
+        let args = type_expr[open + 1..type_expr.len() - 1].trim();
+        if args.is_empty() {
+            return None;
+        }
+
+        let normalized_args = Self::split_jsdoc_params(args)
+            .into_iter()
+            .map(Self::normalize_jsdoc_type_expr)
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("{base}<{normalized_args}>"))
     }
 
     fn normalize_jsdoc_object_index_type(type_expr: &str) -> Option<String> {
@@ -879,7 +910,17 @@ impl<'a> DeclarationEmitter<'a> {
                 member.push('?');
             }
             member.push_str(": ");
-            member.push_str(&prop_decl.type_text);
+            if matches!(prop_decl.type_text.as_str(), "object" | "Object")
+                && let Some(nested) = Self::jsdoc_nested_object_type_literal(
+                    &params,
+                    &qualified_name,
+                    (self.indent_level + 1) as usize,
+                )
+            {
+                member.push_str(&nested);
+            } else {
+                member.push_str(&prop_decl.type_text);
+            }
             if prop_decl.optional && !Self::type_text_has_undefined_branch(&prop_decl.type_text) {
                 member.push_str(" | undefined");
             }
@@ -894,6 +935,59 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|member| format!("{member_indent}{member}"))
             .collect();
         (!lines.is_empty()).then(|| format!("{{\n{}\n{closing_indent}}}", lines.join("\n")))
+    }
+
+    fn jsdoc_nested_object_type_literal(
+        params: &[JsdocParamDecl],
+        prefix: &str,
+        type_indent_level: usize,
+    ) -> Option<String> {
+        let child_prefix = format!("{prefix}.");
+        let mut members = Vec::new();
+        for decl in params {
+            let Some(rest) = decl.name.strip_prefix(&child_prefix) else {
+                continue;
+            };
+            if rest.is_empty() || rest.contains('.') {
+                continue;
+            }
+
+            let mut member = String::new();
+            member.push_str(rest);
+            if decl.optional {
+                member.push('?');
+            }
+            member.push_str(": ");
+            if matches!(decl.type_text.as_str(), "object" | "Object")
+                && let Some(nested) = Self::jsdoc_nested_object_type_literal(
+                    params,
+                    &decl.name,
+                    type_indent_level + 1,
+                )
+            {
+                member.push_str(&nested);
+            } else {
+                member.push_str(&decl.type_text);
+            }
+            if decl.optional && !Self::type_text_has_undefined_branch(&decl.type_text) {
+                member.push_str(" | undefined");
+            }
+            member.push(';');
+            members.push(member);
+        }
+
+        if members.is_empty() {
+            return None;
+        }
+
+        let member_indent = "    ".repeat(type_indent_level + 1);
+        let closing_indent = "    ".repeat(type_indent_level);
+        let lines = members
+            .into_iter()
+            .map(|member| format!("{member_indent}{member}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("{{\n{lines}\n{closing_indent}}}"))
     }
 
     pub(crate) fn jsdoc_satisfies_param_decl_for_parameter(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -30,7 +30,15 @@ use tsz_scanner::SyntaxKind;
 use super::jsdoc_function_signature::{
     JsdocFunctionTypeSignature, parse_jsdoc_function_type_signature,
 };
-use super::{JsdocParamDecl, JsdocTypeAliasDecl};
+use super::{JsdocParamDecl, JsdocTypeAliasDecl, escape_string_for_double_quote};
+
+#[derive(Clone)]
+pub(crate) struct JsdocOverloadSignature {
+    pub(crate) comment: String,
+    pub(crate) type_params: Vec<String>,
+    pub(crate) params: Vec<JsdocParamDecl>,
+    pub(crate) return_type: Option<String>,
+}
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn statement_has_attached_jsdoc(
@@ -722,6 +730,9 @@ impl<'a> DeclarationEmitter<'a> {
     /// Normalize a single JSDoc type atom: `*` -> `any`, otherwise pass through.
     fn normalize_jsdoc_type_atom(s: &str) -> String {
         let s = s.trim();
+        if let Some(inner) = s.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+            return format!("\"{}\"", escape_string_for_double_quote(inner));
+        }
         match s {
             "*" | "?" => "any".to_string(),
             // `Array<>` is the form after `normalize_jsdoc_type_expr` strips
@@ -831,6 +842,87 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|raw_line| raw_line.trim_start_matches('*').trim())
             .filter_map(Self::parse_jsdoc_param_decl)
             .collect()
+    }
+
+    pub(in crate::declaration_emitter) fn jsdoc_has_overload_tag(jsdoc: &str) -> bool {
+        jsdoc.lines().any(|raw_line| {
+            let line = raw_line.trim_start_matches('*').trim();
+            let Some(rest) = line.strip_prefix("@overload") else {
+                return false;
+            };
+            rest.chars()
+                .next()
+                .is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '$')
+        })
+    }
+
+    pub(crate) fn jsdoc_overload_signatures_from_chain(
+        chain: &[String],
+    ) -> Vec<JsdocOverloadSignature> {
+        let mut overloads = Vec::new();
+        for jsdoc in chain {
+            if !Self::jsdoc_has_overload_tag(jsdoc) {
+                continue;
+            }
+
+            let lines = jsdoc
+                .lines()
+                .map(|line| line.trim_start_matches('*').trim().to_string())
+                .collect::<Vec<_>>();
+            let overload_starts = lines
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, line)| {
+                    line.strip_prefix("@overload").and_then(|rest| {
+                        rest.chars()
+                            .next()
+                            .is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '$')
+                            .then_some(idx)
+                    })
+                })
+                .collect::<Vec<_>>();
+            if overload_starts.is_empty() {
+                continue;
+            }
+
+            let type_params = Self::parse_jsdoc_template_params(jsdoc);
+            for (idx, &start) in overload_starts.iter().enumerate() {
+                let end = overload_starts
+                    .get(idx + 1)
+                    .copied()
+                    .unwrap_or_else(|| Self::jsdoc_last_overload_segment_end(&lines, start));
+                let segment = lines[start..end].join("\n");
+                let params = Self::parse_jsdoc_param_decls(&segment);
+                let return_type = Self::parse_jsdoc_return_type_text(&segment);
+                if params.is_empty() && return_type.is_none() {
+                    continue;
+                }
+
+                overloads.push(JsdocOverloadSignature {
+                    comment: jsdoc.clone(),
+                    type_params: type_params.clone(),
+                    params,
+                    return_type,
+                });
+            }
+        }
+        overloads
+    }
+
+    fn jsdoc_last_overload_segment_end(lines: &[String], start: usize) -> usize {
+        for idx in start + 1..lines.len().saturating_sub(1) {
+            if !lines[idx].trim().is_empty() {
+                continue;
+            }
+            let next = lines[idx + 1].trim();
+            if next.starts_with("@param")
+                || next.starts_with("@return")
+                || next.starts_with("@returns")
+            {
+                return idx;
+            }
+        }
+        lines.len()
     }
 
     pub(crate) fn jsdoc_param_decl_for_parameter(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -2292,6 +2292,9 @@ impl<'a> DeclarationEmitter<'a> {
         let exported = self.source_file_has_module_syntax(source_file)
             && self.js_export_equals_names.is_empty();
 
+        let alias_can_share_declaration_name =
+            self.js_default_typedef_alias_can_share_declaration_name(source_file, &alias_name);
+
         for &stmt_idx in &source_file.statements.nodes {
             let Some(stmt_node) = self.arena.get(stmt_idx) else {
                 continue;
@@ -2301,6 +2304,7 @@ impl<'a> DeclarationEmitter<'a> {
                     &jsdoc,
                     &alias_name,
                     exported,
+                    alias_can_share_declaration_name,
                 );
             }
         }
@@ -2309,7 +2313,12 @@ impl<'a> DeclarationEmitter<'a> {
             return;
         };
         for jsdoc in self.leading_jsdoc_comment_chain_for_pos(eof_pos) {
-            self.emit_jsdoc_default_typedef_alias_decl_for_comment(&jsdoc, &alias_name, exported);
+            self.emit_jsdoc_default_typedef_alias_decl_for_comment(
+                &jsdoc,
+                &alias_name,
+                exported,
+                alias_can_share_declaration_name,
+            );
         }
     }
 
@@ -2318,20 +2327,41 @@ impl<'a> DeclarationEmitter<'a> {
         jsdoc: &str,
         alias_name: &str,
         exported: bool,
+        alias_can_share_declaration_name: bool,
     ) {
         let Some(mut decl) = Self::parse_jsdoc_default_typedef_alias_decl(jsdoc, alias_name) else {
             return;
         };
 
-        // A `@typedef {…} default` can map to an existing default-export local
-        // name (e.g. `class Cls; export default Cls;`). Emitting `export type Cls`
-        // would collide with that declaration in `.d.ts`, so synthesize a unique
-        // alias and reserve it for subsequent import/export name generation.
-        if self.reserved_names.contains(&decl.name) {
+        if self.reserved_names.contains(&decl.name) && !alias_can_share_declaration_name {
             decl.name = self.generate_unique_name(&decl.name);
         }
         self.reserved_names.insert(decl.name.clone());
 
         self.emit_rendered_jsdoc_type_alias(decl, exported);
+    }
+
+    fn js_default_typedef_alias_can_share_declaration_name(
+        &self,
+        source_file: &tsz_parser::parser::node::SourceFileData,
+        alias_name: &str,
+    ) -> bool {
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            match stmt_node.kind {
+                k if k == syntax_kind_ext::CLASS_DECLARATION
+                    || k == syntax_kind_ext::FUNCTION_DECLARATION =>
+                {
+                    if self.extract_declaration_name(stmt_idx).as_deref() == Some(alias_name) {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        false
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -336,12 +336,54 @@ impl<'a> DeclarationEmitter<'a> {
             .flatten();
         let has_direct_function_return = direct_function_return.is_some();
         let return_text = direct_function_return
+            .or_else(|| self.function_body_nonnullable_short_circuit_return_text(func, func_body))
             .or_else(|| self.function_body_preferred_return_type_text(func_body))
             .map(|type_text| {
                 self.expand_rest_tuple_parameters_in_function_type_text(func_body, &type_text)
                     .unwrap_or(type_text)
             });
         (return_text, has_direct_function_return)
+    }
+
+    fn function_body_nonnullable_short_circuit_return_text(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        func_body: NodeIndex,
+    ) -> Option<String> {
+        let body_node = self.arena.get(func_body)?;
+        let block = self.arena.get_block(body_node)?;
+        let [return_idx] = block.statements.nodes.as_slice() else {
+            return None;
+        };
+        let return_node = self.arena.get(*return_idx)?;
+        let ret = self.arena.get_return_statement(return_node)?;
+        let expr_idx = self.skip_parenthesized_expression(ret.expression)?;
+        let expr_node = self.arena.get(expr_idx)?;
+        let binary = self.arena.get_binary_expr(expr_node)?;
+        if binary.operator_token != SyntaxKind::BarBarToken as u16
+            && binary.operator_token != SyntaxKind::QuestionQuestionToken as u16
+        {
+            return None;
+        }
+        if !self.expression_type_is_never_for_decl_emit(binary.right) {
+            return None;
+        }
+        let left_name = self.get_identifier_text(binary.left)?;
+        for param_idx in func.parameters.nodes.iter().copied() {
+            let param_node = self.arena.get(param_idx)?;
+            let param = self.arena.get_parameter(param_node)?;
+            if self.get_identifier_text(param.name).as_deref() != Some(left_name.as_str()) {
+                continue;
+            }
+            let param_text = self
+                .emit_type_node_text(param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))?;
+            let non_undefined = Self::remove_undefined_from_union_text(param_text.trim())?;
+            if Self::is_simple_identifier_text(&non_undefined) {
+                return Some(format!("NonNullable<{non_undefined}>"));
+            }
+        }
+        None
     }
 
     pub(in crate::declaration_emitter) fn class_property_function_initializer_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -6977,6 +6977,11 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return Some(type_text);
         }
+        if let Some(type_text) =
+            self.function_body_string_literal_return_union_type_text(&block.statements)
+        {
+            return Some(type_text);
+        }
         let mut preferred = None;
         if self.collect_unique_return_type_text_from_block(&block.statements, &mut preferred) {
             preferred
@@ -6991,6 +6996,12 @@ impl<'a> DeclarationEmitter<'a> {
         inferred_return_type: tsz_solver::types::TypeId,
     ) -> bool {
         if Self::numeric_literal_union_widens_to_number(
+            source_type_text,
+            &self.print_type_id(inferred_return_type),
+        ) {
+            return true;
+        }
+        if Self::string_literal_union_widens_to_string(
             source_type_text,
             &self.print_type_id(inferred_return_type),
         ) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -7612,7 +7612,10 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    fn function_expression_type_text_from_ast(&self, expr_idx: NodeIndex) -> Option<String> {
+    pub(in crate::declaration_emitter) fn function_expression_type_text_from_ast(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
         let expr_node = self.arena.get(expr_idx)?;
         if expr_node.kind != syntax_kind_ext::ARROW_FUNCTION
             && expr_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -5817,6 +5817,11 @@ impl<'a> DeclarationEmitter<'a> {
                     return Some(inferred);
                 }
             }
+            if let Some(inferred) =
+                self.generic_new_expression_inferred_type_text(&base_text, new_expr)
+            {
+                return Some(inferred);
+            }
             if let Some(ident) = self.get_identifier_text(new_expr.expression)
                 && let Some(sym_id) = self.resolve_identifier_symbol(new_expr.expression, &ident)
                 && let Some(symbol) = self.binder.and_then(|binder| binder.symbols.get(sym_id))
@@ -5858,6 +5863,249 @@ impl<'a> DeclarationEmitter<'a> {
             Some(base_text)
         } else {
             Some(format!("{base_text}<{}>", type_args.join(", ")))
+        }
+    }
+
+    fn generic_new_expression_inferred_type_text(
+        &self,
+        base_text: &str,
+        new_expr: &tsz_parser::parser::node::CallExprData,
+    ) -> Option<String> {
+        let args = new_expr.arguments.as_ref()?;
+        if args.nodes.is_empty() {
+            return None;
+        }
+
+        let ident = self.get_identifier_text(new_expr.expression)?;
+        let sym_id = self.resolve_identifier_symbol(new_expr.expression, &ident)?;
+        let symbol = self.binder.and_then(|binder| binder.symbols.get(sym_id))?;
+        if symbol.flags & symbol_flags::CLASS == 0 {
+            return None;
+        }
+
+        for &decl_idx in &symbol.declarations {
+            let Some(class_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(class_data) = self.arena.get_class(class_node) else {
+                continue;
+            };
+            let Some(type_parameters) = class_data.type_parameters.as_ref() else {
+                continue;
+            };
+            if type_parameters.nodes.is_empty() {
+                continue;
+            }
+
+            let type_param_names = type_parameters
+                .nodes
+                .iter()
+                .filter_map(|&param_idx| {
+                    let param_node = self.arena.get(param_idx)?;
+                    let param = self.arena.get_type_parameter(param_node)?;
+                    self.get_identifier_text(param.name)
+                })
+                .collect::<Vec<_>>();
+            if type_param_names.is_empty() {
+                continue;
+            }
+
+            let mut inferred_args =
+                self.generic_new_expression_default_type_args(type_parameters)?;
+            if inferred_args.len() != type_param_names.len() {
+                continue;
+            }
+
+            let mut inferred_any = false;
+            self.infer_generic_new_expression_args_from_constructor(
+                class_data,
+                &type_param_names,
+                &args.nodes,
+                &mut inferred_args,
+                &mut inferred_any,
+            );
+            self.infer_generic_new_expression_args_from_base(
+                class_data,
+                &type_param_names,
+                &args.nodes,
+                &mut inferred_args,
+                &mut inferred_any,
+            );
+
+            if inferred_any {
+                return Some(format!("{base_text}<{}>", inferred_args.join(", ")));
+            }
+        }
+
+        None
+    }
+
+    fn generic_new_expression_default_type_args(
+        &self,
+        type_parameters: &NodeList,
+    ) -> Option<Vec<String>> {
+        type_parameters
+            .nodes
+            .iter()
+            .map(|&param_idx| {
+                let param_node = self.arena.get(param_idx)?;
+                let param = self.arena.get_type_parameter(param_node)?;
+                if param.default.is_some() {
+                    let default_node = self.arena.get(param.default)?;
+                    self.get_source_slice_no_semi(default_node.pos, default_node.end)
+                } else {
+                    Some("unknown".to_string())
+                }
+            })
+            .collect()
+    }
+
+    fn infer_generic_new_expression_args_from_constructor(
+        &self,
+        class_data: &tsz_parser::parser::node::ClassData,
+        type_param_names: &[String],
+        arg_nodes: &[NodeIndex],
+        inferred_args: &mut [String],
+        inferred_any: &mut bool,
+    ) {
+        let Some(constructor) = class_data.members.nodes.iter().find_map(|&member_idx| {
+            let member_node = self.arena.get(member_idx)?;
+            self.arena.get_constructor(member_node)
+        }) else {
+            return;
+        };
+
+        for (param_idx, &arg_idx) in constructor.parameters.nodes.iter().zip(arg_nodes.iter()) {
+            let Some(param_node) = self.arena.get(*param_idx) else {
+                continue;
+            };
+            let Some(param) = self.arena.get_parameter(param_node) else {
+                continue;
+            };
+            let Some(type_text) = self.source_slice_from_arena(self.arena, param.type_annotation)
+            else {
+                continue;
+            };
+            let type_text = type_text.trim();
+            if let Some(type_param_index) = type_param_names
+                .iter()
+                .position(|name| name.as_str() == type_text)
+                && let Some(arg_type_text) = self.generic_new_expression_arg_type_text(arg_idx)
+            {
+                inferred_args[type_param_index] = arg_type_text;
+                *inferred_any = true;
+            }
+        }
+    }
+
+    fn infer_generic_new_expression_args_from_base(
+        &self,
+        class_data: &tsz_parser::parser::node::ClassData,
+        type_param_names: &[String],
+        arg_nodes: &[NodeIndex],
+        inferred_args: &mut [String],
+        inferred_any: &mut bool,
+    ) {
+        if class_data.members.nodes.iter().any(|&member_idx| {
+            self.arena
+                .get(member_idx)
+                .is_some_and(|member_node| self.arena.get_constructor(member_node).is_some())
+        }) {
+            return;
+        }
+        let Some(first_arg) = arg_nodes.first().copied() else {
+            return;
+        };
+        let Some(heritage_clauses) = class_data.heritage_clauses.as_ref() else {
+            return;
+        };
+        for &clause_idx in &heritage_clauses.nodes {
+            let Some(clause_node) = self.arena.get(clause_idx) else {
+                continue;
+            };
+            let Some(heritage) = self.arena.get_heritage_clause(clause_node) else {
+                continue;
+            };
+            if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                continue;
+            }
+            let Some(&heritage_type_idx) = heritage.types.nodes.first() else {
+                return;
+            };
+            let Some(heritage_type_node) = self.arena.get(heritage_type_idx) else {
+                return;
+            };
+            let Some(expr_type_args) = self.arena.get_expr_type_args(heritage_type_node) else {
+                return;
+            };
+            if expr_type_args
+                .type_arguments
+                .as_ref()
+                .map_or(0, |args| args.nodes.len())
+                != 1
+                || type_param_names.len() != 1
+            {
+                return;
+            }
+            let Some(type_arg_idx) = expr_type_args
+                .type_arguments
+                .as_ref()
+                .and_then(|args| args.nodes.first().copied())
+            else {
+                return;
+            };
+            let Some(type_arg_text) = self
+                .get_source_slice_no_semi(
+                    self.arena.get(type_arg_idx).map_or(0, |node| node.pos),
+                    self.arena.get(type_arg_idx).map_or(0, |node| node.end),
+                )
+                .map(|text| text.trim().to_string())
+            else {
+                return;
+            };
+            if type_arg_text != type_param_names[0] {
+                return;
+            }
+            if let Some(arg_type_text) = self.generic_new_expression_arg_type_text(first_arg) {
+                inferred_args[0] = arg_type_text;
+                *inferred_any = true;
+            }
+            return;
+        }
+    }
+
+    fn generic_new_expression_arg_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        if let Some(interner) = self.type_interner
+            && let Some(type_id) = self.get_node_type_or_names(&[arg_idx])
+        {
+            let widened = tsz_solver::operations::widening::widen_literal_type(interner, type_id);
+            return Some(self.print_type_id_for_inferred_declaration(widened));
+        }
+
+        self.widened_primitive_literal_type_text(arg_idx)
+    }
+
+    fn widened_primitive_literal_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        match expr_node.kind {
+            k if k == SyntaxKind::StringLiteral as u16 => Some("string".to_string()),
+            k if k == SyntaxKind::NumericLiteral as u16 => Some("number".to_string()),
+            k if k == SyntaxKind::BigIntLiteral as u16 => Some("bigint".to_string()),
+            k if k == SyntaxKind::TrueKeyword as u16 || k == SyntaxKind::FalseKeyword as u16 => {
+                Some("boolean".to_string())
+            }
+            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+                && self.is_negative_literal(expr_node) =>
+            {
+                let unary = self.arena.get_unary_expr(expr_node)?;
+                let operand = self.arena.get(unary.operand)?;
+                match operand.kind {
+                    k if k == SyntaxKind::NumericLiteral as u16 => Some("number".to_string()),
+                    k if k == SyntaxKind::BigIntLiteral as u16 => Some("bigint".to_string()),
+                    _ => None,
+                }
+            }
+            _ => None,
         }
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -2656,6 +2656,17 @@ impl<'a> DeclarationEmitter<'a> {
             return self.rewrite_exported_import_equals_type_text(type_text);
         }
 
+        if self
+            .namespace_import_module_specifier_from_syntax(initializer)
+            .or_else(|| self.imported_value_module_specifier_from_syntax(initializer))
+            .is_some_and(|module_specifier| module_specifier.ends_with(".json"))
+        {
+            let type_text = self.print_type_id_expanded_for_inferred_declaration(type_id);
+            if type_text != "any" && !type_text.starts_with("typeof ") {
+                return self.rewrite_exported_import_equals_type_text(type_text);
+            }
+        }
+
         if let Some(typeof_text) =
             self.typeof_prefix_for_value_entity(initializer, true, Some(type_id))
         {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -4341,7 +4341,7 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
-    fn enclosing_parameter_type_annotation_text_for_identifier(
+    pub(in crate::declaration_emitter) fn enclosing_parameter_type_annotation_text_for_identifier(
         &self,
         arg_idx: NodeIndex,
     ) -> Option<String> {
@@ -4355,12 +4355,18 @@ impl<'a> DeclarationEmitter<'a> {
                     let param_node = self.arena.get(param_idx)?;
                     let param = self.arena.get_parameter(param_node)?;
                     if self.get_identifier_text(param.name).as_deref() == Some(arg_name.as_str()) {
-                        return self
-                            .type_annotation_text_from_arena_node(self.arena, param.type_annotation)
-                            .or_else(|| {
-                                self.source_slice_from_arena(self.arena, param.type_annotation)
-                            })
-                            .map(|text| text.trim().to_string());
+                        let typed = self.type_annotation_text_from_arena_node(
+                            self.arena,
+                            param.type_annotation,
+                        );
+                        let source =
+                            self.source_slice_from_arena(self.arena, param.type_annotation);
+                        return match typed.as_deref() {
+                            Some("any" | "unknown") => source.or(typed),
+                            Some(_) => typed,
+                            None => source,
+                        }
+                        .map(|text| text.trim().to_string());
                     }
                 }
                 return None;
@@ -6740,6 +6746,11 @@ impl<'a> DeclarationEmitter<'a> {
             source_type_text,
             &self.print_type_id(inferred_return_type),
         ) {
+            return true;
+        }
+        if source_type_text.starts_with("NonNullable<")
+            && self.print_type_id(inferred_return_type) != source_type_text
+        {
             return true;
         }
         if source_type_text.contains("{\n    new ")

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_function_text.rs
@@ -70,6 +70,16 @@ impl<'a> DeclarationEmitter<'a> {
                             .iter()
                             .any(|(name, _)| name.as_str() == source_param.type_text)
                     {
+                        if let Some(argument_param) = argument.parameters.get(source_param_index)
+                            && argument_param.rest
+                            && argument.parameters.len() == source_param_index + 1
+                        {
+                            substitutions.push((
+                                source_param.type_text.clone(),
+                                argument_param.type_text.clone(),
+                            ));
+                            continue;
+                        }
                         let tuple_items = argument
                             .parameters
                             .iter()

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
@@ -6,6 +6,12 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::types::TypeId;
 
+#[derive(Clone)]
+struct ShortCircuitOrTypeText {
+    text: String,
+    widened_from_inferred_literal: bool,
+}
+
 impl<'a> DeclarationEmitter<'a> {
     pub(super) fn short_circuit_expression_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
         let expr_node = self.arena.get(expr_idx)?;
@@ -47,6 +53,10 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         if binary.operator_token == SyntaxKind::BarBarToken as u16 {
+            if let Some(type_text) = self.short_circuit_or_literal_type_text(expr_idx) {
+                return Some(type_text.text);
+            }
+
             if !self.expression_is_always_truthy_for_decl_emit(binary.left) {
                 return None;
             }
@@ -60,6 +70,250 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         None
+    }
+
+    fn short_circuit_or_literal_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<ShortCircuitOrTypeText> {
+        let expr_idx = self.skip_parenthesized_expression_via_parent_node(expr_idx)?;
+        let expr_node = self.arena.get(expr_idx)?;
+        let binary = self.arena.get_binary_expr(expr_node)?;
+        if binary.operator_token != SyntaxKind::BarBarToken as u16 {
+            return None;
+        }
+
+        let left = self.short_circuit_or_literal_operand_type_text(binary.left)?;
+        let right = self.short_circuit_or_literal_operand_type_text(binary.right)?;
+        Self::combine_short_circuit_or_literal_types(left, right)
+    }
+
+    fn short_circuit_or_literal_operand_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<ShortCircuitOrTypeText> {
+        let expr_idx = self.skip_parenthesized_expression_via_parent_node(expr_idx)?;
+        let expr_node = self.arena.get(expr_idx)?;
+
+        if expr_node.kind == syntax_kind_ext::BINARY_EXPRESSION
+            && self
+                .arena
+                .get_binary_expr(expr_node)
+                .is_some_and(|binary| binary.operator_token == SyntaxKind::BarBarToken as u16)
+        {
+            return self.short_circuit_or_literal_type_text(expr_idx);
+        }
+
+        if expr_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        if let Some(type_text) = self.reference_declared_type_annotation_text(expr_idx) {
+            return Self::short_circuit_or_literal_operand_from_text(&type_text, false);
+        }
+
+        if let Some(initializer) = self.unannotated_const_literal_reference_initializer(expr_idx) {
+            let initializer = self.skip_parenthesized_expression_via_parent_node(initializer)?;
+            if let Some(type_text) = self.short_circuit_or_literal_type_text(initializer) {
+                return Some(type_text);
+            }
+            if let Some(type_text) =
+                self.short_circuit_widened_literal_initializer_type_text(initializer)
+            {
+                return Self::short_circuit_or_literal_operand_from_text(&type_text, true);
+            }
+        }
+
+        None
+    }
+
+    fn unannotated_const_literal_reference_initializer(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.value_reference_symbol(expr_idx)?;
+        let binder = self.binder?;
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let decl_node = self.arena.get(decl_idx)?;
+            let Some(var_decl) = self.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            if self.arena.is_const_variable_declaration(decl_idx)
+                && var_decl.type_annotation.is_none()
+                && var_decl.initializer.is_some()
+            {
+                return Some(var_decl.initializer);
+            }
+        }
+
+        None
+    }
+
+    fn short_circuit_widened_literal_initializer_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_idx = self.skip_parenthesized_expression_via_parent_node(expr_idx)?;
+        let expr_node = self.arena.get(expr_idx)?;
+        match expr_node.kind {
+            k if k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
+            {
+                Some("string".to_string())
+            }
+            k if k == SyntaxKind::NumericLiteral as u16 => Some("number".to_string()),
+            k if k == SyntaxKind::BigIntLiteral as u16 => Some("bigint".to_string()),
+            k if k == SyntaxKind::TrueKeyword as u16 || k == SyntaxKind::FalseKeyword as u16 => {
+                Some("boolean".to_string())
+            }
+            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+                && self.is_negative_literal(expr_node) =>
+            {
+                let unary = self.arena.get_unary_expr(expr_node)?;
+                let operand = self.arena.get(unary.operand)?;
+                match operand.kind {
+                    k if k == SyntaxKind::NumericLiteral as u16 => Some("number".to_string()),
+                    k if k == SyntaxKind::BigIntLiteral as u16 => Some("bigint".to_string()),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn short_circuit_or_literal_operand_from_text(
+        type_text: &str,
+        widened_from_inferred_literal: bool,
+    ) -> Option<ShortCircuitOrTypeText> {
+        let parts = Self::split_top_level_union_type_parts(type_text);
+        if parts
+            .iter()
+            .all(|part| Self::short_circuit_literal_part_kind(part).is_some())
+        {
+            return Some(ShortCircuitOrTypeText {
+                text: parts.join(" | "),
+                widened_from_inferred_literal,
+            });
+        }
+        None
+    }
+
+    fn combine_short_circuit_or_literal_types(
+        left: ShortCircuitOrTypeText,
+        right: ShortCircuitOrTypeText,
+    ) -> Option<ShortCircuitOrTypeText> {
+        let left_parts = Self::split_top_level_union_type_parts(&left.text);
+        let right_parts = Self::split_top_level_union_type_parts(&right.text);
+        let mut parts = Vec::new();
+        parts.extend(left_parts);
+        parts.extend(right_parts);
+
+        if parts
+            .iter()
+            .any(|part| Self::short_circuit_literal_part_kind(part).is_none())
+        {
+            return None;
+        }
+
+        let should_widen = left.widened_from_inferred_literal
+            || right.widened_from_inferred_literal
+            || parts
+                .iter()
+                .any(|part| Self::short_circuit_literal_part_is_wide(part));
+
+        if should_widen {
+            let mut widened_parts = Vec::new();
+            for kind in ["string", "number", "boolean", "bigint"] {
+                if parts
+                    .iter()
+                    .any(|part| Self::short_circuit_literal_part_kind(part) == Some(kind))
+                {
+                    widened_parts.push(kind.to_string());
+                }
+            }
+            return Some(ShortCircuitOrTypeText {
+                text: widened_parts.join(" | "),
+                widened_from_inferred_literal: true,
+            });
+        }
+
+        let mut literal_parts = Vec::new();
+        for part in parts {
+            if !literal_parts.contains(&part) {
+                literal_parts.push(part);
+            }
+        }
+        Self::sort_primitive_name_string_literals(&mut literal_parts);
+
+        Some(ShortCircuitOrTypeText {
+            text: literal_parts.join(" | "),
+            widened_from_inferred_literal: false,
+        })
+    }
+
+    fn short_circuit_literal_part_kind(part: &str) -> Option<&'static str> {
+        let part = part.trim();
+        match part {
+            "string" => return Some("string"),
+            "number" => return Some("number"),
+            "boolean" => return Some("boolean"),
+            "bigint" => return Some("bigint"),
+            "true" | "false" => return Some("boolean"),
+            _ => {}
+        }
+
+        if (part.starts_with('"') && part.ends_with('"'))
+            || (part.starts_with('\'') && part.ends_with('\''))
+        {
+            return Some("string");
+        }
+
+        if part
+            .strip_prefix('-')
+            .unwrap_or(part)
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ch == '.')
+            && part.chars().any(|ch| ch.is_ascii_digit())
+        {
+            return Some("number");
+        }
+
+        if part.ends_with('n')
+            && part[..part.len() - 1]
+                .strip_prefix('-')
+                .unwrap_or(&part[..part.len() - 1])
+                .chars()
+                .all(|ch| ch.is_ascii_digit())
+        {
+            return Some("bigint");
+        }
+
+        None
+    }
+
+    fn short_circuit_literal_part_is_wide(part: &str) -> bool {
+        matches!(part.trim(), "string" | "number" | "boolean" | "bigint")
+    }
+
+    fn sort_primitive_name_string_literals(parts: &mut [String]) {
+        fn primitive_name_rank(part: &str) -> Option<usize> {
+            match part.trim() {
+                r#""string""# | "'string'" => Some(0),
+                r#""number""# | "'number'" => Some(1),
+                r#""boolean""# | "'boolean'" => Some(2),
+                _ => None,
+            }
+        }
+
+        if parts.iter().all(|part| primitive_name_rank(part).is_some()) {
+            parts.sort_by_key(|part| primitive_name_rank(part).unwrap_or(usize::MAX));
+        }
     }
 
     pub(in crate::declaration_emitter) fn expression_type_is_never_for_decl_emit(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
@@ -4,6 +4,7 @@ use super::super::DeclarationEmitter;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
+use tsz_solver::types::TypeId;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(super) fn short_circuit_expression_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
@@ -13,6 +14,20 @@ impl<'a> DeclarationEmitter<'a> {
         if binary.operator_token == SyntaxKind::BarBarToken as u16
             || binary.operator_token == SyntaxKind::QuestionQuestionToken as u16
         {
+            if self.expression_type_is_never_for_decl_emit(binary.right)
+                && let Some(left_text) = self
+                    .short_circuit_operand_type_text(binary.left)
+                    .filter(|text| text != "any" && text != "unknown")
+                    .or_else(|| {
+                        self.enclosing_parameter_type_annotation_text_for_identifier(binary.left)
+                    })
+                    .or_else(|| self.reference_declared_type_annotation_text(binary.left))
+                && let Some(non_undefined) = Self::remove_undefined_from_union_text(&left_text)
+                && Self::is_simple_identifier_text(&non_undefined)
+            {
+                return Some(format!("NonNullable<{non_undefined}>"));
+            }
+
             if let (Some(left_text), Some(right_text)) = (
                 self.short_circuit_operand_type_text(binary.left),
                 self.short_circuit_operand_type_text(binary.right),
@@ -45,6 +60,17 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         None
+    }
+
+    pub(in crate::declaration_emitter) fn expression_type_is_never_for_decl_emit(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(expr_idx) = self.skip_parenthesized_expression(expr_idx) else {
+            return false;
+        };
+        self.get_node_type_or_names(&[expr_idx])
+            .is_some_and(|type_id| type_id == TypeId::NEVER)
     }
 
     fn short_circuit_operand_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
@@ -172,7 +198,9 @@ impl<'a> DeclarationEmitter<'a> {
         Some(format!("{prefix}{instantiated}{suffix}"))
     }
 
-    fn remove_undefined_from_union_text(type_text: &str) -> Option<String> {
+    pub(in crate::declaration_emitter) fn remove_undefined_from_union_text(
+        type_text: &str,
+    ) -> Option<String> {
         let parts = Self::split_top_level_union_type_parts(type_text);
         if parts.len() <= 1 || !parts.iter().any(|part| part == "undefined") {
             return None;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_unions.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_unions.rs
@@ -41,6 +41,31 @@ impl<'a> DeclarationEmitter<'a> {
         count > 1
     }
 
+    pub(in crate::declaration_emitter) fn string_literal_union_widens_to_string(
+        source_type_text: &str,
+        inferred_text: &str,
+    ) -> bool {
+        if inferred_text != "string" {
+            return false;
+        }
+
+        let mut count = 0usize;
+        for part in source_type_text.split(" | ") {
+            let part = part.trim();
+            let Some(first) = part.chars().next() else {
+                return false;
+            };
+            let Some(last) = part.chars().next_back() else {
+                return false;
+            };
+            if (first != '"' && first != '\'') || first != last || part.len() < 2 {
+                return false;
+            }
+            count += 1;
+        }
+        count > 1
+    }
+
     pub(in crate::declaration_emitter) fn simplify_uniform_object_keyof_index_access_text(
         &self,
         type_text: &str,
@@ -245,6 +270,159 @@ impl<'a> DeclarationEmitter<'a> {
                     conditional.when_true,
                     literals,
                 ) && self.collect_numeric_literal_return_type_text_from_expression(
+                    conditional.when_false,
+                    literals,
+                );
+            }
+            _ => None,
+        };
+
+        let Some(type_text) = type_text else {
+            return false;
+        };
+        if !literals.contains(&type_text) {
+            literals.push(type_text);
+        }
+        true
+    }
+
+    pub(in crate::declaration_emitter) fn function_body_string_literal_return_union_type_text(
+        &self,
+        statements: &NodeList,
+    ) -> Option<String> {
+        let mut literals = Vec::new();
+        if !self.collect_string_literal_return_type_text_from_block(statements, &mut literals) {
+            return None;
+        }
+        (literals.len() > 1).then(|| literals.join(" | "))
+    }
+
+    fn collect_string_literal_return_type_text_from_block(
+        &self,
+        statements: &NodeList,
+        literals: &mut Vec<String>,
+    ) -> bool {
+        statements.nodes.iter().copied().all(|stmt_idx| {
+            self.collect_string_literal_return_type_text_from_statement(stmt_idx, literals)
+        })
+    }
+
+    fn collect_string_literal_return_type_text_from_statement(
+        &self,
+        stmt_idx: NodeIndex,
+        literals: &mut Vec<String>,
+    ) -> bool {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return true;
+        };
+
+        match stmt_node.kind {
+            k if k == syntax_kind_ext::RETURN_STATEMENT => {
+                let Some(ret) = self.arena.get_return_statement(stmt_node) else {
+                    return false;
+                };
+                let Some(expr_idx) = self.skip_parenthesized_expression(ret.expression) else {
+                    return false;
+                };
+                self.collect_string_literal_return_type_text_from_expression(expr_idx, literals)
+            }
+            k if k == syntax_kind_ext::BLOCK => {
+                self.arena.get_block(stmt_node).is_some_and(|block| {
+                    self.collect_string_literal_return_type_text_from_block(
+                        &block.statements,
+                        literals,
+                    )
+                })
+            }
+            k if k == syntax_kind_ext::IF_STATEMENT => self
+                .arena
+                .get_if_statement(stmt_node)
+                .is_some_and(|if_data| {
+                    self.collect_string_literal_return_type_text_from_statement(
+                        if_data.then_statement,
+                        literals,
+                    ) && (!if_data.else_statement.is_some()
+                        || self.collect_string_literal_return_type_text_from_statement(
+                            if_data.else_statement,
+                            literals,
+                        ))
+                }),
+            k if k == syntax_kind_ext::TRY_STATEMENT => {
+                self.arena.get_try(stmt_node).is_some_and(|try_data| {
+                    self.collect_string_literal_return_type_text_from_statement(
+                        try_data.try_block,
+                        literals,
+                    ) && (!try_data.catch_clause.is_some()
+                        || self.collect_string_literal_return_type_text_from_statement(
+                            try_data.catch_clause,
+                            literals,
+                        ))
+                        && (!try_data.finally_block.is_some()
+                            || self.collect_string_literal_return_type_text_from_statement(
+                                try_data.finally_block,
+                                literals,
+                            ))
+                })
+            }
+            k if k == syntax_kind_ext::CATCH_CLAUSE => self
+                .arena
+                .get_catch_clause(stmt_node)
+                .is_some_and(|catch_data| {
+                    self.collect_string_literal_return_type_text_from_statement(
+                        catch_data.block,
+                        literals,
+                    )
+                }),
+            k if k == syntax_kind_ext::CASE_CLAUSE || k == syntax_kind_ext::DEFAULT_CLAUSE => {
+                self.arena.get_case_clause(stmt_node).is_some_and(|clause| {
+                    self.collect_string_literal_return_type_text_from_block(
+                        &clause.statements,
+                        literals,
+                    )
+                })
+            }
+            k if k == syntax_kind_ext::SWITCH_STATEMENT => {
+                self.arena.get_switch(stmt_node).is_some_and(|switch_data| {
+                    self.arena
+                        .get(switch_data.case_block)
+                        .and_then(|case_block_node| self.arena.get_block(case_block_node))
+                        .is_some_and(|block| {
+                            self.collect_string_literal_return_type_text_from_block(
+                                &block.statements,
+                                literals,
+                            )
+                        })
+                })
+            }
+            _ => true,
+        }
+    }
+
+    fn collect_string_literal_return_type_text_from_expression(
+        &self,
+        expr_idx: NodeIndex,
+        literals: &mut Vec<String>,
+    ) -> bool {
+        let Some(expr_idx) = self.skip_parenthesized_expression(expr_idx) else {
+            return false;
+        };
+        if self.expression_type_is_never_for_decl_emit(expr_idx) {
+            return true;
+        }
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+
+        let type_text = match expr_node.kind {
+            k if k == SyntaxKind::StringLiteral as u16 => self.js_literal_type_text(expr_idx),
+            k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => {
+                let Some(conditional) = self.arena.get_conditional_expr(expr_node) else {
+                    return false;
+                };
+                return self.collect_string_literal_return_type_text_from_expression(
+                    conditional.when_true,
+                    literals,
+                ) && self.collect_string_literal_return_type_text_from_expression(
                     conditional.when_false,
                     literals,
                 );

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_unions.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_unions.rs
@@ -117,19 +117,7 @@ impl<'a> DeclarationEmitter<'a> {
                 let Some(expr_idx) = self.skip_parenthesized_expression(ret.expression) else {
                     return false;
                 };
-                let Some(expr_node) = self.arena.get(expr_idx) else {
-                    return false;
-                };
-                if expr_node.kind != SyntaxKind::NumericLiteral as u16 {
-                    return false;
-                }
-                let Some(type_text) = self.js_literal_type_text(expr_idx) else {
-                    return false;
-                };
-                if !literals.contains(&type_text) {
-                    literals.push(type_text);
-                }
-                true
+                self.collect_numeric_literal_return_type_text_from_expression(expr_idx, literals)
             }
             k if k == syntax_kind_ext::BLOCK => {
                 self.arena.get_block(stmt_node).is_some_and(|block| {
@@ -207,5 +195,69 @@ impl<'a> DeclarationEmitter<'a> {
             }
             _ => true,
         }
+    }
+
+    fn collect_numeric_literal_return_type_text_from_expression(
+        &self,
+        expr_idx: NodeIndex,
+        literals: &mut Vec<String>,
+    ) -> bool {
+        let Some(expr_idx) = self.skip_parenthesized_expression(expr_idx) else {
+            return false;
+        };
+        if self.expression_type_is_never_for_decl_emit(expr_idx) {
+            return true;
+        }
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+
+        let type_text = match expr_node.kind {
+            k if k == SyntaxKind::NumericLiteral as u16 => self.js_literal_type_text(expr_idx),
+            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
+                let Some(unary) = self.arena.get_unary_expr(expr_node) else {
+                    return false;
+                };
+                let Some(operand_idx) = self.skip_parenthesized_expression(unary.operand) else {
+                    return false;
+                };
+                let Some(operand_node) = self.arena.get(operand_idx) else {
+                    return false;
+                };
+                if operand_node.kind != SyntaxKind::NumericLiteral as u16 {
+                    return false;
+                }
+                let Some(literal) = self.arena.get_literal(operand_node) else {
+                    return false;
+                };
+                let normalized = Self::normalize_numeric_literal(literal.text.as_ref());
+                match unary.operator {
+                    k if k == SyntaxKind::MinusToken as u16 => Some(format!("-{normalized}")),
+                    k if k == SyntaxKind::PlusToken as u16 => Some(normalized),
+                    _ => None,
+                }
+            }
+            k if k == syntax_kind_ext::CONDITIONAL_EXPRESSION => {
+                let Some(conditional) = self.arena.get_conditional_expr(expr_node) else {
+                    return false;
+                };
+                return self.collect_numeric_literal_return_type_text_from_expression(
+                    conditional.when_true,
+                    literals,
+                ) && self.collect_numeric_literal_return_type_text_from_expression(
+                    conditional.when_false,
+                    literals,
+                );
+            }
+            _ => None,
+        };
+
+        let Some(type_text) = type_text else {
+            return false;
+        };
+        if !literals.contains(&type_text) {
+            literals.push(type_text);
+        }
+        true
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -15,6 +15,22 @@ fn simultaneous_word_replacement_does_not_rewrite_inserted_import_paths() {
 }
 
 #[test]
+fn string_literal_union_is_preferred_when_solver_widens_to_string() {
+    assert!(DeclarationEmitter::string_literal_union_widens_to_string(
+        "\"ROAAAAR!\" | \"yip yip!\"",
+        "string",
+    ));
+    assert!(!DeclarationEmitter::string_literal_union_widens_to_string(
+        "\"ROAAAAR!\"",
+        "string",
+    ));
+    assert!(!DeclarationEmitter::string_literal_union_widens_to_string(
+        "\"ROAAAAR!\" | number",
+        "string",
+    ));
+}
+
+#[test]
 fn simultaneous_word_replacement_does_not_chain_type_parameter_substitutions() {
     let rewritten = DeclarationEmitter::replace_whole_words_in_text(
         "T | U",

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -347,7 +347,7 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 self.write(": ");
                 self.write(&type_text);
-            } else if is_const_null_or_undefined
+            } else if (is_const_null_or_undefined && !js_has_jsdoc_type)
                 || (has_initializer && self.invalid_const_enum_object_access(initializer))
                 || (has_initializer
                     && self.initializer_uses_inaccessible_class_constructor(initializer))

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -413,16 +413,33 @@ impl<'a> DeclarationEmitter<'a> {
                     .arena
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                && let Some(type_text) =
+                    self.call_expression_reused_type_text(initializer)
+                        .filter(|text| {
+                            text.contains("=>")
+                                && !text.contains("any")
+                                && !text.contains("unknown")
+                        })
+            {
+                self.write(": ");
+                self.write(&type_text);
+            } else if has_initializer
+                && self
+                    .arena
+                    .get(initializer)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
                 && let Some(type_text) = self.preferred_expression_type_text(initializer)
             {
-                let type_text = self
-                    .call_expression_reused_type_text(initializer)
+                let reused_type_text = self.call_expression_reused_type_text(initializer);
+                let type_text = reused_type_text
+                    .as_ref()
                     .filter(|text| {
                         !text.contains("unknown")
                             && (text.contains("=>")
                                 || text.starts_with('[')
                                 || type_text.contains("unknown"))
                     })
+                    .cloned()
                     .unwrap_or(type_text);
                 let has_public_import_type = Self::type_text_starts_with_import_type(&type_text)
                     && !self.import_type_uses_private_package_subpath(&type_text);
@@ -440,7 +457,11 @@ impl<'a> DeclarationEmitter<'a> {
                 let mut type_text = self
                     .expand_rest_tuple_parameters_in_function_type_text(initializer, &type_text)
                     .unwrap_or(type_text);
+                let preserves_reused_literal_call_type = reused_type_text
+                    .as_deref()
+                    .is_some_and(|reused| reused == type_text && reused.contains('"'));
                 if keyword != "const"
+                    && !preserves_reused_literal_call_type
                     && let Some(widened_type_text) =
                         self.widen_mutable_call_initializer_literal_type_text(initializer)
                 {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -1255,6 +1255,11 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(import_module) = symbol.import_module.as_deref() else {
             return false;
         };
+        if import_module.ends_with(".json")
+            && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"))
+        {
+            return false;
+        }
         let local_name = symbol.escaped_name.as_str();
         let import_name = symbol
             .import_name
@@ -1350,7 +1355,13 @@ impl<'a> DeclarationEmitter<'a> {
                     && let Some(bindings) = self.arena.get_named_imports(bindings_node)
                 {
                     if bindings.name.is_some() && bindings.elements.nodes.is_empty() {
-                        if self.imported_name_is_used(binder, used, bindings.name)
+                        let is_json_namespace_import = self
+                            .arena
+                            .get(import.module_specifier)
+                            .and_then(|node| self.arena.get_literal(node))
+                            .is_some_and(|literal| literal.text.ends_with(".json"));
+                        if !is_json_namespace_import
+                            && self.imported_name_is_used(binder, used, bindings.name)
                             || self.namespace_import_needed_for_shadowed_self_type(
                                 bindings.name,
                                 import.module_specifier,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1734,6 +1734,45 @@ let gResult3 = g(helloOrWorld);
 }
 
 #[test]
+fn fix_short_circuit_string_literal_overload_operands_match_tsc_dts_widening() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+const explicitString: "string" = "string";
+const explicitNumber: "number" = "number";
+const explicitBoolean: "boolean" = "boolean";
+const explicitStringOrNumber = explicitString || explicitNumber;
+const explicitStringOrBoolean = explicitString || explicitBoolean;
+const explicitBooleanOrNumber = explicitNumber || explicitBoolean;
+const explicitStringOrBooleanOrNumber = explicitStringOrBoolean || explicitNumber;
+
+const inferredString = "string";
+const inferredNumber = "number";
+const inferredBoolean = "boolean";
+const inferredStringOrNumber = inferredString || inferredNumber;
+const inferredStringOrBoolean = inferredString || inferredBoolean;
+const inferredBooleanOrNumber = inferredNumber || inferredBoolean;
+const inferredStringOrBooleanOrNumber = inferredStringOrBoolean || inferredNumber;
+"#,
+    );
+
+    for expected in [
+        r#"declare const explicitStringOrNumber: "string" | "number";"#,
+        r#"declare const explicitStringOrBoolean: "string" | "boolean";"#,
+        r#"declare const explicitBooleanOrNumber: "number" | "boolean";"#,
+        r#"declare const explicitStringOrBooleanOrNumber: "string" | "number" | "boolean";"#,
+        "declare const inferredStringOrNumber: string;",
+        "declare const inferredStringOrBoolean: string;",
+        "declare const inferredBooleanOrNumber: string;",
+        "declare const inferredStringOrBooleanOrNumber: string;",
+    ] {
+        assert!(
+            output.contains(expected),
+            "expected short-circuit operand type `{expected}`: {output}"
+        );
+    }
+}
+
+#[test]
 fn fix_generic_call_constructor_return_object_formats_multiline() {
     let output = emit_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1632,6 +1632,45 @@ const result = getInterfaceFromString({ type: "two" }, "three");
 }
 
 #[test]
+fn fix_generic_call_identity_callback_uses_type_parameter_constraint() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+function foo<T extends "foo">(f: (x: T) => T) {
+    return f;
+}
+
+function bar<T extends "foo" | "bar">(f: (x: T) => T) {
+    return f;
+}
+
+let f = foo(x => x);
+let fResult = f("foo");
+
+let g = foo((x => x));
+let gResult = g("foo");
+
+let h = bar(x => x);
+let hResult = h("foo");
+hResult = h("bar");
+"#,
+    );
+
+    for expected in [
+        r#"declare let f: (x: "foo") => "foo";"#,
+        r#"declare let fResult: "foo";"#,
+        r#"declare let g: (x: "foo") => "foo";"#,
+        r#"declare let gResult: "foo";"#,
+        r#"declare let h: (x: "foo" | "bar") => "foo" | "bar";"#,
+        r#"declare let hResult: "foo" | "bar";"#,
+    ] {
+        assert!(
+            output.contains(expected),
+            "expected constrained identity callback inference to emit `{expected}`: {output}"
+        );
+    }
+}
+
+#[test]
 fn fix_generic_call_constructor_return_object_formats_multiline() {
     let output = emit_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1671,6 +1671,69 @@ hResult = h("bar");
 }
 
 #[test]
+fn fix_local_overloaded_call_uses_matching_literal_signature_return() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+interface Base {
+    x: string;
+    y: number;
+}
+interface HelloOrWorld extends Base {
+    p1: boolean;
+}
+interface JustHello extends Base {
+    p2: boolean;
+}
+interface JustWorld extends Base {
+    p3: boolean;
+}
+
+let hello: "hello";
+let world: "world";
+let helloOrWorld: "hello" | "world";
+
+function f(p: "hello"): JustHello;
+function f(p: "hello" | "world"): HelloOrWorld;
+function f(p: "world"): JustWorld;
+function f(p: string): Base;
+function f(...args: any[]): any {
+    return undefined;
+}
+
+let fResult1 = f(hello);
+let fResult2 = f(world);
+let fResult3 = f(helloOrWorld);
+
+function g(p: string): Base;
+function g(p: "hello"): JustHello;
+function g(p: "hello" | "world"): HelloOrWorld;
+function g(p: "world"): JustWorld;
+function g(...args: any[]): any {
+    return undefined;
+}
+
+let gResult1 = g(hello);
+let gResult2 = g(world);
+let gResult3 = g(helloOrWorld);
+"#,
+    );
+
+    for expected in [
+        "declare let fResult1: JustHello;",
+        "declare let fResult2: JustWorld;",
+        "declare let fResult3: HelloOrWorld;",
+        "declare let gResult1: JustHello;",
+        "declare let gResult2: JustWorld;",
+        "declare let gResult3: Base;",
+    ] {
+        assert!(
+            output.contains(expected),
+            "expected overload call return `{expected}`: {output}"
+        );
+    }
+}
+
+#[test]
 fn fix_generic_call_constructor_return_object_formats_multiline() {
     let output = emit_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -1773,6 +1773,30 @@ const inferredStringOrBooleanOrNumber = inferredStringOrBoolean || inferredNumbe
 }
 
 #[test]
+fn fix_generic_rest_identity_preserves_parameters_tuple_labels() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+declare function f<T extends any[]>(...x: T): T;
+declare function g(elem: object, index: number): object;
+declare function getArgsForInjection<T extends (...args: any[]) => any>(x: T): Parameters<T>;
+
+export const argumentsOfGAsFirstArgument = f(getArgsForInjection(g));
+export const argumentsOfG = f(...getArgsForInjection(g));
+"#,
+    );
+
+    for expected in [
+        "export declare const argumentsOfGAsFirstArgument: [[elem: object, index: number]];",
+        "export declare const argumentsOfG: [elem: object, index: number];",
+    ] {
+        assert!(
+            output.contains(expected),
+            "expected labeled Parameters tuple `{expected}`: {output}"
+        );
+    }
+}
+
+#[test]
 fn fix_generic_call_constructor_return_object_formats_multiline() {
     let output = emit_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification.rs
@@ -495,6 +495,25 @@ fn fix_numeric_property_name_separator() {
     );
 }
 
+#[test]
+fn fix_never_return_declarations_match_tsc_text() {
+    let output = emit_dts(
+        r#"export function errorVoid(message: string) { throw new Error(message); }
+export class C {
+    void1() { throw new Error(); }
+}"#,
+    );
+    println!("never return declarations:\n{output}");
+    assert!(
+        output.contains("export declare function errorVoid(message: string): void;"),
+        "throw-only function should emit void: {output}"
+    );
+    assert!(
+        output.contains("void1(): void;"),
+        "throw-only class method should emit void: {output}"
+    );
+}
+
 // =============================================================================
 // Edge case exploration tests (Round 5 - finding new issues)
 // =============================================================================

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -57,6 +57,31 @@ fn test_generic_class_with_default() {
 }
 
 #[test]
+fn test_generic_new_expression_infers_forwarded_base_type_argument() {
+    let output = emit_dts_with_binding(
+        r#"
+    interface Base<T> {
+        a: T;
+    }
+    declare class Derived<T> extends Base<T> {
+    }
+    declare class DerivedDefault<T = string> extends Base<T> {
+    }
+    const a = new Derived(1);
+    const b = new DerivedDefault(1);
+    "#,
+    );
+    assert!(
+        output.contains("declare const a: Derived<number>;"),
+        "Expected forwarded base type argument inference: {output}"
+    );
+    assert!(
+        output.contains("declare const b: DerivedDefault<number>;"),
+        "Expected argument inference to override class default: {output}"
+    );
+}
+
+#[test]
 fn test_multiple_type_parameters() {
     let output = emit_dts(
         "export function map<T, U>(arr: T[], fn: (x: T) => U): U[] { return arr.map(fn); }",

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -82,6 +82,24 @@ fn test_generic_new_expression_infers_forwarded_base_type_argument() {
 }
 
 #[test]
+fn test_generic_rest_tuple_inference_preserves_rest_parameter() {
+    let output = emit_dts_with_binding(
+        r#"
+    declare function f<T extends any[], U>(fn: (...args: T) => U): (...args: T) => U;
+    let g = f((...args) => true);
+    "#,
+    );
+    assert!(
+        output.contains("declare let g: (...args: any[]) => boolean;"),
+        "Expected rest parameter to remain rest after generic tuple inference: {output}"
+    );
+    assert!(
+        !output.contains("declare let g: (args: any[]) => boolean;"),
+        "Rest tuple inference should not collapse to a regular array parameter: {output}"
+    );
+}
+
+#[test]
 fn test_multiple_type_parameters() {
     let output = emit_dts(
         "export function map<T, U>(arr: T[], fn: (x: T) => U): U[] { return arr.map(fn); }",

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
@@ -1250,6 +1250,35 @@ fn test_destructuring_variable_declaration_groups_typed_bindings() {
 }
 
 #[test]
+fn test_string_literal_tuple_binding_preserves_alias_and_return_union() {
+    let output = emit_dts(
+        r#"
+type RexOrRaptor = "t-rex" | "raptor";
+let [im, a, dinosaur]: ["I'm", "a", RexOrRaptor] = ["I'm", "a", "t-rex"];
+
+function rawr(dino: RexOrRaptor) {
+    if (dino === "t-rex") {
+        return "ROAAAAR!";
+    }
+    if (dino === "raptor") {
+        return "yip yip!";
+    }
+    throw "Unexpected " + dino;
+}
+"#,
+    );
+
+    assert!(
+        output.contains("declare let im: \"I'm\", a: \"a\", dinosaur: RexOrRaptor;"),
+        "Expected tuple destructuring to preserve the alias from the source tuple annotation: {output}"
+    );
+    assert!(
+        output.contains("declare function rawr(dino: RexOrRaptor): \"ROAAAAR!\" | \"yip yip!\";"),
+        "Expected string literal returns from guarded branches to emit as a union: {output}"
+    );
+}
+
+#[test]
 fn test_destructured_parameter_with_defaulted_property_uses_multiline_object_type() {
     let output = emit_dts("const k = ({ x: z = 'y' }) => {};");
     assert!(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2078,6 +2078,59 @@ export function convert(value) {
 }
 
 #[test]
+fn test_jsdoc_overload_function_declaration_hoists_before_variables() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @template T
+ * @param {T} x
+ * @returns {T}
+ */
+const identity = x => x;
+
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ */
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
+/**
+ * @param {unknown[]} array
+ * @param {(x: unknown) => unknown} iterable
+ * @returns {unknown[]}
+ */
+function flatMap(array, iterable = identity) {
+    return array;
+}
+"#,
+    );
+
+    let flat_map_pos = output
+        .find("declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];")
+        .expect("expected first flatMap overload");
+    let identity_pos = output
+        .find("declare function identity<T>(x: T): T;")
+        .expect("expected identity helper declaration");
+
+    assert!(
+        flat_map_pos < identity_pos,
+        "Expected JSDoc overload function declarations before variables: {output}"
+    );
+    assert!(
+        output.contains("declare function flatMap<T>(array: T[][]): T[];"),
+        "Expected second flatMap overload: {output}"
+    );
+}
+
+#[test]
 fn test_jsdoc_constructor_overload_tags_emit_constructor_signatures() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -1009,6 +1009,10 @@ export const x = () => 1;
         "Expected JS @type alias reference to be preserved: {output}"
     );
     assert!(
+        output.contains("@callback Foo") && output.contains("@type {Foo}"),
+        "Expected callback and variable JSDoc comments to remain in declaration output: {output}"
+    );
+    assert!(
         output.contains("export type Foo = (...args: string[]) => number;"),
         "Expected JS @callback alias to be synthesized after the exported value: {output}"
     );
@@ -3666,6 +3670,36 @@ export const h = null;
     assert!(output.contains("export const f: (arg0: string, arg1: number) => object;"));
     assert!(output.contains("export const g: new (arg1: string, arg2: number) => object;"));
     assert!(output.contains("export const h: {\n    [x: string]: number;\n};"));
+}
+
+#[test]
+fn test_jsdoc_typedef_comment_before_namespace_object_is_not_duplicated() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @template T
+ * @template {keyof T} K
+ * @typedef {T[K]} Foo
+ */
+const x = { a: 1 };
+
+/** @type {Foo<typeof x, "a">} */
+const y = "a";
+"#,
+    );
+
+    assert!(
+        output.starts_with("declare namespace x {\n    let a: number;\n}"),
+        "Expected namespace object emit without leaking implementation-only typedef JSDoc: {output}"
+    );
+    assert!(
+        output.contains("type Foo<T, K extends keyof T> = T[K];"),
+        "Expected typedef alias to still be emitted: {output}"
+    );
+    assert!(
+        !output.contains("@typedef"),
+        "Did not expect the source typedef comment to be duplicated in the DTS: {output}"
+    );
 }
 
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3540,6 +3540,37 @@ module.exports = class {
 }
 
 #[test]
+fn test_js_module_exports_anonymous_class_secondary_class_emits_once() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+module.exports = class {
+    constructor(p) {
+        this.t = 12 + p;
+    }
+};
+module.exports.Sub = class {
+    constructor() {
+        this.instance = new module.exports(10);
+    }
+};
+"#,
+    );
+
+    assert!(
+        output.contains("declare namespace exports {\n    export { Sub };\n}"),
+        "Expected secondary anonymous class exports to be aliased through the export= namespace: {output}"
+    );
+    assert!(
+        output.contains("declare class Sub {"),
+        "Expected secondary anonymous class exports to emit a local class declaration: {output}"
+    );
+    assert!(
+        !output.contains("export class Sub"),
+        "Did not expect the secondary class assignment to also emit as a named export: {output}"
+    );
+}
+
+#[test]
 fn test_js_array_subclass_emits_array_any_and_constructors() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2135,6 +2135,77 @@ export class Foo {
 }
 
 #[test]
+fn test_jsdoc_method_overload_tags_emit_method_signatures() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @template T
+ */
+class Example {
+  /**
+   * @param {T} value
+   */
+  constructor(value) {
+    this.value = value;
+  }
+
+  /**
+   * @overload
+   * @param {Example<number>} this
+   * @returns {'number'}
+   *
+   * @overload
+   * @param {Example<string>} this
+   * @returns {'string'}
+   *
+   * @returns {string}
+   */
+  getTypeName() {
+    return typeof this.value;
+  }
+
+  /**
+   * @template U
+   * @overload
+   * @param {(y: T) => U} fn
+   * @returns {U}
+   *
+   * @overload
+   * @returns {T}
+   *
+   * @param {(y: T) => unknown} [fn]
+   * @returns {unknown}
+   */
+  transform(fn) {
+    return fn ? fn(this.value) : this.value;
+  }
+}
+"#,
+    );
+
+    assert!(
+        output.contains("getTypeName(this: Example<number>): \"number\";"),
+        "Expected number overload: {output}"
+    );
+    assert!(
+        output.contains("getTypeName(this: Example<string>): \"string\";"),
+        "Expected string overload: {output}"
+    );
+    assert!(
+        output.contains("transform<U>(fn: (y: T) => U): U;"),
+        "Expected generic transform overload: {output}"
+    );
+    assert!(
+        output.contains("transform<U>(): T;"),
+        "Expected no-argument transform overload: {output}"
+    );
+    assert!(
+        !output.contains("getTypeName(): string;") && !output.contains("transform(fn:"),
+        "Did not expect implementation method signatures: {output}"
+    );
+}
+
+#[test]
 fn test_js_module_exports_function_with_typedef_members() {
     let output = emit_js_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -5668,12 +5668,12 @@ export default Cls;
     );
     let trimmed = output.trim();
     assert!(
-        trimmed.starts_with("export type Cls_1 = string | number;\nexport default Cls;"),
-        "Expected default typedef to use a collision-safe alias before the hoisted default export: {trimmed}"
+        trimmed.starts_with("export type Cls = string | number;\nexport default Cls;"),
+        "Expected default typedef to reuse the default-exported class name before the hoisted default export: {trimmed}"
     );
     assert!(
-        !trimmed.contains("export type Cls = string | number;"),
-        "Default typedef alias should not collide with the class declaration name: {trimmed}"
+        !trimmed.contains("export type Cls_1 = string | number;"),
+        "Default typedef alias should not synthesize a unique name for a default-exported class: {trimmed}"
     );
     assert!(
         trimmed.contains("declare class Cls"),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -1149,6 +1149,36 @@ function p() { return Promise.resolve(); }
 }
 
 #[test]
+fn test_jsdoc_nested_object_binding_params_and_promise_star() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+class Y {
+    /**
+     * @param {Object} error
+     * @param {string?} error.reason
+     * @param {Object} error.suberr
+     * @param {string?} error.suberr.reason
+     * @param {string?} error.suberr.code
+     * @returns {Promise.<*>}
+     */
+    async cancel({reason, suberr}) {}
+}
+"#,
+    );
+
+    for expected in [
+        "reason: string | null;",
+        "suberr: {\n            reason: string | null;\n            code: string | null;\n        };",
+        "): Promise<any>;",
+    ] {
+        assert!(
+            output.contains(expected),
+            "Expected nested JSDoc parameter output `{expected}`: {output}"
+        );
+    }
+}
+
+#[test]
 fn test_js_trailing_jsdoc_type_aliases_are_emitted() {
     let source = r#"
 export {};

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3600,6 +3600,39 @@ module.exports.MyClass.prototype = {
 }
 
 #[test]
+fn test_js_commonjs_export_assignment_inside_closure_emits_export_surface() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+function foo() {
+    module.exports = exports = function (o) {
+        return o;
+    };
+    const m = function () {
+    }
+    exports.methods = m;
+}
+"#,
+    );
+
+    assert!(
+        output.contains("declare function _exports(o: any): any;"),
+        "Expected closure CommonJS root assignment to emit export= function surface: {output}"
+    );
+    assert!(
+        output.contains("declare namespace _exports {\n    export { m as methods };\n}"),
+        "Expected closure CommonJS secondary exports to attach to the synthetic namespace: {output}"
+    );
+    assert!(
+        output.contains("export = _exports;\ndeclare function m(): void;"),
+        "Expected local function secondary export target to be emitted after export=: {output}"
+    );
+    assert!(
+        !output.contains("declare function foo"),
+        "Did not expect enclosing helper closure to leak as the declaration surface: {output}"
+    );
+}
+
+#[test]
 fn test_js_array_subclass_emits_array_any_and_constructors() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3633,6 +3633,42 @@ function foo() {
 }
 
 #[test]
+fn test_jsdoc_type_tags_on_const_null_preserve_closure_type_syntax() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/** @type {?} */
+export const a = null;
+/** @type {*} */
+export const b = null;
+/** @type {string?} */
+export const c = null;
+/** @type {string=} */
+export const d = null;
+/** @type {string!} */
+export const e = null;
+/** @type {function(string, number): object} */
+export const f = null;
+/** @type {function(new: object, string, number)} */
+export const g = null;
+/** @type {Object.<string, number>} */
+export const h = null;
+"#,
+    );
+
+    assert!(
+        output.contains("export const a: unknown;"),
+        "Expected bare Closure unknown @type to win over const null fallback: {output}"
+    );
+    assert!(output.contains("export const b: any;"));
+    assert!(output.contains("export const c: string | null;"));
+    assert!(output.contains("export const d: string | undefined;"));
+    assert!(output.contains("export const e: string;"));
+    assert!(output.contains("export const f: (arg0: string, arg1: number) => object;"));
+    assert!(output.contains("export const g: new (arg1: string, arg2: number) => object;"));
+    assert!(output.contains("export const h: {\n    [x: string]: number;\n};"));
+}
+
+#[test]
 fn test_js_array_subclass_emits_array_any_and_constructors() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3835,7 +3835,7 @@ Object.defineProperty(E.prototype, "x", { set: setter });
 
 #[test]
 fn test_js_named_export_equals_class_expression_shadowing_preserves_root_name() {
-    let output = emit_js_dts(
+    let output = emit_js_dts_with_usage_analysis(
         r#"
 class A {
     member = new Q();
@@ -3859,6 +3859,10 @@ module.exports.Another = Q;
     assert!(
         output.contains("declare namespace Q {"),
         "Expected named CommonJS class export-equals roots to own their namespace aliases: {output}"
+    );
+    assert!(
+        output.contains("declare class A {\n    member: Q;\n}"),
+        "Expected local classes referenced by the exported class expression surface to be retained: {output}"
     );
     assert!(
         output.contains("export { Q_1 as Another };"),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3571,6 +3571,35 @@ module.exports.Sub = class {
 }
 
 #[test]
+fn test_js_commonjs_constructor_function_prototype_object_emits_single_class() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/** @constructor */
+module.exports.MyClass = function() {
+    this.x = 1;
+};
+module.exports.MyClass.prototype = {
+    a: function() {
+    }
+};
+"#,
+    );
+
+    assert!(
+        output.contains("export class MyClass {\n    a: () => void;\n}"),
+        "Expected CommonJS constructor functions with prototype object literals to emit as a single class surface: {output}"
+    );
+    assert!(
+        !output.contains("export function MyClass"),
+        "Did not expect the constructor function assignment to emit beside the class: {output}"
+    );
+    assert!(
+        !output.contains("constructor();") && !output.contains("x: number;"),
+        "Did not expect constructor-body properties to leak when tsc uses the prototype object surface: {output}"
+    );
+}
+
+#[test]
 fn test_js_array_subclass_emits_array_any_and_constructors() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -1297,6 +1297,44 @@ const send = handlers => Promise.resolve(handlers);
 }
 
 #[test]
+fn test_js_multiline_typedef_before_variable_comment_is_preserved() {
+    let source = r#"
+/**
+ * @typedef {{
+ *   [id: string]: [Function, Function];
+ * }} ResolveRejectMap
+ */
+let id = 0;
+
+/**
+ * @param {ResolveRejectMap} handlers
+ * @returns {Promise<any>}
+ */
+const send = handlers => Promise.resolve(handlers);
+"#;
+    let mut parser = ParserState::new("test.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut emitter = DeclarationEmitter::new(&parser.arena);
+    let output = emitter.emit(root);
+
+    assert!(
+        output.starts_with(
+            "/**\n * @typedef {{\n * [id: string]: [Function, Function];\n * }} ResolveRejectMap\n */\ndeclare let id: number;"
+        ),
+        "Expected source typedef comment to stay attached to the variable declaration: {output}"
+    );
+    assert!(
+        output.contains("declare function send(handlers: ResolveRejectMap): Promise<any>;"),
+        "Expected function variable to use the typedef alias: {output}"
+    );
+    assert!(
+        output.contains("type ResolveRejectMap = {\n    [id: string]: [Function, Function];\n};"),
+        "Expected typedef alias to still be emitted: {output}"
+    );
+}
+
+#[test]
 fn test_js_multiline_typedef_before_export_equals_function_variable_is_emitted() {
     let source = r#"
 /**

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2004,6 +2004,28 @@ export = X;
 }
 
 #[test]
+fn test_private_namespace_exports_do_not_retain_private_top_level_interfaces() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export var x = 1;
+interface Iterator<T> {
+    value: T;
+}
+namespace Query {
+    export function fromDoWhile<T>(test: (value: Iterator<T>) => boolean): Iterator<T> {
+        return null as any;
+    }
+    function fromOrderBy() {
+        return fromDoWhile(test => true);
+    }
+}
+"#,
+    );
+
+    assert_eq!("export declare var x: number;", output.trim());
+}
+
+#[test]
 fn test_namespace_shadowed_default_export_uses_self_import_type_names() {
     let (parser, _root) = parse_test_source("");
     let mut emitter = DeclarationEmitter::new(&parser.arena);

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2007,6 +2007,41 @@ module.exports = a;
 }
 
 #[test]
+fn test_js_module_exports_defers_dependency_class_until_after_root_namespace() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+class Base {}
+
+/** @returns {Base} */
+function BaseFactory() {
+    return new Base();
+}
+
+BaseFactory.Base = Base;
+module.exports = BaseFactory;
+"#,
+    );
+
+    let export_pos = output
+        .find("export = BaseFactory;")
+        .expect("Expected CommonJS export assignment");
+    let function_pos = output
+        .find("declare function BaseFactory(): Base;")
+        .expect("Expected exported function declaration");
+    let namespace_pos = output
+        .find("declare namespace BaseFactory")
+        .expect("Expected namespace for static Base member");
+    let class_pos = output
+        .find("declare class Base")
+        .expect("Expected dependency class declaration");
+
+    assert!(
+        export_pos < function_pos && function_pos < namespace_pos && namespace_pos < class_pos,
+        "Expected dependency class to follow the export root namespace: {output}"
+    );
+}
+
+#[test]
 fn test_js_module_exports_function_with_typedef_members() {
     let output = emit_js_dts(
         r#"
@@ -4071,6 +4106,19 @@ module.exports.Another = Q;
     assert!(
         output.contains("declare class Q_1 {"),
         "Expected the shadowed local class declaration to be emitted under a stable unique alias: {output}"
+    );
+    let namespace_pos = output
+        .find("declare namespace Q")
+        .expect("Expected namespace for export-equals root");
+    let class_a_pos = output
+        .find("declare class A")
+        .expect("Expected local dependency class A");
+    let class_q_alias_pos = output
+        .find("declare class Q_1")
+        .expect("Expected shadowed local class alias");
+    assert!(
+        namespace_pos < class_a_pos && class_a_pos < class_q_alias_pos,
+        "Expected local dependency class A to stay before the deferred shadowed alias: {output}"
     );
     assert!(
         !output.contains("export = exports;"),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2042,6 +2042,42 @@ module.exports = BaseFactory;
 }
 
 #[test]
+fn test_jsdoc_combined_overload_tags_emit_all_function_signatures() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+/**
+ * @overload
+ * @param {number} value
+ * @returns {number}
+ *
+ * @overload
+ * @param {string} value
+ * @returns {string}
+ *
+ * @param {string | number} value
+ * @returns {string | number}
+ */
+export function convert(value) {
+    return value;
+}
+"#,
+    );
+
+    assert!(
+        output.contains("export function convert(value: number): number;"),
+        "Expected numeric JSDoc overload signature: {output}"
+    );
+    assert!(
+        output.contains("export function convert(value: string): string;"),
+        "Expected string JSDoc overload signature: {output}"
+    );
+    assert!(
+        !output.contains("convert(value: string | number)"),
+        "Did not expect the implementation signature to be emitted: {output}"
+    );
+}
+
+#[test]
 fn test_js_module_exports_function_with_typedef_members() {
     let output = emit_js_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -5997,6 +5997,73 @@ export class C {
 }
 
 #[test]
+fn test_js_getter_uses_jsdoc_type_tag() {
+    let output = emit_js_dts(
+        r#"
+class C {
+    /** @type {string=} */
+    get p1() {
+        return undefined;
+    }
+
+    /** @type {?string} */
+    get p2() {
+        return null;
+    }
+
+    /** @type {string | null} */
+    get p3() {
+        return null;
+    }
+}
+"#,
+    );
+
+    assert!(
+        output.contains("get p1(): string | undefined;"),
+        "Expected getter @type to override undefined body inference: {output}"
+    );
+    assert!(
+        output.contains("get p2(): string | null;"),
+        "Expected nullable getter @type to override null body inference: {output}"
+    );
+    assert!(
+        output.contains("get p3(): string | null;"),
+        "Expected explicit union getter @type to override null body inference: {output}"
+    );
+}
+
+#[test]
+fn test_js_accessor_pair_preserves_jsdoc_type_comments_and_optional_param_type() {
+    let output = emit_js_dts(
+        r#"
+class C {
+    /** @type {string=} */
+    get value() {
+        return undefined;
+    }
+
+    /** @param {string=} value */
+    set value(value) {
+        this.value = value;
+    }
+}
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "    /** @param {string=} value */\n    set value(value: string | undefined);"
+        ),
+        "Expected reordered setter comment to stay single-line and optional param to emit as a union: {output}"
+    );
+    assert!(
+        output.contains("    /** @type {string=} */\n    get value(): string | undefined;"),
+        "Expected reordered getter comment to stay single-line and @type to drive getter type: {output}"
+    );
+}
+
+#[test]
 fn test_js_setter_does_not_lift_nested_nullish_from_array_element_union() {
     let output = emit_js_dts_with_usage_analysis(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -2078,6 +2078,63 @@ export function convert(value) {
 }
 
 #[test]
+fn test_jsdoc_constructor_overload_tags_emit_constructor_signatures() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+export class Foo {
+    #a = true ? 1 : "1"
+    #b
+
+    /**
+     * @constructor
+     * @overload
+     * @param {string} a
+     * @param {number} b
+     */
+    /**
+     * @constructor
+     * @overload
+     * @param {number} a
+     */
+    /**
+     * @constructor
+     * @overload
+     * @param {string} a
+     *//**
+     * @constructor
+     * @param {number | string} a
+     */
+    constructor(a, b) {
+        this.#a = a
+        this.#b = b
+    }
+}
+"#,
+    );
+
+    let first = output
+        .find("constructor(a: string, b: number);")
+        .expect("expected two-parameter constructor overload");
+    let second = output
+        .find("constructor(a: number);")
+        .expect("expected number constructor overload");
+    let third = output
+        .find("constructor(a: string);")
+        .expect("expected string constructor overload");
+    let private_marker = output
+        .find("#private;")
+        .expect("expected private marker for private fields");
+    assert!(
+        first < second && second < third && third < private_marker,
+        "Expected constructor overloads before #private marker: {output}"
+    );
+    assert!(
+        !output.contains("constructor(a: string, b: any);"),
+        "Did not expect implementation constructor signature: {output}"
+    );
+}
+
+#[test]
 fn test_js_module_exports_function_with_typedef_members() {
     let output = emit_js_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3465,6 +3465,48 @@ module.exports.Strings = Strings;
 }
 
 #[test]
+fn test_js_exported_object_literal_empty_object_member_emits_namespace_value() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+const x = {
+    grey: {}
+};
+export { x };
+"#,
+    );
+
+    assert!(
+        output.contains("export namespace x {\n    let grey: {};\n}"),
+        "Expected named JS object exports with empty object members to emit as namespaces: {output}"
+    );
+    assert!(
+        !output.contains("export const x:"),
+        "Did not expect named JS object exports with empty object members to fall back to const object types: {output}"
+    );
+}
+
+#[test]
+fn test_js_commonjs_named_object_alias_empty_object_member_emits_namespace_value() {
+    let output = emit_js_dts_with_usage_analysis(
+        r#"
+const chalk = {
+    grey: {}
+};
+module.exports.chalk = chalk;
+"#,
+    );
+
+    assert!(
+        output.contains("export namespace chalk {\n    let grey: {};\n}"),
+        "Expected CommonJS named object aliases with empty object members to emit as namespaces: {output}"
+    );
+    assert!(
+        !output.contains("export const chalk:"),
+        "Did not expect CommonJS named object aliases with empty object members to fall back to const object types: {output}"
+    );
+}
+
+#[test]
 fn test_js_module_exports_anonymous_class_expression_uses_exports_class_surface() {
     let output = emit_js_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -940,6 +940,39 @@ fn test_tuple_type_in_declaration() {
 }
 
 #[test]
+fn test_multiline_tuple_type_argument_preserves_tuple_breaks() {
+    let output = emit_dts(
+        r#"
+export type Point = TypedObject<[
+    {
+        name: "x";
+        type: "f64";
+    },
+    {
+        name: "y";
+        type: "f64";
+    }
+]>;
+"#,
+    );
+    assert!(
+        output.contains(
+            "export type Point = TypedObject<[\n    {\n        name: \"x\";\n        type: \"f64\";\n    },\n    {\n        name: \"y\";\n        type: \"f64\";\n    }\n]>;"
+        ),
+        "Expected multiline tuple type argument to preserve tuple breaks: {output}"
+    );
+}
+
+#[test]
+fn test_single_line_tuple_type_argument_stays_compact() {
+    let output = emit_dts("export type PairBox = Box<[string, number]>;");
+    assert!(
+        output.contains("export type PairBox = Box<[string, number]>;"),
+        "Expected single-line tuple type argument to stay compact: {output}"
+    );
+}
+
+#[test]
 fn test_conditional_type_in_declaration() {
     let output = emit_dts("export type IsString<T> = T extends string ? true : false;");
     assert!(

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -860,6 +860,27 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    fn type_argument_tuple_should_preserve_multiline(&self, type_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(type_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TUPLE_TYPE {
+            return false;
+        }
+        let Some(text) = self.source_file_text.as_deref() else {
+            return false;
+        };
+        let start = node.pos as usize;
+        let end = node.end as usize;
+        if start >= end || end > text.len() {
+            return false;
+        }
+
+        let raw = &text[start..end];
+        let tuple_text = raw.find('[').map_or(raw, |index| &raw[index..]);
+        tuple_text.contains('\n')
+    }
+
     fn emit_tuple_type_multiline(&mut self, tuple_idx: NodeIndex) {
         let Some(tuple_node) = self.arena.get(tuple_idx) else {
             self.emit_type(tuple_idx);
@@ -915,6 +936,10 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write("(");
                 self.emit_type(arg_idx);
                 self.write(")");
+                continue;
+            }
+            if self.type_argument_tuple_should_preserve_multiline(arg_idx) {
+                self.emit_tuple_type_multiline(arg_idx);
                 continue;
             }
             self.emit_type(arg_idx);

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
@@ -296,10 +296,110 @@ impl<'a> UsageAnalyzer<'a> {
                 self.analyze_export_assignment(stmt_idx);
             }
             k if k == syntax_kind_ext::MODULE_DECLARATION => {
-                self.analyze_module_declaration(stmt_idx);
+                if let Some(module) = self.arena.get_module(stmt_node)
+                    && self.module_declaration_contributes_public_surface(module)
+                {
+                    self.analyze_module_declaration(stmt_idx);
+                }
             }
             _ => {}
         }
+    }
+
+    fn module_declaration_contributes_public_surface(
+        &self,
+        module: &tsz_parser::parser::node::ModuleData,
+    ) -> bool {
+        if !self.binder.is_external_module() {
+            return true;
+        }
+        if self
+            .arena
+            .has_modifier(&module.modifiers, SyntaxKind::ExportKeyword)
+        {
+            return true;
+        }
+        if string_literal_text(self.arena, module.name).is_some() {
+            return true;
+        }
+        if self
+            .arena
+            .get(module.name)
+            .and_then(|node| self.arena.get_identifier(node))
+            .is_some_and(|ident| ident.escaped_text == "global")
+        {
+            return true;
+        }
+        let Some(module_name) = self.identifier_text(module.name) else {
+            return false;
+        };
+        self.source_file_exports_name(&module_name)
+    }
+
+    fn identifier_text(&self, idx: NodeIndex) -> Option<String> {
+        self.arena
+            .get(idx)
+            .and_then(|node| self.arena.get_identifier(node))
+            .map(|ident| ident.escaped_text.clone())
+    }
+
+    fn source_file_exports_name(&self, name: &str) -> bool {
+        let Some(source_file) = self
+            .arena
+            .nodes
+            .iter()
+            .rev()
+            .find_map(|node| self.arena.get_source_file(node))
+        else {
+            return false;
+        };
+
+        source_file
+            .statements
+            .nodes
+            .iter()
+            .copied()
+            .any(|stmt_idx| self.export_statement_references_name(stmt_idx, name))
+    }
+
+    fn export_statement_references_name(&self, stmt_idx: NodeIndex, name: &str) -> bool {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return false;
+        };
+        if let Some(export) = self.arena.get_export_decl(stmt_node) {
+            return self.export_clause_references_name(export.export_clause, name);
+        }
+        if let Some(export_assignment) = self.arena.get_export_assignment(stmt_node) {
+            let expr_idx = self.unwrap_export_default_expression(export_assignment.expression);
+            return self.identifier_text(expr_idx).as_deref() == Some(name);
+        }
+        false
+    }
+
+    fn export_clause_references_name(&self, clause_idx: NodeIndex, name: &str) -> bool {
+        let Some(clause_node) = self.arena.get(clause_idx) else {
+            return false;
+        };
+        if self.arena.get_identifier(clause_node).is_some() {
+            return self.identifier_text(clause_idx).as_deref() == Some(name);
+        }
+        let Some(named) = self.arena.get_named_imports(clause_node) else {
+            return false;
+        };
+        named.elements.nodes.iter().copied().any(|spec_idx| {
+            let Some(spec_node) = self.arena.get(spec_idx) else {
+                return false;
+            };
+            let Some(spec) = self.arena.get_specifier(spec_node) else {
+                return false;
+            };
+            let local_name_idx = if spec.property_name.is_some() {
+                spec.property_name
+            } else {
+                spec.name
+            };
+            self.identifier_text(local_name_idx).as_deref() == Some(name)
+        })
     }
 
     fn analyze_module_declaration(&mut self, module_idx: NodeIndex) {

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer.rs
@@ -295,6 +295,9 @@ impl<'a> UsageAnalyzer<'a> {
             k if k == syntax_kind_ext::EXPORT_ASSIGNMENT => {
                 self.analyze_export_assignment(stmt_idx);
             }
+            k if k == syntax_kind_ext::EXPRESSION_STATEMENT => {
+                self.analyze_commonjs_assignment_public_surface(stmt_idx);
+            }
             k if k == syntax_kind_ext::MODULE_DECLARATION => {
                 if let Some(module) = self.arena.get_module(stmt_node)
                     && self.module_declaration_contributes_public_surface(module)
@@ -304,6 +307,74 @@ impl<'a> UsageAnalyzer<'a> {
             }
             _ => {}
         }
+    }
+
+    fn analyze_commonjs_assignment_public_surface(&mut self, stmt_idx: NodeIndex) {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return;
+        };
+        let Some(expr_stmt) = self.arena.get_expression_statement(stmt_node) else {
+            return;
+        };
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_stmt.expression);
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return;
+        };
+        if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return;
+        }
+        let Some(binary) = self.arena.get_binary_expr(expr_node) else {
+            return;
+        };
+        if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+            return;
+        }
+
+        let lhs = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.left);
+        if !self.expression_is_module_exports_reference(lhs)
+            && !self.expression_is_module_exports_property_reference(lhs)
+        {
+            return;
+        }
+
+        self.analyze_expression_public_surface(binary.right);
+    }
+
+    fn expression_is_module_exports_reference(&self, expr_idx: NodeIndex) -> bool {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return false;
+        }
+        let Some(access) = self.arena.get_access_expr(expr_node) else {
+            return false;
+        };
+        self.identifier_text(access.expression).as_deref() == Some("module")
+            && self.identifier_text(access.name_or_argument).as_deref() == Some("exports")
+    }
+
+    fn expression_is_module_exports_property_reference(&self, expr_idx: NodeIndex) -> bool {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return false;
+        }
+        let Some(access) = self.arena.get_access_expr(expr_node) else {
+            return false;
+        };
+        self.expression_is_module_exports_reference(access.expression)
     }
 
     fn module_declaration_contributes_public_surface(
@@ -891,6 +962,12 @@ impl<'a> UsageAnalyzer<'a> {
                 self.analyze_type_node(prop.type_annotation);
             } else {
                 self.walk_inferred_type(prop_idx);
+                if prop.initializer.is_some() {
+                    let referenced = self.unwrap_export_default_expression(prop.initializer);
+                    if referenced != prop.initializer {
+                        self.analyze_reference_as_value_and_type(referenced);
+                    }
+                }
             }
         }
 
@@ -968,6 +1045,85 @@ impl<'a> UsageAnalyzer<'a> {
         for &param_idx in &ctor.parameters.nodes {
             self.analyze_parameter(param_idx);
         }
+
+        if ctor.body.is_some() {
+            self.analyze_constructor_public_surface_assignments(ctor.body);
+        }
+    }
+
+    fn analyze_constructor_public_surface_assignments(&mut self, node_idx: NodeIndex) {
+        let Some(node) = self.arena.get(node_idx) else {
+            return;
+        };
+
+        match node.kind {
+            k if k == syntax_kind_ext::BLOCK => {
+                if let Some(block) = self.arena.get_block(node) {
+                    for &stmt_idx in &block.statements.nodes {
+                        self.analyze_constructor_public_surface_assignments(stmt_idx);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::EXPRESSION_STATEMENT => {
+                if let Some(expr_stmt) = self.arena.get_expression_statement(node) {
+                    self.analyze_constructor_public_surface_expression(expr_stmt.expression);
+                }
+            }
+            k if k == syntax_kind_ext::IF_STATEMENT => {
+                if let Some(if_data) = self.arena.get_if_statement(node) {
+                    self.analyze_constructor_public_surface_assignments(if_data.then_statement);
+                    if if_data.else_statement.is_some() {
+                        self.analyze_constructor_public_surface_assignments(if_data.else_statement);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn analyze_constructor_public_surface_expression(&mut self, expr_idx: NodeIndex) {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return;
+        };
+        if expr_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return;
+        }
+        let Some(binary) = self.arena.get_binary_expr(expr_node) else {
+            return;
+        };
+        if binary.operator_token != SyntaxKind::EqualsToken as u16
+            || !self.expression_is_this_property_reference(binary.left)
+        {
+            return;
+        }
+
+        let referenced = self.unwrap_export_default_expression(binary.right);
+        if referenced != binary.right {
+            self.analyze_reference_as_value_and_type(referenced);
+        } else {
+            self.analyze_expression_public_surface(binary.right);
+        }
+    }
+
+    fn expression_is_this_property_reference(&self, expr_idx: NodeIndex) -> bool {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return false;
+        }
+        let Some(access) = self.arena.get_access_expr(expr_node) else {
+            return false;
+        };
+        self.arena
+            .get(access.expression)
+            .is_some_and(|node| node.kind == SyntaxKind::ThisKeyword as u16)
     }
 
     /// Analyze an accessor (getter/setter).

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/type_walk.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/type_walk.rs
@@ -163,7 +163,10 @@ impl<'a> UsageAnalyzer<'a> {
         }
 
         if let Some(sym_ref) = visitor::module_namespace_symbol_ref(self.type_interner, type_id) {
-            Self::add_symbol_usage(usages, SymbolId(sym_ref.0), UsageKind::TYPE);
+            let sym_id = SymbolId(sym_ref.0);
+            if !self.symbol_is_json_namespace_import(sym_id) {
+                Self::add_symbol_usage(usages, sym_id, UsageKind::TYPE);
+            }
         }
 
         if let Some(shape_id) = visitor::object_shape_id(self.type_interner, type_id)
@@ -186,6 +189,17 @@ impl<'a> UsageAnalyzer<'a> {
                 Self::add_symbol_usage(usages, sym_id, UsageKind::TYPE);
             }
         }
+    }
+
+    fn symbol_is_json_namespace_import(&self, sym_id: SymbolId) -> bool {
+        self.binder.symbols.get(sym_id).is_some_and(|symbol| {
+            symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
+                && symbol
+                    .import_module
+                    .as_deref()
+                    .is_some_and(|module| module.ends_with(".json"))
+                && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"))
+        })
     }
 
     fn unique_symbol_property_name_symbol(

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
@@ -36,6 +36,16 @@ impl UsageAnalyzer<'_> {
         let Some(source_symbol) = self.binder.symbols.get(sym_id) else {
             return false;
         };
+        if source_symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
+            && source_symbol
+                .import_module
+                .as_deref()
+                .is_some_and(|module| module.ends_with(".json"))
+            && (source_symbol.import_name.is_none()
+                || source_symbol.import_name.as_deref() == Some("*"))
+        {
+            return false;
+        }
         let resolved_sym_id = if source_symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
             && source_symbol.import_module.is_some()
         {

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -85,14 +85,13 @@ struct InternCacheEntry {
 
 /// Combined thread-local cache for both `lookup()` and `intern()` directions.
 ///
-/// Uses `Cell<[T; N]>` for interior mutability. Both cache entry types are
-/// `Copy`, so `Cell::as_array_of_cells()` gives us per-slot `get`/`set` that
-/// lowers to the same single load / single store as a raw pointer deref —
+/// Uses per-slot `Cell<T>` values for interior mutability. Both cache entry
+/// types are `Copy`, so each probe/insert remains one direct slot `get`/`set`
 /// with no `unsafe` and no manual `Send`/`Sync` impls. The cache is reached
 /// only through `thread_local!`, which requires neither bound.
 struct TypeInternerCache {
-    lookup: Cell<[LookupCacheEntry; LOOKUP_CACHE_SIZE]>,
-    intern: Cell<[InternCacheEntry; INTERN_CACHE_SIZE]>,
+    lookup: [Cell<LookupCacheEntry>; LOOKUP_CACHE_SIZE],
+    intern: [Cell<InternCacheEntry>; INTERN_CACHE_SIZE],
 }
 
 const EMPTY_LOOKUP_ENTRY: LookupCacheEntry = LookupCacheEntry {
@@ -112,15 +111,15 @@ const EMPTY_INTERN_ENTRY: InternCacheEntry = InternCacheEntry {
 impl TypeInternerCache {
     const fn new() -> Self {
         Self {
-            lookup: Cell::new([EMPTY_LOOKUP_ENTRY; LOOKUP_CACHE_SIZE]),
-            intern: Cell::new([EMPTY_INTERN_ENTRY; INTERN_CACHE_SIZE]),
+            lookup: [const { Cell::new(EMPTY_LOOKUP_ENTRY) }; LOOKUP_CACHE_SIZE],
+            intern: [const { Cell::new(EMPTY_INTERN_ENTRY) }; INTERN_CACHE_SIZE],
         }
     }
 
     #[inline(always)]
-    const fn lookup_probe(&self, id: TypeId, instance_id: u32) -> Option<TypeData> {
+    fn lookup_probe(&self, id: TypeId, instance_id: u32) -> Option<TypeData> {
         let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
-        let entry = self.lookup.as_array_of_cells()[idx].get();
+        let entry = self.lookup[idx].get();
         if entry.tag == id.0 && entry.instance_id == instance_id {
             Some(entry.data)
         } else {
@@ -131,7 +130,7 @@ impl TypeInternerCache {
     #[inline(always)]
     fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) {
         let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
-        self.lookup.as_array_of_cells()[idx].set(LookupCacheEntry {
+        self.lookup[idx].set(LookupCacheEntry {
             tag: id.0,
             instance_id,
             data,
@@ -141,7 +140,7 @@ impl TypeInternerCache {
     #[inline(always)]
     fn intern_probe(&self, hash: u64, instance_id: u32, key: &TypeData) -> Option<TypeId> {
         let idx = (hash & INTERN_CACHE_MASK) as usize;
-        let entry = self.intern.as_array_of_cells()[idx].get();
+        let entry = self.intern[idx].get();
         if entry.hash == hash && entry.instance_id == instance_id && &entry.key == key {
             Some(entry.result)
         } else {
@@ -152,7 +151,7 @@ impl TypeInternerCache {
     #[inline(always)]
     fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
         let idx = (hash & INTERN_CACHE_MASK) as usize;
-        self.intern.as_array_of_cells()[idx].set(InternCacheEntry {
+        self.intern[idx].set(InternCacheEntry {
             hash,
             instance_id,
             key,
@@ -179,10 +178,10 @@ static NEXT_INTERNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 /// causing incorrect type resolution and panics.
 pub fn clear_thread_local_cache() {
     TL_CACHE.with(|cache| {
-        for cell in cache.lookup.as_array_of_cells() {
+        for cell in &cache.lookup {
             cell.set(EMPTY_LOOKUP_ENTRY);
         }
-        for cell in cache.intern.as_array_of_cells() {
+        for cell in &cache.intern {
             cell.set(EMPTY_INTERN_ENTRY);
         }
     });

--- a/scripts/emit/src/cli-transpiler.ts
+++ b/scripts/emit/src/cli-transpiler.ts
@@ -66,6 +66,7 @@ interface CompilerFlagOptions {
   preserveConstEnums?: boolean;
   verbatimModuleSyntax?: boolean;
   rewriteRelativeImportExtensions?: boolean;
+  resolveJsonModule?: boolean;
   isolatedModules?: boolean;
   importsNotUsedAsValues?: string;
   preserveValueImports?: boolean;
@@ -118,6 +119,7 @@ function appendCompilerOptionFlags(args: string[], opts: CompilerFlagOptions): v
   if (opts.preserveConstEnums) args.push('--preserveConstEnums');
   if (opts.verbatimModuleSyntax) args.push('--verbatimModuleSyntax');
   if (opts.rewriteRelativeImportExtensions) args.push('--rewriteRelativeImportExtensions');
+  if (opts.resolveJsonModule) args.push('--resolveJsonModule');
   if (opts.isolatedModules) args.push('--isolatedModules');
   if (opts.importsNotUsedAsValues) args.push('--importsNotUsedAsValues', opts.importsNotUsedAsValues);
   if (opts.preserveValueImports) args.push('--preserveValueImports');
@@ -260,6 +262,7 @@ export class CliTranspiler {
       preserveConstEnums?: boolean;
       verbatimModuleSyntax?: boolean;
       rewriteRelativeImportExtensions?: boolean;
+      resolveJsonModule?: boolean;
       isolatedModules?: boolean;
       importsNotUsedAsValues?: string;
       preserveValueImports?: boolean;
@@ -305,6 +308,7 @@ export class CliTranspiler {
       preserveConstEnums = false,
       verbatimModuleSyntax = false,
       rewriteRelativeImportExtensions = false,
+      resolveJsonModule = false,
       isolatedModules = false,
       importsNotUsedAsValues,
       preserveValueImports = false,
@@ -500,6 +504,7 @@ export class CliTranspiler {
         preserveConstEnums,
         verbatimModuleSyntax,
         rewriteRelativeImportExtensions,
+        resolveJsonModule,
         isolatedModules,
         importsNotUsedAsValues,
         preserveValueImports,
@@ -605,6 +610,7 @@ export class CliTranspiler {
             preserveConstEnums,
             verbatimModuleSyntax,
             rewriteRelativeImportExtensions,
+            resolveJsonModule,
             isolatedModules,
             importsNotUsedAsValues,
             preserveValueImports,

--- a/scripts/emit/src/runner.ts
+++ b/scripts/emit/src/runner.ts
@@ -85,6 +85,7 @@ interface TestCase {
   preserveConstEnums: boolean;
   verbatimModuleSyntax: boolean;
   rewriteRelativeImportExtensions: boolean;
+  resolveJsonModule: boolean;
   isolatedModules: boolean;
   importsNotUsedAsValues?: string;
   preserveValueImports: boolean;
@@ -185,6 +186,7 @@ function getCacheKey(
   preserveConstEnums: boolean = false,
   verbatimModuleSyntax: boolean = false,
   rewriteRelativeImportExtensions: boolean = false,
+  resolveJsonModule: boolean = false,
   isolatedModules: boolean = false,
   importsNotUsedAsValues: string = '',
   preserveValueImports: boolean = false,
@@ -241,6 +243,7 @@ function getCacheKey(
     preserveConstEnums,
     verbatimModuleSyntax,
     rewriteRelativeImportExtensions,
+    resolveJsonModule,
     isolatedModules,
     importsNotUsedAsValues,
     preserveValueImports,
@@ -672,6 +675,8 @@ async function findTestCases(filter: string, maxTests: number, dtsOnly: boolean)
     const rewriteRelativeImportExtensions = variant.rewriterelativeimportextensions !== undefined
       ? variant.rewriterelativeimportextensions === 'true'
       : directives.rewriterelativeimportextensions === true;
+    const resolveJsonModule =
+      directives.resolvejsonmodule === true || tsconfigOptions.resolveJsonModule === true;
     const isolatedModules = variant.isolatedmodules !== undefined
       ? variant.isolatedmodules === 'true'
       : directives.isolatedmodules === true
@@ -790,6 +795,7 @@ async function findTestCases(filter: string, maxTests: number, dtsOnly: boolean)
       preserveConstEnums,
       verbatimModuleSyntax,
       rewriteRelativeImportExtensions,
+      resolveJsonModule,
       isolatedModules,
       importsNotUsedAsValues,
       preserveValueImports,
@@ -940,6 +946,7 @@ async function runTest(transpiler: CliTranspiler, testCase: TestCase, config: Co
       testCase.preserveConstEnums,
       testCase.verbatimModuleSyntax,
       testCase.rewriteRelativeImportExtensions,
+      testCase.resolveJsonModule,
       testCase.isolatedModules,
       testCase.importsNotUsedAsValues ?? '',
       testCase.preserveValueImports,
@@ -987,6 +994,7 @@ async function runTest(transpiler: CliTranspiler, testCase: TestCase, config: Co
         preserveConstEnums: testCase.preserveConstEnums,
         verbatimModuleSyntax: testCase.verbatimModuleSyntax,
         rewriteRelativeImportExtensions: testCase.rewriteRelativeImportExtensions,
+        resolveJsonModule: testCase.resolveJsonModule,
         isolatedModules: testCase.isolatedModules,
         importsNotUsedAsValues: testCase.importsNotUsedAsValues,
         preserveValueImports: testCase.preserveValueImports,


### PR DESCRIPTION
Restored from closed, non-merged PR #6526.

Original branch: `codex/dts-jsdoc-function-overload-order-20260513`
Original head: `cf0807fb20450b5f2800a01e77ee50dd00ba81b2`
Original title: fix(dts): preserve jsdoc function overload order

This replacement exists to preserve a non-empty diff during branch/PR cleanup. It has not been validated for readiness.

## Project Corpus Impact
- Row: n/a
- Bug family: preservation-only PR restore
- Evidence: management restore from closed non-merged PR; needs owner validation before WIP removal.

AgentName: M5Manager