### PR TITLE
refactor(checker): route jsx overload relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -415,7 +415,7 @@ impl<'a> CheckerState<'a> {
             // is not assignable to type parameters like `P`, so we can't just assume
             // empty attrs match when the shape can't be resolved.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.is_assignable_to(attrs_type, props_type);
+            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
         };
 
         let has_string_index = shape.string_index.is_some();
@@ -494,7 +494,7 @@ impl<'a> CheckerState<'a> {
             // and explicit-excess checks have already passed, defer to the
             // canonical assignability gate before rejecting the overload.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.is_assignable_to(attrs_type, props_type);
+            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
         }
 
         true
@@ -587,7 +587,7 @@ impl<'a> CheckerState<'a> {
     /// keeps overload matching aligned with the canonical generic-constraint
     /// path without naming any particular helper alias.
     fn jsx_attr_assignable_to_expected(&mut self, attr_type: TypeId, expected: TypeId) -> bool {
-        self.is_assignable_to(attr_type, expected)
+        self.diagnostic_relation_boolean_guard(attr_type, expected)
             || self.jsx_attr_assignable_after_referenced_constraints(attr_type, expected)
     }
 
@@ -633,8 +633,8 @@ impl<'a> CheckerState<'a> {
         }
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.is_assignable_to(restricted_evaluated, expected)
-            || self.is_assignable_to(restricted, expected)
+        self.diagnostic_relation_boolean_guard(restricted_evaluated, expected)
+            || self.diagnostic_relation_boolean_guard(restricted, expected)
     }
 
     /// Build an object type from collected JSX attribute info.

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        61,
+        56,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9498 (`codex/m1pd2-jsx-return-relation-guards-20260520`)
Child: #9504 (`codex/m1pd2-jsx-spread-relation-guards-20260520`)

## Structural Rule
When JSX overload applicability checks whether synthesized attributes or individual JSX attribute types satisfy component props, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic and overload orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/overloads.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Fallback object assignability when the props shape cannot be resolved.
- Fallback object assignability after pointwise mismatch checks on generic props.
- Attribute type and constraint-restricted attribute type checks against expected prop types.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-return-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9498 head `90ce30d2e01edfa71ae84312037e769bc9f85c38`; current head is `5e0916ad5f48b190925311627c819c76867d95c7`.
- Draft because this is stacked above #9498 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9504 is based on this refreshed head and is the next branch to inspect/restack.