### PR TITLE
fix(solver): replace def_guard with occurrence counter for conditional alias subtyping

### DIFF
--- a/crates/tsz-checker/tests/deeply_nested_conditional_mapped_recursion_tests.rs
+++ b/crates/tsz-checker/tests/deeply_nested_conditional_mapped_recursion_tests.rs
@@ -145,11 +145,15 @@ accept(a, b);
     );
 }
 
-/// tsc rule: a genuinely incompatible assignment to a deeply nested conditional
-/// type must still produce an error — the recursion identity bail-out must
-/// only fire when the same alias is seen twice, not suppress genuine mismatches.
+/// tsc rule: a genuinely incompatible assignment to a conditional type must
+/// produce TS2322 — the recursion counter (threshold 5) must not suppress
+/// shallow mismatches like DeepReadonly<{a:number}> vs DeepReadonly<{a:string}>.
+///
+/// Structural rule: "When same-base conditional alias Applications with different
+/// type arguments are compared, the occurrence counter fires only at threshold 5,
+/// allowing leaf-level mismatches (number vs string) to propagate as False."
 #[test]
-fn deeply_nested_conditional_type_still_errors_on_mismatch() {
+fn conditional_type_mismatch_still_errors_ts2322() {
     let source = r#"
 type DeepReadonly<T> = T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T;
 
@@ -157,12 +161,56 @@ declare const good: DeepReadonly<{ a: number }>;
 const bad: DeepReadonly<{ a: string }> = good;
 "#;
     let codes = check_source_codes(source);
-    // This should still produce TS2322 — the types have incompatible leaf values.
-    // We don't assert it does (tsc's recursion guard may also bail compatible here),
-    // but we DO assert no TS2589 appears.
+    assert!(
+        codes.contains(&2322),
+        "DeepReadonly<{{a:number}}> assigned to DeepReadonly<{{a:string}}> must produce TS2322. Got: {codes:?}"
+    );
     assert!(
         !codes.contains(&2589),
         "DeepReadonly mismatch test must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// Alternative alias name to verify the rule is structural (§25 anti-hardcoding).
+#[test]
+fn conditional_type_mismatch_still_errors_ts2322_alt_name() {
+    let source = r#"
+type StripReadonly<T> = T extends object ? { [K in keyof T]: StripReadonly<T[K]> } : T;
+
+declare const src: StripReadonly<{ x: boolean }>;
+const dst: StripReadonly<{ x: string }> = src;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "StripReadonly<{{x:boolean}}> assigned to StripReadonly<{{x:string}}> must produce TS2322. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2589),
+        "StripReadonly mismatch must not produce TS2589. Got: {codes:?}"
+    );
+}
+
+/// NestedRecord with different value types must produce TS2322.
+/// Structural rule: same as above — different leaf value types cause a mismatch.
+#[test]
+fn nested_record_different_value_types_errors_ts2322() {
+    let source = r#"
+type NestedRecord<K extends string, V> = K extends `${infer A}.${infer B}`
+    ? { [X in A]: NestedRecord<B, V> }
+    : { [X in K]: V };
+
+declare const r1: NestedRecord<"a.b", number>;
+const bad: NestedRecord<"a.b", string> = r1;
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "NestedRecord<\"a.b\",number> assigned to NestedRecord<\"a.b\",string> must produce TS2322. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2589),
+        "NestedRecord mismatch must not produce TS2589. Got: {codes:?}"
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -65,6 +65,11 @@ pub fn reset_subtype_thread_local_state() {
 // enough to prevent runaway recursion from hanging.
 const MAX_GLOBAL_SUBTYPE_FUEL: u32 = 10_000;
 
+/// Maximum times a conditional alias base may appear in the current subtype call
+/// stack before the check assumes compatible. Matches tsc's `recursionCount >= 5`
+/// policy in `isRelatedTo` / `getRecursionIdentity`.
+const COND_ALIAS_RECURSION_THRESHOLD: u32 = 5;
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if a Lazy type resolved to an Enum with the same DefId.
     ///
@@ -462,19 +467,31 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             false
         };
 
-        // For conditional type aliases that are same-base-app, we STILL enter the
-        // def_guard (unlike non-conditional same-base-app where def_pair = None).
-        // This implements tsc's recursion identity mechanism: the def_guard fires
-        // as a cycle on the second occurrence of the same conditional alias,
-        // returning `result_on_cycle` (compatible). This matches tsc's behavior for
-        // deeply recursive conditional types like `NestedRecord<K,V>` where tsc
-        // intentionally bails out after detecting the alias has appeared twice.
-        // Mapped type aliases (Id<T>) are NOT conditional and continue with def_pair=None.
+        // Conditional alias occurrence counter (tsc's recursionCount mechanism).
+        // count < 5: proceed structurally so different args (e.g., number vs string)
+        //   propagate mismatches — TS2322 fires correctly.
+        // count >= 5: assume compatible to prevent TS2589 on deep-but-consistent types.
+        // def_guard fired at count == 2, silencing TS2322 (issue #9305). Counter fixes this.
         let is_cond_same_base_app = both_same_base_app
             && s_app_id
                 .map(|aid| self.interner.type_application(aid).base)
                 .is_some_and(|base| self.is_conditional_alias_base_inline(base));
-        let def_pair = if both_same_base_app && !is_cond_same_base_app {
+
+        let mut cond_alias_entered: Option<DefId> = None;
+        if is_cond_same_base_app {
+            if let Some(base_def) = s_def_id {
+                let count = self.cond_alias_depth.entry(base_def).or_insert(0);
+                if *count >= COND_ALIAS_RECURSION_THRESHOLD {
+                    self.guard.leave(pair);
+                    leave_global!();
+                    return self.result_on_cycle(source, target);
+                }
+                *count += 1;
+                cond_alias_entered = Some(base_def);
+            }
+        }
+
+        let def_pair = if is_cond_same_base_app || both_same_base_app {
             None
         } else if let (Some(s_def), Some(t_def)) = (s_def_id, t_def_id) {
             Some((s_def, t_def))
@@ -520,6 +537,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     s_rev_match && t_rev_match
                 });
                 if found_cycle {
+                    if let Some(d) = cond_alias_entered {
+                        self.cond_alias_leave(d);
+                    }
                     self.guard.leave(pair);
                     leave_global!();
                     return self.result_on_cycle(source, target);
@@ -530,12 +550,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let mut def_entered = if let Some((s_def, t_def)) = def_pair {
             // Check reversed pair for bivariant cross-recursion
             if self.def_guard.is_visiting(&(t_def, s_def)) {
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
+                }
                 self.guard.leave(pair);
                 leave_global!();
                 return self.result_on_cycle(source, target);
             }
             match self.def_guard.enter((s_def, t_def)) {
                 RecursionResult::Cycle => {
+                    if let Some(d) = cond_alias_entered {
+                        self.cond_alias_leave(d);
+                    }
                     self.guard.leave(pair);
                     leave_global!();
                     return self.result_on_cycle(source, target);
@@ -572,6 +598,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     if let Some(dp) = def_entered {
                         self.def_guard.leave(dp);
                     }
+                    if let Some(d) = cond_alias_entered {
+                        self.cond_alias_leave(d);
+                    }
                     self.guard.leave(pair);
                     leave_global!();
                     return SubtypeResult::False;
@@ -579,6 +608,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let result = self.check_object_contract(source, target);
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);
+                }
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
                 }
                 self.guard.leave(pair);
                 leave_global!();
@@ -605,6 +637,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // the source is genuinely a callable type.
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);
+                }
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
                 }
                 self.guard.leave(pair);
                 leave_global!();
@@ -666,6 +701,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     if let Some(dp) = def_entered {
                         self.def_guard.leave(dp);
                     }
+                    if let Some(d) = cond_alias_entered {
+                        self.cond_alias_leave(d);
+                    }
                     self.guard.leave(pair);
                     leave_global!();
                     return SubtypeResult::True;
@@ -673,6 +711,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let result = self.subtype_of_conditional_target(source, &target_cond);
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);
+                }
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
                 }
                 self.guard.leave(pair);
                 leave_global!();
@@ -724,6 +765,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if let Some(result) = variance_result {
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);
+                }
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
                 }
                 self.guard.leave(pair);
                 if !has_this_type && let Some(db) = self.query_db {
@@ -788,6 +832,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if let Some(dp) = def_entered {
                 self.def_guard.leave(dp);
             }
+            if let Some(d) = cond_alias_entered {
+                self.cond_alias_leave(d);
+            }
             self.guard.leave(pair);
             if !has_this_type && let Some(db) = self.query_db {
                 let key = self.make_cache_key(source, target);
@@ -812,6 +859,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let result = self.check_subtype(s_elem, t_elem);
             if let Some(dp) = def_entered {
                 self.def_guard.leave(dp);
+            }
+            if let Some(d) = cond_alias_entered {
+                self.cond_alias_leave(d);
             }
             self.guard.leave(pair);
             if !has_this_type && let Some(db) = self.query_db {
@@ -865,6 +915,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);
                 }
+                if let Some(d) = cond_alias_entered {
+                    self.cond_alias_leave(d);
+                }
                 self.guard.leave(pair);
                 leave_global!();
                 return result;
@@ -890,9 +943,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         };
 
-        // Cleanup: leave both guards
+        // Cleanup: leave all guards
         if let Some(dp) = def_entered {
             self.def_guard.leave(dp);
+        }
+        if let Some(d) = cond_alias_entered {
+            self.cond_alias_leave(d);
         }
         self.guard.leave(pair);
 
@@ -996,5 +1052,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return true;
         }
         false
+    }
+
+    /// Decrement the conditional-alias occurrence counter for `def_id`.
+    ///
+    /// Must be called once for every successful `cond_alias_entered = Some(def_id)`
+    /// at each exit path from `check_subtype`, matching tsc's decrement after
+    /// the `isRelatedTo` body that uses `recursionCount`.
+    #[inline]
+    fn cond_alias_leave(&mut self, def_id: DefId) {
+        use std::collections::hash_map::Entry;
+        if let Entry::Occupied(mut e) = self.cond_alias_depth.entry(def_id) {
+            let new_val = e.get().saturating_sub(1);
+            if new_val == 0 {
+                e.remove();
+            } else {
+                *e.get_mut() = new_val;
+            }
+        }
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -252,6 +252,15 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// evaluated multiple times across different subtype checks.
     /// Key is (`TypeId`, `no_unchecked_indexed_access`) since that flag affects evaluation.
     pub(crate) eval_cache: FxHashMap<(TypeId, bool), TypeId>,
+    /// Occurrence counter for conditional-alias same-base Application comparisons.
+    ///
+    /// Tracks how many times each conditional alias `DefId` is currently on the
+    /// subtype call stack. Matches tsc's `recursionCount` mechanism: at threshold 5
+    /// the check returns compatible to prevent TS2589. Unlike the set-based
+    /// `def_guard`, this counter allows multiple entries so comparisons with
+    /// different type arguments (e.g., `DeepReadonly<{a: number}>` vs
+    /// `DeepReadonly<{a: string}>`) still propagate structural mismatches.
+    pub(crate) cond_alias_depth: FxHashMap<DefId, u32>,
     /// Apparent object shapes for primitive wrapper fallback.
     ///
     /// Primitive structural subtype checks can ask for the same wrapper shape
@@ -350,6 +359,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             erase_generics: true,
             allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
+            cond_alias_depth: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -398,6 +408,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             erase_generics: true,
             allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
+            cond_alias_depth: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             tracer: None,
             type_param_equivalences: Vec::new(),
@@ -512,6 +523,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.def_guard.reset();
         self.sym_visiting.clear();
         self.eval_cache.clear();
+        self.cond_alias_depth.clear();
     }
 
     /// Return entry and size accounting for this checker's operation-local caches.

--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -3899,6 +3899,129 @@ fn test_conditional_alias_self_comparison_is_compatible_renamed_param() {
     );
 }
 
+// Tests for conditional alias subtyping: same base, different type args must NOT be compatible.
+
+/// DeepReadonly<{a: number}> must NOT be assignable to DeepReadonly<{a: string}>.
+/// tsc reports TS2322 here: structural mismatches in conditional alias args must propagate.
+#[test]
+fn test_cond_alias_different_args_is_not_compatible() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    // type DeepReadonly<T> = T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T
+    // Represented as a simple non-recursive stub that is still a conditional alias.
+    // Body: T extends object ? {a: DR<inner>} : T — the exact shape doesn't matter
+    // for this test; what matters is that the leaf args (number vs string) differ.
+    let alias_def = DefId(9010);
+
+    let t_info = TypeParamInfo::simple(interner.intern_string("T"));
+    let t_type = interner.type_param(t_info);
+
+    // Non-recursive conditional body: T extends object ? { v: T } : T
+    // When instantiated with number → number extends object (false) → number
+    // When instantiated with string → string
+    let prop_v = interner.intern_string("v");
+    let true_br = interner.object(vec![PropertyInfo::new(prop_v, t_type)]);
+    let body = interner.conditional(ConditionalType {
+        check_type: t_type,
+        extends_type: TypeId::OBJECT,
+        true_type: true_br,
+        false_type: t_type,
+        is_distributive: false,
+    });
+    env.insert_def_with_params(alias_def, body, vec![t_info]);
+    env.insert_def_kind(alias_def, crate::def::DefKind::TypeAlias);
+
+    let base = interner.lazy(alias_def);
+    let app_number = interner.application(base, vec![TypeId::NUMBER]);
+    let app_string = interner.application(base, vec![TypeId::STRING]);
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    // DR<number> <: DR<string>: tsc rejects (TS2322), must be False
+    let result = checker.check_subtype(app_number, app_string);
+    assert!(
+        !result.is_true(),
+        "DR<number> must NOT be assignable to DR<string> (different leaf args)"
+    );
+}
+
+/// Variant with a type-param named "U" to confirm the fix is not name-dependent
+/// (§25 anti-hardcoding directive: two name variants required).
+#[test]
+fn test_cond_alias_different_args_is_not_compatible_renamed_param() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    let alias_def = DefId(9011);
+
+    let u_info = TypeParamInfo::simple(interner.intern_string("U"));
+    let u_type = interner.type_param(u_info);
+
+    let prop_w = interner.intern_string("w");
+    let true_br = interner.object(vec![PropertyInfo::new(prop_w, u_type)]);
+    let body = interner.conditional(ConditionalType {
+        check_type: u_type,
+        extends_type: TypeId::OBJECT,
+        true_type: true_br,
+        false_type: u_type,
+        is_distributive: false,
+    });
+    env.insert_def_with_params(alias_def, body, vec![u_info]);
+    env.insert_def_kind(alias_def, crate::def::DefKind::TypeAlias);
+
+    let base = interner.lazy(alias_def);
+    let app_bool = interner.application(base, vec![TypeId::BOOLEAN]);
+    let app_string = interner.application(base, vec![TypeId::STRING]);
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    let result = checker.check_subtype(app_bool, app_string);
+    assert!(
+        !result.is_true(),
+        "Alias<boolean> (U-named param) must NOT be assignable to Alias<string>"
+    );
+}
+
+/// Self-comparison of same-base conditional alias with SAME args must still be
+/// compatible even after the false-negative fix.
+#[test]
+fn test_cond_alias_same_args_still_compatible() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    let alias_def = DefId(9012);
+
+    let t_info = TypeParamInfo::simple(interner.intern_string("T"));
+    let t_type = interner.type_param(t_info);
+
+    let lazy_alias = interner.lazy(alias_def);
+    let recursive_app = interner.application(lazy_alias, vec![t_type]);
+    let prop_inner = interner.intern_string("inner");
+    let true_br = interner.object(vec![PropertyInfo::new(prop_inner, recursive_app)]);
+    let body = interner.conditional(ConditionalType {
+        check_type: t_type,
+        extends_type: TypeId::OBJECT,
+        true_type: true_br,
+        false_type: t_type,
+        is_distributive: false,
+    });
+    env.insert_def_with_params(alias_def, body, vec![t_info]);
+    env.insert_def_kind(alias_def, crate::def::DefKind::TypeAlias);
+
+    let base = interner.lazy(alias_def);
+    let app1 = interner.application(base, vec![TypeId::STRING]);
+    let app2 = interner.application(base, vec![TypeId::STRING]);
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    let result = checker.check_subtype(app1, app2);
+    assert!(
+        result.is_true(),
+        "Recursive cond alias with same args must be compatible (cycle assumed at threshold)"
+    );
+}
+
 #[test]
 fn test_object_with_index_noncanonical_numeric_property_fails() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
## Summary

**Structural rule:** When same-base Application types whose base is a conditional alias are compared, tsc uses a `recursionCount >= 5` occurrence counter to decide whether to assume compatible. tsz was incorrectly using a set-based `def_guard` that fired on the **2nd** occurrence, silencing TS2322 for structurally different args.

**Fix:** Replace the `def_guard` path for conditional same-base Applications with a per-`DefId` occurrence counter (`cond_alias_depth: FxHashMap<DefId, u32>`):
- `count < 5` → proceed structurally, allowing leaf mismatches (`number` vs `string`) to propagate as `False` → TS2322 fires correctly
- `count >= 5` → assume compatible, preventing TS2589 on deeply recursive self-consistent types

Non-conditional same-base Applications (`Id<T>`, `Readonly<T>`) are unaffected and continue using the variance fast path.

**Owner layer:** `tsz-solver` — this is a pure type-relation decision (`WHAT`), not a diagnostic location concern.

## Changes

- `crates/tsz-solver/src/relations/subtype/core.rs` — new `cond_alias_depth` field on `SubtypeChecker`; initialized in `new()`, `with_resolver()`, and cleared in `reset()`
- `crates/tsz-solver/src/relations/subtype/cache.rs` — new `COND_ALIAS_RECURSION_THRESHOLD = 5` constant; occurrence counter logic in `check_subtype`; `cond_alias_leave()` helper using Entry API for single hash lookup; `def_pair = None` for both conditional and non-conditional same-base apps
- `crates/tsz-solver/tests/subtype_tests.rs` — 3 unit tests: `Alias<T>` (T-named), `Alias<U>` (U-named, §25 anti-hardcoding), same-args-still-compatible
- `crates/tsz-checker/tests/deeply_nested_conditional_mapped_recursion_tests.rs` — strengthened existing test to assert TS2322 IS produced; added 2 alt-name regression tests (`StripReadonly`, `NestedRecord`)

## Adjacent-case test matrix (§26 requirement)

| Case | Behavior | Covered by |
|------|----------|-----------| 
| `DeepReadonly<{a:number}>` vs `DeepReadonly<{a:string}>` | TS2322 | checker test + solver unit test |
| `StripReadonly<{x:boolean}>` vs `StripReadonly<{x:string}>` | TS2322 | checker alt-name test |
| `NestedRecord<"a.b",number>` vs `NestedRecord<"a.b",string>` | TS2322 | checker test |
| `RequiredDeep<T>` same-type deep nesting | no TS2589 | existing checker tests |
| `Alias<U>` (renamed param) | not compatible with different arg | solver unit test (§25) |
| Same-base, same-args (T-named) | compatible (cycle at threshold) | solver unit test |
| Non-conditional `Id<T>` same-base | no errors (variance path intact) | existing checker test |

## Project Corpus Impact

- Row: tsz-solver subtype relations
- Bug family: false-negative TS2322 on conditional alias Applications with different type args
- Evidence: `cargo test -p tsz-solver cond_alias` — 3/3 pass; `cargo check -p tsz-solver -p tsz-checker` clean; fixes issue #9305

AgentName: claude-sonnet-4-6