### PR TITLE
refactor(checker): route jsx component props relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -693,7 +693,7 @@ impl<'a> CheckerState<'a> {
                 if !crate::query_boundaries::common::is_template_literal_type(
                     self.ctx.types,
                     key_type,
-                ) || !self.is_assignable_to(tag_literal, key_type)
+                ) || !self.diagnostic_relation_boolean_guard(tag_literal, key_type)
                 {
                     continue;
                 }
@@ -714,15 +714,17 @@ impl<'a> CheckerState<'a> {
             let mut i = 0;
             while i < best_matches.len() {
                 let (best_key, _) = best_matches[i];
-                let candidate_more_specific = self.is_assignable_to(candidate_key, best_key)
-                    && !self.is_assignable_to(best_key, candidate_key);
+                let candidate_more_specific = self
+                    .diagnostic_relation_boolean_guard(candidate_key, best_key)
+                    && !self.diagnostic_relation_boolean_guard(best_key, candidate_key);
                 if candidate_more_specific {
                     best_matches.swap_remove(i);
                     continue;
                 }
 
-                let best_more_specific = self.is_assignable_to(best_key, candidate_key)
-                    && !self.is_assignable_to(candidate_key, best_key);
+                let best_more_specific = self
+                    .diagnostic_relation_boolean_guard(best_key, candidate_key)
+                    && !self.diagnostic_relation_boolean_guard(candidate_key, best_key);
                 if best_more_specific {
                     candidate_is_best = false;
                     break;
@@ -851,7 +853,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let tag_type = self.ctx.types.literal_string(tag);
-        if self.is_assignable_to(tag_type, element_type) {
+        if self.diagnostic_relation_boolean_guard(tag_type, element_type) {
             return;
         }
 
@@ -894,7 +896,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
         let tag_type = self.ctx.types.literal_string(tag);
-        if self.is_assignable_to(tag_type, evaluated) {
+        if self.diagnostic_relation_boolean_guard(tag_type, evaluated) {
             return;
         }
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        12,
+        5,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9518 (`codex/m1pd2-assignability-env-relation-guards-20260520`)
Child: #9521 (`codex/m1pd2-jsx-fallback-diagnostic-relation-guards-20260520`)

## Structural Rule
When JSX component props orchestration decides whether a source props type, synthesized props object, or JSX tag literal is already assignable to the expected component props type, those boolean relation probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX component props diagnostic orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Component props compatibility before emitting JSX attribute diagnostics.
- Template-literal and tag-literal specificity checks for intrinsic component matching.
- Synthesized props object checks used to suppress duplicate diagnostics.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-assignability-env-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9518 head `58af75abd3c1820ab3816a7c098a3393ad5f5cc6`; current head is `c06600f2645536e635984a72cf4b101a86d18439`.
- Child #9521 is based on this refreshed head; #9521 current head is `ec430781a11752806625f978ed476e46bcb8dc28` and is the next branch to inspect/restack.
- Draft because this is stacked above #9518 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9521 continues the raw diagnostic relation guard ratchet above this branch; next continuation after #9521 is #9522.