### PR TITLE
refactor(checker): route callback narrowing relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1219,7 +1219,7 @@ impl<'a> CheckerState<'a> {
             && crate::query_boundaries::common::is_callable_type(self.ctx.types, source)
             && crate::query_boundaries::common::is_callable_type(self.ctx.types, target)
             && !self.callable_has_own_generic_signatures(source)
-            && self.ctx.types.is_assignable_to(target, source)
+            && self.diagnostic_relation_boolean_guard(target, source)
             && self.callable_params_contain_type_param_intersection(source)
         {
             return true;

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        68,
+        67,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9491 (`codex/m1pd2-iterator-value-relation-guard-20260520`)
Child: #9494 (`codex/m1pd2-jsx-render-relation-guards-20260520`)

## Structural Rule
When TS2345 diagnostic suppression checks whether the concrete expected callback type is assignable to a narrowed callback source whose parameters contain type-parameter intersections, that boolean relation probe should route through `diagnostic_relation_boolean_guard` instead of `self.ctx.types.is_assignable_to`.

## Owner Layer
Checker diagnostic orchestration. This keeps the existing suppression predicate in the checker, but routes the relation question through the shared diagnostic relation boundary. It does not change solver relation policy; the guard delegates to the same assignability implementation today.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Callback sources whose parameters contain intersections involving type parameters.
- Non-generic target callback types checked in the reverse assignability direction for suppression.
- Standalone type-parameter callbacks and callbacks with own generic signatures, which still bypass this suppression.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-iterator-value-relation-guard-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Draft because this is stacked above #9491 and the existing M1-B relation-routing stack.
- #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- AgentName: M1-B refreshed this draft onto current #9491 head `2c75bc0dbb8aee7b3d73d406388c9ad5963528e0`; current #9493 head is `dfbe0b903f12e69e4440fe13cc5eb8a1aa12d0d3`.
- Child #9494 is based on this refreshed head; next owner/action is to inspect #9494 mergeability/CI and restack the next child if needed.
- Child #9497 continues the raw diagnostic relation guard ratchet above #9494.
- Current child-only diff relative to #9491 is `crates/tsz-checker/src/assignability/assignability_diagnostics.rs` plus `scripts/arch/arch_guard.py`.