### PR TITLE
refactor(checker,solver): generalize call-site this: receiver gate to decorators and tagged templates

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1294,6 +1294,10 @@ name = "template_literal_empty_placeholder_tests"
 path = "tests/template_literal_empty_placeholder_tests.rs"
 
 [[test]]
+name = "tagged_template_this_binding_tests"
+path = "tests/tagged_template_this_binding_tests.rs"
+
+[[test]]
 name = "template_literal_recursive_replace_tests"
 path = "tests/template_literal_recursive_replace_tests.rs"
 

--- a/crates/tsz-checker/src/query_boundaries/class_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/class_type.rs
@@ -13,6 +13,15 @@ pub(crate) fn function_shape(
     tsz_solver::type_queries::get_function_shape(db, type_id)
 }
 
+/// Boundary for [`tsz_solver::type_queries::callable_requires_explicit_receiver`].
+/// See the solver query for the structural rule.
+pub(crate) fn callable_requires_explicit_receiver(
+    db: &dyn TypeDatabase,
+    callee_type: TypeId,
+) -> bool {
+    tsz_solver::type_queries::callable_requires_explicit_receiver(db, callee_type)
+}
+
 pub(crate) fn type_includes_undefined(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::type_includes_undefined(db, type_id)
 }

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1141,6 +1141,10 @@ impl<'a> CheckerState<'a> {
     /// non-trivial `this:` constraint AND the callee expression is a property
     /// or element access. Both conditions must hold to avoid perturbing
     /// generic inference for the dominant `this`-less or bare-identifier case.
+    ///
+    /// A `this:` constraint is trivial when it is `any`, `unknown`, `void`,
+    /// `undefined`, `null`, or `error` — the same set the solver's call
+    /// resolver already treats as "no real receiver required."
     pub(crate) fn call_site_receiver_type(
         &mut self,
         callee_type: TypeId,

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1134,6 +1134,28 @@ impl<'a> CheckerState<'a> {
         Some(self.get_type_of_node(access.expression))
     }
 
+    /// Receiver type for non-call-expression call sites (decorators, tagged
+    /// templates) that need to decide whether to thread `actual_this_type`.
+    ///
+    /// Returns `Some(receiver)` only when `callee_type` carries an explicit,
+    /// non-trivial `this:` constraint AND the callee expression is a property
+    /// or element access. Both conditions must hold to avoid perturbing
+    /// generic inference for the dominant `this`-less or bare-identifier case.
+    pub(crate) fn call_site_receiver_type(
+        &mut self,
+        callee_type: TypeId,
+        callee_expr: NodeIndex,
+    ) -> Option<TypeId> {
+        if crate::query_boundaries::class_type::callable_requires_explicit_receiver(
+            self.ctx.types,
+            callee_type,
+        ) {
+            self.access_receiver_type(callee_expr)
+        } else {
+            None
+        }
+    }
+
     /// Compute the type of a node using an explicit [`TypingRequest`] instead of
     /// mutating ambient context fields.
     pub fn get_type_of_node_with_request(

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -15,22 +15,6 @@ const fn decorator_type_is_unchecked(t: TypeId) -> bool {
     matches!(t, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN)
 }
 
-/// Trivial `this:` constraints that don't require a real receiver — any
-/// receiver is assignable to them, so binding `actual_this_type` adds no
-/// information to the call resolver and can be safely skipped.
-#[inline]
-const fn is_explicit_this_constraint(this_type: TypeId) -> bool {
-    !matches!(
-        this_type,
-        TypeId::ANY
-            | TypeId::UNKNOWN
-            | TypeId::VOID
-            | TypeId::UNDEFINED
-            | TypeId::NULL
-            | TypeId::ERROR
-    )
-}
-
 impl<'a> CheckerState<'a> {
     /// TS1240 for ES class-member decorators (TC39 stage 3).
     ///
@@ -166,6 +150,28 @@ impl<'a> CheckerState<'a> {
         self.is_assignable_to(decorator_type, function_type)
     }
 
+    /// Receiver to thread into the call resolver for a decorator whose
+    /// callee was resolved from `decorator_expr`.
+    ///
+    /// Returns `Some(receiver)` only when the decorator's signature carries
+    /// an explicit, non-trivial `this:` constraint that a real receiver is
+    /// needed to satisfy. The dominant `this`-less case returns `None`,
+    /// keeping generic-inference inputs unchanged for the common shape.
+    pub(crate) fn decorator_receiver_type(
+        &mut self,
+        decorator_type: TypeId,
+        decorator_expr: NodeIndex,
+    ) -> Option<TypeId> {
+        if crate::query_boundaries::class_type::callable_requires_explicit_receiver(
+            self.ctx.types,
+            decorator_type,
+        ) {
+            self.access_receiver_type(decorator_expr)
+        } else {
+            None
+        }
+    }
+
     fn global_function_type_id(&mut self) -> Option<TypeId> {
         let lib_binders = self.get_lib_binders();
         let sym_id = self
@@ -173,39 +179,6 @@ impl<'a> CheckerState<'a> {
             .binder
             .get_global_type_with_libs("Function", &lib_binders)?;
         Some(self.ctx.create_lazy_type_ref(sym_id))
-    }
-
-    /// True when the decorator type carries an explicit, non-trivial `this:`
-    /// parameter that requires a real receiver binding.
-    ///
-    /// Threading `actual_this_type` from a property/element-access decorator
-    /// receiver is only meaningful when the callee actually constrains
-    /// `this:`. For the common case of `this`-less decorators (or
-    /// `this: any` / `this: unknown`), the receiver binding has no effect on
-    /// the solver's call resolution but does flow through generic inference
-    /// — so gating on this predicate avoids touching the call-resolution
-    /// inputs for the dominant case while still fixing the explicit-`this:`
-    /// case targeted by #8717.
-    ///
-    /// Returns `true` when the resolved decorator type's function shape (or
-    /// any signature in a callable shape) has `this_type: Some(t)` with `t`
-    /// not equal to `any`, `unknown`, `void`, `undefined`, or `null` —
-    /// matching tsc's "explicit this" filter for receiver binding.
-    pub(crate) fn decorator_has_explicit_this(&self, decorator_type: TypeId) -> bool {
-        let db = self.ctx.types;
-        if let Some(shape) = crate::query_boundaries::class_type::function_shape(db, decorator_type)
-        {
-            return shape.this_type.is_some_and(is_explicit_this_constraint);
-        }
-        if let Some(callable) =
-            crate::query_boundaries::class_type::callable_shape_for_type(db, decorator_type)
-        {
-            return callable
-                .call_signatures
-                .iter()
-                .any(|sig| sig.this_type.is_some_and(is_explicit_this_constraint));
-        }
-        false
     }
 
     /// Resolve `ClassAccessorDecoratorTarget<any, any>` from the lib globals.

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -150,28 +150,6 @@ impl<'a> CheckerState<'a> {
         self.is_assignable_to(decorator_type, function_type)
     }
 
-    /// Receiver to thread into the call resolver for a decorator whose
-    /// callee was resolved from `decorator_expr`.
-    ///
-    /// Returns `Some(receiver)` only when the decorator's signature carries
-    /// an explicit, non-trivial `this:` constraint that a real receiver is
-    /// needed to satisfy. The dominant `this`-less case returns `None`,
-    /// keeping generic-inference inputs unchanged for the common shape.
-    pub(crate) fn decorator_receiver_type(
-        &mut self,
-        decorator_type: TypeId,
-        decorator_expr: NodeIndex,
-    ) -> Option<TypeId> {
-        if crate::query_boundaries::class_type::callable_requires_explicit_receiver(
-            self.ctx.types,
-            decorator_type,
-        ) {
-            self.access_receiver_type(decorator_expr)
-        } else {
-            None
-        }
-    }
-
     fn global_function_type_id(&mut self) -> Option<TypeId> {
         let lib_binders = self.get_lib_binders();
         let sym_id = self

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1579,7 +1579,7 @@ impl<'a> CheckerState<'a> {
 
                 let decorator_type = self.compute_type_of_node(decorator.expression);
                 let actual_this_type =
-                    self.decorator_receiver_type(decorator_type, decorator.expression);
+                    self.call_site_receiver_type(decorator_type, decorator.expression);
 
                 if let Some(first_arg) = es_member_first_arg {
                     self.check_es_member_decorator_call_signature(
@@ -1674,7 +1674,7 @@ impl<'a> CheckerState<'a> {
                                 let is_constructor_parameter =
                                     node.kind == syntax_kind_ext::CONSTRUCTOR;
                                 let actual_this_type = self
-                                    .decorator_receiver_type(decorator_type, decorator.expression);
+                                    .call_site_receiver_type(decorator_type, decorator.expression);
                                 self.check_parameter_decorator_call_signature(
                                     modifier_idx,
                                     decorator_type,

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1578,16 +1578,8 @@ impl<'a> CheckerState<'a> {
                 self.check_grammar_decorator(decorator.expression);
 
                 let decorator_type = self.compute_type_of_node(decorator.expression);
-                // Only thread a receiver for decorators whose signature
-                // actually constrains `this:`; the dominant case
-                // (`this`-less decorators or `this: any`) skips this so
-                // we don't perturb generic inference for unrelated
-                // decorator shapes.
-                let actual_this_type = if self.decorator_has_explicit_this(decorator_type) {
-                    self.access_receiver_type(decorator.expression)
-                } else {
-                    None
-                };
+                let actual_this_type =
+                    self.decorator_receiver_type(decorator_type, decorator.expression);
 
                 if let Some(first_arg) = es_member_first_arg {
                     self.check_es_member_decorator_call_signature(
@@ -1681,12 +1673,8 @@ impl<'a> CheckerState<'a> {
                             if self.ctx.compiler_options.experimental_decorators {
                                 let is_constructor_parameter =
                                     node.kind == syntax_kind_ext::CONSTRUCTOR;
-                                let actual_this_type =
-                                    if self.decorator_has_explicit_this(decorator_type) {
-                                        self.access_receiver_type(decorator.expression)
-                                    } else {
-                                        None
-                                    };
+                                let actual_this_type = self
+                                    .decorator_receiver_type(decorator_type, decorator.expression);
                                 self.check_parameter_decorator_call_signature(
                                     modifier_idx,
                                     decorator_type,

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -204,7 +204,7 @@ impl<'a> CheckerState<'a> {
                     | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
             )
         );
-        let actual_this_type = self.access_receiver_type(unwrapped_tag);
+        let actual_this_type = self.call_site_receiver_type(call_target_type, unwrapped_tag);
 
         // For tagged templates, the tag function parameters are:
         //   param[0] = TemplateStringsArray (always)

--- a/crates/tsz-checker/tests/tagged_template_this_binding_tests.rs
+++ b/crates/tsz-checker/tests/tagged_template_this_binding_tests.rs
@@ -1,0 +1,211 @@
+//! Tests for `this:`-typed tag functions in tagged template expressions.
+//!
+//! Structural rule: when a tagged template's tag is a property or element
+//! access expression AND the resolved tag function type carries an explicit,
+//! non-trivial `this:` constraint, the receiver type must be bound to that
+//! `this:` parameter during call resolution — matching the same policy used
+//! for decorator call sites.
+//!
+//! When the tag function has no `this:` constraint (or a trivial one such as
+//! `this: any` / `this: void`), the receiver must NOT be threaded into the
+//! call resolver, so generic inference is not perturbed.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// Minimal `TemplateStringsArray` shim so tests don't need the full lib.
+const PREAMBLE: &str = r#"
+interface ReadonlyArray<T> { [n: number]: T; readonly length: number; }
+interface TemplateStringsArray extends ReadonlyArray<string> { readonly raw: ReadonlyArray<string>; }
+"#;
+
+fn check(src: &str) -> Vec<u32> {
+    check_source_codes(&format!("{PREAMBLE}\n{src}"))
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Passing cases: explicit this: constraint that matches the receiver
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn property_access_tag_with_explicit_this_no_error() {
+    // Tag function constrained to `this: TagHost`. When the tag is accessed via
+    // `host.tag`, the receiver type `TagHost` satisfies the constraint.
+    let codes = check(
+        r#"
+class TagHost {
+    tag(this: TagHost, strings: TemplateStringsArray, x: number): string {
+        return "";
+    }
+}
+
+declare const host: TagHost;
+const result = host.tag`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Property-access tag with matching this: should not produce errors; got: {codes:?}"
+    );
+}
+
+#[test]
+fn element_access_tag_with_explicit_this_no_error() {
+    // Same structural rule via element access (`host["tag"]`).
+    let codes = check(
+        r#"
+class TagHost {
+    tag(this: TagHost, strings: TemplateStringsArray, x: number): string {
+        return "";
+    }
+}
+
+declare const host: TagHost;
+const result = host["tag"]`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Element-access tag with matching this: should not produce errors; got: {codes:?}"
+    );
+}
+
+#[test]
+fn generic_tag_with_explicit_this_infers_type_param() {
+    // Generic tag: `tag<T>(this: Provider, strings: TemplateStringsArray, v: T): T`.
+    // The receiver binds `this:`, and `T` should be inferred from the substitution.
+    let codes = check(
+        r#"
+class Provider {
+    tag<T>(this: Provider, strings: TemplateStringsArray, v: T): T {
+        return v;
+    }
+}
+
+declare const p: Provider;
+const x: number = p.tag`prefix ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Generic tag with explicit this: must infer T without error; got: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Passing cases: trivial / absent this: — receiver must not perturb inference
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn property_access_tag_no_this_constraint_no_error() {
+    // Tag has no `this:` constraint. Even though accessed via property access,
+    // the receiver must NOT be threaded into call resolution.
+    let codes = check(
+        r#"
+class Holder {
+    tag(strings: TemplateStringsArray, x: number): string {
+        return "";
+    }
+}
+
+declare const holder: Holder;
+const result = holder.tag`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Tag without this: constraint should not produce errors; got: {codes:?}"
+    );
+}
+
+#[test]
+fn property_access_tag_this_any_no_error() {
+    // `this: any` is trivial — any receiver is assignable. Same as no constraint.
+    let codes = check(
+        r#"
+class Holder {
+    tag(this: any, strings: TemplateStringsArray, x: number): string {
+        return "";
+    }
+}
+
+declare const holder: Holder;
+const result = holder.tag`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Tag with this: any should not produce errors; got: {codes:?}"
+    );
+}
+
+#[test]
+fn property_access_tag_this_void_no_error() {
+    // `this: void` is the tsc-standard "no receiver" sentinel — treated as trivial.
+    let codes = check(
+        r#"
+class Holder {
+    tag(this: void, strings: TemplateStringsArray, x: number): string {
+        return "";
+    }
+}
+
+declare const holder: Holder;
+const result = holder.tag`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Tag with this: void should not produce errors; got: {codes:?}"
+    );
+}
+
+#[test]
+fn bare_identifier_tag_with_explicit_this_no_error() {
+    // When the tag is a bare identifier (not a property access), the receiver
+    // is None regardless of the this: constraint.
+    let codes = check(
+        r#"
+function tag(this: unknown, strings: TemplateStringsArray, x: number): string {
+    return "";
+}
+const result = tag`hello ${42}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Bare identifier tag should not produce receiver-related errors; got: {codes:?}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Name-variation coverage: the rule is structural, not name-dependent
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn explicit_this_constraint_name_variation_k() {
+    // Same structural rule with a renamed tag method (`render` instead of `tag`).
+    let codes = check(
+        r#"
+class Renderer {
+    render<K>(this: Renderer, strings: TemplateStringsArray, v: K): K {
+        return v;
+    }
+}
+
+declare const r: Renderer;
+const x: string = r.render`prefix ${"hello"}`;
+"#,
+    );
+
+    assert!(
+        codes.is_empty(),
+        "Rule must be independent of tag method name; got: {codes:?}"
+    );
+}

--- a/crates/tsz-core/tests/conformance_snapshot.txt
+++ b/crates/tsz-core/tests/conformance_snapshot.txt
@@ -15,7 +15,6 @@ FAIL TypeScript/tests/cases/compiler/convertKeywordsYes.ts
 FAIL TypeScript/tests/cases/compiler/customAsyncIterator.ts
 FAIL TypeScript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
 FAIL TypeScript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
-FAIL TypeScript/tests/cases/compiler/declarationEmitPrivatePromiseLikeInterface.ts
 FAIL TypeScript/tests/cases/compiler/decoratorUsedBeforeDeclaration.ts
 FAIL TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 FAIL TypeScript/tests/cases/compiler/destructuringTuple.ts
@@ -61,7 +60,6 @@ FAIL TypeScript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
 FAIL TypeScript/tests/cases/compiler/jsxComponentTypeErrors.tsx
 FAIL TypeScript/tests/cases/compiler/jsxElementType.tsx
 FAIL TypeScript/tests/cases/compiler/jsxElementTypeLiteral.tsx
-FAIL TypeScript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
 FAIL TypeScript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 FAIL TypeScript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
 FAIL TypeScript/tests/cases/compiler/jsxNamespaceNoElementChildrenAttributeReactJsx.tsx

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -50,12 +50,32 @@ impl<'a> DeclarationEmitter<'a> {
         let call = self.arena.get_call_expr(expr_node)?;
         let sym_id = self.value_reference_symbol(call.expression)?;
         let binder = self.binder?;
-        let symbol = binder.symbols.get(sym_id)?;
+
+        // Resolve import aliases to the actual exported function symbol using the
+        // portability resolver, which correctly handles relative path normalization
+        // via matching_module_export_paths (unlike binder.resolve_import_symbol which
+        // uses raw module specifiers as keys and fails for relative imports).
+        let resolved_sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or(sym_id);
+        let symbol = binder.symbols.get(resolved_sym_id)?;
         let source_arena = binder
             .symbol_arenas
-            .get(&sym_id)
+            .get(&resolved_sym_id)
+            .or_else(|| self.global_symbol_arenas.get(&resolved_sym_id))
             .map(|arena| arena.as_ref())
             .unwrap_or(self.arena);
+
+        // Ambient declaration file functions (e.g. `declare function f(): T`) have no body to
+        // inspect. call_expression_declared_return_type_text handles those; return None here so
+        // the caller falls through to that handler, which preserves the full portability check
+        // path including TS4118 diagnostics for non-serializable types.
+        if self
+            .arena_source_file(source_arena)
+            .is_some_and(|sf| sf.is_declaration_file)
+        {
+            return None;
+        }
 
         let mut function_decl_count = 0usize;
         for decl_idx in symbol.declarations.iter().copied() {
@@ -123,7 +143,10 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 // Text-based reconstruction loses call-site refinements (e.g. index signatures
                 // derived from abstract constructor constraints). Prefer the checker's computed
-                // TypeId when it is non-trivial.
+                // TypeId when it is non-trivial. For functions defined in a foreign source file,
+                // the printed name may be unqualified; qualify it against the source file's
+                // imports so the emitted type uses `import("./path").Name` form.
+                let source_is_foreign = !std::ptr::eq(source_arena, self.arena);
                 if self.type_interner.is_some()
                     && self.type_cache.is_some()
                     && let Some(call_type_id) = self.get_node_type_or_names(&[expr_idx])
@@ -131,6 +154,11 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     let type_text = self.print_type_id_for_inferred_declaration(call_type_id);
                     if !type_text.is_empty() && !matches!(type_text.as_str(), "any" | "unknown") {
+                        let type_text = if source_is_foreign {
+                            self.qualify_foreign_imported_names_in_text(source_arena, &type_text)
+                        } else {
+                            type_text
+                        };
                         return Some(Self::strip_synthetic_anonymous_object_members(&type_text));
                     }
                 }

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -160,6 +160,60 @@ pub fn collect_callable_property_types(db: &dyn TypeDatabase, type_id: TypeId) -
     result
 }
 
+/// True when calling `callee_type` would require a real receiver binding to
+/// satisfy an explicit, non-trivial `this:` constraint on any of its call
+/// signatures.
+///
+/// Mirrors tsc's "explicit `this:`" filter (see also
+/// `tsz-solver::operations::core::call_resolution`): a `this:` constraint is
+/// trivial when the constraint is `any`, `unknown`, `void`, `undefined`,
+/// `null`, or `error` — `void` because tsc explicitly carves it out as
+/// "ignore at call sites" in `resolveUntypedCall`, the rest because any
+/// receiver is assignable to them. For trivial constraints, threading
+/// `actual_this_type` adds no information to the call resolver and risks
+/// perturbing generic inference (the issue #8717 follow-up scope).
+///
+/// Used by non-call-expression call sites (decorators today, tagged
+/// templates and possibly regular calls later) to decide whether to compute
+/// and pass a receiver type for call resolution.
+pub fn callable_requires_explicit_receiver(db: &dyn TypeDatabase, callee_type: TypeId) -> bool {
+    // Walk the underlying shape directly instead of going through
+    // `get_callable_shape_for_type`, which allocates a synthetic
+    // `Arc<CallableShape>` (and a one-element signature vec) for every
+    // Function-typed decorator. Decorator-signature checks are warm: every
+    // class member, every decorator. Avoid the synthetic-shape allocation.
+    if let Some(shape_id) = crate::visitor::callable_shape_id(db, callee_type) {
+        return db
+            .callable_shape(shape_id)
+            .call_signatures
+            .iter()
+            .any(|sig| sig.this_type.is_some_and(is_explicit_this_constraint));
+    }
+    if let Some(shape_id) = crate::visitor::function_shape_id(db, callee_type) {
+        return db
+            .function_shape(shape_id)
+            .this_type
+            .is_some_and(is_explicit_this_constraint);
+    }
+    false
+}
+
+/// Trivial `this:` constraints that don't require a real receiver — any
+/// receiver is assignable to them, so binding `actual_this_type` adds no
+/// information to the call resolver.
+#[inline]
+const fn is_explicit_this_constraint(this_type: TypeId) -> bool {
+    !matches!(
+        this_type,
+        TypeId::ANY
+            | TypeId::UNKNOWN
+            | TypeId::VOID
+            | TypeId::UNDEFINED
+            | TypeId::NULL
+            | TypeId::ERROR
+    )
+}
+
 /// Check if a type is a callable type (Function or Callable with call signatures).
 fn is_callable_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id.is_intrinsic() {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,6 +8,7 @@ TypeScript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxElementType.tsx

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,7 +8,6 @@ TypeScript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/jsxElementType.tsx


### PR DESCRIPTION
AgentName: M4-C
Runner: `sonnet-4-6-remote`

Closes: #9536

---

## Summary

### Structural rule (primary fix)

> When a callable has no explicit `this:` constraint (i.e. `this: any/unknown/void/undefined/null/error`), tsc does not thread a receiver type through the call site; tsz now matches that behavior for both decorated call sites and tagged-template call sites.

### Structural rule (secondary fix — dts emitter)

> When `call_expression_source_return_type_text` resolves the called symbol to an ambient declaration file function (one without a body), it must defer to `call_expression_declared_return_type_text` rather than trying to inspect a body that does not exist. Without this guard the function incorrectly returned a type annotation string directly, bypassing the full portability check chain (including TS4118 for non-serializable unique-symbol properties) and producing un-qualified type names for cross-file imports.

Additionally: import-alias resolution now uses `resolve_portability_import_alias` (which handles relative path normalization via `matching_module_export_paths`) rather than `binder.resolve_import_symbol` (which uses raw module specifiers as map keys and fails for relative imports). This ensures that a named import like `import { func } from "./reexporter"` correctly identifies `reexporter.ts` as the source file.

### Owner layer

- Solver (`tsz-solver/src/type_queries/data/accessors.rs`): owns the predicate `callable_requires_explicit_receiver` — pure structural query over `TypeId`.
- Boundary (`tsz-checker/src/query_boundaries/class_type.rs`): thin wrapper re-exporting the predicate into checker-safe scope.
- Checker (`tsz-checker/src/state/state.rs`): `call_site_receiver_type` combines the gate with `access_receiver_type` — shared by decorators and tagged templates.
- Decorator sites (`member_declaration_checks.rs`): replaced local `decorator_receiver_type` with the shared helper.
- Tagged-template site (`tagged_template.rs:189`): replaced unconditional `access_receiver_type` with gated `call_site_receiver_type`.
- Emitter (`type_inference_source_callables.rs`): declaration-file guard + import alias resolution via `resolve_portability_import_alias`.

### Adjacent cases covered (generalization matrix)

1. Property-access tag with explicit `this: Foo` — receiver threaded ✓
2. Element-access tag with explicit `this: Foo` — receiver threaded ✓
3. Generic tag, explicit `this: T` — receiver threaded, type param inferred ✓
4. Named variation (type param `K` not `T`) — receiver threaded ✓
5. Tag with no `this:` annotation — no receiver threaded, no error ✓
6. Tag with `this: any` — treated as trivial, no receiver threaded ✓
7. Tag with `this: void` — treated as trivial, no receiver threaded ✓
8. Bare identifier tag with explicit `this:` — no receiver (not member expr), no error ✓
9. Cross-file import via reexporter (non-declaration source) — type text qualified with `import("./path").Name` ✓
10. Named import of ambient declaration function — TS4118 still fires for non-serializable unique-symbol properties ✓

---

## Track

Checker / Solver boundary hygiene — issue #9536

## Invariant

`call_site_receiver_type` is the single gate for both decorated and tagged-template call sites. Neither caller re-implements the predicate.

## Scope

- `tsz-solver`: adds `callable_requires_explicit_receiver` query
- `tsz-checker`: adds `call_site_receiver_type` shared helper; removes `decorator_has_explicit_this` / `decorator_receiver_type` local duplicates; fixes tagged-template receiver gate
- `tsz-emitter`: declaration-file guard in `call_expression_source_return_type_text`; import alias resolved via `resolve_portability_import_alias`; foreign-source type text qualified against source-file imports
- New integration test file with 8 cases; new driver test for cross-file qualified return type

Also fixes a pre-existing arch guard violation introduced by PR #9481: `type_environment/core.rs` had 3 inline `query_boundaries::common::` calls (`is_conditional_type`, `is_index_access_type`, `is_mapped_type`) that pushed the reference count 2 over the 3384 cap set by PR #9593. These are now wrapped in `is_safe_for_generic_display_alias` in `query_boundaries/type_computation/complex.rs`, restoring the count to exactly 3384.

## Project Corpus Impact

- Row: n/a
- Bug family: false-positive TS2684 on tagged template calls where the tag function has no explicit `this:` parameter; incorrect dts qualification for cross-file inferred return types
- Evidence: 8 new unit tests in `tagged_template_this_binding_tests.rs` all pass locally; `compile_dts_qualifies_imported_return_type_reused_from_another_file` and `declaration_emit_reports_non_serializable_foreign_unique_symbol_property` pass locally; no conformance regression expected (emitter-only dts change, checker commits only suppress false-positive TS2684 on trivial-this callables)

## Verification

```
cargo check -p tsz-checker                              # clean
cargo check -p tsz-emitter                              # clean
cargo test -p tsz-checker --test tagged_template_this_binding_tests  # 8/8 pass
cargo test -p tsz-cli compile_dts_qualifies_imported_return_type_reused_from_another_file  # pass
cargo test -p tsz-cli declaration_emit_reports_non_serializable_foreign_unique_symbol_property  # pass
python3 scripts/arch/arch_guard.py                      # Architecture guardrails passed
```

## Coordination Notes

- Issue #9536 is claimed by this PR; issue-level status can be handled separately after the PR has a definitive merge result
- Pre-existing arch guard failure (introduced by #9481 after #9593 lowered the cap) fixed in this PR rather than filed separately, since it was blocking lint CI
- Current head: `57ffbf668afeec22764c3e3f771122cc842475be` with green draft-light CI on run `26244226862`
- Previous run `26211878184` (head `3a932b9`) had `conformance-aggregate` fail due to a transient artifact-indexing race: conformance-1 finished at 07:42:23Z and the aggregate job started at 07:42:24Z — a 1-second gap insufficient for artifact indexing. All 6 individual conformance shards showed `conclusion: success`. No actual regression.
- AgentName M4-C is re-promoting this after current-head draft-light CI passed and the PR is mergeable/not WIP.