### PR TITLE
refactor(checker): route jsx props compat relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -242,7 +242,8 @@ impl<'a> CheckerState<'a> {
                                 Some(attr_type) => {
                                     *attr_type == TypeId::ANY
                                         || *attr_type == TypeId::ERROR
-                                        || self.is_assignable_to(*attr_type, expected)
+                                        || self
+                                            .diagnostic_relation_boolean_guard(*attr_type, expected)
                                 }
                                 None => expected != TypeId::NEVER && expected != TypeId::ERROR,
                             }
@@ -1188,7 +1189,9 @@ impl<'a> CheckerState<'a> {
                     spread_type,
                 ) {
                     spread_covers_all = true;
-                } else if !skip_prop_checks && self.is_assignable_to(spread_type, props_type) {
+                } else if !skip_prop_checks
+                    && self.diagnostic_relation_boolean_guard(spread_type, props_type)
+                {
                     // The solver reports the spread is structurally assignable to the
                     // whole props type, so all required members are satisfied — including
                     // ones inherited from Object.prototype (toString, valueOf, …) that
@@ -1922,7 +1925,7 @@ impl<'a> CheckerState<'a> {
                         if *attr_type == TypeId::ANY || *attr_type == TypeId::ERROR {
                             return true;
                         }
-                        self.is_assignable_to(*attr_type, expected)
+                        self.diagnostic_relation_boolean_guard(*attr_type, expected)
                     }
                     // PropertyNotFound or other results: still compatible
                     // (excess property checking is separate)

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        39,
+        36,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9511 (`codex/m1pd2-jsx-props-object-relation-guards-20260520`)
Child: #9516 (`codex/m1pd2-jsx-props-display-relation-guards-20260520`)

## Structural Rule
When JSX props compatibility diagnostics decide whether attribute types, spread props, or resolved props objects should suppress a later diagnostic, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX props compatibility diagnostics. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/resolution.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Attribute type compatibility against expected props members.
- Spread prop compatibility checks used to avoid duplicate missing-property diagnostics.
- Resolved provided-attribute compatibility before display-oriented diagnostics.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-props-object-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9511 head `c247392b43df18250904d971e5feb8d000a4e904`; current head is `7f4093f7402968980a81cf9d8916e601a66bd73d`.
- Child #9516 is based on this refreshed head; #9516 current head is `bb33e94fba87cf0ea44a56a73e3dc0a3090ed769` and is the next branch to inspect/restack.
- Draft because this is stacked above #9511 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9516 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9516 is #9517.