### PR TITLE
refactor(checker): route jsx generic spread relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -63,7 +63,7 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
-            !self.is_assignable_to(*actual_type, expected_type)
+            !self.diagnostic_relation_boolean_guard(*actual_type, expected_type)
         });
 
         let has_alias_string_prop_mismatch = provided_attrs.iter().any(|(name, actual_type)| {
@@ -79,7 +79,7 @@ impl<'a> CheckerState<'a> {
 
         if !has_explicit_prop_mismatch
             && !has_alias_string_prop_mismatch
-            && self.is_assignable_to(attrs_type, props_type)
+            && self.diagnostic_relation_boolean_guard(attrs_type, props_type)
         {
             return false;
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        51,
+        49,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9504 (`codex/m1pd2-jsx-spread-relation-guards-20260520`)
Child: #9506 (`codex/m1pd2-jsx-props-validation-relation-guards-20260520`)

## Structural Rule
When JSX generic spread diagnostics decide whether explicit attributes mismatch the target props type or whether the synthesized attributes object already satisfies props, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic orchestration for generic spread reporting. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Explicit JSX attributes combined with generic spread members.
- Per-attribute expected write type mismatch detection.
- Whole synthesized attribute-object suppression when attributes are already assignable to props.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-spread-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9504 head `b24c2fc318aa70153a5ea68799160cae7ec1cf0e`; current head is `3f12a95fe6ef92dc9dc46f989596d0042317bc62`.
- Child #9506 is based on this refreshed head; current #9506 head is `7d53ae6699768045590a9a27ce4927d9a07835f0` and is the next branch to inspect/restack.
- Draft because this is stacked above #9504 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9506 continues the raw diagnostic relation guard ratchet above this branch; next continuation after that is #9509.