### PR TITLE
fix(parser): recover JSX namespaced closing tails

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1632,6 +1632,9 @@ impl<'a> Printer<'a> {
                     k if k == SyntaxKind::Identifier as u16
                         || k == syntax_kind_ext::QUALIFIED_NAME =>
                     {
+                        if self.ctx.options.verbatim_module_syntax {
+                            return true;
+                        }
                         self.namespace_alias_target_has_runtime_value(
                             import_decl.module_specifier,
                             None,

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -217,6 +217,14 @@ impl<'a> Printer<'a> {
     }
 
     pub(in crate::emitter) fn emit_import_declaration(&mut self, node: &Node) {
+        if let Some(import) = self.arena.get_import_decl(node)
+            && let Some(clause_node) = self.arena.get(import.import_clause)
+            && clause_node.kind != syntax_kind_ext::IMPORT_CLAUSE
+        {
+            self.emit_import_equals_declaration(node);
+            return;
+        }
+
         if self.ctx.is_commonjs() {
             self.emit_import_declaration_commonjs(node);
         } else {

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1246,6 +1246,7 @@ impl<'a> Printer<'a> {
             // Defer `export {}` (empty named exports, no module specifier) to end
             // of file. TSC places these at the end as ESM markers.
             if is_es_module_output
+                && !self.ctx.options.verbatim_module_syntax
                 && stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION
                 && let Some(export) = self.arena.get_export_decl(stmt_node)
                 && export.module_specifier.is_none()

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -2014,23 +2014,27 @@ impl ParserState {
         self.parse_expected(SyntaxKind::LessThanSlashToken);
         let tag_name = self.parse_jsx_element_name();
         let end_pos = self.token_end();
-        if !self.parse_expected(SyntaxKind::GreaterThanToken)
-            && self.is_token(SyntaxKind::ColonToken)
-        {
-            // Match tsc's malformed namespaced-closing-tag recovery: report
-            // the missing `>` at the stray `:`, then consume the dangling
-            // namespace tail so outer expression recovery resumes at the real
-            // `>`/`;` tokens instead of the extra identifier segment.
-            self.next_token();
-            self.scanner.scan_jsx_identifier();
-            if self.is_identifier_or_keyword() {
-                self.parse_identifier_name();
-            }
-            if self.is_token(SyntaxKind::GreaterThanToken) {
-                self.parse_error_at_current_token(
-                    "',' expected.",
-                    tsz_common::diagnostics::diagnostic_codes::EXPECTED,
-                );
+        if !self.parse_expected(SyntaxKind::GreaterThanToken) {
+            if self.is_token(SyntaxKind::ColonToken) {
+                // Match tsc's malformed namespaced-closing-tag recovery: report
+                // the missing `>` at the stray `:`, then consume the dangling
+                // namespace tail so outer expression recovery resumes at the real
+                // `>`/`;` tokens instead of the extra identifier segment.
+                self.next_token();
+                self.scanner.scan_jsx_identifier();
+                if self.is_identifier_or_keyword() {
+                    self.parse_identifier_name();
+                }
+                if self.is_token(SyntaxKind::GreaterThanToken) {
+                    self.parse_error_at_current_token(
+                        "',' expected.",
+                        tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+                    );
+                }
+            } else if self.is_token(SyntaxKind::DotToken) {
+                // For a malformed namespaced close like `</b:c.x>`, tsc drops
+                // the stray `.` and lets `x >` recover as a following expression.
+                self.next_token();
             }
         }
         self.arena.add_jsx_closing(


### PR DESCRIPTION
Restored by AgentName: M5Manager

This is a management restoration of closed PR #2270 because the original head still has a non-empty diff against current `origin/main` and no exact-title/head open/merged PR currently preserves it.

Original PR: #2270
Original branch: `codex/emit-jsx-namespaced-closing-recovery`
Original head: `a485b87fbd081a649d53618f2effd2847d804efa`
Original title: `fix(parser): recover JSX namespaced closing tails`

Current state: WIP/help wanted. This branch was restored for preservation and has not been revalidated against current main.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: management-preservation-only; original diff requires owner review before landing

AgentName: M5Manager