### PR TITLE
[WIP] fix(checker,solver): wide-symbol computed key in object literal becomes `[s: symbol]` index signature

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1246,6 +1246,10 @@ name = "non_unique_symbol_late_bound_member_tests"
 path = "tests/non_unique_symbol_late_bound_member_tests.rs"
 
 [[test]]
+name = "object_literal_wide_symbol_index_tests"
+path = "tests/object_literal_wide_symbol_index_tests.rs"
+
+[[test]]
 name = "ts2855_static_super_field_tests"
 path = "tests/ts2855_static_super_field_tests.rs"
 

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -539,11 +539,7 @@ impl<'a> CheckerState<'a> {
         let mut display_type_overrides: FxHashMap<Atom, TypeId> = FxHashMap::default();
         let mut string_index_types: Vec<TypeId> = Vec::new();
         let mut number_index_types: Vec<TypeId> = Vec::new();
-        // Value types contributed by computed property names whose key type is
-        // the wide `symbol` intrinsic. These become a single `[s: symbol]: V`
-        // index signature on the resulting object literal type — matching tsc's
-        // late-bound symbol-key inference (`{ [sym]: 1 }` with `sym: symbol`
-        // yields `{ [s: symbol]: number }`).
+        // Wide-`symbol`-typed computed keys: see `finalize_object_literal_type`.
         let mut symbol_index_types: Vec<TypeId> = Vec::new();
         // Index signatures inherited from spread sources (kept separate because
         // they should only be included when the literal has no explicit properties —
@@ -692,12 +688,9 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|computed| {
                         self.get_type_of_node(computed.expression) == TypeId::ERROR
                     });
-                // A computed key whose expression has the wide `symbol` intrinsic
-                // contributes to a `[s: symbol]: V` index signature on the
-                // object literal type, not a named member. Detect this *before*
-                // dispatching to `get_property_name_resolved` (which would
-                // otherwise pin it under a `__symbol_<file>_<sym>` synthetic
-                // named key, breaking `(typeof o)[symbol]` and `keyof typeof o`).
+                // Wide-`symbol` computed keys feed the index-sig path; skip
+                // `get_property_name_resolved` so the named-member branch
+                // doesn't pin them under a synthetic `__symbol_<file>_<sym>`.
                 let is_wide_symbol_index_key = !computed_key_is_error
                     && self.object_literal_computed_key_is_wide_symbol_index(prop.name);
                 let name_opt = if computed_key_is_error || is_wide_symbol_index_key {
@@ -1744,11 +1737,9 @@ impl<'a> CheckerState<'a> {
                 }
                 let method_is_wide_symbol_index_key =
                     self.object_literal_computed_key_is_wide_symbol_index(method.name);
-                let name_opt = if method_is_wide_symbol_index_key {
-                    None
-                } else {
-                    self.get_property_name_resolved(method.name)
-                };
+                let name_opt = (!method_is_wide_symbol_index_key)
+                    .then(|| self.get_property_name_resolved(method.name))
+                    .flatten();
                 if let Some(name) = name_opt.clone() {
                     // Set contextual type for method
                     let jsdoc_declared_type = self.jsdoc_type_annotation_for_node_direct(elem_idx);
@@ -2262,11 +2253,9 @@ impl<'a> CheckerState<'a> {
 
                 let accessor_is_wide_symbol_index_key =
                     self.object_literal_computed_key_is_wide_symbol_index(accessor.name);
-                let name_opt = if accessor_is_wide_symbol_index_key {
-                    None
-                } else {
-                    self.get_property_name_resolved(accessor.name)
-                };
+                let name_opt = (!accessor_is_wide_symbol_index_key)
+                    .then(|| self.get_property_name_resolved(accessor.name))
+                    .flatten();
                 if let Some(name) = name_opt.clone() {
                     // For non-contextual object literals, TypeScript treats `this` inside
                     // accessors as the object literal under construction. Provide a

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -539,6 +539,12 @@ impl<'a> CheckerState<'a> {
         let mut display_type_overrides: FxHashMap<Atom, TypeId> = FxHashMap::default();
         let mut string_index_types: Vec<TypeId> = Vec::new();
         let mut number_index_types: Vec<TypeId> = Vec::new();
+        // Value types contributed by computed property names whose key type is
+        // the wide `symbol` intrinsic. These become a single `[s: symbol]: V`
+        // index signature on the resulting object literal type — matching tsc's
+        // late-bound symbol-key inference (`{ [sym]: 1 }` with `sym: symbol`
+        // yields `{ [s: symbol]: number }`).
+        let mut symbol_index_types: Vec<TypeId> = Vec::new();
         // Index signatures inherited from spread sources (kept separate because
         // they should only be included when the literal has no explicit properties —
         // tsc drops spread index signatures when explicit properties exist).
@@ -686,7 +692,15 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|computed| {
                         self.get_type_of_node(computed.expression) == TypeId::ERROR
                     });
-                let name_opt = if computed_key_is_error {
+                // A computed key whose expression has the wide `symbol` intrinsic
+                // contributes to a `[s: symbol]: V` index signature on the
+                // object literal type, not a named member. Detect this *before*
+                // dispatching to `get_property_name_resolved` (which would
+                // otherwise pin it under a `__symbol_<file>_<sym>` synthetic
+                // named key, breaking `(typeof o)[symbol]` and `keyof typeof o`).
+                let is_wide_symbol_index_key = !computed_key_is_error
+                    && self.object_literal_computed_key_is_wide_symbol_index(prop.name);
+                let name_opt = if computed_key_is_error || is_wide_symbol_index_key {
                     None
                 } else {
                     self.get_property_name_resolved(prop.name)
@@ -1420,7 +1434,9 @@ impl<'a> CheckerState<'a> {
                         value_type = literal_type;
                     }
 
-                    if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
+                    if is_wide_symbol_index_key {
+                        symbol_index_types.push(value_type);
+                    } else if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
                         number_index_types.push(value_type);
                     } else if self.is_assignable_to(prop_name_type, TypeId::STRING)
                         || self.is_assignable_to(prop_name_type, TypeId::ANY)
@@ -1726,7 +1742,13 @@ impl<'a> CheckerState<'a> {
                 {
                     self.get_type_of_node(computed.expression);
                 }
-                let name_opt = self.get_property_name_resolved(method.name);
+                let method_is_wide_symbol_index_key =
+                    self.object_literal_computed_key_is_wide_symbol_index(method.name);
+                let name_opt = if method_is_wide_symbol_index_key {
+                    None
+                } else {
+                    self.get_property_name_resolved(method.name)
+                };
                 if let Some(name) = name_opt.clone() {
                     // Set contextual type for method
                     let jsdoc_declared_type = self.jsdoc_type_annotation_for_node_direct(elem_idx);
@@ -2153,7 +2175,9 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
-                    if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
+                    if method_is_wide_symbol_index_key {
+                        symbol_index_types.push(method_type);
+                    } else if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
                         number_index_types.push(method_type);
                     } else if self.is_assignable_to(prop_name_type, TypeId::STRING)
                         || self.is_assignable_to(prop_name_type, TypeId::ANY)
@@ -2236,7 +2260,13 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                let name_opt = self.get_property_name_resolved(accessor.name);
+                let accessor_is_wide_symbol_index_key =
+                    self.object_literal_computed_key_is_wide_symbol_index(accessor.name);
+                let name_opt = if accessor_is_wide_symbol_index_key {
+                    None
+                } else {
+                    self.get_property_name_resolved(accessor.name)
+                };
                 if let Some(name) = name_opt.clone() {
                     // For non-contextual object literals, TypeScript treats `this` inside
                     // accessors as the object literal under construction. Provide a
@@ -2580,7 +2610,9 @@ impl<'a> CheckerState<'a> {
                             .unwrap_or(TypeId::ANY)
                     };
 
-                    if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
+                    if accessor_is_wide_symbol_index_key {
+                        symbol_index_types.push(accessor_type);
+                    } else if self.is_assignable_to(prop_name_type, TypeId::NUMBER) {
                         number_index_types.push(accessor_type);
                     } else if self.is_assignable_to(prop_name_type, TypeId::STRING)
                         || self.is_assignable_to(prop_name_type, TypeId::ANY)
@@ -3052,6 +3084,7 @@ impl<'a> CheckerState<'a> {
                 display_type_overrides,
                 string_index_types,
                 number_index_types,
+                symbol_index_types,
                 string_index_param_name,
                 number_index_param_name,
                 has_spread,

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -16,6 +16,11 @@ pub(crate) struct ObjectLiteralFinalizeCtx {
     pub(crate) string_index_types: Vec<TypeId>,
     /// Value types for number index signatures collected from spreads.
     pub(crate) number_index_types: Vec<TypeId>,
+    /// Value types contributed by computed property names whose key type is
+    /// the wide `symbol` intrinsic. When non-empty, the resulting object type
+    /// gains a `[s: symbol]: union<values>` index signature (parity with tsc's
+    /// inference for `{ [sym]: 1 }` where `sym: symbol`).
+    pub(crate) symbol_index_types: Vec<TypeId>,
     /// Parameter name atom for the string index signature, if present.
     pub(crate) string_index_param_name: Option<Atom>,
     /// Parameter name atom for the number index signature, if present.
@@ -321,6 +326,7 @@ impl<'a> CheckerState<'a> {
             display_type_overrides,
             mut string_index_types,
             number_index_types,
+            symbol_index_types,
             string_index_param_name,
             number_index_param_name,
             has_spread,
@@ -362,7 +368,10 @@ impl<'a> CheckerState<'a> {
             let mut properties: Vec<PropertyInfo> = properties.into_values().collect();
             properties.sort_by_key(|p| p.declaration_order);
 
-            if string_index_types.is_empty() && number_index_types.is_empty() {
+            if string_index_types.is_empty()
+                && number_index_types.is_empty()
+                && symbol_index_types.is_empty()
+            {
                 if has_spread {
                     let mut display_props = properties.clone();
                     crate::query_boundaries::common::normalize_display_property_order(
@@ -422,20 +431,47 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                let string_index = if !string_index_types.is_empty() {
-                    let value_type = if self.ctx.in_const_assertion {
-                        order_preserving_union(self.ctx.types.factory(), string_index_types)
+                // The `ObjectShape.string_index` slot is polymorphic: its
+                // `key_type` discriminates ordinary string-keyed signatures
+                // (`STRING`), symbol-keyed signatures (`SYMBOL`), and
+                // template-literal-restricted string subtypes. When an object
+                // literal has both string-typed *and* wide-symbol-typed
+                // computed keys, we merge them via a union — the same
+                // convention `interface_type::merge_string_index_by_union`
+                // uses for interfaces declaring both `[s: string]` and
+                // `[s: symbol]` signatures.
+                let in_const_assertion = self.ctx.in_const_assertion;
+                let union_value_type = |types: Vec<TypeId>| {
+                    let factory = self.ctx.types.factory();
+                    if in_const_assertion {
+                        order_preserving_union(factory, types)
                     } else {
-                        self.ctx.types.factory().union(string_index_types)
-                    };
-                    Some(IndexSignature {
-                        key_type: TypeId::STRING,
-                        value_type,
-                        readonly: false,
-                        param_name: string_index_param_name,
-                    })
-                } else {
-                    None
+                        factory.union(types)
+                    }
+                };
+                let string_part = (!string_index_types.is_empty())
+                    .then(|| (TypeId::STRING, union_value_type(string_index_types)));
+                let symbol_part = (!symbol_index_types.is_empty())
+                    .then(|| (TypeId::SYMBOL, union_value_type(symbol_index_types)));
+                let string_index = match (string_part, symbol_part) {
+                    (None, None) => None,
+                    (Some((key, value)), None) | (None, Some((key, value))) => {
+                        Some(IndexSignature {
+                            key_type: key,
+                            value_type: value,
+                            readonly: false,
+                            param_name: string_index_param_name,
+                        })
+                    }
+                    (Some((_, str_value)), Some((_, sym_value))) => {
+                        let factory = self.ctx.types.factory();
+                        Some(IndexSignature {
+                            key_type: factory.union2(TypeId::STRING, TypeId::SYMBOL),
+                            value_type: factory.union2(str_value, sym_value),
+                            readonly: false,
+                            param_name: string_index_param_name,
+                        })
+                    }
                 };
 
                 let number_index = if !number_index_types.is_empty() {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -153,6 +153,43 @@ impl<'a> CheckerState<'a> {
         Some(format!("__symbol_{}_{}", file_idx, sym_id.0))
     }
 
+    /// Returns `true` when `name_idx` is a computed property name whose key
+    /// expression has the wide `symbol` intrinsic type — meaning, per `tsc`,
+    /// the property contributes to a `[s: symbol]: T` index signature on the
+    /// constructed object literal type rather than to a named member.
+    ///
+    /// Excludes:
+    /// - `unique symbol` keys (different `TypeData` — kept as named members).
+    /// - Well-known `Symbol.foo` access (syntactic or via a binding initialised
+    ///   to/annotated `typeof Symbol.foo`) — these carry a stable `[Symbol.foo]`
+    ///   identity and stay as named members for parity with `tsc`.
+    pub(crate) fn object_literal_computed_key_is_wide_symbol_index(
+        &mut self,
+        name_idx: NodeIndex,
+    ) -> bool {
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        // Require exactly the wide intrinsic. Do NOT evaluate further: eager
+        // `evaluate_type_with_env` on a `UniqueSymbol` could widen through its
+        // apparent base and break the unique-symbol boundary.
+        if self.get_type_of_node(computed.expression) != TypeId::SYMBOL {
+            return false;
+        }
+        // Anything resolvable to a stable `[Symbol.foo]` identity stays named.
+        self.get_symbol_property_name_from_expr(computed.expression)
+            .is_none()
+            && self
+                .resolve_computed_symbol_property_name(computed.expression)
+                .is_none()
+    }
+
     // =========================================================================
     // Section 27: Modifier and Member Access Utilities
     // =========================================================================

--- a/crates/tsz-checker/tests/object_literal_wide_symbol_index_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_wide_symbol_index_tests.rs
@@ -1,0 +1,205 @@
+//! Tests for object literal types with computed property names whose key
+//! expression has the wide `symbol` intrinsic type.
+//!
+//! Structural rule: when a computed property name in an object literal has
+//! the wide `symbol` type (not `unique symbol`, not a well-known symbol like
+//! `Symbol.iterator`), tsc synthesises a `[s: symbol]: V` index signature on
+//! the resulting object type rather than a named member. Therefore:
+//!
+//! - `(typeof o)[symbol]` resolves to the value type
+//! - `keyof typeof o` includes `symbol`
+//! - `o[wideSym]` resolves to the value type (no TS2536)
+//!
+//! Negative coverage: `unique symbol` and well-known symbol (`Symbol.iterator`)
+//! computed keys keep their named-member behaviour.
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn has_ts(source: &str, code: u32) -> bool {
+    codes(source).contains(&code)
+}
+
+// ── Issue-9755 repro: indexed access via wide `symbol` type ──────────────────
+
+#[test]
+fn issue_9755_indexed_access_with_wide_symbol_key_type_no_false_ts2536() {
+    // `(typeof o)[symbol]` must resolve to `number`, not raise TS2536.
+    assert!(!has_ts(
+        r#"
+declare const sym: symbol;
+const o = { [sym]: 1 };
+type V = (typeof o)[symbol];
+const _check: number = (null as unknown as V);
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+#[test]
+fn issue_9755_indexed_access_value_assignable_to_number() {
+    // Beyond TS2536, the resolved indexed access must actually be `number`
+    // (or compatible). A wrong widening to `unknown`/`any` would still pass
+    // the TS2536 check above, so we also require an assignability gate.
+    assert!(!has_ts(
+        r#"
+declare const sym: symbol;
+const o = { [sym]: 1 };
+const probe: number = (null as unknown as (typeof o)[symbol]);
+"#,
+        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+    ));
+}
+
+// ── keyof on object literal with mixed wide-symbol + string-named members ────
+
+#[test]
+fn issue_9755_keyof_with_mixed_symbol_and_string_named_members() {
+    // `keyof typeof o2` should be `symbol | "a"`. We verify by checking that:
+    //   - `"a"` is assignable to keyof (named member is kept)
+    //   - `symbol` is assignable to keyof (symbol index signature is present)
+    assert!(!has_ts(
+        r#"
+declare const sym: symbol;
+const o2 = { [sym]: 1, a: 2 };
+type K = keyof typeof o2;
+const probe_a: K = "a";
+const probe_sym: K = (null as unknown as symbol);
+"#,
+        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+    ));
+}
+
+// ── Rule generalisation: different binding name ──────────────────────────────
+
+#[test]
+fn wide_symbol_index_works_with_renamed_binding() {
+    // The rule must be structural — the binding name is irrelevant.
+    assert!(!has_ts(
+        r#"
+declare const myKey: symbol;
+const o = { [myKey]: "hi" };
+const _check: string = (null as unknown as (typeof o)[symbol]);
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+#[test]
+fn wide_symbol_index_works_with_third_binding_name() {
+    assert!(!has_ts(
+        r#"
+declare const anotherSym: symbol;
+const o = { [anotherSym]: true };
+const _check: boolean = (null as unknown as (typeof o)[symbol]);
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+// ── Value-level access by the same wide-symbol binding ────────────────────────
+
+#[test]
+fn value_level_access_via_same_wide_symbol_binding_no_ts2536() {
+    // `o[sym]` (value-level) must resolve to the value type.
+    assert!(!has_ts(
+        r#"
+declare const sym: symbol;
+const o = { [sym]: 42 };
+const probe: number = o[sym];
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+// ── Negative control: unique symbol stays a named member ──────────────────────
+
+#[test]
+fn unique_symbol_computed_key_still_named_member_not_index_signature() {
+    // For `unique symbol`, the value-level `o[usym]` must still work (named
+    // member path). This is the boundary that distinguishes the fix from a
+    // blanket "all symbol-typed keys are index signatures" rule.
+    assert!(!has_ts(
+        r#"
+declare const usym: unique symbol;
+const o = { [usym]: 7 };
+const probe: number = o[usym];
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+#[test]
+fn unique_symbol_keyof_does_not_include_wide_symbol() {
+    // For `{ [usym]: ... }` with `usym: unique symbol`, `keyof` should yield
+    // `typeof usym` (the unique-symbol type), not the wide `symbol`. We probe
+    // by asserting the wide `symbol` type is NOT assignable to the keyof.
+    assert!(has_ts(
+        r#"
+declare const usym: unique symbol;
+const o = { [usym]: 7 };
+type K = keyof typeof o;
+declare const widesym: symbol;
+const probe: K = widesym;
+"#,
+        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+    ));
+}
+
+// ── Negative control: well-known symbols stay named ───────────────────────────
+
+#[test]
+fn well_known_symbol_iterator_stays_a_named_member() {
+    // Well-known symbols like `Symbol.iterator` get a stable `[Symbol.iterator]`
+    // named key and must not be folded into a `[s: symbol]` index signature.
+    // Verify that `o[Symbol.iterator]` resolves correctly.
+    assert!(!has_ts(
+        r#"
+const o = { [Symbol.iterator]: () => null };
+const fn = o[Symbol.iterator];
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}
+
+// ── Wide-symbol parameter (not a const binding) ───────────────────────────────
+
+#[test]
+fn wide_symbol_parameter_keyed_object_literal_no_silent_drop() {
+    // A parameter typed `s: symbol` (not a const binding) must also produce
+    // a symbol-keyed index signature. Without the fix, tsz silently dropped
+    // the property and `o[s]` would not return the value type.
+    assert!(!has_ts(
+        r#"
+function f(s: symbol) {
+    const o = { [s]: 99 };
+    const probe: number = o[s];
+    return probe;
+}
+"#,
+        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+    ));
+}
+
+// ── Method form: `{ [sym]() {} }` ─────────────────────────────────────────────
+
+#[test]
+fn wide_symbol_keyed_method_becomes_callable_symbol_index() {
+    // A method declared with a wide-symbol computed key should still be
+    // callable via that key — and importantly should not crash or emit
+    // TS2536 on `(typeof o)[symbol]` access.
+    assert!(!has_ts(
+        r#"
+declare const sym: symbol;
+const o = { [sym]() { return 1; } };
+type V = (typeof o)[symbol];
+"#,
+        diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE
+    ));
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -82,6 +82,40 @@ impl KeyofKeySet {
     }
 }
 
+/// Append the keyof contribution(s) of an `ObjectShape.string_index` (or
+/// `CallableShape.string_index`) slot. The slot is polymorphic: its `key_type`
+/// can be the string intrinsic, the symbol intrinsic, a template-literal-
+/// restricted string subtype, or a union of those. The keyof set must reflect
+/// what is actually indexable:
+///
+/// - `symbol` → `symbol`
+/// - any string subtype (string intrinsic or template-literal) → `string` and
+///   `number` (matching `tsc`'s `getIndexInfosOfType`)
+/// - union → recurse over members
+fn push_string_index_keyof_contributions(
+    db: &dyn TypeDatabase,
+    key_type: TypeId,
+    key_types: &mut Vec<TypeId>,
+) {
+    if key_type == TypeId::SYMBOL {
+        if !key_types.contains(&TypeId::SYMBOL) {
+            key_types.push(TypeId::SYMBOL);
+        }
+        return;
+    }
+    if let Some(TypeData::Union(list_id)) = db.lookup(key_type) {
+        for member in db.type_list(list_id).to_vec() {
+            push_string_index_keyof_contributions(db, member, key_types);
+        }
+        return;
+    }
+    for default in [TypeId::STRING, TypeId::NUMBER] {
+        if !key_types.contains(&default) {
+            key_types.push(default);
+        }
+    }
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn unique_symbol_ref_from_synthetic_atom(&self, name: Atom) -> Option<SymbolRef> {
         let name_text = self.interner().resolve_atom_ref(name);
@@ -442,9 +476,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .map(|p| self.property_name_to_key_type(p))
                         .collect();
 
-                    if shape.string_index.is_some() {
-                        key_types.push(TypeId::STRING);
-                        key_types.push(TypeId::NUMBER);
+                    if let Some(string_index) = shape.string_index.as_ref() {
+                        push_string_index_keyof_contributions(
+                            self.interner(),
+                            string_index.key_type,
+                            &mut key_types,
+                        );
                     } else if shape.number_index.is_some()
                         // Enum namespace types carry `[index: number]: string` only for
                         // reverse-lookup bracket access (E[0]). tsc excludes this from
@@ -473,9 +510,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .map(|p| self.property_name_to_key_type(p))
                         .collect();
 
-                    if shape.string_index.is_some() {
-                        key_types.push(TypeId::STRING);
-                        key_types.push(TypeId::NUMBER);
+                    if let Some(string_index) = shape.string_index.as_ref() {
+                        push_string_index_keyof_contributions(
+                            self.interner(),
+                            string_index.key_type,
+                            &mut key_types,
+                        );
                     } else if shape.number_index.is_some() {
                         key_types.push(TypeId::NUMBER);
                     }

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -623,6 +623,15 @@ pub fn keyof_object_properties(db: &dyn TypeDatabase, type_id: TypeId) -> Option
     if has_symbol_key {
         key_types.push(TypeId::SYMBOL);
     }
+    // A symbol-keyed index signature (stored in the `string_index` slot with
+    // `key_type == SYMBOL`) also contributes `symbol` to keyof — matching
+    // tsc's `getIndexInfosOfType` symbol-key projection.
+    if let Some(string_index) = shape.string_index.as_ref()
+        && string_index.key_type == TypeId::SYMBOL
+        && !key_types.contains(&TypeId::SYMBOL)
+    {
+        key_types.push(TypeId::SYMBOL);
+    }
     if key_types.is_empty() {
         return Some(TypeId::NEVER);
     }


### PR DESCRIPTION
AgentName: m3-max-64g-opus47

Closes #9755

## Track
Conformance / checker false-positive on `(typeof o)[symbol]` and `keyof typeof o` for object literals with wide-`symbol`-typed computed keys.

## Structural Rule
When a computed property name in an object literal has exactly the wide `symbol` intrinsic type — not `unique symbol`, not a syntactic `Symbol.foo` access, not an identifier resolving to `typeof Symbol.foo` — `tsc` synthesises a `[s: symbol]: V` index signature on the resulting object literal type rather than a named member. tsz now does the same, and `keyof` over any object whose `string_index` slot is symbol-keyed (object literals, interfaces, type literals) yields `symbol` rather than `string | number`.

## Owner Layer
- **Checker** owns the *construction* policy: `crates/tsz-checker/src/types/computation/object_literal/computation.rs` and `object_literal_support.rs` route wide-symbol-keyed computed properties into a new `symbol_index_types` bucket and turn it into the `[s: symbol]: V` slot. The new helper `object_literal_computed_key_is_wide_symbol_index` lives next to its sibling resolvers in `crates/tsz-checker/src/types/queries/core.rs`.
- **Solver** owns the *query* policy: `crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs` and `crates/tsz-solver/src/type_queries/data/accessors.rs` recognise symbol-keyed entries in the polymorphic `string_index` slot, so `keyof` returns the correct set for any object that carries one (also fixes pre-existing `interface I { [s: symbol]: V }` `keyof` divergence as a side effect).

## Invariant
- `unique symbol` and well-known `Symbol.foo` computed keys retain their named-member behaviour — the predicate is restricted to keys whose key expression has *exactly* `TypeId::SYMBOL` and is not syntactically or by-binding a `Symbol.foo` reference.
- The `ObjectShape.string_index` slot continues to be polymorphic; symbol-keyed signatures piggyback on it via `key_type = SYMBOL` (the convention already in `interface_type::merge_string_index_by_union`).
- Spread of a wide-symbol-keyed source: pre-existing `IndexSignatureResolver::resolve_string_index` already filters out `key_type == SYMBOL`, so spreads do not accidentally widen symbol-index into string-index. (The reverse case — propagating the source's symbol index through spread — is unchanged by this PR.)

## Scope
1. Issue #9755 repro: `(typeof o)[symbol]` and `keyof typeof o` for `{ [sym]: 1 }` with `sym: symbol`.
2. Mixed named + wide-symbol-keyed members (`{ [sym]: 1, a: 2 }`).
3. Wide-symbol *parameter* (not just const binding) keyed object literal — pre-fix silently dropped the value.
4. Method and accessor forms (`{ [sym]() {} }`, `{ get [sym]() {} }`).
5. `keyof` for explicit `interface I { [s: symbol]: V; a: V; }` (pre-existing divergence, now correct).

## Adjacent Coverage
The new test file `crates/tsz-checker/tests/object_literal_wide_symbol_index_tests.rs` exercises 11 cases including:
- The reported repro and its assignability follow-up.
- Mixed `[sym]` + named `a` — both `"a"` and `symbol` are assignable to `keyof`.
- Three different binding names to prove the rule is structural, not spelling-dependent.
- Value-level `o[sym]` lookup.
- Negative: `unique symbol` still produces a named member with the unique-symbol identity in `keyof`.
- Negative: `Symbol.iterator` stays a named member.
- Method form `{ [sym]() {} }` with `(typeof o)[symbol]` access.
- Wide-symbol parameter (non-const).

## Project Corpus Impact
- Row: n/a
- Bug family: false-positive TS2536 / missing `symbol` member in `keyof` for object literals with wide-`symbol` computed keys (issue #9755) and the related `keyof I` divergence for interfaces with `[s: symbol]: V`.
- Evidence: new `object_literal_wide_symbol_index_tests` (11 tests, all green); pre-existing `symbol_index_signature_tests` (14), `non_unique_symbol_late_bound_member_tests` (10), `symbol_resolution_tests`, and the broader keyof/index-signature test set (`assertion_overlap_keyof_primitive_tests`, `class_implements_index_signature_tests`, `class_index_signature_compat_tests`, `conditional_keyof_test`, `contextual_literal_keyof_lib_tests`, `deferred_keyof_index_access_assignability_tests`, `index_signature_argument_assignability_tests`, `intersection_index_signature_fingerprint_tests`, `keyof_array_literal_diagnostic_tests`, `keyof_mapped_as_clause_tests`) — all green and unchanged.

## Verification
- `cargo fmt --all --check`
- `cargo clippy -p tsz-checker -p tsz-solver --all-targets --all-features -- -D warnings`
- `cargo test -p tsz-checker --test object_literal_wide_symbol_index_tests` (11 / 11 passed)
- `cargo test -p tsz-checker --test symbol_index_signature_tests` (14 / 14 passed)
- `cargo test -p tsz-checker --test non_unique_symbol_late_bound_member_tests` (10 / 10 passed)
- `cargo test -p tsz-checker --lib`: 30 pre-existing failures, byte-identical with `main` baseline (no new regressions introduced).
- Manual repro of the issue's source: `.target/release/tsz --noEmit repro.ts` emits zero diagnostics (matching `tsc`).
- Rebased onto `origin/main` at `1ad1bc2`.

## Coordination Notes
- WIP until CI runs the heavy suites (conformance, emit, fourslash, WASM). Holding draft and `[WIP]` title prefix so other agents see this branch is in flight before marking ready.
- The polymorphic `string_index`-slot convention is load-bearing; if a future refactor splits symbol-keyed signatures into their own slot, this fix's symbol-index synthesis and the keyof helper would need a corresponding update.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXRpyXjDch4r9XiRe41unC)_