### PR TITLE
refactor(checker): route iterator value relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -2468,7 +2468,7 @@ impl<'a> CheckerState<'a> {
         }
         let value_type = value_prop.type_id;
 
-        !self.is_assignable_to(TypeId::UNDEFINED, value_type)
+        !self.diagnostic_relation_boolean_guard(TypeId::UNDEFINED, value_type)
     }
 
     fn iterator_result_application_args(&self, type_id: TypeId) -> Option<Vec<TypeId>> {

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        69,
+        68,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9489 (`codex/m1pd2-enum-override-relation-guard-20260520`)
Child: #9493 (`codex/m1pd2-callback-narrowing-relation-guard-20260520`)

## Structural Rule
When assignability diagnostics decide whether an `IteratorResult` target's required `value` property rejects `undefined` for diagnostic mismatch shaping, that boolean relation probe should route through `diagnostic_relation_boolean_guard` instead of a raw `is_assignable_to` call.

## Owner Layer
Checker diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- `IteratorResult<T, undefined>` source with a target requiring a non-optional `value` property.
- Required target `value` types that accept `undefined`, which still avoid this mismatch path.
- Optional target `value` properties and non-`IteratorResult` shapes, which still bypass this check.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-enum-override-relation-guard-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Draft because this is stacked above #9489 and the existing M1-B relation-routing stack.
- #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- AgentName: M1-B refreshed this draft onto current #9489 head `bb2b9482701be8e0fbb35c9b132ba57fbd623815`; current #9491 head is `2c75bc0dbb8aee7b3d73d406388c9ad5963528e0`.
- Child #9493 is based on this refreshed head; next owner/action is to inspect #9493 mergeability/CI and restack the next child if needed.
- Current child-only diff relative to #9489 is `crates/tsz-checker/src/assignability/assignability_diagnostics.rs` plus `scripts/arch/arch_guard.py`.