### PR TITLE
refactor(checker): route enum override relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -964,7 +964,9 @@ impl<'a> CheckerState<'a> {
                 let structural_target =
                     crate::query_boundaries::common::enum_member_type(self.ctx.types, target)
                         .unwrap_or(target);
-                return Some(self.is_assignable_to(source_literal, structural_target));
+                return Some(
+                    self.diagnostic_relation_boolean_guard(source_literal, structural_target),
+                );
             }
             return None;
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        70,
+        69,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9487 (`codex/m1pd2-call-return-relation-guards-20260520`)
Child: #9491 (`codex/m1pd2-iterator-value-relation-guard-20260520`)

## Structural Rule
When assignability diagnostics decide whether a numeric enum literal initializer structurally satisfies an enum member target for diagnostic override shaping, that boolean relation probe should route through `diagnostic_relation_boolean_guard` instead of a raw `is_assignable_to` call.

## Owner Layer
Checker diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Numeric enum type target with a numeric literal initializer.
- Numeric enum member target with an equivalent literal initializer.
- Non-number-like initializer path, which still bypasses the override.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-call-return-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Draft because this is stacked above #9487 and the existing M1-B relation-routing stack.
- #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- AgentName: M1-B refreshed this draft onto current #9487 head `d13a631d06b024c30cd8986dfeaad7a5247b1fe9`; current #9489 head is `bb2b9482701be8e0fbb35c9b132ba57fbd623815`.
- Child #9491 is based on this refreshed head; next owner/action is to inspect #9491 mergeability/CI and restack the next child if needed.
- Current child-only diff relative to #9487 is `crates/tsz-checker/src/assignability/assignability_diagnostics.rs` plus `scripts/arch/arch_guard.py`.