### PR TITLE
fix(checker): remove intersection + variance-annotations fingerprints via provisional class-expr ctor type

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -1343,26 +1343,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn rewrite_variance_annotations_fingerprints(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::diagnostic_codes;
-
-        if !source_text.contains("interface Baz<out T>")
-            || !source_text.contains("interface Baz<in T>")
-            || !source_text.contains("let Anon = class <out T>")
-            || !source_text.contains("foo(): InstanceType<(typeof Anon<T>)>")
-        {
-            return;
-        }
-
-        self.ctx.diagnostics.retain(|diag| {
-            !(diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                && diag.message_text.contains("Type '(Anonymous class)")
-                && diag
-                    .message_text
-                    .contains("is not assignable to type 'InstanceType<Anon<T>>'."))
-        });
-    }
-
     fn has_ts_nocheck_pragma(&self, source: &str) -> bool {
         tsz_common::comments::source_has_ts_nocheck_directive(source)
     }

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -645,7 +645,6 @@ impl<'a> CheckerState<'a> {
         self.rewrite_type_argument_inference_with_constraints_fingerprints(&sf.text);
         self.rewrite_recursive_type_references1_fingerprints(&sf.text);
         self.rewrite_audit_followup_conformance_fingerprints(&sf.text);
-        self.rewrite_variance_annotations_fingerprints(&sf.text);
     }
 
     fn is_index_signatures1_fixture(source_text: &str) -> bool {

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -637,9 +637,6 @@ impl<'a> CheckerState<'a> {
         });
 
         self.rewrite_infer_generic_return_fingerprints(&sf.text);
-        if self.ctx.allow_source_file_test_pragmas {
-            self.rewrite_intersection_index_signature_fingerprints(&sf.text);
-        }
         if self.ctx.allow_source_file_test_pragmas || Self::is_index_signatures1_fixture(&sf.text) {
             self.rewrite_index_signatures1_fingerprints(&sf.text);
         }
@@ -712,36 +709,6 @@ impl<'a> CheckerState<'a> {
                     "type '{ state: State.A; }[]'",
                     1,
                 );
-        }
-    }
-
-    fn rewrite_intersection_index_signature_fingerprints(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::diagnostic_codes;
-
-        if !source_text.contains("type constr<Source, Tgt>")
-            || !source_text.contains("q[\"asd\"].b")
-        {
-            return;
-        }
-
-        for diag in &mut self.ctx.diagnostics {
-            if diag.code != diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE
-                || diag.message_text != "Property 'b' does not exist on type 'A'."
-            {
-                continue;
-            }
-
-            let start = diag.start as usize;
-            if start >= source_text.len() {
-                continue;
-            }
-            let nearby_start = start.saturating_sub(16);
-            let nearby_end = source_text.len().min(start + 16);
-            if !source_text[nearby_start..nearby_end].contains("q[\"asd\"].b") {
-                continue;
-            }
-
-            diag.message_text = "Property 'b' does not exist on type '{ a: string; }'.".into();
         }
     }
 

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -414,10 +414,16 @@ impl<'a> CheckerState<'a> {
         // Previously we called type_reference_symbol_type and get_type_params_for_symbol
         // separately, which created DIFFERENT TypeIds for the same type parameters.
         let (mut body_type, type_params) = self.type_reference_symbol_type_with_params(sym_id);
-        if self
-            .get_cross_file_symbol(sym_id)
-            .or_else(|| self.ctx.binder.get_symbol(sym_id))
-            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::CLASS))
+
+        // `typeof ClassName<T>` keeps the constructor type; only bare type references
+        // like `ClassName<T>` (i.e. Lazy-based, not TypeQuery-based) should resolve to
+        // the instance type. If base is a TypeQuery, the caller wants the constructor.
+        let is_typeof_query = query::type_query_symbol(self.ctx.types, base).is_some();
+        if !is_typeof_query
+            && self
+                .get_cross_file_symbol(sym_id)
+                .or_else(|| self.ctx.binder.get_symbol(sym_id))
+                .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::CLASS))
             && crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, body_type)
                 .is_some_and(|shape| !shape.construct_signatures.is_empty())
             && let Some(def_id) = self.ctx.get_existing_def_id(sym_id)

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -618,12 +618,107 @@ impl<'a> CheckerState<'a> {
         for symbol_ref in type_queries {
             let sym_id = tsz_binder::SymbolId(symbol_ref.0);
             let _ = self.get_type_of_symbol(sym_id);
-            if let Some(&value_type) = self.ctx.symbol_types.get(&sym_id)
+            let value_type = self
+                .ctx
+                .symbol_types
+                .get(&sym_id)
+                .copied()
+                .unwrap_or(TypeId::ERROR);
+            // When circular resolution causes ERROR (e.g. `let Anon = class<T> {}` and
+            // `typeof Anon` appears in the class body), inserting ERROR into the TypeEnvironment
+            // would poison all TypeQuery resolutions for this symbol. Instead, build a minimal
+            // provisional constructor Callable so the solver can satisfy `InstanceType<typeof Anon<T>>`
+            // without a false-positive TS2322.
+            let effective_type = if value_type == TypeId::ERROR {
+                self.try_provisional_class_expr_ctor_type(sym_id)
+                    .unwrap_or(TypeId::ERROR)
+            } else {
+                value_type
+            };
+            if effective_type != TypeId::ERROR
                 && let Ok(mut env) = self.ctx.type_env.try_borrow_mut()
             {
-                env.insert(tsz_solver::SymbolRef(sym_id.0), value_type);
+                env.insert(tsz_solver::SymbolRef(sym_id.0), effective_type);
             }
         }
+    }
+
+    /// Build a minimal provisional constructor callable for a class expression variable
+    /// that is currently being circularly resolved.
+    ///
+    /// When `let Anon = class<T> {}` is computed and `typeof Anon` appears inside the
+    /// class body (e.g. as `InstanceType<(typeof Anon<T>)>`), `get_type_of_symbol` hits
+    /// a circular reference and returns `TypeId::ERROR`. The provisional callable has one
+    /// construct signature per class type-parameter count, returning `any`, so the
+    /// conditional `typeof Anon<T> extends abstract new (...) => infer R ? R : any`
+    /// resolves to `any` instead of staying deferred.
+    fn try_provisional_class_expr_ctor_type(&self, sym_id: SymbolId) -> Option<TypeId> {
+        use tsz_parser::parser::base::NodeIndex;
+        use tsz_parser::parser::syntax_kind_ext;
+        use tsz_solver::{CallSignature, CallableShape, TypeParamInfo};
+
+        // Only handle VARIABLE symbols (class declarations already return Lazy on circular ref).
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(symbol_flags::VARIABLE)
+            || symbol.has_any_flags(symbol_flags::CLASS)
+        {
+            return None;
+        }
+
+        // Get the variable's primary declaration node.
+        let decl_idx = symbol.primary_declaration()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        let var_decl = self.ctx.arena.get_variable_declaration(decl_node)?;
+
+        if var_decl.initializer == NodeIndex::NONE {
+            return None;
+        }
+
+        // Check if the initializer is a class expression.
+        let init_node = self.ctx.arena.get(var_decl.initializer)?;
+        if init_node.kind != syntax_kind_ext::CLASS_EXPRESSION {
+            return None;
+        }
+
+        // Count the class type parameters so the provisional sig has the right arity.
+        let class_data = self.ctx.arena.get_class(init_node)?;
+        let n_type_params = class_data
+            .type_parameters
+            .as_ref()
+            .map(|tp| tp.nodes.len())
+            .unwrap_or(0);
+
+        // Build provisional type params with placeholder names.
+        let prov_type_params: Vec<TypeParamInfo> = (0..n_type_params)
+            .map(|i| {
+                let name = self.ctx.types.intern_string(&format!("$$prov{i}"));
+                TypeParamInfo::simple(name)
+            })
+            .collect();
+
+        // Build construct signature: `new<$$prov0, ...>() => any`.
+        // The return type is `any` so `InstanceType<typeof Anon<T>>` reduces to `any`
+        // during circular resolution, which is assignable to everything.
+        let construct_sig = CallSignature {
+            type_params: prov_type_params,
+            params: Vec::new(),
+            return_type: TypeId::ANY,
+            this_type: None,
+            type_predicate: None,
+            is_method: false,
+        };
+
+        let callable = self.ctx.types.factory().callable(CallableShape {
+            construct_signatures: vec![construct_sig],
+            call_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        });
+
+        Some(callable)
     }
 
     pub(crate) fn evaluate_type_with_env_uncached(&mut self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/tests/ts2344_class_constructor_constraint_expr.rs
+++ b/crates/tsz-checker/tests/ts2344_class_constructor_constraint_expr.rs
@@ -144,3 +144,50 @@ let Anon = class <out T> {
         "Should NOT emit TS2344 for InstanceType<typeof Anon<T>> because typeof Anon<T> is constructable.\nGot: {ts2344_errors:#?}\nAll: {diagnostics:#?}"
     );
 }
+
+/// `return this` in a method whose return type is `InstanceType<(typeof Anon<T>)>`
+/// must NOT emit TS2322. The constructor type must be preserved when evaluating
+/// `Application(TypeQuery(ClassSym), [T])` so that `InstanceType<...>` correctly
+/// reduces to the instance type rather than wrapping it again.
+#[test]
+fn instance_type_of_generic_class_expr_type_query_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type InstanceType<T extends abstract new (...args: any) => any> =
+    T extends abstract new (...args: any) => infer R ? R : any;
+
+let Anon = class <out T> {
+    foo(): InstanceType<(typeof Anon<T>)> {
+        return this;
+    }
+}
+"#,
+    );
+    let ts2322_errors = diagnostics_for_code(&diagnostics, 2322);
+    assert!(
+        ts2322_errors.is_empty(),
+        "Should NOT emit TS2322 for return this in InstanceType<typeof Anon<T>> context.\nGot: {ts2322_errors:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// Same shape with a renamed type parameter proves the fix is structural, not name-keyed.
+#[test]
+fn instance_type_of_generic_class_expr_type_query_renamed_param_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type InstanceType<T extends abstract new (...args: any) => any> =
+    T extends abstract new (...args: any) => infer R ? R : any;
+
+let Container = class <out Value> {
+    wrap(): InstanceType<(typeof Container<Value>)> {
+        return this;
+    }
+}
+"#,
+    );
+    let ts2322_errors = diagnostics_for_code(&diagnostics, 2322);
+    assert!(
+        ts2322_errors.is_empty(),
+        "Should NOT emit TS2322 regardless of type parameter name choice.\nGot: {ts2322_errors:#?}\nAll: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -227,6 +227,11 @@ struct ApplicationEvalContext {
     /// Whether display-alias bookkeeping should prefer the `Application`
     /// form. True only for non-conditional type-alias applications.
     prefer_application_display_alias: bool,
+    /// Set when `app.base` is a `TypeQuery` (i.e. `typeof ClassName<T>`).
+    /// For `TypeQuery`-based applications the caller wants the constructor
+    /// type, not the instance type, so `extract_class_instance_body` must
+    /// be skipped.
+    base_is_type_query: bool,
 }
 
 /// Common opening preamble for the homomorphic-mapped shortcuts:
@@ -942,7 +947,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         app_base: TypeId,
     ) -> ApplicationEvalContext {
         let type_params = self.resolver.get_lazy_type_params(def_id);
-        let resolved = self.resolver.resolve_lazy(def_id, self.interner);
+        let base_is_type_query =
+            matches!(self.interner.lookup(app_base), Some(TypeData::TypeQuery(_)));
+        // For `typeof ClassName<T>` (TypeQuery base), use `resolve_type_query` to get
+        // the constructor type rather than the instance type that `resolve_lazy` returns
+        // for classes. Type-position references (`ClassName<T>`) continue to use
+        // `resolve_lazy` which correctly provides the instance type.
+        let resolved = if base_is_type_query {
+            if let Some(TypeData::TypeQuery(sym_ref)) = self.interner.lookup(app_base) {
+                self.resolver
+                    .resolve_type_query(sym_ref, self.interner)
+                    .or_else(|| self.resolver.resolve_lazy(def_id, self.interner))
+            } else {
+                self.resolver.resolve_lazy(def_id, self.interner)
+            }
+        } else {
+            self.resolver.resolve_lazy(def_id, self.interner)
+        };
         let def_kind = self.resolver.get_def_kind(def_id);
         let is_type_alias_def = matches!(def_kind, Some(DefKind::TypeAlias));
         let resolved_has_conditional_body = resolved.is_some_and(|body| {
@@ -967,6 +988,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             resolved,
             is_type_alias_def,
             prefer_application_display_alias,
+            base_is_type_query,
         }
     }
 
@@ -1002,10 +1024,29 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 resolved,
                 type_params,
                 ctx.prefer_application_display_alias,
+                ctx.base_is_type_query,
             )
         } else if let Some(resolved) = ctx.resolved {
             // Lite-resolver fallback: extract type parameters from the
             // resolved type's properties.
+            //
+            // For `typeof ClassExpr<T>` (TypeQuery base, Callable resolved type),
+            // use per-signature instantiation so that the class type parameters
+            // stored in `sig.type_params` are CONSUMED rather than SHADOWED.
+            // `instantiate_generic` calls `TypeInstantiator` which calls
+            // `enter_shadowing_scope(&sig.type_params)`, blocking substitution
+            // of those names from the outer substitution built from extracted params.
+            if ctx.base_is_type_query
+                && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
+                && !args.is_empty()
+            {
+                if let Some(specialized) = self.try_instantiate_callable_type_params(resolved, args)
+                {
+                    let evaluated = self.evaluate(specialized);
+                    return ApplicationEvalOutcome::Computed(evaluated);
+                }
+                return ApplicationEvalOutcome::Computed(original_type_id);
+            }
             let extracted_params = self.extract_type_params_from_type(resolved);
             if !extracted_params.is_empty() && extracted_params.len() == args.len() {
                 self.evaluate_application_with_extracted_params(
@@ -1036,6 +1077,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         resolved: TypeId,
         type_params: &[TypeParamInfo],
         prefer_application_display_alias: bool,
+        base_is_type_query: bool,
     ) -> ApplicationEvalOutcome {
         let expanded_args = self.prepare_expanded_args_for_body(resolved, args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
@@ -1072,7 +1114,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // not the class constructor type. Only applies for
         // `DefKind::Class`; interfaces with construct signatures keep
         // their Callable shape intact.
-        let effective_body = self.extract_class_instance_body(def_id, resolved);
+        //
+        // Exception: when the base is a `TypeQuery` (`typeof ClassName<T>`),
+        // the caller wants the constructor type — skipping extraction keeps
+        // the specialized constructor so `InstanceType<typeof Cls<T>>` can
+        // correctly reduce to the class instance type via conditional infer.
+        let effective_body = if base_is_type_query {
+            resolved
+        } else {
+            self.extract_class_instance_body(def_id, resolved)
+        };
 
         // Homomorphic mapped-type union distribution: when the alias body
         // is `{ [K in keyof T]: ... }` and T's argument resolves to a
@@ -2079,6 +2130,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 for span in spans.iter() {
                     if let TemplateSpan::Type(inner) = span {
                         self.collect_type_params(*inner, seen, params);
+                    }
+                }
+            }
+            TypeData::Callable(cs_id) => {
+                // Collect the type parameters declared by construct and call signatures.
+                // This handles `typeof ClassName<T>` where the constructor type is a
+                // Callable whose signatures own the class type parameters.
+                let shape = self.interner.callable_shape(cs_id);
+                for sig in shape
+                    .construct_signatures
+                    .iter()
+                    .chain(shape.call_signatures.iter())
+                {
+                    for tp in &sig.type_params {
+                        if !seen.contains(&tp.name) {
+                            seen.insert(tp.name);
+                            params.push(*tp);
+                        }
                     }
                 }
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -4,13 +4,13 @@
 //! Including distributive conditional types over union types.
 
 use crate::instantiation::instantiate::{
-    TypeSubstitution, instantiate_generic, instantiate_type_with_infer,
+    TypeSubstitution, instantiate_generic, instantiate_type, instantiate_type_with_infer,
 };
 use crate::operations::property::PropertyAccessResult;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
-    ConditionalType, ObjectShape, ObjectShapeId, PropertyInfo, TupleElement, TypeData, TypeId,
-    TypeParamInfo,
+    CallSignature, CallableShape, ConditionalType, ObjectShape, ObjectShapeId, ParamInfo,
+    PropertyInfo, TupleElement, TypeData, TypeId, TypeParamInfo,
 };
 use crate::visitor::{callable_shape_id, function_shape_id};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1258,12 +1258,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return None;
         };
         let app = self.interner().type_application(app_id);
-        let def_id = match self.interner().lookup(app.base)? {
-            TypeData::Lazy(def_id) => Some(def_id),
-            TypeData::TypeQuery(sym_ref) => self.resolver().symbol_to_def_id(sym_ref),
-            _ => None,
-        }?;
-        let resolved = self.resolver().resolve_lazy(def_id, self.interner())?;
+        // For TypeQuery bases (e.g. `typeof ClassName<T>`), always use
+        // `resolve_type_query` to get the CONSTRUCTOR type. `resolve_lazy` would
+        // return the INSTANCE type for classes (via `class_instance_types`), so
+        // `InstanceType<typeof Class<T>>` would fail its constructor constraint check.
+        let (def_id_opt, resolved, base_is_type_query) = match self.interner().lookup(app.base)? {
+            TypeData::Lazy(def_id) => {
+                let r = self.resolver().resolve_lazy(def_id, self.interner())?;
+                (Some(def_id), r, false)
+            }
+            TypeData::TypeQuery(sym_ref) => {
+                let def_id_opt = self.resolver().symbol_to_def_id(sym_ref);
+                let r = self
+                    .resolver()
+                    .resolve_type_query(sym_ref, self.interner())?;
+                (def_id_opt, r, true)
+            }
+            _ => return None,
+        };
         if app.args.len() == 1
             && let Some(TypeData::IndexAccess(obj, idx)) = self.interner().lookup(resolved)
             && let Some(TypeData::TypeParameter(tp)) = self.interner().lookup(obj)
@@ -1278,9 +1290,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return Some(direct);
             }
         }
-        let type_params = self
-            .resolver()
-            .get_lazy_type_params(def_id)
+        // For TypeQuery-based Applications (e.g. `typeof ClassExpr<T>`), use
+        // per-signature instantiation so that the class type parameters stored in
+        // `sig.type_params` are CONSUMED rather than SHADOWED. The standard
+        // `instantiate_generic` path calls `TypeInstantiator` which calls
+        // `enter_shadowing_scope(&sig.type_params)`, blocking substitution of those
+        // names from an outer substitution.
+        if base_is_type_query {
+            let instantiate_result = self.try_instantiate_callable_type_params(resolved, &app.args);
+            if let Some(specialized) = instantiate_result {
+                let evaluated = self.evaluate(specialized);
+                return (evaluated != type_id).then_some(evaluated);
+            }
+            // If per-sig instantiation didn't apply (e.g., resolved is not a
+            // Callable), fall through to the generic path below.
+        }
+
+        let type_params = def_id_opt
+            .and_then(|def_id| self.resolver().get_lazy_type_params(def_id))
             .filter(|params| params.len() == app.args.len())
             .unwrap_or_else(|| self.extract_type_params_from_type(resolved));
         if type_params.len() != app.args.len() {
@@ -1297,6 +1324,93 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
         let evaluated = self.evaluate(instantiated);
         (evaluated != type_id).then_some(evaluated)
+    }
+
+    /// Instantiate a `Callable` type's signatures using per-signature substitution.
+    ///
+    /// When `typeof ClassExpr<T>` appears as the check type of a conditional like
+    /// `InstanceType<typeof ClassExpr<T>>`, the class's type parameters live inside
+    /// `sig.type_params` on the constructor signatures. The standard
+    /// `instantiate_generic` path calls `TypeInstantiator` which calls
+    /// `enter_shadowing_scope(&sig.type_params)`, adding those names to the shadowed
+    /// set and preventing them from being substituted.
+    ///
+    /// This method bypasses that by building a substitution from each signature's own
+    /// `type_params` and applying it to the signature's parts individually (the same
+    /// approach as the checker's `instantiate_signature`). Type params are consumed
+    /// (set to `Vec::new()`) in the output signatures so the resulting Callable is
+    /// fully concrete with respect to the supplied `type_args`.
+    ///
+    /// Returns `Some(new_callable_id)` when at least one construct signature was
+    /// successfully instantiated; returns `None` otherwise (wrong arg count, not a
+    /// Callable, etc.).
+    pub(in crate::evaluation) fn try_instantiate_callable_type_params(
+        &mut self,
+        callable_id: TypeId,
+        type_args: &[TypeId],
+    ) -> Option<TypeId> {
+        let cs_id = match self.interner().lookup(callable_id)? {
+            TypeData::Callable(cs_id) => cs_id,
+            _ => return None,
+        };
+        let shape = self.interner().callable_shape(cs_id);
+
+        fn instantiate_sig(
+            interner: &dyn crate::construction::TypeDatabase,
+            sig: &CallSignature,
+            type_args: &[TypeId],
+        ) -> Option<CallSignature> {
+            if sig.type_params.len() != type_args.len() {
+                return None;
+            }
+            let subst = TypeSubstitution::from_args(interner, &sig.type_params, type_args);
+            let params: Vec<ParamInfo> = sig
+                .params
+                .iter()
+                .map(|p| ParamInfo {
+                    type_id: instantiate_type(interner, p.type_id, &subst),
+                    ..*p
+                })
+                .collect();
+            let return_type = instantiate_type(interner, sig.return_type, &subst);
+            let this_type = sig.this_type.map(|t| instantiate_type(interner, t, &subst));
+            Some(CallSignature {
+                type_params: Vec::new(),
+                params,
+                return_type,
+                this_type,
+                type_predicate: sig.type_predicate,
+                is_method: sig.is_method,
+            })
+        }
+
+        let mut new_construct_sigs: Vec<CallSignature> = Vec::new();
+        let mut any_changed = false;
+        for sig in shape.construct_signatures.iter() {
+            match instantiate_sig(self.interner(), sig, type_args) {
+                Some(new_sig) => {
+                    any_changed = true;
+                    new_construct_sigs.push(new_sig);
+                }
+                None => {
+                    new_construct_sigs.push(sig.clone());
+                }
+            }
+        }
+        if !any_changed {
+            return None;
+        }
+
+        let new_shape = CallableShape {
+            construct_signatures: new_construct_sigs,
+            call_signatures: shape.call_signatures.to_vec(),
+            properties: shape.properties.to_vec(),
+            string_index: shape.string_index,
+            number_index: shape.number_index,
+            symbol: shape.symbol,
+            is_abstract: shape.is_abstract,
+        };
+        Some(self.interner().callable(new_shape))
     }
 
     /// Check if this is a primitive type vs Function/callable target.


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 8: rendered/source-text fingerprint debt burn-down.

## Invariant
When a class expression variable's `typeof` appears inside the class body as the argument to a generic utility type (`InstanceType`, `ConstructorParameters`), tsz must not emit TS2344 or TS2322 false positives. The fix is structural: provide a provisional constructor callable during circular resolution rather than masking diagnostics with source-text fingerprinting.

## Scope
- Delete dead `rewrite_intersection_index_signature_fingerprints` helper and callsite from `source_file.rs`.
- Delete `rewrite_variance_annotations_fingerprints` helper and callsite from `source_file.rs`.
- Add provisional class-expression constructor type support in `state/type_environment/lazy.rs`.
- Preserve TypeQuery-based `Application` behavior in checker type-environment resolution and solver conditional evaluation.
- Add focused `ts2344_class_constructor_constraint_expr` tests covering non-generic, generic, renamed type parameter, and type-query-in-method-return cases.
- Deliberately no longer edits `scripts/conformance/conformance-accepted-regressions.txt`; that belongs to the separate conformance-maintenance lane.

## Project Corpus Impact
- Row: n/a
- Bug family: false-positive TS2322/TS2344 on class expression constructor types; source-text fingerprint burn-down
- Evidence: 17 focused checker tests pass locally, and the source-text fingerprint functions are removed rather than extended.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-checker`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo clippy -p tsz-checker -p tsz-solver --lib -- -D warnings`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-checker --test ts2344_class_constructor_constraint_expr --test intersection_index_signature_fingerprint_tests --no-fail-fast`

## Coordination Notes
- M1-C rebased the branch onto current `origin/main` `ce00bb78c6e94478231889f3ac54c34a58c1df01` and force-with-lease pushed head `c43df6e3eba86fe7988db2a6aa477b92344165d7`.
- The previous branch included a conformance accepted-regression cleanup that is no longer a duplicate on current main. M1-C dropped that commit to avoid overlapping #9904 / conformance-maintenance ownership.
- Keep draft until fresh draft/light CI completes on `c43df6e3`. If light CI passes and no new blocker appears, next action is to mark ready for heavy CI. Do not enable auto-merge until the exact ready head has a complete green required-check picture.


## M1-C Refresh 2026-05-24
- AgentName: M1-C
- Rebased onto current `origin/main` after #10035 merged; refreshed head `92698f92c2` was force-with-lease pushed.
- Local refresh verification: `cargo fmt --all -- --check`, `python3 scripts/arch/arch_guard.py`, and `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-checker`.
- Draft/light CI is expected to rerun on the refreshed head; keep draft until that check picture is clean.
