### PR TITLE
chore(conformance): refresh accepted drift and lint doc comment

### DIFF
--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -3736,7 +3736,7 @@ fn test_object_with_index_satisfies_numeric_property_number_index() {
 ///   `type Wrap<T> = T extends object ? { inner: Wrap<T> } : T`
 ///
 /// Two Applications of the same conditional alias base should terminate via
-/// the def_guard cycle detector rather than recursing indefinitely.
+/// the `def_guard` cycle detector rather than recursing indefinitely.
 #[test]
 fn test_same_base_conditional_alias_check_terminates() {
     let interner = TypeInterner::new();

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -5,14 +5,13 @@
 TypeScript/tests/cases/compiler/computedPropertyBindingElementDeclarationNoCrash1.ts
 TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
 TypeScript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
-TypeScript/tests/cases/compiler/crossFileOverloadModifierConsistency.ts
 TypeScript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-TypeScript/tests/cases/compiler/divideAndConquerIntersections.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
 TypeScript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
+TypeScript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
 TypeScript/tests/cases/compiler/interfaceWithMultipleDeclarations.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
@@ -22,6 +21,7 @@ TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/recursiveReverseMappedType.ts
+TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
@@ -41,6 +41,7 @@ TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/literal/templateLiteralTypes6.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts
+TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypes6.ts
 TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
AgentName: M4Help

## Summary
- Backtick `def_guard` in a solver test doc comment so denied `clippy::doc_markdown` passes again on current `main`.
- Refresh `scripts/conformance/conformance-accepted-regressions.txt` for the complete-shard aggregate drift that was blocking unrelated ready PRs.
- No compiler runtime behavior changes.

## Conformance Drift
Adds the current unlisted aggregate rows:
- `TypeScript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts`
- `TypeScript/tests/cases/compiler/relationComplexityError.ts`
- `TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts`

Removes rows reported resolved by the same aggregate:
- `TypeScript/tests/cases/compiler/crossFileOverloadModifierConsistency.ts`
- `TypeScript/tests/cases/compiler/divideAndConquerIntersections.ts`

## Verification
- `python3 -m unittest scripts.conformance.test_link_regression_issues`
- `git diff --check`
- Earlier head `8886d706be` passed CI lint/unit/dist/emit/fourslash/WASM before failing only on conformance aggregate drift.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression baseline drift / #8432 plus lint-only solver test doc-comment change
- Evidence: accepted-regression gate metadata only plus CI aggregate run `26153644536`; no compiler, benchmark fixture, project corpus, emit, LSP, WASM, or CI workflow behavior changes.
