### PR TITLE
fix(binder): preserve do-while exit narrowing

### DIFF
--- a/crates/tsz-binder/src/nodes/flow_statements.rs
+++ b/crates/tsz-binder/src/nodes/flow_statements.rs
@@ -114,7 +114,10 @@ impl BinderState {
                     pre_condition_flow,
                     loop_data.condition,
                 );
-                self.add_antecedent(post_loop, pre_condition_flow);
+                // Normal fallthrough from a `do ... while` loop occurs only
+                // when the bottom condition is false, so the post-loop edge
+                // must carry the false-condition flow rather than the raw
+                // pre-condition body flow.
                 self.add_antecedent(post_loop, false_flow);
             }
         } else {

--- a/crates/tsz-binder/src/state/tests/loop_flow.rs
+++ b/crates/tsz-binder/src/state/tests/loop_flow.rs
@@ -103,3 +103,60 @@ function f(x: string | number) {
         "conditionless for post-loop merge should be reachable through the conditional break edge"
     );
 }
+
+#[test]
+fn do_while_post_loop_uses_false_condition_edge_only() {
+    let (binder, _parser) = parse_and_bind(
+        r#"
+let value: string | number;
+do {
+} while (typeof value === "string");
+value;
+"#,
+    );
+
+    let false_flows: Vec<_> = (0..binder.flow_nodes.len())
+        .map(|idx| FlowNodeId(idx as u32))
+        .filter(|&flow_id| {
+            binder.flow_nodes.get(flow_id).is_some_and(|flow| {
+                flow.has_any_flags(flow_flags::FALSE_CONDITION) && flow.node.is_some()
+            })
+        })
+        .collect();
+    assert!(
+        !false_flows.is_empty(),
+        "do-while condition should create a false-condition flow"
+    );
+
+    let mut saw_post_loop_false_edge = false;
+    for false_flow in false_flows {
+        let Some(false_node) = binder.flow_nodes.get(false_flow) else {
+            continue;
+        };
+        let raw_pre_condition_flow = false_node.antecedent.first().copied();
+
+        for branch_id in (0..binder.flow_nodes.len()).map(|idx| FlowNodeId(idx as u32)) {
+            let Some(branch) = binder.flow_nodes.get(branch_id) else {
+                continue;
+            };
+            if !branch.has_any_flags(flow_flags::BRANCH_LABEL)
+                || !branch.antecedent.contains(&false_flow)
+            {
+                continue;
+            }
+
+            saw_post_loop_false_edge = true;
+            if let Some(raw_pre_condition_flow) = raw_pre_condition_flow {
+                assert!(
+                    !branch.antecedent.contains(&raw_pre_condition_flow),
+                    "post-loop merge must not union the raw pre-condition flow with the false-condition exit"
+                );
+            }
+        }
+    }
+
+    assert!(
+        saw_post_loop_false_edge,
+        "do-while post-loop merge should be reached through the false-condition edge"
+    );
+}

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -469,6 +469,9 @@ mod direct_generic_return_tests;
 #[path = "tests/dispatch_tests.rs"]
 mod dispatch_tests;
 #[cfg(test)]
+#[path = "tests/do_while_exit_narrowing_tests.rs"]
+mod do_while_exit_narrowing_tests;
+#[cfg(test)]
 #[path = "../tests/dynamic_import_ts2307_per_callsite_tests.rs"]
 mod dynamic_import_ts2307_per_callsite_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/do_while_exit_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/do_while_exit_narrowing_tests.rs
@@ -1,0 +1,96 @@
+//! Post-loop narrowing for `do ... while` exit conditions.
+//!
+//! A `do ... while (cond)` statement reaches the following statement only when
+//! `cond` is false, so the post-loop flow must apply the false branch of the
+//! loop condition.
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn diags(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    diags(source).iter().map(|diag| diag.code).collect()
+}
+
+#[test]
+fn do_while_exit_applies_false_typeof_branch() {
+    let codes = codes(
+        r#"
+function f(value: string | number) {
+  do {
+  } while (typeof value === "string");
+  const narrowed: number = value;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&2322),
+        "expected do-while exit to narrow value to number; got {codes:?}"
+    );
+}
+
+#[test]
+fn do_while_exit_applies_false_null_branch_with_renamed_binding() {
+    let codes = codes(
+        r#"
+function f(item: { n: number } | null) {
+  do {
+  } while (item === null);
+  item.n;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&18047) && !codes.contains(&2531),
+        "expected do-while exit to narrow item away from null; got {codes:?}"
+    );
+}
+
+#[test]
+fn while_and_for_exit_controls_keep_false_branch_narrowing() {
+    let codes = codes(
+        r#"
+function f(value: string | number, other: string | number) {
+  while (typeof value === "string") {
+  }
+  const a: number = value;
+
+  for (; typeof other === "string"; ) {
+  }
+  const b: number = other;
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&2322),
+        "while and for exit narrowing controls should stay passing; got {codes:?}"
+    );
+}
+
+#[test]
+fn do_while_exit_does_not_apply_true_branch_after_normal_exit() {
+    let codes = codes(
+        r#"
+function f(value: string | number) {
+  do {
+  } while (typeof value === "string");
+  const wrong: string = value;
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&2322),
+        "normal do-while exit must not narrow to the true branch; got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Track 6 semantic campaign: flow graph and solver-owned narrowing predicates.

## Invariant
When a `do ... while` loop falls through normally, `tsc` applies the false branch of the loop condition to the post-loop flow. This PR makes tsz bind that post-loop edge through the false-condition flow instead of also unioning the raw pre-condition body flow.

## Scope
- `crates/tsz-binder/src/nodes/flow_statements.rs`: remove the raw pre-condition antecedent from do-while post-loop merge wiring.
- `crates/tsz-binder/src/state/tests/loop_flow.rs`: pin the do-while CFG edge shape alongside the existing loop-flow tests.
- `crates/tsz-checker/src/lib.rs`: register the focused checker tests.
- `crates/tsz-checker/src/tests/do_while_exit_narrowing_tests.rs`: pin TS2322/nullish behavior and while/for controls.

## Adjacent Cases
- `typeof value === "string"` exits with value narrowed to number.
- `item === null` exits with item narrowed away from null under a renamed binding.
- while and for false-condition exit narrowing stay unchanged.
- The normal exit does not incorrectly apply the true branch.

## Verification
- `cargo fmt --check` -> passed.
- `cargo nextest run -p tsz-binder loop_flow` -> 3/3 passed.
- `timeout 180 cargo nextest run -p tsz-checker --lib do_while_exit_narrowing_tests` -> 4/4 passed.
- `git diff --check origin/main...HEAD` -> passed.
- `wc -l crates/tsz-binder/src/nodes/flow_statements.rs crates/tsz-binder/src/state/tests/loop_flow.rs crates/tsz-checker/src/tests/do_while_exit_narrowing_tests.rs` -> 318, 162, and 96 lines.
- Exact-head GitGuardian check on `091aa30ed5a1dc3153169a166fcff4fa9f4200de` -> passed.

## Project Corpus Impact
- Row: n/a
- Bug family: flow narrowing false positive
- Evidence: focused binder/checker unit tests for issue #9664; no project corpus row identified.

## Coordination Notes
- Fixes #9664.
- #9933 merged, so this PR was rebased onto `main` and retargeted from the previous stack base to `main`.
- Current head: `091aa30ed5a1dc3153169a166fcff4fa9f4200de`.
- The rebased draft head only received GitGuardian rather than a full light CI run; local focused verification is complete, so M1-D is marking this ready and leaving auto-merge off. Ready-review CI is the landing authority for this exact head.
