### PR TITLE
refactor(checker): route jsx props resolution relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -584,7 +584,10 @@ impl<'a> CheckerState<'a> {
                     }
                     if let Some(expected_type) = expected_special_type {
                         if attr_data.initializer.is_none() {
-                            if !self.is_assignable_to(TypeId::BOOLEAN_TRUE, expected_type) {
+                            if !self.diagnostic_relation_boolean_guard(
+                                TypeId::BOOLEAN_TRUE,
+                                expected_type,
+                            ) {
                                 use crate::diagnostics::{
                                     diagnostic_codes, diagnostic_messages, format_message,
                                 };
@@ -850,7 +853,8 @@ impl<'a> CheckerState<'a> {
                     if let Some(entry) = provided_attrs.last_mut() {
                         entry.1 = TypeId::BOOLEAN_TRUE;
                     }
-                    if !self.is_assignable_to(TypeId::BOOLEAN_TRUE, expected_type) {
+                    if !self.diagnostic_relation_boolean_guard(TypeId::BOOLEAN_TRUE, expected_type)
+                    {
                         use crate::diagnostics::{
                             diagnostic_codes, diagnostic_messages, format_message,
                         };
@@ -992,7 +996,7 @@ impl<'a> CheckerState<'a> {
                     if is_special_named_attr {
                         if actual_type != TypeId::ANY
                             && actual_type != TypeId::ERROR
-                            && !self.is_assignable_to(actual_type, expected_type)
+                            && !self.diagnostic_relation_boolean_guard(actual_type, expected_type)
                         {
                             needs_special_attr_object_assignability = true;
                         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        47,
+        44,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9506 (`codex/m1pd2-jsx-props-validation-relation-guards-20260520`)
Child: #9511 (`codex/m1pd2-jsx-props-object-relation-guards-20260520`)

## Structural Rule
When JSX props resolution decides whether a shorthand attribute or special named attribute should produce or defer a props assignability diagnostic, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX props resolution diagnostics. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/resolution.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Special JSX attributes without an initializer where `true` is checked against the expected type.
- Ordinary shorthand JSX attributes where `true` is checked before emitting TS2322.
- Special named attributes that defer to the synthesized attribute-object assignability diagnostic.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-props-validation-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9506 head `1151d7c348487c6fac937cbdc27efffa23132b13`; current head is `03c0eccd0729545348a9e831683906e6163661c3`.
- Child #9511 is based on this refreshed head; #9511 current head is `9b06a0f68b226a0249b54f29fa376ad6273d9ef7` and is the next branch to inspect/restack.
- Draft because this is stacked above #9506 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9511 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9511 is #9514.