### PR TITLE
fix(dts): preserve mapped alias return surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -84,6 +84,11 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return true;
         }
+        if self.source_return_type_preserves_mapped_alias_application(source_type_text)
+            && self.print_type_id(inferred_return_type) != source_type_text
+        {
+            return true;
+        }
         if !source_type_text.contains("typeof ") {
             return Self::type_text_contains_mapped_type_literal(source_type_text)
                 && self.print_type_id(inferred_return_type) != source_type_text;
@@ -128,6 +133,18 @@ impl<'a> DeclarationEmitter<'a> {
         };
         self.inferred_return_application_base_name(inferred_return_type)
             .is_some_and(|base_name| source_name == base_name)
+    }
+
+    fn source_return_type_preserves_mapped_alias_application(
+        &self,
+        source_type_text: &str,
+    ) -> bool {
+        let Some((alias_name, _)) = Self::single_type_reference_application(source_type_text)
+        else {
+            return false;
+        };
+        self.source_type_alias_type_text(self.arena, alias_name)
+            .is_some_and(|alias_text| Self::type_text_contains_mapped_type_literal(&alias_text))
     }
 
     fn inferred_return_application_base_name(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
@@ -1200,6 +1200,35 @@ function f2(item: A | B | undefined) {
 }
 
 #[test]
+fn test_function_returning_implemented_generic_mapped_alias_call_preserves_alias_surface() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Box<T> = {};
+type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+function boxify<T>(obj: T): Boxified<T> {
+    return obj as any;
+}
+type A = { a: string };
+type B = { b: string };
+function f1(x: A | B | undefined) {
+    return boxify(x);
+}
+"#,
+    );
+
+    assert!(
+        output.contains("declare function f1(x: A | B | undefined): Boxified<A | B | undefined>;"),
+        "Expected implemented helper return to keep the generic mapped alias instantiation: {output}"
+    );
+    assert!(
+        !output.contains("declare function f1(x: A | B | undefined): {\n    a: Box<string>;"),
+        "Did not expect the mapped alias return to expand into object-union members: {output}"
+    );
+}
+
+#[test]
 fn test_function_return_prefers_object_literal_over_return_type_wrapper() {
     let source = r#"
     function f1(s: string) {


### PR DESCRIPTION
## Agent
AgentName: StuduiEmit

## Track
Emit/DTS parity: declaration type-display/nameability

## Invariant
When an inferred declaration return reuses a source-visible generic type-alias application whose alias body is a mapped type, `tsc` keeps the alias application as the public return surface; this PR makes tsz preserve that source alias instead of printing the evaluated object-union expansion.

## Scope
- Preserve mapped alias application return text in declaration return normalization when the inferred TypeId would expand to a different structural surface.
- Add focused regression coverage for implemented helper functions returning mapped alias applications.

## Architecture
Owner layer: declaration return type-display policy. The change does not add checker semantic validation or output surgery; it uses source-backed declaration text plus existing alias body inspection to choose the printable public API surface.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS mapped alias return surface preservation

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-emitter -E 'test(test_function_returning_generic_mapped_alias_call_preserves_alias_surface) | test(test_function_returning_implemented_generic_mapped_alias_call_preserves_alias_surface) | test(test_exported_function_returning_mapped_infer_call_expands_alias_return_type)'`
- `./scripts/emit/run.sh --filter=mappedTypes4 --dts-only --verbose --timeout=60000 --json-out=/tmp/studui-mappedTypes4-after-fmt-rerun.json`
- `git diff --check`
- `cargo check -p tsz-emitter`
- `cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
No open PR currently claims `mappedTypes4` / mapped alias return surface preservation. This is intentionally separate from active remapped-keyof and spread-object DTS branches.
