### PR TITLE
refactor(cli): split implement-interface codefix plan

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs
@@ -14,7 +14,7 @@ use super::handlers_code_fixes_utils::{
     extract_quoted_text, extract_type_identifiers, find_first_implements_class,
     find_matching_brace, is_identifier, parse_bare_identifier_expression,
     parse_identifier_call_expression, parse_interface_properties, parse_named_import_map,
-    positions_overlap, resolve_module_path, should_import_identifier,
+    positions_overlap, resolve_module_path,
 };
 use super::{Server, TsServerRequest, TsServerResponse};
 use tsz::checker::diagnostics::DiagnosticCategory;
@@ -3469,130 +3469,6 @@ impl Server {
         }
 
         None
-    }
-
-    fn synthetic_implement_interface_codefix(
-        &self,
-        file_path: &str,
-        content: &str,
-        auto_import_file_exclude_patterns: &[String],
-        auto_import_specifier_exclude_regexes: &[String],
-        import_module_specifier_ending: Option<&str>,
-        import_module_specifier_preference: Option<&str>,
-        line_map: &LineMap,
-    ) -> Option<serde_json::Value> {
-        let (_, interface_name, class_open_brace, class_close_brace) =
-            find_first_implements_class(content)?;
-        let mut class_imports = parse_named_import_map(content);
-        let (interface_file_path, interface_content) =
-            if let Some(interface_module_specifier) = class_imports.get(&interface_name).cloned() {
-                let interface_file_path =
-                    resolve_module_path(file_path, &interface_module_specifier, &self.open_files)?;
-                let interface_content = self
-                    .open_files
-                    .get(&interface_file_path)
-                    .cloned()
-                    .or_else(|| std::fs::read_to_string(&interface_file_path).ok())?;
-                (interface_file_path, interface_content)
-            } else if content.contains(&format!("interface {interface_name}")) {
-                (file_path.to_string(), content.to_string())
-            } else {
-                return None;
-            };
-
-        let interface_properties = parse_interface_properties(&interface_content, &interface_name)?;
-        if interface_properties.is_empty() {
-            return None;
-        }
-
-        let class_body = content.get(class_open_brace + 1..class_close_brace)?;
-        let mut missing_members = Vec::new();
-        for member in interface_properties {
-            if !class_body_has_member(class_body, member.name()) {
-                missing_members.push(member);
-            }
-        }
-        if missing_members.is_empty() {
-            return None;
-        }
-
-        let interface_imports = parse_named_import_map(&interface_content);
-        let mut needed_imports: std::collections::BTreeSet<String> =
-            std::collections::BTreeSet::new();
-        for member in &missing_members {
-            for ident in extract_type_identifiers(member.referenced_types()) {
-                if should_import_identifier(&ident) && !class_imports.contains_key(&ident) {
-                    needed_imports.insert(ident);
-                }
-            }
-        }
-
-        let mut import_lines = Vec::new();
-        for ident in needed_imports {
-            if !self.interface_symbol_import_is_usable(
-                &interface_file_path,
-                &interface_imports,
-                &ident,
-                auto_import_file_exclude_patterns,
-            ) {
-                continue;
-            }
-            if let Some(module_specifier) = self.best_import_module_specifier_for_name(
-                file_path,
-                &ident,
-                auto_import_file_exclude_patterns,
-                auto_import_specifier_exclude_regexes,
-                import_module_specifier_ending,
-                import_module_specifier_preference,
-            ) && let std::collections::hash_map::Entry::Vacant(entry) =
-                class_imports.entry(ident.clone())
-            {
-                import_lines.push(format!("import {{ {ident} }} from '{module_specifier}';"));
-                entry.insert(module_specifier);
-            }
-        }
-
-        let members_text = missing_members
-            .iter()
-            .map(|m| format!("    {}", m.render()))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let updated_body = if class_body.trim().is_empty() {
-            format!("\n{members_text}\n")
-        } else {
-            format!("{}\n{}\n", class_body.trim_end(), members_text)
-        };
-        let mut updated_content = format!(
-            "{}{}{}",
-            &content[..class_open_brace + 1],
-            updated_body,
-            &content[class_close_brace..]
-        );
-
-        for import_line in import_lines.iter().rev() {
-            if !updated_content.contains(import_line) {
-                updated_content = format!("{import_line}\n{updated_content}");
-            }
-        }
-        if updated_content == content {
-            return None;
-        }
-        let end_pos = line_map.offset_to_position(content.len() as u32, content);
-
-        Some(serde_json::json!({
-            "fixName": "fixClassIncorrectlyImplementsInterface",
-            "description": format!("Implement interface '{interface_name}'"),
-            "changes": [{
-                "fileName": file_path,
-                "textChanges": [{
-                    "start": { "line": 1, "offset": 1 },
-                    "end": { "line": end_pos.line + 1, "offset": end_pos.character + 1 },
-                    "newText": updated_content
-                }]
-            }],
-            "fixId": "fixClassIncorrectlyImplementsInterface",
-            "fixAllDescription": "Implement all unimplemented interfaces",
-        }))
     }
 
     pub(crate) fn handle_get_combined_code_fix(

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface.rs
@@ -1,0 +1,198 @@
+//! Implement-interface code-fix planning and rendering.
+//!
+//! Extracted from `handlers_code_fixes.rs` so the top-level code-fix handler
+//! can stay focused on request orchestration.
+
+use super::Server;
+use super::handlers_code_fixes_utils::{
+    InterfaceMember, class_body_has_member, extract_type_identifiers, find_first_implements_class,
+    parse_interface_properties, parse_named_import_map, resolve_module_path,
+    should_import_identifier,
+};
+use tsz::lsp::position::LineMap;
+
+#[derive(Debug)]
+pub(super) struct ImplementInterfacePlan {
+    pub(super) interface_name: String,
+    pub(super) interface_file_path: String,
+    class_open_brace: usize,
+    class_close_brace: usize,
+    class_imports: std::collections::HashMap<String, String>,
+    interface_imports: std::collections::HashMap<String, String>,
+    pub(super) missing_members: Vec<InterfaceMember>,
+}
+
+impl Server {
+    pub(super) fn synthetic_implement_interface_codefix(
+        &self,
+        file_path: &str,
+        content: &str,
+        auto_import_file_exclude_patterns: &[String],
+        auto_import_specifier_exclude_regexes: &[String],
+        import_module_specifier_ending: Option<&str>,
+        import_module_specifier_preference: Option<&str>,
+        line_map: &LineMap,
+    ) -> Option<serde_json::Value> {
+        let mut plan = self.implement_interface_plan(file_path, content)?;
+        let import_lines = self.implement_interface_import_lines(
+            file_path,
+            &mut plan,
+            auto_import_file_exclude_patterns,
+            auto_import_specifier_exclude_regexes,
+            import_module_specifier_ending,
+            import_module_specifier_preference,
+        );
+        let updated_content =
+            Self::render_implement_interface_content(content, &plan, &import_lines)?;
+        let end_pos = line_map.offset_to_position(content.len() as u32, content);
+
+        Some(serde_json::json!({
+            "fixName": "fixClassIncorrectlyImplementsInterface",
+            "description": format!("Implement interface '{}'", plan.interface_name),
+            "changes": [{
+                "fileName": file_path,
+                "textChanges": [{
+                    "start": { "line": 1, "offset": 1 },
+                    "end": { "line": end_pos.line + 1, "offset": end_pos.character + 1 },
+                    "newText": updated_content
+                }]
+            }],
+            "fixId": "fixClassIncorrectlyImplementsInterface",
+            "fixAllDescription": "Implement all unimplemented interfaces",
+        }))
+    }
+
+    pub(super) fn implement_interface_plan(
+        &self,
+        file_path: &str,
+        content: &str,
+    ) -> Option<ImplementInterfacePlan> {
+        let (_, interface_name, class_open_brace, class_close_brace) =
+            find_first_implements_class(content)?;
+        let class_imports = parse_named_import_map(content);
+        let (interface_file_path, interface_content) =
+            if let Some(interface_module_specifier) = class_imports.get(&interface_name).cloned() {
+                let interface_file_path =
+                    resolve_module_path(file_path, &interface_module_specifier, &self.open_files)?;
+                let interface_content = self
+                    .open_files
+                    .get(&interface_file_path)
+                    .cloned()
+                    .or_else(|| std::fs::read_to_string(&interface_file_path).ok())?;
+                (interface_file_path, interface_content)
+            } else if content.contains(&format!("interface {interface_name}")) {
+                (file_path.to_string(), content.to_string())
+            } else {
+                return None;
+            };
+
+        let interface_properties = parse_interface_properties(&interface_content, &interface_name)?;
+        if interface_properties.is_empty() {
+            return None;
+        }
+
+        let class_body = content.get(class_open_brace + 1..class_close_brace)?;
+        let mut missing_members = Vec::new();
+        for member in interface_properties {
+            if !class_body_has_member(class_body, member.name()) {
+                missing_members.push(member);
+            }
+        }
+        if missing_members.is_empty() {
+            return None;
+        }
+
+        let interface_imports = parse_named_import_map(&interface_content);
+        Some(ImplementInterfacePlan {
+            interface_name,
+            interface_file_path,
+            class_open_brace,
+            class_close_brace,
+            class_imports,
+            interface_imports,
+            missing_members,
+        })
+    }
+
+    fn implement_interface_import_lines(
+        &self,
+        file_path: &str,
+        plan: &mut ImplementInterfacePlan,
+        auto_import_file_exclude_patterns: &[String],
+        auto_import_specifier_exclude_regexes: &[String],
+        import_module_specifier_ending: Option<&str>,
+        import_module_specifier_preference: Option<&str>,
+    ) -> Vec<String> {
+        let mut needed_imports: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        for member in &plan.missing_members {
+            for ident in extract_type_identifiers(member.referenced_types()) {
+                if should_import_identifier(&ident) && !plan.class_imports.contains_key(&ident) {
+                    needed_imports.insert(ident);
+                }
+            }
+        }
+
+        let mut import_lines = Vec::new();
+        for ident in needed_imports {
+            if !self.interface_symbol_import_is_usable(
+                &plan.interface_file_path,
+                &plan.interface_imports,
+                &ident,
+                auto_import_file_exclude_patterns,
+            ) {
+                continue;
+            }
+            if let Some(module_specifier) = self.best_import_module_specifier_for_name(
+                file_path,
+                &ident,
+                auto_import_file_exclude_patterns,
+                auto_import_specifier_exclude_regexes,
+                import_module_specifier_ending,
+                import_module_specifier_preference,
+            ) && let std::collections::hash_map::Entry::Vacant(entry) =
+                plan.class_imports.entry(ident.clone())
+            {
+                import_lines.push(format!("import {{ {ident} }} from '{module_specifier}';"));
+                entry.insert(module_specifier);
+            }
+        }
+        import_lines
+    }
+
+    pub(super) fn render_implement_interface_content(
+        content: &str,
+        plan: &ImplementInterfacePlan,
+        import_lines: &[String],
+    ) -> Option<String> {
+        let class_body = content.get(plan.class_open_brace + 1..plan.class_close_brace)?;
+        let members_text = plan
+            .missing_members
+            .iter()
+            .map(|m| format!("    {}", m.render()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let updated_body = if class_body.trim().is_empty() {
+            format!("\n{members_text}\n")
+        } else {
+            format!("{}\n{}\n", class_body.trim_end(), members_text)
+        };
+        let mut updated_content = format!(
+            "{}{}{}",
+            &content[..plan.class_open_brace + 1],
+            updated_body,
+            &content[plan.class_close_brace..]
+        );
+
+        for import_line in import_lines.iter().rev() {
+            if !updated_content.contains(import_line) {
+                updated_content = format!("{import_line}\n{updated_content}");
+            }
+        }
+        (updated_content != content).then_some(updated_content)
+    }
+}
+
+#[cfg(test)]
+#[path = "handlers_code_fixes_implement_interface_tests.rs"]
+mod tests;

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
@@ -1,0 +1,64 @@
+use super::Server;
+use crate::{CheckOptions, LogConfig, LogLevel, ServerMode};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
+
+fn make_server() -> Server {
+    Server {
+        completion_import_module_specifier_ending: None,
+        import_module_specifier_preference: None,
+        organize_imports_type_order: None,
+        organize_imports_ignore_case: false,
+        auto_import_file_exclude_patterns: Vec::new(),
+        lib_dir: PathBuf::from("/nonexistent"),
+        tests_lib_dir: PathBuf::from("/nonexistent"),
+        lib_cache: FxHashMap::default(),
+        unified_lib_cache: None,
+        checks_completed: 0,
+        response_seq: 0,
+        open_files: FxHashMap::default(),
+        external_project_files: FxHashMap::default(),
+        _server_mode: ServerMode::Semantic,
+        _log_config: LogConfig {
+            level: LogLevel::Off,
+            file: None,
+            trace_to_console: false,
+        },
+        enable_telemetry: false,
+        allow_importing_ts_extensions: false,
+        inferred_check_options: CheckOptions::default(),
+        inferred_projectinfo_options: None,
+        auto_imports_allowed_for_inferred_projects: true,
+        inferred_module_is_none_for_projects: false,
+        auto_import_specifier_exclude_regexes: Vec::new(),
+        include_completions_with_class_member_snippets: false,
+        include_inlay_parameter_name_hints: None,
+        generate_return_in_doc_template: None,
+        new_line_character: None,
+        plugin_configs: FxHashMap::default(),
+        native_ts_worker: None,
+        pending_events: Vec::new(),
+    }
+}
+
+#[test]
+fn implement_interface_plan_separates_analysis_from_rendering() {
+    let server = make_server();
+    let content = "interface I { value: string; }\nclass C implements I {}\n";
+
+    let plan = server
+        .implement_interface_plan("/same_file.ts", content)
+        .expect("expected implement-interface analysis plan");
+
+    assert_eq!(plan.interface_name, "I");
+    assert_eq!(plan.interface_file_path, "/same_file.ts");
+    assert_eq!(plan.missing_members.len(), 1);
+    assert_eq!(plan.missing_members[0].name(), "value");
+
+    let updated = Server::render_implement_interface_content(content, &plan, &[])
+        .expect("expected rendered implement-interface edit");
+    assert_eq!(
+        updated,
+        "interface I { value: string; }\nclass C implements I {\n    value: string;\n}\n"
+    );
+}

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -31,6 +31,7 @@
 
 mod check;
 mod handlers_code_fixes;
+mod handlers_code_fixes_implement_interface;
 mod handlers_code_fixes_imports;
 mod handlers_code_fixes_jsdoc;
 mod handlers_code_fixes_utils;


### PR DESCRIPTION
AgentName: Studio-E

## Track
Track 9 / LSP-tsserver CLI refactor-only cleanup for #9415.

## Invariant
When the implement-interface code fix synthesizes missing class members, tsz should preserve the same public `fixClassIncorrectlyImplementsInterface` protocol edit while first deriving a named analysis plan, then resolving any imports, then rendering the edit.

## Scope
- Add `ImplementInterfacePlan` to hold the interface target, class span, import maps, and missing member stubs.
- Split `synthetic_implement_interface_codefix` into plan analysis, import-line resolution, and source rendering helpers.
- Extract the implement-interface plan/render helpers into `handlers_code_fixes_implement_interface.rs` so the top-level code-fix handler remains request orchestration.
- Add a focused unit test that pins the analysis/render split while existing implement-interface output-shape tests continue covering public behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only tsserver code-fix fallback; no parser, binder, checker, solver, emitter, conformance, fourslash, WASM, or project-corpus behavior intended to change.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- Before the final main refreshes, `cargo nextest run -p tsz-cli -E 'test(synthetic_implement_interface_codefix) | test(implement_interface)'` passed on the same PR diff (5 passed, 1781 skipped). The latest CI run provides the refreshed build/test signal after the rebase.
- Exact-head draft-light CI for head `e71483260503a05f7b408f6c77fefcd2e5e9c405` passed: https://github.com/mohsen1/tsz/actions/runs/26372306482
- Latest-main queue/main signals completed successfully on head `d3a983de7bba3ce091eb42f43151b71a304f743c` before promotion.

## Coordination Notes
- Closes #9415.
- Issue #8432 remains open as semantic cleanup context.
- AgentName: Studio-E refreshed this branch onto current `origin/main` after #9809 advanced main.
- AgentName: Studio-C promoted the PR after exact-head draft-light CI and latest-main queue/main signals were green.
- Ready-review CI is now the source of truth for landing this branch.
