### PR TITLE
refactor(checker): route jsx props object relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -1497,7 +1497,7 @@ impl<'a> CheckerState<'a> {
             && !suppress_for_primitive_props_with_missing_ia_required
         {
             let attrs_type = self.build_jsx_provided_attrs_object_type(&provided_attrs);
-            if !self.is_assignable_to(attrs_type, props_type) {
+            if !self.diagnostic_relation_boolean_guard(attrs_type, props_type) {
                 self.report_jsx_synthesized_props_assignability_error(
                     attrs_type,
                     &display_target,
@@ -1554,9 +1554,9 @@ impl<'a> CheckerState<'a> {
         // Checking a synthesized object (which loses the type parameter identity)
         // against the type parameter would produce a false TS2322.
         let spread_satisfies_type_param = props_is_type_param
-            && spread_entries
-                .iter()
-                .any(|&(spread_type, _, _, _)| self.is_assignable_to(spread_type, props_type));
+            && spread_entries.iter().any(|&(spread_type, _, _, _)| {
+                self.diagnostic_relation_boolean_guard(spread_type, props_type)
+            });
         let reported_type_param_assignability = if !reported_custom_children_assignability
             && !reported_special_attr_assignability
             && !reported_class_missing_props_assignability
@@ -1568,7 +1568,7 @@ impl<'a> CheckerState<'a> {
             && !spread_satisfies_type_param
         {
             let attrs_type = self.build_jsx_provided_attrs_object_type(&provided_attrs);
-            if !self.is_assignable_to(attrs_type, props_type) {
+            if !self.diagnostic_relation_boolean_guard(attrs_type, props_type) {
                 // tsc uses just the type parameter name here (e.g. "P"), not the
                 // full "IntrinsicAttributes & P" display target. The IntrinsicAttributes
                 // intersection check for spread attributes is handled separately by
@@ -1639,7 +1639,7 @@ impl<'a> CheckerState<'a> {
                 && self.jsx_props_type_is_library_managed_attributes_application(raw_props_type)
             {
                 let attrs_type = self.build_jsx_provided_attrs_object_type(&provided_attrs);
-                if !self.is_assignable_to(attrs_type, raw_props_type) {
+                if !self.diagnostic_relation_boolean_guard(attrs_type, raw_props_type) {
                     let mut target = self.format_type(raw_props_type);
                     if target.starts_with("LibraryManagedAttributes<")
                         && target.ends_with(", Element>")
@@ -2010,7 +2010,7 @@ impl<'a> CheckerState<'a> {
                     })
                     .collect();
                 let attrs_type = self.ctx.types.factory().object(properties);
-                if self.is_assignable_to(attrs_type, props_type) {
+                if self.diagnostic_relation_boolean_guard(attrs_type, props_type) {
                     return;
                 }
                 // tsc anchors JSX union props errors at the tag name (e.g., <TextComponent>),

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        44,
+        39,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9509 (`codex/m1pd2-jsx-props-resolution-relation-guards-20260520`)
Child: #9514 (`codex/m1pd2-jsx-props-compat-relation-guards-20260520`)

## Structural Rule
When JSX props object diagnostics decide whether synthesized attributes, spread entries, or library-managed raw props already satisfy the target props type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX props object diagnostics. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/resolution.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Synthesized JSX attributes object compatibility against resolved props.
- Type-parameter props diagnostics suppressed when a spread entry already satisfies the target type parameter.
- Library-managed raw props and union props object checks before emitting assignability diagnostics.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-props-resolution-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9509 head `03c0eccd0729545348a9e831683906e6163661c3`; current head is `c247392b43df18250904d971e5feb8d000a4e904`.
- Child #9514 is based on this refreshed head; #9514 current head is `15ce8e3c9c19ab2f8ba1b82b13658a5d4ca9d99b` and is the next branch to inspect/restack.
- Draft because this is stacked above #9509 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9514 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9514 is #9516.