### PR TITLE
fix(parser): preserve recovered unicode initializer statement

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -2343,7 +2343,11 @@ impl<'a> Printer<'a> {
             && !self.defer_class_static_blocks
             && !deferred_static_blocks.is_empty()
         {
-            self.emit_static_block_iife_comma_items(deferred_static_blocks);
+            self.emit_static_block_iife_comma_items_with_context(
+                deferred_static_blocks,
+                static_initializer_this_binding,
+                static_initializer_super_base,
+            );
             self.write(",");
             self.write_line();
             self.increase_indent();
@@ -2356,7 +2360,11 @@ impl<'a> Printer<'a> {
             self.deferred_class_static_blocks
                 .extend(deferred_static_blocks);
         } else {
-            self.emit_static_block_iifes(deferred_static_blocks);
+            self.emit_static_block_iifes_with_context(
+                deferred_static_blocks,
+                static_initializer_this_binding,
+                static_initializer_super_base,
+            );
         }
 
         // Restore private field state (for nested classes)

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -108,6 +108,21 @@ impl<'a> Printer<'a> {
         }
     }
 
+    pub(in crate::emitter) fn emit_static_block_iifes_with_context(
+        &mut self,
+        blocks: Vec<(NodeIndex, usize)>,
+        this_alias: Option<&str>,
+        super_base_alias: Option<&str>,
+    ) {
+        let prev_this_alias = self.scoped_static_this_alias.clone();
+        let prev_super_alias = self.scoped_static_super_base_alias.clone();
+        self.scoped_static_this_alias = this_alias.map(std::sync::Arc::from);
+        self.scoped_static_super_base_alias = super_base_alias.map(std::sync::Arc::from);
+        self.emit_static_block_iifes(blocks);
+        self.scoped_static_this_alias = prev_this_alias;
+        self.scoped_static_super_base_alias = prev_super_alias;
+    }
+
     pub(in crate::emitter) fn emit_static_block_iife_comma_items(
         &mut self,
         blocks: Vec<(NodeIndex, usize)>,
@@ -119,6 +134,21 @@ impl<'a> Printer<'a> {
             self.emit_static_block_iife_expression(static_block_idx, saved_comment_idx);
             self.decrease_indent();
         }
+    }
+
+    pub(in crate::emitter) fn emit_static_block_iife_comma_items_with_context(
+        &mut self,
+        blocks: Vec<(NodeIndex, usize)>,
+        this_alias: Option<&str>,
+        super_base_alias: Option<&str>,
+    ) {
+        let prev_this_alias = self.scoped_static_this_alias.clone();
+        let prev_super_alias = self.scoped_static_super_base_alias.clone();
+        self.scoped_static_this_alias = this_alias.map(std::sync::Arc::from);
+        self.scoped_static_super_base_alias = super_base_alias.map(std::sync::Arc::from);
+        self.emit_static_block_iife_comma_items(blocks);
+        self.scoped_static_this_alias = prev_this_alias;
+        self.scoped_static_super_base_alias = prev_super_alias;
     }
 
     pub(in crate::emitter) fn class_has_auto_accessor_members(

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -82,7 +82,9 @@ impl<'a> Printer<'a> {
         self.comment_emit_idx = saved_comment_idx;
         if let Some(static_node) = self.arena.get(static_block_idx) {
             let prev = self.emitting_function_body_block;
+            let saved_await_as_yield = self.ctx.emit_await_as_yield;
             self.emitting_function_body_block = true;
+            self.ctx.emit_await_as_yield = true;
             // Save and restore hoisted temps so outer-scope vars (e.g. private
             // field WeakMap names) don't get re-declared inside the IIFE body.
             let saved_temps = std::mem::take(&mut self.hoisted_assignment_temps);
@@ -90,6 +92,7 @@ impl<'a> Printer<'a> {
             // Any temps generated inside the IIFE block have already been
             // emitted by emit_block; restore the outer-scope temps.
             self.hoisted_assignment_temps = saved_temps;
+            self.ctx.emit_await_as_yield = saved_await_as_yield;
             self.emitting_function_body_block = prev;
         } else {
             self.write("{ }");

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -800,6 +800,7 @@ impl<'a> Printer<'a> {
             node,
             recovered_async_arrow_return.is_some(),
         );
+        self.emit_recovered_typeof_member_call_after_variable_statement(node);
 
         // CommonJS: emit exports.X = X; after the declaration
         if is_exported && !export_names.is_empty() {
@@ -948,6 +949,83 @@ impl<'a> Printer<'a> {
         self.write("}");
         self.write_line();
         self.write_semicolon();
+    }
+
+    fn emit_recovered_typeof_member_call_after_variable_statement(&mut self, node: &Node) {
+        let Some(text) = self.source_text else {
+            return;
+        };
+        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
+        let end = std::cmp::min(node.end as usize, text.len());
+        if start >= end {
+            return;
+        }
+        let segment = &text[start..end];
+        let Some(typeof_rel) = segment.find(".typeof(") else {
+            return;
+        };
+        let open = start + typeof_rel + ".typeof".len();
+        let Some(close) = self.find_matching_source_paren(open, end) else {
+            return;
+        };
+        let argument = text[open + 1..close].trim();
+        if argument.is_empty() {
+            return;
+        }
+
+        self.write_line();
+        self.write("typeof (");
+        self.write(argument);
+        self.write(");");
+    }
+
+    fn find_matching_source_paren(&self, open: usize, limit: usize) -> Option<usize> {
+        let text = self.source_text?;
+        let bytes = text.as_bytes();
+        if bytes.get(open) != Some(&b'(') {
+            return None;
+        }
+
+        let mut depth = 1u32;
+        let mut i = open + 1;
+        while i < limit && i < bytes.len() {
+            match bytes[i] {
+                b'\'' | b'"' | b'`' => {
+                    i = self.skip_quoted_source_text(i, limit);
+                    continue;
+                }
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        None
+    }
+
+    fn skip_quoted_source_text(&self, quote_start: usize, limit: usize) -> usize {
+        let Some(text) = self.source_text else {
+            return quote_start + 1;
+        };
+        let bytes = text.as_bytes();
+        let quote = bytes[quote_start];
+        let mut i = quote_start + 1;
+        while i < limit && i < bytes.len() {
+            if bytes[i] == b'\\' {
+                i = (i + 2).min(limit);
+                continue;
+            }
+            if bytes[i] == quote {
+                return i + 1;
+            }
+            i += 1;
+        }
+        i
     }
 
     fn recovered_async_arrow_return_name(&self, node: &Node) -> Option<String> {

--- a/crates/tsz-emitter/tests/printer.rs
+++ b/crates/tsz-emitter/tests/printer.rs
@@ -629,6 +629,23 @@ fn test_commonjs_class_export_before_static_block_iife() {
     );
 }
 
+#[test]
+fn test_lowered_static_block_recovered_await_emits_yield() {
+    let source = "class C {\n    static {\n        await 1;\n        yield 1;\n    }\n}\n";
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("(() => {\n    yield 1;\n    yield 1;\n})();"),
+        "Lowered static block should emit recovered await as yield, got: {output}"
+    );
+}
+
 // =========================================================================
 // Comment skipping for erased type annotations
 // =========================================================================

--- a/crates/tsz-emitter/tests/printer.rs
+++ b/crates/tsz-emitter/tests/printer.rs
@@ -646,6 +646,27 @@ fn test_lowered_static_block_recovered_await_emits_yield() {
     );
 }
 
+#[test]
+fn test_lowered_static_block_uses_static_initializer_context() {
+    let source = "class B { static a = 1; }\nclass C extends B { static c = super.a; static { this.c; super.a; } }\n";
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("C.c = Reflect.get("),
+        "Static field super access should use Reflect.get, got: {output}"
+    );
+    assert!(
+        output.contains("(() => { _a.c; Reflect.get(_b, \"a\", _a); })();"),
+        "Lowered static block should reuse static this/super aliases, got: {output}"
+    );
+}
+
 // =========================================================================
 // Comment skipping for erased type annotations
 // =========================================================================

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -964,3 +964,24 @@ fn namespace_export_declaration_inline_comment_erased() {
         "Trailing comment on erased `export as namespace` should not leak.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn recovered_unicode_identifier_initializer_emits_as_statement() {
+    let subscript_one = '\u{2081}';
+    let source = format!("var a{subscript_one} = \"hello\"; alert(a{subscript_one})");
+
+    let output = parse_and_print(&source);
+
+    assert!(
+        output.contains("var a;"),
+        "Malformed unicode identifier declaration should still emit the declaration.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("\"hello\";"),
+        "Recovered initializer literal should emit as its own statement.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("alert(a);"),
+        "Malformed unicode identifier use should recover to the valid identifier.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -985,3 +985,23 @@ fn recovered_unicode_identifier_initializer_emits_as_statement() {
         "Malformed unicode identifier use should recover to the valid identifier.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn recovered_typeof_member_type_tail_emits_as_statement() {
+    let source = r#"class C {
+    foo() {
+        const x: "".typeof(this.foo);
+    }
+}"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("const x;"),
+        "Malformed declaration should still emit the declaration.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("typeof (this.foo);"),
+        "Recovered `.typeof(...)` type tail should emit as a runtime typeof statement.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -2109,7 +2109,6 @@ impl ParserState {
                                     "Variable declaration expected.",
                                     diagnostic_codes::VARIABLE_DECLARATION_EXPECTED,
                                 );
-                                self.next_token();
                             }
                         }
                         break;


### PR DESCRIPTION
Restored by AgentName: M5Manager

This is a management restoration of closed PR #2325 because the original head still has a non-empty diff against current `origin/main` and no exact-title/head open/merged PR currently preserves it.

Original PR: #2325
Original branch: `codex/emit-unicode-identifier-recovery`
Original head: `7a64ae0769bd8130005fca95a67e4f7218ae8d4f`
Original title: `fix(parser): preserve recovered unicode initializer statement`

Current state: WIP/help wanted. This branch was restored for preservation and has not been revalidated against current main.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: management-preservation-only; original diff requires owner review before landing

AgentName: M5Manager