### PR TITLE
refactor(checker): route jsx props validation relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -220,7 +220,7 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
-            !self.is_assignable_to(*attr_type, expected_type)
+            !self.diagnostic_relation_boolean_guard(*attr_type, expected_type)
         });
         let explicit_type = self.build_jsx_provided_attrs_object_type(&explicit_attrs);
         generic_spreads.push(explicit_type);
@@ -238,7 +238,9 @@ impl<'a> CheckerState<'a> {
                     &self.ctx.definition_store,
                     attrs_type,
                 );
-            if !source_retains_explicit_object && self.is_assignable_to(attrs_type, props_type) {
+            if !source_retains_explicit_object
+                && self.diagnostic_relation_boolean_guard(attrs_type, props_type)
+            {
                 return;
             }
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        49,
+        47,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9505 (`codex/m1pd2-jsx-generic-spread-relation-guards-20260520`)
Child: #9509 (`codex/m1pd2-jsx-props-resolution-relation-guards-20260520`)

## Structural Rule
When JSX props validation decides whether explicit attributes mismatch the target props type or whether the synthesized attributes object already satisfies props, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX props validation diagnostics. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/validation.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Generic JSX spreads combined with explicit attributes.
- Per-attribute write-type mismatch checks.
- Whole synthesized attribute-object suppression when the source does not retain an explicit anonymous object surface.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-generic-spread-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9505 head `3f12a95fe6ef92dc9dc46f989596d0042317bc62`; current head is `1151d7c348487c6fac937cbdc27efffa23132b13`.
- Child #9509 is based on this refreshed head; #9509 current head is `4599948c5a94941b8d90659d7d9f30f05b0c09e0` and is the next branch to inspect/restack.
- Draft because this is stacked above #9505 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9509 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9509 is #9511.