### PR TITLE
refactor(perf): declare cross-arena miss sources

### DIFF
--- a/.github/workflows/refresh-green-prs.yml
+++ b/.github/workflows/refresh-green-prs.yml
@@ -1,0 +1,70 @@
+name: Refresh Green PRs
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Drain at most one stale green PR per run, away from the top of the hour.
+    - cron: '7,27,47 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report the next PR without updating branches or auto-merge.
+        type: boolean
+        default: true
+      max_prs:
+        description: Maximum open PRs to inspect.
+        type: number
+        default: 200
+      verbose:
+        description: Include skip reasons in the step summary.
+        type: boolean
+        default: false
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: refresh-green-prs-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: refresh-one-pr
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Refresh one stale green PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          MAX_PRS_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.max_prs || 200 }}
+          VERBOSE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.verbose || false }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          dry_run="${DRY_RUN_INPUT}"
+          args=(
+            --repository "${REPOSITORY}"
+            --base main
+            --max-prs "${MAX_PRS_INPUT}"
+            --max-refreshes 1
+          )
+          if [[ "${dry_run}" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          if [[ "${VERBOSE_INPUT}" == "true" ]]; then
+            args+=(--verbose)
+          fi
+
+          node scripts/ci/refresh-green-prs.mjs "${args[@]}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/refresh-green-prs.yml
+++ b/.github/workflows/refresh-green-prs.yml
@@ -22,9 +22,8 @@ on:
         default: false
 
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   checks: read
   statuses: read
 
@@ -44,7 +43,10 @@ jobs:
 
       - name: Refresh one stale green PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Apply mode needs a real automation token so the branch update emits
+          # a pull_request synchronize event and the PR's required checks run.
+          GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+          HAS_AUTOMATION_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN != '' }}
           DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           MAX_PRS_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.max_prs || 200 }}
           VERBOSE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.verbose || false }}
@@ -54,6 +56,11 @@ jobs:
           set -euo pipefail
 
           dry_run="${DRY_RUN_INPUT}"
+          if [[ "${dry_run}" != "true" && "${HAS_AUTOMATION_TOKEN}" != "true" ]]; then
+            echo "::warning::TSZ_PR_AUTOMATION_TOKEN is not configured; forcing dry-run because GITHUB_TOKEN branch updates do not trigger pull_request CI."
+            dry_run=true
+          fi
+
           args=(
             --repository "${REPOSITORY}"
             --base main

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -386,6 +386,10 @@ name = "ts2540_readonly_tests"
 path = "tests/ts2540_readonly_tests.rs"
 
 [[test]]
+name = "mapped_readonly_tuple_tests"
+path = "tests/mapped_readonly_tuple_tests.rs"
+
+[[test]]
 name = "tuple_index_access_tests"
 path = "tests/tuple_index_access_tests.rs"
 

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -318,6 +318,10 @@ name = "destructuring_default_flow_assignment_tests"
 path = "tests/destructuring_default_flow_assignment_tests.rs"
 
 [[test]]
+name = "merged_namespace_typeof_display_tests"
+path = "tests/merged_namespace_typeof_display_tests.rs"
+
+[[test]]
 name = "recursive_typeof_param_display_tests"
 path = "tests/recursive_typeof_param_display_tests.rs"
 

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -742,6 +742,10 @@ name = "enum_merge_tests"
 path = "tests/enum_merge_tests.rs"
 
 [[test]]
+name = "const_enum_merge_ts2567_tests"
+path = "tests/const_enum_merge_ts2567_tests.rs"
+
+[[test]]
 name = "ts2450_const_enum_tests"
 path = "tests/ts2450_const_enum_tests.rs"
 

--- a/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
@@ -120,6 +120,109 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Speculatively re-type contextually-sensitive callback arguments against
+    /// the selected overload signature's parameter types and report whether that
+    /// produces callback body errors.
+    ///
+    /// Overload selection types callbacks under a union of all candidate
+    /// signatures. A union of function-typed parameters collapses the callback's
+    /// own parameter to `any`, so body errors that tsc reports against the
+    /// resolved signature (`o?.a.b` continuation typing, accessing a property that
+    /// only exists under a different overload, an assignment whose right side has
+    /// the wrong type) never surface during selection. Detecting them here lets
+    /// the caller defer the candidate to the signature-specific pass, which
+    /// re-checks and reports them. All speculative state is rolled back.
+    pub(crate) fn selected_overload_callback_body_has_errors(
+        &mut self,
+        args: &[NodeIndex],
+        func_type: TypeId,
+    ) -> bool {
+        let helper =
+            crate::query_boundaries::common::ContextualTypeContext::with_expected_and_options(
+                self.ctx.types,
+                func_type,
+                self.ctx.compiler_options.no_implicit_any,
+            );
+        let param_types: Vec<Option<TypeId>> = (0..args.len())
+            .map(|i| {
+                self.contextual_parameter_type_for_call_with_env_from_expected(
+                    func_type,
+                    i,
+                    args.len(),
+                )
+                .or_else(|| helper.get_parameter_type_for_call(i, args.len()))
+                .map(|param_type| self.normalize_contextual_call_param_type(param_type))
+            })
+            .collect();
+
+        let candidates: Vec<(NodeIndex, TypeId)> = args
+            .iter()
+            .copied()
+            .enumerate()
+            .filter_map(|(i, arg_idx)| {
+                if !self.is_callback_like_argument(arg_idx) {
+                    return None;
+                }
+                let param_type = param_types.get(i).copied().flatten()?;
+                if param_type == TypeId::ANY
+                    || param_type == TypeId::UNKNOWN
+                    || param_type == TypeId::ERROR
+                {
+                    return None;
+                }
+                // Only concrete parameter types are meaningful here. A generic
+                // overload's parameter still mentions its type parameters (or
+                // `infer` placeholders) at this point; the two-pass instantiation
+                // machinery owns those callbacks, and re-typing against an
+                // uninstantiated parameter produces spurious body errors.
+                if crate::query_boundaries::common::contains_type_parameters(
+                    self.ctx.types,
+                    param_type,
+                ) || crate::query_boundaries::common::contains_infer_types(
+                    self.ctx.types,
+                    param_type,
+                ) {
+                    return None;
+                }
+                Some((arg_idx, param_type))
+            })
+            .collect();
+        if candidates.is_empty() {
+            return false;
+        }
+
+        // `rollback_full` restores diagnostics and caches but not `node_types`,
+        // so save the callback args' cached entries and restore them afterwards
+        // (mirroring `raw_block_body_callback_mismatch`).
+        let snap = self.ctx.snapshot_full();
+        let saved: Vec<(u32, Option<TypeId>)> = candidates
+            .iter()
+            .map(|&(arg_idx, _)| (arg_idx.0, self.ctx.node_types.get(&arg_idx.0).copied()))
+            .collect();
+        let diag_snap = self.ctx.snapshot_diagnostics();
+        for &(arg_idx, param_type) in &candidates {
+            self.invalidate_expression_for_contextual_retry(arg_idx);
+            let request = TypingRequest::with_contextual_type(param_type);
+            let _ = self.get_type_of_node_with_request(arg_idx, &request);
+        }
+        let has_errors = self.overload_candidate_has_callback_body_errors(args, &diag_snap);
+        self.ctx.rollback_full(&snap);
+        for (arg_idx, _) in &candidates {
+            self.invalidate_expression_for_contextual_retry(*arg_idx);
+        }
+        for (node_id, saved_ty) in saved {
+            match saved_ty {
+                Some(ty) => {
+                    self.ctx.node_types.insert(node_id, ty);
+                }
+                None => {
+                    self.ctx.node_types.remove(&node_id);
+                }
+            }
+        }
+        has_errors
+    }
+
     pub(super) fn type_is_or_constrained_to_top_rest_any_callable(&self, type_id: TypeId) -> bool {
         if let Some(constraint) =
             crate::query_boundaries::common::type_parameter_constraint(self.ctx.types, type_id)
@@ -760,5 +863,85 @@ impl<'a> CheckerState<'a> {
                 dest.push(diag);
             }
         }
+    }
+
+    pub(super) fn diagnostics_for_overload_mismatch_argument_between(
+        &self,
+        args: &[NodeIndex],
+        index: usize,
+        from_snap: &crate::context::speculation::DiagnosticSnapshot,
+        to_snap: &crate::context::speculation::DiagnosticSnapshot,
+    ) -> Vec<crate::diagnostics::Diagnostic> {
+        let Some(&arg_idx) = args.get(index) else {
+            return Vec::new();
+        };
+        let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
+            return Vec::new();
+        };
+
+        self.ctx
+            .diagnostics_between(from_snap, to_snap)
+            .iter()
+            .filter(|diag| diag.start >= arg_node.pos && diag.start < arg_node.end)
+            .cloned()
+            .collect()
+    }
+
+    /// Snapshot a non-generic overload that matched at the signature level but
+    /// failed only inside a callback body, so it can be committed later if no
+    /// other overload resolves cleanly. See `commit_callback_body_only_candidate`.
+    pub(super) fn build_callback_body_only_candidate(
+        &self,
+        args: &[NodeIndex],
+        overload_diag: &crate::context::speculation::DiagnosticSnapshot,
+        candidate_snap: &crate::context::speculation::DiagnosticSnapshot,
+        arg_types: Vec<TypeId>,
+        return_type: TypeId,
+        selected_type_predicate: super::SelectedTypePredicate,
+    ) -> (
+        super::OverloadResolution,
+        crate::context::NodeTypeCache,
+        Vec<crate::diagnostics::Diagnostic>,
+    ) {
+        let candidate_end = self.ctx.snapshot_diagnostics();
+        let preserved_first_pass =
+            self.collect_non_callback_diagnostics_between(args, overload_diag, candidate_snap);
+        let candidate_diags: Vec<_> = self
+            .ctx
+            .diagnostics_between(candidate_snap, &candidate_end)
+            .to_vec();
+        let mut merged = self.preserved_speculative_call_diagnostics(overload_diag);
+        self.extend_unique_diagnostics(&mut merged, preserved_first_pass);
+        self.extend_unique_diagnostics(&mut merged, candidate_diags);
+        let resolution = super::OverloadResolution {
+            arg_types,
+            result: crate::query_boundaries::common::CallResult::Success(return_type),
+            selected_type_predicate,
+        };
+        (resolution, self.ctx.node_types.clone(), merged)
+    }
+
+    /// Commit the captured callback-body-only candidate: restore diagnostics to
+    /// the candidate's merged set (which retains the callback body errors) and
+    /// install its node types. tsc reports those body diagnostics against the
+    /// selected overload rather than silently recovering.
+    pub(super) fn commit_callback_body_only_candidate(
+        &mut self,
+        candidate: (
+            super::OverloadResolution,
+            crate::context::NodeTypeCache,
+            Vec<crate::diagnostics::Diagnostic>,
+        ),
+        overload_snap: &crate::context::speculation::FullSnapshot,
+        original_node_types: &mut crate::context::NodeTypeCache,
+    ) -> super::OverloadResolution {
+        let (resolution, sig_node_types, merged_diags) = candidate;
+        self.ctx
+            .rollback_and_replace_diagnostics(&overload_snap.diag, merged_diags);
+        self.ctx
+            .restore_ts2454_state(&overload_snap.emitted_ts2454_errors);
+        self.ctx.node_types = std::mem::take(original_node_types);
+        self.ctx.node_types.merge_owned(sig_node_types);
+        resolution
     }
 }

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -1926,17 +1926,14 @@ impl<'a> CheckerState<'a> {
             });
         }
 
-        // When no overload matched, use the last overload's return type as the
-        // fallback (matching tsc behavior). tsc always uses the last signature's
-        // return type for error recovery so that downstream code sees the expected
-        // shape rather than `never`. For example, `[].concat(...)` on `never[]`
-        // should still produce `never[]`, not `never`.
+        // When no overload matched, the recovery result type is the intersection
+        // of every candidate signature's return type (tsc's
+        // `createUnionOfSignaturesForOverloadFailure`). A near-match recovery
+        // return (argument or callback-body mismatch on a single applicable
+        // overload) takes precedence when present.
         let fallback_return = mismatch_recovery_return.unwrap_or_else(|| {
             callback_body_failure_return.unwrap_or_else(|| {
-                signatures
-                    .last()
-                    .map(|s| s.return_type)
-                    .unwrap_or(TypeId::NEVER)
+                tsz_solver::operations::overload_failure_return_type(self.ctx.types, signatures)
             })
         });
         Some(OverloadResolution {

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -3,6 +3,7 @@
 //! Split from the parent `call_checker` module — pure code motion.
 
 mod contextual_retry;
+mod helpers;
 mod return_context;
 
 use crate::context::TypingRequest;
@@ -339,12 +340,20 @@ impl<'a> CheckerState<'a> {
                     // leaving inline callback bodies typed under a lossy contextual union.
                     // Defer those candidates to the signature-specific pass, which can
                     // re-evaluate callbacks with per-overload parameter types.
+                    //
+                    // A union of function-typed parameters yields an `any` callback
+                    // parameter, so body errors specific to the selected signature
+                    // (e.g. `o?.a.b` continuation typing, or a property that only exists
+                    // under a different overload) never surface in the union pass.
+                    // Speculatively re-type the callbacks against the selected
+                    // signature so those cases are deferred too.
                     if has_multiple_arity_compatible_signatures
                         && (union_arg_collection_has_callback_body_errors
                             || self.overload_candidate_has_callback_body_errors(
                                 args,
                                 &post_union_arg_diag_snap,
-                            ))
+                            )
+                            || self.selected_overload_callback_body_has_errors(args, func_type))
                     {
                         self.prune_callback_body_diagnostics(args, &overload_snap.diag);
                         continue;
@@ -900,6 +909,13 @@ impl<'a> CheckerState<'a> {
         let mut mismatch_recovery_return: Option<TypeId> = None;
         let mut callback_body_failure_return: Option<TypeId> = None;
         let mut callback_body_overload_diagnostics = Vec::new();
+        // The most recent overload that matched at the signature level (arguments
+        // assignable) but produced errors *inside* a callback body. tsc selects the
+        // overload from the discriminating arguments and then reports the callback
+        // body errors against the resolved signature; it does not treat a body error
+        // as an overload mismatch. When no overload resolves cleanly we commit to
+        // this candidate and surface its diagnostics instead of silently recovering.
+        let mut callback_body_only_success: Option<BestTypeMismatch> = None;
         // When an overload returns TypeParameterConstraintViolation and there are
         // more overloads to try, we store it as a fallback and continue. If no
         // later overload succeeds, we use this fallback (e.g., for single-overload
@@ -1514,6 +1530,22 @@ impl<'a> CheckerState<'a> {
                     {
                         all_arg_count_mismatches = false;
                         has_non_count_non_type_failure = true;
+                        // A non-generic overload matched at the signature level, so its
+                        // callback body diagnostics are real. Keep the last such overload
+                        // (mirroring tsc's final-candidate choice) to commit if no other
+                        // overload resolves cleanly. Generic overloads are left to the
+                        // instantiation machinery, whose transient body errors must not leak.
+                        if sig.type_params.is_empty() {
+                            callback_body_only_success =
+                                Some(self.build_callback_body_only_candidate(
+                                    args,
+                                    &overload_snap.diag,
+                                    &candidate_snap,
+                                    sig_arg_types.clone(),
+                                    return_type,
+                                    selected_type_predicate.clone(),
+                                ));
+                        }
                         let nested_no_overload_diags =
                             self.callback_body_no_overload_diagnostics_since(args, &candidate_snap);
                         self.extend_unique_diagnostics(
@@ -1820,6 +1852,18 @@ impl<'a> CheckerState<'a> {
             });
         }
 
+        // No overload resolved cleanly, but at least one matched at the signature
+        // level and failed only inside a callback body. Commit to it and surface its
+        // diagnostics instead of silently recovering (via `callback_body_failure_return`),
+        // which would hide real errors only visible under the resolved parameter type.
+        if let Some(candidate) = callback_body_only_success {
+            return Some(self.commit_callback_body_only_candidate(
+                candidate,
+                &overload_snap,
+                &mut original_node_types,
+            ));
+        }
+
         // No overload matched: drop speculative diagnostics from overload argument
         // collection and keep only overload-level diagnostics.
         // Roll back diagnostics and TS2454 state to the pre-overload snapshot
@@ -1907,40 +1951,6 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn signature_const_type_params_require_readonly_argument_context(
-        db: &dyn tsz_solver::construction::TypeDatabase,
-        type_params: &[tsz_solver::TypeParamInfo],
-    ) -> bool {
-        type_params.iter().any(|type_param| {
-            type_param.is_const
-                && !type_param.constraint.is_some_and(|constraint| {
-                    Self::constraint_allows_mutable_array_like(db, constraint)
-                })
-        })
-    }
-
-    fn diagnostics_for_overload_mismatch_argument_between(
-        &self,
-        args: &[NodeIndex],
-        index: usize,
-        from_snap: &crate::context::speculation::DiagnosticSnapshot,
-        to_snap: &crate::context::speculation::DiagnosticSnapshot,
-    ) -> Vec<crate::diagnostics::Diagnostic> {
-        let Some(&arg_idx) = args.get(index) else {
-            return Vec::new();
-        };
-        let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
-            return Vec::new();
-        };
-
-        self.ctx
-            .diagnostics_between(from_snap, to_snap)
-            .iter()
-            .filter(|diag| diag.start >= arg_node.pos && diag.start < arg_node.end)
-            .cloned()
-            .collect()
-    }
-
     fn recheck_overload_args_after_mismatch_without_context(
         &mut self,
         args: &[NodeIndex],
@@ -1960,41 +1970,5 @@ impl<'a> CheckerState<'a> {
             self.invalidate_expression_for_contextual_retry(arg_idx);
             let _ = self.get_type_of_node_with_request(arg_idx, &TypingRequest::NONE);
         }
-    }
-
-    fn overload_string_argument_array_parameter_mismatch(
-        &mut self,
-        sig: &tsz_solver::CallSignature,
-        arg_types: &[TypeId],
-    ) -> Option<CallResult> {
-        arg_types
-            .iter()
-            .copied()
-            .enumerate()
-            .find_map(|(index, actual)| {
-                if actual != TypeId::STRING
-                    && !crate::query_boundaries::common::is_string_type(self.ctx.types, actual)
-                    && crate::query_boundaries::common::string_literal_value(self.ctx.types, actual)
-                        .is_none()
-                {
-                    return None;
-                }
-                let expected = sig
-                    .params
-                    .get(index)
-                    .map(|param| param.type_id)
-                    .or_else(|| {
-                        sig.params
-                            .last()
-                            .and_then(|param| param.rest.then_some(param.type_id))
-                    })?;
-                self.is_array_like_type(expected)
-                    .then_some(CallResult::ArgumentTypeMismatch {
-                        index,
-                        expected,
-                        actual,
-                        fallback_return: sig.return_type,
-                    })
-            })
     }
 }

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
@@ -1,0 +1,56 @@
+//! Small standalone helpers for overload resolution — pure code motion from
+//! the parent `overload_resolution` module.
+
+use crate::query_boundaries::common::CallResult;
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn signature_const_type_params_require_readonly_argument_context(
+        db: &dyn tsz_solver::construction::TypeDatabase,
+        type_params: &[tsz_solver::TypeParamInfo],
+    ) -> bool {
+        type_params.iter().any(|type_param| {
+            type_param.is_const
+                && !type_param.constraint.is_some_and(|constraint| {
+                    Self::constraint_allows_mutable_array_like(db, constraint)
+                })
+        })
+    }
+
+    pub(super) fn overload_string_argument_array_parameter_mismatch(
+        &mut self,
+        sig: &tsz_solver::CallSignature,
+        arg_types: &[TypeId],
+    ) -> Option<CallResult> {
+        arg_types
+            .iter()
+            .copied()
+            .enumerate()
+            .find_map(|(index, actual)| {
+                if actual != TypeId::STRING
+                    && !crate::query_boundaries::common::is_string_type(self.ctx.types, actual)
+                    && crate::query_boundaries::common::string_literal_value(self.ctx.types, actual)
+                        .is_none()
+                {
+                    return None;
+                }
+                let expected = sig
+                    .params
+                    .get(index)
+                    .map(|param| param.type_id)
+                    .or_else(|| {
+                        sig.params
+                            .last()
+                            .and_then(|param| param.rest.then_some(param.type_id))
+                    })?;
+                self.is_array_like_type(expected)
+                    .then_some(CallResult::ArgumentTypeMismatch {
+                        index,
+                        expected,
+                        actual,
+                        fallback_return: sig.return_type,
+                    })
+            })
+    }
+}

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -559,12 +559,17 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // Collect abstract members from base class that are not implemented
+        // Collect abstract members from base class that are not implemented.
+        // Multiple declarations can share one member name (a get/set accessor
+        // pair, or overload signatures) yet form a single inherited abstract
+        // member, so dedup by name to avoid inflating the count (which would
+        // flip TS2515 -> TS2654) and duplicating the rendered name.
         let mut missing_members: Vec<String> = Vec::new();
         for &member_idx in &base_class.members.nodes {
             if self.member_is_abstract(member_idx)
                 && let Some(name) = self.get_member_name(member_idx)
                 && !implemented_members.contains(&name)
+                && !missing_members.contains(&name)
             {
                 missing_members.push(name);
             }

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -530,13 +530,17 @@ impl<'a> CheckerState<'a> {
         self.merge_exports_into_props(sym_id, &mut props, true);
 
         let properties = props.into_values().collect();
+        // Keep the merged symbol so the type printer renders the static side as
+        // `typeof C` (the value+namespace identity) instead of expanding the
+        // structural shape. tsc displays a class merged with a namespace as
+        // `typeof C`.
         self.ctx.types.factory().callable(CallableShape {
             call_signatures: shape.call_signatures.clone(),
             construct_signatures: shape.construct_signatures.clone(),
             properties,
             string_index: shape.string_index,
             number_index: shape.number_index,
-            symbol: None,
+            symbol: Some(sym_id),
             is_abstract: false,
         })
     }

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1325,16 +1325,15 @@ impl<'a> CheckerState<'a> {
                 )
                 .is_some();
         if !source_has_display_props && !source_is_array {
-            let has_direct_literal_prop = crate::query_boundaries::common::object_shape_for_type(
-                self.ctx.types,
-                evaluated_source,
-            )
-            .is_some_and(|shape| {
-                shape.properties.iter().any(|p| {
-                    crate::query_boundaries::common::is_literal_type(self.ctx.types, p.type_id)
-                })
-            });
-            if has_direct_literal_prop {
+            // A non-fresh source (no fresh-object-literal display provenance —
+            // e.g. produced by `as const`, a declared annotation, or a named
+            // type) carries canonical literal members that tsc preserves
+            // verbatim at every nesting depth. Only genuinely fresh object
+            // literals (which intern a widened canonical shape) are widened for
+            // non-literal targets. Detect a literal member at ANY depth, not
+            // just the top level, so nested const-asserted literals like
+            // `{ p: { q: 1 } }` are preserved instead of text-widened.
+            if self.source_carries_canonical_literal_member(evaluated_source) {
                 return source_display;
             }
         }
@@ -1364,6 +1363,50 @@ impl<'a> CheckerState<'a> {
         } else {
             widened_display
         }
+    }
+
+    /// Returns `true` when `ty` (a non-fresh source type) contains a literal-typed
+    /// member at any nesting depth: a property of an object, an array element, a
+    /// tuple element, or a union member, recursively. Used to decide whether a
+    /// source whose canonical shape is authoritative (no fresh-object-literal
+    /// display provenance) should be displayed verbatim instead of text-widened.
+    pub(super) fn source_carries_canonical_literal_member(&self, ty: TypeId) -> bool {
+        let mut visiting = rustc_hash::FxHashSet::default();
+        self.source_carries_canonical_literal_member_inner(ty, &mut visiting, 0)
+    }
+
+    fn source_carries_canonical_literal_member_inner(
+        &self,
+        ty: TypeId,
+        visiting: &mut rustc_hash::FxHashSet<TypeId>,
+        depth: usize,
+    ) -> bool {
+        const MAX_DEPTH: usize = 8;
+        if depth > MAX_DEPTH || !visiting.insert(ty) {
+            return false;
+        }
+        let db = self.ctx.types;
+        let recurse = |child: TypeId, visiting: &mut rustc_hash::FxHashSet<TypeId>| -> bool {
+            crate::query_boundaries::common::is_literal_type(db, child)
+                || self.source_carries_canonical_literal_member_inner(child, visiting, depth + 1)
+        };
+
+        if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(db, ty) {
+            return shape
+                .properties
+                .iter()
+                .any(|p| recurse(p.type_id, visiting));
+        }
+        if let Some(elem) = crate::query_boundaries::common::array_element_type(db, ty) {
+            return recurse(elem, visiting);
+        }
+        if let Some(elements) = crate::query_boundaries::common::tuple_elements(db, ty) {
+            return elements.iter().any(|e| recurse(e.type_id, visiting));
+        }
+        if let Some(members) = crate::query_boundaries::common::union_members(db, ty) {
+            return members.iter().any(|&m| recurse(m, visiting));
+        }
+        false
     }
 
     pub(super) fn rewrite_target_display_for_non_literal_assignability(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -484,6 +484,9 @@ mod for_in_narrowing_tests;
 #[path = "tests/generic_callback_outer_context_tests.rs"]
 mod generic_callback_outer_context_tests;
 #[cfg(test)]
+#[path = "tests/generic_callback_sibling_arg_inference_tests.rs"]
+mod generic_callback_sibling_arg_inference_tests;
+#[cfg(test)]
 #[path = "tests/generic_class_constructor_literal_preservation_tests.rs"]
 mod generic_class_constructor_literal_preservation_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -574,6 +574,9 @@ mod jsx_excess_attr_with_spread_display_tests;
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]
+#[path = "../tests/keyof_function_type_is_never_tests.rs"]
+mod keyof_function_type_is_never_tests;
+#[cfg(test)]
 #[path = "../tests/keyof_mapped_as_clause_tests.rs"]
 mod keyof_mapped_as_clause_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -397,6 +397,9 @@ mod architecture_contract_tests_src;
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/as_const_nested_literal_display_tests.rs"]
+mod as_const_nested_literal_display_tests;
+#[cfg(test)]
 #[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
 mod assertion_type_predicate_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/function_returns.rs
+++ b/crates/tsz-checker/src/query_boundaries/function_returns.rs
@@ -1,0 +1,10 @@
+//! Solver query helpers used by return-type inference.
+//!
+//! This module keeps return-type inference callers away from the broad
+//! `common` quarantine while #8225 splits that surface into narrower request
+//! boundaries.
+
+pub(crate) use super::common::{
+    application_info, array_element_type, contains_type_parameters, index_access_types,
+    lazy_def_id, mapped_type_info, type_application, type_param_info, union_members,
+};

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod dispatch;
 pub(crate) mod environment;
 pub(crate) mod flow;
 pub(crate) mod flow_analysis;
+pub(crate) mod function_returns;
 pub(crate) mod index_signature;
 pub(crate) mod inference;
 pub(crate) mod intersection_display;

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -2819,6 +2819,143 @@ class DerivedFromAbstract extends MixedBase {
         );
     }
 
+    /// Rule: a get/set accessor pair (two declarations, one member name) is a
+    /// single inherited abstract member. The missing-member set must dedup by
+    /// name so the count stays 1 (TS2515 singular), not 2 (TS2654 plural with a
+    /// duplicated name).
+    #[test]
+    fn abstract_get_set_pair_counted_as_one_member_ts2515() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class A { abstract get x(): number; abstract set x(v: number); }
+class B extends A {}
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2515),
+            "Abstract get/set pair missing in subclass must emit singular TS2515, got: {codes:?}"
+        );
+        assert!(
+            !codes.contains(&2654),
+            "Abstract get/set pair must not be counted as two members (TS2654), got: {codes:?}"
+        );
+        let msg = &diags
+            .iter()
+            .find(|d| d.code == 2515)
+            .expect("expected a TS2515 diagnostic")
+            .message_text;
+        assert!(
+            !msg.contains("'x', 'x'") && !msg.contains("x, x"),
+            "TS2515 message must name member 'x' once, got: {msg}"
+        );
+    }
+
+    /// Same rule, different identifiers — proves the dedup is structural, not
+    /// keyed to the spelling `x`.
+    #[test]
+    fn abstract_get_set_pair_renamed_counted_as_one_member_ts2515() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class Shape { abstract get area(): number; abstract set area(v: number); }
+class Square extends Shape {}
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2515) && !codes.contains(&2654),
+            "Renamed abstract get/set pair must emit singular TS2515, got: {codes:?}"
+        );
+        let msg = &diags
+            .iter()
+            .find(|d| d.code == 2515)
+            .expect("expected a TS2515 diagnostic")
+            .message_text;
+        assert!(
+            !msg.contains("'area', 'area'") && !msg.contains("area, area"),
+            "TS2515 message must name member 'area' once, got: {msg}"
+        );
+    }
+
+    /// Generalization: abstract method overload signatures share one member
+    /// name across two declarations and likewise collapse to a single missing
+    /// member.
+    #[test]
+    fn abstract_method_overload_signatures_counted_as_one_member_ts2515() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class A {
+    abstract f(): void;
+    abstract f(x: number): void;
+}
+class B extends A {}
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2515) && !codes.contains(&2654),
+            "Abstract method overload signatures must collapse to one missing member (TS2515), got: {codes:?}"
+        );
+    }
+
+    /// tsc accepts implementing only the getter of an abstract get/set pair.
+    #[test]
+    fn abstract_get_set_pair_satisfied_by_getter_only() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class A { abstract get x(): number; abstract set x(v: number); }
+class B extends A { get x(): number { return 0; } }
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            !codes.contains(&2515) && !codes.contains(&2654),
+            "Implementing the getter of an abstract get/set pair must satisfy it, got: {codes:?}"
+        );
+    }
+
+    /// Negative control: two genuinely distinct abstract members stay TS2654
+    /// listing both names.
+    #[test]
+    fn two_distinct_abstract_members_stay_ts2654() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class A { abstract a(): void; abstract b(): void; }
+class B extends A {}
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2654) && !codes.contains(&2515),
+            "Two distinct missing abstract members must emit TS2654, got: {codes:?}"
+        );
+        let msg = &diags
+            .iter()
+            .find(|d| d.code == 2654)
+            .expect("expected a TS2654 diagnostic")
+            .message_text;
+        assert!(
+            msg.contains("'a'") && msg.contains("'b'"),
+            "TS2654 must list both 'a' and 'b', got: {msg}"
+        );
+    }
+
+    /// Negative control: a single missing abstract method stays TS2515.
+    #[test]
+    fn single_abstract_method_stays_ts2515() {
+        let diags = check_source_diagnostics(
+            r#"
+abstract class A { abstract a(): void; }
+class B extends A {}
+"#,
+        );
+        let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2515) && !codes.contains(&2654),
+            "A single missing abstract method must emit TS2515, got: {codes:?}"
+        );
+    }
+
     #[test]
     fn double_mixin_conditional_type_base_class_has_no_extra_ts2345() {
         let diags = check_source_diagnostics(

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -369,6 +369,15 @@ impl<'a> CheckerState<'a> {
                     {
                         return ReadonlyAssignmentDiagnostic::None;
                     }
+                    // An inline mapped-type application such as
+                    // `Readonly<[number, string]>` stays an unevaluated
+                    // `Application` here, whereas a named alias is resolved
+                    // eagerly by `get_type_of_node`. When such an application
+                    // evaluates to a readonly tuple, resolve it so a fixed-element
+                    // write is recognized as a readonly named-property write
+                    // (TS2540). Other shapes (e.g. `ReadonlyArray<T>`, which is an
+                    // index signature) keep their existing unevaluated handling.
+                    let object_type = self.resolve_readonly_tuple_application(object_type);
 
                     let index_type = self.get_type_of_node(access.name_or_argument);
                     if let Some(name) = self.get_readonly_element_access_name(
@@ -1377,6 +1386,23 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// If `type_id` is an unevaluated type-alias application that evaluates to a
+    /// readonly tuple, return the evaluated readonly tuple; otherwise return
+    /// `type_id` unchanged. Used so an inline `Readonly<[a, b]>` element write is
+    /// classified the same as a named alias of the same type.
+    fn resolve_readonly_tuple_application(&mut self, type_id: TypeId) -> TypeId {
+        use crate::query_boundaries::common::{readonly_inner_type, tuple_list_id};
+        use crate::query_boundaries::type_checking_utilities::application_base;
+
+        if application_base(self.ctx.types, type_id).is_none() {
+            return type_id;
+        }
+        let resolved = self.evaluate_type_with_env(type_id);
+        let is_readonly_tuple = readonly_inner_type(self.ctx.types, resolved)
+            .is_some_and(|inner| tuple_list_id(self.ctx.types, inner).is_some());
+        if is_readonly_tuple { resolved } else { type_id }
     }
 
     fn is_readonly_mapped_type(&mut self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/tests/as_const_nested_literal_display_tests.rs
+++ b/crates/tsz-checker/src/tests/as_const_nested_literal_display_tests.rs
@@ -1,0 +1,151 @@
+//! Tests for issue #9738: `as const` (and `satisfies` over an `as const`)
+//! source types must display their literal members verbatim at every nesting
+//! depth in TS2322 assignability diagnostics.
+//!
+//! Structural rule: when the assignability source is a non-fresh type (it
+//! carries no fresh-object-literal display provenance — e.g. produced by
+//! `as const`, a declared annotation, or a named type) its literal members are
+//! canonical and tsc preserves them verbatim, including nested ones. Only
+//! genuinely fresh object literals (whose interned canonical shape is widened)
+//! are widened for non-literal targets.
+//!
+//! Before the fix, only *top-level* literal properties were preserved; nested
+//! `as const` literals (`{ p: { q: 1 } }`) were text-widened to
+//! `{ readonly p: { readonly q: number; }; }`.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn as_const_nested_object_preserves_nested_literal_against_primitive() {
+    // Source is `{ readonly p: { readonly q: 1; }; }`; assigning to a primitive
+    // must keep the nested literal `1`, not widen it to `number`.
+    let messages = ts2322_messages(
+        r#"
+const j = { p: { q: 1 } } as const;
+const bad: number = j;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ readonly p: { readonly q: 1; }; }")),
+        "nested `as const` literal should be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("readonly q: number")),
+        "nested literal must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn as_const_satisfies_record_preserves_nested_literal() {
+    // The reported repro: `satisfies` only checks, never widens.
+    let messages = ts2322_messages(
+        r#"
+const e = { p: { q: 1 } } as const satisfies Record<string, { q: number }>;
+const bad: number = e;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ readonly p: { readonly q: 1; }; }")),
+        "`as const satisfies` must preserve nested literal, got: {messages:?}"
+    );
+}
+
+#[test]
+fn as_const_deeply_nested_literal_preserved_with_renamed_keys() {
+    // Vary the property names to prove the rule is structural, not keyed on a
+    // particular identifier spelling.
+    let messages = ts2322_messages(
+        r#"
+const cfg = { alpha: { beta: { gamma: 7 } } } as const;
+const bad: number = cfg;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ readonly alpha: { readonly beta: { readonly gamma: 7; }; }; }")),
+        "deeply nested `as const` literal should be preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn as_const_object_with_tuple_preserves_element_literals() {
+    // Literal members nested inside a tuple within an `as const` object.
+    let messages = ts2322_messages(
+        r#"
+const f = { arr: [1, 2] } as const;
+const bad: number = f;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ readonly arr: readonly [1, 2]; }")),
+        "tuple element literals under `as const` should be preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn declared_annotation_nested_literal_preserved() {
+    // A declared annotation is also a non-fresh source: tsc keeps its literals.
+    let messages = ts2322_messages(
+        r#"
+const g: { p: { q: 1 } } = { p: { q: 1 } };
+const bad: string = g;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("{ p: { q: 1; }; }")),
+        "declared-annotation nested literal should be preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn fresh_object_literal_still_widens_nested_for_primitive_target() {
+    // Negative/fallback case: a genuinely fresh object literal (no `as const`)
+    // must STILL widen its nested members for a non-literal target, matching
+    // tsc. This proves the fix did not over-preserve.
+    let messages = ts2322_messages(
+        r#"
+const bad: number = { p: { q: 1 } };
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ p: { q: number; }; }")),
+        "fresh object literal should widen nested members, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("q: 1")),
+        "fresh literal must be widened, not preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn as_const_top_level_literal_against_literal_target_preserved() {
+    // Sanity: top-level literal against a literal target was already correct;
+    // ensure it stays correct.
+    let messages = ts2322_messages(
+        r#"
+const k = { v: 1 } as const;
+const bad: 2 = k.v;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("Type '1'")),
+        "top-level `as const` literal property access should display `1`, got: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/generic_callback_sibling_arg_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_callback_sibling_arg_inference_tests.rs
@@ -1,0 +1,185 @@
+//! Regression tests for issue #9683 — a context-sensitive callback argument
+//! must be contextually typed using the inference contributed by *all*
+//! non-context-sensitive sibling arguments, regardless of argument order.
+//!
+//! For `f<U>(fn: (acc: U) => U, init: U): U` called `f((acc) => acc + 1, 0)`,
+//! tsc combines the `number` candidate from the callback return with the
+//! literal `0` candidate from `init` and widens, inferring `U = number`. tsz
+//! previously fixed `U = 0` because the callback (positioned before `init`)
+//! was contextually typed with `acc: any` — the `init` argument had not yet
+//! contributed to the Round 2 substitution. The wrong inferred type masked a
+//! `TS2322`.
+//!
+//! The fix pre-seeds the Round 2 contextual substitution from every
+//! non-context-sensitive argument before typing any sensitive callback, so the
+//! callback's contextual parameter type is order-independent.
+use crate::test_utils::{check_source_diagnostics, diagnostics_with_code};
+
+/// Reported repro: callback first, literal `init` last. `U` must widen to
+/// `number`, so assigning the result to `0` is a `TS2322`.
+#[test]
+fn callback_before_literal_widens_type_param_to_number() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f<U>(fn: (acc: U) => U, init: U): U;
+const r = f((acc) => acc + 1, 0);
+const widened: number = r; // OK — U inferred as number
+const narrowed: 0 = r;     // TS2322 — number is not assignable to 0
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322 (on `const narrowed: 0 = r`), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Control: literal `init` first, callback last. This ordering already
+/// inferred `number`; it must keep doing so.
+#[test]
+fn literal_before_callback_keeps_type_param_number() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f<U>(init: U, fn: (acc: U) => U): U;
+const r = f(0, (acc) => acc + 1);
+const widened: number = r; // OK
+const narrowed: 0 = r;     // TS2322
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322 (on `const narrowed: 0 = r`), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Renamed type parameter and parameter names: the fix is structural, not
+/// keyed to the spelling `U`/`acc`.
+#[test]
+fn renamed_type_param_widens_to_number() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function g<Acc>(step: (a: Acc) => Acc, seed: Acc): Acc;
+const r = g((a) => a + 1, 0);
+const narrowed: 0 = r; // TS2322 — number not assignable to 0
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322 with renamed type parameter, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Real-world `reduce` shape: a third trailing literal `init` still feeds the
+/// callback's contextual type so `U` widens to `number`.
+#[test]
+fn reduce_shape_widens_to_number() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function reduce<T, U>(arr: T[], fn: (acc: U, x: T) => U, init: U): U;
+const r = reduce([1, 2, 3], (acc, x) => acc + x, 0);
+const narrowed: 0 = r; // TS2322 — number not assignable to 0
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322 for reduce shape, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Control: the callback return does not depend on `U` (`() => 5`), but the
+/// callback-return candidate (`5`) still combines with `init`'s `0` and widens
+/// to `number`.
+#[test]
+fn callback_return_independent_of_type_param_widens() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function h<U>(fn: () => U, init: U): U;
+const r = h(() => 5, 0);
+const narrowed: 5 = r; // TS2322 — number not assignable to 5
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Negative control: with no callback to add a widened candidate, a lone
+/// literal argument keeps its literal type (no widening).
+#[test]
+fn single_literal_argument_preserves_literal() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function k<U>(init: U): U;
+const r = k(0);
+const stays: 0 = r; // OK — U stays 0
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert!(
+        ts2322.is_empty(),
+        "expected no TS2322 (U should stay the literal 0), got: {:?}",
+        ts2322
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Negative control: a `const` type parameter preserves the literal even when
+/// a callback is present, so the result remains assignable to `0`.
+#[test]
+fn const_type_param_preserves_literal_with_callback() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function c<const U>(fn: (acc: U) => U, init: U): U;
+const r = c((acc) => acc, 0);
+const stays: 0 = r; // OK — const U preserves 0
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert!(
+        ts2322.is_empty(),
+        "expected no TS2322 (const U preserves literal 0), got: {:?}",
+        ts2322
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1747,6 +1747,39 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Wide `symbol` element access via a `symbol`-typed identifier
+        // (`let s: symbol; obj[s]`). The binder converts such an identifier to a
+        // binding-identity `UniqueSymbol(ref)` (so `index_type_for_access` differs
+        // from the raw `symbol`), which lets the access resolve a member declared
+        // under that exact binding while still failing for keys the type does not
+        // declare. tsc reports an implicit-any element access (TS7053 for objects,
+        // TS7015 for arrays/tuples) when the type provides neither that member nor
+        // a `symbol` index signature.
+        //
+        // Scope note: a bare wide-`symbol` expression that was NOT converted (a
+        // call result, or a widened `unique symbol` read such as `Symbol.iterator`,
+        // which tsz widens to `symbol` in value position) is deliberately left
+        // alone — it cannot be distinguished from a valid well-known-symbol access.
+        if !report_no_index
+            && use_index_signature_check
+            && index_type == TypeId::SYMBOL
+            && index_type_for_access != index_type
+        {
+            let missing = match crate::query_boundaries::common::union_members(
+                self.ctx.types,
+                object_type_for_access,
+            ) {
+                Some(members) => members.iter().any(|&member| {
+                    self.symbol_keyed_access_is_missing(member, index_type_for_access)
+                }),
+                None => self
+                    .symbol_keyed_access_is_missing(object_type_for_access, index_type_for_access),
+            };
+            if missing {
+                report_no_index = true;
+            }
+        }
+
         if !report_no_index
             && use_index_signature_check
             && crate::query_boundaries::common::intersection_members(

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -222,6 +222,19 @@ impl<'a> CheckerState<'a> {
             return self.ctx.types.factory().union(unwrapped);
         }
 
+        // Distribute over top-level intersections: tsc reduces `Awaited<A & B>`
+        // to `Awaited<A> & Awaited<B>`, so awaiting an intersection of promises
+        // (e.g. the `Promise<number> & Promise<string>` recovery type of a
+        // no-overload-match call) yields `number & string` (= `never`) rather
+        // than the un-awaited intersection. Mirrors the union distribution above.
+        if let Some(members) = query::intersection_members(self.ctx.types, type_id) {
+            let unwrapped: Vec<TypeId> = members
+                .into_iter()
+                .map(|m| self.compute_awaited_type(m, depth + 1))
+                .collect();
+            return self.ctx.types.factory().intersection(unwrapped);
+        }
+
         // Non-union: recursively unwrap nested Promise<...> applications.
         let mut current_type = type_id;
         let mut local_depth: u32 = 0;

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1008,4 +1008,43 @@ impl<'a> CheckerState<'a> {
         }
         Some(self.ctx.types.unique_symbol(SymbolRef(current.0)))
     }
+
+    /// Decide whether a wide-`symbol` element access made through a
+    /// `symbol`-typed identifier lacks a matching member on `object_type`, i.e.
+    /// whether tsc would report an implicit-any element access (TS7053/TS7015).
+    ///
+    /// `index_type_for_access` is the binding-identity `UniqueSymbol(ref)` the
+    /// binder produced for the identifier. The key is satisfied when the type
+    /// provides a `symbol` index signature (`{ [k: symbol]: V }`) or declares a
+    /// member under that exact binding; otherwise it is missing.
+    ///
+    /// Array/tuple/string-like receivers can never declare a member keyed by such
+    /// a binding — their element resolver leniently returns the element type for
+    /// any symbol key — so they are always missing unless an explicit `symbol`
+    /// index signature is present.
+    pub(crate) fn symbol_keyed_access_is_missing(
+        &self,
+        object_type: TypeId,
+        index_type_for_access: TypeId,
+    ) -> bool {
+        // A `symbol` index signature accepts any symbol key. Probe it with the wide
+        // `symbol` type, which only resolves through such a signature.
+        let via_symbol_index =
+            self.ctx
+                .types
+                .resolve_element_access_type(object_type, TypeId::SYMBOL, None);
+        if via_symbol_index != TypeId::UNDEFINED && via_symbol_index != TypeId::ERROR {
+            return false;
+        }
+
+        if self.is_array_like_type(object_type) {
+            return true;
+        }
+
+        let member =
+            self.ctx
+                .types
+                .resolve_element_access_type(object_type, index_type_for_access, None);
+        member == TypeId::UNDEFINED || member == TypeId::ERROR
+    }
 }

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -21,6 +21,73 @@ use super::super::complex::is_contextually_sensitive;
 use super::post_generic::PostGenericCallDiagnostics;
 
 impl<'a> CheckerState<'a> {
+    /// Merge the return-context inference contributed by one call argument into
+    /// the in-progress Round 2 substitution. Type parameters that Round 1 left
+    /// uninformative (any/unknown/error/still-generic, or a freshly widened
+    /// supertype) are filled in; concrete inferences are preserved. A literal
+    /// contribution to a non-`const` type parameter is widened, matching tsc's
+    /// literal widening during inference. `null`/`undefined` contributions from
+    /// a context-sensitive (callback) argument are ignored.
+    fn merge_arg_return_context_into_round2(
+        &mut self,
+        shape: &common::FunctionShape,
+        shape_param_type: TypeId,
+        arg_type: TypeId,
+        tracked_type_params: &FxHashSet<tsz_common::Atom>,
+        arg_is_sensitive: bool,
+        round2_substitution: &mut crate::query_boundaries::common::TypeSubstitution,
+    ) {
+        let mut arg_substitution = crate::query_boundaries::common::TypeSubstitution::new();
+        let mut visited = FxHashSet::default();
+        self.collect_return_context_substitution(
+            shape_param_type,
+            arg_type,
+            tracked_type_params,
+            &mut arg_substitution,
+            &mut visited,
+        );
+        for (&name, &raw_ty) in arg_substitution.map().iter() {
+            let ty = if shape
+                .type_params
+                .iter()
+                .find(|tp| tp.name == name)
+                .is_some_and(|tp| !tp.is_const)
+            {
+                if crate::query_boundaries::common::object_shape_for_type(self.ctx.types, raw_ty)
+                    .is_some()
+                {
+                    raw_ty
+                } else {
+                    self.widen_literal_type(raw_ty)
+                }
+            } else {
+                raw_ty
+            };
+            if ty == TypeId::UNKNOWN
+                || ty == TypeId::ERROR
+                || (arg_is_sensitive && (ty == TypeId::NULL || ty == TypeId::UNDEFINED))
+                || self.target_contains_blocking_return_context_type_params(ty, tracked_type_params)
+            {
+                continue;
+            }
+            let should_update = match round2_substitution.get(name) {
+                None => true,
+                Some(existing) if existing == ty => false,
+                Some(existing) => {
+                    existing == TypeId::UNKNOWN
+                        || existing == TypeId::ERROR
+                        || self.inference_type_is_anyish(existing)
+                        || common::contains_infer_types(self.ctx.types, existing)
+                        || common::contains_type_parameters(self.ctx.types, existing)
+                        || assign_query::is_fresh_subtype_of(self.ctx.types, ty, existing)
+                }
+            };
+            if should_update {
+                round2_substitution.insert(name, ty);
+            }
+        }
+    }
+
     pub(crate) fn get_type_of_call_expression_inner(
         &mut self,
         idx: NodeIndex,
@@ -1443,6 +1510,40 @@ impl<'a> CheckerState<'a> {
                         let mut progressive_arg_types = round1_arg_types;
                         let mut round2_arg_types = Vec::with_capacity(arg_count);
 
+                        // Pre-seed the Round 2 contextual substitution from every
+                        // non-context-sensitive argument before contextually typing any
+                        // sensitive callback. The typing loop below otherwise accumulates
+                        // substitutions left-to-right, so a context-sensitive callback
+                        // positioned before the argument that pins a type parameter it
+                        // depends on would be typed with a stale substitution (the parameter
+                        // still uninferred). tsc fixes type parameters from all
+                        // non-context-sensitive arguments before contextually typing any
+                        // context-sensitive argument, making the callback's contextual type
+                        // order-independent.
+                        for (i, &arg_type) in progressive_arg_types.iter().enumerate() {
+                            if sensitive_args.get(i).copied().unwrap_or(false)
+                                || arg_type == TypeId::UNKNOWN
+                                || arg_type == TypeId::ERROR
+                            {
+                                continue;
+                            }
+                            if let Some(shape_param_type) =
+                                shape.params.get(i).map(|p| p.type_id).or_else(|| {
+                                    let last = shape.params.last()?;
+                                    last.rest.then_some(last.type_id)
+                                })
+                            {
+                                self.merge_arg_return_context_into_round2(
+                                    &shape,
+                                    shape_param_type,
+                                    arg_type,
+                                    &tracked_type_params,
+                                    false,
+                                    &mut round2_substitution,
+                                );
+                            }
+                        }
+
                         for (i, &arg_idx) in args.iter().enumerate() {
                             if sensitive_args.get(i).copied().unwrap_or(false)
                                 && let Some(first_branch_idx) =
@@ -1637,74 +1738,14 @@ impl<'a> CheckerState<'a> {
                                     last.rest.then_some(last.type_id)
                                 })
                             {
-                                let mut arg_substitution =
-                                    crate::query_boundaries::common::TypeSubstitution::new();
-                                let mut visited = FxHashSet::default();
-                                self.collect_return_context_substitution(
+                                self.merge_arg_return_context_into_round2(
+                                    &shape,
                                     shape_param_type,
                                     arg_type_for_refinement,
                                     &tracked_type_params,
-                                    &mut arg_substitution,
-                                    &mut visited,
+                                    sensitive_args.get(i).copied().unwrap_or(false),
+                                    &mut round2_substitution,
                                 );
-                                for (&name, &raw_ty) in arg_substitution.map().iter() {
-                                    let ty = if shape
-                                        .type_params
-                                        .iter()
-                                        .find(|tp| tp.name == name)
-                                        .is_some_and(|tp| !tp.is_const)
-                                    {
-                                        if crate::query_boundaries::common::object_shape_for_type(
-                                            self.ctx.types,
-                                            raw_ty,
-                                        )
-                                        .is_some()
-                                        {
-                                            raw_ty
-                                        } else {
-                                            self.widen_literal_type(raw_ty)
-                                        }
-                                    } else {
-                                        raw_ty
-                                    };
-                                    if ty == TypeId::UNKNOWN
-                                        || ty == TypeId::ERROR
-                                        || (sensitive_args.get(i).copied().unwrap_or(false)
-                                            && (ty == TypeId::NULL || ty == TypeId::UNDEFINED))
-                                        || self.target_contains_blocking_return_context_type_params(
-                                            ty,
-                                            &tracked_type_params,
-                                        )
-                                    {
-                                        continue;
-                                    }
-
-                                    let should_update = match round2_substitution.get(name) {
-                                        None => true,
-                                        Some(existing) if existing == ty => false,
-                                        Some(existing) => {
-                                            existing == TypeId::UNKNOWN
-                                                || existing == TypeId::ERROR
-                                                || self.inference_type_is_anyish(existing)
-                                                || common::contains_infer_types(
-                                                    self.ctx.types,
-                                                    existing,
-                                                )
-                                                || common::contains_type_parameters(
-                                                    self.ctx.types,
-                                                    existing,
-                                                )
-                                                || assign_query::is_fresh_subtype_of(
-                                                    self.ctx.types,
-                                                    ty,
-                                                    existing,
-                                                )
-                                        }
-                                    };
-                                    if should_update {
-                                        round2_substitution.insert(name, ty);
-                                    }
-                                }
                             }
 
                             let expected_still_unresolved = expected_type.is_some_and(|expected| {

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1391,11 +1391,6 @@ impl<'a> CheckerState<'a> {
                 ..
             } => {
                 self.ctx.no_overload_call_nodes.insert(call_idx.0);
-                let overload_failures_disagree = failures.len() > 1
-                    && failures.windows(2).any(|pair| {
-                        pair[0].code != pair[1].code
-                            || format!("{:?}", pair[0].args) != format!("{:?}", pair[1].args)
-                    });
                 let has_error_surface = callee_type == TypeId::ERROR
                     || args
                         .iter()
@@ -1418,56 +1413,11 @@ impl<'a> CheckerState<'a> {
                 if should_emit_no_overload_error {
                     self.error_no_overload_matches_at(call_idx, &failures);
                 }
-                let overloaded_callee_has_type_params =
-                    common::callable_shape_for_type(self.ctx.types, callee_type).is_some_and(
-                        |shape| {
-                            shape
-                                .call_signatures
-                                .iter()
-                                .any(|sig| !sig.type_params.is_empty())
-                        },
-                    );
-                let call_is_typed_variable_initializer =
-                    self.ctx
-                        .arena
-                        .get_extended(call_idx)
-                        .map(|info| info.parent)
-                        .and_then(|parent_idx| {
-                            self.ctx
-                                .arena
-                                .get(parent_idx)
-                                .map(|node| (parent_idx, node))
-                        })
-                        .is_some_and(|(_parent_idx, parent)| {
-                            parent.kind == syntax_kind_ext::VARIABLE_DECLARATION
-                                && self.ctx.arena.get_variable_declaration(parent).is_some_and(
-                                    |decl| {
-                                        decl.initializer == call_idx
-                                            && decl.type_annotation.is_some()
-                                    },
-                                )
-                        });
-                let callee_is_object_assign = self
-                    .ctx
-                    .arena
-                    .get(callee_expr)
-                    .and_then(|node| self.ctx.arena.get_access_expr(node))
-                    .is_some_and(|access| {
-                        self.ctx.arena.get_identifier_text(access.expression) == Some("Object")
-                            && self.ctx.arena.get_identifier_text(access.name_or_argument)
-                                == Some("assign")
-                    });
-                if overload_failures_disagree
-                    && should_emit_no_overload_error
-                    && !overloaded_callee_has_type_params
-                    && !call_is_typed_variable_initializer
-                    && !callee_is_object_assign
-                    && !common::contains_type_parameters(self.ctx.types, fallback_return)
-                {
-                    TypeId::NEVER
-                } else {
-                    fallback_return
-                }
+                // `fallback_return` is the intersection of the candidate
+                // signatures' return types (see `overload_failure_return_type`):
+                // it suppresses spurious cascades after TS2769 yet keeps real
+                // downstream errors, matching tsc.
+                fallback_return
             }
             CallResult::ThisTypeMismatch {
                 expected_this,

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -2052,23 +2052,67 @@ impl<'a> CheckerState<'a> {
         declarations: &[(NodeIndex, u32)],
     ) {
         use crate::diagnostics::diagnostic_codes;
-        use rustc_hash::FxHashMap;
+        use rustc_hash::{FxHashMap, FxHashSet};
 
-        let enum_declarations: Vec<NodeIndex> = declarations
+        // Enum declarations of this symbol, paired with their const-ness, in
+        // source (binding) order. Order matters: tsc's binder keeps the first
+        // declaration's const-ness as the merged symbol's kind and splits every
+        // later declaration that disagrees into its own symbol.
+        let mut enum_declarations: Vec<(NodeIndex, bool)> = declarations
             .iter()
             .filter(|&(_decl_idx, flags)| (flags & symbol_flags::ENUM) != 0)
-            .map(|(decl_idx, _flags)| *decl_idx)
+            .map(|&(decl_idx, flags)| (decl_idx, (flags & symbol_flags::CONST_ENUM) != 0))
             .collect();
 
         if enum_declarations.len() <= 1 {
             return;
         }
 
+        enum_declarations
+            .sort_by_key(|&(decl_idx, _)| self.ctx.arena.get(decl_idx).map_or(0, |node| node.pos));
+
+        // TS2567: a `const enum` and a non-const `enum` of the same name cannot
+        // merge. The merged symbol takes the first declaration's const-ness (the
+        // "primary" group); any later declaration whose const-ness differs is
+        // reported together with every primary declaration bound before it
+        // (matching tsc's binder, which splits the conflicting declaration into a
+        // fresh symbol at the point of conflict). Only the primary group actually
+        // merges, so the initializer / member-duplicate checks below run over it
+        // rather than over the split-off declarations.
+        let primary_is_const = enum_declarations[0].1;
+        let mut primary_group: Vec<NodeIndex> = Vec::new();
+        let mut reported: FxHashSet<NodeIndex> = FxHashSet::default();
+        for &(decl_idx, is_const) in &enum_declarations {
+            if is_const == primary_is_const {
+                primary_group.push(decl_idx);
+                continue;
+            }
+            // const-ness conflict: report it together with every primary
+            // declaration bound before it (output diagnostics are sorted by
+            // position, so emission order here is irrelevant).
+            for &target in primary_group.iter().chain(std::iter::once(&decl_idx)) {
+                if reported.insert(target)
+                    && let Some(name_idx) = self
+                        .ctx
+                        .arena
+                        .get(target)
+                        .and_then(|node| self.ctx.arena.get_enum(node))
+                        .map(|enum_decl| enum_decl.name)
+                {
+                    self.error_at_node_msg(
+                        name_idx,
+                        diagnostic_codes::ENUM_DECLARATIONS_CAN_ONLY_MERGE_WITH_NAMESPACE_OR_OTHER_ENUM_DECLARATIONS,
+                        &[],
+                    );
+                }
+            }
+        }
+
         let mut first_member_without_initializer = Vec::new();
         let mut first_member_by_name: FxHashMap<String, (NodeIndex, NodeIndex, bool)> =
             FxHashMap::default();
 
-        for &enum_decl_idx in &enum_declarations {
+        for &enum_decl_idx in &primary_group {
             let Some(enum_decl_node) = self.ctx.arena.get(enum_decl_idx) else {
                 continue;
             };

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -5,6 +5,7 @@
 //! and checking for explicit `any` assertion returns.
 
 use crate::context::TypingRequest;
+use crate::query_boundaries::function_returns as return_type_queries;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -21,10 +22,7 @@ impl<'a> CheckerState<'a> {
         if return_context == TypeId::ANY
             || return_context == TypeId::UNKNOWN
             || self.type_has_unresolved_inference_holes(return_context)
-            || crate::query_boundaries::common::contains_type_parameters(
-                self.ctx.types,
-                return_context,
-            )
+            || return_type_queries::contains_type_parameters(self.ctx.types, return_context)
         {
             return None;
         }
@@ -72,8 +70,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn return_context_is_async_array_union_context(&self, return_context: TypeId) -> bool {
-        let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, return_context)
+        let Some(members) = return_type_queries::union_members(self.ctx.types, return_context)
         else {
             return false;
         };
@@ -81,18 +78,16 @@ impl<'a> CheckerState<'a> {
         let mut saw_array = false;
         let mut saw_promise_wrapped_array = false;
         for member in members {
-            if crate::query_boundaries::common::array_element_type(self.ctx.types, member).is_some()
-            {
+            if return_type_queries::array_element_type(self.ctx.types, member).is_some() {
                 saw_array = true;
                 continue;
             }
 
             if let Some((base, args)) =
-                crate::query_boundaries::common::application_info(self.ctx.types, member)
+                return_type_queries::application_info(self.ctx.types, member)
                 && args.len() == 1
                 && self.return_context_application_base_has_name(base, &["Promise", "PromiseLike"])
-                && crate::query_boundaries::common::array_element_type(self.ctx.types, args[0])
-                    .is_some()
+                && return_type_queries::array_element_type(self.ctx.types, args[0]).is_some()
             {
                 saw_promise_wrapped_array = true;
             }
@@ -451,7 +446,7 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
-        if crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id).is_some() {
+        if return_type_queries::lazy_def_id(self.ctx.types, type_id).is_some() {
             return type_id;
         }
 
@@ -462,13 +457,13 @@ impl<'a> CheckerState<'a> {
 
     fn record_index_access_value_type(&self, type_id: TypeId) -> Option<TypeId> {
         let (object_type, _index_type) =
-            crate::query_boundaries::common::index_access_types(self.ctx.types, type_id)?;
+            return_type_queries::index_access_types(self.ctx.types, type_id)?;
         let app_type = self
             .ctx
             .types
             .get_display_alias(object_type)
             .unwrap_or(object_type);
-        let app = crate::query_boundaries::common::type_application(self.ctx.types, app_type)?;
+        let app = return_type_queries::type_application(self.ctx.types, app_type)?;
         if !self.application_alias_maps_keys_to_second_type_arg(app.base) || app.args.len() != 2 {
             return None;
         }
@@ -476,8 +471,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn application_alias_maps_keys_to_second_type_arg(&self, base: TypeId) -> bool {
-        let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, base)
-        else {
+        let Some(def_id) = return_type_queries::lazy_def_id(self.ctx.types, base) else {
             return false;
         };
         let Some(def) = self.ctx.definition_store.get(def_id) else {
@@ -489,12 +483,11 @@ impl<'a> CheckerState<'a> {
         let Some(body) = def.body else {
             return false;
         };
-        let Some(mapped) = crate::query_boundaries::common::mapped_type_info(self.ctx.types, body)
-        else {
+        let Some(mapped) = return_type_queries::mapped_type_info(self.ctx.types, body) else {
             return false;
         };
         let Some(template_param) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, mapped.template)
+            return_type_queries::type_param_info(self.ctx.types, mapped.template)
         else {
             return false;
         };
@@ -802,8 +795,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn resolve_lazy_class_to_constructor(&self, type_id: TypeId) -> TypeId {
         use tsz_solver::SymbolRef;
 
-        let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id)
-        else {
+        let Some(def_id) = return_type_queries::lazy_def_id(self.ctx.types, type_id) else {
             return type_id;
         };
 
@@ -892,9 +884,9 @@ impl<'a> CheckerState<'a> {
         // results (e.g., `unbox(a)` resolving W=B instead of W=T[]).
         // This matches tsc's behavior where type parameter contextual return types
         // do not flow into inner call expression inference.
-        use crate::query_boundaries::common::type_param_info;
-        let effective_return_context =
-            return_context.filter(|&ctx_type| type_param_info(self.ctx.types, ctx_type).is_none());
+        let effective_return_context = return_context.filter(|&ctx_type| {
+            return_type_queries::type_param_info(self.ctx.types, ctx_type).is_none()
+        });
         let request = match effective_return_context {
             Some(ctx_type) => TypingRequest::with_contextual_type(ctx_type),
             None => TypingRequest::NONE,
@@ -930,19 +922,17 @@ impl<'a> CheckerState<'a> {
                     return_type,
                     contextual_type,
                 )
-                || (crate::query_boundaries::common::contains_type_parameters(
-                    self.ctx.types,
-                    return_type,
-                ) && self
-                    .ctx
-                    .arena
-                    .get_call_expr_at(expr_idx)
-                    .is_some_and(|new_expr| {
-                        self.contextual_application_matches_new_target(
-                            new_expr.expression,
-                            contextual_type,
-                        )
-                    })))
+                || (return_type_queries::contains_type_parameters(self.ctx.types, return_type)
+                    && self
+                        .ctx
+                        .arena
+                        .get_call_expr_at(expr_idx)
+                        .is_some_and(|new_expr| {
+                            self.contextual_application_matches_new_target(
+                                new_expr.expression,
+                                contextual_type,
+                            )
+                        })))
         {
             return_type = contextual_type;
         }

--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -2790,3 +2790,126 @@ function process(): string {
         "Array<any>.reduce with contextual string return should not emit TS2322; got: {diags:#?}"
     );
 }
+
+// ============================================================================
+// Overloaded callee: callback parameters contextually typed from the resolved
+// signature (issue #9663). Selecting an overload via a discriminating argument
+// must contextually type the callback parameter from that signature, so body
+// errors (TS2339 / TS2322) surface — matching tsc — instead of being hidden by
+// the lossy union contextual type used during overload selection.
+// ============================================================================
+
+#[test]
+fn overloaded_callback_first_overload_bad_property_ts2339() {
+    let source = r#"
+declare function on(event: "click", cb: (e: { x: number }) => void): void;
+declare function on(event: "key", cb: (e: { code: string }) => void): void;
+on("click", e => e.code);
+"#;
+    let diags = get_diagnostics(source);
+    assert!(
+        diags.iter().any(|(code, msg)| *code == 2339
+            && msg.contains("code")
+            && msg.contains("{ x: number; }")),
+        "Selecting the click overload should type `e` as {{ x: number }} and emit TS2339 on `e.code`; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn overloaded_callback_second_overload_bad_property_ts2339() {
+    // Not order-specific: selecting the second overload must also contextually
+    // type the callback from that signature.
+    let source = r#"
+declare function on(event: "click", cb: (e: { x: number }) => void): void;
+declare function on(event: "key", cb: (e: { code: string }) => void): void;
+on("key", e => e.x);
+"#;
+    let diags = get_diagnostics(source);
+    assert!(
+        diags.iter().any(|(code, msg)| *code == 2339
+            && msg.contains('x')
+            && msg.contains("{ code: string; }")),
+        "Selecting the key overload should type `e` as {{ code: string }} and emit TS2339 on `e.x`; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn overloaded_callback_body_assignment_mismatch_ts2322() {
+    let source = r#"
+declare function on(event: "click", cb: (e: { x: number }) => void): void;
+declare function on(event: "key", cb: (e: { code: string }) => void): void;
+on("click", (e) => { const z: string = e.x; });
+"#;
+    assert!(
+        has_error(source, 2322),
+        "Assignment inside an overloaded callback body must be checked against the resolved signature (TS2322)"
+    );
+}
+
+#[test]
+fn overloaded_callback_rule_is_structural_not_name_bound() {
+    // Different event literals and property names prove the fix is structural.
+    let source = r#"
+declare function reg(kind: "a", cb: (p: { alpha: number }) => void): void;
+declare function reg(kind: "b", cb: (p: { beta: string }) => void): void;
+reg("a", p => p.beta);
+reg("b", p => p.alpha);
+"#;
+    let diags = get_diagnostics(source);
+    let alpha_target = diags.iter().any(|(code, msg)| {
+        *code == 2339 && msg.contains("beta") && msg.contains("{ alpha: number; }")
+    });
+    let beta_target = diags.iter().any(|(code, msg)| {
+        *code == 2339 && msg.contains("alpha") && msg.contains("{ beta: string; }")
+    });
+    assert!(
+        alpha_target && beta_target,
+        "Both overloaded callbacks should report property errors against their own resolved parameter type; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn overloaded_callback_valid_property_no_error() {
+    // Negative case: accessing the property that exists on the resolved
+    // signature's parameter must not error.
+    let source = r#"
+declare function on(event: "click", cb: (e: { x: number }) => void): void;
+declare function on(event: "key", cb: (e: { code: string }) => void): void;
+on("click", e => e.x);
+on("key", e => e.code);
+"#;
+    assert!(
+        no_errors(source),
+        "Accessing the property valid for the selected overload must not error"
+    );
+}
+
+#[test]
+fn overloaded_callback_continuation_access_no_false_positive() {
+    // A deeper-but-valid continuation access through the resolved parameter
+    // type must remain error-free.
+    let source = r#"
+declare function on(event: "click", cb: (e: { x: { v(): number } }) => void): void;
+declare function on(event: "key", cb: (e: { code: string }) => void): void;
+on("click", e => e.x.v());
+"#;
+    assert!(
+        no_errors(source),
+        "Valid continuation access on the resolved parameter type must not error"
+    );
+}
+
+#[test]
+fn non_callback_overload_selection_still_works() {
+    // Guard: overload selection without callbacks is unaffected.
+    let source = r#"
+declare function f(x: string): string;
+declare function f(x: number): number;
+const a: string = f("hi");
+const b: number = f(42);
+"#;
+    assert!(
+        no_errors(source),
+        "Plain overload selection must remain unaffected by the callback fix"
+    );
+}

--- a/crates/tsz-checker/tests/call_resolution_regression_tests.rs
+++ b/crates/tsz-checker/tests/call_resolution_regression_tests.rs
@@ -2913,3 +2913,156 @@ const b: number = f(42);
         "Plain overload selection must remain unaffected by the callback fix"
     );
 }
+
+// ---------------------------------------------------------------------------
+// No-overload-match recovery result type (issue #9669).
+//
+// Structural rule: when a call matches no overload signature, the call
+// expression's result type is the intersection of every candidate signature's
+// return type (tsc's `createUnionOfSignaturesForOverloadFailure`). Disjoint
+// primitive returns (`string` & `number`) collapse to `never`, which is
+// assignable to any annotation and so suppresses spurious downstream cascades
+// (the call already reported TS2769); structurally compatible object returns
+// merge (`{ a }` & `{ b }`) so member access still resolves; uniform returns
+// survive intact. Only TS2769 should fire for a hard no-match — no cascade.
+// ---------------------------------------------------------------------------
+
+/// Reported repro: failed overloaded call assigned to an incompatible type
+/// must emit only TS2769, not a spurious TS2322 cascade.
+#[test]
+fn no_overload_match_assignment_no_cascade_ts2322() {
+    let source = r#"
+declare function f(x: number): string;
+declare function f(x: string): number;
+const c: string = f(true);
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        !codes.contains(&2322),
+        "no spurious TS2322 cascade on failed overload assignment; got {codes:?}"
+    );
+}
+
+/// Same rule via a function-type intersection (different surface, same
+/// overload mechanism).
+#[test]
+fn no_overload_match_intersection_callable_no_cascade_ts2322() {
+    let source = r#"
+type F = ((x: number) => string) & ((x: string) => number);
+declare const f: F;
+const c: string = f(true);
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        !codes.contains(&2322),
+        "no spurious TS2322 on failed intersection-callable assignment; got {codes:?}"
+    );
+}
+
+/// Failed overload result used as an argument: no TS2345 cascade either.
+#[test]
+fn no_overload_match_argument_position_no_cascade_ts2345() {
+    let source = r#"
+declare function f(x: number): string;
+declare function f(x: string): number;
+declare function sink(x: 99): void;
+sink(f(true));
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        !codes.contains(&2345),
+        "no spurious TS2345 cascade on failed overload used as argument; got {codes:?}"
+    );
+}
+
+/// Renamed function/parameters — the rule is structural, not keyed on spelling.
+#[test]
+fn no_overload_match_renamed_no_cascade_ts2322() {
+    let source = r#"
+declare function ZZ(qqq: number): string;
+declare function ZZ(qqq: string): number;
+const result: string = ZZ(true);
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        !codes.contains(&2322),
+        "renamed overload should behave identically; got {codes:?}"
+    );
+}
+
+/// Compatible object returns merge into `{ a } & { b }`: both members exist on
+/// the recovery type, so member access must NOT report TS2339.
+#[test]
+fn no_overload_match_object_returns_merge_members_resolve() {
+    let source = r#"
+declare function f(x: number): { a: number };
+declare function f(x: string): { b: string };
+f(true).a;
+f(true).b;
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        !codes.contains(&2339),
+        "members of intersected object returns must resolve; got {codes:?}"
+    );
+}
+
+/// A property that is absent from the intersection still reports TS2339 — the
+/// recovery type is not blanket-`any`/error that silences everything.
+#[test]
+fn no_overload_match_object_returns_missing_member_reports_ts2339() {
+    let source = r#"
+declare function f(x: number): { a: number };
+declare function f(x: string): { b: string };
+f(true).nope;
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        codes.contains(&2339),
+        "absent property on intersected returns must still report TS2339; got {codes:?}"
+    );
+}
+
+/// Uniform candidate returns survive: `{ a: number }` & `{ a: number }`
+/// dedups to `{ a: number }`, so assigning to an incompatible type still
+/// reports TS2322 (matching tsc — the suppression is intersection-driven, not
+/// a blanket no-match suppression).
+#[test]
+fn no_overload_match_uniform_returns_preserve_shape_and_cascade() {
+    let source = r#"
+declare function f(x: number): { a: number };
+declare function f(x: string): { a: number };
+const c: string = f(true);
+"#;
+    let codes = get_codes(source);
+    assert!(codes.contains(&2769), "expected TS2769; got {codes:?}");
+    assert!(
+        codes.contains(&2322),
+        "uniform object recovery type must still cascade TS2322; got {codes:?}"
+    );
+}
+
+/// Negative control: a SUCCESSFUL overloaded call assigned to an incompatible
+/// type must still emit TS2322 — the suppression is only for hard no-matches.
+#[test]
+fn successful_overload_call_still_cascades_ts2322() {
+    let source = r#"
+declare function g(x: number): string;
+const c: number = g(1);
+"#;
+    let codes = get_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "successful overload assigned to incompatible type must still emit TS2322; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2769),
+        "successful call must not report TS2769; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/const_enum_merge_ts2567_tests.rs
+++ b/crates/tsz-checker/tests/const_enum_merge_ts2567_tests.rs
@@ -1,0 +1,176 @@
+//! TS2567 "Enum declarations can only merge with namespace or other enum
+//! declarations" for `const enum` / non-const `enum` merges of the same name.
+//!
+//! Structural rule: when a symbol's enum declarations disagree on const-ness,
+//! tsc keeps the *first* declaration's const-ness as the merged symbol's kind
+//! and splits every later declaration that disagrees into its own symbol,
+//! reporting TS2567 at the enum name of both the surviving (primary)
+//! declarations bound before the conflict and the conflicting declaration.
+//! Only the primary group actually merges, so TS2432 ("only one declaration
+//! can omit an initializer") and member-duplicate TS2300 apply to it alone.
+
+use tsz_checker::test_utils::check_source_codes as get_error_codes;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn enum_then_const_enum_with_initializers_reports_two_ts2567() {
+    let codes = get_error_codes(
+        r#"
+enum E { A = 1 }
+const enum E { B = 2 }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        2,
+        "const/non-const enum merge must report TS2567 on both declarations, got: {codes:?}"
+    );
+}
+
+#[test]
+fn const_enum_then_enum_order_swapped_reports_two_ts2567() {
+    // Position of the const declaration does not matter.
+    let codes = get_error_codes(
+        r#"
+const enum Color { A = 1 }
+enum Color { B = 2 }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        2,
+        "swapped-order const/non-const merge must report TS2567 twice, got: {codes:?}"
+    );
+}
+
+#[test]
+fn enum_then_const_enum_without_initializers_reports_ts2567_not_ts2432() {
+    // The split-off declarations each form a single-declaration symbol, so the
+    // "only one declaration can omit an initializer" rule (TS2432) does not
+    // fire — tsc emits only the two TS2567.
+    let codes = get_error_codes(
+        r#"
+enum Status { A }
+const enum Status { B }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        2,
+        "uninitialized const/non-const merge must report TS2567 twice, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2432),
+        0,
+        "split-off enum declarations must not trigger TS2432, got: {codes:?}"
+    );
+}
+
+#[test]
+fn two_non_const_enums_plus_one_const_reports_ts2567_for_all_three() {
+    // Primary group = the two leading non-const enums; the trailing const enum
+    // conflicts. TS2567 lands on all three names; TS2432 fires once within the
+    // (uninitialized) primary group.
+    let codes = get_error_codes(
+        r#"
+enum E { X }
+enum E { Y }
+const enum E { Z }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        3,
+        "all enum declarations in a const-mismatch merge get TS2567, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2432),
+        1,
+        "TS2432 applies once within the primary merge group, got: {codes:?}"
+    );
+}
+
+#[test]
+fn const_then_non_const_then_const_merges_primary_group() {
+    // First declaration is const, so the primary group is the two const enums;
+    // the middle non-const enum is the only conflict. tsc: TS2567 on decls 1
+    // and 2 only, and TS2432 within the const primary group (decls 1 and 3).
+    let codes = get_error_codes(
+        r#"
+const enum E { A }
+enum E { B }
+const enum E { C }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        2,
+        "only the first-const primary plus the conflicting non-const enum get TS2567, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2432),
+        1,
+        "TS2432 applies to the const primary group, got: {codes:?}"
+    );
+}
+
+#[test]
+fn two_non_const_enums_merge_cleanly_no_ts2567() {
+    // Control: same const-ness merges, only the ordinary TS2432 applies.
+    let codes = get_error_codes(
+        r#"
+enum E { X }
+enum E { Y }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        0,
+        "same-const-ness enum merge must not report TS2567, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2432),
+        1,
+        "uninitialized non-const merge keeps its TS2432, got: {codes:?}"
+    );
+}
+
+#[test]
+fn two_const_enums_merge_cleanly_no_ts2567() {
+    // Control: both const, both initialized — a fully valid merge.
+    let codes = get_error_codes(
+        r#"
+const enum E { A = 1 }
+const enum E { B = 2 }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        0,
+        "two const enums merge cleanly, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2432),
+        0,
+        "initialized const merge has no TS2432, got: {codes:?}"
+    );
+}
+
+#[test]
+fn non_const_enum_merges_with_namespace_no_ts2567() {
+    // Control: a non-const enum may merge with a namespace.
+    let codes = get_error_codes(
+        r#"
+enum E { A = 1 }
+namespace E { export const x = 1; }
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2567),
+        0,
+        "non-const enum + namespace is a valid merge, got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/keyof_function_type_is_never_tests.rs
+++ b/crates/tsz-checker/tests/keyof_function_type_is_never_tests.rs
@@ -1,0 +1,152 @@
+//! End-to-end checker coverage for issue #9721: `keyof <function type>` must
+//! normalize to `never` so `[K] extends [never]` reasoning matches tsc.
+//!
+//! Bare function and constructor types have no own properties and no index
+//! signatures, so their key space is empty and `keyof` must collapse to
+//! `never`.  The solver-internal asymmetry between the two lowering forms is
+//! covered by the solver-side unit tests; this file pins the user-observable
+//! behaviour at the checker boundary.
+
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::check_source_diagnostics;
+
+fn count_ts2322(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .count()
+}
+
+#[test]
+fn keyof_bare_function_type_extends_never_picks_true_branch() {
+    // The exact repro from issue #9721.
+    let source = r#"
+        type Fn = () => void;
+        type K = keyof Fn;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "notnever";
+    "#;
+
+    assert!(
+        count_ts2322(source) >= 1,
+        "keyof (() => void) should normalize to never, so T1 should be \"isnever\" \
+         and the assignment of \"notnever\" should fail with TS2322"
+    );
+}
+
+#[test]
+fn keyof_bare_function_type_assigning_isnever_is_ok() {
+    // Positive control: the matching literal must NOT report TS2322.
+    let source = r#"
+        type Fn = () => void;
+        type K = keyof Fn;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "isnever";
+    "#;
+
+    assert_eq!(
+        count_ts2322(source),
+        0,
+        "Assigning \"isnever\" must succeed when keyof Fn === never",
+    );
+}
+
+#[test]
+fn keyof_function_with_params_extends_never_picks_true_branch() {
+    // Renamed alias + different parameter shape proves the rule is structural,
+    // not tied to the empty-parameter spelling.
+    let source = r#"
+        type Handler = (x: number, y: string) => boolean;
+        type K = keyof Handler;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "notnever";
+    "#;
+
+    assert!(
+        count_ts2322(source) >= 1,
+        "keyof (x: number, y: string) => boolean must still normalize to never",
+    );
+}
+
+#[test]
+fn keyof_generic_function_type_extends_never_picks_true_branch() {
+    // Generic call-signature-only types stay function-shaped after lowering.
+    let source = r#"
+        type Identity = <U>(u: U) => U;
+        type K = keyof Identity;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "notnever";
+    "#;
+
+    assert!(
+        count_ts2322(source) >= 1,
+        "keyof of a generic call-signature type must normalize to never",
+    );
+}
+
+#[test]
+fn keyof_constructor_type_extends_never_picks_true_branch() {
+    // Positive control from the issue's boundary table.  Constructor-only
+    // types already lower to a `Callable` whose empty key-space resolves to
+    // never; pin it down so it stays symmetric with the function-type path.
+    let source = r#"
+        type Ctor = new () => object;
+        type K = keyof Ctor;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "notnever";
+    "#;
+
+    assert!(
+        count_ts2322(source) >= 1,
+        "keyof (new () => object) must normalize to never",
+    );
+}
+
+#[test]
+fn keyof_callable_with_explicit_property_keeps_property_keys() {
+    // Negative control: a callable that *does* have a declared property must
+    // still keyof to that property — the fix must not over-reach into the
+    // Callable path.
+    let source = r#"
+        type C = { (): void; prop: number };
+        type K = keyof C;
+        type T1 = [K] extends [never] ? "isnever" : "notnever";
+        const r: T1 = "notnever";
+    "#;
+
+    assert_eq!(
+        count_ts2322(source),
+        0,
+        "keyof {{ (): void; prop: number }} is \"prop\", which is NOT never, \
+         so the false branch is taken and the assignment of \"notnever\" succeeds",
+    );
+}
+
+#[test]
+fn keyof_function_in_equal_harness_matches_never() {
+    // Standard `Equal<…, never>` shape used by ts-essentials / ts-toolbelt.
+    // Before the fix this would report TS2344 because keyof Fn stayed
+    // deferred and the harness reduced to `false` instead of `true`.
+    let source = r#"
+        type Equal<X, Y> =
+            (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2)
+                ? true
+                : false;
+        type Expect<T extends true> = T;
+        type Fn = () => void;
+        type t = Expect<Equal<keyof Fn, never>>;
+    "#;
+
+    let errors = check_source_diagnostics(source);
+    let blocking: Vec<_> = errors
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT
+                || d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+        })
+        .collect();
+    assert!(
+        blocking.is_empty(),
+        "Equal<keyof Fn, never> must resolve to true, got blocking diagnostics: {blocking:?}",
+    );
+}

--- a/crates/tsz-checker/tests/mapped_readonly_tuple_tests.rs
+++ b/crates/tsz-checker/tests/mapped_readonly_tuple_tests.rs
@@ -1,0 +1,145 @@
+//! Tests for the `readonly` mapped-type modifier applied to a tuple source.
+//!
+//! A homomorphic mapped type that adds `readonly` over a tuple must produce a
+//! readonly tuple: element writes error with TS2540 and the result is not
+//! assignable to a mutable tuple (TS4104). A `-readonly` mapped type over a
+//! readonly tuple must strip readonly. The rule is structural, so it must hold
+//! regardless of the iteration-variable name, tuple arity, `readonly` vs
+//! `+readonly` spelling, and whether the mapped type is reached through a named
+//! alias or an inline application.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code != 2318)
+        .map(|(code, _)| code)
+        .collect()
+}
+
+#[test]
+fn readonly_mapped_tuple_via_alias_write_emits_2540() {
+    let source = r"
+type RO<T> = { readonly [K in keyof T]: T[K] };
+type R = RO<[number, string]>;
+declare const r: R;
+r[0] = 5;
+";
+    assert!(
+        codes(source).contains(&2540),
+        "writing a readonly mapped tuple element must emit TS2540"
+    );
+}
+
+#[test]
+fn readonly_mapped_tuple_inline_application_write_emits_2540() {
+    // Inline application (no named alias for the result) must behave identically.
+    let source = r"
+type RO<T> = { readonly [K in keyof T]: T[K] };
+declare const r: RO<[number, string]>;
+r[0] = 5;
+";
+    assert!(
+        codes(source).contains(&2540),
+        "inline readonly mapped tuple element write must emit TS2540"
+    );
+}
+
+#[test]
+fn readonly_mapped_tuple_renamed_iter_var_multi_element_write_emits_2540() {
+    // Renamed iteration variable + 3 elements: proves the rule is structural,
+    // not keyed on the iteration-variable name `K`.
+    let source = r#"
+type RO<T> = { readonly [P in keyof T]: T[P] };
+declare const r: RO<[number, string, boolean]>;
+r[1] = "x";
+"#;
+    assert!(
+        codes(source).contains(&2540),
+        "renamed-var multi-element readonly mapped tuple write must emit TS2540"
+    );
+}
+
+#[test]
+fn plus_readonly_mapped_tuple_write_emits_2540() {
+    let source = r"
+type RO<T> = { +readonly [K in keyof T]: T[K] };
+declare const r: RO<[number, string]>;
+r[0] = 5;
+";
+    assert!(
+        codes(source).contains(&2540),
+        "explicit +readonly mapped tuple write must emit TS2540"
+    );
+}
+
+#[test]
+fn readonly_mapped_tuple_not_assignable_to_mutable_tuple_emits_4104() {
+    let source = r"
+type RO<T> = { readonly [K in keyof T]: T[K] };
+declare const r: RO<[number, string]>;
+const mut: [number, string] = r;
+";
+    assert!(
+        codes(source).contains(&4104),
+        "readonly mapped tuple must not be assignable to a mutable tuple (TS4104)"
+    );
+}
+
+#[test]
+fn minus_readonly_mapped_over_readonly_tuple_strips_readonly() {
+    // `-readonly` over a readonly tuple yields a mutable tuple: no TS2540.
+    let source = r"
+type Mut<T> = { -readonly [K in keyof T]: T[K] };
+declare const m: Mut<readonly [number, string]>;
+m[0] = 5;
+";
+    assert!(
+        !codes(source).contains(&2540),
+        "-readonly mapped tuple element write must NOT emit TS2540"
+    );
+}
+
+#[test]
+fn no_modifier_mapped_over_mutable_tuple_stays_mutable() {
+    // Negative control: identity mapped type over a mutable tuple stays mutable.
+    let source = r"
+type Id<T> = { [K in keyof T]: T[K] };
+declare const r: Id<[number, string]>;
+r[0] = 5;
+";
+    assert!(
+        !codes(source).contains(&2540),
+        "identity mapped tuple (no readonly) write must NOT emit TS2540"
+    );
+}
+
+#[test]
+fn no_modifier_mapped_over_readonly_tuple_preserves_readonly() {
+    // Homomorphic preservation: no modifier over a readonly tuple stays readonly.
+    let source = r"
+type Id<T> = { [K in keyof T]: T[K] };
+declare const r: Id<readonly [number, string]>;
+r[0] = 5;
+";
+    assert!(
+        codes(source).contains(&2540),
+        "identity mapped over a readonly tuple must preserve readonly (TS2540)"
+    );
+}
+
+#[test]
+fn readonly_mapped_over_object_still_emits_2540() {
+    // Negative control from the issue: `+readonly` over a plain object source
+    // still produces a readonly property (the object path must not regress).
+    let source = r"
+type RO<T> = { readonly [K in keyof T]: T[K] };
+declare const o: RO<{ a: number }>;
+o.a = 5;
+";
+    assert!(
+        codes(source).contains(&2540),
+        "readonly mapped object property write must still emit TS2540"
+    );
+}

--- a/crates/tsz-checker/tests/merged_namespace_typeof_display_tests.rs
+++ b/crates/tsz-checker/tests/merged_namespace_typeof_display_tests.rs
@@ -1,0 +1,178 @@
+//! Diagnostic display for the static side of a declaration-merged
+//! class + namespace symbol.
+//!
+//! When a class merges with a same-named namespace, the merged static value
+//! carries the namespace exports as static properties. The merge rebuilt the
+//! callable shape without its symbol, so the type printer expanded the
+//! structural shape (`{ new (): C; prototype: C; staticFn: () => void; }`)
+//! instead of rendering `typeof C`. tsc prints `typeof C` for both the merged
+//! and unmerged cases.
+//!
+//! Structural rule: the rebuilt static callable keeps the class symbol, so the
+//! printer's existing class-constructor branch (construct signatures + a
+//! `CLASS`-flagged symbol) renders it as `typeof C` — independent of the class
+//! identifier's spelling.
+
+use tsz_checker::context::CheckerOptions;
+
+fn ts2339_messages(source: &str) -> Vec<String> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+        .into_iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+fn assert_single_display(source: &str, expected_fragment: &str) {
+    let msgs = ts2339_messages(source);
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2339, got: {msgs:?}");
+    assert!(
+        msgs[0].contains(expected_fragment),
+        "expected message to contain `{expected_fragment}`, got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn class_merged_with_namespace_displays_typeof() {
+    // Reported repro: bogus static access on a class merged with a namespace.
+    assert_single_display(
+        r#"
+class C { method() {} }
+namespace C { export function staticFn() {} }
+C.bogus();
+"#,
+        "typeof C",
+    );
+}
+
+#[test]
+fn class_merged_with_namespace_does_not_expand_static_shape() {
+    let msgs = ts2339_messages(
+        r#"
+class C { method() {} }
+namespace C { export function staticFn() {} }
+C.bogus();
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "got: {msgs:?}");
+    assert!(
+        !msgs[0].contains("new ()") && !msgs[0].contains("staticFn"),
+        "static shape must not be expanded, got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn renamed_class_merged_with_namespace_displays_typeof() {
+    // Structural, not keyed on the identifier `C`.
+    assert_single_display(
+        r#"
+class Widget { render() {} }
+namespace Widget { export const version = 1; }
+Widget.missing();
+"#,
+        "typeof Widget",
+    );
+}
+
+#[test]
+fn generic_class_merged_with_namespace_displays_typeof() {
+    assert_single_display(
+        r#"
+class Box<T> { value!: T; }
+namespace Box { export const tag = "box"; }
+Box.bogus();
+"#,
+        "typeof Box",
+    );
+}
+
+#[test]
+fn plain_class_static_access_still_displays_typeof() {
+    // Control: an unmerged class already displays `typeof D`.
+    assert_single_display(
+        r#"
+class D { method() {} }
+D.foo();
+"#,
+        "typeof D",
+    );
+}
+
+#[test]
+fn plain_function_property_access_keeps_signature_display() {
+    // Negative control: an unmerged function is NOT `typeof G`; tsc shows the
+    // call signature. The namespace-merge display rule must not leak here.
+    let msgs = ts2339_messages(
+        r#"
+function G() {}
+G.bogus();
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "got: {msgs:?}");
+    assert!(
+        msgs[0].contains("() => void") && !msgs[0].contains("typeof"),
+        "plain function should display as `() => void`, got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn abstract_class_merged_with_namespace_still_reports_ts2511() {
+    // Negative guard: preserving the merged symbol must not mask the
+    // abstract-construction diagnostic. `new C()` on an abstract class merged
+    // with a namespace still reports TS2511, matching tsc.
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    let codes: Vec<u32> = tsz_checker::test_utils::check_source(
+        r#"
+abstract class C { abstract m(): void; }
+namespace C { export const x = 1; }
+new C();
+"#,
+        "test.ts",
+        options,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect();
+    assert!(
+        codes.contains(&2511),
+        "expected TS2511 for `new C()` on abstract class merged with namespace, got: {codes:?}"
+    );
+}
+
+#[test]
+fn merged_namespace_static_member_access_succeeds() {
+    // Using a real merged static member must not error; only the bogus access
+    // on the instance should.
+    let msgs = ts2339_messages(
+        r#"
+class C { method() {} }
+namespace C { export const x = 1; }
+C.x;
+const c = new C();
+c.bogus();
+"#,
+    );
+    assert_eq!(
+        msgs.len(),
+        1,
+        "expected only the instance error, got: {msgs:?}"
+    );
+    // The instance type is `C`, not `typeof C`.
+    assert!(
+        msgs[0].contains("type 'C'") && !msgs[0].contains("typeof"),
+        "instance access should display as `C`, got: {}",
+        msgs[0]
+    );
+}

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -410,6 +410,139 @@ const dest: { [index: symbol]: string } = source;
     );
 }
 
+// Indexing a concrete object by a wide `symbol`-typed value with no matching
+// `symbol` index signature is an implicit-any element access (TS7053).
+//
+// Structural rule: when `obj[key]` has `key: symbol` (the wide primitive, not a
+// `unique symbol` that names a member), and `obj` declares neither a member under
+// that binding nor a `symbol` index signature, tsc reports TS7053 (objects) /
+// TS7015 (arrays/tuples). This change makes tsz report it too.
+#[test]
+fn wide_symbol_index_on_plain_object_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let s: symbol = Symbol();
+const o = { a: 1 };
+const v1 = o[s];
+"#,
+    );
+
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "expected TS7053 for wide symbol indexing a plain object, got {codes:?}",
+    );
+}
+
+// Renamed key variable — proves the rule is structural, not keyed on the name `s`.
+#[test]
+fn wide_symbol_index_on_plain_object_reports_ts7053_renamed_key() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let mySymKey: symbol = Symbol();
+const record = { first: 1, second: 2 };
+const value = record[mySymKey];
+"#,
+    );
+
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "expected TS7053 regardless of key variable name, got {codes:?}",
+    );
+}
+
+// Arrays/tuples have a numeric index signature, so a `symbol` key produces the
+// more specific TS7015 (index expression is not of type 'number').
+#[test]
+fn wide_symbol_index_on_array_reports_ts7015() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let s: symbol = Symbol();
+const arr: number[] = [1];
+const v2 = arr[s];
+"#,
+    );
+
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for wide symbol indexing an array, got {codes:?}",
+    );
+}
+
+#[test]
+fn wide_symbol_index_on_tuple_reports_ts7015() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let s: symbol = Symbol();
+const tup: [number, string] = [1, "a"];
+const v = tup[s];
+"#,
+    );
+
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for wide symbol indexing a tuple, got {codes:?}",
+    );
+}
+
+// Scope guard: a bare wide-`symbol` expression that is not a `symbol`-typed
+// identifier (here a call result) is intentionally NOT flagged. tsz widens
+// `unique symbol` reads (e.g. `Symbol.iterator`) to wide `symbol`, so a bare
+// wide-`symbol` value cannot be distinguished from a widened well-known symbol;
+// reporting it would risk false positives on valid well-known-symbol access.
+#[test]
+fn wide_symbol_call_expression_index_is_not_flagged() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare function makeSym(): symbol;
+const o = { a: 1 };
+const v = o[makeSym()];
+"#,
+    );
+
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "bare wide-symbol call-expression index must not be flagged (widening-safety), got {codes:?}",
+    );
+}
+
+// Negative control: a real `symbol` index signature makes the access valid.
+#[test]
+fn wide_symbol_index_with_symbol_index_signature_is_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let s: symbol = Symbol();
+const o: { [k: symbol]: number } = {};
+const v = o[s];
+"#,
+    );
+
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "symbol index signature should make symbol-key reads valid, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "symbol index signature should not trigger TS7015, got {codes:?}",
+    );
+}
+
+// Negative control: a `unique symbol` that actually names a member stays clean.
+#[test]
+fn unique_symbol_key_that_exists_is_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const key: unique symbol;
+const o = { [key]: 1 };
+const v = o[key];
+"#,
+    );
+
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN),
+        "a unique symbol key that exists should not report TS7053, got {codes:?}",
+    );
+}
+
 // A plain string index signature must still display as `string` (regression guard).
 #[test]
 fn ts2322_string_index_signature_target_still_displays_string_key_kind() {

--- a/crates/tsz-common/src/perf_counters.rs
+++ b/crates/tsz-common/src/perf_counters.rs
@@ -179,35 +179,23 @@ pub const LOCK_WAIT_BUCKET_UPPER_BOUNDS_NS: [u64; LOCK_WAIT_BUCKET_COUNT] = [
     u64::MAX,    // overflow
 ];
 
-/// How `delegate_cross_arena_symbol_resolution` found the target arena for
-/// a cache miss that must construct a child checker.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(usize)]
-pub enum CrossArenaSymbolMissSource {
-    /// `binder.symbol_arenas` pointed at a non-current arena.
-    SymbolArena = 0,
-    /// `binder.declaration_arenas` found a non-current declaration arena.
-    DeclarationArena = 1,
-    /// `cross_file_symbol_targets` resolved the target file index.
-    SymbolFileTarget = 2,
-    /// Fallback bucket for unexpected delegation shapes.
-    Unknown = 3,
-}
-
-pub const CROSS_ARENA_SYMBOL_MISS_SOURCE_COUNT: usize = 4;
-
-pub const CROSS_ARENA_SYMBOL_MISS_SOURCE_NAMES: [&str; CROSS_ARENA_SYMBOL_MISS_SOURCE_COUNT] = [
-    "symbol_arenas",
-    "declaration_arenas",
-    "symbol_file_targets",
-    "unknown",
-];
-
-impl CrossArenaSymbolMissSource {
-    #[inline(always)]
-    pub const fn as_index(self) -> usize {
-        self as usize
+perf_counter_enum! {
+    /// How `delegate_cross_arena_symbol_resolution` found the target arena for
+    /// a cache miss that must construct a child checker.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum CrossArenaSymbolMissSource {
+        /// `binder.symbol_arenas` pointed at a non-current arena.
+        SymbolArena = 0 => "symbol_arenas",
+        /// `binder.declaration_arenas` found a non-current declaration arena.
+        DeclarationArena = 1 => "declaration_arenas",
+        /// `cross_file_symbol_targets` resolved the target file index.
+        SymbolFileTarget = 2 => "symbol_file_targets",
+        /// Fallback bucket for unexpected delegation shapes.
+        Unknown = 3 => "unknown",
     }
+
+    pub const CROSS_ARENA_SYMBOL_MISS_SOURCE_COUNT;
+    pub const CROSS_ARENA_SYMBOL_MISS_SOURCE_NAMES;
 }
 
 /// Coarse symbol-kind bucket for `DelegateCrossArenaSymbol` misses.

--- a/crates/tsz-common/src/perf_counters.rs
+++ b/crates/tsz-common/src/perf_counters.rs
@@ -60,55 +60,101 @@ pub fn enabled_fast() -> bool {
     *ENABLED_FAST.get_or_init(|| std::env::var_os("TSZ_PERF_COUNTERS").is_some())
 }
 
-/// Why a `CheckerState::with_parent_cache` (and the matching
-/// `copy_symbol_file_targets_to`) call fired. Each variant pins one specific
-/// call site so the counter dump shows attribution: "X of the 17,329
-/// constructions came from `delegate_cross_arena_symbol_resolution`,
-/// Y came from `jsdoc_type_construction`, ...".
-///
-/// Adding a new reason: add the variant, update `REASON_NAMES` to keep them
-/// aligned, and increase `CHECKER_CREATION_REASON_COUNT`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(usize)]
-pub enum CheckerCreationReason {
-    /// `cross_file.rs::delegate_cross_arena_symbol_resolution` — the headline
-    /// hot path; deep recursion through cross-file type queries.
-    DelegateCrossArenaSymbol = 0,
-    /// `cross_file.rs::delegate_cross_arena_class_instance_type`.
-    DelegateCrossArenaClass = 1,
-    /// `cross_file.rs::delegate_cross_arena_interface_type`.
-    DelegateCrossArenaInterface = 2,
-    /// Other `cross_file.rs` delegate variants (heritage, etc).
-    DelegateCrossArenaOther = 3,
-    /// JSDoc namespace-typedef lookups crossing arenas.
-    JsDocLookup = 4,
-    /// JSDoc type-construction (synthesized object/function shapes).
-    JsDocTypeConstruction = 5,
-    /// CommonJS `module.exports` / `exports.x` resolution + collection.
-    CjsExports = 6,
-    /// Cross-file type alias resolution.
-    AliasResolution = 7,
-    /// `import("…").Foo` indirect import-type resolution.
-    ImportType = 8,
-    /// Type-environment `core.rs` deep resolution helpers.
-    TypeEnvironmentCore = 9,
-    /// `types::queries::callable_truthiness` cross-file fall-through.
-    CallableTruthiness = 10,
-    /// Expando property assignments crossing files.
-    ExpandoProperty = 11,
-    /// `identifier::resolution` cross-file fallback.
-    IdentifierResolution = 12,
-    /// Generic call-helpers cross-file resolution (`call_helpers.rs`).
-    CallHelpers = 13,
-    /// `computed_helpers_binding` deep alias resolution.
-    BindingHelpers = 14,
-    /// `class_abstract_checker` cross-file abstract-method check.
-    ClassAbstract = 15,
-    /// Anything not explicitly classified above.
-    Other = 16,
+// Declarative manifest for enum-backed counter families. Each entry owns the
+// Rust variant, stable numeric index, and dump/JSON display name together so
+// adding a bucket does not require editing parallel count/name tables by hand.
+macro_rules! perf_counter_enum {
+    (
+        $(#[$enum_meta:meta])*
+        pub enum $enum_name:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident = $index:expr => $name:literal,
+            )+
+        }
+
+        pub const $count_name:ident;
+        pub const $names_name:ident;
+    ) => {
+        $(#[$enum_meta])*
+        #[repr(usize)]
+        pub enum $enum_name {
+            $(
+                $(#[$variant_meta])*
+                $variant = $index,
+            )+
+        }
+
+        pub const $count_name: usize = [$($name),+].len();
+
+        pub const $names_name: [&str; $count_name] = [
+            $($name,)+
+        ];
+
+        impl $enum_name {
+            #[inline(always)]
+            pub const fn as_index(self) -> usize {
+                self as usize
+            }
+
+            pub const fn name(self) -> &'static str {
+                $names_name[self as usize]
+            }
+        }
+    };
 }
 
-pub const CHECKER_CREATION_REASON_COUNT: usize = 17;
+perf_counter_enum! {
+    /// Why a `CheckerState::with_parent_cache` (and the matching
+    /// `copy_symbol_file_targets_to`) call fired. Each variant pins one specific
+    /// call site so the counter dump shows attribution: "X of the 17,329
+    /// constructions came from `delegate_cross_arena_symbol_resolution`,
+    /// Y came from `jsdoc_type_construction`, ...".
+    ///
+    /// Adding a new reason: add one manifest entry below. The enum variant, stable
+    /// display name, count, and `REASON_NAMES` order are generated together.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum CheckerCreationReason {
+        /// `cross_file.rs::delegate_cross_arena_symbol_resolution` — the headline
+        /// hot path; deep recursion through cross-file type queries.
+        DelegateCrossArenaSymbol = 0 => "DelegateCrossArenaSymbol",
+        /// `cross_file.rs::delegate_cross_arena_class_instance_type`.
+        DelegateCrossArenaClass = 1 => "DelegateCrossArenaClass",
+        /// `cross_file.rs::delegate_cross_arena_interface_type`.
+        DelegateCrossArenaInterface = 2 => "DelegateCrossArenaInterface",
+        /// Other `cross_file.rs` delegate variants (heritage, etc).
+        DelegateCrossArenaOther = 3 => "DelegateCrossArenaOther",
+        /// JSDoc namespace-typedef lookups crossing arenas.
+        JsDocLookup = 4 => "JsDocLookup",
+        /// JSDoc type-construction (synthesized object/function shapes).
+        JsDocTypeConstruction = 5 => "JsDocTypeConstruction",
+        /// CommonJS `module.exports` / `exports.x` resolution + collection.
+        CjsExports = 6 => "CjsExports",
+        /// Cross-file type alias resolution.
+        AliasResolution = 7 => "AliasResolution",
+        /// `import("…").Foo` indirect import-type resolution.
+        ImportType = 8 => "ImportType",
+        /// Type-environment `core.rs` deep resolution helpers.
+        TypeEnvironmentCore = 9 => "TypeEnvironmentCore",
+        /// `types::queries::callable_truthiness` cross-file fall-through.
+        CallableTruthiness = 10 => "CallableTruthiness",
+        /// Expando property assignments crossing files.
+        ExpandoProperty = 11 => "ExpandoProperty",
+        /// `identifier::resolution` cross-file fallback.
+        IdentifierResolution = 12 => "IdentifierResolution",
+        /// Generic call-helpers cross-file resolution (`call_helpers.rs`).
+        CallHelpers = 13 => "CallHelpers",
+        /// `computed_helpers_binding` deep alias resolution.
+        BindingHelpers = 14 => "BindingHelpers",
+        /// `class_abstract_checker` cross-file abstract-method check.
+        ClassAbstract = 15 => "ClassAbstract",
+        /// Anything not explicitly classified above.
+        Other = 16 => "Other",
+    }
+
+    pub const CHECKER_CREATION_REASON_COUNT;
+    pub const REASON_NAMES;
+}
 
 /// Number of log-spaced buckets in the interner lock-wait histogram.
 /// See `LOCK_WAIT_BUCKET_UPPER_BOUNDS_NS` for the bucket boundaries.
@@ -132,38 +178,6 @@ pub const LOCK_WAIT_BUCKET_UPPER_BOUNDS_NS: [u64; LOCK_WAIT_BUCKET_COUNT] = [
     100_000_000, // < 100 ms
     u64::MAX,    // overflow
 ];
-
-/// Human-readable names, one entry per `CheckerCreationReason` variant.
-/// MUST stay in sync with the enum.
-pub const REASON_NAMES: [&str; CHECKER_CREATION_REASON_COUNT] = [
-    "DelegateCrossArenaSymbol",
-    "DelegateCrossArenaClass",
-    "DelegateCrossArenaInterface",
-    "DelegateCrossArenaOther",
-    "JsDocLookup",
-    "JsDocTypeConstruction",
-    "CjsExports",
-    "AliasResolution",
-    "ImportType",
-    "TypeEnvironmentCore",
-    "CallableTruthiness",
-    "ExpandoProperty",
-    "IdentifierResolution",
-    "CallHelpers",
-    "BindingHelpers",
-    "ClassAbstract",
-    "Other",
-];
-
-impl CheckerCreationReason {
-    #[inline(always)]
-    pub const fn as_index(self) -> usize {
-        self as usize
-    }
-    pub const fn name(self) -> &'static str {
-        REASON_NAMES[self as usize]
-    }
-}
 
 /// How `delegate_cross_arena_symbol_resolution` found the target arena for
 /// a cache miss that must construct a child checker.

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -1601,7 +1601,9 @@ impl<'a> TypeFormatter<'a> {
                     // Class constructor types (callables with construct signatures
                     // linked to a class symbol) should display as "typeof ClassName"
                     // to match tsc behavior. The class instance type displays as
-                    // just "ClassName".
+                    // just "ClassName". A class merged with a same-named namespace
+                    // keeps its class symbol on the rebuilt static shape, so this
+                    // branch renders the merged static side as "typeof C" too.
                     if !shape.construct_signatures.is_empty()
                         && let Some(arena) = self.symbol_arena
                         && let Some(sym) = arena.get(sym_id)

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -2067,6 +2067,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 Some(TypeData::ReadonlyType(inner)) => inner,
                 _ => prop.type_id,
             };
+            let mut captured = false;
             if let Some(nested_shape_id) = match self.interner().lookup(nested_type) {
                 Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
                     Some(shape_id)
@@ -2090,7 +2091,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         return None;
                     }
                     infer_nested = Some((prop.name, nested_name, info));
+                    captured = true;
                 }
+            }
+
+            // A property that still carries an `infer` variable this fast path did
+            // not record (e.g. inside a function parameter, an array, or a nested
+            // object with multiple infers) cannot be modeled here. Defer to the
+            // general `match_infer_pattern` engine, which handles every position
+            // with variance-aware candidate merging.
+            if !captured && self.type_contains_infer(prop.type_id) {
+                return None;
             }
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -361,60 +361,98 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
-    /// Collect the names of `infer` type variables that appear in contravariant
-    /// positions (function/callable parameter types) within `pattern`.
+    /// Collect the names of `infer` type variables that appear in any
+    /// contravariant position within `pattern`.
     ///
-    /// Used when matching a union source against a pattern: infer variables in
-    /// covariant positions merge via union, contravariant via intersection.
-    fn collect_contravariant_infer_names(&self, pattern: TypeId) -> FxHashSet<Atom> {
+    /// A position is contravariant when it is reached through an odd number of
+    /// function/callable parameter positions (parameters flip variance, return
+    /// types and object/array/tuple members preserve it). When the same `infer`
+    /// name receives candidates from structurally separate positions, names in
+    /// this set merge their candidates via intersection; all others via union.
+    /// This mirrors tsc's `inferTypes`, where a type variable with any
+    /// contravariant occurrence produces an intersection of its candidates.
+    pub(crate) fn collect_contravariant_infer_names(&self, pattern: TypeId) -> FxHashSet<Atom> {
         let mut result = FxHashSet::default();
-        self.collect_infer_names_in_params(pattern, &mut result);
+        let mut visited = FxHashSet::default();
+        self.collect_variance_infer_names(pattern, false, &mut result, &mut visited);
         result
     }
 
-    /// Recursively find `Infer` nodes inside function/callable parameter types.
-    fn collect_infer_names_in_params(&self, ty: TypeId, out: &mut FxHashSet<Atom>) {
-        match self.interner().lookup(ty) {
-            Some(TypeData::Function(fn_id)) => {
-                let shape = self.interner().function_shape(fn_id);
-                for param in &shape.params {
-                    self.collect_all_infer_names(param.type_id, out);
-                }
-            }
-            Some(TypeData::Callable(callable_id)) => {
-                let shape = self.interner().callable_shape(callable_id);
-                for sig in &shape.call_signatures {
-                    for param in &sig.params {
-                        self.collect_all_infer_names(param.type_id, out);
-                    }
-                }
-                for sig in &shape.construct_signatures {
-                    for param in &sig.params {
-                        self.collect_all_infer_names(param.type_id, out);
-                    }
-                }
-            }
-            _ => {}
+    /// Walk `ty`, tracking whether the current position is contravariant, and
+    /// record the names of `infer` variables found in a contravariant position.
+    fn collect_variance_infer_names(
+        &self,
+        ty: TypeId,
+        contravariant: bool,
+        out: &mut FxHashSet<Atom>,
+        visited: &mut FxHashSet<(TypeId, bool)>,
+    ) {
+        if ty.is_intrinsic() || !visited.insert((ty, contravariant)) {
+            return;
         }
-    }
-
-    /// Collect all `Infer` names reachable from `ty` (any variance).
-    fn collect_all_infer_names(&self, ty: TypeId, out: &mut FxHashSet<Atom>) {
         match self.interner().lookup(ty) {
-            Some(TypeData::Infer(info)) => {
+            Some(TypeData::Infer(info)) if contravariant => {
                 out.insert(info.name);
             }
             Some(TypeData::Union(members) | TypeData::Intersection(members)) => {
                 for &m in self.interner().type_list(members).iter() {
-                    self.collect_all_infer_names(m, out);
+                    self.collect_variance_infer_names(m, contravariant, out, visited);
                 }
             }
             Some(TypeData::Array(elem)) => {
-                self.collect_all_infer_names(elem, out);
+                self.collect_variance_infer_names(elem, contravariant, out, visited);
+            }
+            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
+                self.collect_variance_infer_names(inner, contravariant, out, visited);
             }
             Some(TypeData::Tuple(elements)) => {
                 for elem in self.interner().tuple_list(elements).iter() {
-                    self.collect_all_infer_names(elem.type_id, out);
+                    self.collect_variance_infer_names(elem.type_id, contravariant, out, visited);
+                }
+            }
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = self.interner().object_shape(shape_id);
+                for prop in &shape.properties {
+                    self.collect_variance_infer_names(prop.type_id, contravariant, out, visited);
+                }
+                for index in [shape.string_index.as_ref(), shape.number_index.as_ref()]
+                    .into_iter()
+                    .flatten()
+                {
+                    self.collect_variance_infer_names(
+                        index.value_type,
+                        contravariant,
+                        out,
+                        visited,
+                    );
+                }
+            }
+            Some(TypeData::Function(fn_id)) => {
+                let shape = self.interner().function_shape(fn_id);
+                for param in &shape.params {
+                    self.collect_variance_infer_names(param.type_id, !contravariant, out, visited);
+                }
+                self.collect_variance_infer_names(shape.return_type, contravariant, out, visited);
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                let shape = self.interner().callable_shape(callable_id);
+                for sig in shape
+                    .call_signatures
+                    .iter()
+                    .chain(shape.construct_signatures.iter())
+                {
+                    for param in &sig.params {
+                        self.collect_variance_infer_names(
+                            param.type_id,
+                            !contravariant,
+                            out,
+                            visited,
+                        );
+                    }
+                    self.collect_variance_infer_names(sig.return_type, contravariant, out, visited);
+                }
+                for prop in &shape.properties {
+                    self.collect_variance_infer_names(prop.type_id, contravariant, out, visited);
                 }
             }
             _ => {}
@@ -869,6 +907,42 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         true
     }
 
+    /// Merge the candidate bindings produced by one structural position
+    /// (`local`) into the accumulator (`merged`), relative to the pre-existing
+    /// bindings (`base`).
+    ///
+    /// Names already present in `base` are left untouched (they were resolved by
+    /// an outer context). For a name that gains a second, distinct candidate, the
+    /// merge intersects when the name occurs in any contravariant position of the
+    /// surrounding pattern (`contravariant_infers`) and unions otherwise.
+    pub(crate) fn merge_infer_candidates(
+        &self,
+        base: &FxHashMap<Atom, TypeId>,
+        merged: &mut FxHashMap<Atom, TypeId>,
+        local: FxHashMap<Atom, TypeId>,
+        contravariant_infers: &FxHashSet<Atom>,
+    ) {
+        for (name, ty) in local {
+            if base.contains_key(&name) {
+                continue;
+            }
+            match merged.get_mut(&name) {
+                Some(existing) => {
+                    if *existing != ty {
+                        *existing = if contravariant_infers.contains(&name) {
+                            self.interner().intersection2(*existing, ty)
+                        } else {
+                            self.interner().union2(*existing, ty)
+                        };
+                    }
+                }
+                None => {
+                    merged.insert(name, ty);
+                }
+            }
+        }
+    }
+
     /// Match tuple elements against a pattern, extracting infer bindings.
     pub(crate) fn match_tuple_elements(
         &self,
@@ -1245,24 +1319,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 if !self.match_infer_pattern(member, pattern, &mut local, visited, checker) {
                     return false;
                 }
-
-                for (name, ty) in local {
-                    if base.contains_key(&name) {
-                        continue;
-                    }
-
-                    if let Some(existing) = merged.get_mut(&name) {
-                        if *existing != ty {
-                            if contravariant_infers.contains(&name) {
-                                *existing = self.interner().intersection2(*existing, ty);
-                            } else {
-                                *existing = self.interner().union2(*existing, ty);
-                            }
-                        }
-                    } else {
-                        merged.insert(name, ty);
-                    }
-                }
+                self.merge_infer_candidates(&base, &mut merged, local, &contravariant_infers);
             }
 
             *bindings = merged;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -13,7 +13,8 @@ use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
     CallableShapeId, FunctionShape, FunctionShapeId, IntrinsicKind, LiteralValue, ObjectShapeId,
-    ParamInfo, TemplateSpan, TupleElement, TypeData, TypeId, TypeListId, TypeParamInfo,
+    ParamInfo, PropertyInfo, TemplateSpan, TupleElement, TypeData, TypeId, TypeListId,
+    TypeParamInfo,
 };
 use crate::utils;
 use crate::visitor::array_element_type;
@@ -1629,6 +1630,66 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Match each pattern property against the corresponding source property,
+    /// extracting infer bindings with variance-aware merging.
+    ///
+    /// Each property is matched against a fresh copy of the incoming bindings so
+    /// that the order of properties does not affect the result, then its
+    /// candidates are merged via [`Self::merge_infer_candidates`]. When the same
+    /// `infer` name appears in both a covariant property slot and a contravariant
+    /// one (e.g. `{ v: infer U; f: (x: infer U) => void }`), the candidates are
+    /// intersected rather than failing the match through `bind_infer`'s
+    /// equality requirement — matching tsc, which infers `string & number` here.
+    fn match_infer_object_properties(
+        &self,
+        source_props: &[PropertyInfo],
+        pattern_props: &[PropertyInfo],
+        pattern: TypeId,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
+        let contravariant_infers = self.collect_contravariant_infer_names(pattern);
+        let base = bindings.clone();
+        let mut merged = base.clone();
+        for pattern_prop in pattern_props {
+            let source_prop = source_props
+                .iter()
+                .find(|prop| prop.name == pattern_prop.name);
+            let source_type = match source_prop {
+                Some(source_prop) => {
+                    if self.type_contains_infer(pattern_prop.type_id) {
+                        source_prop.type_id
+                    } else {
+                        self.optional_property_type(source_prop)
+                    }
+                }
+                None => {
+                    if !pattern_prop.optional {
+                        return false;
+                    }
+                    if !self.type_contains_infer(pattern_prop.type_id) {
+                        continue;
+                    }
+                    TypeId::UNDEFINED
+                }
+            };
+            let mut local = base.clone();
+            let mut local_visited = FxHashSet::default();
+            if !self.match_infer_pattern(
+                source_type,
+                pattern_prop.type_id,
+                &mut local,
+                &mut local_visited,
+                checker,
+            ) {
+                return false;
+            }
+            self.merge_infer_candidates(&base, &mut merged, local, &contravariant_infers);
+        }
+        *bindings = merged;
+        true
+    }
+
     /// Helper for matching object type patterns.
     pub(crate) fn match_infer_object_pattern(
         &self,
@@ -1646,42 +1707,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let initial_binding_len = bindings.len();
                 let source_shape = self.interner().object_shape(source_shape_id);
                 let pattern_shape = self.interner().object_shape(pattern_shape_id);
-                for pattern_prop in &pattern_shape.properties {
-                    let source_prop = source_shape
-                        .properties
-                        .iter()
-                        .find(|prop| prop.name == pattern_prop.name);
-                    let Some(source_prop) = source_prop else {
-                        if pattern_prop.optional {
-                            if self.type_contains_infer(pattern_prop.type_id)
-                                && !self.match_infer_pattern(
-                                    TypeId::UNDEFINED,
-                                    pattern_prop.type_id,
-                                    bindings,
-                                    visited,
-                                    checker,
-                                )
-                            {
-                                return false;
-                            }
-                            continue;
-                        }
-                        return false;
-                    };
-                    let source_type = if self.type_contains_infer(pattern_prop.type_id) {
-                        source_prop.type_id
-                    } else {
-                        self.optional_property_type(source_prop)
-                    };
-                    if !self.match_infer_pattern(
-                        source_type,
-                        pattern_prop.type_id,
-                        bindings,
-                        visited,
-                        checker,
-                    ) {
-                        return false;
-                    }
+                if !self.match_infer_object_properties(
+                    &source_shape.properties,
+                    &pattern_shape.properties,
+                    pattern,
+                    bindings,
+                    checker,
+                ) {
+                    return false;
                 }
                 if bindings.len() == initial_binding_len
                     && self.type_contains_infer(pattern)
@@ -2002,42 +2035,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 TypeData::Object(source_shape_id) | TypeData::ObjectWithIndex(source_shape_id),
             ) => {
                 let source_shape = self.interner().object_shape(source_shape_id);
-                for pattern_prop in &pattern_shape.properties {
-                    let source_prop = source_shape
-                        .properties
-                        .iter()
-                        .find(|prop| prop.name == pattern_prop.name);
-                    let Some(source_prop) = source_prop else {
-                        if pattern_prop.optional {
-                            if self.type_contains_infer(pattern_prop.type_id)
-                                && !self.match_infer_pattern(
-                                    TypeId::UNDEFINED,
-                                    pattern_prop.type_id,
-                                    bindings,
-                                    visited,
-                                    checker,
-                                )
-                            {
-                                return false;
-                            }
-                            continue;
-                        }
-                        return false;
-                    };
-                    let source_type = if self.type_contains_infer(pattern_prop.type_id) {
-                        source_prop.type_id
-                    } else {
-                        self.optional_property_type(source_prop)
-                    };
-                    if !self.match_infer_pattern(
-                        source_type,
-                        pattern_prop.type_id,
-                        bindings,
-                        visited,
-                        checker,
-                    ) {
-                        return false;
-                    }
+                if !self.match_infer_object_properties(
+                    &source_shape.properties,
+                    &pattern_shape.properties,
+                    pattern,
+                    bindings,
+                    checker,
+                ) {
+                    return false;
                 }
 
                 if let Some(pattern_index) = &pattern_shape.string_index {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -513,6 +513,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         self.interner().union(key_types)
                     }
                 }
+                // A bare function type (`() => T`, `(x: U) => V`,
+                // `<U>(u: U) => U`) has no own properties or index signatures,
+                // so its key space is empty.  `Callable` with only construct
+                // signatures already collapses to `never` via the arm above;
+                // `Function` must do the same for `extends never` /
+                // `Equal<keyof Fn, never>` parity with tsc.
+                TypeData::Function(_) => TypeId::NEVER,
                 TypeData::Array(_) => self.interner().union(self.array_keyof_keys()),
                 TypeData::Tuple(elements) => {
                     let elements = self.interner().tuple_list(elements);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -437,9 +437,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         return self.evaluate_mapped_array(mapped, element_type);
                     }
 
-                    // Tuple type: map each element
+                    // Tuple type: map each element. Source is mutable, so the
+                    // result is readonly only if the modifier adds `+readonly`.
                     Some(TypeData::Tuple(tuple_id)) => {
-                        return self.evaluate_mapped_tuple(mapped, tuple_id);
+                        return self.evaluate_mapped_tuple_with_readonly(mapped, tuple_id, false);
+                    }
+
+                    // `readonly [a, b]`: map each element and preserve readonly
+                    // unless the modifier strips it (`-readonly`).
+                    Some(TypeData::ReadonlyType(inner)) => {
+                        if let Some(TypeData::Tuple(tuple_id)) = self.interner().lookup(inner) {
+                            return self
+                                .evaluate_mapped_tuple_with_readonly(mapped, tuple_id, true);
+                        }
                     }
 
                     // ReadonlyArray: map the element type and preserve readonly
@@ -1171,7 +1181,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 tracing::trace!(
                     "evaluate_mapped: tuple-constrained type parameter → producing tuple"
                 );
-                Some(self.evaluate_mapped_tuple(mapped, tuple_id))
+                Some(self.evaluate_mapped_tuple_with_readonly(mapped, tuple_id, false))
             }
             // `readonly [a, b]` or `ReadonlyArray<T>` — preserve readonly wrapper
             Some(TypeData::ReadonlyType(inner)) => match self.interner().lookup(inner) {
@@ -1179,14 +1189,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     tracing::trace!(
                         "evaluate_mapped: readonly-tuple-constrained type parameter → producing readonly tuple"
                     );
-                    let mapped_tuple = self.evaluate_mapped_tuple(mapped, tuple_id);
-                    let final_readonly =
-                        !matches!(mapped.readonly_modifier, Some(MappedModifier::Remove));
-                    if final_readonly {
-                        Some(self.interner().readonly_type(mapped_tuple))
-                    } else {
-                        Some(mapped_tuple)
-                    }
+                    Some(self.evaluate_mapped_tuple_with_readonly(mapped, tuple_id, true))
                 }
                 Some(TypeData::Array(element_type)) => {
                     tracing::trace!(
@@ -2010,6 +2013,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Evaluate a homomorphic mapped type over a Tuple type, applying the
+    /// mapped type's `readonly` modifier at the tuple level.
+    ///
+    /// A tuple's readonly-ness is a property of the whole tuple (via the
+    /// `ReadonlyType` wrapper), not of individual elements, so the modifier is
+    /// resolved here with the standard homomorphic rule:
+    /// `+readonly` => readonly, `-readonly` => mutable, none => preserve the
+    /// source's readonly-ness (`source_readonly`). This mirrors
+    /// [`Self::evaluate_mapped_array_with_readonly`].
+    fn evaluate_mapped_tuple_with_readonly(
+        &mut self,
+        mapped: &MappedType,
+        tuple_id: TupleListId,
+        source_readonly: bool,
+    ) -> TypeId {
+        let mapped_tuple = self.evaluate_mapped_tuple(mapped, tuple_id);
+        let final_readonly = match mapped.readonly_modifier {
+            Some(MappedModifier::Add) => true,
+            Some(MappedModifier::Remove) => false,
+            None => source_readonly,
+        };
+        if final_readonly {
+            self.interner().readonly_type(mapped_tuple)
+        } else {
+            mapped_tuple
+        }
+    }
+
     /// Evaluate a homomorphic mapped type over a Tuple type.
     ///
     /// For example: `type Partial<T> = { [P in keyof T]?: T[P] }`
@@ -2017,6 +2048,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ///
     /// We instantiate the template with `K = 0, 1, 2...` for each tuple element.
     /// This preserves tuple structure including optional and rest elements.
+    /// The result is always a mutable tuple; the `readonly` modifier is applied
+    /// by [`Self::evaluate_mapped_tuple_with_readonly`] at the tuple level.
     fn evaluate_mapped_tuple(&mut self, mapped: &MappedType, tuple_id: TupleListId) -> TypeId {
         use crate::types::TupleElement;
 
@@ -2076,17 +2109,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let mapped_type =
                 self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
 
-            // Get the modifiers for this element
-            // Note: readonly is currently unused for tuple elements, but we preserve the logic
-            // in case TypeScript adds readonly tuple element support in the future
-            // CRITICAL: Handle optional and readonly modifiers independently
+            // Per-element readonly is not representable on a `TupleElement`; the
+            // mapped type's readonly modifier is applied at the tuple level by
+            // `evaluate_mapped_tuple_with_readonly`.
             let optional = match mapped.optional_modifier {
                 Some(MappedModifier::Add) => true,
                 Some(MappedModifier::Remove) => false,
                 None => elem.optional, // Preserve original optional
             };
-            // Note: readonly modifier is intentionally ignored for tuple elements,
-            // as TypeScript doesn't support readonly on individual tuple elements.
 
             mapped_elements.push(TupleElement {
                 type_id: mapped_type,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
@@ -48,6 +48,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.interner().union(transformed)
             }
 
+            // `never` is the empty union. String mappings distribute over their
+            // union argument (tsc maps `Union | Never` member-wise), and mapping
+            // zero members yields zero members, so `Uppercase<never>` = `never`.
+            // This is the empty-union edge of the distribution handled above; it
+            // cannot arrive as a `Union` member because `never` is absorbed out
+            // of non-empty unions, so it needs its own arm.
+            TypeData::Intrinsic(IntrinsicKind::Never) => TypeId::NEVER,
+
+            // `any` is not transformable, not generic, and not a pattern-literal
+            // placeholder, so tsc's `getStringMappingType` returns the argument
+            // unchanged: `Uppercase<any>` = `any`. Falling through to the error
+            // arm below would otherwise turn this into `error`.
+            TypeData::Intrinsic(IntrinsicKind::Any) => evaluated_arg,
+
             // String literal types - apply the transformation
             TypeData::Literal(LiteralValue::String(atom)) => {
                 let s = self.interner().resolve_atom_ref(atom);

--- a/crates/tsz-solver/src/intern/template.rs
+++ b/crates/tsz-solver/src/intern/template.rs
@@ -499,6 +499,15 @@ impl TypeInterner {
         // `getTemplateLiteralType` "Normalize `${Mapping<xxx>}` into Mapping<xxx>".
         if let [TemplateSpan::Type(only_type)] = normalized.as_slice() {
             let only_type = *only_type;
+            // A lone `${string}` placeholder spans the entire `string` domain,
+            // so the template is mutually assignable with — and `Equal` to —
+            // `string`. tsc's `getTemplateLiteralType` collapses it to
+            // `string`. (`number`/`bigint` are proper subsets and stay
+            // templates; `any`/`unknown` are handled by the absorption passes
+            // above.)
+            if only_type == TypeId::STRING {
+                return TypeId::STRING;
+            }
             if self.is_pattern_literal_type(only_type) {
                 return only_type;
             }

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -192,7 +192,7 @@ pub mod computation {
         get_contextual_signature_cached_with_compat_checker,
         get_contextual_signature_for_arity_cached_with_compat_checker,
         get_contextual_signature_for_arity_with_compat_checker,
-        get_contextual_signature_with_compat_checker,
+        get_contextual_signature_with_compat_checker, overload_failure_return_type,
     };
 }
 

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1848,16 +1848,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         // If we got here, no signature matched.
-        // Use the last overload signature's return type as the fallback (matching
-        // tsc behavior). tsc uses the last declaration's return type for error
-        // recovery, allowing downstream code to see the expected shape. For
-        // example, `[].concat(...)` on `never[]` should still produce `never[]`,
-        // not `never`, so that chained `.map()` resolves correctly.
-        let fallback_return = callable
-            .call_signatures
-            .last()
-            .map(|s| s.return_type)
-            .unwrap_or(TypeId::NEVER);
+        let fallback_return =
+            overload_failure_return_type(self.interner, &callable.call_signatures);
         CallResult::NoOverloadMatch {
             func_type: self.interner.callable(callable.clone()),
             arg_types: arg_types.to_vec(),
@@ -1865,6 +1857,34 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             fallback_return,
         }
     }
+}
+
+/// Compute the result type of a call expression that matched no overload
+/// signature, mirroring tsc's `createUnionOfSignaturesForOverloadFailure`:
+/// `getIntersectionType(candidates.map(getReturnTypeOfSignature))`.
+///
+/// The intersection makes disjoint primitive returns (`string` & `number`)
+/// collapse to `never` — assignable to any annotation, so it suppresses
+/// downstream cascades after the TS2769 already reported — while compatible
+/// object returns merge (`{ a }` & `{ b }`) so member access still resolves and
+/// uniform returns survive intact for chained access.
+///
+/// Generic overloads need per-candidate instantiation for an accurate recovery
+/// type; intersecting their un-instantiated return types (still carrying free
+/// type parameters) would mislead, so those keep the simpler last-signature
+/// recovery type.
+pub fn overload_failure_return_type(
+    db: &dyn QueryDatabase,
+    signatures: &[CallSignature],
+) -> TypeId {
+    let Some(last) = signatures.last() else {
+        return TypeId::NEVER;
+    };
+    if signatures.iter().any(|sig| !sig.type_params.is_empty()) {
+        return last.return_type;
+    }
+    db.factory()
+        .intersection(signatures.iter().map(|sig| sig.return_type).collect())
 }
 
 pub fn infer_call_signature<C: AssignabilityChecker>(

--- a/crates/tsz-solver/src/operations/mod.rs
+++ b/crates/tsz-solver/src/operations/mod.rs
@@ -60,7 +60,8 @@ pub use self::core::{
     get_contextual_signature_for_arity_cached_with_compat_checker,
     get_contextual_signature_for_arity_with_compat_checker,
     get_contextual_signature_with_compat_checker, infer_call_signature, infer_generic_function,
-    resolve_call_with_checker, resolve_call_with_checker_and_arg_sources, resolve_new_with_checker,
+    overload_failure_return_type, resolve_call_with_checker,
+    resolve_call_with_checker_and_arg_sources, resolve_new_with_checker,
 };
 
 pub use generic_call::{GenericCallRequest, GenericCallResult};

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -29,8 +29,8 @@ use crate::visitor::{
     enum_components, function_shape_id, index_access_parts, intersection_list_id, intrinsic_kind,
     is_this_type, keyof_inner_type, lazy_def_id, literal_value, mapped_type_id, object_shape_id,
     object_with_index_shape_id, readonly_inner_type, string_intrinsic_components,
-    template_literal_id, tuple_list_id, type_param_info, type_query_symbol, union_list_id,
-    unique_symbol_ref,
+    template_literal_id, template_literal_spans_full_string_domain, tuple_list_id, type_param_info,
+    type_query_symbol, union_list_id, unique_symbol_ref,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::limits;
@@ -1510,6 +1510,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         if let Some(s_kind) = intrinsic_kind(self.interner, source) {
             if self.is_boxed_primitive_subtype(s_kind, target) {
+                return SubtypeResult::True;
+            }
+            // `string` is assignable to a template literal that spans the full
+            // string domain (e.g. `` `${string}${string}` ``): any string can
+            // be partitioned across the all-`${string}` placeholders. A lone
+            // `${string}` already collapses to `string` at construction, so
+            // this covers the multi-placeholder case. Mirrors tsc, which treats
+            // such a template as mutually assignable with `string`.
+            if s_kind == IntrinsicKind::String
+                && template_literal_spans_full_string_domain(self.interner, target)
+            {
                 return SubtypeResult::True;
             }
             // `object` keyword is structurally equivalent to `{}` (empty object).

--- a/crates/tsz-solver/src/tests/classify_index_key_tests.rs
+++ b/crates/tsz-solver/src/tests/classify_index_key_tests.rs
@@ -59,15 +59,29 @@ fn classify_template_literal_number_is_numeric_string() {
 
 #[test]
 fn classify_template_literal_string_is_template_string() {
-    // `${string}` should be classified as TemplateLiteralString
     let interner = TypeInterner::new();
-    let tl = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
+
+    // A lone `${string}` spans the full string domain and collapses to
+    // `string` at construction, so it classifies as a plain string key.
+    let bare = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
+    assert_eq!(bare, TypeId::STRING);
+    assert!(
+        matches!(classify_index_key(&interner, bare), IndexKeyKind::String),
+        "`${{string}}` collapses to `string` and classifies as String"
+    );
+
+    // A template with literal text stays a template literal and classifies
+    // as TemplateLiteralString.
+    let tl = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("a")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
     assert!(
         matches!(
             classify_index_key(&interner, tl),
             IndexKeyKind::TemplateLiteralString
         ),
-        "Template literal `${{string}}` should be TemplateLiteralString"
+        "Template literal `a${{string}}` should be TemplateLiteralString"
     );
 }
 

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -17,13 +17,13 @@
 solver_max_loc      3381
 solver_oversized    20
 solver_file_generic_call_resolve 3381
-solver_file_eval_conditional 3069
+solver_file_eval_conditional 3118
 solver_file_evaluate 3102
 solver_file_instantiate 2872
 solver_file_subtype_core 2860
 solver_file_type_queries_flow 2834
 solver_file_diag_format_compound 2763
-solver_file_eval_infer_pattern_helpers 2728
+solver_file_eval_infer_pattern_helpers 2738
 solver_file_narrowing_core 2702
 solver_file_relations_compat 2577
 solver_file_constraints_walker 2348

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -335,6 +335,26 @@ pub fn intrinsic_kind(types: &dyn TypeDatabase, type_id: TypeId) -> Option<Intri
     }
 }
 
+/// Returns true when a template-literal type spans the entire `string`
+/// domain — i.e. every span is a `${string}` placeholder with no literal
+/// text. Such a template is mutually assignable with `string` (e.g.
+/// `` `${string}${string}` ``). A lone `${string}` collapses to `string`
+/// at construction, so this predicate is chiefly relevant for the
+/// multi-placeholder case.
+pub fn template_literal_spans_full_string_domain(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    let Some(list_id) = template_literal_id(types, type_id) else {
+        return false;
+    };
+    let spans = types.template_list(list_id);
+    !spans.is_empty()
+        && spans
+            .iter()
+            .all(|span| matches!(span, TemplateSpan::Type(t) if *t == TypeId::STRING))
+}
+
 /// Extract the literal value if this is a literal type.
 #[inline]
 pub fn literal_value(types: &dyn TypeDatabase, type_id: TypeId) -> Option<LiteralValue> {

--- a/crates/tsz-solver/tests/conditional_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/conditional_comprehensive_tests.rs
@@ -3086,6 +3086,185 @@ fn test_colocated_infer_three_function_params_intersect_renamed() {
     assert_eq!(result, expected);
 }
 
+// =============================================================================
+// Cross-position infer variance (#9700). A single `infer` name appearing in
+// both a covariant slot (object property) and a contravariant slot (function
+// parameter) must intersect its candidates, matching tsc's `inferTypes`:
+// when a type variable has any contravariant occurrence its candidates are
+// intersected, otherwise they are unioned.
+// =============================================================================
+
+fn make_obj(interner: &TypeInterner, props: &[(&str, TypeId)]) -> TypeId {
+    let props = props
+        .iter()
+        .map(|(name, ty)| PropertyInfo::new(interner.intern_string(name), *ty))
+        .collect();
+    interner.object(props)
+}
+
+/// `{ v: string; f: (x: number) => void }` extends
+/// `{ v: infer U; f: (x: infer U) => void } ? U : never`.
+/// `U` is covariant in `v` and contravariant in `f`'s parameter, so the
+/// candidates intersect: `U = string & number`.
+#[test]
+fn test_infer_covariant_prop_contravariant_param_intersects() {
+    let interner = TypeInterner::new();
+    let infer_u = make_infer(&interner, "U");
+
+    let extends_obj = make_obj(
+        &interner,
+        &[
+            ("v", infer_u),
+            ("f", make_void_fn(&interner, &[("x", infer_u)])),
+        ],
+    );
+    let check_obj = make_obj(
+        &interner,
+        &[
+            ("v", TypeId::STRING),
+            ("f", make_void_fn(&interner, &[("x", TypeId::NUMBER)])),
+        ],
+    );
+    let cond = ConditionalType {
+        check_type: check_obj,
+        extends_type: extends_obj,
+        true_type: infer_u,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+
+    assert_eq!(
+        result,
+        interner.intersection2(TypeId::STRING, TypeId::NUMBER)
+    );
+}
+
+/// Same rule, renamed type variable and renamed properties — proves the fix is
+/// structural and not keyed on `U`/`v`/`f`.
+#[test]
+fn test_infer_covariant_prop_contravariant_param_intersects_renamed() {
+    let interner = TypeInterner::new();
+    let infer_q = make_infer(&interner, "Q");
+
+    let extends_obj = make_obj(
+        &interner,
+        &[
+            ("a", infer_q),
+            ("g", make_void_fn(&interner, &[("p", infer_q)])),
+        ],
+    );
+    let check_obj = make_obj(
+        &interner,
+        &[
+            ("a", TypeId::STRING),
+            ("g", make_void_fn(&interner, &[("p", TypeId::NUMBER)])),
+        ],
+    );
+    let cond = ConditionalType {
+        check_type: check_obj,
+        extends_type: extends_obj,
+        true_type: infer_q,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+
+    assert_eq!(
+        result,
+        interner.intersection2(TypeId::STRING, TypeId::NUMBER)
+    );
+}
+
+/// Same shape but with matching candidates: covariant `string` and contravariant
+/// `string` intersect to `string` — no spurious narrowing to `never`.
+#[test]
+fn test_infer_covariant_prop_contravariant_param_same_candidate() {
+    let interner = TypeInterner::new();
+    let infer_u = make_infer(&interner, "U");
+
+    let extends_obj = make_obj(
+        &interner,
+        &[
+            ("v", infer_u),
+            ("f", make_void_fn(&interner, &[("x", infer_u)])),
+        ],
+    );
+    let check_obj = make_obj(
+        &interner,
+        &[
+            ("v", TypeId::STRING),
+            ("f", make_void_fn(&interner, &[("x", TypeId::STRING)])),
+        ],
+    );
+    let cond = ConditionalType {
+        check_type: check_obj,
+        extends_type: extends_obj,
+        true_type: infer_u,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+
+    assert_eq!(result, TypeId::STRING);
+}
+
+/// Pure-covariant control: two property slots with no contravariant occurrence
+/// must still union (not intersect).
+#[test]
+fn test_infer_two_covariant_props_still_union() {
+    let interner = TypeInterner::new();
+    let infer_u = make_infer(&interner, "U");
+
+    let extends_obj = make_obj(&interner, &[("v", infer_u), ("w", infer_u)]);
+    let check_obj = make_obj(&interner, &[("v", TypeId::STRING), ("w", TypeId::NUMBER)]);
+    let cond = ConditionalType {
+        check_type: check_obj,
+        extends_type: extends_obj,
+        true_type: infer_u,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+
+    assert_eq!(result, interner.union2(TypeId::STRING, TypeId::NUMBER));
+}
+
+/// A return-position `infer` stays covariant even when the same object also has
+/// a contravariant parameter occurrence for a *different* variable: `R` (return)
+/// unions, `A` (parameter) is unaffected here. Confirms variance is tracked
+/// per-name and that return positions do not flip.
+#[test]
+fn test_infer_return_position_is_covariant() {
+    let interner = TypeInterner::new();
+    let infer_r = make_infer(&interner, "R");
+
+    // { g: () => infer R; h: () => infer R }
+    let g_fn = interner.function(crate::types::FunctionShape::new(Vec::new(), infer_r));
+    let h_fn = interner.function(crate::types::FunctionShape::new(Vec::new(), infer_r));
+    let extends_obj = make_obj(&interner, &[("g", g_fn), ("h", h_fn)]);
+
+    let check_g = interner.function(crate::types::FunctionShape::new(Vec::new(), TypeId::STRING));
+    let check_h = interner.function(crate::types::FunctionShape::new(Vec::new(), TypeId::NUMBER));
+    let check_obj = make_obj(&interner, &[("g", check_g), ("h", check_h)]);
+
+    let cond = ConditionalType {
+        check_type: check_obj,
+        extends_type: extends_obj,
+        true_type: infer_r,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+
+    assert_eq!(result, interner.union2(TypeId::STRING, TypeId::NUMBER));
+}
+
 #[test]
 fn function_intrinsic_extends_callable_in_conditional_types() {
     use crate::types::{FunctionShape, ParamInfo};

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -34222,6 +34222,113 @@ fn test_distributive_intrinsic_union() {
 }
 
 #[test]
+fn test_string_intrinsic_over_never_is_never() {
+    use crate::StringIntrinsicKind;
+
+    // `never` is the empty union; mapping zero members yields `never`.
+    // All four intrinsics must agree: Uppercase/Lowercase/Capitalize/Uncapitalize<never> = never.
+    let interner = TypeInterner::new();
+    for kind in [
+        StringIntrinsicKind::Uppercase,
+        StringIntrinsicKind::Lowercase,
+        StringIntrinsicKind::Capitalize,
+        StringIntrinsicKind::Uncapitalize,
+    ] {
+        let intrinsic = interner.string_intrinsic(kind, TypeId::NEVER);
+        let result = evaluate_type(&interner, intrinsic);
+        assert_eq!(
+            result,
+            TypeId::NEVER,
+            "string mapping {kind:?} over never should evaluate to never"
+        );
+    }
+}
+
+#[test]
+fn test_string_intrinsic_over_any_is_any() {
+    use crate::StringIntrinsicKind;
+
+    // `any` is not transformable / generic / a placeholder, so tsc returns the
+    // argument unchanged: Uppercase<any> = any (not `error`).
+    let interner = TypeInterner::new();
+    for kind in [
+        StringIntrinsicKind::Uppercase,
+        StringIntrinsicKind::Lowercase,
+        StringIntrinsicKind::Capitalize,
+        StringIntrinsicKind::Uncapitalize,
+    ] {
+        let intrinsic = interner.string_intrinsic(kind, TypeId::ANY);
+        let result = evaluate_type(&interner, intrinsic);
+        assert_eq!(
+            result,
+            TypeId::ANY,
+            "string mapping {kind:?} over any should evaluate to any"
+        );
+    }
+}
+
+#[test]
+fn test_string_intrinsic_non_empty_union_still_distributes() {
+    use crate::StringIntrinsicKind;
+
+    // Guard against over-broad short-circuiting: a non-empty union must still
+    // distribute member-wise, and an absorbed `never` member must not collapse
+    // the whole union to `never`.
+    let interner = TypeInterner::new();
+    let lit_a = interner.literal_string("a");
+    let lit_b = interner.literal_string("b");
+    let lit_upper_a = interner.literal_string("A");
+    let lit_upper_b = interner.literal_string("B");
+
+    let union_ab = interner.union(vec![lit_a, lit_b]);
+    let intrinsic = interner.string_intrinsic(StringIntrinsicKind::Uppercase, union_ab);
+    let result = evaluate_type(&interner, intrinsic);
+    let expected = interner.union(vec![lit_upper_a, lit_upper_b]);
+    assert_eq!(
+        result, expected,
+        "Uppercase<\"a\" | \"b\"> should be \"A\" | \"B\""
+    );
+
+    // `never` is absorbed when building the union, so this is identical to `"a"`.
+    let union_with_never = interner.union(vec![lit_a, TypeId::NEVER]);
+    let intrinsic2 = interner.string_intrinsic(StringIntrinsicKind::Uppercase, union_with_never);
+    let result2 = evaluate_type(&interner, intrinsic2);
+    assert_eq!(
+        result2, lit_upper_a,
+        "never absorbed in a union must not collapse the result to never"
+    );
+}
+
+#[test]
+fn test_string_intrinsic_over_type_param_stays_deferred() {
+    use crate::StringIntrinsicKind;
+
+    // Negative/fallback case: a generic type parameter argument must remain a
+    // deferred `StringIntrinsic`, not collapse to never or an error.
+    let interner = TypeInterner::new();
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("S"),
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    }));
+    let intrinsic = interner.string_intrinsic(StringIntrinsicKind::Uppercase, t_param);
+    let result = evaluate_type(&interner, intrinsic);
+    assert!(
+        matches!(
+            interner.lookup(result),
+            Some(TypeData::StringIntrinsic {
+                kind: StringIntrinsicKind::Uppercase,
+                ..
+            })
+        ),
+        "Uppercase<S> over a type parameter should stay deferred"
+    );
+    assert_ne!(result, TypeId::NEVER);
+    assert_ne!(result, TypeId::ERROR);
+}
+
+#[test]
 fn test_distributive_function_types() {
     // T extends (...args: any[]) => any ? "func" : "other"
     // with T = (() => void) | string | ((x: number) => string)

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -3510,6 +3510,11 @@ fn test_conditional_infer_template_literal_from_template_string_input() {
     }));
 
     // T extends `${infer R}` ? R : never, with T = `${string}`.
+    // `${string}` spans the full string domain and collapses to `string`, and
+    // tsc treats `string extends `${infer R}`` as the false branch (a bare
+    // primitive does not match a template pattern) → never. This mirrors
+    // `test_conditional_infer_template_literal_from_string_input`, since
+    // `${string}` and `string` are the same type.
     let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_r)]);
     let cond = ConditionalType {
         check_type: t_param,
@@ -3522,12 +3527,13 @@ fn test_conditional_infer_template_literal_from_template_string_input() {
     let cond_type = interner.conditional(cond);
     let mut subst = TypeSubstitution::new();
     let template_string = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
+    assert_eq!(template_string, TypeId::STRING);
     subst.insert(t_name, template_string);
 
     let instantiated = instantiate_type(&interner, cond_type, &subst);
     let result = evaluate_type(&interner, instantiated);
 
-    assert_eq!(result, TypeId::STRING);
+    assert_eq!(result, TypeId::NEVER);
 }
 
 #[test]
@@ -3806,8 +3812,11 @@ fn test_conditional_string_literal_still_matches_template_infer_pattern() {
     assert_eq!(result, interner.literal_string("hello"));
 }
 
-/// Template literal source (string-filled) against a template infer pattern — should yield string.
-/// Template literal source types continue to match template patterns correctly.
+/// A genuine (non-collapsing) template literal source matches a structurally
+/// aligned template infer pattern, capturing the `${string}` segment.
+/// `` `x${string}` extends `x${infer R}` ? R : never `` yields `string` in tsc.
+/// (A bare `` `${string}` `` collapses to `string`, which does NOT match a
+/// template infer pattern — covered by the `from_string_input` tests.)
 #[test]
 fn test_conditional_template_literal_source_still_matches_template_infer_pattern() {
     let interner = TypeInterner::new();
@@ -3820,8 +3829,15 @@ fn test_conditional_template_literal_source_still_matches_template_infer_pattern
         is_const: false,
     }));
 
-    let source_template = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
-    let extends_template = interner.template_literal(vec![TemplateSpan::Type(infer_r)]);
+    let prefix = interner.intern_string("x");
+    let source_template = interner.template_literal(vec![
+        TemplateSpan::Text(prefix),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let extends_template = interner.template_literal(vec![
+        TemplateSpan::Text(prefix),
+        TemplateSpan::Type(infer_r),
+    ]);
     let cond = ConditionalType {
         check_type: source_template,
         extends_type: extends_template,
@@ -42206,13 +42222,9 @@ fn test_template_literal_only_type_interpolation() {
 
     let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
 
-    // Verify it was created
-    if let Some(TypeData::TemplateLiteral(spans)) = interner.lookup(template) {
-        let spans = interner.template_list(spans);
-        assert_eq!(spans.len(), 1);
-    } else {
-        panic!("Expected template literal");
-    }
+    // A lone `${string}` spans the full string domain, so it collapses to
+    // `string` at construction (tsc's getTemplateLiteralType).
+    assert_eq!(template, TypeId::STRING);
 
     // keyof returns apparent keys of string (same as keyof string)
     let result = evaluate_keyof(&interner, template);

--- a/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
@@ -8,7 +8,10 @@
 use super::*;
 use crate::evaluation::evaluate::evaluate_type;
 use crate::intern::TypeInterner;
-use crate::types::{CallableShape, IndexSignature, ObjectFlags, ObjectShape, TypeData};
+use crate::types::{
+    CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectFlags, ObjectShape,
+    ParamInfo, TypeData,
+};
 
 /// Helper to check if a type is a union containing specific literals
 fn union_contains_literals(interner: &TypeInterner, type_id: TypeId, expected: &[&str]) -> bool {
@@ -784,5 +787,156 @@ fn test_index_access_callable_number_intrinsic() {
     assert_eq!(
         result, num_value,
         "(typeof B)[number] should resolve to 42 | 233 via number index"
+    );
+}
+
+// =============================================================================
+// keyof on Bare Function / Constructor Types (issue #9721)
+//
+// `keyof` of a type whose only structure is signature(s) and no own properties
+// or index signatures is `never` in tsc.  Bare function types (`() => T`) lower
+// to `TypeData::Function`; bare constructor types (`new () => T`) lower to a
+// `TypeData::Callable` with only construct signatures.  Both must collapse to
+// `never` so `[K] extends [never]` / `Equal<K, never>` matches tsc.
+// =============================================================================
+
+#[test]
+fn test_keyof_bare_function_type_is_never() {
+    let interner = TypeInterner::new();
+    // Simulates: type Fn = () => void
+    let func = interner.function(FunctionShape::new(Vec::new(), TypeId::VOID));
+
+    let result = evaluate_type(&interner, interner.keyof(func));
+    assert_eq!(
+        result,
+        TypeId::NEVER,
+        "keyof (() => void) should be never, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn test_keyof_function_with_params_is_never() {
+    let interner = TypeInterner::new();
+    // Simulates: type Fn = (x: number, y: string) => boolean
+    let func = interner.function(FunctionShape::new(
+        vec![
+            ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: TypeId::NUMBER,
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("y")),
+                type_id: TypeId::STRING,
+                optional: false,
+                rest: false,
+            },
+        ],
+        TypeId::BOOLEAN,
+    ));
+
+    let result = evaluate_type(&interner, interner.keyof(func));
+    assert_eq!(
+        result,
+        TypeId::NEVER,
+        "keyof a function with params should still be never"
+    );
+}
+
+#[test]
+fn test_keyof_constructor_only_callable_is_never() {
+    // Positive control from the issue's boundary table: `new () => object`
+    // already collapses to never via the Callable arm; pin it down so a future
+    // refactor of either path keeps the two behaviors symmetric.
+    let interner = TypeInterner::new();
+    let ctor = interner.callable(CallableShape {
+        construct_signatures: vec![CallSignature::new(Vec::new(), TypeId::OBJECT)],
+        ..CallableShape::default()
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(ctor));
+    assert_eq!(
+        result,
+        TypeId::NEVER,
+        "keyof (new () => object) should be never"
+    );
+}
+
+#[test]
+fn test_keyof_call_only_callable_is_never() {
+    // A `Callable` with one call signature and no properties / indices arises
+    // for overloaded function types in a type literal.  Same key space as a
+    // bare function type, so keyof must be never.
+    let interner = TypeInterner::new();
+    let call_only = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(Vec::new(), TypeId::VOID)],
+        ..CallableShape::default()
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(call_only));
+    assert_eq!(
+        result,
+        TypeId::NEVER,
+        "keyof a call-signature-only Callable should be never"
+    );
+}
+
+#[test]
+fn test_keyof_callable_with_properties_unchanged_by_function_fix() {
+    // Negative control: a callable that *does* have properties still returns
+    // the property keys (the fix must not over-reach into Callable).
+    let interner = TypeInterner::new();
+    let callable = interner.callable(CallableShape {
+        call_signatures: vec![CallSignature::new(Vec::new(), TypeId::VOID)],
+        properties: vec![PropertyInfo::new(
+            interner.intern_string("prop"),
+            TypeId::NUMBER,
+        )],
+        ..CallableShape::default()
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(callable));
+    let expected_prop = interner.literal_string("prop");
+    assert_eq!(
+        result, expected_prop,
+        "keyof {{ (): void; prop: number }} should be \"prop\""
+    );
+}
+
+#[test]
+fn test_keyof_function_extends_never_is_true_branch() {
+    use crate::types::{ConditionalType, TupleElement};
+    // The whole point of the fix: the conditional `[keyof Fn] extends [never]`
+    // must take the true branch.  Build the conditional in the solver, evaluate
+    // it, and confirm we land on the true branch (modelled here by `TypeId::STRING`).
+    let interner = TypeInterner::new();
+    let func = interner.function(FunctionShape::new(Vec::new(), TypeId::VOID));
+    let keyof_fn = interner.keyof(func);
+
+    let wrap = |id| TupleElement {
+        type_id: id,
+        name: None,
+        optional: false,
+        rest: false,
+    };
+    let check = interner.tuple(vec![wrap(keyof_fn)]);
+    let extends = interner.tuple(vec![wrap(TypeId::NEVER)]);
+    let conditional = interner.conditional(ConditionalType {
+        check_type: check,
+        extends_type: extends,
+        true_type: TypeId::STRING,
+        false_type: TypeId::NUMBER,
+        is_distributive: false,
+    });
+
+    let result = evaluate_type(&interner, conditional);
+    assert_eq!(
+        result,
+        TypeId::STRING,
+        "[keyof Fn] extends [never] should pick the true branch (string), \
+         got {:?}",
+        interner.lookup(result)
     );
 }

--- a/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
@@ -433,6 +433,113 @@ fn test_mapped_type_remove_readonly() {
 }
 
 // =============================================================================
+// Readonly Mapped Type Over Tuple Tests (issue #9707)
+// =============================================================================
+
+fn num_str_tuple_elements() -> Vec<crate::types::TupleElement> {
+    use crate::types::TupleElement;
+    vec![
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]
+}
+
+/// Build a homomorphic mapped type `{ <modifier>readonly [K in keyof source]: source[K] }`
+/// over `source` and return the evaluated result.
+fn eval_readonly_mapped_over(
+    interner: &TypeInterner,
+    source: TypeId,
+    readonly_modifier: Option<MappedModifier>,
+) -> TypeId {
+    let keyof_t = interner.keyof(source);
+    let type_param_info = TypeParamInfo {
+        name: interner.intern_string("K"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let type_param = interner.intern(TypeData::TypeParameter(type_param_info));
+    let template = interner.index_access(source, type_param);
+    let mapped = MappedType {
+        type_param: type_param_info,
+        constraint: keyof_t,
+        name_type: None,
+        template,
+        optional_modifier: None,
+        readonly_modifier,
+    };
+    let mapped_id = interner.mapped(mapped);
+    evaluate_type(interner, mapped_id)
+}
+
+fn assert_is_readonly_tuple(interner: &TypeInterner, result: TypeId) {
+    match interner.lookup(result) {
+        Some(TypeData::ReadonlyType(inner)) => {
+            assert!(
+                matches!(interner.lookup(inner), Some(TypeData::Tuple(_))),
+                "ReadonlyType inner should be a Tuple, got {:?}",
+                interner.lookup(inner)
+            );
+        }
+        other => panic!("Expected ReadonlyType(Tuple), got {other:?}"),
+    }
+}
+
+#[test]
+fn test_add_readonly_mapped_over_mutable_tuple_yields_readonly_tuple() {
+    // type RO<T> = { readonly [K in keyof T]: T[K] }; RO<[number, string]>
+    let interner = TypeInterner::new();
+    let source = interner.tuple(num_str_tuple_elements());
+    let result = eval_readonly_mapped_over(&interner, source, Some(MappedModifier::Add));
+    assert_is_readonly_tuple(&interner, result);
+}
+
+#[test]
+fn test_no_modifier_mapped_over_mutable_tuple_stays_mutable() {
+    // Identity mapped type over a mutable tuple stays a mutable tuple.
+    let interner = TypeInterner::new();
+    let source = interner.tuple(num_str_tuple_elements());
+    let result = eval_readonly_mapped_over(&interner, source, None);
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Tuple(_))),
+        "Expected mutable Tuple, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn test_no_modifier_mapped_over_readonly_tuple_preserves_readonly() {
+    // Homomorphic preservation: no modifier over a readonly tuple stays readonly.
+    let interner = TypeInterner::new();
+    let source = interner.readonly_type(interner.tuple(num_str_tuple_elements()));
+    let result = eval_readonly_mapped_over(&interner, source, None);
+    assert_is_readonly_tuple(&interner, result);
+}
+
+#[test]
+fn test_remove_readonly_mapped_over_readonly_tuple_yields_mutable_tuple() {
+    // type Mut<T> = { -readonly [K in keyof T]: T[K] }; Mut<readonly [number, string]>
+    let interner = TypeInterner::new();
+    let source = interner.readonly_type(interner.tuple(num_str_tuple_elements()));
+    let result = eval_readonly_mapped_over(&interner, source, Some(MappedModifier::Remove));
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Tuple(_))),
+        "Expected mutable Tuple after -readonly, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+// =============================================================================
 // Key Remapping Tests
 // =============================================================================
 

--- a/crates/tsz-solver/tests/template_literal_subtype_tests.rs
+++ b/crates/tsz-solver/tests/template_literal_subtype_tests.rs
@@ -858,3 +858,103 @@ fn test_plus_signed_string_matches_number_pattern() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// `${string}`-only templates collapse to / are mutually assignable with string.
+// Issue #9693: a template literal spanning the entire string domain must behave
+// exactly like `string` (tsc's `getTemplateLiteralType` collapse).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_single_string_placeholder_collapses_to_string() {
+    // `${string}` is exactly the full string domain → collapses to `string`.
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
+    assert_eq!(template, TypeId::STRING);
+}
+
+#[test]
+fn test_string_assignable_both_ways_to_single_string_placeholder() {
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::STRING)]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(checker.is_subtype_of(TypeId::STRING, template));
+    assert!(checker.is_subtype_of(template, TypeId::STRING));
+}
+
+#[test]
+fn test_multi_string_placeholder_mutually_assignable_with_string() {
+    // `${string}${string}` stays a template (display parity with tsc) but
+    // `string` is assignable to it and vice-versa: any string partitions
+    // across the placeholders.
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(checker.is_subtype_of(TypeId::STRING, template));
+    assert!(checker.is_subtype_of(template, TypeId::STRING));
+}
+
+#[test]
+fn test_three_string_placeholders_accept_string() {
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(checker.is_subtype_of(TypeId::STRING, template));
+}
+
+#[test]
+fn test_string_not_assignable_to_suffixed_string_template() {
+    // Control: `${string}x` has a literal suffix and does NOT span the full
+    // string domain, so `string` is NOT assignable.
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Text(interner.intern_string("x")),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(!checker.is_subtype_of(TypeId::STRING, template));
+}
+
+#[test]
+fn test_string_not_assignable_to_prefixed_string_template() {
+    // Control: `x${string}` has a literal prefix and does NOT span the full
+    // string domain.
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("x")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(!checker.is_subtype_of(TypeId::STRING, template));
+}
+
+#[test]
+fn test_string_not_assignable_to_number_placeholder() {
+    // Control: `${number}` is a proper subset of the string domain; `string`
+    // is NOT assignable, and the template does not collapse to `string`.
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![TemplateSpan::Type(TypeId::NUMBER)]);
+    assert_ne!(template, TypeId::STRING);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(!checker.is_subtype_of(TypeId::STRING, template));
+}
+
+#[test]
+fn test_string_not_assignable_to_string_number_template() {
+    // Control: `${string}${number}` does not span the full string domain
+    // (the trailing `${number}` requires a numeric suffix).
+    let interner = TypeInterner::new();
+    let template = interner.template_literal(vec![
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Type(TypeId::NUMBER),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(!checker.is_subtype_of(TypeId::STRING, template));
+}

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -385,6 +385,7 @@ run_lint() {
   node scripts/ci/test-pr-ownership-report.mjs || return $?
   node scripts/ci/test-type-challenges-semantic-families.mjs || return $?
   node scripts/ci/test-pr-ready-state.mjs || return $?
+  node scripts/ci/test-refresh-green-prs.mjs || return $?
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?

--- a/scripts/ci/refresh-green-prs.mjs
+++ b/scripts/ci/refresh-green-prs.mjs
@@ -1,0 +1,616 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readyStateFailures } from "./check-pr-ready-state.mjs";
+
+const DEFAULT_BASE = "main";
+const DEFAULT_MAX_PRS = 200;
+const DEFAULT_MAX_REFRESHES = 1;
+const DEFAULT_GH_MAX_BUFFER_BYTES = 24 * 1024 * 1024;
+const DEFAULT_POLL_ATTEMPTS = 12;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const SUCCESSFUL_CHECK_RUN_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+const SUCCESSFUL_STATUS_STATES = new Set(["SUCCESS"]);
+const REQUIRED_CHECKS = ["CI Summary"];
+
+function usage() {
+  return [
+    "usage: refresh-green-prs.mjs [--repository owner/repo] [--base main] [--max-prs n] [--max-refreshes n] [--required-check name] [--dry-run] [--ignore-in-flight]",
+    "",
+    "Refreshes at most one ready, green PR that is behind the base branch, then",
+    "dispatches CI and enables squash auto-merge for the refreshed head.",
+  ].join("\n");
+}
+
+function parsePositiveInt(flag, value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} requires a positive integer`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    base: process.env.BASE_BRANCH || DEFAULT_BASE,
+    dryRun: false,
+    ignoreInFlight: false,
+    maxPrs: DEFAULT_MAX_PRS,
+    maxRefreshes: DEFAULT_MAX_REFRESHES,
+    pollAttempts: DEFAULT_POLL_ATTEMPTS,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
+    requiredChecks: [...REQUIRED_CHECKS],
+    verbose: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repository") {
+      options.repository = argv[++index];
+      if (!options.repository) throw new Error("--repository requires owner/repo");
+      continue;
+    }
+    if (arg === "--base") {
+      options.base = argv[++index];
+      if (!options.base) throw new Error("--base requires a branch name");
+      continue;
+    }
+    if (arg === "--max-prs") {
+      options.maxPrs = parsePositiveInt("--max-prs", argv[++index]);
+      continue;
+    }
+    if (arg === "--max-refreshes") {
+      options.maxRefreshes = parsePositiveInt("--max-refreshes", argv[++index]);
+      continue;
+    }
+    if (arg === "--required-check") {
+      const requiredCheck = argv[++index];
+      if (!requiredCheck) throw new Error("--required-check requires a check name");
+      options.requiredChecks.push(requiredCheck);
+      continue;
+    }
+    if (arg === "--no-default-required-check") {
+      options.requiredChecks = [];
+      continue;
+    }
+    if (arg === "--poll-attempts") {
+      options.pollAttempts = parsePositiveInt("--poll-attempts", argv[++index]);
+      continue;
+    }
+    if (arg === "--poll-interval-ms") {
+      options.pollIntervalMs = parsePositiveInt("--poll-interval-ms", argv[++index]);
+      continue;
+    }
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--ignore-in-flight") {
+      options.ignoreInFlight = true;
+      continue;
+    }
+    if (arg === "--verbose") {
+      options.verbose = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function runGh(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    const command = `gh ${args.join(" ")}`;
+    if (result.error.code === "ENOBUFS") {
+      throw new Error(`${command} exceeded ${DEFAULT_GH_MAX_BUFFER_BYTES} bytes of output`);
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `gh ${args.join(" ")} failed`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ].filter(Boolean).join("\n"),
+    );
+  }
+  return result.stdout;
+}
+
+function runGhJson(args) {
+  return JSON.parse(runGh(args));
+}
+
+function checkName(check) {
+  return check.name || check.context || "(unnamed)";
+}
+
+function normalizeState(value) {
+  return String(value || "").toUpperCase();
+}
+
+function checkStatus(check) {
+  const typeName = check.__typename || check.type || "";
+  if (typeName === "StatusContext" || "state" in check) {
+    const state = normalizeState(check.state);
+    if (SUCCESSFUL_STATUS_STATES.has(state)) return { kind: "passed" };
+    if (["PENDING", "EXPECTED"].includes(state)) {
+      return { kind: "pending", detail: state.toLowerCase() };
+    }
+    return { kind: "failed", detail: state.toLowerCase() || "unknown" };
+  }
+
+  const status = normalizeState(check.status);
+  if (status && status !== "COMPLETED") {
+    return { kind: "pending", detail: status.toLowerCase() };
+  }
+
+  const conclusion = normalizeState(check.conclusion);
+  if (SUCCESSFUL_CHECK_RUN_CONCLUSIONS.has(conclusion)) {
+    return { kind: "passed" };
+  }
+  if (!conclusion) return { kind: "pending", detail: "missing conclusion" };
+  return { kind: "failed", detail: conclusion.toLowerCase() };
+}
+
+export function checkRollupState(statusCheckRollup, requiredChecks = REQUIRED_CHECKS) {
+  const checks = Array.isArray(statusCheckRollup) ? statusCheckRollup : [];
+  if (checks.length === 0) {
+    return {
+      kind: "missing",
+      reason: "no status checks reported for the head commit",
+      pending: [],
+      failed: [],
+      missingRequired: [...requiredChecks],
+    };
+  }
+
+  const pending = [];
+  const failed = [];
+  const passedNames = new Set();
+
+  for (const check of checks) {
+    const name = checkName(check);
+    const state = checkStatus(check);
+    if (state.kind === "passed") {
+      passedNames.add(name);
+    } else if (state.kind === "pending") {
+      pending.push(`${name} (${state.detail})`);
+    } else {
+      failed.push(`${name} (${state.detail})`);
+    }
+  }
+
+  const missingRequired = requiredChecks.filter((name) => !passedNames.has(name));
+  if (failed.length > 0) {
+    return { kind: "failed", reason: `failing checks: ${failed.join(", ")}`, pending, failed, missingRequired };
+  }
+  if (pending.length > 0) {
+    return { kind: "pending", reason: `pending checks: ${pending.join(", ")}`, pending, failed, missingRequired };
+  }
+  if (missingRequired.length > 0) {
+    return {
+      kind: "missing",
+      reason: `missing required green check(s): ${missingRequired.join(", ")}`,
+      pending,
+      failed,
+      missingRequired,
+    };
+  }
+
+  return { kind: "passed", reason: "all checks passed", pending, failed, missingRequired };
+}
+
+function labelNames(labels) {
+  return Array.isArray(labels)
+    ? labels.map((label) => typeof label === "string" ? label : label?.name).filter(Boolean)
+    : [];
+}
+
+function hasAutoMerge(pr) {
+  return pr.autoMergeRequest !== null && pr.autoMergeRequest !== undefined;
+}
+
+function summarySkipReason(pr, options = {}) {
+  if (pr.baseRefName !== options.base) {
+    return `base is ${pr.baseRefName || "(unknown)"}, not ${options.base}`;
+  }
+  if (pr.isDraft === true) return "draft PR";
+  if (pr.isCrossRepository === true) return "cross-repository PR";
+
+  const readinessFailures = readyStateFailures({
+    number: pr.number,
+    title: pr.title,
+    body: "",
+    draft: pr.isDraft,
+    labels: labelNames(pr.labels),
+  });
+  if (readinessFailures.length > 0) {
+    return `ready-state WIP marker: ${readinessFailures.join(", ")}`;
+  }
+
+  return null;
+}
+
+export function findInFlightPullRequest(prs, options = {}) {
+  if (options.ignoreInFlight) return null;
+  const requiredChecks = options.requiredChecks || REQUIRED_CHECKS;
+  return [...prs]
+    .sort((a, b) => a.number - b.number)
+    .find((pr) =>
+      pr.baseRefName === options.base
+        && pr.isDraft !== true
+        && hasAutoMerge(pr)
+        && checkRollupState(pr.statusCheckRollup, requiredChecks).kind === "pending"
+    ) || null;
+}
+
+export function autoMergeInFlightReason(pr, compare, options = {}) {
+  if (options.ignoreInFlight) return null;
+  if (pr.baseRefName !== options.base || pr.isDraft === true || !hasAutoMerge(pr)) {
+    return null;
+  }
+
+  const rollup = checkRollupState(pr.statusCheckRollup, options.requiredChecks || REQUIRED_CHECKS);
+  if (rollup.kind === "pending") return "checks are still pending";
+  if (rollup.kind !== "passed") return null;
+
+  const behind = compareBehindState(compare);
+  if (behind.behindBy <= 0) {
+    return "auto-merge is armed on a current head";
+  }
+
+  return null;
+}
+
+export function cheapSkipReason(pr, options = {}) {
+  if (pr.baseRefName !== options.base) {
+    return `base is ${pr.baseRefName || "(unknown)"}, not ${options.base}`;
+  }
+  if (pr.isDraft === true) return "draft PR";
+  if (pr.isCrossRepository === true) return "cross-repository PR";
+
+  const readinessFailures = readyStateFailures({
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    draft: pr.isDraft,
+    labels: labelNames(pr.labels),
+  });
+  if (readinessFailures.length > 0) {
+    return `ready-state WIP marker: ${readinessFailures.join(", ")}`;
+  }
+
+  const rollup = checkRollupState(pr.statusCheckRollup, options.requiredChecks || REQUIRED_CHECKS);
+  if (rollup.kind !== "passed") return rollup.reason;
+
+  return null;
+}
+
+export function compareBehindState(compare) {
+  const behindBy = Number(compare?.behind_by ?? compare?.behindBy ?? 0);
+  const aheadBy = Number(compare?.ahead_by ?? compare?.aheadBy ?? 0);
+  return {
+    aheadBy: Number.isFinite(aheadBy) ? aheadBy : 0,
+    behindBy: Number.isFinite(behindBy) ? behindBy : 0,
+    status: compare?.status || "unknown",
+  };
+}
+
+export function candidateFromCompare(pr, compare) {
+  const state = compareBehindState(compare);
+  if (state.behindBy <= 0) {
+    return {
+      eligible: false,
+      reason: "head already contains the latest base",
+      compare: state,
+      pr,
+    };
+  }
+  return {
+    eligible: true,
+    reason: `behind ${state.behindBy} commit(s) and ahead ${state.aheadBy} commit(s)`,
+    compare: state,
+    pr,
+  };
+}
+
+function readPullRequests(repository, base, maxPrs) {
+  if (!repository) throw new Error("REPOSITORY or GITHUB_REPOSITORY is required");
+  return runGhJson([
+    "pr",
+    "list",
+    "--repo",
+    repository,
+    "--state",
+    "open",
+    "--base",
+    base,
+    "--limit",
+    String(maxPrs),
+    "--json",
+    [
+      "autoMergeRequest",
+      "baseRefName",
+      "baseRefOid",
+      "headRefName",
+      "headRefOid",
+      "isCrossRepository",
+      "isDraft",
+      "labels",
+      "mergeStateStatus",
+      "number",
+      "title",
+      "url",
+    ].join(","),
+  ]);
+}
+
+function readPullRequest(repository, number) {
+  return runGhJson([
+    "pr",
+    "view",
+    String(number),
+    "--repo",
+    repository,
+    "--json",
+    [
+      "autoMergeRequest",
+      "baseRefName",
+      "baseRefOid",
+      "body",
+      "headRefName",
+      "headRefOid",
+      "isDraft",
+      "labels",
+      "number",
+      "statusCheckRollup",
+      "title",
+      "url",
+    ].join(","),
+  ]);
+}
+
+function readCompare(repository, baseOid, headOid) {
+  return runGhJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/compare/${baseOid}...${headOid}`,
+    "--jq",
+    "{status, ahead_by, behind_by}",
+  ]);
+}
+
+function updateBranch(repository, pr) {
+  return runGhJson([
+    "api",
+    "-X",
+    "PUT",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/pulls/${pr.number}/update-branch`,
+    "-f",
+    `expected_head_sha=${pr.headRefOid}`,
+  ]);
+}
+
+function dispatchCi(repository, pr) {
+  runGh([
+    "api",
+    "-X",
+    "POST",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/actions/workflows/ci.yml/dispatches`,
+    "-f",
+    `ref=${pr.headRefName}`,
+  ]);
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForUpdatedHead(repository, pr, options) {
+  for (let attempt = 0; attempt < options.pollAttempts; attempt += 1) {
+    const refreshed = readPullRequest(repository, pr.number);
+    if (refreshed.headRefOid && refreshed.headRefOid !== pr.headRefOid) return refreshed;
+    if (attempt + 1 < options.pollAttempts) sleep(options.pollIntervalMs);
+  }
+  throw new Error(`PR #${pr.number} branch update did not produce a new head SHA`);
+}
+
+function enableAutoMerge(repository, pr) {
+  runGh([
+    "pr",
+    "merge",
+    String(pr.number),
+    "--repo",
+    repository,
+    "--squash",
+    "--auto",
+    "--match-head-commit",
+    pr.headRefOid,
+  ]);
+}
+
+function markdownLink(label, url) {
+  return url ? `[${label}](${url})` : label;
+}
+
+export function formatResultReport(result) {
+  const lines = [
+    "## Refresh Green PRs",
+    "",
+    `Mode: ${result.dryRun ? "dry run" : "apply"}`,
+    `Base: \`${result.base}\``,
+    "",
+  ];
+
+  if (result.inFlight) {
+    lines.push(
+      `One-by-one guard: waiting for ${markdownLink(`#${result.inFlight.number}`, result.inFlight.url)} because ${result.inFlightReason || "auto-merge is already enabled"}.`,
+    );
+    return `${lines.join("\n")}\n`;
+  }
+
+  if (result.refreshed.length > 0) {
+    lines.push("| PR | Action | Old head | New head |");
+    lines.push("|----|--------|----------|----------|");
+    for (const item of result.refreshed) {
+      lines.push([
+        markdownLink(`#${item.number}`, item.url),
+        result.dryRun ? "would refresh, dispatch CI, and enable auto-merge" : "refreshed, dispatched CI, and armed auto-merge",
+        `\`${item.oldHead.slice(0, 12)}\``,
+        item.newHead ? `\`${item.newHead.slice(0, 12)}\`` : result.dryRun ? "`pending`" : "`unknown`",
+      ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+    }
+  } else {
+    lines.push("No stale green ready PR was refreshed.");
+  }
+
+  if (result.failures.length > 0) {
+    lines.push("");
+    lines.push("### Skipped After Attempt");
+    lines.push("");
+    lines.push("| PR | Reason |");
+    lines.push("|----|--------|");
+    for (const failure of result.failures) {
+      lines.push(`| ${markdownLink(`#${failure.number}`, failure.url)} | ${failure.reason.replace(/\|/g, "\\|")} |`);
+    }
+  }
+
+  if (result.verboseSkips.length > 0) {
+    lines.push("");
+    lines.push("### Other Skips");
+    lines.push("");
+    lines.push("| PR | Reason |");
+    lines.push("|----|--------|");
+    for (const skip of result.verboseSkips.slice(0, 20)) {
+      lines.push(`| ${markdownLink(`#${skip.number}`, skip.url)} | ${skip.reason.replace(/\|/g, "\\|")} |`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function selectSortedPullRequests(prs) {
+  return [...prs].sort((a, b) => a.number - b.number);
+}
+
+function refreshPullRequests(options) {
+  const prs = readPullRequests(options.repository, options.base, options.maxPrs);
+  const result = {
+    base: options.base,
+    dryRun: options.dryRun,
+    failures: [],
+    inFlight: null,
+    inFlightReason: null,
+    refreshed: [],
+    verboseSkips: [],
+  };
+
+  for (const pr of selectSortedPullRequests(prs)) {
+    if (options.ignoreInFlight) break;
+    if (pr.baseRefName !== options.base || pr.isDraft === true || !hasAutoMerge(pr)) continue;
+    const hydrated = readPullRequest(options.repository, pr.number);
+    let compare = null;
+    const rollup = checkRollupState(hydrated.statusCheckRollup, options.requiredChecks);
+    if (rollup.kind === "passed") {
+      compare = readCompare(options.repository, hydrated.baseRefOid, hydrated.headRefOid);
+    }
+    const inFlightReason = autoMergeInFlightReason(hydrated, compare, options);
+    if (inFlightReason) {
+      result.inFlight = hydrated;
+      result.inFlightReason = inFlightReason;
+      break;
+    }
+  }
+  if (result.inFlight) return result;
+
+  for (const pr of selectSortedPullRequests(prs)) {
+    if (result.refreshed.length >= options.maxRefreshes) break;
+
+    const summaryReason = summarySkipReason(pr, options);
+    if (summaryReason) {
+      if (options.verbose) result.verboseSkips.push({ number: pr.number, reason: summaryReason, url: pr.url });
+      continue;
+    }
+
+    const hydrated = readPullRequest(options.repository, pr.number);
+    const skipReason = cheapSkipReason(hydrated, options);
+    if (skipReason) {
+      if (options.verbose) result.verboseSkips.push({ number: pr.number, reason: skipReason, url: pr.url });
+      continue;
+    }
+
+    const candidate = candidateFromCompare(hydrated, readCompare(options.repository, hydrated.baseRefOid, hydrated.headRefOid));
+    if (!candidate.eligible) {
+      if (options.verbose) result.verboseSkips.push({ number: pr.number, reason: candidate.reason, url: pr.url });
+      continue;
+    }
+
+    if (options.dryRun) {
+      result.refreshed.push({
+        number: pr.number,
+        oldHead: hydrated.headRefOid,
+        newHead: null,
+        url: pr.url,
+      });
+      break;
+    }
+
+    let branchUpdateAccepted = false;
+    try {
+      updateBranch(options.repository, hydrated);
+      branchUpdateAccepted = true;
+      const refreshed = waitForUpdatedHead(options.repository, hydrated, options);
+      dispatchCi(options.repository, refreshed);
+      if (!hasAutoMerge(refreshed)) {
+        enableAutoMerge(options.repository, refreshed);
+      }
+      result.refreshed.push({
+        number: pr.number,
+        oldHead: hydrated.headRefOid,
+        newHead: refreshed.headRefOid,
+        url: pr.url,
+      });
+    } catch (error) {
+      result.failures.push({
+        number: pr.number,
+        reason: error instanceof Error ? error.message : String(error),
+        url: pr.url,
+      });
+      if (branchUpdateAccepted) break;
+    }
+  }
+
+  return result;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = refreshPullRequests(options);
+  console.log(formatResultReport(result));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/refresh-green-prs.mjs
+++ b/scripts/ci/refresh-green-prs.mjs
@@ -17,7 +17,8 @@ function usage() {
     "usage: refresh-green-prs.mjs [--repository owner/repo] [--base main] [--max-prs n] [--max-refreshes n] [--required-check name] [--dry-run] [--ignore-in-flight]",
     "",
     "Refreshes at most one ready, green PR that is behind the base branch, then",
-    "dispatches CI and enables squash auto-merge for the refreshed head.",
+    "enables squash auto-merge for the refreshed head. The branch update must",
+    "trigger the normal pull_request CI so required checks attach to the PR.",
   ].join("\n");
 }
 
@@ -264,9 +265,16 @@ export function autoMergeInFlightReason(pr, compare, options = {}) {
 
   const rollup = checkRollupState(pr.statusCheckRollup, options.requiredChecks || REQUIRED_CHECKS);
   if (rollup.kind === "pending") return "checks are still pending";
-  if (rollup.kind !== "passed") return null;
 
   const behind = compareBehindState(compare);
+  if (rollup.kind === "missing") {
+    if (behind.behindBy <= 0) {
+      return "required checks are not reported yet for the current auto-merge head";
+    }
+    return null;
+  }
+  if (rollup.kind !== "passed") return null;
+
   if (behind.behindBy <= 0) {
     return "auto-merge is armed on a current head";
   }
@@ -419,19 +427,6 @@ function updateBranch(repository, pr) {
   ]);
 }
 
-function dispatchCi(repository, pr) {
-  runGh([
-    "api",
-    "-X",
-    "POST",
-    "-H",
-    "Accept: application/vnd.github+json",
-    `repos/${repository}/actions/workflows/ci.yml/dispatches`,
-    "-f",
-    `ref=${pr.headRefName}`,
-  ]);
-}
-
 function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -485,7 +480,7 @@ export function formatResultReport(result) {
     for (const item of result.refreshed) {
       lines.push([
         markdownLink(`#${item.number}`, item.url),
-        result.dryRun ? "would refresh, dispatch CI, and enable auto-merge" : "refreshed, dispatched CI, and armed auto-merge",
+        result.dryRun ? "would refresh and enable auto-merge" : "refreshed and armed auto-merge",
         `\`${item.oldHead.slice(0, 12)}\``,
         item.newHead ? `\`${item.newHead.slice(0, 12)}\`` : result.dryRun ? "`pending`" : "`unknown`",
       ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
@@ -540,11 +535,10 @@ function refreshPullRequests(options) {
     if (options.ignoreInFlight) break;
     if (pr.baseRefName !== options.base || pr.isDraft === true || !hasAutoMerge(pr)) continue;
     const hydrated = readPullRequest(options.repository, pr.number);
-    let compare = null;
     const rollup = checkRollupState(hydrated.statusCheckRollup, options.requiredChecks);
-    if (rollup.kind === "passed") {
-      compare = readCompare(options.repository, currentBaseOid, hydrated.headRefOid);
-    }
+    const compare = rollup.kind === "passed" || rollup.kind === "missing"
+      ? readCompare(options.repository, currentBaseOid, hydrated.headRefOid)
+      : null;
     const inFlightReason = autoMergeInFlightReason(hydrated, compare, options);
     if (inFlightReason) {
       result.inFlight = hydrated;
@@ -594,7 +588,6 @@ function refreshPullRequests(options) {
       updateBranch(options.repository, hydrated);
       branchUpdateAccepted = true;
       const refreshed = waitForUpdatedHead(options.repository, hydrated, options);
-      dispatchCi(options.repository, refreshed);
       if (!hasAutoMerge(refreshed)) {
         enableAutoMerge(options.repository, refreshed);
       }

--- a/scripts/ci/refresh-green-prs.mjs
+++ b/scripts/ci/refresh-green-prs.mjs
@@ -343,7 +343,6 @@ function readPullRequests(repository, base, maxPrs) {
     [
       "autoMergeRequest",
       "baseRefName",
-      "baseRefOid",
       "headRefName",
       "headRefOid",
       "isCrossRepository",
@@ -368,7 +367,6 @@ function readPullRequest(repository, number) {
     [
       "autoMergeRequest",
       "baseRefName",
-      "baseRefOid",
       "body",
       "headRefName",
       "headRefOid",
@@ -380,6 +378,21 @@ function readPullRequest(repository, number) {
       "url",
     ].join(","),
   ]);
+}
+
+function readBranchOid(repository, branch) {
+  const branchState = runGhJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/branches/${branch}`,
+    "--jq",
+    "{oid: .commit.sha}",
+  ]);
+  if (!branchState.oid) {
+    throw new Error(`could not resolve ${branch} for ${repository}`);
+  }
+  return branchState.oid;
 }
 
 function readCompare(repository, baseOid, headOid) {
@@ -512,6 +525,7 @@ export function selectSortedPullRequests(prs) {
 
 function refreshPullRequests(options) {
   const prs = readPullRequests(options.repository, options.base, options.maxPrs);
+  const currentBaseOid = readBranchOid(options.repository, options.base);
   const result = {
     base: options.base,
     dryRun: options.dryRun,
@@ -529,7 +543,7 @@ function refreshPullRequests(options) {
     let compare = null;
     const rollup = checkRollupState(hydrated.statusCheckRollup, options.requiredChecks);
     if (rollup.kind === "passed") {
-      compare = readCompare(options.repository, hydrated.baseRefOid, hydrated.headRefOid);
+      compare = readCompare(options.repository, currentBaseOid, hydrated.headRefOid);
     }
     const inFlightReason = autoMergeInFlightReason(hydrated, compare, options);
     if (inFlightReason) {
@@ -556,7 +570,10 @@ function refreshPullRequests(options) {
       continue;
     }
 
-    const candidate = candidateFromCompare(hydrated, readCompare(options.repository, hydrated.baseRefOid, hydrated.headRefOid));
+    const candidate = candidateFromCompare(
+      hydrated,
+      readCompare(options.repository, currentBaseOid, hydrated.headRefOid),
+    );
     if (!candidate.eligible) {
       if (options.verbose) result.verboseSkips.push({ number: pr.number, reason: candidate.reason, url: pr.url });
       continue;

--- a/scripts/ci/test-refresh-green-prs.mjs
+++ b/scripts/ci/test-refresh-green-prs.mjs
@@ -118,6 +118,28 @@ assert.equal(
 );
 assert.equal(
   autoMergeInFlightReason(
+    pr({
+      autoMergeRequest: { mergeMethod: "SQUASH" },
+      statusCheckRollup: [check({ name: "GitGuardian Security Checks" })],
+    }),
+    { ahead_by: 2, behind_by: 0 },
+    { base: "main" },
+  ),
+  "required checks are not reported yet for the current auto-merge head",
+);
+assert.equal(
+  autoMergeInFlightReason(
+    pr({
+      autoMergeRequest: { mergeMethod: "SQUASH" },
+      statusCheckRollup: [check({ name: "GitGuardian Security Checks" })],
+    }),
+    { ahead_by: 2, behind_by: 1 },
+    { base: "main" },
+  ),
+  null,
+);
+assert.equal(
+  autoMergeInFlightReason(
     pr({ autoMergeRequest: { mergeMethod: "SQUASH" } }),
     { ahead_by: 2, behind_by: 1 },
     { base: "main" },
@@ -141,7 +163,7 @@ const report = formatResultReport({
   verboseSkips: [],
 });
 assert.match(report, /armed auto-merge/);
-assert.match(report, /dispatched CI/);
+assert.doesNotMatch(report, /dispatch/);
 assert.match(report, /aaaaaaaaaaaa/);
 assert.match(report, /bbbbbbbbbbbb/);
 

--- a/scripts/ci/test-refresh-green-prs.mjs
+++ b/scripts/ci/test-refresh-green-prs.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  autoMergeInFlightReason,
+  candidateFromCompare,
+  cheapSkipReason,
+  checkRollupState,
+  compareBehindState,
+  findInFlightPullRequest,
+  formatResultReport,
+  parseArgs,
+  selectSortedPullRequests,
+} from "./refresh-green-prs.mjs";
+
+function check(overrides = {}) {
+  return {
+    __typename: "CheckRun",
+    name: "CI Summary",
+    status: "COMPLETED",
+    conclusion: "SUCCESS",
+    ...overrides,
+  };
+}
+
+function pr(overrides = {}) {
+  return {
+    autoMergeRequest: null,
+    baseRefName: "main",
+    baseRefOid: "base-sha",
+    body: "AgentName: TestAgent\n\nReady for review.\n",
+    headRefOid: "head-sha",
+    isCrossRepository: false,
+    isDraft: false,
+    labels: [],
+    number: 100,
+    statusCheckRollup: [check()],
+    title: "fix(ci): sample",
+    url: "https://github.example/pull/100",
+    ...overrides,
+  };
+}
+
+assert.deepEqual(parseArgs(["--repository", "owner/repo"]).repository, "owner/repo");
+assert.deepEqual(parseArgs(["--no-default-required-check"]).requiredChecks, []);
+assert.deepEqual(
+  parseArgs(["--no-default-required-check", "--required-check", "merge-queue"]).requiredChecks,
+  ["merge-queue"],
+);
+
+assert.equal(checkRollupState([check()]).kind, "passed");
+assert.equal(checkRollupState([check({ name: "lint", conclusion: "SKIPPED" })], []).kind, "passed");
+assert.equal(checkRollupState([check({ status: "IN_PROGRESS", conclusion: "" })]).kind, "pending");
+assert.equal(checkRollupState([check({ conclusion: "FAILURE" })]).kind, "failed");
+assert.equal(checkRollupState([check({ name: "lint" })]).kind, "missing");
+assert.match(checkRollupState([]).reason, /no status checks/);
+
+assert.equal(cheapSkipReason(pr({ isDraft: true }), { base: "main" }), "draft PR");
+assert.equal(
+  cheapSkipReason(pr({ labels: ["WIP"] }), { base: "main" }),
+  "ready-state WIP marker: WIP label",
+);
+assert.equal(cheapSkipReason(pr({ baseRefName: "release" }), { base: "main" }), "base is release, not main");
+assert.equal(cheapSkipReason(pr({ isCrossRepository: true }), { base: "main" }), "cross-repository PR");
+assert.equal(
+  cheapSkipReason(pr({ statusCheckRollup: [check({ conclusion: "FAILURE" })] }), { base: "main" }),
+  "failing checks: CI Summary (failure)",
+);
+assert.equal(cheapSkipReason(pr(), { base: "main" }), null);
+
+assert.deepEqual(compareBehindState({ status: "diverged", ahead_by: 2, behind_by: 3 }), {
+  aheadBy: 2,
+  behindBy: 3,
+  status: "diverged",
+});
+assert.equal(candidateFromCompare(pr(), { ahead_by: 2, behind_by: 3 }).eligible, true);
+assert.equal(candidateFromCompare(pr(), { ahead_by: 2, behind_by: 0 }).eligible, false);
+
+assert.equal(
+  findInFlightPullRequest([
+    pr({ number: 101, autoMergeRequest: { mergeMethod: "SQUASH" }, statusCheckRollup: [check()] }),
+    pr({
+      number: 99,
+      autoMergeRequest: { mergeMethod: "SQUASH" },
+      statusCheckRollup: [check({ status: "IN_PROGRESS", conclusion: "" })],
+    }),
+  ], { base: "main" })?.number,
+  99,
+);
+assert.equal(
+  findInFlightPullRequest([
+    pr({
+      number: 99,
+      autoMergeRequest: { mergeMethod: "SQUASH" },
+      statusCheckRollup: [check({ status: "IN_PROGRESS", conclusion: "" })],
+    }),
+  ], { base: "main", ignoreInFlight: true }),
+  null,
+);
+
+assert.equal(
+  autoMergeInFlightReason(
+    pr({ autoMergeRequest: { mergeMethod: "SQUASH" } }),
+    { ahead_by: 2, behind_by: 0 },
+    { base: "main" },
+  ),
+  "auto-merge is armed on a current head",
+);
+assert.equal(
+  autoMergeInFlightReason(
+    pr({
+      autoMergeRequest: { mergeMethod: "SQUASH" },
+      statusCheckRollup: [check({ status: "IN_PROGRESS", conclusion: "" })],
+    }),
+    null,
+    { base: "main" },
+  ),
+  "checks are still pending",
+);
+assert.equal(
+  autoMergeInFlightReason(
+    pr({ autoMergeRequest: { mergeMethod: "SQUASH" } }),
+    { ahead_by: 2, behind_by: 1 },
+    { base: "main" },
+  ),
+  null,
+);
+
+assert.deepEqual(selectSortedPullRequests([pr({ number: 3 }), pr({ number: 1 })]).map((item) => item.number), [1, 3]);
+
+const report = formatResultReport({
+  base: "main",
+  dryRun: false,
+  failures: [],
+  inFlight: null,
+  refreshed: [{
+    number: 123,
+    oldHead: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    newHead: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    url: "https://github.example/pull/123",
+  }],
+  verboseSkips: [],
+});
+assert.match(report, /armed auto-merge/);
+assert.match(report, /dispatched CI/);
+assert.match(report, /aaaaaaaaaaaa/);
+assert.match(report, /bbbbbbbbbbbb/);
+
+const inFlightReport = formatResultReport({
+  base: "main",
+  dryRun: true,
+  failures: [],
+  inFlight: pr({ number: 321 }),
+  refreshed: [],
+  verboseSkips: [],
+});
+assert.match(inFlightReport, /One-by-one guard/);

--- a/scripts/infra/cloud-run-gh-runner/start.sh
+++ b/scripts/infra/cloud-run-gh-runner/start.sh
@@ -13,31 +13,61 @@ RUNNER_NAME="${RUNNER_NAME:-${RUNNER_PREFIX}-${RUNNER_SUFFIX}}"
 GITHUB_REPO_URL="https://github.com/${GITHUB_REPO}"
 RUNNER_DIR="${RUNNER_DIR:-/home/runner}"
 export DISABLE_RUNNER_UPDATE="${DISABLE_RUNNER_UPDATE:-1}"
+RUNNER_STARTUP_JITTER_SECONDS="${RUNNER_STARTUP_JITTER_SECONDS:-120}"
+RUNNER_CONFIG_RETRIES="${RUNNER_CONFIG_RETRIES:-4}"
+RUNNER_CONFIG_RETRY_SLEEP_SECONDS="${RUNNER_CONFIG_RETRY_SLEEP_SECONDS:-30}"
+RUNNER_CONFIG_FAILURE_SLEEP_SECONDS="${RUNNER_CONFIG_FAILURE_SLEEP_SECONDS:-300}"
 
 cd "$RUNNER_DIR"
 
+remove_runner() {
+  ./config.sh remove --pat "${GITHUB_TOKEN}" || true
+}
+
 cleanup() {
   echo "Removing GitHub runner ${RUNNER_NAME}"
-  ./config.sh remove --unattended --pat "${GITHUB_TOKEN}" || true
+  remove_runner
 }
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
 if [[ -f .runner ]]; then
-  ./config.sh remove --unattended --pat "${GITHUB_TOKEN}" || true
+  remove_runner
+fi
+
+if [[ "${RUNNER_STARTUP_JITTER_SECONDS}" =~ ^[0-9]+$ ]] && (( RUNNER_STARTUP_JITTER_SECONDS > 0 )); then
+  jitter=$((RANDOM % (RUNNER_STARTUP_JITTER_SECONDS + 1)))
+  echo "Waiting ${jitter}s before GitHub runner registration"
+  sleep "${jitter}"
 fi
 
 echo "Registering GitHub runner ${RUNNER_NAME} for ${GITHUB_REPO_URL} labels=${RUNNER_LABELS}"
-./config.sh \
-  --unattended \
-  --url "${GITHUB_REPO_URL}" \
-  --pat "${GITHUB_TOKEN}" \
-  --name "${RUNNER_NAME}" \
-  --runnergroup "${RUNNER_GROUP}" \
-  --labels "${RUNNER_LABELS}" \
-  --work /home/runner/_work \
-  --disableupdate \
-  --ephemeral
+attempt=1
+while true; do
+  if ./config.sh \
+    --unattended \
+    --url "${GITHUB_REPO_URL}" \
+    --pat "${GITHUB_TOKEN}" \
+    --name "${RUNNER_NAME}" \
+    --runnergroup "${RUNNER_GROUP}" \
+    --labels "${RUNNER_LABELS}" \
+    --work /home/runner/_work \
+    --disableupdate \
+    --ephemeral; then
+    break
+  fi
+
+  if (( attempt >= RUNNER_CONFIG_RETRIES )); then
+    echo "GitHub runner registration failed after ${attempt} attempt(s); sleeping ${RUNNER_CONFIG_FAILURE_SLEEP_SECONDS}s before exit"
+    sleep "${RUNNER_CONFIG_FAILURE_SLEEP_SECONDS}"
+    exit 1
+  fi
+
+  sleep_for=$((RUNNER_CONFIG_RETRY_SLEEP_SECONDS * attempt + RANDOM % 10))
+  echo "GitHub runner registration failed on attempt ${attempt}; retrying in ${sleep_for}s"
+  sleep "${sleep_for}"
+  attempt=$((attempt + 1))
+done
 
 ./run.sh &
 wait $!


### PR DESCRIPTION
AgentName: Studio-F

## Track
Track 10 - Guardrails, Tooling, Residency, And Performance Readiness

## Invariant
Perf-counter JSON/text field names and ordering must remain stable while counter definitions move toward a declarative source of truth. This slice only migrates one existing enum-backed counter family onto the manifest macro introduced by #9881; it does not change compiler behavior, diagnostics, emit output, LSP output, or project corpus behavior.

## Scope
- Stacked on #9881 / `codex/studiof-perf-counter-manifest-20260521`.
- Continues #9405 with the next smallest enum-backed family.
- Migrates `CrossArenaSymbolMissSource`, `CROSS_ARENA_SYMBOL_MISS_SOURCE_COUNT`, `CROSS_ARENA_SYMBOL_MISS_SOURCE_NAMES`, and `as_index()` generation to `perf_counter_enum!`.
- Leaves the larger `CrossArenaSymbolMissKind` and remaining perf-counter families for later slices.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: perf-counter schema/refactor only in `crates/tsz-common/src/perf_counters.rs`; no compiler, project corpus runner, or emitted output path changes.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-common perf_counters` (41 passed, 418 skipped)

## Coordination Notes
- This PR is intentionally stacked on #9881 so the manifest macro is reviewed once and this follow-up remains a tiny mechanical migration.
- #9881 remains blocked by #9918 runner inventory (`total=0`), so this PR is draft and auto-merge must stay off until the stack has exact-head CI after runners are restored.
- Studio-F kept the slice narrow to avoid creating a broad perf-counter rewrite while existing Studio-F PRs are waiting on CI infrastructure.