### PR TITLE
fix(emitter): capture complex private field call receiver in temp var

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -181,13 +181,30 @@ impl<'a> Printer<'a> {
             && name_node.kind == SyntaxKind::PrivateIdentifier as u16
             && let Some(field_name) = get_private_field_name(self.arena, access.name_or_argument)
         {
-            let clean_name = field_name.strip_prefix('#').unwrap_or(&field_name);
-            if let Some(weakmap_name) = self.private_field_weakmaps.get(clean_name).cloned() {
+            let clean_name = field_name
+                .strip_prefix('#')
+                .unwrap_or(&field_name)
+                .to_string();
+            if let Some(weakmap_name) = self.private_field_weakmaps.get(&clean_name).cloned() {
+                let expression = access.expression;
+                // Side-effecting receivers must be captured once; `this` in `.call()` must
+                // match the receiver used in `__classPrivateFieldGet`.
+                let receiver_temp = if !self.receiver_is_simple(expression) {
+                    Some(self.make_unique_name_hoisted())
+                } else {
+                    None
+                };
+
+                let receiver_temp_str = receiver_temp.as_deref();
                 self.write_helper("__classPrivateFieldGet");
                 self.write("(");
-                self.emit_private_receiver(access.expression, clean_name);
+                if let Some(temp) = receiver_temp_str {
+                    self.write(temp);
+                    self.write(" = ");
+                }
+                self.emit_private_receiver(expression, &clean_name);
                 self.write(", ");
-                if let Some(info) = self.private_member_info.get(clean_name).cloned() {
+                if let Some(info) = self.private_member_info.get(&clean_name).cloned() {
                     if let Some(ref state_var) = info.state_var {
                         self.write(state_var);
                     } else {
@@ -205,11 +222,17 @@ impl<'a> Printer<'a> {
                     self.write(", \"f\"");
                 }
                 self.write(").call(");
-                self.emit_private_receiver(access.expression, clean_name);
+                if let Some(temp) = receiver_temp_str {
+                    self.write(temp);
+                } else {
+                    self.emit_private_receiver(expression, &clean_name);
+                }
                 if let Some(ref args) = call.arguments {
                     for &arg_idx in &args.nodes {
-                        self.write(", ");
-                        self.emit(arg_idx);
+                        if arg_idx.is_some() {
+                            self.write(", ");
+                            self.emit(arg_idx);
+                        }
                     }
                 }
                 self.write(")");

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -67,7 +67,7 @@ impl<'a> Printer<'a> {
 
     /// Check if a receiver expression is simple (this keyword or an identifier)
     /// and doesn't need to be cached in a temp variable to avoid double-evaluation.
-    fn receiver_is_simple(&self, idx: NodeIndex) -> bool {
+    pub(crate) fn receiver_is_simple(&self, idx: NodeIndex) -> bool {
         let Some(node) = self.arena.get(idx) else {
             return true;
         };

--- a/crates/tsz-emitter/tests/printer.rs
+++ b/crates/tsz-emitter/tests/printer.rs
@@ -3327,3 +3327,104 @@ fn system_namespace_tslib_import_uses_user_binding_for_helpers() {
         "No redundant helper-binding hoist when the user already provides a binding.\nOutput:\n{output}"
     );
 }
+
+/// Private field-stored-function calls must use `__classPrivateFieldGet(...).call(receiver)`.
+#[test]
+fn test_private_field_call_expression_lowering() {
+    let source = r#"class Foo {
+    #field = function() { return 1; };
+    test() {
+        this.#field();
+        this.#field(1, 2);
+    }
+}
+"#;
+    let output = parse_lower_print(source, PrintOptions::es6());
+    assert!(
+        output.contains("__classPrivateFieldGet(this, _Foo_field, \"f\").call(this)"),
+        "Private field call with no args should use .call(this)\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(this, _Foo_field, \"f\").call(this, 1, 2)"),
+        "Private field call with args should pass them after this\nOutput:\n{output}"
+    );
+}
+
+/// Private method calls must use `__classPrivateFieldGet(..., "m", fn).call(receiver)`.
+#[test]
+fn test_private_method_call_expression_lowering() {
+    let source = r#"class Bar {
+    #run() { return 1; }
+    test() {
+        this.#run();
+        this.#run(1, 2);
+    }
+}
+"#;
+    let output = parse_lower_print(source, PrintOptions::es6());
+    assert!(
+        output.contains("__classPrivateFieldGet(this, _Bar_instances, \"m\", _Bar_run).call(this)"),
+        "Private method call should use __classPrivateFieldGet with 'm' kind\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "__classPrivateFieldGet(this, _Bar_instances, \"m\", _Bar_run).call(this, 1, 2)"
+        ),
+        "Private method call with args should pass them after this\nOutput:\n{output}"
+    );
+}
+
+/// Non-simple receivers must be captured in a temp var — `__classPrivateFieldGet(_a = expr, ...).call(_a)`.
+/// Without the temp, the receiver is evaluated twice (side effects fire twice and `this` mismatches).
+#[test]
+fn test_private_field_call_complex_receiver() {
+    let source = r#"class Foo {
+    #fn = () => 1;
+    static getInstance(): Foo { return new Foo(); }
+    test() {
+        Foo.getInstance().#fn();
+        Foo.getInstance().#fn(1, 2);
+    }
+}
+"#;
+    let output = parse_lower_print(source, PrintOptions::es6());
+    // Each call site gets its own temp (_a, _b, …) so both calls can coexist safely.
+    assert!(
+        output.contains("__classPrivateFieldGet(_a = Foo.getInstance(), _Foo_fn, \"f\").call(_a)"),
+        "First call should capture receiver in temp and reuse it in .call()\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "__classPrivateFieldGet(_b = Foo.getInstance(), _Foo_fn, \"f\").call(_b, 1, 2)"
+        ),
+        "Second call should use its own temp and reuse it in .call()\nOutput:\n{output}"
+    );
+    // Confirm the receiver is never emitted raw in a .call() position.
+    assert!(
+        !output.contains(".call(Foo.getInstance())"),
+        "Complex receiver must not be evaluated twice in .call()\nOutput:\n{output}"
+    );
+}
+
+/// Static private field calls: simple (class-name) receiver — no temp needed, class alias substituted.
+#[test]
+fn test_private_static_field_call_expression() {
+    let source = r#"class Baz {
+    static #method = function() { return 1; };
+    static test() {
+        Baz.#method();
+        Baz.#method(1, 2);
+    }
+}
+"#;
+    let output = parse_lower_print(source, PrintOptions::es6());
+    // Static members use the class alias (_a = Baz) as both receiver and state.
+    assert!(
+        output.contains("__classPrivateFieldGet(_a, _a, \"f\", _Baz_method).call(_a)"),
+        "Static private field call should use class alias as receiver\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__classPrivateFieldGet(_a, _a, \"f\", _Baz_method).call(_a, 1, 2)"),
+        "Static private field call with args should pass them after alias\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: M1-A
Original author/session: claude-sonnet-4-6 / busy-lamport-wLUZB

## Track
Emit parity — private class field/method/accessor call expression lowering.

## Invariant
When a private member is called on a non-simple receiver (anything other than `this`, a plain identifier, or `super`), tsc captures the receiver in a hoisted temp variable so:
1. The receiver expression is evaluated **exactly once** (no double side effects).
2. The **same object** is passed as `this` to `.call()` as was used in `__classPrivateFieldGet`.

Structural rule: `expr.#fn(args)` → `__classPrivateFieldGet(_a = expr, state, kind, fnRef).call(_a, args)` when `expr` is non-simple.

## Scope
- `crates/tsz-emitter/src/emitter/expressions/call.rs` — private field call lowering path
- `crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs` — expose `receiver_is_simple` as `pub(crate)`
- `crates/tsz-emitter/tests/printer.rs` — 4 regression tests covering fields, methods, complex receivers, and static variants

## The Bug
Before this fix tsz emitted the receiver expression twice:
```js
// tsz (wrong)
__classPrivateFieldGet(Foo.getInstance(), _Foo_fn, "f").call(Foo.getInstance())
```
After, matching tsc:
```js
// tsz (correct)
__classPrivateFieldGet(_a = Foo.getInstance(), _Foo_fn, "f").call(_a)
```
This caused double evaluation of the receiver (side effects fired twice) and broke `this` binding when the receiver expression is not referentially stable.

## Fix
- Check `receiver_is_simple(expression)` (already existed for unary/binary ops).
- If non-simple: allocate a fresh hoisted temp via `make_unique_name_hoisted()`.
- Emit `temp = ` before the receiver in the first argument position; reuse `temp` in `.call()`.
- Each call site gets its own fresh temp (matching tsc's per-site allocation).
- Also add `arg_idx.is_some()` guard to skip `NodeIndex::NONE` sentinel args.

## Project Corpus Impact
- Row: class/private/accessor/decorator lowering (178-failure family in offline emit data)
- Bug family: private field/method/accessor call expression lowering — receiver double-evaluation
- Evidence: unit tests `test_private_field_call_complex_receiver`, `test_private_method_call_expression_lowering`, `test_private_field_call_expression_lowering`, `test_private_static_field_call_expression` all pass. Targets emit failures: `privateNameFieldCallExpression`, `privateNameMethodCallExpression`, `privateNameAccessorsCallExpression`, `privateNameStaticFieldCallExpression`, `privateNameStaticMethodCallExpression`, `privateNameStaticAccessorsCallExpression`, and related.

## Verification
- `cargo build -p tsz-emitter`: clean
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`: clean
- `cargo nextest run -p tsz-emitter`: 2983 passed, 2 pre-existing failures (unrelated), 0 new failures
- All 4 new regression tests pass

## Coordination Notes
Claimed issue #8506 (unclaimed, 0 WIP comments). Branch is `claude/busy-lamport-wLUZB`. The fix is behavioral — no snapshot refresh needed. CI will run conformance/emit/fourslash suites to validate the full impact.

Closes #8506

