### PR TITLE
fix(emit): CJS live-binding rewrite inside exported function bodies (#8746)

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -63,6 +63,10 @@ impl<'a> Printer<'a> {
     const fn is_commonjs_live_export_context(&self) -> bool {
         self.ctx.is_commonjs()
             || matches!(self.ctx.original_module_kind, Some(ModuleKind::CommonJS))
+            || matches!(
+                self.ctx.cjs_export_body_outer_module,
+                Some(ModuleKind::CommonJS)
+            )
     }
 
     /// Write `exports.name` or `exports["name"]` depending on whether the name

--- a/crates/tsz-emitter/tests/class_member_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/class_member_recovery_tests.rs
@@ -220,10 +220,14 @@ fn downlevel_assign_typed_only_field_emits_nothing() {
     );
 }
 
+/// In native class-field mode (ES2022+ with `useDefineForClassFields`), TypeScript erases
+/// type annotations but keeps the field declaration itself. Only fields marked with `declare`
+/// are truly ambient and get erased entirely. This matches tsc behavior where
+/// `prop: number;` → `prop;` and `declare baz: boolean;` → nothing.
 #[test]
-fn native_define_typed_only_public_field_emits_nothing() {
+fn native_define_typed_public_field_emits_bare_field_declaration() {
     let output = print_with_printer_options(
-        "class Test {\n    prop: number;\n    bare;\n    #privateProp: number;\n}\n",
+        "class Test {\n    prop: number;\n    bare;\n    #privateProp: number;\n    declare ambient: string;\n}\n",
         PrinterOptions {
             target: ScriptTarget::ES2022,
             use_define_for_class_fields: true,
@@ -232,8 +236,8 @@ fn native_define_typed_only_public_field_emits_nothing() {
     );
 
     assert!(
-        !output.contains("prop;"),
-        "Typed-only public field should be erased in native class-field emit.\nOutput:\n{output}"
+        output.contains("prop;"),
+        "Typed public field should emit as a bare native field declaration (type erased).\nOutput:\n{output}"
     );
     assert!(
         output.contains("bare;"),
@@ -241,7 +245,11 @@ fn native_define_typed_only_public_field_emits_nothing() {
     );
     assert!(
         output.contains("#privateProp;"),
-        "Private fields remain runtime declarations even when annotated.\nOutput:\n{output}"
+        "Private typed field should remain a runtime class field declaration.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("ambient"),
+        "`declare` fields are ambient-only and must be erased entirely.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
AgentName: M1-A
Original author/session: claude-sonnet-4-6-remote

## Summary

**Track:** Emit / CJS module output

**Invariant:** When an exported function in a CommonJS module mutates a clause-exported local variable, every mutation must be rewritten to also update `exports.X`.

**Scope:** `tsz-emitter` — `is_commonjs_live_export_context()` predicate and one pre-existing test with inverted expectations.

---

### Root cause (issue #8746)

`with_cjs_export_body_mask()` temporarily sets `options.module = ModuleKind::None` while emitting exported function bodies. This suppresses the redundant `exports.foo = function foo(...)` preamble that would otherwise be emitted inside the body.

**Side effect:** `is_commonjs_live_export_context()` only checked `options.module` and `original_module_kind`. Inside the mask, `options.module` is `None` and `original_module_kind` is `None` (it only applies to UMD/System wrappers), so the predicate returned `false`. Mutations of clause-exported locals such as `x++` inside `export function foo() { x++ }` were silently **not** rewritten to `exports.x = (...)` during function body emission.

**Fix:** Add a third arm to `is_commonjs_live_export_context()` that checks `ctx.cjs_export_body_outer_module == Some(CommonJS)`. This field is set by `with_cjs_export_body_mask()` before it zeroes `options.module`, so it correctly identifies "we are inside a CJS-module exported function body."

### Structural rule

> When `with_cjs_export_body_mask()` is active, the CJS live-binding predicate must detect the outer CommonJS context via `cjs_export_body_outer_module`, not `options.module`, because the mask deliberately zeroes the latter.

### Pre-existing test correction

The test `native_define_typed_only_public_field_emits_nothing` had inverted expectations. In native class-field mode (ES2022+ with `useDefineForClassFields: true`), tsc keeps `prop: number;` as `prop;` — the type annotation is erased but the field declaration is preserved. Only `declare`-prefixed fields are fully ambient and get erased entirely.

The adjacent unit test `esnext_define_class_fields_preserve_type_only_ts_fields` (passing throughout) correctly reflects this tsc behavior; the integration test contradicted it. The integration test is renamed to `native_define_typed_public_field_emits_bare_field_declaration` with:
- Corrected first assertion: `output.contains("prop;")` (not `!output.contains`)
- Added `declare ambient: string;` to explicitly verify `declare`-field erasure

---

## Project Corpus Impact

- Row: n/a
- Bug family: CJS live-binding rewrite inside exported function bodies
- Evidence: 21 targeted unit tests in `cjs_clause_export_live_binding_tests.rs` all pass, including the previously failing `exported_function_body_updates_later_clause_export`. Full `tsz-emitter` suite (2700+ tests) passes with zero failures.

## Verification

```bash
# Targeted CJS live-binding tests (all 21 pass)
cargo test -p tsz-emitter cjs_clause_export

# Native class-field tests
cargo test -p tsz-emitter native_define

# Full emitter suite
scripts/safe-run.sh cargo test -p tsz-emitter
# -> 2700+ passed, 0 failed
```

## Coordination Notes

- Claimed issue #8746 (CJS clause-export live binding inside exported function bodies).
- M1-A moved this PR back to draft and disabled auto-merge because ready CI failed `project-corpus-pr-body` before the PR had an owner label and corrected body metadata.
- #9442 has landed, so the CI-summary metadata-only rerun bug is fixed and this PR can safely use ready CI again.
- M1-A is marking this PR ready again and re-arming auto-merge; current-head ready CI is authoritative before landing.

https://claude.ai/code/session_018wKDvADc5PVkv1NjYQox4k

---
_Generated by [Claude Code](https://claude.ai/code/session_018wKDvADc5PVkv1NjYQox4k)_

