### PR TITLE
fix(lsp): run tsz-server on large-stack thread to prevent stack overflow

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -1738,6 +1738,20 @@ fn main() -> Result<()> {
     tsz_cli::tracing_config::init_tracing();
 
     let args = ServerArgs::parse();
+
+    // Run the server on a large-stack thread to prevent stack overflow from
+    // recursive AST traversals in find-references, document-highlight, and
+    // other LSP operations on complex TypeScript files. The same
+    // THREAD_STACK_SIZE_BYTES limit is already used by the tsz CLI binary.
+    std::thread::Builder::new()
+        .stack_size(tsz_common::limits::THREAD_STACK_SIZE_BYTES)
+        .spawn(move || run_server(args))
+        .expect("failed to spawn server thread")
+        .join()
+        .expect("server thread panicked")
+}
+
+fn run_server(args: ServerArgs) -> Result<()> {
     let mut server = Server::new(&args).context("failed to initialize server")?;
 
     info!("tsz-server ready (protocol: {:?})", args.protocol);

--- a/crates/tsz-cli/src/bin/tsz_server/tests_navigation.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_navigation.rs
@@ -1931,6 +1931,41 @@ fn test_document_highlights_honors_files_to_search_across_files() {
     );
 }
 
+/// documentHighlights on an inherited property in a deep linear class chain
+/// must not crash. Previously the server ran on the default 8 MB thread stack
+/// and SIGABRT'd for deeply-nested ASTs / large inheritance hierarchies.
+#[test]
+fn test_document_highlights_does_not_overflow_on_deep_linear_chain() {
+    let mut server = make_server();
+    // 30-level linear inheritance chain: Base <- L1 <- L2 <- … <- L29
+    let mut source = String::from("class Base { prop: string; }\n");
+    for i in 1..30 {
+        source.push_str(&format!("class L{i} extends L{} {{}}\n", i - 1));
+    }
+    source.push_str("class L0 extends Base {}\n");
+    source.push_str("var x: L29; x.prop;\n");
+    let file_path = "/tests/cases/fourslash/deep_chain.ts";
+    server
+        .open_files
+        .insert(file_path.to_string(), source.clone());
+    // Line = last line (1-based), offset past 'x.' to land on 'prop'
+    let last_line = source.lines().count() as u32;
+    let req = make_request(
+        "documentHighlights",
+        serde_json::json!({
+            "file": file_path,
+            "line": last_line,
+            "offset": 5,
+            "filesToSearch": [file_path],
+        }),
+    );
+    let resp = server.handle_tsserver_request(req);
+    assert!(
+        resp.success,
+        "documentHighlights must not crash on a deep linear class chain; response: {resp:?}"
+    );
+}
+
 /// Regression for issue #8527: documentHighlight on a heritage-cycle source
 /// must not crash the server (previously SIGABRT'd via stack overflow).
 #[test]


### PR DESCRIPTION
## Agent
AgentName: claude-sonnet-4-6-remote

## Track
Track 9 (LSP/WASM consumers) — LSP server crash fix

## Invariant
When any tsz-server request handler (find-references, document-highlight, rename, etc.) recursively traverses a TypeScript AST via `ScopeWalker::collect_references`, `walk_to_node`, or `walk_for_scope`, the call depth is proportional to the maximum AST nesting depth of the source files. With the default 8 MB OS thread stack this causes SIGABRT for complex TypeScript files or large inheritance hierarchies; this PR makes tsz-server run its main loop on a 128 MB thread, the same limit already used by `tsz.rs` and the Rayon worker pools.

## Scope
- `crates/tsz-cli/src/bin/tsz_server/main.rs` — split `main` to spawn a large-stack thread; move server setup + event loop into `run_server`
- `crates/tsz-cli/src/bin/tsz_server/tests_navigation.rs` — add regression test for deep linear class chain

## Project Corpus Impact

- Row: n/a (LSP server crash, not a compiler correctness change)
- Bug family: stack-overflow / SIGABRT in tsz-server LSP handler
- Evidence: fourslash `documentHighlightAtInheritedProperties6` CI gate (currently failing with `SIGABRT / stack overflow`); new unit test `test_document_highlights_does_not_overflow_on_deep_linear_chain` passes locally.

## Verification
- `cargo check -p tsz-cli --bin tsz-server` — clean
- `cargo clippy -p tsz-cli --bin tsz-server -- -D warnings` — clean
- `cargo test -p tsz-cli "test_document_highlights_does_not_overflow_on_deep_linear_chain"` — passes
- Existing circular-heritage crash regression tests still pass
- fourslash `documentHighlightAtInheritedProperties6` expected to pass in CI (was previously SIGABRT)

## Coordination Notes
- Project Corpus Impact metadata normalized by AgentName: M1-A.
- No overlap with open PRs: this fixes the server process itself, not any type algorithm
- Pattern mirrors `crates/tsz-cli/src/bin/tsz.rs` lines 62-71 (`should_use_large_stack_thread`)
- The two timeout fourslash cases (`codeFixMissingTypeAnnotationOnExports47/48`) are a separate performance issue not addressed here

---
_Generated by [Claude Code](https://claude.ai/code/session_01EypJtazSXeZvFHCadrWuUv)_

