### PR TITLE
refactor(checker): extract instantiate_remaining_contextual_type_params to query boundary

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/inference.rs
+++ b/crates/tsz-checker/src/query_boundaries/inference.rs
@@ -1,8 +1,9 @@
 //! Query-boundary wrappers for generic inference helpers.
 
+use crate::query_boundaries::common;
 use crate::query_boundaries::common::QueryDatabase;
 use tsz_common::interner::Atom;
-use tsz_solver::{TypeId, computation::TypeSubstitution};
+use tsz_solver::{TypeId, TypeParamInfo, computation::TypeSubstitution};
 
 pub(crate) fn instantiate_type_with_infer(
     db: &dyn QueryDatabase,
@@ -22,4 +23,116 @@ pub(crate) fn collect_infer_bindings(
     type_id: TypeId,
 ) -> Vec<(Atom, TypeId)> {
     tsz_solver::collect_infer_bindings(db, type_id)
+}
+
+/// `true` when `type_id` still has free type parameters or unresolved `infer` placeholders.
+fn has_inference_holes(db: &dyn QueryDatabase, type_id: TypeId) -> bool {
+    common::contains_type_parameters(db, type_id) || common::contains_infer_types(db, type_id)
+}
+
+/// Instantiate `raw` with `substitution`, replacing the result with `TypeId::UNKNOWN`
+/// when inference holes survive — they cannot be meaningfully used as contextual types.
+fn resolve_replacement(
+    db: &dyn QueryDatabase,
+    raw: TypeId,
+    substitution: &TypeSubstitution,
+) -> TypeId {
+    let replacement = common::instantiate_type(db, raw, substitution);
+    if has_inference_holes(db, replacement) {
+        TypeId::UNKNOWN
+    } else {
+        replacement
+    }
+}
+
+/// Apply default or constraint substitutions for any remaining unbound contextual
+/// type parameters in `type_id`.
+///
+/// When a return-context substitution binds a callee type parameter to a
+/// contextual callback that mentions an outer type parameter with the same name,
+/// the outer parameter must not be defaulted to the callee's constraint — use
+/// the outer parameter's own bound instead.  After handling that case, any
+/// remaining `infer`-introduced names and ordinary unbound type params are
+/// filled with their declared defaults or constraints (falling back to
+/// `unknown`).
+pub(crate) fn instantiate_remaining_contextual_type_params(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    type_params: &[TypeParamInfo],
+    current_substitution: &TypeSubstitution,
+) -> TypeId {
+    let referenced_types = common::collect_referenced_types(db, type_id);
+
+    for tp in type_params {
+        // Catches the case where a return-context substitution bound the callee's param
+        // to a callback that transitively references the same-named outer param.
+        if current_substitution.get(tp.name) != Some(type_id)
+            || !common::contains_type_parameter_named(db, type_id, tp.name)
+        {
+            continue;
+        }
+
+        // Distinguishes the callee's declaration from any identically-named outer param.
+        let declared_param = db.factory().type_param(*tp);
+        let mut shadow_substitution = TypeSubstitution::new();
+        for &referenced in &referenced_types {
+            let Some(referenced_info) = common::type_param_info(db, referenced) else {
+                continue;
+            };
+            if referenced_info.name != tp.name || referenced == declared_param {
+                continue;
+            }
+            if let Some(replacement) = referenced_info.default.or(referenced_info.constraint) {
+                shadow_substitution.insert(tp.name, replacement);
+            } else {
+                return type_id;
+            }
+        }
+
+        if !shadow_substitution.is_empty() {
+            return common::instantiate_type(db, type_id, &shadow_substitution);
+        }
+    }
+
+    let mut infer_bindings = collect_infer_bindings(db, type_id);
+    for &referenced in &referenced_types {
+        let Some(info) = common::type_param_info(db, referenced) else {
+            continue;
+        };
+        // `__infer_` and `__infer_src_` are internal names the solver assigns to
+        // `infer T` placeholders; they must be treated the same as explicit infer bindings.
+        let name = db.resolve_atom_ref(info.name);
+        if name.starts_with("__infer_") || name.starts_with("__infer_src_") {
+            infer_bindings.push((info.name, referenced));
+        }
+    }
+    if type_params.is_empty() && infer_bindings.is_empty() {
+        return type_id;
+    }
+
+    let mut substitution = current_substitution.clone();
+    for tp in type_params {
+        if substitution
+            .get(tp.name)
+            .is_some_and(|mapped| !has_inference_holes(db, mapped))
+        {
+            continue;
+        }
+        let raw = tp.default.or(tp.constraint).unwrap_or(TypeId::UNKNOWN);
+        substitution.insert(tp.name, resolve_replacement(db, raw, &substitution));
+    }
+    for (name, infer_type) in infer_bindings {
+        if substitution
+            .get(name)
+            .is_some_and(|mapped| !has_inference_holes(db, mapped))
+        {
+            continue;
+        }
+        let raw = common::type_param_info(db, infer_type)
+            .and_then(|info| info.default.or(info.constraint))
+            .unwrap_or(TypeId::UNKNOWN);
+        substitution.insert(name, resolve_replacement(db, raw, &substitution));
+    }
+
+    instantiate_type_with_infer(db, type_id, &substitution)
 }

--- a/crates/tsz-checker/src/query_boundaries/inference.rs
+++ b/crates/tsz-checker/src/query_boundaries/inference.rs
@@ -25,26 +25,6 @@ pub(crate) fn collect_infer_bindings(
     tsz_solver::collect_infer_bindings(db, type_id)
 }
 
-/// `true` when `type_id` still has free type parameters or unresolved `infer` placeholders.
-fn has_inference_holes(db: &dyn QueryDatabase, type_id: TypeId) -> bool {
-    common::contains_type_parameters(db, type_id) || common::contains_infer_types(db, type_id)
-}
-
-/// Instantiate `raw` with `substitution`, replacing the result with `TypeId::UNKNOWN`
-/// when inference holes survive — they cannot be meaningfully used as contextual types.
-fn resolve_replacement(
-    db: &dyn QueryDatabase,
-    raw: TypeId,
-    substitution: &TypeSubstitution,
-) -> TypeId {
-    let replacement = common::instantiate_type(db, raw, substitution);
-    if has_inference_holes(db, replacement) {
-        TypeId::UNKNOWN
-    } else {
-        replacement
-    }
-}
-
 /// Apply default or constraint substitutions for any remaining unbound contextual
 /// type parameters in `type_id`.
 ///
@@ -61,21 +41,16 @@ pub(crate) fn instantiate_remaining_contextual_type_params(
     type_params: &[TypeParamInfo],
     current_substitution: &TypeSubstitution,
 ) -> TypeId {
-    let referenced_types = common::collect_referenced_types(db, type_id);
-
     for tp in type_params {
-        // Catches the case where a return-context substitution bound the callee's param
-        // to a callback that transitively references the same-named outer param.
         if current_substitution.get(tp.name) != Some(type_id)
             || !common::contains_type_parameter_named(db, type_id, tp.name)
         {
             continue;
         }
 
-        // Distinguishes the callee's declaration from any identically-named outer param.
         let declared_param = db.factory().type_param(*tp);
         let mut shadow_substitution = TypeSubstitution::new();
-        for &referenced in &referenced_types {
+        for referenced in common::collect_referenced_types(db, type_id) {
             let Some(referenced_info) = common::type_param_info(db, referenced) else {
                 continue;
             };
@@ -95,13 +70,11 @@ pub(crate) fn instantiate_remaining_contextual_type_params(
     }
 
     let mut infer_bindings = collect_infer_bindings(db, type_id);
-    for &referenced in &referenced_types {
+    for referenced in common::collect_referenced_types(db, type_id) {
         let Some(info) = common::type_param_info(db, referenced) else {
             continue;
         };
-        // `__infer_` and `__infer_src_` are internal names the solver assigns to
-        // `infer T` placeholders; they must be treated the same as explicit infer bindings.
-        let name = db.resolve_atom_ref(info.name);
+        let name = db.resolve_atom(info.name);
         if name.starts_with("__infer_") || name.starts_with("__infer_src_") {
             infer_bindings.push((info.name, referenced));
         }
@@ -112,26 +85,42 @@ pub(crate) fn instantiate_remaining_contextual_type_params(
 
     let mut substitution = current_substitution.clone();
     for tp in type_params {
-        if substitution
-            .get(tp.name)
-            .is_some_and(|mapped| !has_inference_holes(db, mapped))
-        {
+        if substitution.get(tp.name).is_some_and(|mapped| {
+            !common::contains_type_parameters(db, mapped)
+                && !common::contains_infer_types(db, mapped)
+        }) {
             continue;
         }
-        let raw = tp.default.or(tp.constraint).unwrap_or(TypeId::UNKNOWN);
-        substitution.insert(tp.name, resolve_replacement(db, raw, &substitution));
+        let replacement = tp.default.or(tp.constraint).unwrap_or(TypeId::UNKNOWN);
+        let replacement = common::instantiate_type(db, replacement, &substitution);
+        let replacement = if common::contains_type_parameters(db, replacement)
+            || common::contains_infer_types(db, replacement)
+        {
+            TypeId::UNKNOWN
+        } else {
+            replacement
+        };
+        substitution.insert(tp.name, replacement);
     }
     for (name, infer_type) in infer_bindings {
-        if substitution
-            .get(name)
-            .is_some_and(|mapped| !has_inference_holes(db, mapped))
-        {
+        if substitution.get(name).is_some_and(|mapped| {
+            !common::contains_type_parameters(db, mapped)
+                && !common::contains_infer_types(db, mapped)
+        }) {
             continue;
         }
-        let raw = common::type_param_info(db, infer_type)
+        let replacement = common::type_param_info(db, infer_type)
             .and_then(|info| info.default.or(info.constraint))
             .unwrap_or(TypeId::UNKNOWN);
-        substitution.insert(name, resolve_replacement(db, raw, &substitution));
+        let replacement = common::instantiate_type(db, replacement, &substitution);
+        let replacement = if common::contains_type_parameters(db, replacement)
+            || common::contains_infer_types(db, replacement)
+        {
+            TypeId::UNKNOWN
+        } else {
+            replacement
+        };
+        substitution.insert(name, replacement);
     }
 
     instantiate_type_with_infer(db, type_id, &substitution)

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -2433,7 +2433,8 @@ impl<'a> CheckerState<'a> {
                     && (common::contains_type_parameters(self.ctx.types, evaluated)
                         || common::contains_infer_types(self.ctx.types, evaluated))
                 {
-                    self.instantiate_remaining_contextual_type_params(
+                    crate::query_boundaries::inference::instantiate_remaining_contextual_type_params(
+                        self.ctx.types,
                         evaluated,
                         &shape.type_params,
                         &contextual_substitution,
@@ -2452,120 +2453,6 @@ impl<'a> CheckerState<'a> {
             round2_contextual_types.push(ctx_type);
         }
         round2_contextual_types
-    }
-
-    fn instantiate_remaining_contextual_type_params(
-        &self,
-        type_id: TypeId,
-        type_params: &[tsz_solver::TypeParamInfo],
-        current_substitution: &crate::query_boundaries::common::TypeSubstitution,
-    ) -> TypeId {
-        // A return-context substitution can bind a callee type parameter to a
-        // contextual callback that mentions an outer type parameter with the
-        // same name. Because substitutions are name-keyed, do not default that
-        // outer parameter to the callee's constraint; use the outer parameter's
-        // own bound instead.
-        for tp in type_params {
-            if current_substitution.get(tp.name) != Some(type_id)
-                || !common::contains_type_parameter_named(self.ctx.types, type_id, tp.name)
-            {
-                continue;
-            }
-
-            let declared_param = self.ctx.types.factory().type_param(*tp);
-            let mut shadow_substitution = crate::query_boundaries::common::TypeSubstitution::new();
-            for referenced in common::collect_referenced_types(self.ctx.types, type_id) {
-                let Some(referenced_info) = common::type_param_info(self.ctx.types, referenced)
-                else {
-                    continue;
-                };
-                if referenced_info.name != tp.name || referenced == declared_param {
-                    continue;
-                }
-                if let Some(replacement) = referenced_info.default.or(referenced_info.constraint) {
-                    shadow_substitution.insert(tp.name, replacement);
-                } else {
-                    return type_id;
-                }
-            }
-
-            if !shadow_substitution.is_empty() {
-                return crate::query_boundaries::common::instantiate_type(
-                    self.ctx.types,
-                    type_id,
-                    &shadow_substitution,
-                );
-            }
-        }
-
-        let mut infer_bindings =
-            crate::query_boundaries::inference::collect_infer_bindings(self.ctx.types, type_id);
-        for referenced in common::collect_referenced_types(self.ctx.types, type_id) {
-            let Some(info) = common::type_param_info(self.ctx.types, referenced) else {
-                continue;
-            };
-            let name = self.ctx.types.resolve_atom(info.name);
-            if name.starts_with("__infer_") || name.starts_with("__infer_src_") {
-                infer_bindings.push((info.name, referenced));
-            }
-        }
-        if type_params.is_empty() && infer_bindings.is_empty() {
-            return type_id;
-        }
-
-        let mut substitution = current_substitution.clone();
-        for tp in type_params {
-            if substitution.get(tp.name).is_some_and(|mapped| {
-                !common::contains_type_parameters(self.ctx.types, mapped)
-                    && !common::contains_infer_types(self.ctx.types, mapped)
-            }) {
-                continue;
-            }
-            let replacement = tp.default.or(tp.constraint).unwrap_or(TypeId::UNKNOWN);
-            let replacement = crate::query_boundaries::common::instantiate_type(
-                self.ctx.types,
-                replacement,
-                &substitution,
-            );
-            let replacement = if common::contains_type_parameters(self.ctx.types, replacement)
-                || common::contains_infer_types(self.ctx.types, replacement)
-            {
-                TypeId::UNKNOWN
-            } else {
-                replacement
-            };
-            substitution.insert(tp.name, replacement);
-        }
-        for (name, infer_type) in infer_bindings {
-            if substitution.get(name).is_some_and(|mapped| {
-                !common::contains_type_parameters(self.ctx.types, mapped)
-                    && !common::contains_infer_types(self.ctx.types, mapped)
-            }) {
-                continue;
-            }
-            let replacement = common::type_param_info(self.ctx.types, infer_type)
-                .and_then(|info| info.default.or(info.constraint))
-                .unwrap_or(TypeId::UNKNOWN);
-            let replacement = crate::query_boundaries::common::instantiate_type(
-                self.ctx.types,
-                replacement,
-                &substitution,
-            );
-            let replacement = if common::contains_type_parameters(self.ctx.types, replacement)
-                || common::contains_infer_types(self.ctx.types, replacement)
-            {
-                TypeId::UNKNOWN
-            } else {
-                replacement
-            };
-            substitution.insert(name, replacement);
-        }
-
-        crate::query_boundaries::inference::instantiate_type_with_infer(
-            self.ctx.types,
-            type_id,
-            &substitution,
-        )
     }
 
     pub(crate) fn compute_single_call_argument_type(

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -510,7 +510,7 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         "Checker query boundary: direct common quarantine references outside query_boundaries (#8225)",
         [ROOT / "crates" / "tsz-checker" / "src"],
         ("crates/tsz-checker/src/query_boundaries/",),
-        3395,
+        3390,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6 (remote / beautiful-maxwell-GwTAT)

## Track
Tech-debt / checker architecture (#9435)

## Invariant
When contextual type-parameter instantiation logic lives in a `CheckerState` method, it cannot be used without a full checker instance. This PR moves it to `query_boundaries/inference.rs` so the policy is accessible as a pure `db: &dyn QueryDatabase` call.

## Scope
- Moves `instantiate_remaining_contextual_type_params` from a private `CheckerState` method in `call_inference.rs` to a free function in `query_boundaries/inference.rs` (verbatim body; only mechanical substitutions: `self.ctx.types` → `db`, module paths adjusted)
- Updates the single call site in `call_inference.rs` to use the boundary function
- Ratchets #8225 query-boundary common-reference cap: 3395 → 3390

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: pure architectural relocation — identical semantics, no diagnostic/emit/LSP changes. All local lint, fmt, arch-guard, and checker-field-inventory checks pass.

## Verification
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- `python3 scripts/arch/arch_guard.py` → guardrails passed
- `bash scripts/arch/check-checker-boundaries.sh` → 236 field(s) classified, exit 0

## Coordination Notes
- Fixes #9435
- No overlap with other open PRs (touches only `query_boundaries/inference.rs`, `call_inference.rs`, and `arch_guard.py` ratchet cap)
- Prior simplify-pass optimizations (helper extraction, N+1 hoisting) caused 171 conformance regressions in the async/contextual-typing cluster and were reverted; the verbatim copy is correct here