### PR TITLE
refactor(checker): route comparability relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1863,9 +1863,13 @@ impl<'a> CheckerState<'a> {
                     }
                     (None, None) => {
                         // Neither is a function type — check normal comparability
-                        let prop_comparable = self
-                            .is_assignable_to(source_prop.type_id, target_prop.type_id)
-                            || self.is_assignable_to(target_prop.type_id, source_prop.type_id);
+                        let prop_comparable = self.diagnostic_relation_boolean_guard(
+                            source_prop.type_id,
+                            target_prop.type_id,
+                        ) || self.diagnostic_relation_boolean_guard(
+                            target_prop.type_id,
+                            source_prop.type_id,
+                        );
                         if !prop_comparable {
                             return false;
                         }
@@ -1932,8 +1936,8 @@ impl<'a> CheckerState<'a> {
         // Skip this for pure call/construct signature objects because TS overlap
         // checks are stricter than general object assignability there.
         if !skip_signature_only_fast_path
-            && (self.is_assignable_to(source_apparent, target_apparent)
-                || self.is_assignable_to(target_apparent, source_apparent))
+            && (self.diagnostic_relation_boolean_guard(source_apparent, target_apparent)
+                || self.diagnostic_relation_boolean_guard(target_apparent, source_apparent))
         {
             return true;
         }
@@ -1946,8 +1950,8 @@ impl<'a> CheckerState<'a> {
         // Decompose source union: check if any member is assignable in either direction
         if let Some(members) = query::union_members(self.ctx.types, source_apparent) {
             for member in &members {
-                if self.is_assignable_to(*member, target_apparent)
-                    || self.is_assignable_to(target_apparent, *member)
+                if self.diagnostic_relation_boolean_guard(*member, target_apparent)
+                    || self.diagnostic_relation_boolean_guard(target_apparent, *member)
                 {
                     return true;
                 }
@@ -1957,8 +1961,8 @@ impl<'a> CheckerState<'a> {
         // Decompose target union: check if any member is assignable in either direction
         if let Some(members) = query::union_members(self.ctx.types, target_apparent) {
             for member in &members {
-                if self.is_assignable_to(source_apparent, *member)
-                    || self.is_assignable_to(*member, source_apparent)
+                if self.diagnostic_relation_boolean_guard(source_apparent, *member)
+                    || self.diagnostic_relation_boolean_guard(*member, source_apparent)
                 {
                     return true;
                 }
@@ -1970,8 +1974,8 @@ impl<'a> CheckerState<'a> {
         // treats intersections as comparable if the source overlaps with ANY member.
         if let Some(members) = query::intersection_members(self.ctx.types, source_apparent) {
             for member in &members {
-                if self.is_assignable_to(*member, target_apparent)
-                    || self.is_assignable_to(target_apparent, *member)
+                if self.diagnostic_relation_boolean_guard(*member, target_apparent)
+                    || self.diagnostic_relation_boolean_guard(target_apparent, *member)
                 {
                     return true;
                 }
@@ -1979,8 +1983,8 @@ impl<'a> CheckerState<'a> {
         }
         if let Some(members) = query::intersection_members(self.ctx.types, target_apparent) {
             for member in &members {
-                if self.is_assignable_to(source_apparent, *member)
-                    || self.is_assignable_to(*member, source_apparent)
+                if self.diagnostic_relation_boolean_guard(source_apparent, *member)
+                    || self.diagnostic_relation_boolean_guard(*member, source_apparent)
                 {
                     return true;
                 }
@@ -2110,8 +2114,11 @@ impl<'a> CheckerState<'a> {
                 found_common = true;
                 // Property types must be comparable (assignable in at least one direction)
                 let prop_comparable = self
-                    .is_assignable_to(source_prop.type_id, target_prop.type_id)
-                    || self.is_assignable_to(target_prop.type_id, source_prop.type_id);
+                    .diagnostic_relation_boolean_guard(source_prop.type_id, target_prop.type_id)
+                    || self.diagnostic_relation_boolean_guard(
+                        target_prop.type_id,
+                        source_prop.type_id,
+                    );
                 if !prop_comparable {
                     return false;
                 }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        84,
+        72,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #8223
- Child: #8227
- Stacked on: #9245 (`codex/m1pd2-variadic-env-relation-guard-20260520`)
- Child: #9487 (`codex/m1pd2-call-return-relation-guards-20260520`)

## Structural Rule
When checker diagnostic comparability code uses assignability only as a local boolean overlap predicate, it should route through the diagnostic relation guard instead of calling raw assignability directly.

## Owner Layer
Checker diagnostic reasoning in `assignability_diagnostics.rs`; this is refactor-only boundary cleanup and delegates to the existing assignability implementation through the diagnostic guard.

## Scope
- Routes comparable-property overlap checks through `diagnostic_relation_boolean_guard`.
- Routes apparent-type and union/intersection comparable-relation probes through `diagnostic_relation_boolean_guard`.
- Ratchets the #8227 raw diagnostic assignability predicate cap from 84 to 72.

## Adjacent Cases
- Type-parameter comparability still uses the existing type-parameter-specific predicate.
- Pure call/construct signature objects still bypass the general fast path before relation probing.
- Union and intersection decomposition still checks overlap in both directions.
- Special bivariant, no-weak, env-aware, and direct solver-only relation paths are left unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / diagnostic comparability relation guards
- Evidence: behavior-preserving helper routing only; local verification covered focused arch ratchet, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-variadic-env-relation-guard-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9245 head `aa6bbffab6036b7b1c225ec3d455f595a0d3beaf`; current #9247 head is `689d3b9ac88b8956b22f88a363d686ee57885253`.
- Draft because this is stacked on #9245/#9242/#9238/#9236. #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- No WIP label added. Draft state is only preserving stack order.
- Current child-only diff relative to #9245 is `crates/tsz-checker/src/assignability/assignability_diagnostics.rs` plus `scripts/arch/arch_guard.py`.
- Child #9487 is based on this refreshed head; next owner/action is to inspect #9487 mergeability/CI and restack the next child if needed.