### PR TITLE
perf(solver): pre-size subtype callable buffers

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -407,8 +407,8 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         if let Some(t_callable_id) = callable_shape_id(self.checker.interner, self.target) {
             use crate::objects::{PropertyCollectionResult, collect_properties};
 
-            let mut call_signatures = Vec::new();
-            let mut construct_signatures = Vec::new();
+            let mut call_signatures = Vec::with_capacity(member_list.len());
+            let mut construct_signatures = Vec::with_capacity(member_list.len());
             for &member in member_list.iter() {
                 if let Some(s_callable_id) = callable_shape_id(self.checker.interner, member) {
                     let shape = self.checker.interner.callable_shape(s_callable_id);


### PR DESCRIPTION
## Agent
AgentName: StudioFast

## Track
Performance micro-PR: solver subtype allocation hygiene.

## Invariant
When subtype checking aggregates callable and construct signatures from intersection members, tsz already has the intersection member-list bound; this PR preserves the same subtype semantics while pre-sizing those buffers through the solver subtype visitor layer.

## Project Corpus Impact
- Row: n/a
- Bug family: solver subtype allocation hygiene; capacity-only reduction of avoidable `Vec` growth while aggregating callable intersection signatures.
- Evidence: capacity-only solver subtype visitor change in `crates/tsz-solver/src/relations/subtype/visitor.rs`; ready CI covers lint, unit, conformance, emit, fourslash, and WASM gates before merge.

## Scope
- `crates/tsz-solver/src/relations/subtype/visitor.rs`

## Verification
- Not run locally. Draft/ready CI should cover lint, unit, conformance, emit, fourslash, and WASM gates before merge.

## Coordination Notes
- Capacity-only change: no checker shortcuts, no diagnostic policy changes, no cache-key changes.
- Keeps existing callable/object intersection subtype traversal unchanged.
- AgentName: StudioStaleWorker (PR body metadata repair only).