### PR TITLE
refactor(checker): route missing-property relation guards

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -148,10 +148,11 @@ impl<'a> CheckerState<'a> {
         let read_ok = if source_prop.is_method || target_prop.is_method {
             self.is_assignable_to_bivariant(source_prop.type_id, target_prop.type_id)
         } else {
-            self.is_assignable_to(source_prop.type_id, target_prop.type_id)
+            self.diagnostic_relation_boolean_guard(source_prop.type_id, target_prop.type_id)
         };
         let write_ok = target_prop.readonly
-            || self.is_assignable_to(target_prop.write_type, source_prop.write_type);
+            || self
+                .diagnostic_relation_boolean_guard(target_prop.write_type, source_prop.write_type);
 
         read_ok && write_ok
     }
@@ -930,7 +931,7 @@ impl<'a> CheckerState<'a> {
         let mismatched: Vec<TypeId> = members
             .iter()
             .copied()
-            .filter(|&m| !self.is_assignable_to(m, target_eval))
+            .filter(|&m| !self.diagnostic_relation_boolean_guard(m, target_eval))
             .collect();
         if mismatched.len() == members.len()
             && members.len() == 2

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        94,
+        91,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #8223
- Child: #8227
- Based on: #9222 (merged into `main` at 2026-05-20T11:51:44Z)
- Follows: #9226, now merged into the #9222 stack branch
- Child: #9238 (`codex/m1pd2-generic-constraint-relation-guards-20260520`)

## Structural Rule
When diagnostic missing-property/exact-optional rendering code only needs a boolean assignability answer to decide whether a nested diagnostic should be suppressed or narrowed, it should route through `diagnostic_relation_boolean_guard` instead of directly calling raw `is_assignable_to`.

## Owner Layer
This is checker diagnostic orchestration. The named guard delegates to the same assignability implementation today, so this is behavior-preserving and only makes the remaining diagnostic predicate debt visible to the #8227 ratchet.

## Scope
- Routes missing-property satisfaction read/write checks in `error_reporter/assignability.rs` through `diagnostic_relation_boolean_guard`, leaving the existing bivariant method-property path unchanged.
- Routes exact-optional union-member mismatch filtering through `diagnostic_relation_boolean_guard`.
- Ratchets the #8227 raw diagnostic assignability predicate cap from 94 to 91.

## Adjacent Cases
- Missing-property diagnostics still accept public non-optional source properties whose read/write types are assignable to the target shape.
- Method-property compatibility still uses the existing bivariant relation path.
- Exact-optional diagnostics still narrow the displayed source to `undefined` only when every source union member mismatches the target and the target does not include `undefined`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / missing-property relation guards
- Evidence: behavior-preserving helper routing only; `diagnostic_relation_boolean_guard` delegates to the same assignability implementation today. Local verification covered the focused arch ratchet test, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B rebased this draft onto current `origin/main` `13644f383d3ea5ec70c6296fb3a18198a159b96e`; current #9236 head is `a07a9a8d7429545f383d066bb6ca557559b17559`.
- This PR remains draft because external/shared-account queue actions previously re-parked it after ready CI attempts; see the signed comments for the runner/lint/unit-cloudbuild history before re-promoting.
- Next owner/action: continue restacking from #9247 upward. After downstream is current, decide whether #9236 should be re-promoted. If re-promoted, re-arm squash auto-merge and let ready-review CI run; do not add a WIP label silently.