### PR TITLE
refactor(checker): route jsx render relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -739,7 +739,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if self.is_assignable_to(source_render, target_render) {
+        if self.diagnostic_relation_boolean_guard(source_render, target_render) {
             return true;
         }
 
@@ -750,9 +750,9 @@ impl<'a> CheckerState<'a> {
         }
 
         source_returns.iter().any(|&source_return| {
-            target_returns
-                .iter()
-                .any(|&target_return| self.is_assignable_to(source_return, target_return))
+            target_returns.iter().any(|&target_return| {
+                self.diagnostic_relation_boolean_guard(source_return, target_return)
+            })
         })
     }
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        67,
+        65,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9493 (`codex/m1pd2-callback-narrowing-relation-guard-20260520`)
Child: #9497 (`codex/m1pd2-jsx-elementtype-relation-guard-20260520`)

## Structural Rule
When JSX TS2786 return checking decides whether a component instance `render` type, or one of its callable return types, satisfies the target `JSX.ElementClass.render` type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Direct `render` property type compatibility between a component instance and `JSX.ElementClass`.
- Callable `render` return type compatibility when direct render-type compatibility is not enough.
- Missing render types or empty callable return sets, which still bypass this relation path.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-callback-narrowing-relation-guard-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9493 head `dfbe0b903f12e69e4440fe13cc5eb8a1aa12d0d3`; current #9494 head is `c8a78ed3efad7fa13e423251a4ed913f80a3e256`.
- Draft because this is stacked above #9493 and the existing M1-B relation-routing stack.
- #9236 remains draft after an external/shared queue action re-parked it after M1-B previously marked it ready.
- Child #9497 is based on this refreshed head; next owner/action is to inspect #9497 mergeability/CI and restack the next child if needed.
- Current child-only diff relative to #9493 is `crates/tsz-checker/src/checkers/jsx/extraction.rs` plus `scripts/arch/arch_guard.py`.