### PR TITLE
fix(checker): prevent ERROR/VOID poisoning from structural nodes in expression dispatch

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1577,5 +1577,9 @@ path = "tests/type_parameter_canonical_typeid_tests.rs"
 name = "jsdoc_enum_member_assignability_tests"
 path = "tests/jsdoc_enum_member_assignability_tests.rs"
 
+[[test]]
+name = "structural_dispatch_void_tests"
+path = "tests/structural_dispatch_void_tests.rs"
+
 [lints]
 workspace = true

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1925,35 +1925,41 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     _ => TypeId::ANY,
                 }
             }
-            // Structural/declaration nodes reached by broad expression walks
-            // (cross-file traversal, import/export processing, callback-shape
-            // resolution). None are value-producing expressions; return VOID
-            // instead of ERROR to avoid poisoning downstream relation checks.
+            // Structural declaration/statement nodes reached by broad expression
+            // walks. These produce no value; VOID is correct.
             k if k == syntax_kind_ext::BLOCK
                 || k == syntax_kind_ext::NAMED_IMPORTS
                 || k == syntax_kind_ext::NAMED_EXPORTS
                 || k == syntax_kind_ext::METHOD_SIGNATURE
                 || k == syntax_kind_ext::IMPORT_DECLARATION
                 || k == syntax_kind_ext::IMPORT_CLAUSE
-                || k == syntax_kind_ext::NAMESPACE_IMPORT
-                || k == syntax_kind_ext::IMPORT_SPECIFIER
                 || k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
                 || k == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
                 || k == syntax_kind_ext::IMPORT_ATTRIBUTE
                 || k == syntax_kind_ext::IMPORT_ATTRIBUTES
                 || k == syntax_kind_ext::EXPORT_DECLARATION
-                || k == syntax_kind_ext::EXPORT_SPECIFIER
-                || k == syntax_kind_ext::NAMESPACE_EXPORT
                 || k == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
-                // Parameter/type-parameter declarations; types resolved via
-                // dedicated param APIs, not expression dispatch.
-                || k == syntax_kind_ext::PARAMETER
+                // Type parameters are erased and produce no runtime value.
                 || k == syntax_kind_ext::TYPE_PARAMETER =>
             {
                 TypeId::VOID
             }
+            // Binding nodes that accidentally reach expression dispatch through
+            // cross-file traversal. They refer to named bindings that carry real
+            // types, so VOID would be incorrect (void participates in
+            // assignability and triggers spurious diagnostics). Return ANY as a
+            // conservative placeholder — permissive like ERROR but without
+            // triggering the uncoded-diagnostic path.
+            k if k == syntax_kind_ext::IMPORT_SPECIFIER
+                || k == syntax_kind_ext::NAMESPACE_IMPORT
+                || k == syntax_kind_ext::EXPORT_SPECIFIER
+                || k == syntax_kind_ext::NAMESPACE_EXPORT
+                || k == syntax_kind_ext::PARAMETER =>
+            {
+                TypeId::ANY
+            }
             // `import` keyword token in structural positions (import declarations,
-            // ExpressionWithTypeArguments). Not a value-producing expression.
+            // `ExpressionWithTypeArguments`). Not a value-producing expression.
             k if k == SyntaxKind::ImportKeyword as u16 => TypeId::VOID,
             // Default case - unknown node kind is an error
             _ => {

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1816,7 +1816,8 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         && expr_node.kind == SyntaxKind::ImportKeyword as u16
                         && let Some(type_arguments) = &data.type_arguments
                     {
-                        // Bail early — the generic path would call instantiation_expression_applicability_error_type(VOID) producing a spurious extra error.
+                        // Bail early: the generic path would otherwise report
+                        // a spurious extra error for applying type args to VOID.
                         for &type_arg in &type_arguments.nodes {
                             let _ = self.checker.get_type_from_type_node(type_arg);
                         }
@@ -1950,7 +1951,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             // cross-file traversal. They refer to named bindings that carry real
             // types, so VOID would be incorrect (void participates in
             // assignability and triggers spurious diagnostics). Return ANY as a
-            // conservative placeholder — permissive like ERROR but without
+            // conservative placeholder: permissive like ERROR but without
             // triggering the uncoded-diagnostic path.
             k if k == syntax_kind_ext::IMPORT_SPECIFIER
                 || k == syntax_kind_ext::NAMESPACE_IMPORT

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1953,8 +1953,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             k if k == syntax_kind_ext::IMPORT_SPECIFIER
                 || k == syntax_kind_ext::NAMESPACE_IMPORT
                 || k == syntax_kind_ext::EXPORT_SPECIFIER
-                || k == syntax_kind_ext::NAMESPACE_EXPORT
-                || k == syntax_kind_ext::PARAMETER =>
+                || k == syntax_kind_ext::NAMESPACE_EXPORT =>
             {
                 TypeId::ANY
             }

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1925,19 +1925,36 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     _ => TypeId::ANY,
                 }
             }
-            // Structural statement/import/export nodes can be reached by broad
-            // expression walks in real projects. They do not have a value type,
-            // but they also should not poison checking with TypeId::ERROR.
+            // Structural/declaration nodes reached by broad expression walks
+            // (cross-file traversal, import/export processing, callback-shape
+            // resolution). None are value-producing expressions; return VOID
+            // instead of ERROR to avoid poisoning downstream relation checks.
             k if k == syntax_kind_ext::BLOCK
                 || k == syntax_kind_ext::NAMED_IMPORTS
                 || k == syntax_kind_ext::NAMED_EXPORTS
-                || k == syntax_kind_ext::METHOD_SIGNATURE =>
+                || k == syntax_kind_ext::METHOD_SIGNATURE
+                || k == syntax_kind_ext::IMPORT_DECLARATION
+                || k == syntax_kind_ext::IMPORT_CLAUSE
+                || k == syntax_kind_ext::NAMESPACE_IMPORT
+                || k == syntax_kind_ext::IMPORT_SPECIFIER
+                || k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                || k == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
+                || k == syntax_kind_ext::IMPORT_ATTRIBUTE
+                || k == syntax_kind_ext::IMPORT_ATTRIBUTES
+                || k == syntax_kind_ext::EXPORT_DECLARATION
+                || k == syntax_kind_ext::EXPORT_SPECIFIER
+                || k == syntax_kind_ext::NAMESPACE_EXPORT
+                || k == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION
+                // Parameter/type-parameter declarations; types resolved via
+                // dedicated param APIs, not expression dispatch.
+                || k == syntax_kind_ext::PARAMETER
+                || k == syntax_kind_ext::TYPE_PARAMETER =>
             {
                 TypeId::VOID
             }
-            k if k == syntax_kind_ext::METHOD_SIGNATURE => {
-                self.checker.get_type_of_interface_member_simple(idx)
-            }
+            // `import` keyword token in structural positions (import declarations,
+            // ExpressionWithTypeArguments). Not a value-producing expression.
+            k if k == SyntaxKind::ImportKeyword as u16 => TypeId::VOID,
             // Default case - unknown node kind is an error
             _ => {
                 tracing::warn!(

--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -1816,9 +1816,11 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         && expr_node.kind == SyntaxKind::ImportKeyword as u16
                         && let Some(type_arguments) = &data.type_arguments
                     {
+                        // Bail early — the generic path would call instantiation_expression_applicability_error_type(VOID) producing a spurious extra error.
                         for &type_arg in &type_arguments.nodes {
                             let _ = self.checker.get_type_from_type_node(type_arg);
                         }
+                        return TypeId::ERROR;
                     }
                     let expr_type = self.checker.get_type_of_node(data.expression);
                     if self

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -16,7 +16,7 @@
 //!   resolution is in place.
 //!
 //! An `ERROR` return propagates through assignability checks and produces
-//! "uncoded diagnostics" — diagnostics without a standard TS error code.
+//! "uncoded diagnostics" - diagnostics without a standard TS error code.
 //!
 //! Adjacent-case coverage (per `CLAUDE.md` §25/§26):
 //! - import declaration node family: `import { X } from '...'`
@@ -116,7 +116,8 @@ const strs: string[] = applyAll(nums, fn1);
 // ── Parameter declaration family ─────────────────────────────────────────────
 
 /// Callback parameters in a generic type must not cause ERROR contamination.
-/// Shape: `(param: T) => R` — the PARAMETER node for `param` must yield VOID.
+/// Shape: `(param: T) => R` - PARAMETER nodes must keep their existing
+/// diagnostic behavior and not be hidden by the structural-node fallback.
 #[test]
 fn parameter_node_in_callback_type_no_false_diagnostics_param_name_x() {
     let source = r#"

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -1,13 +1,21 @@
 //! Tests that structural/declaration/import nodes reaching expression-type
-//! dispatch return VOID (not ERROR), preventing poisoning of downstream
+//! dispatch do not return `TypeId::ERROR`, preventing poisoning of downstream
 //! relation checks.
 //!
 //! Structural rule: when `dispatch_type_computation` is called on a node that
-//! is not a value-producing expression (import declaration, import specifier,
-//! parameter declaration, import keyword token, export declaration, etc.), the
-//! result must be `TypeId::VOID`, not `TypeId::ERROR`. An ERROR return
-//! propagates through assignability checks and can suppress legitimate
-//! diagnostics or manufacture spurious ones.
+//! is not a value-producing expression, the result must not be `TypeId::ERROR`.
+//! Two categories apply:
+//!
+//! - **Statement/declaration nodes** (`IMPORT_DECLARATION`, `EXPORT_DECLARATION`,
+//!   `BLOCK`, etc.) produce no value → return `TypeId::VOID`.
+//! - **Binding nodes** (`IMPORT_SPECIFIER`, `EXPORT_SPECIFIER`, `PARAMETER`,
+//!   `NAMESPACE_IMPORT`) refer to named bindings that carry real types. `VOID`
+//!   would be incorrect because `void` participates in assignability and
+//!   triggers spurious diagnostics; `ANY` is returned as a conservative
+//!   permissive placeholder until proper per-node type resolution is in place.
+//!
+//! An `ERROR` return propagates through assignability checks and produces
+//! "uncoded diagnostics" — diagnostics without a standard TS error code.
 //!
 //! Adjacent-case coverage (per CLAUDE.md §25/§26):
 //! - import declaration node family: `import { X } from '...'`

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -8,11 +8,12 @@
 //!
 //! - **Statement/declaration nodes** (`IMPORT_DECLARATION`, `EXPORT_DECLARATION`,
 //!   `BLOCK`, etc.) produce no value → return `TypeId::VOID`.
-//! - **Binding nodes** (`IMPORT_SPECIFIER`, `EXPORT_SPECIFIER`, `PARAMETER`,
-//!   `NAMESPACE_IMPORT`) refer to named bindings that carry real types. `VOID`
-//!   would be incorrect because `void` participates in assignability and
-//!   triggers spurious diagnostics; `ANY` is returned as a conservative
-//!   permissive placeholder until proper per-node type resolution is in place.
+//! - **Binding nodes** (`IMPORT_SPECIFIER`, `EXPORT_SPECIFIER`,
+//!   `NAMESPACE_IMPORT`, `NAMESPACE_EXPORT`) refer to named bindings that
+//!   carry real types. `VOID` would be incorrect because `void` participates
+//!   in assignability and triggers spurious diagnostics; `ANY` is returned as
+//!   a conservative permissive placeholder until proper per-node type
+//!   resolution is in place.
 //!
 //! An `ERROR` return propagates through assignability checks and produces
 //! "uncoded diagnostics" — diagnostics without a standard TS error code.

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -18,7 +18,7 @@
 //! An `ERROR` return propagates through assignability checks and produces
 //! "uncoded diagnostics" — diagnostics without a standard TS error code.
 //!
-//! Adjacent-case coverage (per CLAUDE.md §25/§26):
+//! Adjacent-case coverage (per `CLAUDE.md` §25/§26):
 //! - import declaration node family: `import { X } from '...'`
 //! - export declaration node family: `export { X }`
 //! - parameter declaration: `(x: T) => void`

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -50,7 +50,7 @@ fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
 
 /// Cross-file import specifier traversal must not poison the entry-file's
 /// assignability checks with ERROR types from the import specifier node.
-/// Name: `Widget` / `render` (varies from the Kysely repro spelling).
+/// Name: `Widget` / `render` (varies from the `Kysely` repro spelling).
 #[test]
 fn import_specifier_traversal_does_not_poison_assignability_widget() {
     let lib = r#"

--- a/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
+++ b/crates/tsz-checker/tests/structural_dispatch_void_tests.rs
@@ -1,0 +1,263 @@
+//! Tests that structural/declaration/import nodes reaching expression-type
+//! dispatch return VOID (not ERROR), preventing poisoning of downstream
+//! relation checks.
+//!
+//! Structural rule: when `dispatch_type_computation` is called on a node that
+//! is not a value-producing expression (import declaration, import specifier,
+//! parameter declaration, import keyword token, export declaration, etc.), the
+//! result must be `TypeId::VOID`, not `TypeId::ERROR`. An ERROR return
+//! propagates through assignability checks and can suppress legitimate
+//! diagnostics or manufacture spurious ones.
+//!
+//! Adjacent-case coverage (per CLAUDE.md §25/§26):
+//! - import declaration node family: `import { X } from '...'`
+//! - export declaration node family: `export { X }`
+//! - parameter declaration: `(x: T) => void`
+//! - import keyword token in structural position
+//! - multiple name choices to prove no hardcoded name dependency
+//!
+//! The multi-file tests exercise the cross-file traversal path, which is
+//! the primary way these structural nodes reach expression dispatch in
+//! real-world projects.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_multi_file, check_source_codes};
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file(files, entry, opts())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ── Import declaration / import specifier family ─────────────────────────────
+
+/// Cross-file import specifier traversal must not poison the entry-file's
+/// assignability checks with ERROR types from the import specifier node.
+/// Name: `Widget` / `render` (varies from the Kysely repro spelling).
+#[test]
+fn import_specifier_traversal_does_not_poison_assignability_widget() {
+    let lib = r#"
+export type Widget = { id: number; label: string };
+export function render(w: Widget): string { return w.label; }
+"#;
+    let entry = r#"
+import { Widget, render } from './lib';
+const w: Widget = { id: 1, label: 'hello' };
+const s: string = render(w);
+"#;
+    let result = codes(&[("lib.ts", lib), ("entry.ts", entry)], "entry.ts");
+    assert!(
+        result.is_empty(),
+        "valid import-specifier cross-file usage must produce no diagnostics; got {result:?}"
+    );
+}
+
+/// Import-specifier traversal with a renamed identifier to prove the rule
+/// is structural, not name-dependent. Name: `Gadget` / `display`.
+#[test]
+fn import_specifier_traversal_does_not_poison_assignability_gadget() {
+    let lib = r#"
+export type Gadget = { code: string };
+export function display(g: Gadget): void {}
+"#;
+    let entry = r#"
+import { Gadget, display } from './lib';
+const g: Gadget = { code: 'abc' };
+display(g);
+"#;
+    let result = codes(&[("lib.ts", lib), ("entry.ts", entry)], "entry.ts");
+    assert!(
+        result.is_empty(),
+        "import specifier with renamed types must produce no diagnostics; got {result:?}"
+    );
+}
+
+/// An import declaration whose specifiers introduce a function type.
+/// Verifies no false TS2345 from structural-node ERROR contamination.
+/// Uses explicit annotations to avoid inference-limit interference.
+#[test]
+fn import_declaration_with_function_type_no_false_ts2345() {
+    let lib = r#"
+export type Transformer<A, B> = (input: A) => B;
+export function applyAll<T, U>(items: T[], fn: Transformer<T, U>): U[] {
+    return items.map(fn);
+}
+"#;
+    let entry = r#"
+import { Transformer, applyAll } from './lib';
+const nums: number[] = [1, 2, 3];
+const fn1: Transformer<number, string> = (n: number) => n.toString();
+const strs: string[] = applyAll(nums, fn1);
+"#;
+    let result = codes(&[("lib.ts", lib), ("entry.ts", entry)], "entry.ts");
+    assert!(
+        result.is_empty(),
+        "import of generic function type must produce no diagnostics; got {result:?}"
+    );
+}
+
+// ── Parameter declaration family ─────────────────────────────────────────────
+
+/// Callback parameters in a generic type must not cause ERROR contamination.
+/// Shape: `(param: T) => R` — the PARAMETER node for `param` must yield VOID.
+#[test]
+fn parameter_node_in_callback_type_no_false_diagnostics_param_name_x() {
+    let source = r#"
+declare function map<T, U>(arr: T[], fn: (x: T) => U): U[];
+const result: string[] = map([1, 2, 3], (x) => x.toString());
+"#;
+    let result = check_source_codes(source);
+    assert!(
+        result.is_empty(),
+        "callback with parameter `x` must produce no diagnostics; got {result:?}"
+    );
+}
+
+/// Same rule, different parameter name to prove no hardcoded `x` dependency.
+#[test]
+fn parameter_node_in_callback_type_no_false_diagnostics_param_name_item() {
+    let source = r#"
+declare function transform<T, U>(arr: T[], fn: (item: T) => U): U[];
+const result: string[] = transform([1, 2, 3], (item) => item.toString());
+"#;
+    let result = check_source_codes(source);
+    assert!(
+        result.is_empty(),
+        "callback with parameter `item` must produce no diagnostics; got {result:?}"
+    );
+}
+
+/// Constructor parameter declarations must not reach dispatch and return ERROR.
+/// Shape: class with typed constructor parameter.
+#[test]
+fn constructor_parameter_declaration_no_false_diagnostics() {
+    let source = r#"
+class Service {
+    constructor(private name: string, private port: number) {}
+    describe(): string { return `${this.name}:${this.port}`; }
+}
+const svc: Service = new Service('api', 8080);
+const desc: string = svc.describe();
+"#;
+    let result = check_source_codes(source);
+    assert!(
+        result.is_empty(),
+        "constructor parameters must produce no diagnostics; got {result:?}"
+    );
+}
+
+/// Multi-file: parameter node in an exported function signature does not
+/// contaminate the importer's type checks.
+#[test]
+fn cross_file_parameter_node_does_not_contaminate_importer() {
+    let lib = r#"
+export function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+"#;
+    let entry = r#"
+import { clamp } from './lib';
+const c: number = clamp(5, 0, 10);
+"#;
+    let result = codes(&[("lib.ts", lib), ("entry.ts", entry)], "entry.ts");
+    assert!(
+        result.is_empty(),
+        "cross-file function with parameters must produce no diagnostics; got {result:?}"
+    );
+}
+
+// ── Export declaration family ─────────────────────────────────────────────────
+
+/// Export specifiers re-exporting imported symbols must not poison the
+/// consumer's type checks with `ERROR` from `EXPORT_SPECIFIER` nodes.
+#[test]
+fn export_specifier_traversal_does_not_poison_consumer() {
+    let base = r#"
+export type Config = { host: string; port: number };
+"#;
+    let re_export = r#"
+export { Config } from './base';
+"#;
+    let entry = r#"
+import { Config } from './re_export';
+const cfg: Config = { host: 'localhost', port: 3000 };
+"#;
+    let result = codes(
+        &[
+            ("base.ts", base),
+            ("re_export.ts", re_export),
+            ("entry.ts", entry),
+        ],
+        "entry.ts",
+    );
+    assert!(
+        result.is_empty(),
+        "re-export specifier traversal must produce no diagnostics; got {result:?}"
+    );
+}
+
+// ── Import keyword in structural position ────────────────────────────────────
+
+/// `import("…").T` type-import exercises the `ImportKeyword` path.
+/// VOID must be returned for the keyword token; no ERROR cascades.
+#[test]
+fn import_keyword_in_type_position_does_not_produce_error_type() {
+    let source = r#"
+type Loaded = import('./some-module').default;
+"#;
+    let result = check_source_codes(source);
+    // TS2307 (cannot find module) is expected; no other codes should appear.
+    let unexpected: Vec<u32> = result
+        .into_iter()
+        .filter(|&c| c != 2307 && c != 2792)
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "import type expression must not produce unexpected diagnostics; got {unexpected:?}"
+    );
+}
+
+// ── Absence of ERROR-cascade diagnostics across all families ─────────────────
+
+/// Verifies that none of the specific TS error codes that are characteristic
+/// of ERROR-type propagation appear spuriously for clean import-specifier code.
+/// ERROR contamination typically surfaces as TS2322, TS2345, or TS2339.
+#[test]
+fn no_error_cascade_codes_from_structural_nodes_multi_file() {
+    let lib = r#"
+export interface Repository<T> {
+    findById(id: number): T | undefined;
+    save(entity: T): void;
+}
+export type User = { id: number; email: string };
+export function createUserRepo(): Repository<User> {
+    return {
+        findById: (_id) => undefined,
+        save: (_u) => {},
+    };
+}
+"#;
+    let entry = r#"
+import { Repository, User, createUserRepo } from './lib';
+const repo: Repository<User> = createUserRepo();
+const user: User | undefined = repo.findById(42);
+"#;
+    let result = codes(&[("lib.ts", lib), ("entry.ts", entry)], "entry.ts");
+    let cascade_codes = [2322u32, 2345, 2339];
+    let cascades: Vec<u32> = result
+        .into_iter()
+        .filter(|c| cascade_codes.contains(c))
+        .collect();
+    assert!(
+        cascades.is_empty(),
+        "structural node traversal must not produce cascade diagnostics; got {cascades:?}"
+    );
+}


### PR DESCRIPTION
AgentName: M4-D
Runner: `codex/m4d-refresh-9634-v2`

## Track

Track 4 - checker / expression dispatch correctness.

## Invariant

When `dispatch_type_computation` is called on a structural node that is not a value-producing expression, it must not return `TypeId::ERROR` and trigger uncoded diagnostics. Statement/declaration nodes return `TypeId::VOID`; import/export binding specifiers return `TypeId::ANY` because `void` participates in assignability and caused spurious diagnostics in the earlier attempt. `import<T>()` through `ExpressionWithTypeArguments` resolves type arguments and returns `ERROR` early to avoid an extra `VOID` instantiation diagnostic.

## Structural Rule

When broad checker walks accidentally route non-expression syntax through expression dispatch, `tsc` does not treat those nodes as value expressions. This PR keeps `tsz` from leaking `ERROR`/`VOID` into relation checks while preserving existing parameter diagnostics.

## Scope

- `crates/tsz-checker/src/dispatch.rs`: classify structural declaration nodes, binding nodes, and `ImportKeyword` before the unknown-node fallback; add the `import<T>()` early return.
- `crates/tsz-checker/tests/structural_dispatch_void_tests.rs`: cover import/export specifiers, import declarations, parameter-adjacent cases, constructor parameters, import type syntax, and cascade diagnostic absence.
- `crates/tsz-checker/Cargo.toml`: register the structural dispatch test target.

## Project Corpus Impact

- Row: `kysely-project`
- Bug family: `uncoded diagnostic` / `dispatch_type_computation: unknown expression kind` from structural nodes reaching expression dispatch
- Evidence: issue #9618 reported `IMPORT_SPECIFIER`, `ImportKeyword`, and `IMPORT_DECLARATION` reaching expression dispatch; focused checker tests were preserved during the 2026-05-25 refresh.

## Verification

2026-05-21 M4-D refresh on head `0493f76c9b` rebased to `origin/main` (`51361c9b52`):

```bash
git diff --check
cargo fmt --all -- --check
python3 scripts/arch/arch_guard.py
cargo nextest run -p tsz-checker --test structural_dispatch_void_tests
# result: 10 tests run: 10 passed, 0 skipped
```

2026-05-25 M4-D dependency refresh on head `9d0623e41626b076d622e9e49ce45728411e815e`:

```bash
git diff --check
cargo fmt --all --check
python3 scripts/arch/arch_guard.py
```

Targeted `cargo nextest` was not rerun locally on the refreshed head because `scripts/agents/disk-preflight.sh M4-D` reported only ~1.9 GB free. Draft-light CI should provide the fresh build/unit signal for exact head `9d0623e41626b076d622e9e49ce45728411e815e`.

## Coordination Notes

- AgentName: M4-D
- Closes #9618 if refreshed CI remains clean and the PR lands.
- Dependency #9904 is now merged into `main` as part of the refreshed base.
- Rebased the branch onto `origin/main` at `67400adcc0`; the only manual conflict was the end-of-file `[[test]]` registration in `crates/tsz-checker/Cargo.toml`, resolved by keeping both `jsdoc_enum_member_assignability_tests` and `structural_dispatch_void_tests`.
- Current state: non-draft with auto-merge off on exact head `9d0623e41626b076d622e9e49ce45728411e815e`. Exact-head CI run `26377806572` has passed the light build/unit phase and ready-review heavy jobs are now queued. Keep auto-merge off until all required checks, including `Queue Tested`, are complete and green.
- No `agent:M4-C` labels were changed.


