### PR TITLE
test(dts): keep JS expando members exported with aliases

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -8192,12 +8192,48 @@ foo.default = 2;
     );
 
     assert!(
-        output.contains("declare namespace foo {\n    let x: number;"),
-        "Expected ordinary expando property to emit as an ambient namespace member: {output}"
+        output.contains("declare namespace foo {\n    export let x: number;"),
+        "Expected direct expando property to stay exported when a sibling needs an export alias: {output}"
     );
     assert!(
         output.contains("let _default: number;\n    export { _default as default };"),
         "Expected reserved expando property to use local alias plus export specifier: {output}"
+    );
+}
+
+#[test]
+fn test_js_function_static_function_expando_exports_with_reserved_sibling() {
+    let output = emit_js_dts(
+        r#"
+function foo() {}
+foo.handler = function(value) { return value; };
+foo.default = 2;
+"#,
+    );
+
+    assert!(
+        output.contains("declare namespace foo {\n    export function handler(value: any): any;"),
+        "Expected direct function-valued expando to stay exported when a sibling needs an alias: {output}"
+    );
+    assert!(
+        output.contains("let _default: number;\n    export { _default as default };"),
+        "Expected reserved sibling to use a local alias without exporting the alias declaration: {output}"
+    );
+}
+
+#[test]
+fn test_js_function_static_contextual_keyword_exports_with_reserved_sibling() {
+    let output = emit_js_dts(
+        r#"
+function foo() {}
+foo.class = 1;
+foo.async = 2;
+"#,
+    );
+
+    assert!(
+        output.contains("declare namespace foo {\n    let _class: number;\n    export { _class as class };\n    export let async: number;"),
+        "Expected contextual keyword property to stay direct and exported after a reserved-word alias: {output}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M4General

## Failure Family
DTS declaration emit / JS function expando namespaces with reserved-word export aliases. This is a focused replacement for the closed #9301 review finding.

## Structural Rule
When a JS function expando namespace has a direct-named member and any sibling requires a reserved-word export alias, `tsc` keeps the direct member exported from the namespace while the reserved member is emitted as a local alias plus `export { local as keyword }`. This applies to value members, function-valued members, and contextual-keyword properties that can remain direct names.

## Owner Layer
Declaration-emitter test coverage only. Current `main` already emits the reviewed-correct shape; this PR updates the stale test expectation and adds adjacent cases so future emitter changes do not regress it. No checker/solver semantic validation and no output surgery are added.

## Verification
- RED before patch: `cargo nextest run -p tsz-emitter test_js_function_static_properties_export_from_merged_namespace --no-fail-fast` failed because the stale test expected `let x` while current emit produced `export let x`.
- GREEN after patch: `cargo nextest run -p tsz-emitter test_js_function_static_properties_export_from_merged_namespace test_js_function_static_function_expando_exports_with_reserved_sibling test_js_function_static_contextual_keyword_exports_with_reserved_sibling test_js_function_static_property_without_alias_omits_member_export --no-fail-fast` (4/4 pass)
- `cargo fmt --all --check`
- `git diff --check`

## Project Corpus Impact
- Row: n/a
- Bug family: declaration-emit / JS expando namespace reserved-word aliasing
- Evidence: test-only DTS coverage correction; no compiler behavior, project-corpus fixture, benchmark, LSP, WASM, or CI workflow behavior changed.

## Coordination Notes
- #9301 was closed because its implementation suppressed export too broadly. This PR does not revive that implementation; it locks the reviewed `tsc`-compatible shape already present on `main`.
