### PR TITLE
fix(dts): keep class expression variables structural

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
@@ -540,7 +540,7 @@ fn test_private_identifier_emits_private_marker() {
 }
 
 // =============================================================================
-// Class Expression Synthesis
+// Class Expression Variable Declarations
 // tsc rule: JS exports with class expression initializers synthesize class
 // declarations, while TS exports keep the variable shape and emit structural
 // constructor object types.
@@ -628,6 +628,38 @@ fn ts_export_const_generic_class_expr_emits_structural_constructor_type() {
 }
 
 #[test]
+fn ts_export_const_class_expr_with_private_unique_symbol_types_emits_constructor_type() {
+    let output = emit_dts(
+        r#"
+declare const key: unique symbol;
+interface Shape {
+    readonly token: unique symbol;
+}
+export const C = class {
+    method(p: typeof key): typeof key { return p; }
+    other(p: Shape["token"]): Shape["token"] { return p; }
+};
+"#,
+    );
+    assert!(
+        output.contains("export declare const C: {"),
+        "class expression with private unique-symbol types should remain a value declaration: {output}"
+    );
+    assert!(
+        !output.contains("export declare class C"),
+        "class expression variable should not be promoted to a class declaration: {output}"
+    );
+    assert!(
+        output.contains("method(p: typeof key): typeof key;"),
+        "unique-symbol method signature should be preserved in constructor instance type: {output}"
+    );
+    assert!(
+        output.contains("other(p: Shape[\"token\"]): Shape[\"token\"];"),
+        "indexed unique-symbol method signature should be preserved in constructor instance type: {output}"
+    );
+}
+
+#[test]
 fn js_export_const_class_expr_synthesizes_class_decl() {
     let output = emit_js_dts("export const C = class {\n    foo() {}\n};");
     assert!(
@@ -647,7 +679,13 @@ fn js_export_const_class_expr_synthesizes_class_decl() {
 #[test]
 fn ts_namespace_export_const_class_expr_emits_structural_constructor_type() {
     let output = emit_dts(
-        "export namespace N {\n    export const C = class {\n        foo(): void {}\n    };\n}",
+        r#"
+export namespace N {
+    export const C = class {
+        foo(): void {}
+    };
+}
+"#,
     );
     assert!(
         output.contains("    const C: {"),


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Track 2 / Emit-DTS parity coverage

## Invariant
When TS source exports a variable initialized by a class expression, `tsc` keeps the value declaration and emits a structural construct-signature object type; JS declaration emit may still use the synthetic exported-class surface for JS class-expression exports.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs`
- Current branch is test-only after rebasing onto `origin/main` `ce00bb78c6`; the guarded JS-vs-TS source behavior is already present upstream, so this PR now preserves the M4-A regression coverage for that behavior.

## Project Corpus Impact
Row: n/a
Bug family: DTS class-expression variable declaration classification / unique-symbol type preservation
Evidence: focused emitter unit coverage plus `uniqueSymbolsDeclarations` DTS filter; no project-corpus fixture row is directly affected by this test-only refresh.

## Verification
- `git diff --check origin/main...HEAD` on `63328d80d3`
- `cargo nextest run -p tsz-emitter class_expr` on `63328d80d3` (52 passed, 3168 skipped; nextest run ID `6ad11ade-3967-4715-9b5c-5d0bb0059e0c`)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=uniqueSymbolsDeclarations --dts-only --verbose --json-out=/tmp/m4a-9638-unique-symbols-main-ce00.json` on `63328d80d3` (DTS 2/2, 100%)
- Draft-light CI on `63328d80d3`: `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `gate`, `project-row-drift`, and GitGuardian are green; `lint`, `unit`, and `dist-binaries` are still in progress as of this update.

## Coordination Notes
- Rebased the branch from `31958e24f7` to `63328d80d3` on top of current `origin/main` `ce00bb78c6` and force-with-lease pushed.
- Conflict resolution kept the newer upstream guarded emitter behavior and carried forward the unique-symbol / TS-vs-JS class-expression tests.
- Keep draft/off-auto until exact-head draft-light CI is fully green; promoting this draft would trigger heavy CI.
