### PR TITLE
refactor(checker): route jsx spread relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -93,7 +93,9 @@ impl<'a> CheckerState<'a> {
         // For generic spreads, the relation can be too optimistic; keep them on the
         // normalized JSX spread path below so we can classify TS2322 vs TS2741 from
         // the apparent/object shape first.
-        if !spread_has_type_params && self.is_assignable_to(spread_type, props_type) {
+        if !spread_has_type_params
+            && self.diagnostic_relation_boolean_guard(spread_type, props_type)
+        {
             return false;
         }
 
@@ -178,7 +180,7 @@ impl<'a> CheckerState<'a> {
                 // so the spread's type issues are masked.
                 return false;
             }
-            if self.is_assignable_to(spread_type, props_type) {
+            if self.diagnostic_relation_boolean_guard(spread_type, props_type) {
                 return false;
             }
             let spread_name = self.format_type(spread_source_type);
@@ -348,7 +350,7 @@ impl<'a> CheckerState<'a> {
                 prop.type_id
             };
 
-            if !self.is_assignable_to(source_type, expected_type) {
+            if !self.diagnostic_relation_boolean_guard(source_type, expected_type) {
                 // This property has a type mismatch.
                 // Check if it will be overwritten by a later explicit attribute.
                 if overridden_names.contains(prop_name.as_str()) {
@@ -389,7 +391,7 @@ impl<'a> CheckerState<'a> {
         let mut has_type_mismatch = has_unfixable_mismatch;
         if !has_type_mismatch
             && spread_has_type_params
-            && !self.is_assignable_to(resolved_spread, props_type)
+            && !self.diagnostic_relation_boolean_guard(resolved_spread, props_type)
         {
             has_type_mismatch = true;
         }
@@ -398,7 +400,7 @@ impl<'a> CheckerState<'a> {
         // resolved spread type is assignable to the props type.
         if has_type_mismatch
             && spread_has_type_params
-            && self.is_assignable_to(resolved_spread, props_type)
+            && self.diagnostic_relation_boolean_guard(resolved_spread, props_type)
         {
             has_type_mismatch = false;
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        56,
+        51,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9500 (`codex/m1pd2-jsx-overload-relation-guards-20260520`)
Child: #9505 (`codex/m1pd2-jsx-generic-spread-relation-guards-20260520`)

## Structural Rule
When JSX spread diagnostics classify whether a spread object or one of its spread properties is assignable to the target props type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic and spread orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/spread.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Concrete spread fast-path compatibility against props.
- Generic spread whole-type compatibility when object-shape extraction cannot prove safety.
- Per-property spread source/expected checks and resolved-spread suppression checks.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-overload-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this slice onto current #9500 head `5e0916ad5f48b190925311627c819c76867d95c7`; current head is `b24c2fc318aa70153a5ea68799160cae7ec1cf0e`.
- Draft because this is stacked above #9500 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9505 is based on this refreshed head; current #9505 head is `57946c4c23db031c102573de1096afbd171a5ade` and is the next branch to inspect/restack.
- Child #9506 continues the raw diagnostic relation guard ratchet above #9505.