### PR TITLE
refactor(checker): route jsx props display relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
@@ -187,8 +187,8 @@ impl<'a> CheckerState<'a> {
         }
         let alias_evaluated = self.evaluate_type_with_env(alias);
         if alias_evaluated != TypeId::ERROR
-            && self.is_assignable_to(alias_evaluated, props_type)
-            && self.is_assignable_to(props_type, alias_evaluated)
+            && self.diagnostic_relation_boolean_guard(alias_evaluated, props_type)
+            && self.diagnostic_relation_boolean_guard(props_type, alias_evaluated)
         {
             self.ctx.types.store_display_alias(props_type, alias);
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -1024,8 +1024,8 @@ impl<'a> CheckerState<'a> {
         {
             let alias_evaluated = self.evaluate_type_with_env(alias_hint);
             if alias_evaluated != TypeId::ERROR
-                && self.is_assignable_to(alias_evaluated, normalized)
-                && self.is_assignable_to(normalized, alias_evaluated)
+                && self.diagnostic_relation_boolean_guard(alias_evaluated, normalized)
+                && self.diagnostic_relation_boolean_guard(normalized, alias_evaluated)
             {
                 self.ctx.types.store_display_alias(normalized, alias_hint);
             }
@@ -1725,7 +1725,7 @@ impl<'a> CheckerState<'a> {
             // Build target: IntrinsicAttributes & spread_type
             let target = self.ctx.types.factory().intersection2(ia_type, spread_type);
 
-            if !self.is_assignable_to(spread_type, target) {
+            if !self.diagnostic_relation_boolean_guard(spread_type, target) {
                 let spread_name = self.format_type(spread_type);
                 let target_name = format!("IntrinsicAttributes & {spread_name}");
                 let message = format_message(
@@ -1862,8 +1862,8 @@ impl<'a> CheckerState<'a> {
             if evaluated != display_type && evaluated != TypeId::ERROR {
                 if let Some(alias_hint) = alias_hint {
                     let alias_evaluated = self.evaluate_type_with_env(alias_hint);
-                    if self.is_assignable_to(alias_evaluated, evaluated)
-                        && self.is_assignable_to(evaluated, alias_evaluated)
+                    if self.diagnostic_relation_boolean_guard(alias_evaluated, evaluated)
+                        && self.diagnostic_relation_boolean_guard(evaluated, alias_evaluated)
                     {
                         self.ctx.types.store_display_alias(evaluated, alias_hint);
                     }
@@ -1890,7 +1890,7 @@ impl<'a> CheckerState<'a> {
     ) -> Option<bool> {
         if !initializer_is_bare_string_literal
             || original_property_type == expected_type
-            || self.is_assignable_to(actual_type, expected_type)
+            || self.diagnostic_relation_boolean_guard(actual_type, expected_type)
         {
             return None;
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        36,
+        28,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9514 (`codex/m1pd2-jsx-props-compat-relation-guards-20260520`)
Child: #9517 (`codex/m1pd2-jsx-children-relation-guards-20260520`)

## Structural Rule
When JSX props display or React alias diagnostics decide whether a source type is already assignable to the expected props/display type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostic display orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs`
- `crates/tsz-checker/src/checkers/jsx/props/validation.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- React alias extraction checks against the expected JSX type.
- Props display alias equivalence checks before storing diagnostic display aliases.
- IntrinsicAttributes spread and bare string literal display suppression checks.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-props-compat-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9514 head `7f4093f7402968980a81cf9d8916e601a66bd73d`; current head is `26626518c915b97c10d2354fb804cce53276bdbe`.
- Child #9517 is based on this refreshed head; #9517 current head is `ca07e83836c6562930bed4232e7502fa0f49bed9` and is the next branch to inspect/restack.
- Draft because this is stacked above #9514 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9517 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9517 is #9518.