### PR TITLE
refactor(checker): route property index relation guards

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -2401,7 +2401,7 @@ impl<'a> CheckerState<'a> {
         };
         if has_number_index
             && !is_for_in_index
-            && !self.ctx.types.is_assignable_to(index_type, TypeId::NUMBER)
+            && !self.diagnostic_relation_boolean_guard(index_type, TypeId::NUMBER)
         {
             // tsc reports TS7015 at the index expression (arg_idx), not the full element access.
             self.error_at_anchor(
@@ -2552,7 +2552,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        self.ctx.types.is_assignable_to(index_type, first.type_id)
+        self.diagnostic_relation_boolean_guard(index_type, first.type_id)
     }
 
     fn is_named_method_suggestion_receiver(&self, idx: NodeIndex) -> bool {

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        87,
+        85,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #8223
- Child: #8227
- Stacked on: #9238 (`codex/m1pd2-generic-constraint-relation-guards-20260520`)
- Child: #9245 (`codex/m1pd2-variadic-env-relation-guard-20260520`)

## Structural Rule
When property/index diagnostic code only needs a boolean relation probe to choose a diagnostic path or suppress an index signature suggestion, it should route through `diagnostic_relation_boolean_guard` instead of directly calling raw assignability on the type database.

## Owner Layer
This is checker diagnostic orchestration in `error_reporter/properties.rs`. The guard delegates to the same assignability implementation today, so this is behavior-preserving and only makes the diagnostic-local predicate debt visible to the #8227 ratchet.

## Scope
- Routes the TS7015 numeric-index diagnostic predicate through `diagnostic_relation_boolean_guard`.
- Routes call-signature index-argument acceptance through `diagnostic_relation_boolean_guard`.
- Ratchets the #8227 raw diagnostic assignability predicate cap from 87 to 85.

## Adjacent Cases
- Arrays/tuples/enums and numeric index signatures still report TS7015 only when the index type is not assignable to `number` and the index is not a for-in variable.
- Method-suggestion receivers still test the first call-signature parameter against the index argument type before suggesting a call.
- For-in suppression and union index-signature checks remain unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / property index relation guards
- Evidence: behavior-preserving helper routing only; `diagnostic_relation_boolean_guard` delegates to the same assignability implementation today. Local verification covered the focused arch ratchet test, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-generic-constraint-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9238 head `29b2f475de6c824c377f0a4c3c707809316c222a`; current #9242 head is `b41247b813db0f4f8debe70d4c2abf5415666f74`.
- Draft because this is stacked on #9238/#9236. #9236 remains draft after external/shared queue actions re-parked it after M1-B previously marked it ready.
- No WIP label added. Draft state is only preserving stack order.
- Current child-only diff relative to #9238 is `crates/tsz-checker/src/error_reporter/properties.rs` plus `scripts/arch/arch_guard.py`.
- Child #9245 is based on this refreshed head; next owner/action is to inspect #9247 mergeability/CI and restack the next child if needed.