### PR TITLE
refactor(perf): declare alias shortcut outcomes

### DIFF
--- a/crates/tsz-common/src/perf_counters.rs
+++ b/crates/tsz-common/src/perf_counters.rs
@@ -226,56 +226,31 @@ perf_counter_enum! {
     pub const CROSS_ARENA_SYMBOL_MISS_KIND_NAMES;
 }
 
-/// Outcome of the no-child named-alias shortcut attempted before constructing
-/// a `DelegateCrossArenaSymbol` child checker.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(usize)]
-pub enum CrossArenaAliasShortcutOutcome {
-    Success = 0,
-    NotAlias = 1,
-    MissingSymbol = 2,
-    MissingModule = 3,
-    MissingImportName = 4,
-    NamespaceImport = 5,
-    DefaultImport = 6,
-    MissingAliasFile = 7,
-    MissingTarget = 8,
-    SelfTarget = 9,
-    MissingTargetSymbol = 10,
-    TargetAlias = 11,
-    AliasPartner = 12,
-    InterfaceValueMerge = 13,
-    UnknownResult = 14,
-    ErrorResult = 15,
-}
-
-pub const CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_COUNT: usize = 16;
-
-pub const CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_NAMES: [&str;
-    CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_COUNT] = [
-    "success",
-    "not_alias",
-    "missing_symbol",
-    "missing_module",
-    "missing_import_name",
-    "namespace_import",
-    "default_import",
-    "missing_alias_file",
-    "missing_target",
-    "self_target",
-    "missing_target_symbol",
-    "target_alias",
-    "alias_partner",
-    "interface_value_merge",
-    "unknown_result",
-    "error_result",
-];
-
-impl CrossArenaAliasShortcutOutcome {
-    #[inline(always)]
-    pub const fn as_index(self) -> usize {
-        self as usize
+perf_counter_enum! {
+    /// Outcome of the no-child named-alias shortcut attempted before
+    /// constructing a `DelegateCrossArenaSymbol` child checker.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum CrossArenaAliasShortcutOutcome {
+        Success = 0 => "success",
+        NotAlias = 1 => "not_alias",
+        MissingSymbol = 2 => "missing_symbol",
+        MissingModule = 3 => "missing_module",
+        MissingImportName = 4 => "missing_import_name",
+        NamespaceImport = 5 => "namespace_import",
+        DefaultImport = 6 => "default_import",
+        MissingAliasFile = 7 => "missing_alias_file",
+        MissingTarget = 8 => "missing_target",
+        SelfTarget = 9 => "self_target",
+        MissingTargetSymbol = 10 => "missing_target_symbol",
+        TargetAlias = 11 => "target_alias",
+        AliasPartner = 12 => "alias_partner",
+        InterfaceValueMerge = 13 => "interface_value_merge",
+        UnknownResult = 14 => "unknown_result",
+        ErrorResult = 15 => "error_result",
     }
+
+    pub const CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_COUNT;
+    pub const CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_NAMES;
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
AgentName: Studio-F

## Track
Track 10 - Guardrails, Tooling, Residency, And Performance Readiness

## Invariant
Perf-counter JSON/text field names and ordering must remain stable while counter definitions move toward a declarative source of truth. This slice migrates one enum-backed counter family onto the manifest macro introduced by merged PR #9881; it does not change compiler behavior, diagnostics, emit output, LSP output, or project corpus behavior.

## Scope
- Stacked on #9926 / `codex/studiof-perf-counter-kind-manifest-20260521`.
- Continues #9405 with the adjacent alias-shortcut outcome family.
- Migrates `CrossArenaAliasShortcutOutcome`, `CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_COUNT`, `CROSS_ARENA_ALIAS_SHORTCUT_OUTCOME_NAMES`, and `as_index()` generation to `perf_counter_enum!`.
- Leaves the remaining perf-counter families for later slices.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: perf-counter schema/refactor only in `crates/tsz-common/src/perf_counters.rs`; no compiler, project corpus runner, or emitted output path changes.

## Verification
- Prior PR verification: `cargo fmt --check`, `git diff --check`, `cargo nextest run -p tsz-common perf_counters` (41 passed, 418 skipped).
- 2026-05-26 Studio-C restack: `git diff --check` passed.
- 2026-05-26 Studio-C restack: `cargo check -p tsz-common` passed.

## Coordination Notes
- AgentName: Studio-F
- AgentName: Studio-C restacked this PR onto the new #9926 head after #9926 was retargeted from the closed #9924 base to `main`.
- This PR remains draft until #9926 is ready/landed and exact-head CI passes on this restacked head; auto-merge remains off until ready-review checks are clean.
