### PR TITLE
refactor(checker): route jsx return relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -898,7 +898,9 @@ impl<'a> CheckerState<'a> {
                             if return_type != TypeId::NEVER && self.ctx.strict_null_checks() {
                                 all_valid = false;
                             }
-                        } else if !self.is_assignable_to(non_null_return, element_type) {
+                        } else if !self
+                            .diagnostic_relation_boolean_guard(non_null_return, element_type)
+                        {
                             all_valid = false;
                         }
                     }
@@ -972,7 +974,7 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 ret
                             };
-                            self.is_assignable_to(check_ret, t)
+                            self.diagnostic_relation_boolean_guard(check_ret, t)
                                 || (!is_call_sig
                                     && self
                                         .jsx_construct_return_can_use_render_fallback(check_ret, t))
@@ -1043,7 +1045,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if !self.is_assignable_to(non_null_return, jsx_element_type) {
+        if !self.diagnostic_relation_boolean_guard(non_null_return, jsx_element_type) {
             self.report_invalid_jsx_component_return_type(tag_name_idx);
         }
     }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        64,
+        61,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9497 (`codex/m1pd2-jsx-elementtype-relation-guard-20260520`)
Child: #9500 (`codex/m1pd2-jsx-overload-relation-guards-20260520`)

## Structural Rule
When JSX TS2786 return checking decides whether a function, call signature, construct signature, or final evaluated non-null return type satisfies `JSX.Element` or `JSX.ElementClass`, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Function-shape returns checked against `JSX.Element` after nullish stripping.
- Call and construct signature returns checked against `JSX.Element` / `JSX.ElementClass`.
- Final evaluated function component return checked against `JSX.Element` after nullish stripping.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-elementtype-relation-guard-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9497 head `fe3dbec8af4e8cb291ef4809c1d945c36eee0e65`; current head is `90ce30d2e01edfa71ae84312037e769bc9f85c38`.
- Draft because this is stacked above #9497 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9500 is based on this refreshed head and is the next branch to inspect/restack.