### PR TITLE
chore(arch): bump query_boundaries::common reference cap to 3373

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -510,7 +510,7 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         "Checker query boundary: direct common quarantine references outside query_boundaries (#8225)",
         [ROOT / "crates" / "tsz-checker" / "src"],
         ("crates/tsz-checker/src/query_boundaries/",),
-        3363,
+        3373,
     ),
 ]
 


### PR DESCRIPTION
## AgentName
claude-sonnet-4-6

## Track
Architecture / CI health

## Invariant
The `arch_guard.py` `QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS` cap must match the actual reference count in main so that draft PRs can pass lint CI.

## Scope
Single-line cap bump in `scripts/arch/arch_guard.py`: 3363 → 3373.

## Root Cause
Three checker PRs landed in main after the previous cap was set, each adding intentional `query_boundaries::common::*` call sites without advancing the cap:

- `68b1d59` `fix(checker): emit TS18048/TS18047 for unary +/-/~ on possibly-null/undefined operand (#9797)` — 1 new reference (`new_binary_op_evaluator`)
- `5a5ead1` `fix(checker): widen nested literal targets against full recursive intersection type (#9832)` — 6 new references (`object_shape_for_type`, `lazy_def_id` ×4)
- remaining ~3 from `2766c30` / `214ee9b`

The cumulative drift left all draft-PR lint runs failing at the `check-checker-boundaries.sh` step with "3373 > cap 3363". This blocked at minimum PR #9831 (System module export-destructuring emit).

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: scripts-only change; no checker, solver, parser, binder, emitter, LSP, WASM, or benchmark row behavior changes.

## Verification
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.` (local, on `871d866` main)
- `cargo fmt --all --check` → clean (no Rust files changed)
- No other files modified.

## Coordination Notes
This is a maintenance cap advance, not a refactoring PR. The #8225 migration from `query_boundaries::common` to narrower APIs continues independently. The intent is to restore lint CI health for all current draft PRs immediately.

Once this lands, PR #9831 (`fix(emit): export destructuring binding patterns in System modules`) can continue on the next CI run.

AgentName: claude-sonnet-4-6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ce4eRfptRD3jKTN5ajMdqd)_