### PR TITLE
refactor(checker): route assignability env relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1467,8 +1467,8 @@ impl<'a> CheckerState<'a> {
         evaluated != target
             && evaluated != TypeId::UNKNOWN
             && evaluated != TypeId::ERROR
-            && (self.is_assignable_to_with_env(source, evaluated)
-                || self.is_assignable_to_with_env(source, contextual)
+            && (self.diagnostic_relation_boolean_guard_with_env(source, evaluated)
+                || self.diagnostic_relation_boolean_guard_with_env(source, contextual)
                 || self.self_referential_mapped_intersection_accepts_object_literal(
                     source, evaluated, arg_idx,
                 ))
@@ -1501,7 +1501,7 @@ impl<'a> CheckerState<'a> {
             let Some(shape) =
                 crate::query_boundaries::common::object_shape_for_type(self.ctx.types, member)
             else {
-                if !self.is_assignable_to_with_env(source, member) {
+                if !self.diagnostic_relation_boolean_guard_with_env(source, member) {
                     return false;
                 }
                 continue;
@@ -1509,9 +1509,9 @@ impl<'a> CheckerState<'a> {
 
             allowed_keys.extend(shape.properties.iter().map(|prop| prop.name));
             if shape.string_index.is_some() || shape.number_index.is_some() {
-                return self.is_assignable_to_with_env(source, member);
+                return self.diagnostic_relation_boolean_guard_with_env(source, member);
             }
-            if !self.is_assignable_to_with_env(source, member) {
+            if !self.diagnostic_relation_boolean_guard_with_env(source, member) {
                 return false;
             }
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        17,
+        12,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9517 (`codex/m1pd2-jsx-children-relation-guards-20260520`)
Child: #9520 (`codex/m1pd2-jsx-component-props-relation-guards-20260520`)

## Structural Rule
When assignability diagnostic setup only needs to know whether source and target types are already compatible under the current diagnostic environment, those boolean relation probes should route through `diagnostic_relation_boolean_guard_with_env` instead of raw `is_assignable_to_with_env` calls.

## Owner Layer
Checker assignability diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Assignability diagnostic environment checks for already-compatible source/target pairs.
- Suppression of redundant nested diagnostic work when the relation succeeds.
- Union member/object-shape diagnostic filtering under the current type environment.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-children-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9517 head `a05edd947973f71e43980ada9855d10eaf3baeef`; current head is `58af75abd3c1820ab3816a7c098a3393ad5f5cc6`.
- Child #9520 is based on this refreshed head; #9520 current head is `4d2c91b9f00808a9ac790efe17452e931245a19d` and is the next branch to inspect/restack.
- Draft because this is stacked above #9517 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9520 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9520 is #9521.