### PR TITLE
refactor(checker): route jsx element type relation guard

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -790,7 +790,7 @@ impl<'a> CheckerState<'a> {
                 element_type,
                 TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN | TypeId::NEVER
             ) {
-                if self.is_assignable_to(component_type, element_type) {
+                if self.diagnostic_relation_boolean_guard(component_type, element_type) {
                     return;
                 }
                 self.report_invalid_jsx_component_return_type(tag_name_idx);

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        65,
+        64,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9494 (`codex/m1pd2-jsx-render-relation-guards-20260520`)
Child: #9498 (`codex/m1pd2-jsx-return-relation-guards-20260520`)

## Structural Rule
When JSX TS2786 checking uses a user-defined `JSX.ElementType` as the authoritative component constraint, the boolean relation probe from the component type to `JSX.ElementType` should route through `diagnostic_relation_boolean_guard` instead of a raw `is_assignable_to` call.

## Owner Layer
Checker JSX diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Function components checked against a user-defined `JSX.ElementType`.
- Class components checked against a user-defined `JSX.ElementType`.
- Missing or top-like `JSX.ElementType` definitions, which still fall through to the older return-type checks.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-render-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto #9494 head `c8a78ed3efad7fa13e423251a4ed913f80a3e256`; current head is `fe3dbec8af4e8cb291ef4809c1d945c36eee0e65`.
- Draft because this is stacked above #9494 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9498 is based on this refreshed head; current #9498 head is `234f5869d21129bd1f279cda5114325ab9f15028` and is the next branch to inspect/restack.
- Child #9500 continues the raw diagnostic relation guard ratchet above #9498.