### PR TITLE
refactor(checker): route jsx fallback relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -1078,7 +1078,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if `string` is assignable to the children type.
-        if self.is_assignable_to(TypeId::STRING, children_type) {
+        if self.diagnostic_relation_boolean_guard(TypeId::STRING, children_type) {
             return;
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
@@ -90,7 +90,7 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::PropertyAccessResult::Success {
                     type_id,
                     ..
-                } if self.is_assignable_to(type_id, prop.type_id)
+                } if self.diagnostic_relation_boolean_guard(type_id, prop.type_id)
             )
         })
     }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        5,
+        3,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9520 (`codex/m1pd2-jsx-component-props-relation-guards-20260520`)
Child: #9522 (`codex/m1pd2-variant-diagnostic-relation-guards-20260520`)

## Structural Rule
When JSX diagnostics and render-fallback recovery need a boolean assignability gate for text children or recovered fallback members, those probes should route through `diagnostic_relation_boolean_guard` instead of raw `is_assignable_to` calls.

## Owner Layer
Checker JSX diagnostics/orchestration. This does not change solver relation policy; the guard delegates to the same assignability implementation today while keeping diagnostic-local relation calls behind the shared boundary.

## Scope
- `crates/tsz-checker/src/checkers/jsx/diagnostics.rs`
- `crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- JSX text children accepted by a component children type.
- JSX render fallback recovery for required members.
- Existing JSX diagnostic paths that already use non-relation structural checks.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only JSX checker routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-component-props-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto current #9520 head `c06600f2645536e635984a72cf4b101a86d18439`; current head is `1e2895afbb683c4d10e774fe87cebe2b0a69c1c5`.
- Draft because this is stacked above #9520 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- Child #9522 is based on this refreshed head and handles the remaining variant diagnostic relation helpers (`bivariant` and `no_weak_checks`) with a separate wrapper decision.