### PR TITLE
refactor(checker): route variadic env relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -2160,6 +2160,18 @@ impl<'a> CheckerState<'a> {
         self.is_assignable_to(source, target)
     }
 
+    /// Environment-aware boolean relation guard for diagnostic code paths.
+    ///
+    /// Use this only when the caller intentionally needs the current
+    /// `TypeEnvironment` and no relation-cache lookup.
+    pub(crate) fn diagnostic_relation_boolean_guard_with_env(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_with_env(source, target)
+    }
+
     /// Check if source type is assignable to target type.
     ///
     /// This is the main entry point for assignability checking, used throughout

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
@@ -62,7 +62,7 @@ impl<'a> CheckerState<'a> {
             let Some(actual) = arg_elements.get(consumed) else {
                 break;
             };
-            if !self.is_assignable_to_with_env(actual.type_id, fixed.type_id) {
+            if !self.diagnostic_relation_boolean_guard_with_env(actual.type_id, fixed.type_id) {
                 break;
             }
             consumed += 1;

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        85,
+        84,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #8223
- Child: #8227
- Stacked on: #9242 (`codex/m1pd2-property-index-relation-guards-20260520`)
- Child: #9247 (`codex/m1pd2-comparability-relation-guards-20260520`)

## Structural Rule
When diagnostic formatting needs an environment-aware boolean assignability answer, it should use an explicit diagnostic relation guard that preserves the current `TypeEnvironment` policy instead of calling the raw assignability method directly.

## Owner Layer
Checker diagnostic formatting in `error_reporter/call_errors/display_formatting_variadic.rs`; the new wrapper lives at the checker assignability gateway and delegates to the existing env-aware relation path, so relation semantics remain unchanged.

## Scope
- Adds `diagnostic_relation_boolean_guard_with_env` for diagnostic-only env-aware boolean probes.
- Routes constrained variadic tuple display consumption through the new guard.
- Ratchets the #8227 raw diagnostic assignability predicate cap from 85 to 84.

## Adjacent Cases
- Non-env diagnostic relation guards continue to use `diagnostic_relation_boolean_guard`.
- Generic call/new inference callsites still use `is_assignable_to_with_env` directly because they are type computation, not diagnostic formatting.
- The constrained variadic tuple display still resolves/evaluates tuple shapes before consuming fixed elements.
- No bivariant, no-weak, or cached relation policy is changed.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / variadic tuple diagnostic formatting
- Evidence: behavior-preserving helper routing only; local verification covered the focused arch ratchet test, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-property-index-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9242 head `b41247b813db0f4f8debe70d4c2abf5415666f74`; current #9245 head is `aa6bbffab6036b7b1c225ec3d455f595a0d3beaf`.
- Draft because this is stacked on #9242/#9238/#9236. #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- No WIP label added. Draft state is only preserving stack order.
- Current child-only diff relative to #9242 is `crates/tsz-checker/src/assignability/assignability_checker.rs`, `crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs`, and `scripts/arch/arch_guard.py`.
- Child #9247 is based on this refreshed head; next owner/action is to inspect #9247 mergeability/CI and restack the next child if needed.