### PR TITLE
refactor(checker): route variant diagnostic relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -2172,6 +2172,30 @@ impl<'a> CheckerState<'a> {
         self.is_assignable_to_with_env(source, target)
     }
 
+    /// Bivariant-callback boolean relation guard for diagnostic code paths.
+    ///
+    /// Use this only when the caller intentionally needs the legacy bivariant
+    /// callback relation rather than the default assignability relation.
+    pub(crate) fn diagnostic_relation_boolean_guard_bivariant(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_bivariant(source, target)
+    }
+
+    /// No-weak-checks boolean relation guard for diagnostic code paths.
+    ///
+    /// Use this only when the caller intentionally mirrors `tsc`'s
+    /// `isTypeAssignableTo` path without TS2559 weak-type detection.
+    pub(crate) fn diagnostic_relation_boolean_guard_no_weak_checks(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_no_weak_checks(source, target)
+    }
+
     /// Check if source type is assignable to target type.
     ///
     /// This is the main entry point for assignability checking, used throughout

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1632,7 +1632,7 @@ impl<'a> CheckerState<'a> {
         {
             return true;
         }
-        if self.is_assignable_to_bivariant(source, target) {
+        if self.diagnostic_relation_boolean_guard_bivariant(source, target) {
             return false;
         }
 

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -146,7 +146,10 @@ impl<'a> CheckerState<'a> {
         }
 
         let read_ok = if source_prop.is_method || target_prop.is_method {
-            self.is_assignable_to_bivariant(source_prop.type_id, target_prop.type_id)
+            self.diagnostic_relation_boolean_guard_bivariant(
+                source_prop.type_id,
+                target_prop.type_id,
+            )
         } else {
             self.diagnostic_relation_boolean_guard(source_prop.type_id, target_prop.type_id)
         };

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -573,7 +573,10 @@ impl<'a> CheckerState<'a> {
             let ready_type_arg_constraint = self.resolve_lazy_type(type_arg_constraint);
             let ready_type_arg_constraint =
                 self.evaluate_type_for_assignability(ready_type_arg_constraint);
-            if self.is_assignable_to_no_weak_checks(ready_type_arg_constraint, ready_constraint) {
+            if self.diagnostic_relation_boolean_guard_no_weak_checks(
+                ready_type_arg_constraint,
+                ready_constraint,
+            ) {
                 return;
             }
         }

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -670,7 +670,7 @@ REGEX_LINE_COUNT_CHECKS = [
             r"\b(?:self|self\.ctx\.types|self\.interner)"
             r"\.is_assignable_to(?:_[A-Za-z0-9_]+)?\s*\("
         ),
-        3,
+        0,
     ),
     (
         "Checker residency boundary: with_parent_cache_attributed migration callsites (Track 10)",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 relation diagnostics / refactor only.

## Parent / Child
Parent: #9521 (`codex/m1pd2-jsx-fallback-diagnostic-relation-guards-20260520`)
Child: none currently visible in the M1-B stack.

## Structural Rule
When diagnostic-only relation checks need the bivariant or no-weak-checks compatibility mode, those variant boolean probes should route through named diagnostic relation guard wrappers instead of raw `is_assignable_to_*` calls.

## Owner Layer
Checker diagnostic orchestration. This does not change solver relation policy; the new wrappers delegate to the same assignability implementation today while keeping diagnostic-local relation calls behind shared boundary helpers.

## Scope
- `crates/tsz-checker/src/assignability/assignability_checker.rs`
- `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`
- `crates/tsz-checker/src/error_reporter/assignability.rs`
- `crates/tsz-checker/src/error_reporter/generics.rs`
- `scripts/arch/arch_guard.py`

## Adjacent Cases
- Diagnostic bivariant relation checks for method-like compatibility.
- Diagnostic no-weak-checks relation probes where weak type handling is intentionally bypassed.
- Existing structured relation-reason paths, which still use the richer relation gateway instead of a boolean guard.

## Project Corpus Impact
Row: n/a
Bug family: n/a
Evidence: refactor-only checker diagnostic routing; no project-corpus behavior change intended.

## Verification
- `python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --all --check`
- `git diff --check codex/m1pd2-jsx-fallback-diagnostic-relation-guards-20260520..HEAD`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- AgentName: M1-B refreshed this draft onto #9521 head `1e2895afbb683c4d10e774fe87cebe2b0a69c1c5`; current head is `5c0a947014e77d46bdd9acb27f586c096d056bca`.
- Draft because this is stacked above #9521 and the existing M1-B relation-routing stack.
- #9236 is currently draft after an external/shared-account queue action re-parked it; see the signed M1-B handoff comment on #9236 before re-promoting the stack root.
- This is the top visible M1-B relation-routing draft in the current local stack.