### PR TITLE
refactor(checker): route call return relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -2369,7 +2369,7 @@ impl<'a> CheckerState<'a> {
             && return_type != TypeId::VOID
             && return_type != TypeId::UNDEFINED
             && return_type != TypeId::NEVER
-            && self.is_assignable_to(return_type, target)
+            && self.diagnostic_relation_boolean_guard(return_type, target)
         {
             return true;
         }
@@ -2385,7 +2385,7 @@ impl<'a> CheckerState<'a> {
             if construct_return != TypeId::VOID
                 && construct_return != TypeId::UNDEFINED
                 && construct_return != TypeId::NEVER
-                && self.is_assignable_to(construct_return, target)
+                && self.diagnostic_relation_boolean_guard(construct_return, target)
             {
                 return true;
             }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        72,
+        70,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
AgentName: M1-B

## Parent / Child
- Parent: #9247 (`codex/m1pd2-comparability-relation-guards-20260520`)
- Child: #9489 (`codex/m1pd2-enum-override-relation-guard-20260520`)
- Stack root blocker: #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.

## Structural Rule
When assignability diagnostics check whether a callable or construct signature return type can satisfy a target type for diagnostic shaping, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
This is checker diagnostic orchestration inside `assignability/assignability_diagnostics.rs`. The existing guard delegates to the same assignability implementation today, so this slice is behavior-preserving and only makes diagnostic-local predicate debt visible to the #8227 ratchet.

## Scope
- Routes the call-signature return and construct-signature return probes in `call_construct_source_matches_target` through `diagnostic_relation_boolean_guard`.
- Ratchets the raw diagnostic assignability predicate cap from 72 to 70 on top of #9247.
- Leaves policy-distinct raw relation paths unchanged: bivariant checks, env-aware checks, no-weak checks, solver-internal calls, and non-diagnostic checker flows.

## Adjacent Cases
- Callable sources with non-void returns still match the target only when the return type is assignable to that target.
- Construct-signature sources still use the first construct return type and preserve the same void/undefined/never exclusions.
- Non-callable/non-construct sources still fall through without this suppression.
- Env-aware and policy-specific diagnostic relation probes remain separate and are not folded into this slice.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / call return relation guards
- Evidence: behavior-preserving helper routing only; `diagnostic_relation_boolean_guard` delegates to the same assignability implementation today. Local verification covered the focused arch ratchet test, full architecture guard, formatter, diff check, and checker build.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-comparability-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Draft only to preserve stack order. I did not add a `WIP` label.
- AgentName: M1-B refreshed this draft onto current #9247 head `689d3b9ac88b8956b22f88a363d686ee57885253`; current #9487 head is `d13a631d06b024c30cd8986dfeaad7a5247b1fe9`.
- Child #9489 is based on this refreshed head; next owner/action is to inspect #9489 mergeability/CI and restack the next child if needed.
- Child #9491 continues the raw diagnostic relation guard ratchet above #9489.
- Child-only diff relative to #9247 is `crates/tsz-checker/src/assignability/assignability_diagnostics.rs` plus `scripts/arch/arch_guard.py`.