### PR TITLE
test(checker): pin Record&lt;TemplateLiteralPattern,V&gt; excess-property check (#8725)

### DIFF
--- a/crates/tsz-checker/tests/ts2353_mapped_template_literal_key_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_mapped_template_literal_key_tests.rs
@@ -7,8 +7,9 @@
 //! source property name against the template literal pattern.
 //!
 //! Issue #8725 (`templateLiteralTypes6`): same rule entered through the
-//! `Record<\`pattern\`, V>` alias; coverage at the bottom of this file pins
-//! the `Record<K, T>` -> `{ [P in K]: T }` lowering path.
+//! `Record` alias when the key is a template-literal pattern; coverage at
+//! the bottom of this file pins the `Record<K, T>` -> `{ [P in K]: T }`
+//! lowering path.
 
 use std::sync::{Arc, OnceLock};
 use tsz_binder::lib_loader::LibFile;

--- a/crates/tsz-checker/tests/ts2353_mapped_template_literal_key_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_mapped_template_literal_key_tests.rs
@@ -5,13 +5,20 @@
 //! `is_key_in_mapped_constraint` had no arm for template-literal constraints
 //! and fell through to a conservative "reject" branch. The fix matches the
 //! source property name against the template literal pattern.
+//!
+//! Issue #8725 (`templateLiteralTypes6`): same rule entered through the
+//! `Record<\`pattern\`, V>` alias; coverage at the bottom of this file pins
+//! the `Record<K, T>` -> `{ [P in K]: T }` lowering path.
 
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::{check_source_with_libs, load_lib_files};
 
 fn diags(source: &str) -> Vec<(u32, String)> {
-    let libs = load_lib_files(&["es5.d.ts"]);
-    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+    static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    let libs = LIBS.get_or_init(|| load_lib_files(&["es5.d.ts"]));
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), libs)
         .iter()
         .filter(|d| d.code != 2318)
         .map(|d| (d.code, d.message_text.clone()))
@@ -92,5 +99,70 @@ const si: SuffixIndex = { "foo-end": "a", "bar-end": "b" };
     assert!(
         ts2353.is_empty(),
         "Expected no TS2353 for suffix template pattern, got: {ts2353:?}",
+    );
+}
+
+// Regression coverage for #8725: same rule as above, reached via the
+// `Record<K, T>` -> `{ [P in K]: T }` alias lowering.
+
+#[test]
+fn record_template_literal_pattern_accepts_matching_keys() {
+    let source = r#"
+const ok: Record<`evt_${string}`, number> = { evt_a: 1, evt_b: 2 };
+"#;
+    let ds = diags(source);
+    let ts2353: Vec<_> = ds.iter().filter(|d| d.0 == 2353).collect();
+    assert!(
+        ts2353.is_empty(),
+        "Expected no TS2353 for keys matching Record<`evt_${{string}}`,_>, got: {ts2353:?}",
+    );
+}
+
+#[test]
+fn record_template_literal_pattern_rejects_non_matching_key() {
+    let source = r#"
+const bad: Record<`evt_${string}`, number> = { other: 1 };
+"#;
+    let ds = diags(source);
+    let ts2353: Vec<_> = ds.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 for non-matching Record key 'other', got: {ts2353:?}",
+    );
+    assert!(
+        ts2353[0].1.contains("'other'"),
+        "Expected TS2353 to mention 'other', got: {}",
+        ts2353[0].1,
+    );
+}
+
+#[test]
+fn record_template_literal_pattern_with_satisfies_operator() {
+    let source = r#"
+const ok = { prefix_foo: 1 } satisfies Record<`prefix_${string}`, number>;
+"#;
+    let ds = diags(source);
+    let ts2353: Vec<_> = ds.iter().filter(|d| d.0 == 2353).collect();
+    assert!(
+        ts2353.is_empty(),
+        "Expected no TS2353 for `satisfies Record<`prefix_${{string}}`,_>`, got: {ts2353:?}",
+    );
+}
+
+#[test]
+fn record_template_literal_pattern_renamed_alias() {
+    // Confirms the rule is structural, not bound to the `Record` name.
+    let source = r#"
+type Bucket<K extends keyof any, T> = { [P in K]: T };
+const ok: Bucket<`evt_${string}`, number> = { evt_a: 1, evt_b: 2 };
+const bad: Bucket<`evt_${string}`, number> = { other: 1 };
+"#;
+    let ds = diags(source);
+    let ts2353: Vec<_> = ds.iter().filter(|d| d.0 == 2353).collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected exactly one TS2353 (for 'other') under renamed Record alias, got: {ts2353:?}",
     );
 }


### PR DESCRIPTION
AgentName: M1-A
Runner: original `cloud-opus47-1m-dreamy-fermi-vLHFG`; M1-A refreshed and is carrying this test-only PR to ready.
Track: parity / conformance regression coverage (solver template-literal pattern keys)
Invariant: behavior-preserving — pure test additions for the existing structural mapped-template key rule.

## Summary

Pin the `Record<\`pattern\`, V>` excess-property check through the same
`{ [P in K]: T }` lowering that the existing template-literal mapped-type
tests cover. The issue body's exact repro — `satisfies Record<\`prefix_${string}\`, number>`
— had no direct unit-test coverage even though `templateLiteralTypes6.ts`
already reports `stale-accepted` against the checked-in conformance
snapshot.

## Structural Rule

> When an object literal is excess-property-checked against a mapped type
> (including its `Record<K, T>` alias entry point) whose constraint is a
> template-literal pattern, each source key must be matched against the
> pattern's spans, not compared lexically against a constant key list.

The rule is already implemented in
`crates/tsz-solver/src/operations/property_helpers.rs:412-509`
(`is_key_in_mapped_constraint` -> `literal_matches_template_pattern` ->
`match_template_spans`). This PR adds regression coverage that would fail
if the `Record` alias path stops delivering the template-literal
constraint into `is_key_in_mapped_constraint`.

## Scope

- `crates/tsz-checker/tests/ts2353_mapped_template_literal_key_tests.rs`
  - 4 new `#[test]` functions covering the `Record` alias entry point.
  - Lib load hoisted to `OnceLock<Vec<Arc<LibFile>>>` so `es5.d.ts` is parsed once per process instead of once per test.
  - File-level doc comment updated to mention #8725.

No source-tree changes; no solver/checker behavior is touched.

## Adjacent-case Test Matrix

| Test | Covers |
| --- | --- |
| `record_template_literal_pattern_accepts_matching_keys` | reported repro positive |
| `record_template_literal_pattern_rejects_non_matching_key` | negative path; asserts diagnostic mentions `'other'` |
| `record_template_literal_pattern_with_satisfies_operator` | `satisfies` variant matching the issue-body phrasing |
| `record_template_literal_pattern_renamed_alias` | structural rule, not bound to the `Record` name |

## Verification

- `cargo fmt --all --check`
- `cargo nextest run -p tsz-checker --test ts2353_mapped_template_literal_key_tests` — 9 passed (5 prior + 4 new)
- `git diff --check origin/main...HEAD`
- Heavy conformance/emit/fourslash/WASM gates run on ready-for-review CI per repo policy.

## Coordination Notes

- M1-A took over this stale test-only draft after the last M4-A note on 2026-05-21 left it parked pending a decision on whether to land independently or be superseded.
- #9512 is closed as superseded by #9515. #9515 remains draft/conflicting and carries broader solver behavior work. This PR is intentionally independent: it lands only the regression pin for the already-implemented `Record` alias path.
- Refs #8725. This PR should not auto-close the issue by itself because #9515 and the accepted-regression cleanup are still separate coordination surfaces.

## Project Corpus Impact

- Row: n/a
- Bug family: solver template-literal pattern key matching against object-literal excess-property checks (`Record` alias entry point)
- Evidence: focused checker unit tests above; no source path that the conformance binary exercises is touched.
