### PR TITLE
fix(emit): lower suspending switch statements into the ES5 generator state machine

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -71,6 +71,8 @@ mod discovery;
 mod loop_control;
 #[path = "async_es5_ir_state.rs"]
 mod state;
+#[path = "async_es5_ir_switch.rs"]
+mod switch;
 #[path = "async_es5_ir_try_region.rs"]
 mod try_region;
 
@@ -2743,6 +2745,15 @@ impl<'a> AsyncES5Transformer<'a> {
 
             k if k == syntax_kind_ext::LABELED_STATEMENT => {
                 self.process_labeled_statement_in_async(
+                    idx,
+                    cases,
+                    current_statements,
+                    current_label,
+                );
+            }
+
+            k if k == syntax_kind_ext::SWITCH_STATEMENT => {
+                self.process_switch_statement_in_async(
                     idx,
                     cases,
                     current_statements,

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_loop_control.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_loop_control.rs
@@ -315,6 +315,17 @@ impl<'a> AsyncES5Transformer<'a> {
             && candidate.as_ref() == placeholder_label.to_string()
         {
             *candidate = target_label.to_string().into();
+            return;
+        }
+        // Recurse into dispatch `switch` statements emitted by the suspending
+        // switch lowering, whose case bodies hold `return [3 /*break*/, L]`
+        // jumps to placeholder clause-body labels.
+        if let IRNode::SwitchStatement { cases, .. } = node {
+            for case in cases {
+                for statement in &mut case.statements {
+                    Self::patch_if_break_target_in_node(statement, placeholder_label, target_label);
+                }
+            }
         }
     }
 }

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_switch.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_switch.rs
@@ -1,0 +1,359 @@
+//! Lowering for `switch` statements that suspend, into the ES5 `__generator`
+//! state machine.
+//!
+//! This mirrors tsc's `transformAndEmitSwitchStatement` (plus `cacheExpression`)
+//! from `src/compiler/transformers/generators.ts`. The structural rule:
+//!
+//! > When a `switch` statement's case block contains a suspension (`await` in an
+//! > async function, `yield` in a generator) — whether in a case-clause
+//! > expression or a clause body — tsc cannot keep the `switch` intact, because
+//! > a suspension splits the surrounding code into `__generator` cases. Instead
+//! > it caches the discriminant into a temp, emits one or more *dispatch*
+//! > `switch` statements that compare the cached discriminant against each
+//! > case-clause expression and `return [3 /*break*/, L]` to that clause's body
+//! > label, then lays out each clause body at its own label with `break`
+//! > rewritten to a jump to the switch-end label. This change makes tsz do the
+//! > same — independent of identifier spelling, target, which clause holds the
+//! > suspension, and the presence/position of a `default` clause.
+//!
+//! When only the discriminant suspends (the case block does not), the `switch`
+//! body stays intact: the discriminant is yielded and the whole `switch` is
+//! emitted verbatim using the sent value as its expression — matching tsc.
+
+use crate::transforms::async_es5_ir::AsyncES5Transformer;
+use crate::transforms::ir::{IRGeneratorCase, IRNode, IRSwitchCase};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::CaseClauseData;
+
+use super::loop_control::AsyncLoopControlTargets;
+use super::opcodes;
+
+impl<'a> AsyncES5Transformer<'a> {
+    /// Process a `switch` statement inside an async/generator body.
+    pub(super) fn process_switch_statement_in_async(
+        &mut self,
+        idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) {
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+        let Some(switch) = self.arena.get_switch(node) else {
+            return;
+        };
+        let discriminant_idx = switch.expression;
+        let case_block_idx = switch.case_block;
+        let Some(case_block_node) = self.arena.get(case_block_idx) else {
+            return;
+        };
+        let Some(case_block) = self.arena.get_block(case_block_node) else {
+            return;
+        };
+        let clause_indices: Vec<NodeIndex> = case_block.statements.nodes.clone();
+
+        if !self.contains_await_recursive(case_block_idx) {
+            // The case block has no suspension. If the discriminant suspends at
+            // the top level, yield it and keep the `switch` intact using the
+            // sent value as the discriminant. Otherwise emit it verbatim.
+            if let Some(operand_idx) = self.top_level_suspension_operand(discriminant_idx) {
+                let operand = self.expression_to_ir(operand_idx);
+                self.push_generator_yield(
+                    opcodes::YIELD,
+                    operand,
+                    "yield",
+                    cases,
+                    current_statements,
+                    current_label,
+                );
+                let verbatim = self.build_verbatim_switch(&clause_indices, IRNode::GeneratorSent);
+                current_statements.push(verbatim);
+                return;
+            }
+            // No top-level suspension to hoist (no suspension at all, or only a
+            // nested one in the discriminant that we cannot lift): emit verbatim.
+            current_statements.push(self.statement_to_ir(idx));
+            return;
+        }
+
+        self.lower_suspending_switch(
+            discriminant_idx,
+            &clause_indices,
+            cases,
+            current_statements,
+            current_label,
+        );
+    }
+
+    /// Lower a `switch` whose case block suspends into dispatch switches plus
+    /// per-clause-body generator cases.
+    fn lower_suspending_switch(
+        &mut self,
+        discriminant_idx: NodeIndex,
+        clause_indices: &[NodeIndex],
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) {
+        let clause_count = clause_indices.len();
+
+        // Cache the discriminant into a hoisted temp so each dispatch switch can
+        // compare against it across yield boundaries.
+        let discriminant_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: discriminant_temp.clone().into(),
+            initializer: None,
+        });
+        let discriminant_value =
+            self.lower_suspending_value(discriminant_idx, cases, current_statements, current_label);
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(discriminant_temp.clone()),
+            discriminant_value,
+        ))));
+
+        // Reserve a placeholder label for each clause body and the switch end.
+        // Real labels are assigned in clause order once the dispatch is built,
+        // matching tsc's label-numbering (which is determined by mark order).
+        let clause_labels: Vec<u32> = (0..clause_count)
+            .map(|_| self.next_loop_exit_placeholder())
+            .collect();
+        let end_label = self.next_loop_exit_placeholder();
+        let default_index = clause_indices.iter().position(|&clause_idx| {
+            self.switch_clause(clause_idx)
+                .is_some_and(|clause| clause.expression.is_none())
+        });
+
+        self.build_switch_dispatch(
+            &discriminant_temp,
+            clause_indices,
+            &clause_labels,
+            cases,
+            current_statements,
+            current_label,
+        );
+
+        // After the dispatch, fall through to the default clause (or the end of
+        // the switch when there is no default).
+        let fallthrough_target = default_index.map_or(end_label, |index| clause_labels[index]);
+        current_statements.push(Self::generator_break_statement(fallthrough_target));
+
+        self.emit_switch_clause_bodies(
+            clause_indices,
+            &clause_labels,
+            end_label,
+            cases,
+            current_statements,
+            current_label,
+        );
+    }
+
+    /// Build the dispatch `switch` statements: a faithful port of the
+    /// clause-grouping loop in tsc's `transformAndEmitSwitchStatement`.
+    ///
+    /// Consecutive case clauses are grouped into a single dispatch `switch`;
+    /// a case clause whose expression itself suspends starts a new group (its
+    /// suspension is yielded before the group's dispatch is emitted). `default`
+    /// clauses are not part of any dispatch (they are the fallthrough target).
+    fn build_switch_dispatch(
+        &mut self,
+        discriminant_temp: &str,
+        clause_indices: &[NodeIndex],
+        clause_labels: &[u32],
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) {
+        let clause_count = clause_indices.len();
+        let mut clauses_written = 0usize;
+        while clauses_written < clause_count {
+            let mut pending: Vec<IRSwitchCase> = Vec::new();
+            let mut default_skipped = 0usize;
+            let mut index = clauses_written;
+            while index < clause_count {
+                let Some(clause) = self.switch_clause(clause_indices[index]) else {
+                    index += 1;
+                    continue;
+                };
+                // A `default` clause has no expression; it is not part of any
+                // dispatch and is reached via the post-dispatch fallthrough.
+                let clause_expr = clause.expression;
+                if clause_expr.is_none() {
+                    default_skipped += 1;
+                    index += 1;
+                    continue;
+                }
+                // A suspending case expression starts a fresh dispatch group so
+                // its yield does not land in the middle of an already-started
+                // dispatch switch.
+                if self.contains_await_recursive(clause_expr) && !pending.is_empty() {
+                    break;
+                }
+                let test = self.lower_suspending_value(
+                    clause_expr,
+                    cases,
+                    current_statements,
+                    current_label,
+                );
+                pending.push(IRSwitchCase {
+                    test: Some(test),
+                    statements: vec![Self::generator_break_statement(clause_labels[index])],
+                    inline: true,
+                });
+                index += 1;
+            }
+
+            if !pending.is_empty() {
+                let written = pending.len();
+                current_statements.push(IRNode::SwitchStatement {
+                    expression: Box::new(IRNode::id(discriminant_temp.to_string())),
+                    cases: std::mem::take(&mut pending),
+                });
+                clauses_written += written;
+            }
+            clauses_written += default_skipped;
+        }
+    }
+
+    /// Lower an expression that may suspend into an IR value, yielding first
+    /// when it is a top-level suspension (`await x` / `yield x`). Used for both
+    /// the cached discriminant and each dispatch-clause test.
+    fn lower_suspending_value(
+        &mut self,
+        expr_idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> IRNode {
+        if let Some(operand_idx) = self.top_level_suspension_operand(expr_idx) {
+            let operand = self.expression_to_ir(operand_idx);
+            self.push_generator_yield(
+                opcodes::YIELD,
+                operand,
+                "yield",
+                cases,
+                current_statements,
+                current_label,
+            );
+            IRNode::GeneratorSent
+        } else if self.contains_await_recursive(expr_idx) {
+            self.emit_nested_suspension(expr_idx, cases, current_statements, current_label);
+            self.expression_to_ir(expr_idx)
+        } else {
+            self.expression_to_ir(expr_idx)
+        }
+    }
+
+    /// Emit each clause body at its own generator-case label, with unlabeled
+    /// `break` rewritten to a jump to the switch-end label and fallthrough
+    /// between non-terminating clauses preserved via `_.label = next`.
+    fn emit_switch_clause_bodies(
+        &mut self,
+        clause_indices: &[NodeIndex],
+        clause_labels: &[u32],
+        end_label: u32,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) {
+        // Inside a `switch`, an unlabeled `break` exits the switch (the end
+        // label). An unlabeled `continue` is only meaningful inside an enclosing
+        // loop; switch clauses do not establish a continue target, so it is left
+        // to the surrounding loop's lowering. We pass the end label as the
+        // continue target as a conservative bound for the (rare) switch-in-loop
+        // case, which is not exercised by the suspending-switch corpus.
+        let control = AsyncLoopControlTargets {
+            break_label: end_label,
+            continue_label: end_label,
+        };
+
+        for (index, &clause_idx) in clause_indices.iter().enumerate() {
+            let label = self.state.next_label();
+            self.open_switch_case(label, cases, current_statements, current_label);
+            Self::patch_if_break_target(cases, clause_labels[index], label);
+
+            let Some(clause) = self.switch_clause(clause_idx) else {
+                continue;
+            };
+            let statements = clause.statements.nodes.clone();
+            for stmt in statements {
+                self.process_loop_body_statement_in_async(
+                    stmt,
+                    cases,
+                    current_statements,
+                    current_label,
+                    control,
+                );
+            }
+        }
+
+        let label = self.state.next_label();
+        self.open_switch_case(label, cases, current_statements, current_label);
+        Self::patch_if_break_target(cases, end_label, label);
+    }
+
+    /// Flush the current generator case and open a new one at `label`. When the
+    /// flushed case does not end in a terminating generator op, append
+    /// `_.label = label` so execution falls through to the new case — matching
+    /// tsc's `flushLabel` behavior.
+    fn open_switch_case(
+        &mut self,
+        label: u32,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) {
+        if !current_statements.is_empty() && !Self::statements_terminate(current_statements) {
+            current_statements.push(Self::generator_label_assignment(label));
+        }
+        cases.push(IRGeneratorCase {
+            label: *current_label,
+            statements: std::mem::take(current_statements),
+        });
+        *current_label = label;
+    }
+
+    /// Whether a case's statements end in a terminating generator op (a
+    /// `return [...]`), in which case the runtime will not fall through.
+    const fn statements_terminate(statements: &[IRNode]) -> bool {
+        matches!(statements.last(), Some(IRNode::ReturnStatement(_)))
+    }
+
+    /// Resolve a `case`/`default` clause node to its data (works for both, with
+    /// a `default` clause carrying a none expression).
+    fn switch_clause(&self, clause_idx: NodeIndex) -> Option<&CaseClauseData> {
+        let node = self.arena.get(clause_idx)?;
+        self.arena.get_case_clause(node)
+    }
+
+    /// Build a verbatim `switch` IR node from clauses (no suspension in the case
+    /// block), substituting `discriminant` for the switch expression.
+    fn build_verbatim_switch(&self, clause_indices: &[NodeIndex], discriminant: IRNode) -> IRNode {
+        let mut switch_cases = Vec::new();
+        for &clause_idx in clause_indices {
+            let Some(clause) = self.switch_clause(clause_idx) else {
+                continue;
+            };
+            let test = if clause.expression.is_none() {
+                None
+            } else {
+                Some(self.expression_to_ir(clause.expression))
+            };
+            let statements = clause
+                .statements
+                .nodes
+                .iter()
+                .map(|&stmt| self.statement_to_ir(stmt))
+                .collect();
+            switch_cases.push(IRSwitchCase {
+                test,
+                statements,
+                inline: false,
+            });
+        }
+        IRNode::SwitchStatement {
+            expression: Box::new(discriminant),
+            cases: switch_cases,
+        }
+    }
+}

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1083,11 +1083,13 @@ impl<'a> AstToIr<'a> {
                     .iter()
                     .map(|&s| self.convert_statement(s))
                     .collect(),
+                inline: false,
             }
         } else {
             IRSwitchCase {
                 test: None,
                 statements: vec![],
+                inline: false,
             }
         }
     }

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -701,6 +701,10 @@ pub struct IRParam {
 pub struct IRSwitchCase {
     pub test: Option<IRNode>, // None for default case
     pub statements: Vec<IRNode>,
+    /// Render the (single) clause statement on the same line as the `case`
+    /// label, e.g. `case x: return [3 /*break*/, 2];`. tsc emits synthesized
+    /// single-statement clauses inline; user-authored clauses stay multi-line.
+    pub inline: bool,
 }
 
 /// Catch clause

--- a/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
@@ -360,8 +360,18 @@ impl<'a> IRPrinter<'a> {
         } else {
             self.write("default:");
         }
-        self.write_line();
 
+        // Synthesized single-statement clauses (e.g. the generator dispatch
+        // `case x: return [3 /*break*/, L];`) are emitted on the same line as
+        // the case label, matching tsc.
+        if case.inline && case.statements.len() == 1 {
+            self.write(" ");
+            self.emit_node(&case.statements[0]);
+            self.write_line();
+            return;
+        }
+
+        self.write_line();
         self.increase_indent();
         for stmt in &case.statements {
             self.write_indent();

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -1678,3 +1678,158 @@ fn async_for_block_scoped_initializer_is_not_var_hoisted() {
 // is emitted verbatim, not a state machine) is covered end-to-end by the
 // `es5-asyncFunctionForStatements` emit baseline (`forStatement0`); the
 // standalone IR-printer test harness cannot render verbatim AST references.
+
+// Structural rule: when a `switch` statement's case block suspends (await in an
+// async function, yield in a generator) — in a case-clause expression or a
+// clause body — tsc lowers it into the `__generator` state machine: the
+// discriminant is cached into a hoisted temp, dispatch `switch`es compare the
+// temp against each clause expression and `return [3 /*break*/, L]` to the
+// matched clause-body label, and each clause body lives at its own label with
+// `break` rewritten to a jump to the switch-end label. This is independent of
+// identifier spelling, which clause holds the suspension, and whether/where a
+// `default` clause appears.
+
+#[test]
+fn switch_with_await_in_clause_expression_lowers_to_dispatch_state_machine() {
+    let output = transform_and_print(
+        "async function f() { switch (x) { case await y: a; break; default: b; break; } }",
+    );
+
+    assert!(
+        output.contains("_a = x;"),
+        "Discriminant must be cached into a hoisted temp before dispatch.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, y];"),
+        "A suspending case expression must yield before the dispatch switch.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case _b.sent(): return [3 /*break*/, 2];"),
+        "Dispatch must compare the cached discriminant against the resumed case value and jump to the clause body label, emitted inline.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [3 /*break*/, 3];"),
+        "With a default clause, the post-dispatch fallthrough must target the default body label.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case 2:")
+            && output.contains("case 3:")
+            && output.contains("case 4: return [2 /*return*/];"),
+        "Clause bodies and the end label must be laid out as sequential generator cases.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn switch_lowering_is_not_keyed_on_identifier_spelling() {
+    // Same shape as above with every identifier renamed; the lowering must be
+    // structural, not name-keyed.
+    let output = transform_and_print(
+        "async function f() { switch (disc) { case await chosen: hit; break; default: miss; break; } }",
+    );
+
+    assert!(
+        output.contains("_a = disc;"),
+        "Discriminant caching must work for any discriminant spelling.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, chosen];"),
+        "Renamed suspending case expression must still yield.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case _b.sent(): return [3 /*break*/, 2];"),
+        "Renamed shape must still produce the dispatch jump.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn switch_with_await_in_clause_body_keeps_dispatch_synchronous() {
+    let output = transform_and_print(
+        "async function f() { switch (x) { case y: await a; break; default: b; break; } }",
+    );
+
+    assert!(
+        output.contains("_a = x;") && output.contains("case y: return [3 /*break*/, 1];"),
+        "When only a clause body suspends, the discriminant is still cached and the dispatch compares it synchronously.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, a];"),
+        "The clause body await must yield inside the clause's body label.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn switch_without_default_falls_through_to_end_label() {
+    let output = transform_and_print(
+        "async function f() { switch (x) { case y: a; break; case await z: b; break; } }",
+    );
+
+    assert!(
+        output.contains("case y: return [3 /*break*/, 2];"),
+        "Non-suspending leading clause must dispatch in its own group.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, z];"),
+        "Suspending clause expression must start a new dispatch group after a yield.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case _b.sent(): return [3 /*break*/, 3];"),
+        "Second dispatch group must compare the resumed value.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [3 /*break*/, 4];")
+            && output.contains("case 4: return [2 /*return*/];"),
+        "With no default, the post-dispatch fallthrough must target the switch-end label.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn switch_default_fallthrough_without_break_sets_label() {
+    let output = transform_and_print(
+        "async function f() { switch (x) { default: c; case y: a; break; case await z: b; break; } }",
+    );
+
+    assert!(
+        output.contains("c;") && output.contains("_b.label = 3;"),
+        "A non-terminating clause (default without break) must set `_b.label` so it falls through to the next case.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn switch_discriminant_await_with_plain_body_keeps_switch_intact() {
+    let output = transform_and_print(
+        "async function f() { switch (await x) { case y: a; break; default: b; break; } }",
+    );
+
+    assert!(
+        output.contains("return [4 /*yield*/, x];"),
+        "A suspending discriminant must be yielded.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("switch (_a.sent()) {"),
+        "When only the discriminant suspends, the switch stays intact over the sent value.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return [3 /*break*/"),
+        "A non-suspending case block must not be lowered into a dispatch state machine.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn generator_switch_with_yield_lowers_like_async() {
+    let output = transform_generator_and_print(
+        "function* g() { switch (x) { case y: a; break; case yield z: b; break; } }",
+    );
+
+    assert!(
+        output.contains("_a = x;"),
+        "Generator-mode switch lowering must cache the discriminant just like async mode.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, z];"),
+        "A `yield` in a generator switch clause expression must yield before the dispatch.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case _b.sent(): return [3 /*break*/, 3];"),
+        "Generator-mode dispatch must compare the resumed value identically to async mode.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

Original runner metadata: `cloud-opus47-1m-confident-thompson`.

## Track
Track 9 — JavaScript emit parity, async/generator ES5 switch lowering.

## Invariant
When a `switch` statement inside an async function or generator has a suspension in a case-clause expression or clause body, `tsc` cannot keep the authored `switch` intact inside the `__generator` callback. It caches the discriminant as needed, emits dispatch `switch` statements that jump to per-clause generator labels, rewrites unlabeled `break` to the switch-end label, and inserts fallthrough labels where a clause continues into the next clause. When only the discriminant suspends, the authored switch body can stay intact over the yielded sent value.

## Root Cause
`tsz-emitter` async/generator ES5 statement dispatch had no `SWITCH_STATEMENT` arm, so a switch containing `await` or `yield` fell through to verbatim AST emission inside the generator callback, leaving invalid ES5 output.

## Owner Layer
Emitter output lowering only: `tsz-emitter` async ES5 IR and printer support. No checker/solver involvement, semantic validation, or output surgery.

## Scope
- Add async ES5 switch lowering in `async_es5_ir_switch.rs`.
- Hook `SWITCH_STATEMENT` dispatch from `async_es5_ir.rs`.
- Patch break-target placeholders inside synthesized dispatch switch IR.
- Add an inline switch-case printer flag for synthesized single-statement dispatch clauses.
- Add focused async ES5 IR tests for await/yield in clause expressions and bodies, default/fallthrough behavior, no-default behavior, discriminant-only suspension, and renamed identifiers.

## Adjacent Cases
| Case | Expected behavior |
|---|---|
| Await in case expression | Cache/dispatch to clause labels. |
| Await in clause body only | Synchronous dispatch, body yields at its label. |
| No default clause | Dispatch falls through to switch end. |
| Default without terminating break | Insert label fallthrough to next clause. |
| Discriminant-only await | Keep authored switch body over `_a.sent()`. |
| Generator `yield` in clause | Same switch lowering shape as async await. |
| Renamed identifiers | Behavior is structural, not name-keyed. |

## Known Unsupported Shapes / Fallback
- An unlabeled `continue` inside a switch nested in a loop is conservatively routed to the switch-end label.
- A discriminant with nested, non-top-level suspension and a non-suspending case block falls back to verbatim emission, matching the existing conservative bound for while/do-while condition lowering.

## Verification
- Previous local evidence from the original PR: `es5-asyncFunctionSwitchStatements` JS emit passed for es5 and es2015, byte-exact vs tsc baselines.
- Previous local async-family check: `--filter=asyncFunction --js-only` moved `es5-asyncFunctionSwitchStatements(target=es5)` from fail to pass with 0 regressions reported by the PR author.
- Previous focused unit coverage: async ES5 switch tests in `crates/tsz-emitter/tests/async_es5_ir.rs`.
- Previous lint/fmt evidence: `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings` and `cargo fmt` clean per original PR notes.
- Studio-C refresh 2026-05-21: `git diff --check origin/main...HEAD` passed after the rebase-only refresh.
- Draft CI light run `26223369807` for exact head `f79e28127bf6c5fcf6f23a5df0cbc1782ac00d5f` completed green on 2026-05-21: lint, unit, dist-binaries, cargo-deny, cargo-shear, project-row-drift, gate, unit-cloudbuild, GitGuardian, and CI Light Summary passed.

## Project Corpus Impact
- Row: n/a.
- Bug family: async/generator ES5 `__generator` lowering of switch statements that suspend, plus discriminant-only suspension.
- Evidence: original local emit filter evidence above; exact-head light CI is green and ready-review CI is the next gate.

## Coordination Notes
- Non-overlapping slice of #8510: this PR owns async/generator switch dispatch. #9553 owns binary/assignment/control-flow async ES5 work, and #9635 owns regular for-statement lowering.
- Refreshed onto current `origin/main` `131ae212e5c18bf41e75e7af4de0c4f1da0a2b68` and pushed exact head `52f9e97f71b514374209f81bdfec60daca767463` with `--force-with-lease`.
- Post-rebase sanity: `git diff --check origin/main...HEAD`.
- Current draft-light CI: https://github.com/mohsen1/tsz/actions/runs/26230424777
- EM2 ready-lane audit 2026-05-21: normalized the body to include the required `Invariant` section name. The PR is currently ready for heavy CI; keep auto-merge off until current-head checks report and required gates are green.

