### PR TITLE
fix(dts): retain imports for arbitrary extension returns

### DIFF
--- a/crates/tsz-cli/tests/driver_tests.rs
+++ b/crates/tsz-cli/tests/driver_tests.rs
@@ -7198,6 +7198,18 @@ export const c = func();
         !dts.contains("c: CustomHtmlRepresentationThing"),
         "Expected no unbound local name from reexporter scope: {dts}"
     );
+
+    let reexporter_dts =
+        std::fs::read_to_string(base.join("dist/reexporter.d.ts")).expect("read reexporter.d.ts");
+    assert!(
+        reexporter_dts.contains(r#"import { CustomHtmlRepresentationThing } from "./foo.html";"#),
+        "Expected source-file import to stay when inferred return uses the imported type: {reexporter_dts}"
+    );
+    assert!(
+        reexporter_dts
+            .contains(r#"export declare function func(): CustomHtmlRepresentationThing;"#),
+        "Expected inferred return in the importing file to use the local imported name: {reexporter_dts}"
+    );
 }
 
 #[test]

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -1008,6 +1008,100 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|(rewritten, _, _, _)| rewritten)
     }
 
+    pub(in crate::declaration_emitter) fn rewrite_current_source_named_import_type_text(
+        &self,
+        type_text: &str,
+    ) -> Option<String> {
+        let (start, module_specifier, tail) = Self::next_import_type_text(type_text)?;
+        if start != 0 {
+            return None;
+        }
+        let tail = tail.strip_prefix('.')?;
+        let imported_name = Self::leading_import_type_member_name(tail)?;
+        let local_name =
+            self.current_source_named_import_local_name(&module_specifier, imported_name)?;
+        Self::rewrite_leading_import_type_member(type_text, imported_name, &local_name)
+    }
+
+    fn rewrite_leading_import_type_member(
+        type_text: &str,
+        imported_name: &str,
+        local_name: &str,
+    ) -> Option<String> {
+        let (start, _, tail) = Self::next_import_type_text(type_text)?;
+        if start != 0 {
+            return None;
+        }
+        let tail = tail.strip_prefix('.')?;
+        let import_type_end = type_text.len() - (tail.len() + 1);
+        let member_start = import_type_end + 1;
+        let member_end = member_start + imported_name.len();
+        let mut rewritten = String::with_capacity(type_text.len());
+        rewritten.push_str(&type_text[..start]);
+        rewritten.push_str(local_name);
+        rewritten.push_str(&type_text[member_end..]);
+        Some(rewritten)
+    }
+
+    fn current_source_named_import_local_name(
+        &self,
+        module_specifier: &str,
+        imported_name: &str,
+    ) -> Option<String> {
+        let source_file = self
+            .current_source_file_idx
+            .and_then(|source_file_idx| self.arena.get(source_file_idx))
+            .and_then(|node| self.arena.get_source_file(node))
+            .or_else(|| self.arena_source_file(self.arena))?;
+
+        for &stmt_idx in &source_file.statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(import) = self.arena.get_import_decl(stmt_node) else {
+                continue;
+            };
+            let Some(module_node) = self.arena.get(import.module_specifier) else {
+                continue;
+            };
+            let Some(module_lit) = self.arena.get_literal(module_node) else {
+                continue;
+            };
+            if module_lit.text != module_specifier {
+                continue;
+            }
+            let Some(clause_node) = self.arena.get(import.import_clause) else {
+                continue;
+            };
+            let Some(clause) = self.arena.get_import_clause(clause_node) else {
+                continue;
+            };
+            if let Some(bindings_node) = self.arena.get(clause.named_bindings)
+                && let Some(bindings) = self.arena.get_named_imports(bindings_node)
+            {
+                for &element_idx in &bindings.elements.nodes {
+                    let Some(element_node) = self.arena.get(element_idx) else {
+                        continue;
+                    };
+                    let Some(specifier) = self.arena.get_specifier(element_node) else {
+                        continue;
+                    };
+                    let imported_idx = if specifier.property_name.is_some() {
+                        specifier.property_name
+                    } else {
+                        specifier.name
+                    };
+                    if self.get_identifier_text(imported_idx).as_deref() != Some(imported_name) {
+                        continue;
+                    }
+                    return self.get_identifier_text(specifier.name);
+                }
+            }
+        }
+
+        None
+    }
+
     pub(in crate::declaration_emitter) fn rewrite_current_source_public_import_type_text_with_import(
         &self,
         type_text: &str,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/synthetic_dependencies.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/synthetic_dependencies.rs
@@ -5,6 +5,7 @@ use tsz_binder::symbol_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
+use tsz_solver::type_queries;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn synthetic_class_extends_alias_type_id(
@@ -426,7 +427,7 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(source_text) = self.source_file_text.as_deref().map(str::to_string) else {
             return;
         };
-        let export_types = statements
+        let mut export_types = statements
             .nodes
             .iter()
             .filter_map(|&stmt_idx| self.arena.get(stmt_idx))
@@ -453,10 +454,14 @@ impl<'a> DeclarationEmitter<'a> {
                 candidates
             })
             .collect::<Vec<_>>();
+        export_types.extend(self.exported_function_return_type_dependencies(statements));
 
         for type_text in export_types {
             let import = self
-                .public_named_import_dependency_for_type_text(statements, &type_text)
+                .current_source_named_import_dependency_for_type_text(statements, &type_text)
+                .or_else(|| {
+                    self.public_named_import_dependency_for_type_text(statements, &type_text)
+                })
                 .or_else(|| {
                     Self::rewrite_leading_import_type_with_public_named_import(
                         &source_text,
@@ -475,6 +480,143 @@ impl<'a> DeclarationEmitter<'a> {
                 self.import_string_aliases.insert((module, imported), alias);
             }
         }
+    }
+
+    fn exported_function_return_type_dependencies(&self, statements: &NodeList) -> Vec<String> {
+        let mut dependencies = Vec::new();
+        for &stmt_idx in &statements.nodes {
+            let Some((func_idx, func)) = self.exported_function_dependency_target(stmt_idx) else {
+                continue;
+            };
+            let (preferred_return, direct_function_return) =
+                self.function_body_return_hint(func, func.body);
+            if direct_function_return && let Some(type_text) = preferred_return.as_ref() {
+                let (type_text, _) =
+                    self.function_return_type_text_for_declaration_scope(func, type_text);
+                dependencies.push(type_text);
+            }
+
+            let (Some(interner), Some(cache)) = (&self.type_interner, &self.type_cache) else {
+                continue;
+            };
+            let func_type_id = cache
+                .node_types
+                .get(&func_idx.0)
+                .copied()
+                .or_else(|| self.get_type_via_symbol_for_func(func_idx, func.name));
+            let Some(func_type_id) = func_type_id else {
+                continue;
+            };
+            let Some(return_type_id) = type_queries::get_return_type(*interner, func_type_id)
+            else {
+                continue;
+            };
+            dependencies.push(self.inferred_function_return_type_text(func, return_type_id));
+        }
+        dependencies
+    }
+
+    fn exported_function_dependency_target(
+        &self,
+        stmt_idx: NodeIndex,
+    ) -> Option<(NodeIndex, &tsz_parser::parser::node::FunctionData)> {
+        let stmt_node = self.arena.get(stmt_idx)?;
+        if stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            if !self.statement_has_effective_export(stmt_idx) {
+                return None;
+            }
+            return self
+                .arena
+                .get_function(stmt_node)
+                .map(|func| (stmt_idx, func));
+        }
+
+        if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+            let export = self.arena.get_export_decl(stmt_node)?;
+            let clause_node = self.arena.get(export.export_clause)?;
+            if clause_node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                return None;
+            }
+            return self
+                .arena
+                .get_function(clause_node)
+                .map(|func| (export.export_clause, func));
+        }
+
+        None
+    }
+
+    fn current_source_named_import_dependency_for_type_text(
+        &self,
+        statements: &NodeList,
+        type_text: &str,
+    ) -> Option<(String, String, Option<String>)> {
+        let (start, module_specifier, tail) = Self::next_import_type_text(type_text)?;
+        if start != 0 {
+            return None;
+        }
+        let tail = tail.strip_prefix('.')?;
+        let type_name = Self::leading_import_type_member_name(tail)?;
+        self.named_import_dependency_for_module_member(statements, &module_specifier, type_name)
+    }
+
+    fn named_import_dependency_for_module_member(
+        &self,
+        statements: &NodeList,
+        module_specifier: &str,
+        type_name: &str,
+    ) -> Option<(String, String, Option<String>)> {
+        for &stmt_idx in &statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            let Some(import) = self.arena.get_import_decl(stmt_node) else {
+                continue;
+            };
+            let Some(module_node) = self.arena.get(import.module_specifier) else {
+                continue;
+            };
+            let Some(module_lit) = self.arena.get_literal(module_node) else {
+                continue;
+            };
+            if module_lit.text != module_specifier {
+                continue;
+            }
+            let Some(clause_node) = self.arena.get(import.import_clause) else {
+                continue;
+            };
+            let Some(clause) = self.arena.get_import_clause(clause_node) else {
+                continue;
+            };
+            if let Some(bindings_node) = self.arena.get(clause.named_bindings)
+                && let Some(bindings) = self.arena.get_named_imports(bindings_node)
+            {
+                for &spec_idx in &bindings.elements.nodes {
+                    let Some(spec_node) = self.arena.get(spec_idx) else {
+                        continue;
+                    };
+                    let Some(specifier) = self.arena.get_specifier(spec_node) else {
+                        continue;
+                    };
+                    let imported_idx = if specifier.property_name.is_some() {
+                        specifier.property_name
+                    } else {
+                        specifier.name
+                    };
+                    let Some(imported_name) = self.get_identifier_text(imported_idx) else {
+                        continue;
+                    };
+                    if imported_name != type_name {
+                        continue;
+                    }
+                    let local_name = self.get_identifier_text(specifier.name);
+                    let alias = local_name.filter(|local| local != &imported_name);
+                    return Some((module_lit.text.clone(), imported_name, alias));
+                }
+            }
+        }
+
+        None
     }
 
     fn public_named_import_dependency_for_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/synthetic_dependencies.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/synthetic_dependencies.rs
@@ -5,7 +5,6 @@ use tsz_binder::symbol_flags;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::type_queries;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn synthetic_class_extends_alias_type_id(
@@ -507,7 +506,8 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(func_type_id) = func_type_id else {
                 continue;
             };
-            let Some(return_type_id) = type_queries::get_return_type(*interner, func_type_id)
+            let Some(return_type_id) =
+                tsz_solver::type_queries::get_return_type(*interner, func_type_id)
             else {
                 continue;
             };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -224,7 +224,10 @@ impl<'a> DeclarationEmitter<'a> {
         let text = self.restore_mapped_return_type_param_constraints(func, &text);
         let text = self.rewrite_returned_auto_accessor_parameter_unknowns(func, &text);
         let text = self.rewrite_returned_call_conditional_unknown_subject(func, &text);
-        self.expand_mapped_alias_index_conditional_text(self.arena, &text)
+        let text = self
+            .expand_mapped_alias_index_conditional_text(self.arena, &text)
+            .unwrap_or(text);
+        self.rewrite_current_source_named_import_type_text(&text)
             .unwrap_or(text)
     }
 


### PR DESCRIPTION
AgentName: StuduiEmit

## Summary
- Plan declaration imports for exported inferred function returns that resolve through a current source named import.
- Rewrite inferred `import("...").Name` return text to the local imported name only when that exact source import exists.
- Extend the arbitrary-extension driver regression to cover both the importing file and downstream transitive use.

## Structural Rule
When an exported inferred function return type names a member that is already imported by a named source import in the same file, `tsc` retains that import and prints the local imported name in the `.d.ts`. This change makes tsz do the same for arbitrary-extension declaration modules such as `./foo.html`, while downstream files without that local import still use a qualified import type.

## Owner Layer
- DTS dependency planning owns retaining imports needed by synthetic declaration surfaces before printing starts.
- DTS return type printing owns using the local source import name when the import is already planned and nameable.
- The change does not add checker semantic validation or output surgery; it uses AST import declarations plus existing inferred return type text.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS nameability / arbitrary-extension declaration import retention

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-cli`
- `cargo nextest run -p tsz-cli compile_dts_qualifies_imported_return_type_reused_from_another_file`
- `./scripts/emit/run.sh --filter=declarationEmitTransitiveImportOfHtmlDeclarationItem --dts-only --verbose --timeout=20000 --json-out=/tmp/studui-html-transitive-dts-after-rebase.json`
- `cargo clippy --profile ci-lint -p tsz-emitter -p tsz-cli --all-targets -- -D warnings`
- `git diff --check`