### PR TITLE
chore(conformance): refresh accepted regression drift

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,28 +2,22 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/computedPropertyBindingElementDeclarationNoCrash1.ts
-TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
 TypeScript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
-TypeScript/tests/cases/compiler/crossFileOverloadModifierConsistency.ts
 TypeScript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-TypeScript/tests/cases/compiler/divideAndConquerIntersections.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
 TypeScript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
 TypeScript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxElementType.tsx
 TypeScript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/recursiveReverseMappedType.ts
+TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
 TypeScript/tests/cases/compiler/spyComparisonChecking.ts
 TypeScript/tests/cases/compiler/temporal.ts
@@ -34,13 +28,12 @@ TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/esDecorators/esDecorators-preservesThis.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts
+TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypes6.ts
 TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
AgentName: M4-T9-10

## Track
Conformance runway stabilization / Project Direction unblocker for #8432.

## Rule
When ready-lane conformance aggregate reports rows that reproduce on `main` as unlisted regressions, and accepted rows that no longer fail in the same aggregate, `conformance-accepted-regressions.txt` should match that observed failing set instead of leaving unrelated ready PRs red.

## Scope
- Add the two currently unlisted aggregate rows from #9250 run `26147131420`, aggregate job `76909499668`:
  - `TypeScript/tests/cases/compiler/relationComplexityError.ts`
  - `TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts`
- Remove the nine rows that the same aggregate reported as resolved.
- Replace closed #9252 with a clean one-file branch; #9252's current head has a 2,929-file diff and was closed unmerged.

## Evidence
- #9250 ready-lane aggregate job `76909499668` completed with all 6/6 shards collected and reported only the two rows above as unlisted regressions.
- #8432 tracks this main-baseline blocker.
- #9252 attempted the same accepted-regression refresh but was closed unmerged after its head became unsafe for review.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression baseline drift / #8432
- Evidence: CI aggregate job `76909499668`; this PR changes only the accepted-regression gate file and does not change compiler, benchmark fixture, project corpus, emit, LSP, WASM, or CI workflow behavior.

## Verification
- `python3 -m unittest scripts.conformance.test_link_regression_issues`
- `git diff --check`
- Direct accepted-regression count/path check: 35 accepted paths; the two unlisted rows are present and the nine resolved rows are absent.
