### PR TITLE
refactor(checker): route jsx children relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -119,7 +119,8 @@ impl<'a> CheckerState<'a> {
             && precise_children_type != children_type
             && !children_type_is_originally_compound
             && !self.type_requires_multiple_children(children_type)
-            && !self.is_assignable_to(synthesized_children_type, precise_children_type)
+            && !self
+                .diagnostic_relation_boolean_guard(synthesized_children_type, precise_children_type)
         {
             children_type = precise_children_type;
         }
@@ -158,7 +159,10 @@ impl<'a> CheckerState<'a> {
                         && let Some(raw_zero_param_child_type) =
                             self.raw_single_jsx_zero_param_callback_type(attributes_idx)
                         && !matches!(raw_zero_param_child_type, TypeId::ANY | TypeId::ERROR)
-                        && !self.is_assignable_to(raw_zero_param_child_type, children_type)
+                        && !self.diagnostic_relation_boolean_guard(
+                            raw_zero_param_child_type,
+                            children_type,
+                        )
                     {
                         self.check_jsx_single_child_assignable(
                             attributes_idx,
@@ -545,7 +549,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        self.is_assignable_to(actual_child_type, children_type)
+        self.diagnostic_relation_boolean_guard(actual_child_type, children_type)
     }
 
     fn single_jsx_child_is_function_like(&self, attributes_idx: NodeIndex) -> bool {
@@ -1163,7 +1167,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn children_type_accepts_text(&mut self, children_type: TypeId) -> bool {
-        self.is_assignable_to(TypeId::STRING, children_type)
+        self.diagnostic_relation_boolean_guard(TypeId::STRING, children_type)
     }
 
     fn check_jsx_multiple_children_assignable(
@@ -1212,7 +1216,7 @@ impl<'a> CheckerState<'a> {
         if actual_children_type == TypeId::ANY || actual_children_type == TypeId::ERROR {
             return;
         }
-        if self.is_assignable_to(actual_children_type, children_type) {
+        if self.diagnostic_relation_boolean_guard(actual_children_type, children_type) {
             return;
         }
 
@@ -1237,7 +1241,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.is_assignable_to(actual_child_type, children_type) {
+        if self.diagnostic_relation_boolean_guard(actual_child_type, children_type) {
             return;
         }
 
@@ -1409,14 +1413,14 @@ impl<'a> CheckerState<'a> {
             if matches!(actual_child_type, TypeId::ANY | TypeId::ERROR) {
                 continue;
             }
-            if self.is_assignable_to(actual_child_type, expected_child_type) {
+            if self.diagnostic_relation_boolean_guard(actual_child_type, expected_child_type) {
                 continue;
             }
             // Fallback: when a child doesn't match the extracted array element type,
             // also check against the original (unfiltered) children type. This handles
             // cases where the children type is a union including non-array members like
             // `{}` (from ReactFragment) that subsume the child type.
-            if self.is_assignable_to(actual_child_type, original_children_type) {
+            if self.diagnostic_relation_boolean_guard(actual_child_type, original_children_type) {
                 continue;
             }
 
@@ -1507,8 +1511,8 @@ impl<'a> CheckerState<'a> {
 
         let resolved_target = self.resolve_type_for_property_access(target_type);
         let resolved_instance = self.resolve_type_for_property_access(instance_type);
-        if !(self.is_assignable_to(resolved_instance, resolved_target)
-            && self.is_assignable_to(resolved_target, resolved_instance))
+        if !(self.diagnostic_relation_boolean_guard(resolved_instance, resolved_target)
+            && self.diagnostic_relation_boolean_guard(resolved_target, resolved_instance))
         {
             return false;
         }
@@ -1700,7 +1704,7 @@ impl<'a> CheckerState<'a> {
         // Array<ReactNode>` is a member of the union, but we can't detect it structurally
         // because it's an interface extending Array rather than a direct Array type.
         let array_of_children = self.ctx.types.factory().array(type_id);
-        if self.is_assignable_to(array_of_children, type_id) {
+        if self.diagnostic_relation_boolean_guard(array_of_children, type_id) {
             return true;
         }
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        28,
+        17,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9516 (`codex/m1pd2-jsx-props-display-relation-guards-20260520`)
Child: #9518 (`codex/m1pd2-assignability-env-relation-guards-20260520`)

## Structural Rule
When JSX children diagnostics decide whether a child, spread child, synthesized children object, or children-related alias shape is assignable to the expected children/props type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX children diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/children.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Child expression compatibility against expected children type.
- Spread and text child compatibility checks.
- Synthesized children object and JSX element instance display compatibility checks.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-props-display-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9516 head `26626518c915b97c10d2354fb804cce53276bdbe`; current head is `a05edd947973f71e43980ada9855d10eaf3baeef`.
- Child #9518 is based on this refreshed head; #9518 current head is `c4ced366706c06495531b3afc53644fcc36b1152` and is the next branch to inspect/restack.
- Draft because this is stacked above #9516 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9518 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9518 is #9520.