### PR TITLE
fix(checker): skip TS2786 return-type check for React alias Application types

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -997,7 +997,6 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
-
         }
 
         if any_checked && !all_valid {

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -819,6 +819,14 @@ impl<'a> CheckerState<'a> {
         let is_union =
             crate::query_boundaries::common::union_members(self.ctx.types, component_type)
                 .is_some();
+        // A React alias application (ComponentType<P>, FunctionComponent<P>, etc.) is
+        // not a union in the TypeData sense, but it evaluates to one and its expanded
+        // members are themselves React alias applications whose recursive return types
+        // (ReactElement<P> ↔ ComponentClass<P>/SFC<P>) trigger cycle-detection false
+        // positives. Treat them the same as direct unions for skip purposes.
+        let is_react_alias_application =
+            self.is_react_jsx_component_alias_application(component_type);
+        let is_union_like = is_union || is_react_alias_application;
         let types_to_check = self.jsx_component_return_check_types(component_type);
 
         let mut any_checked = false;
@@ -840,11 +848,12 @@ impl<'a> CheckerState<'a> {
             ) {
                 continue;
             }
-            // In a union, React component alias Applications (ComponentType<P>,
-            // ReactType<P>, ComponentClass<P>, StatelessComponent<P>, etc.) are
-            // valid JSX component shapes. Skip the return-type check: their
-            // recursive return types (ReactElement<P> ↔ ComponentClass<P>/SFC<P>)
-            // trigger cycle-detection false positives in the assignability checker.
+            // In a union or React alias application context, React component alias
+            // Applications (ComponentType<P>, ReactType<P>, ComponentClass<P>,
+            // StatelessComponent<P>, etc.) are valid JSX component shapes. Skip the
+            // return-type check: their recursive return types
+            // (ReactElement<P> ↔ ComponentClass<P>/SFC<P>) trigger cycle-detection
+            // false positives in the assignability checker.
             // The alias-application skip does not require props to be extractable
             // because the skip reason is cycle avoidance, not props availability.
             // The second clause (branch display) still requires props as an
@@ -856,7 +865,9 @@ impl<'a> CheckerState<'a> {
                 && self
                     .get_jsx_props_type_for_component_member(member_type, None)
                     .is_some();
-            if is_union && (is_alias_app || (is_react_component_alias_union && branch_has_props)) {
+            if is_union_like
+                && (is_alias_app || (is_react_component_alias_union && branch_has_props))
+            {
                 continue;
             }
             let is_unresolved = |t: TypeId| -> bool {
@@ -986,6 +997,7 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+
         }
 
         if any_checked && !all_valid {

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -783,7 +783,7 @@ fn jsx_empty_element_attributes_property_uses_instance_type() {
     assert!(
         ts2322.iter().any(|d| d
             .message_text
-            .contains("is not assignable to type '{ q?: number | undefined; }'") ),
+            .contains("is not assignable to type '{ q?: number | undefined; }'")),
         "expected TS2322 to compare against the instance type, got: {diagnostics:?}"
     );
     assert!(
@@ -1364,7 +1364,7 @@ fn jsx_intrinsic_excess_attrs_report_for_intersection_alias_props() {
     assert!(
         ts2322.iter().any(|diag| diag
             .message_text
-            .contains("and 'class' does not exist in type '{ className?: string | undefined; }'") ),
+            .contains("and 'class' does not exist in type '{ className?: string | undefined; }'")),
         "Expected plain intrinsic excess attr diagnostic, got: {diagnostics:?}"
     );
     assert_eq!(
@@ -3351,14 +3351,14 @@ fn jsx_component_type_application_no_ts2786() {
             type ComponentType<{tp} = {{}}> = ComponentClass<{tp}> | FunctionComponent<{tp}>;
         }}
         interface Props {{ x?: number; }}
-        declare var elem: React.ComponentType<Props>;
+        declare var Elem: React.ComponentType<Props>;
         const _ = <{jsx_tag} />;
         "#
         )
     };
 
     // Shape 1: type-param spelled `T` — ComponentType<T> Application
-    let src1 = make_source("T", "elem");
+    let src1 = make_source("T", "Elem");
     let d1 = check_jsx_codes(&src1);
     assert!(
         !d1.contains(&2786),
@@ -3366,7 +3366,7 @@ fn jsx_component_type_application_no_ts2786() {
     );
 
     // Shape 2: type-param spelled `K` — proves the rule is not tied to `T`
-    let src2 = make_source("K", "elem");
+    let src2 = make_source("K", "Elem");
     let d2 = check_jsx_codes(&src2);
     assert!(
         !d2.contains(&2786),
@@ -3401,7 +3401,7 @@ fn jsx_function_component_application_no_ts2786() {
 
     // FunctionComponent<Props> as JSX tag — must not emit TS2786
     let src_good =
-        format!("{base} declare var fc: React.FunctionComponent<Props>; const _ = <fc />;");
+        format!("{base} declare var Fc: React.FunctionComponent<Props>; const _ = <Fc />;");
     let d_good = check_jsx_codes(&src_good);
     assert!(
         !d_good.contains(&2786),
@@ -3414,8 +3414,8 @@ fn jsx_function_component_application_no_ts2786() {
         interface NonReactSfc {{
             (props: Props): {{ notAnElement: true }};
         }}
-        declare var bad: NonReactSfc;
-        const _ = <bad />;
+        declare var Bad: NonReactSfc;
+        const _ = <Bad />;
         "#
     );
     let d_bad = check_jsx_codes(&src_bad);

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -783,7 +783,7 @@ fn jsx_empty_element_attributes_property_uses_instance_type() {
     assert!(
         ts2322.iter().any(|d| d
             .message_text
-            .contains("is not assignable to type '{ q?: number | undefined; }'")),
+            .contains("is not assignable to type '{ q?: number | undefined; }'") ),
         "expected TS2322 to compare against the instance type, got: {diagnostics:?}"
     );
     assert!(
@@ -3313,7 +3313,7 @@ let k = <Comp>hello<A /></Comp>;
     );
 }
 
-/// `ComponentType<P>` is an Application type (not a direct union in the TypeData sense)
+/// `ComponentType<P>` is an Application type (not a direct union in the `TypeData` sense)
 /// that evaluates to `ComponentClass<P> | FunctionComponent<P>`. When used as a JSX tag,
 /// its expanded members are React alias applications whose recursive return types trigger
 /// cycle-detection false positives if we check them. The Application itself must be treated
@@ -3375,7 +3375,7 @@ fn jsx_component_type_application_no_ts2786() {
 }
 
 /// `FunctionComponent<P>` used directly as a JSX tag type (Application, not a union) must
-/// not emit TS2786. Its return types create the same cycle-detection risk as ComponentType<P>.
+/// not emit TS2786. Its return types create the same cycle-detection risk as `ComponentType<P>`.
 ///
 /// The non-React counterpart (a custom interface with invalid returns) must still emit TS2786
 /// to prove the skip is React-alias-specific, not universal.

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -783,7 +783,7 @@ fn jsx_empty_element_attributes_property_uses_instance_type() {
     assert!(
         ts2322.iter().any(|d| d
             .message_text
-            .contains("is not assignable to type '{ q?: number | undefined; }'")),
+            .contains("is not assignable to type '{ q?: number | undefined; }'") ),
         "expected TS2322 to compare against the instance type, got: {diagnostics:?}"
     );
     assert!(
@@ -1364,7 +1364,7 @@ fn jsx_intrinsic_excess_attrs_report_for_intersection_alias_props() {
     assert!(
         ts2322.iter().any(|diag| diag
             .message_text
-            .contains("and 'class' does not exist in type '{ className?: string | undefined; }'")),
+            .contains("and 'class' does not exist in type '{ className?: string | undefined; }'") ),
         "Expected plain intrinsic excess attr diagnostic, got: {diagnostics:?}"
     );
     assert_eq!(
@@ -3310,5 +3310,117 @@ let k = <Comp>hello<A /></Comp>;
         !ts2747.message_text.contains("Element;"),
         "TS2747 message must NOT include a trailing semicolon; got: {}",
         ts2747.message_text
+    );
+}
+
+/// `ComponentType<P>` is an Application type (not a direct union in the TypeData sense)
+/// that evaluates to `ComponentClass<P> | FunctionComponent<P>`. When used as a JSX tag,
+/// its expanded members are React alias applications whose recursive return types trigger
+/// cycle-detection false positives if we check them. The Application itself must be treated
+/// like a union context so the members are skipped.
+///
+/// Tests use two different type-parameter spellings (`T` and `K`) to prove the rule is
+/// structural and not tied to any specific identifier name.
+#[test]
+fn jsx_component_type_application_no_ts2786() {
+    // Minimal React namespace with complex (multi-construct) ComponentClass — these
+    // overloaded constructors are what the `callsOnComplexSignatures` pattern exercises.
+    let make_source = |tp: &str, jsx_tag: &str| {
+        format!(
+            r#"
+        declare namespace JSX {{
+            interface Element extends React.ReactElement<any> {{}}
+            interface ElementClass extends React.Component<any> {{ render(): any; }}
+            interface ElementAttributesProperty {{ props: {{}}; }}
+            interface IntrinsicElements {{}}
+        }}
+        declare namespace React {{
+            type ReactNode = ReactElement<any> | string | number | null | undefined;
+            interface ReactElement<{tp}> {{ props: {tp}; }}
+            interface Component<{tp}> {{
+                props: {tp};
+                render(): ReactNode;
+            }}
+            interface ComponentClass<{tp} = {{}}> {{
+                new(props: {tp}, context?: any): Component<{tp}>;
+                new(props: {tp}): Component<{tp}>;
+            }}
+            interface FunctionComponent<{tp} = {{}}> {{
+                (props: {tp}, context?: any): ReactElement<any> | null;
+            }}
+            type ComponentType<{tp} = {{}}> = ComponentClass<{tp}> | FunctionComponent<{tp}>;
+        }}
+        interface Props {{ x?: number; }}
+        declare var elem: React.ComponentType<Props>;
+        const _ = <{jsx_tag} />;
+        "#
+        )
+    };
+
+    // Shape 1: type-param spelled `T` — ComponentType<T> Application
+    let src1 = make_source("T", "elem");
+    let d1 = check_jsx_codes(&src1);
+    assert!(
+        !d1.contains(&2786),
+        "ComponentType<T> Application must not emit TS2786, got: {d1:?}"
+    );
+
+    // Shape 2: type-param spelled `K` — proves the rule is not tied to `T`
+    let src2 = make_source("K", "elem");
+    let d2 = check_jsx_codes(&src2);
+    assert!(
+        !d2.contains(&2786),
+        "ComponentType<K> Application must not emit TS2786, got: {d2:?}"
+    );
+}
+
+/// `FunctionComponent<P>` used directly as a JSX tag type (Application, not a union) must
+/// not emit TS2786. Its return types create the same cycle-detection risk as ComponentType<P>.
+///
+/// The non-React counterpart (a custom interface with invalid returns) must still emit TS2786
+/// to prove the skip is React-alias-specific, not universal.
+#[test]
+fn jsx_function_component_application_no_ts2786() {
+    let base = r#"
+        declare namespace JSX {
+            interface Element extends React.ReactElement<any> {}
+            interface ElementClass extends React.Component<any> { render(): any; }
+            interface ElementAttributesProperty { props: {}; }
+            interface IntrinsicElements {}
+        }
+        declare namespace React {
+            type ReactNode = ReactElement<any> | string | number | null | undefined;
+            interface ReactElement<P> { props: P; }
+            interface Component<P> { props: P; render(): ReactNode; }
+            interface FunctionComponent<P = {}> {
+                (props: P, context?: any): ReactElement<any> | null;
+            }
+        }
+        interface Props { x?: number; }
+    "#;
+
+    // FunctionComponent<Props> as JSX tag — must not emit TS2786
+    let src_good =
+        format!("{base} declare var fc: React.FunctionComponent<Props>; const _ = <fc />;");
+    let d_good = check_jsx_codes(&src_good);
+    assert!(
+        !d_good.contains(&2786),
+        "FunctionComponent<Props> Application must not emit TS2786, got: {d_good:?}"
+    );
+
+    // Custom non-React callable that returns a wrong type — must still emit TS2786
+    let src_bad = format!(
+        r#"{base}
+        interface NonReactSfc {{
+            (props: Props): {{ notAnElement: true }};
+        }}
+        declare var bad: NonReactSfc;
+        const _ = <bad />;
+        "#
+    );
+    let d_bad = check_jsx_codes(&src_bad);
+    assert!(
+        d_bad.contains(&2786),
+        "Non-React callable with invalid return type must still emit TS2786, got: {d_bad:?}"
     );
 }


### PR DESCRIPTION
## Summary

- `ComponentType<P>`, `FunctionComponent<P>`, and other React alias Application types are not a union in the `TypeData` sense, but they evaluate to unions whose members are React alias applications.
- The previous `is_union` guard only matched literal union `TypeData`; Application types like `ComponentType<Props>` went through the return-type check. The recursive `ReactElement<P> ↔ ComponentClass<P>/SFC<P>` assignability queries then triggered cycle-detection false positives, emitting a spurious TS2786.
- Fix: detect React alias applications via the existing `is_react_jsx_component_alias_application(component_type)` helper and combine into `is_union_like`, so Application types get the same cycle-avoidance skip that direct unions get.

**Structural rule:** When `component_type` is a React alias application (`ComponentType<P>`, `FunctionComponent<P>`, `ComponentClass<P>`, etc.), treat it as union-like so its expanded members are skipped by the same cycle-avoidance guard that protects direct unions.

## Changes

- `crates/tsz-checker/src/checkers/jsx/extraction.rs`: In `check_jsx_component_return_type`, introduce `is_react_alias_application` detection and `is_union_like = is_union || is_react_alias_application`. Replace `is_union` with `is_union_like` in the member-skip guard.
- `crates/tsz-checker/src/checkers/jsx/tests.rs`: Add two new unit tests:
  1. `jsx_component_type_application_no_ts2786`: Verifies `ComponentType<T>` and `ComponentType<K>` (two different type-param spellings to prove the structural rule, not just the spelling) don't emit TS2786. Uses a multi-construct `ComponentClass` with two `new()` overloads.
  2. `jsx_function_component_application_no_ts2786`: Verifies `FunctionComponent<Props>` Application doesn't emit TS2786, but a custom non-React callable with invalid return type (`NonReactSfc`) still correctly emits TS2786.

## Test plan

- [ ] Unit tests: `cargo nextest run -p tsz_checker -E 'test(jsx_component_type_application_no_ts2786)'`
- [ ] Unit tests: `cargo nextest run -p tsz_checker -E 'test(jsx_function_component_application_no_ts2786)'`
- [ ] Draft CI: lint, dist-fast build, unit tests pass
- [ ] Ready-for-review CI: conformance, emit, fourslash, WASM suites pass (no regressions)

## Track

Checker / JSX conformance

## Invariant

TS2786 must not be emitted for components typed as React alias Application types (`ComponentType<P>`, `FunctionComponent<P>`, `ComponentClass<P>`). The fix operates structurally via `is_react_jsx_component_alias_application`, not by matching user-chosen names.

## Scope

Narrow: only `check_jsx_component_return_type` in `extraction.rs` + two new unit tests.

## Project Corpus Impact

- Row: n/a (no project-corpus fixture for this exact pattern)
- Bug family: TS2786 false-positive on React alias Application types
- Evidence: new unit tests `jsx_component_type_application_no_ts2786` and `jsx_function_component_application_no_ts2786` covering the structural rule with multiple type-parameter spellings.

## Verification

Local: changes compile and unit tests covering the fix are included.
CI: conformance suite will verify no regressions.

## Coordination Notes

AgentName: claude-sonnet-4-6 (remote/beautiful-maxwell-kzYKJ)
No overlapping open PRs found for this fix area at time of creation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzfmEYh6pCUzaLK6n8Q8Wj)_
