### PR TITLE
chore(checker): remove query_boundaries module-level Clippy suppression quarantine

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -497,7 +497,7 @@ pub(crate) struct RelationRequest {
 }
 
 impl RelationRequest {
-    fn new(source: TypeId, target: TypeId, kind: RelationKind) -> Self {
+    const fn new(source: TypeId, target: TypeId, kind: RelationKind) -> Self {
         Self {
             source,
             target,
@@ -509,57 +509,57 @@ impl RelationRequest {
         }
     }
 
-    pub(crate) fn assign(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn assign(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::Assign)
     }
 
-    pub(crate) fn call_arg(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn call_arg(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::CallArg)
     }
 
-    pub(crate) fn return_stmt(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn return_stmt(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::Return)
     }
 
-    pub(crate) fn satisfies(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn satisfies(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::Satisfies)
     }
 
-    pub(crate) fn destructuring(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn destructuring(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::Destructuring)
     }
 
-    pub(crate) fn bivariant_callbacks(source: TypeId, target: TypeId) -> Self {
+    pub(crate) const fn bivariant_callbacks(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::BivariantCallbacks)
     }
 
     /// Mark the source as a fresh object literal, enabling EPC.
-    pub(crate) fn with_fresh_source(mut self) -> Self {
+    pub(crate) const fn with_fresh_source(mut self) -> Self {
         self.source_is_fresh = true;
         self.excess_property_mode = ExcessPropertyMode::Check;
         self
     }
 
     /// Mark the source as a spread expression, enabling explicit-only EPC.
-    pub(crate) fn with_spread_source(mut self) -> Self {
+    pub(crate) const fn with_spread_source(mut self) -> Self {
         self.excess_property_mode = ExcessPropertyMode::CheckExplicitOnly;
         self
     }
 
     /// Override excess property mode.
-    pub(crate) fn with_excess_property_mode(mut self, mode: ExcessPropertyMode) -> Self {
+    pub(crate) const fn with_excess_property_mode(mut self, mode: ExcessPropertyMode) -> Self {
         self.excess_property_mode = mode;
         self
     }
 
     /// Override missing property mode.
-    pub(crate) fn with_missing_property_mode(mut self, mode: MissingPropertyMode) -> Self {
+    pub(crate) const fn with_missing_property_mode(mut self, mode: MissingPropertyMode) -> Self {
         self.missing_property_mode = mode;
         self
     }
 
     /// Allow a failed generic-signature inference to retry with erased signatures.
-    pub(crate) fn with_erased_generic_signature_retry(mut self) -> Self {
+    pub(crate) const fn with_erased_generic_signature_retry(mut self) -> Self {
         self.allow_erased_generic_signature_retry = true;
         self
     }
@@ -606,7 +606,7 @@ pub(crate) use tsz_solver::RelationCacheKey;
 /// The resulting config is produced by the solver's typed `RelationPolicy`
 /// bridge, so this write path lands in the same cache slot as the solver's
 /// internal write path.
-pub(crate) fn assignability_cache_key(
+pub(crate) const fn assignability_cache_key(
     source: TypeId,
     target: TypeId,
     flags: u16,
@@ -619,7 +619,11 @@ pub(crate) fn assignability_cache_key(
 }
 
 /// Build a cache key for a subtype lookup. See [`assignability_cache_key`].
-pub(crate) fn subtype_cache_key(source: TypeId, target: TypeId, flags: u16) -> RelationCacheKey {
+pub(crate) const fn subtype_cache_key(
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+) -> RelationCacheKey {
     RelationCacheKey::for_subtype(
         source,
         target,

--- a/crates/tsz-checker/src/query_boundaries/capabilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/capabilities.rs
@@ -28,7 +28,7 @@ pub enum FeatureGate {
     AwaitUsingDeclaration,
     /// Top-level `await using` (requires specific module + target)
     TopLevelAwaitUsing,
-    /// Top-level `await` expression (requires same module + target as TopLevelAwaitUsing)
+    /// Top-level `await` expression (requires same module + target as `TopLevelAwaitUsing`)
     TopLevelAwait,
     /// `resolveJsonModule` option validity
     ResolveJsonModule,
@@ -255,8 +255,7 @@ impl EnvironmentCapabilities {
             b"IterableIterator" => Some(FeatureGate::Generators),
             b"AsyncIterableIterator" => Some(FeatureGate::AsyncGenerators),
             b"TypedPropertyDescriptor" => Some(FeatureGate::ExperimentalDecorators),
-            b"Promise" => Some(FeatureGate::AsyncFunction),
-            b"Awaited" => Some(FeatureGate::AsyncFunction),
+            b"Promise" | b"Awaited" => Some(FeatureGate::AsyncFunction),
             _ => None,
         }
     }

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -81,7 +81,7 @@ pub(crate) fn conditional_type_components(
 ///
 /// Returns `Some((check_type, extends_type, true_type, false_type))` if the
 /// type is a `Conditional`. Used for distinguishing true Extract patterns
-/// (`T extends C ? T : never` where true_type == check_type) from general
+/// (`T extends C ? T : never` where `true_type` == `check_type`) from general
 /// conditional types with custom true branches.
 pub(crate) fn full_conditional_type_components(
     db: &dyn TypeDatabase,
@@ -201,7 +201,7 @@ pub(crate) fn overload_type_param_counts(
 // Index-key classification
 // =========================================================================
 
-/// Re-export `IndexKeyKind` so generic_checker doesn't import solver directly.
+/// Re-export `IndexKeyKind` so `generic_checker` doesn't import solver directly.
 pub(crate) use tsz_solver::type_queries::IndexKeyKind;
 
 /// Classify a type for index-key matching (string, number, literal, union, etc.).
@@ -288,7 +288,7 @@ pub(crate) fn application_base_def_and_args(
 // Array-like structural surface helpers
 // =========================================================================
 
-/// Re-export `ArrayLikeKind` so generic_checker doesn't import solver directly.
+/// Re-export `ArrayLikeKind` so `generic_checker` doesn't import solver directly.
 pub(crate) use tsz_solver::type_queries::ArrayLikeKind;
 
 /// Classify whether a type is an array, tuple, or readonly array.

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -289,7 +289,7 @@ pub(crate) fn is_generic_mapped_application<R: TypeResolver>(
 
 /// Check if a type contains type parameters that require instantiation,
 /// but correctly handles mapped types by only checking their constraint and
-/// name_type (not the template, which always contains the iteration variable).
+/// `name_type` (not the template, which always contains the iteration variable).
 ///
 /// Use this instead of raw `contains_type_parameters` when deciding whether
 /// to suppress TS2339 — a fully-instantiated mapped type like

--- a/crates/tsz-checker/src/query_boundaries/environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/environment.rs
@@ -31,7 +31,7 @@ use super::capabilities::{EnvironmentCapabilities, FeatureGate, MissingGlobalKin
 /// Each variant maps to a specific diagnostic code family and contains
 /// enough context for the caller to produce the full diagnostic.
 /// The caller (checker error reporter) decides *where* (position/node)
-/// and *how* (error_at_node vs error_at_position) to emit.
+/// and *how* (`error_at_node` vs `error_at_position`) to emit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CapabilityDiagnostic {
     /// TS2304: Cannot find name '{name}'.
@@ -97,10 +97,10 @@ pub(crate) enum CapabilityDiagnostic {
 
 impl CapabilityDiagnostic {
     /// The diagnostic code associated with this capability diagnostic.
-    pub fn code(&self) -> u32 {
+    pub const fn code(&self) -> u32 {
         match self {
             Self::MissingPlainGlobalValue { .. } => 2304,
-            Self::MissingGlobalType { .. } => 2318,
+            Self::MissingGlobalType { .. } | Self::FeatureRequiresGlobalType { .. } => 2318,
             Self::MissingEs2015Type { .. } => 2583,
             Self::MissingDomGlobal { .. } => 2584,
             Self::MissingNodeGlobal { .. } => 2591,
@@ -112,7 +112,6 @@ impl CapabilityDiagnostic {
             Self::TopLevelAwaitUnsupported => 1378,
             Self::ImportAssertDeprecated => 2880,
             Self::ResolveJsonModuleIncompatible => 5071,
-            Self::FeatureRequiresGlobalType { .. } => 2318,
             Self::DeprecatedOption { .. } => 5101,
             Self::DeprecatedOptionValue { .. } => 5107,
         }
@@ -165,15 +164,12 @@ impl EnvironmentCapabilities {
             | FeatureGate::AsyncFunction
             | FeatureGate::AsyncFunctionEs5 => {
                 if !self.has_lib {
-                    if let Some(required_type) = EnvironmentCapabilities::required_global_type(gate)
-                    {
-                        Some(CapabilityDiagnostic::FeatureRequiresGlobalType {
+                    EnvironmentCapabilities::required_global_type(gate).map(|required_type| {
+                        CapabilityDiagnostic::FeatureRequiresGlobalType {
                             gate,
                             required_type,
-                        })
-                    } else {
-                        None
-                    }
+                        }
+                    })
                 } else {
                     None
                 }
@@ -195,12 +191,11 @@ impl EnvironmentCapabilities {
                     name: name.to_string(),
                 })
             }
-            MissingGlobalKind::CoreGlobalType => Some(CapabilityDiagnostic::MissingGlobalType {
-                name: name.to_string(),
-            }),
-            MissingGlobalKind::FeatureGlobalType => Some(CapabilityDiagnostic::MissingGlobalType {
-                name: name.to_string(),
-            }),
+            MissingGlobalKind::CoreGlobalType | MissingGlobalKind::FeatureGlobalType => {
+                Some(CapabilityDiagnostic::MissingGlobalType {
+                    name: name.to_string(),
+                })
+            }
             MissingGlobalKind::Es2015PlusType => {
                 let suggested_lib =
                     tsz_binder::lib_loader::get_suggested_lib_for_type(name).to_string();
@@ -234,7 +229,7 @@ impl EnvironmentCapabilities {
     /// When TS5107/TS5101 deprecation diagnostics are present, tsc stops compilation
     /// early and never resolves lib types. This centralizes the decision that was
     /// previously passed as `skip_lib_type_resolution` from the driver.
-    pub fn should_skip_lib_type_resolution(&self) -> bool {
+    pub const fn should_skip_lib_type_resolution(&self) -> bool {
         self.has_deprecation_diagnostics
     }
 
@@ -243,7 +238,7 @@ impl EnvironmentCapabilities {
     ///
     /// Returns `Some(ImportAssertDeprecated)` when `ignore_deprecations` is false
     /// (meaning the deprecation is not suppressed by the user's config).
-    pub(crate) fn check_import_assert_deprecated(&self) -> Option<CapabilityDiagnostic> {
+    pub(crate) const fn check_import_assert_deprecated(&self) -> Option<CapabilityDiagnostic> {
         if !self.ignore_deprecations {
             Some(CapabilityDiagnostic::ImportAssertDeprecated)
         } else {

--- a/crates/tsz-checker/src/query_boundaries/flow.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow.rs
@@ -127,11 +127,8 @@ pub(crate) fn apply_flow_observation(
             }
         }
 
-        FlowObservation::DestructuringElement { has_default, .. } => {
-            narrow_with_default_policy(db, base_type, *has_default)
-        }
-
-        FlowObservation::DestructuringProperty { has_default, .. } => {
+        FlowObservation::DestructuringElement { has_default, .. }
+        | FlowObservation::DestructuringProperty { has_default, .. } => {
             narrow_with_default_policy(db, base_type, *has_default)
         }
 

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -12,177 +12,40 @@
 //! will replace it. The current module inventory and quarantine list live in
 //! `docs/architecture/QUERY_BOUNDARY_INVENTORY.md`.
 //!
-// Allow dead code and related lints in scaffolding modules that define
-// the unified relation boundary API (NORTH_STAR.md §22). These types
-// will be wired in as checker paths migrate to the boundary API.
-#[allow(dead_code, clippy::missing_const_for_fn, clippy::match_same_arms)]
 pub(crate) mod assignability;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod capabilities;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod checkers;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod class;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod class_type;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod common;
 pub(crate) mod construct_signatures;
 pub(crate) mod definite_assignment;
 pub(crate) mod definition_identity;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod diagnostics;
 pub(crate) mod dispatch;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
-#[allow(private_interfaces)]
 pub(crate) mod environment;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod flow;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod flow_analysis;
-#[allow(dead_code)]
 pub(crate) mod index_signature;
-#[allow(dead_code)]
 pub(crate) mod inference;
 pub(crate) mod intersection_display;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod js_exports;
 pub(crate) mod key_constraints;
-#[allow(dead_code)]
 pub(crate) mod name_resolution;
 pub(crate) mod operator_wrappers;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod property_access;
 pub(crate) mod recursive_alias;
-#[allow(dead_code, clippy::missing_const_for_fn, clippy::match_same_arms)]
 pub(crate) mod relation_types;
 pub(crate) mod spread;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod state;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod type_checking;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod type_checking_utilities;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod type_computation;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod type_construction;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod type_defaults;
 pub(crate) mod type_origin;
 pub(crate) mod type_parameter_identity;
 pub(crate) mod type_predicates;
-#[allow(dead_code, clippy::missing_const_for_fn, clippy::match_same_arms)]
 pub(crate) mod type_rewrite;
-#[allow(
-    dead_code,
-    clippy::missing_const_for_fn,
-    clippy::match_same_arms,
-    clippy::doc_markdown,
-    clippy::manual_map
-)]
 pub(crate) mod variance;
-#[allow(dead_code)]
 pub(crate) mod widening;

--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -170,7 +170,7 @@ pub(crate) fn type_has_property(db: &dyn TypeDatabase, type_id: TypeId, name: &s
 /// Check if a type is the polymorphic `this` type.
 ///
 /// Used during property access resolution to suppress TS2339 when `this`
-/// comes from a ThisType marker (e.g., Vue 2 Options API pattern).
+/// comes from a `ThisType` marker (e.g., Vue 2 Options API pattern).
 pub(crate) fn is_this_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::is_this_type(db, type_id)
 }
@@ -183,7 +183,7 @@ pub(crate) fn contains_never_type(db: &dyn TypeDatabase, type_id: TypeId) -> boo
     tsz_solver::type_queries::contains_never_type_db(db, type_id)
 }
 
-/// Extract object and index types from an IndexAccess type (T[K]).
+/// Extract object and index types from an `IndexAccess` type (T[K]).
 ///
 /// Returns `None` if `type_id` is not an `IndexAccess` type.
 pub(crate) fn index_access_types(

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -248,6 +248,11 @@ impl RelationFailure {
             SubtypeFailureReason::ArrayElementMismatch {
                 source_element,
                 target_element,
+            }
+            | SubtypeFailureReason::TupleElementTypeMismatch {
+                source_element,
+                target_element,
+                ..
             } => Self::TypeMismatch {
                 source_type: source_element,
                 target_type: target_element,
@@ -273,20 +278,10 @@ impl RelationFailure {
             },
             SubtypeFailureReason::OptionalPropertyRequired { property_name }
             | SubtypeFailureReason::ReadonlyPropertyMismatch { property_name }
-            | SubtypeFailureReason::PropertyNominalMismatch { property_name } => {
+            | SubtypeFailureReason::PropertyNominalMismatch { property_name }
+            | SubtypeFailureReason::PropertyVisibilityMismatch { property_name, .. } => {
                 Self::PropertyModifierMismatch { property_name }
             }
-            SubtypeFailureReason::PropertyVisibilityMismatch { property_name, .. } => {
-                Self::PropertyModifierMismatch { property_name }
-            }
-            SubtypeFailureReason::TupleElementTypeMismatch {
-                source_element,
-                target_element,
-                ..
-            } => Self::TypeMismatch {
-                source_type: source_element,
-                target_type: target_element,
-            },
             SubtypeFailureReason::MissingIndexSignature { .. }
             | SubtypeFailureReason::RecursionLimitExceeded => Self::TypeMismatch {
                 source_type: TypeId::ERROR,

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -110,7 +110,7 @@ pub(crate) fn union_members(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Ve
 }
 
 /// Compute modifier values for a mapped-type property.
-pub(crate) fn compute_mapped_modifiers(
+pub(crate) const fn compute_mapped_modifiers(
     mapped: &tsz_solver::MappedType,
     is_homomorphic: bool,
     source_optional: bool,
@@ -140,7 +140,7 @@ pub(crate) fn collect_homomorphic_source_property_infos(
     tsz_solver::type_queries::collect_homomorphic_source_property_infos(db, source)
 }
 
-/// Expand a mapped type with resolved finite keys into PropertyInfo list.
+/// Expand a mapped type with resolved finite keys into `PropertyInfo` list.
 pub(crate) fn expand_mapped_type_to_properties(
     db: &dyn TypeDatabase,
     mapped: &tsz_solver::MappedType,
@@ -202,7 +202,7 @@ pub(crate) fn keyof_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option
 /// Returns `Some(constraint)` if the type is a `TypeParameter` or `Infer`
 /// with a constraint, `None` otherwise. Used by the checker to discover
 /// types reachable through type parameter constraints for pre-resolution
-/// into the TypeEnvironment, without accessing TypeData directly.
+/// into the `TypeEnvironment`, without accessing TypeData directly.
 pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::type_queries::get_type_parameter_constraint(db, type_id)
 }
@@ -243,7 +243,7 @@ pub(crate) fn extract_string_literal_keys(
     tsz_solver::type_queries::extract_string_literal_keys(db, type_id)
 }
 
-/// Get the name of a type parameter (TypeParameter or Infer).
+/// Get the name of a type parameter (`TypeParameter` or Infer).
 ///
 /// Returns `Some(name)` if the type is a type parameter, `None` otherwise.
 /// Used by the checker to match type parameters against declared parameter
@@ -367,8 +367,8 @@ pub(crate) struct EvalWithCacheResult {
 /// Evaluate a type with a resolver, optionally seeding the evaluator cache.
 ///
 /// Returns the result plus side-effects (depth exceeded, cache drain).
-/// This is the canonical boundary for TypeEvaluator construction with cache
-/// management — checker code must not construct TypeEvaluator directly.
+/// This is the canonical boundary for `TypeEvaluator` construction with cache
+/// management — checker code must not construct `TypeEvaluator` directly.
 pub(crate) fn evaluate_type_with_cache<R: tsz_solver::relations::subtype::TypeResolver>(
     db: &dyn TypeDatabase,
     resolver: &R,

--- a/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
@@ -89,7 +89,7 @@ pub(crate) use super::common::{
 };
 
 /// Whether the AST node at `idx` is a bare type-parameter reference whose
-/// name resolves to a TypeParameter symbol in the current lexical scope.
+/// name resolves to a `TypeParameter` symbol in the current lexical scope.
 /// Used to suppress the "any cannot be used as an index type" check when
 /// our type resolution collapsed the parameter to `any` — tsc keeps the
 /// index syntactically generic and defers rejection to instantiation time.

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -231,7 +231,7 @@ pub(crate) fn widen_mutable_object_literal_property_types(
 /// `unknown`, `any`, and `never` do not constrain literal property types in
 /// tsc's contextual literal check, so they should not suppress the normal
 /// widening of property literals in non-fresh object contexts.
-pub(crate) fn is_literal_permissive_object_context(type_id: TypeId) -> bool {
+pub(crate) const fn is_literal_permissive_object_context(type_id: TypeId) -> bool {
     matches!(type_id, TypeId::UNKNOWN | TypeId::ANY | TypeId::NEVER)
 }
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -522,7 +522,7 @@ QUERY_BOUNDARY_MODULE_ALLOWANCE_COUNT_CHECKS = [
     (
         "Checker query boundary: module-level lint allowances must not grow (#8225)",
         ROOT / "crates" / "tsz-checker" / "src" / "query_boundaries" / "mod.rs",
-        104,
+        0,
     ),
 ]
 


### PR DESCRIPTION
AgentName: M1-A
Original author/session: `claude-sonnet-4-6-keen-thompson-DLYVe`

## AgentName
claude-sonnet-4-6-keen-thompson-DLYVe

## Track
Tech-debt / Architecture hygiene (#8225, #9447)

## Invariant
`QUERY_BOUNDARY_MODULE_ALLOWANCE_COUNT_CHECKS` in `scripts/arch/arch_guard.py` is ratcheted to **0** — `query_boundaries/mod.rs` now contains zero `#[allow(...)]` attributes.

## Scope
Fix all Clippy violations previously suppressed by blanket `#[allow(...)]` blocks at the module level in `crates/tsz-checker/src/query_boundaries/mod.rs`, then remove those blocks entirely.

**No behavior changes.** All modifications are:
- Adding `const` to pure builder/accessor functions
- Merging duplicate `match` arms that produced identical results
- Replacing a manual `if let Some / else None` with `.map()`
- Backtick-quoting identifiers in doc comments

### Structural rule
> When a function performs only field assignment, struct construction, or primitive arithmetic on `Copy` types, Clippy's `missing_const_for_fn` encodes that it should be `const`. When two match arms have identical bodies, they should be a single alternative pattern. When doc comments reference code identifiers without backticks, `doc_markdown` flags it. This PR makes tsz satisfy all three rules for the query-boundary layer.

### Lint breakdown

| Lint | Count fixed | Files |
|------|------------|-------|
| `missing_const_for_fn` | 14 | assignability.rs, environment.rs, state/type_environment.rs, type_computation/core.rs |
| `match_same_arms` | 6 | capabilities.rs, environment.rs, flow.rs, relation_types.rs |
| `doc_markdown` | 16 | capabilities.rs, checkers/generic.rs, common.rs, environment.rs, property_access.rs, state/type_environment.rs, type_checking_utilities.rs |
| `manual_map` | 1 | environment.rs |

### Adjacent cases covered
The `const` promotion covers the full `RelationRequest` builder chain (14 methods). The `match_same_arms` fixes cover all arm pairs in the affected files. The `dead_code` and `private_interfaces` suppressions were also removed after verifying the code is live and the private-interfaces issue had already been resolved.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
Evidence: tech-debt-only — removes lint suppressions and adds `const`/arm merges. Zero change to diagnostic output, emitted JS, or type semantics.

## Verification
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` → clean
- `cargo check -p tsz-checker` → zero warnings
- `cargo test -p tsz-checker` → all tests pass
- arch guard live count for `query_boundaries/mod.rs` allowances = 0 (cap ratcheted 104 → 0)
- Pre-existing `test_real_count_passes_at_pinned_cap` failure on main is out of scope

## Coordination Notes
Fixes #9447. The pre-existing arch guard failure (`QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS` slack) exists on `main` before this branch and is unrelated to this PR.

