### PR TITLE
fix(emit): preserve invalid namespace static recovery

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -252,10 +252,21 @@ impl<'a> Printer<'a> {
             }
         }
 
+        let emit_invalid_namespace_static =
+            self.should_emit_invalid_namespace_static_modifier(node, &class.modifiers);
+        if emit_invalid_namespace_static {
+            self.write("static ");
+        }
+
         // Emit modifiers (including decorators) - skip TS-only modifiers for JS output
         if !suppress_modifiers && let Some(ref modifiers) = class.modifiers {
             for &mod_idx in &modifiers.nodes {
                 if let Some(mod_node) = self.arena.get(mod_idx) {
+                    if emit_invalid_namespace_static
+                        && mod_node.kind == SyntaxKind::StaticKeyword as u16
+                    {
+                        continue;
+                    }
                     // Skip export/default modifiers in CommonJS mode or namespace IIFE
                     if (self.ctx.is_commonjs() || self.in_namespace_iife)
                         && (mod_node.kind == SyntaxKind::ExportKeyword as u16

--- a/crates/tsz-emitter/src/emitter/declarations/core.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/core.rs
@@ -650,6 +650,20 @@ impl<'a> Printer<'a> {
                         output = format!("{let_prefix}{}", &output[var_prefix.len()..]);
                     }
                 }
+                if !enum_name.is_empty()
+                    && self.should_emit_invalid_namespace_static_modifier_before_name(
+                        enum_decl.name,
+                        &enum_decl.modifiers,
+                    )
+                {
+                    let let_prefix = format!("let {enum_name};");
+                    let var_prefix = format!("var {enum_name};");
+                    if output.starts_with(&let_prefix) {
+                        output = format!("static {let_prefix}{}", &output[let_prefix.len()..]);
+                    } else if output.starts_with(&var_prefix) {
+                        output = format!("static {var_prefix}{}", &output[var_prefix.len()..]);
+                    }
+                }
                 self.write(&output);
 
                 // The enum IR emitter handles comments INSIDE the enum body,

--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -449,6 +449,12 @@ impl<'a> Printer<'a> {
             } else {
                 "var"
             };
+            if self.should_emit_invalid_namespace_static_modifier_before_name(
+                module.name,
+                &module.modifiers,
+            ) {
+                self.write("static ");
+            }
             self.write(keyword);
             self.write(" ");
             self.write(&name);

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -17,6 +17,18 @@ const fn is_identifier_continue(byte: u8) -> bool {
     byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
 }
 
+fn previous_identifier_token(text: &str, mut end: usize) -> Option<(&str, usize)> {
+    let bytes = text.as_bytes();
+    while end > 0 && matches!(bytes[end - 1], b' ' | b'\t' | b'\r' | b'\n') {
+        end -= 1;
+    }
+    let token_end = end;
+    while end > 0 && is_identifier_continue(bytes[end - 1]) {
+        end -= 1;
+    }
+    (end < token_end).then(|| (&text[end..token_end], end))
+}
+
 impl<'a> Printer<'a> {
     pub(super) const fn take_pending_source_pos(&mut self) -> Option<SourcePosition> {
         self.pending_source_pos.take()
@@ -242,9 +254,19 @@ impl<'a> Printer<'a> {
         if starts_with_keyword_token(remaining, "static") {
             let after_static = &remaining["static".len()..];
             let after_static = after_static.trim_start_matches([' ', '\t']);
-            return ["var", "let", "const", "function", "async"]
-                .iter()
-                .any(|keyword| starts_with_keyword_token(after_static, keyword));
+            return [
+                "var",
+                "let",
+                "const",
+                "function",
+                "async",
+                "class",
+                "namespace",
+                "module",
+                "enum",
+            ]
+            .iter()
+            .any(|keyword| starts_with_keyword_token(after_static, keyword));
         }
 
         let mut static_end = token_start;
@@ -275,9 +297,52 @@ impl<'a> Printer<'a> {
         let Some(leading_token) = text.get(token_start..(node.end as usize).min(text.len())) else {
             return false;
         };
-        ["var", "let", "const", "function", "async"]
-            .iter()
-            .any(|keyword| starts_with_keyword_token(leading_token, keyword))
+        [
+            "var",
+            "let",
+            "const",
+            "function",
+            "async",
+            "class",
+            "namespace",
+            "module",
+            "enum",
+        ]
+        .iter()
+        .any(|keyword| starts_with_keyword_token(leading_token, keyword))
+    }
+
+    pub(in crate::emitter) fn should_emit_invalid_namespace_static_modifier_before_name(
+        &self,
+        name_idx: NodeIndex,
+        modifiers: &Option<NodeList>,
+    ) -> bool {
+        if !self.in_namespace_iife || self.ctx.target_es5 {
+            return false;
+        }
+        if self
+            .arena
+            .has_modifier(modifiers, SyntaxKind::StaticKeyword)
+        {
+            return true;
+        }
+
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(name_idx) else {
+            return false;
+        };
+        let token_start = self.skip_trivia_forward(name_node.pos, name_node.end) as usize;
+        let Some((previous, previous_start)) = previous_identifier_token(text, token_start) else {
+            return false;
+        };
+        if previous == "static" {
+            return true;
+        }
+        matches!(previous, "class" | "namespace" | "module" | "enum")
+            && previous_identifier_token(text, previous_start)
+                .is_some_and(|(before_keyword, _)| before_keyword == "static")
     }
 
     /// Emit an expression, unwrapping `ExpressionWithTypeArguments` without parens.

--- a/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
@@ -60,6 +60,7 @@ pub fn transform_enum_to_ir(arena: &NodeArena, enum_idx: NodeIndex) -> Option<IR
         name: name.into(),
         members,
         namespace_export: None,
+        invalid_namespace_static: false,
     })
 }
 

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -589,6 +589,7 @@ pub enum IRNode {
         name: Cow<'static, str>,
         members: Vec<EnumMember>,
         namespace_export: Option<Cow<'static, str>>,
+        invalid_namespace_static: bool,
     },
 
     /// Namespace IIFE: `(function (NS) { ... })(NS || (NS = {}))`
@@ -623,6 +624,9 @@ pub enum IRNode {
         skip_sequence_indent: bool,
         /// Same-line comment after the namespace declaration closing brace.
         trailing_comment: Option<Cow<'static, str>>,
+        /// Preserve an invalid `static` modifier before the generated namespace
+        /// binding declaration when recovering namespace-body emit.
+        invalid_namespace_static: bool,
     },
 
     /// Namespace export: `NS.foo = ...;`
@@ -1122,6 +1126,7 @@ impl IRNode {
                 name: enum_name,
                 members,
                 namespace_export,
+                ..
             } => {
                 enum_name.as_ref() == name
                     || namespace_export

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -46,6 +46,7 @@ struct NamespaceIifeContext<'a> {
     default_export_merge: bool,
     parent_name: Option<&'a str>,
     param_name: Option<&'a str>,
+    invalid_static_declaration: bool,
 }
 
 /// IR Printer - converts IR nodes to JavaScript strings
@@ -2517,6 +2518,7 @@ impl<'a> IRPrinter<'a> {
                 name,
                 members,
                 namespace_export,
+                invalid_namespace_static,
             } => {
                 if let Some(ns) = namespace_export {
                     self.emit_namespace_bound_enum_iife(name, members, ns);
@@ -2527,6 +2529,10 @@ impl<'a> IRPrinter<'a> {
                     } else {
                         "var"
                     };
+                    if *invalid_namespace_static && self.in_namespace_iife_body && !self.target_es5
+                    {
+                        self.write("static ");
+                    }
                     self.write(keyword);
                     self.write(" ");
                     self.write(name);
@@ -2571,6 +2577,7 @@ impl<'a> IRPrinter<'a> {
                 default_export_merge,
                 skip_sequence_indent: _,
                 trailing_comment,
+                invalid_namespace_static,
             } => {
                 self.emit_namespace_iife(
                     name_parts,
@@ -2585,6 +2592,7 @@ impl<'a> IRPrinter<'a> {
                         default_export_merge: *default_export_merge,
                         parent_name: parent_name.as_deref(),
                         param_name: param_name.as_deref(),
+                        invalid_static_declaration: *invalid_namespace_static,
                     },
                 );
                 if !self.remove_comments
@@ -2692,6 +2700,10 @@ impl<'a> IRPrinter<'a> {
             } else {
                 "var"
             };
+            if context.invalid_static_declaration && self.in_namespace_iife_body && !self.target_es5
+            {
+                self.write("static ");
+            }
             self.write(decl_keyword);
             self.write(" ");
             self.write(current_name);
@@ -2790,6 +2802,7 @@ impl<'a> IRPrinter<'a> {
                     default_export_merge: false,
                     parent_name: None,
                     param_name: context.param_name,
+                    invalid_static_declaration: false,
                 },
             );
             self.write_line();

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -71,6 +71,30 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
+fn starts_with_keyword_token(text: &str, keyword: &str) -> bool {
+    text.strip_prefix(keyword).is_some_and(|tail| {
+        tail.chars()
+            .next()
+            .is_none_or(|ch| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
+    })
+}
+
+const fn is_identifier_continue(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
+}
+
+fn previous_identifier_token(text: &str, mut end: usize) -> Option<(&str, usize)> {
+    let bytes = text.as_bytes();
+    while end > 0 && matches!(bytes[end - 1], b' ' | b'\t' | b'\r' | b'\n') {
+        end -= 1;
+    }
+    let token_end = end;
+    while end > 0 && is_identifier_continue(bytes[end - 1]) {
+        end -= 1;
+    }
+    (end < token_end).then(|| (&text[end..token_end], end))
+}
+
 // =============================================================================
 // NamespaceES5Transformer - Main transformer struct
 // =============================================================================
@@ -655,6 +679,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             trailing_comment: self
                 .extract_namespace_trailing_comment(innermost_body)
                 .map(Into::into),
+            invalid_namespace_static: self.has_invalid_namespace_static_modifier(ns_idx),
         })
     }
 
@@ -800,6 +825,72 @@ impl<'a> NamespaceES5Transformer<'a> {
         });
         let _ = result_name;
         prefix
+    }
+
+    fn has_invalid_namespace_static_modifier(&self, node_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(node_idx) else {
+            return false;
+        };
+        let (modifiers, probe_pos) = match node.kind {
+            k if k == syntax_kind_ext::MODULE_DECLARATION => {
+                let Some(module) = self.arena.get_module(node) else {
+                    return false;
+                };
+                let probe_pos = self
+                    .arena
+                    .get(module.name)
+                    .map_or(node.pos, |name| name.pos);
+                (module.modifiers.as_ref(), probe_pos)
+            }
+            k if k == syntax_kind_ext::ENUM_DECLARATION => {
+                let Some(enum_data) = self.arena.get_enum(node) else {
+                    return false;
+                };
+                let probe_pos = self
+                    .arena
+                    .get(enum_data.name)
+                    .map_or(node.pos, |name| name.pos);
+                (enum_data.modifiers.as_ref(), probe_pos)
+            }
+            _ => (None, node.pos),
+        };
+        if modifiers.is_some_and(|mods| {
+            mods.nodes.iter().any(|&mod_idx| {
+                self.arena
+                    .get(mod_idx)
+                    .is_some_and(|mod_node| mod_node.kind == SyntaxKind::StaticKeyword as u16)
+            })
+        }) {
+            return true;
+        }
+
+        let Some(source_text) = self.source_text else {
+            return false;
+        };
+        let token_start = self.skip_trivia_forward(probe_pos, node.end) as usize;
+        let Some(remaining) =
+            source_text.get(token_start..(node.end as usize).min(source_text.len()))
+        else {
+            return false;
+        };
+        if starts_with_keyword_token(remaining, "static") {
+            return true;
+        }
+
+        let Some((previous, previous_start)) = previous_identifier_token(source_text, token_start)
+        else {
+            return false;
+        };
+        if previous == "static" {
+            return true;
+        }
+        if matches!(previous, "namespace" | "module" | "enum")
+            && let Some((before_keyword, _)) =
+                previous_identifier_token(source_text, previous_start)
+        {
+            return before_keyword == "static";
+        }
+        false
     }
 
     fn source_file_has_default_exported_function(&self, ns_idx: NodeIndex, name: &str) -> bool {
@@ -1137,12 +1228,19 @@ impl<'a> NamespaceES5Transformer<'a> {
             // Start after the opening brace of the module block.
             let mut prev_end = body_node.pos + 1; // skip past '{'
             let mut prev_stmt_pos = body_node.pos + 1;
+            let mut pending_static_modifier = false;
 
             for &stmt_idx in &stmts.nodes {
                 let stmt_node = match self.arena.get(stmt_idx) {
                     Some(n) => n,
                     None => continue,
                 };
+                if stmt_node.kind == SyntaxKind::StaticKeyword as u16 {
+                    pending_static_modifier = true;
+                    prev_end = stmt_node.end;
+                    prev_stmt_pos = stmt_node.pos;
+                    continue;
+                }
 
                 // Some statements have trailing trivia that includes standalone comments
                 // before the next declaration. Capture those comments here so they can
@@ -1186,11 +1284,17 @@ impl<'a> NamespaceES5Transformer<'a> {
                     Vec::new()
                 };
 
-                let ir = self.transform_namespace_member_with_declared(
+                let mut ir = self.transform_namespace_member_with_declared(
                     ns_name,
                     stmt_idx,
                     &declared_names,
                 );
+                if pending_static_modifier {
+                    if let Some(ir_node) = ir.as_mut() {
+                        mark_invalid_namespace_static(ir_node);
+                    }
+                    pending_static_modifier = false;
+                }
                 if ir.is_some() {
                     for c in leading_comments {
                         result.push(c);
@@ -2353,6 +2457,7 @@ impl<'a> NamespaceES5Transformer<'a> {
         };
 
         let mut enum_ir = transform_enum_to_ir(self.arena, enum_idx)?;
+        let invalid_namespace_static = self.has_invalid_namespace_static_modifier(enum_idx);
 
         // For exported enums, fold the namespace export into the IIFE closing:
         // `(Color = A.Color || (A.Color = {}))` instead of separate `A.Color = Color;`
@@ -2362,6 +2467,14 @@ impl<'a> NamespaceES5Transformer<'a> {
             } = &mut enum_ir
         {
             *namespace_export = Some(ns_name.to_string().into());
+        }
+        if invalid_namespace_static
+            && let IRNode::EnumIIFE {
+                invalid_namespace_static,
+                ..
+            } = &mut enum_ir
+        {
+            *invalid_namespace_static = true;
         }
 
         Some(enum_ir)
@@ -2428,7 +2541,27 @@ impl<'a> NamespaceES5Transformer<'a> {
             trailing_comment: self
                 .extract_namespace_trailing_comment(ns_data.body)
                 .map(Into::into),
+            invalid_namespace_static: self.has_invalid_namespace_static_modifier(ns_idx),
         })
+    }
+}
+
+fn mark_invalid_namespace_static(node: &mut IRNode) {
+    match node {
+        IRNode::EnumIIFE {
+            invalid_namespace_static,
+            ..
+        }
+        | IRNode::NamespaceIIFE {
+            invalid_namespace_static,
+            ..
+        } => *invalid_namespace_static = true,
+        IRNode::Sequence(items) => {
+            if let Some(first) = items.first_mut() {
+                mark_invalid_namespace_static(first);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/tsz-emitter/tests/ir_printer.rs
+++ b/crates/tsz-emitter/tests/ir_printer.rs
@@ -270,6 +270,7 @@ fn test_nested_sequence_respects_namespace_skip_indent() {
             param_name: None,
             skip_sequence_indent: true,
             trailing_comment: None,
+            invalid_namespace_static: false,
         },
     ]);
     let mut printer = IRPrinter::new();
@@ -313,6 +314,7 @@ fn test_namespace_iife_generated_object_literal_is_multiline() {
         param_name: None,
         skip_sequence_indent: false,
         trailing_comment: None,
+        invalid_namespace_static: false,
     };
 
     let output = IRPrinter::emit_to_string(&ns);

--- a/crates/tsz-emitter/tests/ir_transforms_tests.rs
+++ b/crates/tsz-emitter/tests/ir_transforms_tests.rs
@@ -22,6 +22,7 @@ fn test_ir_enum_numeric() {
             },
         ],
         namespace_export: None,
+        invalid_namespace_static: false,
     };
 
     let output = IRPrinter::emit_to_string(&enum_ir);
@@ -50,6 +51,7 @@ fn test_ir_enum_string() {
             },
         ],
         namespace_export: None,
+        invalid_namespace_static: false,
     };
 
     let output = IRPrinter::emit_to_string(&enum_ir);
@@ -83,6 +85,7 @@ fn test_ir_namespace_iife() {
         param_name: None,
         skip_sequence_indent: false,
         trailing_comment: None,
+        invalid_namespace_static: false,
     };
 
     let output = IRPrinter::emit_to_string(&namespace_ir);
@@ -108,6 +111,7 @@ fn test_ir_namespace_qualified() {
         param_name: None,
         skip_sequence_indent: false,
         trailing_comment: None,
+        invalid_namespace_static: false,
     };
 
     let output = IRPrinter::emit_to_string(&namespace_ir);

--- a/crates/tsz-emitter/tests/printer.rs
+++ b/crates/tsz-emitter/tests/printer.rs
@@ -2222,10 +2222,56 @@ fn invalid_namespace_static_var_and_function_modifiers_are_preserved() {
 }
 
 #[test]
+fn invalid_namespace_static_class_enum_and_namespace_modifiers_are_preserved() {
+    let source = r#"namespace N {
+    public class PublicClass { }
+    private class PrivateClass { }
+    static class StaticClass { }
+    static namespace Inner { export var value = 1; }
+    static enum Color { Red }
+}"#;
+    let output = parse_lower_print(
+        source,
+        PrintOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("class PublicClass"),
+        "Invalid public modifier on namespace class should be erased.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("class PrivateClass"),
+        "Invalid private modifier on namespace class should be erased.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("public class") && !output.contains("private class"),
+        "Access modifiers on namespace classes must not survive JS emit.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("static class StaticClass"),
+        "Invalid static modifier on namespace class should be preserved.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("static let Inner;"),
+        "Invalid static modifier on nested namespace binding should be preserved.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("static let Color;"),
+        "Invalid static modifier on namespace enum binding should be preserved.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn invalid_namespace_static_modifiers_are_erased_for_es5() {
     let source = r#"namespace N {
     static var staticValue: number = 1;
     static function staticFn(x: string) { }
+    static class StaticClass { }
+    static namespace Inner { export var value = 1; }
+    static enum Color { Red }
 }"#;
     let output = parse_lower_print(source, PrintOptions::es5());
 
@@ -2238,7 +2284,15 @@ fn invalid_namespace_static_modifiers_are_erased_for_es5() {
         "ES5 namespace function recovery should erase invalid static.\nOutput:\n{output}"
     );
     assert!(
-        !output.contains("static var") && !output.contains("static function"),
+        output.contains("var Inner;"),
+        "ES5 namespace recovery should still emit the nested namespace binding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var Color;"),
+        "ES5 namespace recovery should still emit the enum binding.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("static "),
         "ES5 namespace output must not preserve invalid static modifiers.\nOutput:\n{output}"
     );
 }


### PR DESCRIPTION
AgentName: StuduiEmit

## Structural rule
When a namespace/module body contains an invalid `static` modifier on a runtime value declaration that still emits JavaScript, `tsc` preserves that token in ES2015+ recovery output: `static class C`, `static let Inner`, and `static let E`. Access modifiers such as `public`/`private` are still erased, and ES5 namespace lowering still erases the invalid `static` token.

## Owner layer
This belongs in the emitter recovery path. The parser/checker report the invalid modifier; emit is responsible for reproducing `tsc`'s JavaScript recovery text without adding semantic validation. The change updates both namespace emit surfaces: the direct namespace printer and the namespace IR printer.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit parser-recovery for invalid namespace/module modifiers
- Evidence: focused `tsz-emitter` tests plus `invalidModuleWithStatementsOfEveryKind` JS-only emit harness filter; no benchmark fixture targeted.

## Adjacent-case matrix
- `static class C` inside a namespace preserves `static class C` for ES2015+.
- `static namespace Inner` inside a namespace preserves `static let Inner` before the nested IIFE for ES2015+.
- `static enum E` inside a namespace preserves `static let E` before the enum IIFE for ES2015+.
- `public`/`private` namespace-body classes continue to erase access modifiers.
- ES5 namespace output continues to erase invalid `static` before var/function/class/namespace/enum recovery output.

## Fallbacks / unsupported shapes
The recovery probe is source-token based only when the parser did not retain a `StaticKeyword` modifier. If the static token cannot be proven from modifiers or nearby declaration tokens, emit falls back to the existing non-static output.

## Coordination
The `project-corpus-pr-body` failure was due to missing PR metadata, not source behavior. The body now includes the required Project Corpus Impact section and evidence line.

## Verification
- `cargo nextest run -p tsz-emitter invalid_namespace_static --no-fail-fast`
- `cargo check -p tsz-emitter`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings`
- `scripts/architecture-check.sh --quick`
- `./scripts/emit/run.sh --filter=invalidModuleWithStatementsOfEveryKind --js-only --verbose --timeout=30000 --json-out=/tmp/studui-invalid-module-statements-js-after-rebase.json`
