### PR TITLE
[WIP] fix(parser): respect virtual .d.ts filename for await heritage

### DIFF
--- a/docs/plan/claims/fix-parser-dts-await-heritage-20260512.md
+++ b/docs/plan/claims/fix-parser-dts-await-heritage-20260512.md
@@ -1,0 +1,23 @@
+# fix(parser): respect virtual .d.ts filenames for await heritage clauses
+
+- **Date**: 2026-05-12
+- **Branch**: `fix/parser-dts-await-heritage-20260512`
+- **PR**: TBD
+- **Status**: claim
+- **Workstream**: 1 (Diagnostic conformance and fingerprints)
+
+## Intent
+
+Fix the `topLevelAwait.3.ts` conformance false positive where TSZ emits an
+extra TS1109 for `declare class C extends await {}` even though the test's
+virtual file is `index.d.ts`. The parser already suppresses this diagnostic
+when the parser filename is `.d.ts`; this slice will route the conformance/CLI
+path through the virtual declaration filename so the parser and tsc agree.
+
+## Files Touched
+
+- `docs/plan/claims/fix-parser-dts-await-heritage-20260512.md`
+
+## Verification
+
+- Pending


### PR DESCRIPTION
Restored from closed, non-merged PR #5979.

Original branch: `fix/parser-dts-await-heritage-20260512`
Original head: `41c89926adfe1e276edc24bf7efcc813e640645b`
Original title: [WIP] fix(parser): respect virtual .d.ts filename for await heritage

This replacement exists to preserve a non-empty diff during branch/PR cleanup. It has not been validated for readiness.

## Project Corpus Impact
- Row: n/a
- Bug family: preservation-only PR restore
- Evidence: management restore from closed non-merged PR; needs owner validation before WIP removal.

AgentName: M5Manager