### PR TITLE
fix(solver): use getErasedSignature (T→any) for TS2430 generic-vs-concrete property checks

### DIFF
--- a/crates/conformance/src/tsz_wrapper.rs
+++ b/crates/conformance/src/tsz_wrapper.rs
@@ -1540,9 +1540,6 @@ fn retained_diagnostic_code_from_line(line: &str, mode: DiagnosticLineMode) -> O
         .or_else(|| caps.name("code2"))
         .or_else(|| caps.name("code3"))
         .and_then(|m| m.as_str().parse::<u32>().ok())?;
-    if code == 2430 && is_extra_signature_inheritance_line(line) {
-        return None;
-    }
     if let Some(rule) = classify_parity(code, line, MatchScope::RawLine) {
         return match rule.action {
             ParityAction::Drop => None,
@@ -1550,11 +1547,6 @@ fn retained_diagnostic_code_from_line(line: &str, mode: DiagnosticLineMode) -> O
         };
     }
     Some(code)
-}
-
-fn is_extra_signature_inheritance_line(line: &str) -> bool {
-    line.contains("Interface 'I' incorrectly extends interface 'A'.")
-        || line.contains("Interface 'I' incorrectly extends interface 'B'.")
 }
 
 /// Parse @symlink associations from raw test file content.

--- a/crates/conformance/tests/tsz_wrapper.rs
+++ b/crates/conformance/tests/tsz_wrapper.rs
@@ -1385,44 +1385,56 @@ test.ts(1,1): error TS2304: Cannot find name 'missing'.";
 }
 
 #[test]
-fn test_parse_batch_output_drops_fingerprints_for_filtered_codes() {
+fn test_parse_batch_output_retains_ts2430_alongside_other_codes() {
+    // TS2430 is a retained code: all matching lines must survive parse_batch_output
+    // alongside other codes like TS2304.
     let output = "test.ts(1,1): error TS2430: Interface 'I' incorrectly extends interface 'A'.\n\
 test.ts(2,1): error TS2304: Cannot find name 'missing'.";
     let root = std::path::Path::new("/tmp/tsz-test");
 
     let result = parse_batch_output(output, root, HashMap::new());
 
-    assert_eq!(result.error_codes, vec![2304]);
-    assert_eq!(result.diagnostic_fingerprints.len(), 1);
-    assert_eq!(result.diagnostic_fingerprints[0].code, 2304);
+    assert!(
+        result.error_codes.contains(&2430),
+        "TS2430 should be retained in error_codes"
+    );
+    assert!(
+        result.error_codes.contains(&2304),
+        "TS2304 should be retained in error_codes"
+    );
+    assert_eq!(result.diagnostic_fingerprints.len(), 2);
 }
 
 #[test]
-fn test_parse_batch_output_filters_fingerprints_per_diagnostic_line() {
+fn test_parse_batch_output_retains_all_ts2430_lines_uniformly() {
+    // TS2430 is retained regardless of which interface name appears in the message.
     let output = "test.ts(1,1): error TS2430: Interface 'I' incorrectly extends interface 'A'.\n\
 test.ts(2,1): error TS2430: Interface 'Kept' incorrectly extends interface 'Base'.";
     let root = std::path::Path::new("/tmp/tsz-test");
 
     let result = parse_batch_output(output, root, HashMap::new());
 
-    assert_eq!(result.error_codes, vec![2430]);
-    assert_eq!(result.diagnostic_fingerprints.len(), 1);
+    assert_eq!(result.diagnostic_fingerprints.len(), 2);
     assert_eq!(result.diagnostic_fingerprints[0].code, 2430);
-    assert_eq!(result.diagnostic_fingerprints[0].line, 2);
-    assert_eq!(result.diagnostic_fingerprints[0].column, 1);
+    assert_eq!(result.diagnostic_fingerprints[0].line, 1);
+    assert_eq!(result.diagnostic_fingerprints[1].code, 2430);
+    assert_eq!(result.diagnostic_fingerprints[1].line, 2);
 }
 
 #[test]
-fn test_parse_diagnostic_fingerprints_filters_nonretained_codes() {
+fn test_parse_diagnostic_fingerprints_retains_ts2430_lines() {
+    // TS2430 is a retained diagnostic code: fingerprints should include it.
     let output = "test.ts(1,1): error TS2430: Interface 'I' incorrectly extends interface 'A'.";
     let root = std::path::Path::new("/tmp/tsz-test");
 
     let fingerprints = parse_diagnostic_fingerprints_from_text(output, root);
 
-    assert!(
-        fingerprints.is_empty(),
-        "fingerprints should mirror retained diagnostic codes",
+    assert_eq!(
+        fingerprints.len(),
+        1,
+        "TS2430 fingerprint should be retained"
     );
+    assert_eq!(fingerprints[0].code, 2430);
 }
 
 #[test]
@@ -1786,9 +1798,6 @@ fn tsz_wrapper_has_no_ad_hoc_extra_fingerprint_helpers() {
     // sanctioned place to hardcode fingerprint shapes. New ad-hoc
     // `is_extra_*` predicates in `tsz_wrapper.rs` recreate the §25 anti-pattern.
     //
-    // One historical helper (`is_extra_signature_inheritance_*`) is grandfathered
-    // until #8349 lands the inheritance entry into the catalog. Any other
-    // `is_extra_*` function must go through the catalog.
     // Match the function name regardless of visibility (`fn`, `pub fn`,
     // `pub(crate) fn`, `pub(super) fn`, ...). The pattern is intentionally
     // permissive so visibility renames or attribute-prefixed forms still
@@ -1808,9 +1817,6 @@ fn tsz_wrapper_has_no_ad_hoc_extra_fingerprint_helpers() {
             continue;
         }
         let rest = &source[start + needle.len()..];
-        if rest.starts_with("signature_inheritance_") {
-            continue;
-        }
         let name = rest
             .split(|c: char| !c.is_alphanumeric() && c != '_')
             .next()

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -872,3 +872,78 @@ interface Derived<T> extends Base<T> {
         "Got: {diags:?}"
     );
 }
+
+#[test]
+fn test_generic_construct_property_against_concrete_base_no_ts2430() {
+    // tsc accepts via erased signature (T → any) when I overrides a3 with a
+    // generic construct sig and the inherited target is non-generic.
+    let source = r#"
+class Base { foo: string = ""; }
+interface A { a3: new (x: number) => Base; }
+interface B extends A {}
+interface I extends B { a3: new <T extends Base>(x: T) => T; }
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430: Vec<_> = diags.iter().filter(|d| d.0 == 2430).collect();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when generic construct property is compatible \
+         with concrete non-generic base via erased signature (T→any). Got: {ts2430:?}"
+    );
+}
+
+#[test]
+fn test_generic_call_property_against_concrete_base_no_ts2430() {
+    // Call-signature variant of the same structural rule.
+    // `(x: T) => T` where `T extends Base` must satisfy `(x: number) => Base`.
+    let source = r#"
+class Base { foo: string = ""; }
+interface A { a3: (x: number) => Base; }
+interface B extends A {}
+interface I extends B { a3: <T extends Base>(x: T) => T; }
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430: Vec<_> = diags.iter().filter(|d| d.0 == 2430).collect();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when generic call property is compatible \
+         with concrete non-generic base via erased signature (T→any). Got: {ts2430:?}"
+    );
+}
+
+#[test]
+fn test_generic_construct_property_renamed_type_param_against_concrete_base_no_ts2430() {
+    // Same rule as above but with a renamed type parameter (U instead of T)
+    // to ensure the fix is not keyed on a specific identifier.
+    let source = r#"
+class Node { val: number = 0; }
+interface A { make: new (x: number) => Node; }
+interface B extends A {}
+interface I extends B { make: new <U extends Node>(x: U) => U; }
+"#;
+    let diags = get_diagnostics(source);
+    let ts2430: Vec<_> = diags.iter().filter(|d| d.0 == 2430).collect();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430 when generic construct property with renamed type param (U) \
+         is compatible with concrete non-generic base via erased signature. Got: {ts2430:?}"
+    );
+}
+
+#[test]
+fn test_generic_construct_property_genuinely_incompatible_return_still_errors() {
+    // Negative: the declared return type `string` is not assignable to `number`,
+    // so TS2430 fires even after any-erasure clears the parameter mismatch.
+    let source = r#"
+class Base { foo: string = ""; }
+interface A { a3: new (x: number) => number; }
+interface B extends A {}
+interface I extends B { a3: new <T extends Base>(x: T) => string; }
+"#;
+    let diags = get_diagnostics(source);
+    assert!(
+        diags.iter().any(|d| d.0 == 2430),
+        "Should still emit TS2430 when the generic construct property has an \
+         incompatible return type. Got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -13,7 +13,10 @@ use crate::types::{
 use crate::visitor::callable_shape_id;
 
 use super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
-use super::{erase_call_sig_to_any, erase_fn_shape_to_any, erase_type_params_to_constraints};
+use super::{
+    erase_call_sig_to_any, erase_fn_shape_to_any, erase_type_params_to_any,
+    erase_type_params_to_constraints,
+};
 
 mod params;
 
@@ -492,10 +495,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         sub
                     }
                     Err(_) => {
-                        // Inference failed (e.g., bounds violation). Fall back to tsc's
-                        // `getErasedSignature` behavior: replace type params with their
-                        // constraints (or `unknown` if unconstrained).
-                        erase_type_params_to_constraints(&source_instantiated.type_params)
+                        // Inference failed (e.g., bounds violation).
+                        //
+                        // `allow_erased_generic_signature_retry` is set for interface-extends
+                        // property checks (TS2430): use tsc's `getErasedSignature` path and
+                        // replace each type parameter with `any`. Without it (e.g.,
+                        // method-assignability paths with NO_ERASE_GENERICS), keep the
+                        // more conservative erase-to-constraints path.
+                        if self.allow_erased_generic_signature_retry {
+                            erase_type_params_to_any(&source_instantiated.type_params)
+                        } else {
+                            erase_type_params_to_constraints(&source_instantiated.type_params)
+                        }
                     }
                 };
                 source_instantiated =
@@ -1416,7 +1427,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         // tsc N×M path: when a callable has multiple signatures and the direct
-        // comparison above fails, try erasing type parameters to `any`
         // comparison above fails, try erasing type parameters to `any`
         // (matching tsc's `getErasedSignature` / `createTypeEraser`). In tsc's
         // `signaturesRelatedTo`, the N×M case (source.length > 1 || target.length > 1)


### PR DESCRIPTION
AgentName: M4-B
Runner: `claude-sonnet-4-6-remote-great-goodall-Tkxj9`

## Summary

**AgentName**: `claude-sonnet-4-6-remote-great-goodall-Tkxj9`
**Track**: Checker / Solver — TS2430 conformance
**Invariant**: When `allow_erased_generic_signature_retry` is set, the inference-failure fallback must erase type params to `any` (tsc's `getErasedSignature`), not to their constraints.

### Structural rule
When a property with a generic construct/call signature `new <T extends C>(x: T) => T` is checked against a non-generic inherited target `new (x: Concrete) => C` and inference fails (the inferred substitution violates T's constraint), tsc falls back to `getErasedSignature` (T → `any`), yielding `new (x: any) => any` which is assignable; tsz was falling back to `getCanonicalSignature` (T → C), yielding `new (x: C) => C`, which can fail parameter compatibility against concrete targets.

### Root cause
In `checking.rs` Block 2 (generic source → non-generic target), the `Err(_)` arm of `infer_source_type_param_substitution` always called `erase_type_params_to_constraints`. For interface-extends property checks (TS2430), tsc's `signaturesRelatedTo` N×M path uses `erase = true` (T → `any`). The fix branches on `self.allow_erased_generic_signature_retry`, which is already set exclusively by `should_report_property_type_mismatch` for TS2430 paths.

## Scope

**Files changed:**
- `crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs` — core fix: branch on `allow_erased_generic_signature_retry` in the inference-failure fallback
- `crates/conformance/src/tsz_wrapper.rs` — removed `is_extra_signature_inheritance_line` suppressor (the §25 anti-pattern that was masking this false positive)
- `crates/conformance/tests/tsz_wrapper.rs` — removed grandfather clause from architecture guard `tsz_wrapper_has_no_ad_hoc_extra_fingerprint_helpers`; updated 3 tests to reflect TS2430 being retained
- `crates/tsz-checker/tests/ts2430_tests.rs` — 4 new tests covering: construct sig, call sig, renamed type param (U), and negative (genuinely incompatible return)

## Project Corpus Impact

- Row: conformance — `constructSignatureAssignabilityInInheritance5.ts` and `callSignatureAssignabilityInInheritance5.ts` families
- Bug family: TS2430 false positive — generic callable property vs non-generic inherited concrete target
- Evidence: The removed suppressor was matching exactly `Interface 'I' incorrectly extends interface 'A'` and `Interface 'I' incorrectly extends interface 'B'` to hide tsz false positives in those two conformance test families. With the fix, tsz no longer emits the false TS2430, so the suppressor is unnecessary. Local runs: 39/39 TS2430 unit tests pass, 160/160 conformance wrapper tests pass.

## Verification

```
cargo test -p tsz-checker --test ts2430_tests     # 39 passed
cargo test -p tsz-conformance --lib               # 160 passed
cargo clippy --workspace --all-targets -- -D warnings  # clean
```

New test matrix (§26 compliance):
1. `test_generic_construct_property_against_concrete_base_no_ts2430` — direct repro
2. `test_generic_call_property_against_concrete_base_no_ts2430` — call sig variant
3. `test_generic_construct_property_renamed_type_param_against_concrete_base_no_ts2430` — renamed type param (U, not T)
4. `test_generic_construct_property_genuinely_incompatible_return_still_errors` — negative case

## Coordination Notes

- Fixes #9609 (claimed with WIP label before implementation)
- Removes the `is_extra_signature_inheritance_line` function referenced in the architecture guard grandfather clause (PR body for issue #9609 referenced this as future cleanup — cleanup is included here)
- No overlap with other open PRs observed as of 2026-05-21
- Draft CI runs lint + unit tests; ready-for-review CI will run conformance, emit, fourslash, WASM gates

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUJHhZTu6VCdy9zpnmEwuR)_
