### PR TITLE
refactor(cli): extract completion parameter recovery

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions.rs
@@ -4,6 +4,7 @@
 //! `handlers_completions_display.rs`.
 
 use super::{Server, TsServerRequest, TsServerResponse};
+use crate::handlers_completions_parameters::trailing_function_parameter_names_at_declaration_end;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
@@ -2572,76 +2573,6 @@ impl Server {
         out
     }
 
-    fn trailing_function_parameter_names_at_declaration_end(
-        source_text: &str,
-        offset: u32,
-    ) -> FxHashSet<String> {
-        let mut out = FxHashSet::default();
-        let end = (offset as usize).min(source_text.len());
-        let trimmed = source_text[..end].trim_end();
-        if !trimmed.ends_with('}') {
-            return out;
-        }
-
-        let bytes = trimmed.as_bytes();
-        let close = bytes.len() - 1;
-        let mut depth = 0i32;
-        let mut open = None;
-        let mut i = close + 1;
-        while i > 0 {
-            i -= 1;
-            match bytes[i] {
-                b'}' => depth += 1,
-                b'{' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        open = Some(i);
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        let Some(open) = open else {
-            return out;
-        };
-        let before_body = &trimmed[..open];
-        let Some(function_kw) = before_body.rfind("function") else {
-            return out;
-        };
-        let after_kw = &before_body[function_kw + "function".len()..];
-        let Some(paren_rel) = after_kw.find('(') else {
-            return out;
-        };
-        let open_paren = function_kw + "function".len() + paren_rel;
-        let Some(close_rel) = before_body[open_paren + 1..].find(')') else {
-            return out;
-        };
-        let close_paren = open_paren + 1 + close_rel;
-        let params = &before_body[open_paren + 1..close_paren];
-        for segment in params.split(',') {
-            let mut part = segment.trim();
-            if part.starts_with("...") {
-                part = part[3..].trim_start();
-            }
-            let ident_end = part
-                .find(|c: char| !(c == '_' || c == '$' || c.is_ascii_alphanumeric()))
-                .unwrap_or(part.len());
-            if ident_end == 0 {
-                continue;
-            }
-            let ident = &part[..ident_end];
-            if ident
-                .chars()
-                .next()
-                .is_some_and(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphabetic())
-            {
-                out.insert(ident.to_string());
-            }
-        }
-        out
-    }
-
     pub(crate) fn handle_completions(
         &mut self,
         seq: u64,
@@ -2789,7 +2720,7 @@ impl Server {
                         }
                     }
                 }
-                let blocked = Self::trailing_function_parameter_names_at_declaration_end(
+                let blocked = trailing_function_parameter_names_at_declaration_end(
                     &source_text,
                     completion_offset,
                 );

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_parameters.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_parameters.rs
@@ -1,0 +1,142 @@
+//! Parameter-name recovery helpers for completion handlers.
+
+use rustc_hash::FxHashSet;
+
+pub(super) fn trailing_function_parameter_names_at_declaration_end(
+    source_text: &str,
+    offset: u32,
+) -> FxHashSet<String> {
+    let Some(params) = trailing_function_parameter_list_at_declaration_end(source_text, offset)
+    else {
+        return FxHashSet::default();
+    };
+
+    FunctionParameterList::new(params).parameter_names()
+}
+
+struct FunctionParameterList<'a> {
+    text: &'a str,
+}
+
+impl<'a> FunctionParameterList<'a> {
+    fn new(text: &'a str) -> Self {
+        Self { text }
+    }
+
+    fn parameter_names(&self) -> FxHashSet<String> {
+        let mut out = FxHashSet::default();
+        for segment in self.text.split(',') {
+            if let Some(name) = parameter_name_from_segment(segment) {
+                out.insert(name.to_string());
+            }
+        }
+        out
+    }
+}
+
+fn trailing_function_parameter_list_at_declaration_end(
+    source_text: &str,
+    offset: u32,
+) -> Option<&str> {
+    let end = (offset as usize).min(source_text.len());
+    let trimmed = source_text[..end].trim_end();
+    if !trimmed.ends_with('}') {
+        return None;
+    }
+
+    let open = trailing_body_open_brace(trimmed)?;
+    let before_body = &trimmed[..open];
+    let function_kw = before_body.rfind("function")?;
+    let after_kw = &before_body[function_kw + "function".len()..];
+    let paren_rel = after_kw.find('(')?;
+    let open_paren = function_kw + "function".len() + paren_rel;
+    let close_rel = before_body[open_paren + 1..].find(')')?;
+    let close_paren = open_paren + 1 + close_rel;
+    Some(&before_body[open_paren + 1..close_paren])
+}
+
+fn trailing_body_open_brace(trimmed: &str) -> Option<usize> {
+    let bytes = trimmed.as_bytes();
+    let close = bytes.len().checked_sub(1)?;
+    let mut depth = 0i32;
+    let mut i = close + 1;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b'}' => depth += 1,
+            b'{' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parameter_name_from_segment(segment: &str) -> Option<&str> {
+    let mut part = segment.trim();
+    if part.starts_with("...") {
+        part = part[3..].trim_start();
+    }
+    let ident_end = part
+        .find(|c: char| !(c == '_' || c == '$' || c.is_ascii_alphanumeric()))
+        .unwrap_or(part.len());
+    if ident_end == 0 {
+        return None;
+    }
+    let ident = &part[..ident_end];
+    ident
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphabetic())
+        .then_some(ident)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(source_text: &str) -> FxHashSet<String> {
+        trailing_function_parameter_names_at_declaration_end(source_text, source_text.len() as u32)
+    }
+
+    #[test]
+    fn extracts_identifiers_from_trailing_function_declaration() {
+        let blocked = names("function handle(first: string, second = 1, ...rest: unknown[]) {}");
+
+        assert!(blocked.contains("first"));
+        assert!(blocked.contains("second"));
+        assert!(blocked.contains("rest"));
+        assert_eq!(blocked.len(), 3);
+    }
+
+    #[test]
+    fn accepts_identifier_start_variants() {
+        let blocked = names("function handle(_local: string, $value: number, 9bad: string) {}");
+
+        assert!(blocked.contains("_local"));
+        assert!(blocked.contains("$value"));
+        assert!(!blocked.contains("9bad"));
+        assert_eq!(blocked.len(), 2);
+    }
+
+    #[test]
+    fn returns_empty_when_cursor_is_not_after_trailing_body() {
+        let blocked = trailing_function_parameter_names_at_declaration_end(
+            "function handle(first: string) {",
+            32,
+        );
+
+        assert!(blocked.is_empty());
+    }
+
+    #[test]
+    fn returns_empty_when_function_parameter_list_is_incomplete() {
+        let blocked = names("function handle(first: string { }");
+
+        assert!(blocked.is_empty());
+    }
+}

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -36,6 +36,7 @@ mod handlers_code_fixes_jsdoc;
 mod handlers_code_fixes_utils;
 mod handlers_completions;
 mod handlers_completions_display;
+mod handlers_completions_parameters;
 mod handlers_completions_snippets;
 mod handlers_diagnostics;
 mod handlers_editing;


### PR DESCRIPTION
AgentName: Studio-E
AgentName: Studio-A-sidecar-9674

## Track
Track 9 / LSP-tsserver CLI refactor-only cleanup for #9416.

## Invariant
When tsserver completions run immediately after a function declaration body, tsz keeps pruning trailing declaration parameter names from non-member completions while the source-text recovery parser lives behind a focused completion support helper instead of handler glue.

## Scope
- Add `crates/tsz-cli/src/bin/tsz_server/handlers_completions_parameters.rs` for trailing function parameter-name recovery.
- Route `handlers_completions.rs` through the extracted helper.
- Keep `main.rs` wiring aligned with the split helper module.
- Add focused unit coverage for declaration parameters, rest parameters, identifier-start variants, and incomplete/non-trailing fallback cases.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only tsserver completion filtering in `crates/tsz-cli/src/bin/tsz_server`; no parser, binder, checker, solver, emitter, conformance, emit, fourslash, WASM, benchmark, or project-corpus behavior path is intended to change.

## Verification
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo nextest run -p tsz-cli -E 'test(handlers_completions_parameters::tests)'` (4 passed, 1785 skipped)
- Exact-head draft-light CI passed for `91f862d77c67bae8a363af489110964ea36780f6`.
- Ready-review CI was requested after promotion; use current GitHub checks for the landing verdict.

## Coordination Notes
- Closes #9416.
- Branch head: `91f862d77c67bae8a363af489110964ea36780f6`.
- This is a bounded CLI refactor split with no known implementation blocker.
- Auto-merge is off; land only after the required exact-head checks are green.