### PR TITLE
refactor(checker): route literal alias display diagnostics boundary

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/literal_widening_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/literal_widening_policy.rs
@@ -38,6 +38,7 @@
 //! This module is split out of `diagnostic_source.rs` to keep that file
 //! under the architecture LOC ceiling.
 
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
@@ -75,8 +76,7 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         let ast_literal = self.literal_type_from_initializer(arg_idx);
         let basis = ast_literal.unwrap_or(source);
-        let source_primitive =
-            crate::query_boundaries::common::widen_literal_to_primitive(self.ctx.types, basis);
+        let source_primitive = diagnostic_query::widen_literal_to_primitive(self.ctx.types, basis);
         // Basis isn't a literal type — this filter doesn't apply, so leave
         // the existing literal-preserving behaviour untouched.
         if source_primitive == basis {
@@ -121,9 +121,7 @@ impl<'a> CheckerState<'a> {
         if scan.has_unclassifiable_member {
             return;
         }
-        if let Some(inner) =
-            crate::query_boundaries::common::no_infer_inner_type(self.ctx.types, target)
-        {
+        if let Some(inner) = diagnostic_query::no_infer_inner_type(self.ctx.types, target) {
             self.scan_target_primitives(inner, scan);
             return;
         }
@@ -142,20 +140,19 @@ impl<'a> CheckerState<'a> {
             return;
         }
         // Literal types — register their primitive base.
-        if crate::query_boundaries::common::literal_value(self.ctx.types, target).is_some() {
-            let prim =
-                crate::query_boundaries::common::widen_literal_to_primitive(self.ctx.types, target);
+        if diagnostic_query::literal_value(self.ctx.types, target).is_some() {
+            let prim = diagnostic_query::widen_literal_to_primitive(self.ctx.types, target);
             scan.literal_primitive_bases.insert(prim);
             return;
         }
         // Template literal types (e.g. `:${string}:`) are string-shaped and
         // act as string literals for the matching purposes.
-        if crate::query_boundaries::common::is_template_literal_type(self.ctx.types, target) {
+        if diagnostic_query::is_template_literal_type(self.ctx.types, target) {
             scan.literal_primitive_bases.insert(TypeId::STRING);
             return;
         }
         // unique symbol literals are symbol-shaped.
-        if crate::query_boundaries::common::is_symbol_or_unique_symbol(self.ctx.types, target)
+        if diagnostic_query::is_symbol_or_unique_symbol(self.ctx.types, target)
             && target != TypeId::SYMBOL
         {
             scan.literal_primitive_bases.insert(TypeId::SYMBOL);
@@ -165,15 +162,13 @@ impl<'a> CheckerState<'a> {
         // surface doesn't expose it cheaply. Treat them as unclassifiable so
         // the caller falls back to the conservative literal-preserving
         // default — that matches existing enum diagnostic behaviour.
-        if crate::query_boundaries::common::enum_def_id(self.ctx.types, target).is_some() {
+        if diagnostic_query::enum_def_id(self.ctx.types, target).is_some() {
             scan.has_unclassifiable_member = true;
             return;
         }
         // Recurse into unions / intersections.
-        if let Some(list) = crate::query_boundaries::common::union_list_id(self.ctx.types, target)
-            .or_else(|| {
-                crate::query_boundaries::common::intersection_list_id(self.ctx.types, target)
-            })
+        if let Some(list) = diagnostic_query::union_list_id(self.ctx.types, target)
+            .or_else(|| diagnostic_query::intersection_list_id(self.ctx.types, target))
         {
             for member in self.ctx.types.type_list(list).iter().copied() {
                 self.scan_target_primitives(member, scan);

--- a/crates/tsz-checker/src/error_reporter/literal_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/literal_alias_display.rs
@@ -1,5 +1,6 @@
 //! Literal-only generic alias display helpers.
 
+use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -33,8 +34,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         declared_type: TypeId,
     ) -> Option<String> {
-        let (_, args) =
-            crate::query_boundaries::common::application_info(self.ctx.types, declared_type)?;
+        let (_, args) = diagnostic_query::application_info(self.ctx.types, declared_type)?;
         let has_literal_arg = args
             .iter()
             .copied()
@@ -48,14 +48,11 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let is_literal = |state: &Self, ty| {
-            crate::query_boundaries::common::literal_value(state.ctx.types, ty).is_some()
-        };
+        let is_literal =
+            |state: &Self, ty| diagnostic_query::literal_value(state.ctx.types, ty).is_some();
         let literal_only = if is_literal(self, evaluated) {
             true
-        } else if let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, evaluated)
-        {
+        } else if let Some(members) = diagnostic_query::union_members(self.ctx.types, evaluated) {
             !members.is_empty() && members.into_iter().all(|member| is_literal(self, member))
         } else {
             false
@@ -65,10 +62,10 @@ impl<'a> CheckerState<'a> {
     }
 
     fn contains_literal_display_candidate(&self, ty: TypeId) -> bool {
-        if crate::query_boundaries::common::literal_value(self.ctx.types, ty).is_some() {
+        if diagnostic_query::literal_value(self.ctx.types, ty).is_some() {
             return true;
         }
-        if let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, ty) {
+        if let Some(members) = diagnostic_query::union_members(self.ctx.types, ty) {
             return members
                 .into_iter()
                 .any(|member| self.contains_literal_display_candidate(member));

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -2,8 +2,10 @@ use super::state::checking as state_checking;
 use tsz_solver::TypeId;
 
 pub(crate) use super::common::{
-    application_info, array_element_type, callable_shape_for_type, intersection_members,
-    lazy_def_id, union_members,
+    application_info, array_element_type, callable_shape_for_type, enum_def_id,
+    intersection_list_id, intersection_members, is_symbol_or_unique_symbol,
+    is_template_literal_type, lazy_def_id, literal_value, no_infer_inner_type, union_list_id,
+    union_members, widen_literal_to_primitive,
 };
 pub(crate) use tsz_solver::type_queries::AssignmentNumericDisplayChildren;
 

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -513,7 +513,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Bumped by 2 for the deferred-conditional diagnostic-display fix
         # (`is_conditional_type` guards in the assignment-target display path,
         # matching the existing direct-call pattern in type_display.rs).
-        3377,
+        #
+        # Ratcheted down by 5 after literal alias / literal widening
+        # diagnostic display probes moved through query_boundaries::diagnostics.
+        3372,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8225 query-boundary narrowing. Successor to auto-closed stacked draft #9873 after #9595 landed.

## Invariant
When assignment diagnostic display code needs literal, application, union/intersection, or literal-widening shape facts only to decide diagnostic message text, those facts should come through the diagnostic query boundary rather than direct calls into the broad `query_boundaries::common` quarantine barrel. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Re-export the needed literal, application, union/intersection, no-infer, template-literal, symbol, enum, and widening probes through `query_boundaries::diagnostics`.
- Route `literal_alias_display` through `diagnostic_query` for application, literal, and union shape probes.
- Route `literal_widening_policy` through `diagnostic_query` for diagnostic-only literal widening/source display probes.
- Ratchet the #8225 direct `query_boundaries::common` reference cap from current main's corrected `3377` to `3372` after the five direct diagnostic-display call sites move behind the diagnostic boundary.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8225 query-boundary narrowing
- Evidence: refactor-only helper routing; no solver semantics, relation policy, or project corpus behavior changes.

## Verification
- `git diff --check origin/main..HEAD`
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo check -p tsz-checker --lib`
- Previous draft-light CI was green for old exact head `5ab0fbbf718260dfcf037beac12ec879bf0dc7fa`: https://github.com/mohsen1/tsz/actions/runs/26367647125
- Refreshed CI is pending for exact head `93ed074b6b1576ae0a18bd400457d50a099a9a77` after rebase onto current `origin/main`.

## Coordination Notes
- Rebased onto `origin/main` at `bb19ca4177230ddd0be185133b16a86dc6bdb3c7` and force-pushed refreshed head `93ed074b6b1576ae0a18bd400457d50a099a9a77`.
- Resolved the rebase conflict in `scripts/arch/arch_guard.py` by preserving main's corrected `3377` baseline and applying this PR's five-reference ratchet to `3372`.
- Dropped the stale accepted-regression commit from the old draft because it was outside this refactor-only PR scope.
- Non-overlap: does not touch solver policy, relation caches, or relation semantics owned by M4-B.
- Current PR state: ready for review/off-auto, labeled only `agent:M1-B`.
- Next step: refreshed ready-review CI must complete for exact head `93ed074b6b1576ae0a18bd400457d50a099a9a77` before auto-merge or landing.
- Stacked child #9922 remains draft on this branch until this parent has a clean ready-review path.