### PR TITLE
fix(dts): synthesize class declaration for export const with class expression initializer

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -2461,6 +2461,27 @@ impl<'a> DeclarationEmitter<'a> {
                         }
                         continue;
                     }
+                    // When an exported variable has a class expression initializer with no
+                    // explicit type annotation, tsc synthesizes a class declaration using the
+                    // binding name. Covers namespace-exported class expressions:
+                    // `export const C = class { }`, `export const C = class C { }`,
+                    // generic class expressions, and class expressions with heritage.
+                    // (Top-level `export const` goes through emit_exported_variable instead.)
+                    if is_exported
+                        && decl.type_annotation.is_none()
+                        && self.emit_js_named_class_expression_declaration(
+                            decl.name,
+                            decl.initializer,
+                            is_exported,
+                        )
+                    {
+                        if let Some(dn) = self.arena.get(decl_idx) {
+                            let skip_end =
+                                self.arena.get(decl.initializer).map_or(dn.end, |n| n.end);
+                            self.skip_comments_in_node(dn.pos, skip_end);
+                        }
+                        continue;
+                    }
                 }
 
                 // When emitting a non-exported variable statement purely because of

--- a/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/mod.rs
@@ -2043,6 +2043,26 @@ impl<'a> DeclarationEmitter<'a> {
                         }
                         continue;
                     }
+                    // When a variable has a class expression initializer with no explicit
+                    // type annotation, tsc synthesizes a class declaration using the
+                    // binding name. This covers anonymous and same-name class expressions:
+                    // `export const C = class { }`, `export const C = class C { }`,
+                    // generic class expressions, and class expressions with heritage.
+                    let is_exported = self.should_emit_export_keyword();
+                    if decl.type_annotation.is_none()
+                        && self.emit_js_named_class_expression_declaration(
+                            decl.name,
+                            decl.initializer,
+                            is_exported,
+                        )
+                    {
+                        if let Some(dn) = self.arena.get(decl_idx) {
+                            let skip_end =
+                                self.arena.get(decl.initializer).map_or(dn.end, |n| n.end);
+                            self.skip_comments_in_node(dn.pos, skip_end);
+                        }
+                        continue;
+                    }
                 }
 
                 // Emit all regular declarations together on one line

--- a/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
@@ -537,3 +537,83 @@ fn test_private_identifier_emits_private_marker() {
         "#secret should not appear in .d.ts: {output}"
     );
 }
+
+// =============================================================================
+// Class Expression Synthesis
+// tsc rule: when `export const X = class { }` (or `class X { }` with matching
+// name) has no explicit type annotation, the .d.ts synthesizes a class
+// declaration `export declare class X { ... }` preserving all members.
+// =============================================================================
+
+#[test]
+fn export_const_anonymous_class_expr_synthesizes_class_decl() {
+    let output = emit_dts("export const C = class {\n    foo(): void {}\n};");
+    assert!(
+        output.contains("export declare class C"),
+        "anonymous class expression should synthesize class decl: {output}"
+    );
+    assert!(
+        output.contains("foo(): void"),
+        "method should be preserved in synthesized class: {output}"
+    );
+    assert!(
+        !output.contains("new ()"),
+        "should not emit constructor type for synthesized class: {output}"
+    );
+}
+
+#[test]
+fn export_const_same_name_class_expr_synthesizes_class_decl() {
+    let output = emit_dts("export const D = class D {\n    bar(): void {}\n};");
+    assert!(
+        output.contains("export declare class D"),
+        "same-name class expression should synthesize class decl: {output}"
+    );
+    assert!(
+        output.contains("bar(): void"),
+        "method should be preserved in synthesized class: {output}"
+    );
+}
+
+#[test]
+fn export_const_different_name_class_expr_emits_structural_type() {
+    // When inner class name differs from binding name, emit structural type.
+    let output = emit_dts("export const E = class F {\n    baz(): void {}\n};");
+    assert!(
+        !output.contains("export declare class E"),
+        "different-name class expression must not synthesize class decl for binding: {output}"
+    );
+    assert!(
+        output.contains("const E"),
+        "binding name must be preserved for different-name class expression: {output}"
+    );
+}
+
+#[test]
+fn export_const_typed_class_expr_emits_annotation() {
+    // Explicit type annotation takes priority over class synthesis.
+    let output = emit_dts(
+        "interface IC { foo(): void; }\nexport const T: IC = class {\n    foo(): void {}\n};",
+    );
+    assert!(
+        !output.contains("export declare class T"),
+        "annotated class expression must not synthesize class decl: {output}"
+    );
+    assert!(
+        output.contains("const T: IC"),
+        "annotation should be preserved in DTS: {output}"
+    );
+}
+
+#[test]
+fn export_const_generic_class_expr_synthesizes_generic_class_decl() {
+    let output = emit_dts("export const Box = class<T> {\n    value!: T;\n};");
+    assert!(
+        output.contains("export declare class Box<T>"),
+        "generic class expression should synthesize generic class decl: {output}"
+    );
+    assert!(
+        output.contains("value: T"),
+        "generic member should be preserved in synthesized class: {output}"
+    );
+}


### PR DESCRIPTION
AgentName: sonnet-4-6-remote

## Summary

`export const C = class { }` now synthesizes `export declare class C { }` in DTS output instead of a structural constructor type (closes #8743).

## Track

Track 9 (DTS emit parity) — declaration-summary family #8522.

## Invariant

`export const X = class { }` (unannotated, anonymous or same-name) → synthesize `export declare class X { }` in DTS output.

**Key guard:** when inner class name ≠ binding name (`const E = class F { }`), the synthesis returns `false` and the fallback structural type is emitted (correct tsc behavior).

## Scope

### DTS class expression synthesis (`exports/mod.rs`, `emit_members.rs`)

`emit_exported_variable` (top-level `export const`) and `emit_variable_declaration_statement` (namespace-exported) both delegate to the existing `emit_js_named_class_expression_declaration` function. No new emit logic — reuses the JS CJS path.

**No conformance or options-conversion changes in this PR.** The earlier `esnext.typedarrays` one-liner was reverted per review feedback; it belongs in a separate PR scoped to `conformance/options_convert`.

## Structural rule

When the RHS of an `export const` binding is a class expression whose name is absent or identical to the binding name, tsc emits `export declare class X { ... }`. This change makes tsz apply the same synthesis.

## Adjacent cases covered

1. `export const C = class { }` — anonymous class expression → `export declare class C { }`
2. `export const C = class C { }` — same-name class expression → `export declare class C { }`
3. `export const E = class F { }` — different-name → fallback to structural type (correct)
4. `export const C: I = class { }` — typed annotation present → annotation wins (structural type emitted)
5. `export const C = class<T> { }` — generic class expression → `export declare class C<T> { }`

## Project Corpus Impact

- Row: DTS emit — `emitClassExpressionInDeclarationFile` baseline
- Bug family: #8522 (class expression declaration synthesis)
- Evidence: 5 unit tests in `class_features.rs` covering all adjacent cases above; clippy clean on `tsz-emitter`

## Verification

```bash
# DTS fix
cargo nextest run -p tsz-emitter
# → 2695+ passed; 0 failed

# Clippy
cargo clippy -p tsz-emitter --all-targets -- -D warnings
# → clean
```

## Coordination Notes

- No conformance or options-convert changes in this PR.
- No overlap with other open DTS PRs.
- Closes #8743 upon merge.

https://claude.ai/code/session_01DXzCu5o2KBSgXY5tVcnKEw