### PR TITLE
refactor(checker): route generic constraint relation guards

### DIFF
--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -730,10 +730,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
             let prop_value = self.evaluate_type_for_assignability(prop.type_id);
-            if !self.is_assignable_to(prop_value, resolved_constraint)
-                && !self.is_assignable_to(prop.type_id, constraint)
-                && !self.is_assignable_to(prop_value, constraint)
-                && !self.is_assignable_to(prop.type_id, resolved_constraint)
+            if !self.diagnostic_relation_boolean_guard(prop_value, resolved_constraint)
+                && !self.diagnostic_relation_boolean_guard(prop.type_id, constraint)
+                && !self.diagnostic_relation_boolean_guard(prop_value, constraint)
+                && !self.diagnostic_relation_boolean_guard(prop.type_id, resolved_constraint)
             {
                 return false;
             }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        91,
+        87,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #8223
- Child: #8227
- Stacked on: #9236 (`codex/m1pd2-missing-property-relation-guards-20260520`)
- Child: #9242 (`codex/m1pd2-property-index-relation-guards-20260520`)

## Structural Rule
When generic-constraint diagnostic code only needs a boolean relation probe to decide whether to suppress or specialize a diagnostic, it should route through `diagnostic_relation_boolean_guard` instead of directly calling raw assignability on the type database.

## Owner Layer
This is checker diagnostic orchestration in `error_reporter/generics.rs`. The guard delegates to the same assignability implementation today, so this is behavior-preserving and only makes the diagnostic-local predicate debt visible to the #8227 ratchet.

## Scope
- Routes generic-constraint diagnostic suppression predicates through `diagnostic_relation_boolean_guard`.
- Ratchets the #8227 raw diagnostic assignability predicate cap on top of #9236.

## Adjacent Cases
- Generic constraint mismatch diagnostics still choose the same source/target display path.
- Non-diagnostic generic inference and relation policy paths remain unchanged.
- Bivariant, no-weak, and env-aware relation paths are left unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / generic constraint relation guards
- Evidence: behavior-preserving helper routing only; local verification covered the focused arch ratchet test, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-missing-property-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9236 head `a07a9a8d7429545f383d066bb6ca557559b17559`; current #9238 head is `29b2f475de6c824c377f0a4c3c707809316c222a`.
- Draft because this is stacked above #9236 and the existing M1-B relation-routing stack.
- #9236 remains draft after external/shared-account queue actions re-parked it; see the signed M1-B handoff comments on #9236 before re-promoting the stack root.
- Child #9242 is based on this refreshed head; next owner/action is to inspect #9247+ after #9242/#9245 were also refreshed.