### PR TITLE
fix(solver): widen covariant result before contra-candidate assignability check

### DIFF
--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -4888,3 +4888,106 @@ const probe: number[] = v;
         "Object.values on an explicitly-typed primitive object stays primitive. Got: {diags:#?}"
     );
 }
+
+// -----------------------------------------------------------------------------
+// Co/contra-variant inference: covariant result must be widened before the
+// contra-candidate assignability check.
+//
+// When T appears in a return-type position (`() => T`) its candidate carries
+// ReturnType priority and skip_literal_widening is true, so the fresh object
+// literal `{a:1, b:2}` is NOT widened inside resolve_from_candidates.
+// tsc calls getWidenedType(covariantInference) BEFORE testing assignability
+// to the contra-candidate – tsz must do the same so that fresh object literals
+// like `{a:1,b:2}` pass structural checking against `{a:number}`.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn co_contra_fresh_object_widened_before_assignability_check() {
+    // T appears in: produce: () => T  (covariant, ReturnType priority)
+    //               consume: (t: T) => void  (contra)
+    // produce() returns a fresh object literal {a:1, b:2}.
+    // After widening: {a:number, b:number} IS assignable to {a:number}.
+    // Covariant result should win; r.b should be valid.
+    let source = r#"
+declare function bar<T>(produce: () => T, consume: (t: T) => void): T;
+const r = bar(() => ({ a: 1, b: 2 }), (t: { a: number }) => {});
+const _b: number = r.b;
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "fresh object literal covariant result should win after widening; r.b must be valid. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn co_contra_fresh_object_widened_different_type_param_names() {
+    // Same structural rule with renamed type param (U instead of T).
+    let source = r#"
+declare function bar<U>(produce: () => U, consume: (u: U) => void): U;
+const r = bar(() => ({ x: 1, y: 2 }), (u: { x: number }) => {});
+const _y: number = r.y;
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "type param name change should not affect widening behavior. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn co_contra_contra_wins_when_covariant_not_assignable() {
+    // When covariant result (string) is NOT assignable to contra (number),
+    // the contra-candidate should win and produce an error at the use site.
+    let source = r#"
+declare function bar<T>(produce: () => T, consume: (t: T) => void): T;
+bar(() => "hello", (t: number) => {});
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        has_any_diagnostic_code(&diags, &[2345, 2322]),
+        "string is not assignable to number; contra should win and a TS2345/TS2322 error should appear. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn co_contra_multiple_contra_resolved_via_intersection() {
+    // Two contra-candidates → intersection.
+    // produce returns {x:1, y:2}; consume1 expects {x:number}, consume2 expects {y:number}.
+    // Widened covariant {x:number,y:number} IS assignable to both, so it wins.
+    let source = r#"
+declare function combine<T>(
+    produce: () => T,
+    consume1: (t: T) => void,
+    consume2: (t: T) => void,
+): T;
+const r = combine(
+    () => ({ x: 1, y: 2 }),
+    (t: { x: number }) => {},
+    (t: { y: number }) => {},
+);
+const _x: number = r.x;
+const _y: number = r.y;
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "widened covariant {{x:number,y:number}} should win against both contra-candidates. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn co_contra_aliased_shape_covariant_wins_after_widen() {
+    // T via an alias; structural rule should be the same.
+    let source = r#"
+type HasA = { a: number };
+declare function bar<T>(produce: () => T, consume: (t: T) => void): T;
+const r = bar(() => ({ a: 1, b: 2 }), (t: HasA) => {});
+const _b: number = r.b;
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "aliased contra shape should not prevent covariant win after widening. Got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/generic_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_call_inference_tests.rs
@@ -4991,3 +4991,43 @@ const _b: number = r.b;
         "aliased contra shape should not prevent covariant win after widening. Got: {diags:#?}"
     );
 }
+
+#[test]
+fn co_contra_never_contra_does_not_override_covariant_literal() {
+    let source = r#"
+type A = { kind: "a" };
+type B = { kind: "b" };
+declare const a: A;
+declare const b: B;
+declare function fab(arg: A | B): void;
+declare function foo<T>(x: { kind: T }, f: (arg: { kind: T }) => void): void;
+foo(a, fab);
+foo(b, fab);
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "contra evidence that collapses to never must not override useful covariant literals. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn co_contra_primitive_literal_probe_preserves_union_assignability() {
+    let source = r#"
+declare const branch:
+  <T, U extends T>(_: { test: T, if: (t: T) => t is U, then: (u: U) => void }) => void;
+declare const x: "a" | "b";
+branch({
+  test: x,
+  if: (t): t is "a" => t === "a",
+  then: u => {
+    let test1: "a" = u;
+  }
+});
+"#;
+    let diags = relevant_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "primitive literal covariant evidence should be probed as the literal, not widened past its union constraint. Got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -49,7 +49,11 @@ impl<'a> InferenceContext<'a> {
         from_array_element: bool,
         mut external_is_subtype: Option<&mut dyn FnMut(TypeId, TypeId) -> bool>,
     ) -> TypeId {
-        let covariant_widened = widening::widen_type_for_inference(self.interner, covariant_result);
+        let covariant_widened = if is_literal_type(self.interner, covariant_result) {
+            covariant_result
+        } else {
+            widening::widen_type_for_inference(self.interner, covariant_result)
+        };
         let covariant_is_uninformative = matches!(
             covariant_widened,
             TypeId::NEVER | TypeId::UNKNOWN | TypeId::ANY
@@ -62,6 +66,12 @@ impl<'a> InferenceContext<'a> {
                     self.is_subtype(covariant_widened, c.type_id)
                 }
             });
+        if !covariant_assignable_to_contra && !covariant_is_uninformative {
+            let contra_result = self.resolve_from_contra_candidates(concrete_contra_candidates);
+            if contra_result == TypeId::NEVER {
+                return covariant_result;
+            }
+        }
         self.choose_covariant_or_contra(
             covariant_widened,
             concrete_contra_candidates,

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -35,6 +35,42 @@ impl<'a> InferenceContext<'a> {
             .is_some_and(|info| info.constraint.is_none())
     }
 
+    /// Widen the covariant candidate and decide between the covariant and contra result.
+    ///
+    /// Called when both covariant and contra-variant candidates exist.
+    /// tsc calls `getWidenedType(covariantInference)` in `getInferredType` before
+    /// testing assignability to contra-candidates, so fresh object literals like
+    /// `{a:1,b:2}` are widened to `{a:number,b:number}` before the check.
+    /// Without widening, excess property checking rejects them against `{a:number}`.
+    fn resolve_covariant_against_contra(
+        &self,
+        covariant_result: TypeId,
+        concrete_contra_candidates: &[InferenceCandidate],
+        from_array_element: bool,
+        mut external_is_subtype: Option<&mut dyn FnMut(TypeId, TypeId) -> bool>,
+    ) -> TypeId {
+        let covariant_widened = widening::widen_type_for_inference(self.interner, covariant_result);
+        let covariant_is_uninformative = matches!(
+            covariant_widened,
+            TypeId::NEVER | TypeId::UNKNOWN | TypeId::ANY
+        );
+        let covariant_assignable_to_contra = !covariant_is_uninformative
+            && concrete_contra_candidates.iter().any(|c| {
+                if let Some(ref mut ext) = external_is_subtype {
+                    ext(covariant_widened, c.type_id)
+                } else {
+                    self.is_subtype(covariant_widened, c.type_id)
+                }
+            });
+        self.choose_covariant_or_contra(
+            covariant_widened,
+            concrete_contra_candidates,
+            covariant_assignable_to_contra,
+            covariant_is_uninformative,
+            from_array_element,
+        )
+    }
+
     /// Apply the shared "prefer covariant" decision used by both
     /// `compute_constraint_result` and `fix_current_variables_with`.
     ///
@@ -501,30 +537,13 @@ impl<'a> InferenceContext<'a> {
                 // P should be inferred from the function parameter (contra: Props),
                 // not from the object literal (co: { value: "C" }), because the
                 // object literal type is not assignable to Props.
-                let covariant_is_uninformative = matches!(
-                    covariant_result,
-                    TypeId::NEVER | TypeId::UNKNOWN | TypeId::ANY
-                );
-                let covariant_assignable_to_contra = !covariant_is_uninformative
-                    && concrete_contra_candidates.iter().any(|c| {
-                        // Use the external (full checker) assignability test when
-                        // available, falling back to the simplified BCT is_subtype.
-                        // The BCT checker cannot resolve Lazy (interface/class) types
-                        // through their extends chains in all cases, so the full
-                        // checker is needed to correctly determine e.g. B <: A when
-                        // B extends A.
-                        if let Some(ref mut ext) = external_is_subtype {
-                            ext(covariant_result, c.type_id)
-                        } else {
-                            self.is_subtype(covariant_result, c.type_id)
-                        }
-                    });
-                self.choose_covariant_or_contra(
+                self.resolve_covariant_against_contra(
                     covariant_result,
                     &concrete_contra_candidates,
-                    covariant_assignable_to_contra,
-                    covariant_is_uninformative,
                     candidates.iter().any(|c| c.from_array_element),
+                    external_is_subtype
+                        .as_mut()
+                        .map(|e| e as &mut dyn FnMut(TypeId, TypeId) -> bool),
                 )
             } else {
                 covariant_result
@@ -1852,26 +1871,13 @@ impl<'a> InferenceContext<'a> {
                 );
                 // (TypeParameter filtering already done above)
                 if !concrete_contra_candidates.is_empty() {
-                    // Match tsc's getInferredType: prefer covariant ONLY IF it's
-                    // assignable to some contra-candidate. Otherwise use contra result.
-                    let covariant_is_uninformative = matches!(
-                        covariant_result,
-                        TypeId::NEVER | TypeId::UNKNOWN | TypeId::ANY
-                    );
-                    let covariant_assignable_to_contra = !covariant_is_uninformative
-                        && concrete_contra_candidates.iter().any(|c| {
-                            if let Some(ref mut ext) = external_is_subtype {
-                                ext(covariant_result, c.type_id)
-                            } else {
-                                self.is_subtype(covariant_result, c.type_id)
-                            }
-                        });
-                    self.choose_covariant_or_contra(
+                    self.resolve_covariant_against_contra(
                         covariant_result,
                         &concrete_contra_candidates,
-                        covariant_assignable_to_contra,
-                        covariant_is_uninformative,
                         candidates.iter().any(|c| c.from_array_element),
+                        external_is_subtype
+                            .as_mut()
+                            .map(|e| e as &mut dyn FnMut(TypeId, TypeId) -> bool),
                     )
                 } else {
                     covariant_result


### PR DESCRIPTION
## Agent
AgentName: M4-B
Previous owner notes: Studio:DE refreshed earlier heads.

## Track
Track 4 / solver generic inference parity.

## Invariant
When a type parameter has both covariant and contravariant evidence, co/contra reconciliation stays solver-owned. The solver may use a widened covariant probe for fresh object assignability, but primitive literal covariant evidence must still be probed as the literal, and an uninhabitable `never` contra fallback must not erase useful covariant evidence.

## Root Cause
The previous #9230 head widened every covariant result before testing assignability to contra candidates. That fixed fresh object literal cases, but it also widened primitive literal evidence such as `"a"` to `string`, which made literal-union constraints fail the probe and allowed contra evidence to collapse inference to `never` or to the broader constraint. Ready-review CI then reported two unlisted conformance regressions: `coAndContraVariantInferences.ts` and `intraExpressionInferences.ts`.

## Scope
- `crates/tsz-solver/src/inference/infer_resolve.rs`
  - Preserve primitive literal covariant evidence during the co/contra assignability probe.
  - Keep the original covariant result when the contra fallback resolves to `never` instead of inferring an uninhabitable type.
- `crates/tsz-checker/tests/generic_call_inference_tests.rs`
  - Add regression coverage for A/B literal-domain co/contra calls and type-predicate literal-union inference.

## Project Corpus Impact
- Row: n/a
- Bug family: co/contra inference - literal-domain covariant evidence vs widened probes / `never` contra fallback
- Evidence: solver/checker-only inference fix with focused unit tests and narrow conformance filters; no benchmark fixture or project corpus row is expected to change directly.

## Verification
M4-B refresh/fix on current head `8b9be3ccdf7d22618b3dfb5c4b129f43a7f29329` over `origin/main` `4d8177f346347c473da2cb67c9b90c78e317d0a9`:
- `git diff --check origin/main..HEAD`
- `cargo fmt --check --package tsz-checker --package tsz-solver`
- `python3 scripts/arch/arch_guard.py`

Focused conformance before the final rebase to `0d3f55dcf67d35d034aa3e97eddb3dfe285ad2f5`:
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter coAndContraVariantInferences --verbose` (8/8 passed)
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter intraExpressionInferences --verbose` (2/2 passed)
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter spyComparisonChecking --verbose` (1/1 passed)
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter thislessFunctionsNotContextSensitive3 --verbose` (1/1 passed)

Attempted local unit verification:
- `CARGO_TARGET_DIR=/Users/mohsen/.codex/worktrees/fdcb/tsz/.target cargo nextest run -p tsz-checker --test generic_call_inference_tests co_contra` could not complete because the linker failed with `errno=28` (disk full). Current workspace free space was about 170 MB after cache-preserving cleanup, so ready-review CI owns the Rust test rerun and heavy gates per §19.5.

## Coordination Notes
- AgentName: M4-B
- CI run `26400502132` on previous head `68a4f4a9530c4d9309acdf26562b66eeb06753d5` had all conformance shards green but `conformance-aggregate` failed with unlisted regressions:
  - `TypeScript/tests/cases/compiler/coAndContraVariantInferences.ts`
  - `TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts`
- The same aggregate showed accepted regressions resolved in that run:
  - `TypeScript/tests/cases/compiler/spyComparisonChecking.ts`
  - `TypeScript/tests/cases/compiler/thislessFunctionsNotContextSensitive3.ts`
- M4-B pushed current head `8b9be3ccdf7d22618b3dfb5c4b129f43a7f29329` onto current `origin/main` `4d8177f346347c473da2cb67c9b90c78e317d0a9`. Auto-merge remains off; do not merge until fresh exact-head CI, including branch policy / Queue Tested, is complete and green.

