### PR TITLE
refactor(checker): route call recovery relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
@@ -589,15 +589,22 @@ impl<'a> CheckerState<'a> {
                             .get_generator_yield_type_argument(actual_return)
                             .zip(self.get_generator_yield_type_argument(expected_return))
                             .is_some_and(|(actual_yield, expected_yield)| {
-                                !self.is_assignable_to(actual_yield, expected_yield)
-                                    && !self.is_assignable_to(expected_yield, actual_yield)
+                                !self.diagnostic_relation_boolean_guard(
+                                    actual_yield,
+                                    expected_yield,
+                                ) && !self.diagnostic_relation_boolean_guard(
+                                    expected_yield,
+                                    actual_yield,
+                                )
                             })
                             || self
                                 .get_generator_return_type_argument(actual_return)
                                 .zip(self.get_generator_return_type_argument(expected_return))
                                 .is_some_and(|(actual_gen_return, expected_gen_return)| {
-                                    !self.is_assignable_to(actual_gen_return, expected_gen_return)
-                                        && !self.is_assignable_to(
+                                    !self.diagnostic_relation_boolean_guard(
+                                        actual_gen_return,
+                                        expected_gen_return,
+                                    ) && !self.diagnostic_relation_boolean_guard(
                                             expected_gen_return,
                                             actual_gen_return,
                                         )
@@ -606,7 +613,8 @@ impl<'a> CheckerState<'a> {
                                 .get_generator_next_type_argument(actual_return)
                                 .zip(self.get_generator_next_type_argument(expected_return))
                                 .is_some_and(|(actual_next, expected_next)| {
-                                    !self.is_assignable_to(expected_next, actual_next)
+                                    !self
+                                        .diagnostic_relation_boolean_guard(expected_next, actual_next)
                                 });
 
                         // When the expected return type is `void`, there is never
@@ -646,7 +654,10 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 generator_component_mismatch
                                     || (expected_return != TypeId::VOID
-                                        && !self.is_assignable_to(actual_return, expected_return))
+                                        && !self.diagnostic_relation_boolean_guard(
+                                            actual_return,
+                                            expected_return,
+                                        ))
                             };
                         (return_type_mismatch, generator_component_mismatch)
                     })

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -454,6 +454,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability"
             / "assignability_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "call_checker"
+            / "diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "jsx",
         ],
         re.compile(


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227.

## Invariant
When call-checker callback recovery compares generator yield/return/next components or callback return types only to decide whether to force a diagnostic, tsz should route those pure boolean relation probes through the checker diagnostic boolean guard. Behavior is unchanged; the direct raw assignability calls become grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/checkers/call_checker/diagnostics.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing and architecture ratchet config coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Parent #9877 merged into `main` as `56865471ce76cab5b1768044319f502bb56e5916`.
- Rebased cleanly onto current `origin/main` at `a23d7b2b9bbcc6e04e216f9281b754640f30138c`; current exact head is `a9347e918e3e3faa1cd740830ec1d431063effdb`.
- Conflict resolution from the previous cycle kept the split `scripts/arch/arch_guard.py` layout already on `main`, skipped the branch's now-redundant historical split commit, and preserved this PR's #8227 call-checker diagnostics ratchet in `scripts/arch/arch_guard_config.py`.
- Current PR state: ready/off-auto. Ready-review CI is green on `a9347e918e3e3faa1cd740830ec1d431063effdb`, including `CI Summary`, conformance/fourslash aggregates, emit, WASM, project compile guard/canary, lint, unit, dist, project-corpus body, snapshot gate, and GitGuardian.
- Current blocker: required `Queue Tested` is still pending on `a9347e918e3e3faa1cd740830ec1d431063effdb`, so GitHub reports `mergeStateStatus: BLOCKED`.
- Queue dry-run evidence: `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --dry-run --verbose --max-prs 400` reports no queue-ready auto-merge PR found because unarmed ready PRs are skipped.
- Auto-merge remains off by policy while `Queue Tested` is pending. Do not arm auto-merge as a queue/CI watcher; resolve the queue-policy mismatch explicitly or use the repository-approved path for setting `Queue Tested` on this exact head before landing.
- Draft child #10037 must be rebased from prior parent `b0cc6adb82cd6ef71c667e7c31002a0e9974d508` to this new head before promotion.
