### PR TITLE
fix(solver): widen fresh literals in spread-mixed array element inference

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -400,11 +400,11 @@ mod architecture_contract_tests_src;
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]
-#[path = "tests/as_const_nested_literal_display_tests.rs"]
-mod as_const_nested_literal_display_tests;
-#[cfg(test)]
 #[path = "tests/array_literal_spread_inference_widening_tests.rs"]
 mod array_literal_spread_inference_widening_tests;
+#[cfg(test)]
+#[path = "tests/as_const_nested_literal_display_tests.rs"]
+mod as_const_nested_literal_display_tests;
 #[cfg(test)]
 #[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
 mod assertion_type_predicate_diagnostics_tests;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -403,6 +403,9 @@ mod array_isarray_mutual_subtype_narrowing_tests;
 #[path = "tests/as_const_nested_literal_display_tests.rs"]
 mod as_const_nested_literal_display_tests;
 #[cfg(test)]
+#[path = "tests/array_literal_spread_inference_widening_tests.rs"]
+mod array_literal_spread_inference_widening_tests;
+#[cfg(test)]
 #[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
 mod assertion_type_predicate_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/array_literal_spread_inference_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/array_literal_spread_inference_widening_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for issue #9741: fresh literal elements of a spread-containing array
+//! literal must be widened during `T[]` inference.
+//!
+//! When inferring the element type `T` of `arr: T[]` from an array literal that
+//! mixes a spread with non-spread literal elements (e.g. `[...base, "x"]`), the
+//! inferred element-type candidate is a single union (`number | "x"`). tsc's
+//! `getWidenedLiteralType` widens the fresh literal members of that union
+//! independently, yielding `T = string | number`. The bug preserved the literal
+//! members (`T = number | "x"`), masking a TS2322.
+//!
+//! The structural rule: when a type parameter is inferred from array-literal
+//! element types and the inferred element type is a union containing fresh
+//! literal members, those fresh members are widened even when the union also
+//! carries non-literal members.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322(src: &str) -> Vec<String> {
+    check_source_diagnostics(src)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn spread_then_literal_widens_during_array_inference() {
+    // `T` widens to `string | number`, so the narrow literal target is rejected.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x"]);
+const c: number | "x" = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn spread_then_literal_accepts_widened_target() {
+    // The widened element type `string | number` must be accepted.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x"]);
+const c: string | number = r;
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn literal_then_spread_widens_regardless_of_position() {
+    let errs = ts2322(
+        r#"
+declare function pick<U>(items: U[]): U;
+const nums = [1, 2];
+const r = pick(["x", ...nums]);
+const c: number | "x" = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn spread_with_multiple_trailing_literals_widens() {
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x", "y"]);
+const c: number | "x" = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn spread_with_boolean_literal_widens_to_boolean() {
+    // Adjacent shape: a boolean literal mixed with a numeric spread widens to
+    // `number | boolean`, not `number | true`.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, true]);
+const c: number | true = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn plain_literal_array_still_widens_control() {
+    // Control: a plain literal array (no spread) must keep widening to `string`.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const r = f(["x", "y"]);
+const c: "x" | "y" = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn spread_of_literal_array_still_widens_control() {
+    // Control: spreading a literal-typed array (its elements already widened to
+    // `string`) plus another literal still widens.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const sbase = ["a", "b"];
+const r = f([...sbase, "c"]);
+const c: "a" | "b" | "c" = r;
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}
+
+#[test]
+fn const_type_param_preserves_literals_negative_control() {
+    // Negative control: a `const` type parameter must still preserve literal
+    // element types (no widening), so the narrow target is accepted.
+    let errs = ts2322(
+        r#"
+declare function f<const T>(arr: T[]): T;
+const base = [1, 2] as const;
+const r = f([...base, "x"]);
+const c: 1 | 2 | "x" = r;
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "expected no TS2322 for const T, got: {errs:?}"
+    );
+}
+
+#[test]
+fn nullable_literal_array_keeps_literals_boundary() {
+    // Boundary: a plain literal array whose element union also carries a
+    // nullable (`null`) member is left un-widened. The fix only widens when the
+    // non-literal members are widened primitives (the spread-of-widened-array
+    // shape); nullable-mixed unions keep their literal members, so the literal
+    // target is still accepted.
+    let errs = ts2322(
+        r#"
+declare function f<T>(arr: T[]): T;
+const r = f([true, 1, null, "yes"]);
+const c: true | 1 | "yes" | null = r;
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "expected no TS2322 for nullable-mixed literal array, got: {errs:?}"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -14,7 +14,7 @@ use crate::construction::TypeDatabase;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{InferencePriority, TemplateSpan, TypeData, TypeId};
-use crate::visitor::{is_literal_type, is_union_of_fresh_literals};
+use crate::visitor::{array_element_union_widens_literals, is_literal_type};
 use ena::unify::{InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -1252,7 +1252,7 @@ impl<'a> InferenceContext<'a> {
             is_fresh_literal: (!context.from_object_property || context.source_is_fresh)
                 && (is_literal_type(self.interner, ty)
                     || (self.in_array_element_context
-                        && is_union_of_fresh_literals(self.interner, ty)))
+                        && array_element_union_widens_literals(self.interner, ty)))
                 && !self.source_is_type_annotation
                 && !self.in_readonly_source_context,
             from_object_property: context.from_object_property,

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -92,6 +92,48 @@ pub fn is_union_of_fresh_literals(types: &dyn TypeDatabase, type_id: TypeId) -> 
     }
 }
 
+/// Decide whether an array-element inference union should have its fresh literal
+/// members widened to their primitive base.
+///
+/// Returns `true` when the union has at least one literal member and every
+/// member is either a literal or one of the primitives that literal widening
+/// produces (`number` / `string` / `boolean` / `bigint`). This covers:
+/// - pure literal unions (`"a" | "b"`, `1 | 2`) — equivalent to
+///   `is_union_of_fresh_literals`; and
+/// - unions that mix fresh literals with an already-widened primitive, which is
+///   exactly the shape produced by spreading a widened array alongside a literal
+///   element (`number | "x"` from `[...numberArray, "x"]`). The widened
+///   primitive proves the array literal already carries a widened element, so
+///   the fresh literal siblings must widen too, matching tsc's
+///   `getWidenedLiteralType`.
+///
+/// A union whose non-literal members include `null` / `undefined` / objects is
+/// left alone, preserving the literal members for downstream narrowing (the
+/// conservative baseline for mixed literal+nullable element unions).
+pub fn array_element_union_widens_literals(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match types.lookup(type_id) {
+        Some(TypeData::Union(list_id)) => {
+            let members = types.type_list(list_id);
+            let mut has_literal = false;
+            for &member in members.iter() {
+                if is_literal_type(types, member) {
+                    has_literal = true;
+                } else if !matches!(
+                    member,
+                    TypeId::NUMBER | TypeId::STRING | TypeId::BOOLEAN | TypeId::BIGINT
+                ) {
+                    return false;
+                }
+            }
+            has_literal
+        }
+        _ => false,
+    }
+}
+
 /// Check if a type is a module namespace type (import * as ns).
 ///
 /// Matches: `TypeData::ModuleNamespace`(_)


### PR DESCRIPTION
Fixes #9741.

## Agent
AgentName: M4-B
Inherited from: gen-hunter-opus

## Track
Track 4 / solver inference parity.

## Invariant
When inferring the element type `T` of `arr: T[]` from an array literal that mixes a spread of a widened array with non-spread literal elements, tsz should widen fresh literal element siblings the way `tsc` does. The widening decision belongs in solver inference/structural predicates, not in checker-specific spelling checks.

## Structural Rule
When a type parameter is inferred from array-literal element types and the inferred element type is a union containing at least one fresh literal plus already-widened primitive members (`number`, `string`, `boolean`, or `bigint`), the fresh literal members should widen. Unions containing non-literal/non-widened members such as `null`, `undefined`, or object types are intentionally left conservative by this slice.

## Root Cause
`crates/tsz-solver/src/inference/infer.rs` previously treated an array-element candidate as a widenable fresh-literal candidate only when the whole union satisfied the all-fresh-literal predicate. A spread of `number[]` plus `"x"` yields `number | "x"`, which skipped literal widening and caused a false-negative `TS2322`.

## Scope
- Adds a structural solver predicate for array-element unions that should widen literal members beside widened primitive members.
- Applies that predicate in the array-element inference resolver path.
- Adds checker coverage for spread position, multiple trailing literals, boolean/string controls, `const` inference preservation, and nullable-mixed boundaries.
- M4-B landing-shape follow-up splits constraint-unwrapping/object-classification visitor helpers into `visitor_constraint_predicates.rs`; behavior and the `crate::visitor::*` export surface are unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: array-literal element widening during `T[]` generic inference (false-negative `TS2322`)
- Evidence: local CLI repro and focused checker unit tests recorded by the prior owner; M4-B follow-up is refactor-only module organization for the solver visitor file-size gate.

## Verification
Prior owner recorded:
- New 10 tests passed.
- Previously pinned `ts2345_generic_call_parameter_display_preserves_instantiated_alias_name` passed.
- Filtered `cargo test -p tsz-checker --lib -- inference widen array spread generic literal` had no new failures; 8 remaining failures were pre-existing on `main`.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` passed.
- CLI repro confirmed the matrix cases.

M4-B conflict refresh:
- Resolved the stale `crates/tsz-checker/src/lib.rs` module-list conflict by keeping both current `main`'s `as_const_nested_literal_display_tests` module and this PR's `array_literal_spread_inference_widening_tests` module.
- Replaced the temporary merge-commit conflict resolution with a single focused rebased commit on current `main`.
- Prior remote PR head `fcad11f67794e6887a680c4814bb2fa2456458e6` reached ready-review green except required `Queue Tested`, then Studio-A moved the PR back to draft for the touched-file size blocker.

M4-B rebase refresh on head `79bc43f04ec22a993d7dce44531ff0b26273db71` over `origin/main` `6f1bd866b2e3b5e1e96b84b1a0816278072d7e46`:
- `git diff --check origin/main..HEAD`
- `cargo fmt --check --package tsz-checker --package tsz-solver`
- `python3 scripts/arch/arch_guard.py`
- Rust test reruns intentionally skipped because the workspace has less than 1 GB free; ready-review CI owns heavy gates per §19.5.

M4-B landing-shape split on current head `4058f3d4f0559c3755244d17496066638f784438`:
- `wc -l crates/tsz-solver/src/visitors/visitor.rs crates/tsz-solver/src/visitors/visitor_predicates.rs crates/tsz-solver/src/visitors/visitor_constraint_predicates.rs` -> `1474`, `1996`, and `210` lines respectively.
- `cargo fmt --all -- --check` passed.
- `git diff --check` and `git diff --cached --check` passed.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-solver --lib` passed.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo clippy -p tsz-solver --lib --tests -- -D warnings` passed.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-solver -E 'test(test_solver_file_size_ceiling) or test(test_solver_oversized_file_size_ceilings)'` failed on inherited branch ratchet drift in `evaluation/evaluate.rs` (`3405` vs baseline `3398`) and `evaluation/evaluate_rules/conditional.rs` (`3143` vs baseline `3127`); the review-blocking `visitor_predicates.rs` file is now under 2000 lines and below its checked-in `2162` baseline.

## Coordination Notes
- AgentName: M4-B
- Superseded status note: prior heads `4058f3d4f0559c3755244d17496066638f784438` and `023ac1dde31e330514196d178b11d3515f832814` were cleared, but main advanced before landing. M4-B rebased and pushed current head `79bc43f04ec22a993d7dce44531ff0b26273db71` onto `origin/main` `6f1bd866b2e3b5e1e96b84b1a0816278072d7e46`; fresh ready-review CI is running.
- Next owner/action: monitor required `Queue Tested` for the current head. If every required exact-head check is complete and green, land according to TSZ CI rules. Keep auto-merge off while `Queue Tested` is pending, missing, or failing; do not use auto-merge as a CI watcher.

Studio-A-9807 follow-up on head `023ac1dde31e330514196d178b11d3515f832814`:
- Split recursive contains traversal predicates from `visitor_predicates.rs` into `visitor_contains_predicates.rs`; `crate::visitors::visitor_predicates::*` and `crate::visitor::*` continue to re-export the same functions.
- `wc -l crates/tsz-solver/src/visitors/*.rs` -> `mod.rs` 5, `visitor.rs` 1474, `visitor_constraint_predicates.rs` 210, `visitor_contains_predicates.rs` 1434, `visitor_extract.rs` 1096, `visitor_predicates.rs` 570.
- `cargo fmt --all -- --check` passed.
- `git diff --check` and `git diff --cached --check` passed before commit.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-solver --lib` passed.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-solver predicate_checker_memo_entry_counts_are_observable` passed.
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-solver -E 'test(test_solver_file_size_ceiling) or test(test_solver_oversized_file_size_ceilings)'` still fails on inherited branch ratchet drift outside this PR diff: `evaluation/evaluate.rs` 3405 vs baseline 3398 and `evaluation/evaluate_rules/conditional.rs` 3143 vs baseline 3127. The visitor shards are all below 2000 lines.
- AgentName: Studio-A-9807


