### PR TITLE
fix(solver): keep `${any}` and `${unknown}` as deferred TemplateLiteralType

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1226,6 +1226,10 @@ name = "template_literal_bigint_placeholder_tests"
 path = "tests/template_literal_bigint_placeholder_tests.rs"
 
 [[test]]
+name = "template_literal_any_unknown_placeholder_tests"
+path = "tests/template_literal_any_unknown_placeholder_tests.rs"
+
+[[test]]
 name = "template_literal_empty_placeholder_tests"
 path = "tests/template_literal_empty_placeholder_tests.rs"
 

--- a/crates/tsz-checker/tests/template_literal_any_unknown_placeholder_tests.rs
+++ b/crates/tsz-checker/tests/template_literal_any_unknown_placeholder_tests.rs
@@ -1,0 +1,127 @@
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn has_ts2322(source: &str) -> bool {
+    codes(source).contains(&2322)
+}
+
+fn no_errors(source: &str) -> bool {
+    codes(source).is_empty()
+}
+
+// ── ${any} placeholder ────────────────────────────────────────────────────────
+
+#[test]
+fn string_not_assignable_to_template_any() {
+    // tsc: TS2322 — `string` is NOT assignable to `` `${any}` ``
+    assert!(
+        has_ts2322("declare const s: string; const a: `${any}` = s;"),
+        "`string` must not be assignable to `${{any}}`"
+    );
+}
+
+#[test]
+fn string_literal_assignable_to_template_any() {
+    // tsc: ok — a string literal IS assignable to `` `${any}` ``
+    assert!(
+        no_errors(r#"const a: `${any}` = "hello";"#),
+        "string literal must be assignable to `${{any}}`"
+    );
+}
+
+#[test]
+fn any_assignable_to_template_any() {
+    // tsc: ok — `any` itself is assignable to any type
+    assert!(
+        no_errors("declare const x: any; const a: `${any}` = x;"),
+        "`any` must be assignable to `${{any}}`"
+    );
+}
+
+#[test]
+fn template_any_is_subtype_of_string() {
+    // tsc: ok — all template literal types are subtypes of `string`
+    assert!(
+        no_errors("declare const a: `${any}`; const s: string = a;"),
+        "`${{any}}` must be assignable to `string`"
+    );
+}
+
+#[test]
+fn prefixed_any_rejects_string() {
+    // `prefix-${any}` also rejects a bare `string`
+    assert!(
+        has_ts2322("declare const s: string; const a: `prefix-${any}` = s;"),
+        "`string` must not be assignable to `prefix-${{any}}`"
+    );
+}
+
+#[test]
+fn prefixed_any_accepts_matching_literal() {
+    // `prefix-${any}` accepts a literal starting with "prefix-"
+    assert!(
+        no_errors(r#"const a: `prefix-${any}` = "prefix-hello";"#),
+        "matching literal must be assignable to `prefix-${{any}}`"
+    );
+}
+
+// ── ${unknown} placeholder ────────────────────────────────────────────────────
+
+#[test]
+fn string_not_assignable_to_template_unknown() {
+    // tsc: TS2322 — `string` is NOT assignable to `` `${unknown}` ``
+    assert!(
+        has_ts2322("declare const s: string; const a: `${unknown}` = s;"),
+        "`string` must not be assignable to `${{unknown}}`"
+    );
+}
+
+#[test]
+fn string_literal_assignable_to_template_unknown() {
+    // tsc: ok — a string literal IS assignable to `` `${unknown}` ``
+    assert!(
+        no_errors(r#"const a: `${unknown}` = "hello";"#),
+        "string literal must be assignable to `${{unknown}}`"
+    );
+}
+
+#[test]
+fn template_unknown_is_subtype_of_string() {
+    // tsc: ok — all template literal types are subtypes of `string`
+    assert!(
+        no_errors("declare const a: `${unknown}`; const s: string = a;"),
+        "`${{unknown}}` must be assignable to `string`"
+    );
+}
+
+#[test]
+fn multi_span_unknown_rejects_string() {
+    // `a${unknown}b` also rejects a bare `string`
+    assert!(
+        has_ts2322("declare const s: string; const a: `a${unknown}b` = s;"),
+        "`string` must not be assignable to `a${{unknown}}b`"
+    );
+}
+
+#[test]
+fn multi_span_unknown_accepts_matching_literal() {
+    assert!(
+        no_errors(r#"const a: `a${unknown}b` = "axyzb";"#),
+        "matching literal must be assignable to `a${{unknown}}b`"
+    );
+}

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -433,22 +433,11 @@ impl TypeInterner {
             }
         }
 
-        // Bare `${unknown}` and `${any}` collapse to string. Do not widen
-        // prefixed/suffixed `any` patterns like `a${any}`: the fixed text
-        // remains part of the assignability contract.
-        if let [TemplateSpan::Type(type_id)] = spans.as_slice()
-            && (*type_id == TypeId::UNKNOWN || *type_id == TypeId::ANY)
-        {
-            return TypeId::STRING;
-        }
-
-        for span in &spans {
-            if let TemplateSpan::Type(type_id) = span
-                && *type_id == TypeId::UNKNOWN
-            {
-                return TypeId::STRING;
-            }
-        }
+        // Note: `${any}` and `${unknown}` must NOT collapse to `string`.
+        // In tsc, only the `${string}` span can be collapsed (it spans the
+        // full string domain). `${any}` and `${unknown}` remain as deferred
+        // TemplateLiteralType so that `string` is NOT assignable to them
+        // (tsc TS2322) while string literals still are (via match_template_literal_recursive).
 
         // Normalize spans by merging consecutive text spans (Pass 2)
         let normalized = self.normalize_template_spans(spans);

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -38739,14 +38739,19 @@ fn test_template_literal_with_never() {
 
 #[test]
 fn test_template_literal_with_any() {
-    // `${any}` template with any should produce string
-    // TypeScript: `prefix-${any}` collapses to `string` because any can be any value
+    // `${any}` must remain a deferred TemplateLiteralType — tsc does NOT collapse it
+    // to `string`. `string` is NOT assignable to `` `${any}` `` (tsc TS2322).
     let interner = TypeInterner::new();
 
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
 
-    // Template with any should widen to string - any stringifies to any possible string
-    assert_eq!(template, TypeId::STRING);
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "`${{any}}` must remain TemplateLiteralType"
+    );
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_normalize_tests.rs
+++ b/crates/tsz-solver/tests/intern_normalize_tests.rs
@@ -1532,10 +1532,15 @@ fn template_literal_with_never_is_never() {
 }
 
 #[test]
-fn template_literal_with_any_is_string() {
+fn template_literal_with_any_stays_deferred() {
+    // `${any}` must remain a TemplateLiteralType — tsc does not collapse it to `string`.
+    // `string` is NOT assignable to `` `${any}` `` (tsc TS2322).
     let i = TypeInterner::new();
     let t = i.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
-    assert_eq!(t, TypeId::STRING);
+    assert!(
+        matches!(i.lookup(t), Some(TypeData::TemplateLiteral(_))),
+        "`${{any}}` must remain TemplateLiteralType, not collapse to string"
+    );
 }
 
 #[test]

--- a/crates/tsz-solver/tests/intern_tests.rs
+++ b/crates/tsz-solver/tests/intern_tests.rs
@@ -1315,28 +1315,36 @@ fn test_template_empty_string_removal() {
 }
 
 #[test]
-fn test_template_unknown_widening() {
+fn test_template_unknown_deferred() {
     let interner = TypeInterner::new();
 
-    // `` `${unknown}` `` should widen to string
+    // `` `${unknown}` `` must remain a deferred TemplateLiteralType — tsc does NOT
+    // collapse it to `string`. Only `${string}` (which spans the full string domain)
+    // can be collapsed. `string` is NOT assignable to `` `${unknown}` `` in tsc.
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::UNKNOWN)]);
-    assert_eq!(
-        template,
-        TypeId::STRING,
-        "Template with unknown should widen to string"
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "Template `${{unknown}}` must remain as TemplateLiteralType, not collapse to string"
     );
 }
 
 #[test]
-fn test_template_any_widening() {
+fn test_template_any_deferred() {
     let interner = TypeInterner::new();
 
-    // `` `${any}` `` should widen to string (any is infectious in templates)
+    // `` `${any}` `` must remain a deferred TemplateLiteralType — tsc does NOT
+    // collapse it to `string`. `string` is NOT assignable to `` `${any}` `` in tsc
+    // (TS2322), while string literals like `"x"` are assignable.
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::ANY)]);
-    assert_eq!(
-        template,
-        TypeId::STRING,
-        "Template with any should widen to string"
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "Template `${{any}}` must remain as TemplateLiteralType, not collapse to string"
     );
 }
 

--- a/crates/tsz-solver/tests/isomorphism_validation.rs
+++ b/crates/tsz-solver/tests/isomorphism_validation.rs
@@ -317,8 +317,9 @@ fn test_any_widening_in_template() {
 }
 
 #[test]
-fn test_unknown_widening_in_template() {
-    // unknown in template should widen to string
+fn test_unknown_in_template_stays_deferred() {
+    // `${unknown}` must NOT widen to `string` — tsc keeps it as a deferred
+    // TemplateLiteralType. `string` is not assignable to `` `${unknown}` ``.
     let interner = create_test_interner();
 
     let spans = vec![
@@ -328,10 +329,12 @@ fn test_unknown_widening_in_template() {
     ];
     let template = interner.template_literal(spans);
 
-    assert_eq!(
-        template,
-        TypeId::STRING,
-        "Unknown widening in template failed"
+    assert!(
+        matches!(
+            interner.lookup(template),
+            Some(TypeData::TemplateLiteral(_))
+        ),
+        "`a${{unknown}}b` must remain TemplateLiteralType, not collapse to string"
     );
 }
 

--- a/crates/tsz-solver/tests/template_literal_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/template_literal_comprehensive_tests.rs
@@ -284,7 +284,8 @@ fn test_template_literal_with_any() {
 
     let result = evaluate_type(&interner, template);
 
-    // `prefix-${any}` should be string (since any converts to string)
+    // `prefix-${any}` is a TemplateLiteralType and is a subtype of string
+    // (all template literals are subtypes of string).
     let mut checker = SubtypeChecker::new(&interner);
     assert!(
         checker.is_subtype_of(result, TypeId::STRING),

--- a/crates/tsz-solver/tests/template_literal_subtype_tests.rs
+++ b/crates/tsz-solver/tests/template_literal_subtype_tests.rs
@@ -615,8 +615,7 @@ fn test_template_to_template_string_not_subtype_of_number() {
 
 #[test]
 fn test_template_literal_with_prefixed_any_keeps_fixed_text() {
-    // `a${any}` remains a pattern with an `a` prefix; only bare `${any}`
-    // collapses to `string`.
+    // `a${any}` remains a TemplateLiteralType pattern (prefix + any placeholder).
     let interner = TypeInterner::new();
 
     let pattern = interner.template_literal(vec![


### PR DESCRIPTION
AgentName: M4-A
Runner: `claude-sonnet-4-6-remote`
Track: Checker/Solver conformance
Fixes: #9702

## Summary

When a template literal's only span is `any` or `unknown`, tsc keeps it as a deferred `TemplateLiteralType`; `string` is NOT assignable to it (TS2322). Only a bare `${string}` placeholder spans the full string domain. This change makes tsz match tsc.

## Root cause

`TypeInterner::template_literal()` had two incorrect early-returns:

1. A single-span check that collapsed `${any}` and `${unknown}` to `TypeId::STRING`
2. A loop that collapsed **any** template containing an `unknown` span to `TypeId::STRING`

Both were removed. After removal, `${any}` and `${unknown}` fall through the normal normalization/expansion path and are correctly interned as `TypeData::TemplateLiteralType`.

## Scope

Owner layer: `tsz_solver::intern::template` — the template literal construction factory.

No changes to the type relation checker (`match_template_literal_recursive` already correctly treats `any` and `unknown` spans as string wildcards for literal-to-template matching, so `"x" <: \`${any}\`` continues to return `true`).

## Adjacent-case test matrix

| Source | Target | Expected | Result |
|--------|--------|----------|--------|
| `string` | `` `${any}` `` | TS2322 | ✅ fixed |
| `"hello"` | `` `${any}` `` | ok | ✅ |
| `any` | `` `${any}` `` | ok | ✅ |
| `` `${any}` `` | `string` | ok | ✅ |
| `string` | `` `prefix-${any}` `` | TS2322 | ✅ |
| `"prefix-ok"` | `` `prefix-${any}` `` | ok | ✅ |
| `string` | `` `${unknown}` `` | TS2322 | ✅ fixed |
| `"hello"` | `` `${unknown}` `` | ok | ✅ |
| `` `${unknown}` `` | `string` | ok | ✅ |
| `string` | `` `a${unknown}b` `` | TS2322 | ✅ fixed |
| `"axyzb"` | `` `a${unknown}b` `` | ok | ✅ |

Note: `${string}` ← `string` still produces TS2322 (separate pre-existing issue #9693, out of scope).

## Verification

Built `tsz` CLI and ran against all cases from the issue repro directly:
```
$ tsz repro.ts --noEmit --strict --pretty false
repro.ts(3,7): error TS2322: Type 'string' is not assignable to type '`${any}`'.
```
Exactly 1 error on the flagged line; literal and reverse assignments clean.

## Project Corpus Impact

- Row: n/a
- Bug family: false-negative / template-literal deferred-type collapse

Evidence: 11 new checker tests pass; 362 solver template tests pass; 0 new failures introduced (11 pre-existing conditional/file-size failures confirmed identical before and after via `git stash` comparison).

## Coordination Notes

- Issue #9702 claimed with WIP label.
- Issue #9693 (`${string}` ← `string` regression) is a separate tracked issue, not touched here.
- No overlapping open PRs found for this bug family.
