### PR TITLE
refactor(cli): extract indentation text edit narrowing

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -3,6 +3,7 @@
 //! Handles formatting, inlay hints, selection ranges, call hierarchy,
 //! outlining spans, brace matching, refactoring stubs, and related commands.
 
+use super::text_edits::narrow_indentation_only_edit;
 use super::{Server, TsServerRequest, TsServerResponse};
 use tsz::emitter::{ModuleKind, Printer, PrinterOptions};
 
@@ -1146,16 +1147,12 @@ impl Server {
                     let body: Vec<serde_json::Value> = edits
                         .iter()
                         .map(|edit| {
-                            let (normalized_range, normalized_text) =
-                                Self::narrow_to_indentation_only_edit_if_possible(
-                                    &source_text,
-                                    &line_map,
-                                    edit,
-                                );
+                            let normalized =
+                                narrow_indentation_only_edit(&source_text, &line_map, edit);
                             serde_json::json!({
-                                "start": Self::lsp_to_tsserver_position(normalized_range.start),
-                                "end": Self::lsp_to_tsserver_position(normalized_range.end),
-                                "newText": normalized_text,
+                                "start": Self::lsp_to_tsserver_position(normalized.range.start),
+                                "end": Self::lsp_to_tsserver_position(normalized.range.end),
+                                "newText": normalized.new_text,
                             })
                         })
                         .collect();
@@ -1165,73 +1162,6 @@ impl Server {
             }
         })();
         self.success_response(seq, request, Some(result.unwrap_or(serde_json::json!([]))))
-    }
-
-    fn narrow_to_indentation_only_edit_if_possible(
-        source_text: &str,
-        line_map: &LineMap,
-        edit: &tsz::lsp::formatting::TextEdit,
-    ) -> (Range, String) {
-        let Some(start_off) = line_map.position_to_offset(edit.range.start, source_text) else {
-            return (edit.range, edit.new_text.clone());
-        };
-        let Some(end_off) = line_map.position_to_offset(edit.range.end, source_text) else {
-            return (edit.range, edit.new_text.clone());
-        };
-        if start_off >= end_off {
-            return (edit.range, edit.new_text.clone());
-        }
-
-        let Some(old_text) = source_text.get(start_off as usize..end_off as usize) else {
-            return (edit.range, edit.new_text.clone());
-        };
-        if old_text.contains('\n') || old_text.contains('\r') {
-            return (edit.range, edit.new_text.clone());
-        }
-        if edit.new_text.contains('\n') || edit.new_text.contains('\r') {
-            return (edit.range, edit.new_text.clone());
-        }
-
-        let mut prefix = 0usize;
-        for ((old_idx, old_ch), (_, new_ch)) in
-            old_text.char_indices().zip(edit.new_text.char_indices())
-        {
-            if old_ch != new_ch {
-                break;
-            }
-            prefix = old_idx + old_ch.len_utf8();
-        }
-
-        let old_after_prefix = &old_text[prefix..];
-        let new_after_prefix = &edit.new_text[prefix..];
-
-        let mut old_suffix_bytes = 0usize;
-        let mut new_suffix_bytes = 0usize;
-        let mut old_rev = old_after_prefix.char_indices().rev();
-        let mut new_rev = new_after_prefix.char_indices().rev();
-        while let (Some((old_idx, old_ch)), Some((new_idx, new_ch))) =
-            (old_rev.next(), new_rev.next())
-        {
-            if old_ch != new_ch {
-                break;
-            }
-            old_suffix_bytes = old_after_prefix.len() - old_idx;
-            new_suffix_bytes = new_after_prefix.len() - new_idx;
-        }
-
-        let old_mid_end = old_text.len().saturating_sub(old_suffix_bytes);
-        let new_mid_end = edit.new_text.len().saturating_sub(new_suffix_bytes);
-        let narrowed_start = start_off + prefix as u32;
-        let narrowed_end = start_off + old_mid_end as u32;
-        let start_pos = line_map.offset_to_position(narrowed_start, source_text);
-        let end_pos = line_map.offset_to_position(narrowed_end, source_text);
-        let new_text = edit.new_text[prefix..new_mid_end].to_string();
-
-        if narrowed_start == start_off && narrowed_end == end_off && new_text == edit.new_text {
-            return (edit.range, edit.new_text.clone());
-        }
-
-        (Range::new(start_pos, end_pos), new_text)
     }
 
     pub(crate) fn handle_format_on_key(

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -47,6 +47,7 @@ mod handlers_project_info;
 mod handlers_quickinfo;
 mod handlers_quickinfo_text;
 mod handlers_structure;
+mod text_edits;
 
 use anyhow::{Context, Result};
 use clap::Parser;

--- a/crates/tsz-cli/src/bin/tsz_server/text_edits.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/text_edits.rs
@@ -1,0 +1,159 @@
+//! Text edit utilities shared by tsserver handlers.
+
+use tsz::lsp::formatting::TextEdit;
+use tsz::lsp::position::{LineMap, Range};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NarrowedTextEdit {
+    pub(crate) range: Range,
+    pub(crate) new_text: String,
+}
+
+impl NarrowedTextEdit {
+    fn unchanged(edit: &TextEdit) -> Self {
+        Self {
+            range: edit.range,
+            new_text: edit.new_text.clone(),
+        }
+    }
+}
+
+pub(crate) fn narrow_indentation_only_edit(
+    source_text: &str,
+    line_map: &LineMap,
+    edit: &TextEdit,
+) -> NarrowedTextEdit {
+    let Some(start_off) = line_map.position_to_offset(edit.range.start, source_text) else {
+        return NarrowedTextEdit::unchanged(edit);
+    };
+    let Some(end_off) = line_map.position_to_offset(edit.range.end, source_text) else {
+        return NarrowedTextEdit::unchanged(edit);
+    };
+    if start_off >= end_off {
+        return NarrowedTextEdit::unchanged(edit);
+    }
+
+    let Some(old_text) = source_text.get(start_off as usize..end_off as usize) else {
+        return NarrowedTextEdit::unchanged(edit);
+    };
+    if old_text.contains('\n') || old_text.contains('\r') {
+        return NarrowedTextEdit::unchanged(edit);
+    }
+    if edit.new_text.contains('\n') || edit.new_text.contains('\r') {
+        return NarrowedTextEdit::unchanged(edit);
+    }
+
+    let mut prefix = 0usize;
+    for ((old_idx, old_ch), (_, new_ch)) in
+        old_text.char_indices().zip(edit.new_text.char_indices())
+    {
+        if old_ch != new_ch {
+            break;
+        }
+        prefix = old_idx + old_ch.len_utf8();
+    }
+
+    let old_after_prefix = &old_text[prefix..];
+    let new_after_prefix = &edit.new_text[prefix..];
+
+    let mut old_suffix_bytes = 0usize;
+    let mut new_suffix_bytes = 0usize;
+    let mut old_rev = old_after_prefix.char_indices().rev();
+    let mut new_rev = new_after_prefix.char_indices().rev();
+    while let (Some((old_idx, old_ch)), Some((new_idx, new_ch))) = (old_rev.next(), new_rev.next())
+    {
+        if old_ch != new_ch {
+            break;
+        }
+        old_suffix_bytes = old_after_prefix.len() - old_idx;
+        new_suffix_bytes = new_after_prefix.len() - new_idx;
+    }
+
+    let old_mid_end = old_text.len().saturating_sub(old_suffix_bytes);
+    let new_mid_end = edit.new_text.len().saturating_sub(new_suffix_bytes);
+    let narrowed_start = start_off + prefix as u32;
+    let narrowed_end = start_off + old_mid_end as u32;
+    let start_pos = line_map.offset_to_position(narrowed_start, source_text);
+    let end_pos = line_map.offset_to_position(narrowed_end, source_text);
+    let new_text = edit.new_text[prefix..new_mid_end].to_string();
+
+    if narrowed_start == start_off && narrowed_end == end_off && new_text == edit.new_text {
+        return NarrowedTextEdit::unchanged(edit);
+    }
+
+    NarrowedTextEdit {
+        range: Range::new(start_pos, end_pos),
+        new_text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz::lsp::position::Position;
+
+    fn edit_for_offsets(source_text: &str, start: u32, end: u32, new_text: &str) -> TextEdit {
+        let line_map = LineMap::build(source_text);
+        TextEdit::new(
+            Range::new(
+                line_map.offset_to_position(start, source_text),
+                line_map.offset_to_position(end, source_text),
+            ),
+            new_text.to_string(),
+        )
+    }
+
+    #[test]
+    fn indentation_only_delete_trims_common_prefix() {
+        let source_text = "    let value = 1;\n";
+        let line_map = LineMap::build(source_text);
+        let edit = edit_for_offsets(source_text, 0, 4, "  ");
+
+        let narrowed = narrow_indentation_only_edit(source_text, &line_map, &edit);
+
+        assert_eq!(
+            narrowed.range,
+            Range::new(Position::new(0, 2), Position::new(0, 4))
+        );
+        assert_eq!(narrowed.new_text, "");
+    }
+
+    #[test]
+    fn mixed_whitespace_insert_trims_common_prefix() {
+        let source_text = "\t  let value = 1;\n";
+        let line_map = LineMap::build(source_text);
+        let edit = edit_for_offsets(source_text, 0, 3, "\t    ");
+
+        let narrowed = narrow_indentation_only_edit(source_text, &line_map, &edit);
+
+        assert_eq!(
+            narrowed.range,
+            Range::new(Position::new(0, 3), Position::new(0, 3))
+        );
+        assert_eq!(narrowed.new_text, "  ");
+    }
+
+    #[test]
+    fn multiline_old_text_keeps_original_edit() {
+        let source_text = "let a = 1;\nlet b = 2;\n";
+        let line_map = LineMap::build(source_text);
+        let edit = edit_for_offsets(source_text, 0, 20, "let a = 1;\n  let b = 2;");
+
+        let narrowed = narrow_indentation_only_edit(source_text, &line_map, &edit);
+
+        assert_eq!(narrowed.range, edit.range);
+        assert_eq!(narrowed.new_text, edit.new_text);
+    }
+
+    #[test]
+    fn zero_width_edit_keeps_original_edit() {
+        let source_text = "let value = 1;\n";
+        let line_map = LineMap::build(source_text);
+        let edit = edit_for_offsets(source_text, 4, 4, "  ");
+
+        let narrowed = narrow_indentation_only_edit(source_text, &line_map, &edit);
+
+        assert_eq!(narrowed.range, edit.range);
+        assert_eq!(narrowed.new_text, edit.new_text);
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
LSP/tsserver CLI refactor-only cleanup for #9417. Ownership label remains `agent:Studio-E`.

## Invariant
When tsserver formatting returns a single-line indentation edit, tsz should keep the same public protocol edit while the shared prefix/suffix narrowing policy lives behind a named text-edit helper instead of structure-handler glue.

## Scope
- Add `crates/tsz-cli/src/bin/tsz_server/text_edits.rs` with `NarrowedTextEdit` and `narrow_indentation_only_edit`.
- Move the existing narrowing algorithm out of `handlers_structure.rs`.
- Add focused unit coverage for indentation deletion, mixed whitespace insertion, multiline fallback, and zero-width fallback.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only tsserver formatting edit normalization; no parser, binder, checker, solver, emitter, or LSP runtime semantics intended to change.

## Verification
- Rebased onto `origin/main` `4b484e5fd622530e7f21a09353f21e8fd055559c`.
- Current head: `a66274593856f40222aa8a097785052c5b82f94c`.
- `git diff --check origin/main...HEAD`
- `cargo fmt --all --check`
- `cargo nextest run -p tsz-cli -E 'test(text_edits::tests)'` (4 passed, 1785 skipped)
- Exact-head draft-light CI is running: https://github.com/mohsen1/tsz/actions/runs/26417541513

## Coordination Notes
- Closes #9417.
- AgentName: Studio-A-sidecar-9628 refreshed this draft/WIP branch directly, resolved no conflicts, and force-with-lease pushed the rebased head.
- Checked current overlap before updating: #9495 is already merged and this PR remains the active indentation text-edit helper split.
- This PR intentionally keeps issue labels untouched; ownership is expressed on the PR with `agent:Studio-E` only.
- Previous WIP blocker was stale/shared conformance aggregate drift on older ready-review attempts. The branch-local refactor now has fresh local focused verification on current `origin/main`.
- Keep draft + `[WIP]` + `WIP` label and auto-merge off while exact-head draft-light CI is running. If that CI is terminal green, the parent queue controller can remove WIP state, mark ready, and let ready-review heavy CI prove the branch before queue-testing or merging.
