### PR TITLE
fix(solver): map variadic-tuple rest element by its own index

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -2041,6 +2041,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Instantiate a mapped type's template with the iteration variable bound
+    /// to the tuple position `index`, then evaluate it. For a homomorphic
+    /// mapping this makes `X[I]` resolve to that position's element type.
+    fn map_template_at_index(&mut self, mapped: &MappedType, index: usize) -> TypeId {
+        let index_type = self.interner().literal_number(index as f64);
+        let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
+        self.evaluate(instantiate_type(self.interner(), mapped.template, &subst))
+    }
+
     /// Evaluate a homomorphic mapped type over a Tuple type.
     ///
     /// For example: `type Partial<T> = { [P in keyof T]?: T[P] }`
@@ -2057,41 +2066,36 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut mapped_elements = Vec::new();
 
         for (i, elem) in tuple_elements.iter().enumerate() {
-            // CRITICAL: Handle rest elements specially
-            // For rest elements (...T[]), we cannot use index substitution.
-            // We must map the array type itself.
             if elem.rest {
-                // Rest elements like ...number[] need to be mapped as arrays
-                // Check if the rest type is an Array
+                // A homomorphic mapped type `{ [I in keyof X]: F<X[I]> }` binds
+                // `I` to each position's index, including the rest position, so
+                // `X[I]` resolves to that position's own element type. Binding
+                // `I` to `X[number]` instead would wrongly yield the union of
+                // every tuple element.
                 let rest_type = elem.type_id;
                 let mapped_rest_type = match self.interner().lookup(rest_type) {
-                    Some(TypeData::Array(inner_elem)) => {
-                        // Map the inner array element
-                        // Reuse the array mapping logic
-                        self.evaluate_mapped_array(mapped, inner_elem)
-                    }
                     Some(TypeData::Tuple(inner_tuple_id)) => {
-                        // Nested tuple in rest - recurse
+                        // `...[A, B]` spreads a fixed tuple across several
+                        // positions; recurse so each inner position keeps its
+                        // own mapped element type and the variadic shape.
                         self.evaluate_mapped_tuple(mapped, inner_tuple_id)
                     }
                     _ => {
-                        // Fallback: try index substitution (may not work correctly)
-                        let index_type = self.interner().literal_number(i as f64);
-                        let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
-                        self.evaluate(instantiate_type(self.interner(), mapped.template, &subst))
+                        // `...E[]` (or any other single-slot rest): map the
+                        // rest element type via this position's index, apply
+                        // the optional modifier to the element, then re-wrap
+                        // as an array so the slot stays a rest element.
+                        let mut mapped_element = self.map_template_at_index(mapped, i);
+                        if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
+                            mapped_element =
+                                self.interner().union2(mapped_element, TypeId::UNDEFINED);
+                        }
+                        self.interner().array(mapped_element)
                     }
                 };
 
-                // Handle optional modifier for rest elements
-                let final_rest_type =
-                    if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
-                        self.interner().union2(mapped_rest_type, TypeId::UNDEFINED)
-                    } else {
-                        mapped_rest_type
-                    };
-
                 mapped_elements.push(TupleElement {
-                    type_id: final_rest_type,
+                    type_id: mapped_rest_type,
                     name: elem.name,
                     optional: elem.optional,
                     rest: true,
@@ -2099,15 +2103,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 continue;
             }
 
-            // Non-rest elements: use index substitution
-            // Create a literal number type for this tuple position
-            let index_type = self.interner().literal_number(i as f64);
-
-            let subst = TypeSubstitution::single(mapped.type_param.name, index_type);
-
-            // Substitute into the template to get the mapped element type
-            let mapped_type =
-                self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
+            // Non-rest elements: bind the iteration variable to this position's
+            // index so the template's `X[I]` resolves to this element's type.
+            let mapped_type = self.map_template_at_index(mapped, i);
 
             // Per-element readonly is not representable on a `TupleElement`; the
             // mapped type's readonly modifier is applied at the tuple level by

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -2064,38 +2064,52 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         let tuple_elements = self.interner().tuple_list(tuple_id);
         let mut mapped_elements = Vec::new();
+        let mut seen_rest = false;
 
         for (i, elem) in tuple_elements.iter().enumerate() {
             if elem.rest {
-                // A homomorphic mapped type `{ [I in keyof X]: F<X[I]> }` binds
-                // `I` to each position's index, including the rest position, so
-                // `X[I]` resolves to that position's own element type. Binding
-                // `I` to `X[number]` instead would wrongly yield the union of
-                // every tuple element.
+                let is_first_rest = !seen_rest;
+                seen_rest = true;
                 let rest_type = elem.type_id;
                 let mapped_rest_type = match self.interner().lookup(rest_type) {
+                    Some(TypeData::Array(_)) if is_first_rest => {
+                        // `...E[]` as the first rest: every position before it is
+                        // fixed, so `X[i]` (this position's index) unambiguously
+                        // resolves to the rest element's own type. Binding `I` to
+                        // `X[number]` instead — as `evaluate_mapped_array` does —
+                        // would wrongly yield the union of every tuple element
+                        // (e.g. `Identity<[string, ...number[]]>` rest member
+                        // `string | number` rather than `number`). Re-wrap as an
+                        // array so the slot stays a rest element.
+                        //
+                        // A later rest cannot use this: `tuple_index_literal`
+                        // short-circuits on the first rest it meets, so positions
+                        // after an earlier rest/variadic spread are unreliable.
+                        let mapped_element = self.map_template_at_index(mapped, i);
+                        self.interner().array(mapped_element)
+                    }
+                    Some(TypeData::Array(inner_elem)) => {
+                        self.evaluate_mapped_array(mapped, inner_elem)
+                    }
                     Some(TypeData::Tuple(inner_tuple_id)) => {
-                        // `...[A, B]` spreads a fixed tuple across several
-                        // positions; recurse so each inner position keeps its
-                        // own mapped element type and the variadic shape.
+                        // Nested tuple spread (`...[A, B]`) - recurse.
                         self.evaluate_mapped_tuple(mapped, inner_tuple_id)
                     }
                     _ => {
-                        // `...E[]` (or any other single-slot rest): map the
-                        // rest element type via this position's index, apply
-                        // the optional modifier to the element, then re-wrap
-                        // as an array so the slot stays a rest element.
-                        let mut mapped_element = self.map_template_at_index(mapped, i);
-                        if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
-                            mapped_element =
-                                self.interner().union2(mapped_element, TypeId::UNDEFINED);
-                        }
-                        self.interner().array(mapped_element)
+                        // Generic/opaque rest (e.g. `...U`): index substitution.
+                        self.map_template_at_index(mapped, i)
                     }
                 };
 
+                let final_rest_type =
+                    if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
+                        self.interner().union2(mapped_rest_type, TypeId::UNDEFINED)
+                    } else {
+                        mapped_rest_type
+                    };
+
                 mapped_elements.push(TupleElement {
-                    type_id: mapped_rest_type,
+                    type_id: final_rest_type,
                     name: elem.name,
                     optional: elem.optional,
                     rest: true,

--- a/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
@@ -1691,3 +1691,204 @@ fn test_mapped_type_string_filter_as_clause_removes_symbol_keys() {
         "as K extends string ? K : never should filter out symbol key"
     );
 }
+
+// =============================================================================
+// Homomorphic Mapped Types Over Variadic Tuples (issue #9699)
+//
+// Rule: a homomorphic mapped type `{ [I in keyof X]: F<X[I]> }` over a tuple
+// binds `I` to each position's index, including the rest position, so `X[I]`
+// resolves to that position's *own* element type. The rest slot stays a rest
+// (array) element of the mapped element type, never `X[number]` (the union of
+// every tuple element).
+// =============================================================================
+
+fn req_elem(type_id: TypeId) -> crate::types::TupleElement {
+    crate::types::TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    }
+}
+
+fn rest_elem(type_id: TypeId) -> crate::types::TupleElement {
+    crate::types::TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: true,
+    }
+}
+
+/// Build and evaluate the post-instantiation form of the identity homomorphic
+/// mapping `{ [<iter> in keyof X]: X[<iter>] }` with `X` = `source`.
+fn eval_identity_mapped(interner: &TypeInterner, iter: &str, source: TypeId) -> TypeId {
+    let keyof = interner.keyof(source);
+    let tp_info = TypeParamInfo {
+        name: interner.intern_string(iter),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let tp = interner.intern(TypeData::TypeParameter(tp_info));
+    let template = interner.index_access(source, tp);
+    let mapped = MappedType {
+        type_param: tp_info,
+        constraint: keyof,
+        name_type: None,
+        template,
+        optional_modifier: None,
+        readonly_modifier: None,
+    };
+    evaluate_type(interner, interner.mapped(mapped))
+}
+
+#[test]
+fn identity_mapped_over_variadic_tuple_roundtrips() {
+    // Identity<[string, ...number[]]> === [string, ...number[]].
+    // Renaming the iteration variable must not change the result — the fix is
+    // structural, not keyed on the spelling `I`.
+    for iter in ["I", "Idx", "P"] {
+        let interner = TypeInterner::new();
+        let source = interner.tuple(vec![
+            req_elem(TypeId::STRING),
+            rest_elem(interner.array(TypeId::NUMBER)),
+        ]);
+
+        let result = eval_identity_mapped(&interner, iter, source);
+        assert_eq!(
+            result, source,
+            "identity over [string, ...number[]] should roundtrip (iter `{iter}`)"
+        );
+
+        // Pin the rest element type: it must be the rest element's own type
+        // (number[]), not `string | number`.
+        let Some(TypeData::Tuple(list_id)) = interner.lookup(result) else {
+            panic!("expected tuple result, got {:?}", interner.lookup(result));
+        };
+        let elements = interner.tuple_list(list_id);
+        assert_eq!(elements.len(), 2);
+        assert!(elements[1].rest, "second element must stay a rest element");
+        assert_eq!(
+            elements[1].type_id,
+            interner.array(TypeId::NUMBER),
+            "rest member must map to number[], not (string | number)[]"
+        );
+    }
+}
+
+#[test]
+fn identity_mapped_over_labeled_variadic_tuple_roundtrips() {
+    // [a: string, ...b: number[]] — labels must not change the per-position rule.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let source = interner.tuple(vec![
+        crate::types::TupleElement {
+            type_id: TypeId::STRING,
+            name: Some(a),
+            optional: false,
+            rest: false,
+        },
+        crate::types::TupleElement {
+            type_id: interner.array(TypeId::NUMBER),
+            name: Some(b),
+            optional: false,
+            rest: true,
+        },
+    ]);
+
+    let result = eval_identity_mapped(&interner, "I", source);
+    let Some(TypeData::Tuple(list_id)) = interner.lookup(result) else {
+        panic!("expected tuple result, got {:?}", interner.lookup(result));
+    };
+    let elements = interner.tuple_list(list_id);
+    assert_eq!(elements.len(), 2);
+    assert!(elements[1].rest);
+    assert_eq!(
+        elements[1].type_id,
+        interner.array(TypeId::NUMBER),
+        "labeled rest member must map to number[]"
+    );
+}
+
+#[test]
+fn identity_mapped_over_multi_prefix_variadic_tuple_roundtrips() {
+    // [string, symbol, ...number[]] — the rest member must be number, not the
+    // union of the whole tuple (string | symbol | number).
+    let interner = TypeInterner::new();
+    let source = interner.tuple(vec![
+        req_elem(TypeId::STRING),
+        req_elem(TypeId::SYMBOL),
+        rest_elem(interner.array(TypeId::NUMBER)),
+    ]);
+
+    let result = eval_identity_mapped(&interner, "I", source);
+    assert_eq!(
+        result, source,
+        "identity over [string, symbol, ...number[]] should roundtrip"
+    );
+}
+
+#[test]
+fn wrapping_mapped_over_variadic_tuple_wraps_per_position_element() {
+    // { [I in keyof X]: [X[I]] } over [string, ...number[]] should produce
+    // [[string], ...[number][]] — the rest member is [number], NOT [string | number].
+    let interner = TypeInterner::new();
+    let source = interner.tuple(vec![
+        req_elem(TypeId::STRING),
+        rest_elem(interner.array(TypeId::NUMBER)),
+    ]);
+
+    let keyof = interner.keyof(source);
+    let tp_info = TypeParamInfo {
+        name: interner.intern_string("I"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let tp = interner.intern(TypeData::TypeParameter(tp_info));
+    // template: [X[I]]
+    let template = interner.tuple(vec![req_elem(interner.index_access(source, tp))]);
+    let mapped = MappedType {
+        type_param: tp_info,
+        constraint: keyof,
+        name_type: None,
+        template,
+        optional_modifier: None,
+        readonly_modifier: None,
+    };
+    let result = evaluate_type(&interner, interner.mapped(mapped));
+
+    let expected_prefix = interner.tuple(vec![req_elem(TypeId::STRING)]); // [string]
+    let expected_rest_inner = interner.tuple(vec![req_elem(TypeId::NUMBER)]); // [number]
+    let expected = interner.tuple(vec![
+        req_elem(expected_prefix),
+        rest_elem(interner.array(expected_rest_inner)),
+    ]);
+    assert_eq!(
+        result, expected,
+        "wrapping mapper should give [[string], ...[number][]]"
+    );
+}
+
+#[test]
+fn identity_mapped_fixed_tuple_and_plain_array_controls_roundtrip() {
+    // CONTROLS: a fixed tuple and a plain array were never affected and must
+    // continue to roundtrip cleanly.
+    let interner = TypeInterner::new();
+
+    let fixed = interner.tuple(vec![req_elem(TypeId::STRING), req_elem(TypeId::NUMBER)]);
+    assert_eq!(
+        eval_identity_mapped(&interner, "I", fixed),
+        fixed,
+        "identity over fixed tuple [string, number] should roundtrip"
+    );
+
+    let plain = interner.array(TypeId::NUMBER);
+    assert_eq!(
+        eval_identity_mapped(&interner, "I", plain),
+        plain,
+        "identity over number[] should roundtrip"
+    );
+}

--- a/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
@@ -1892,3 +1892,36 @@ fn identity_mapped_fixed_tuple_and_plain_array_controls_roundtrip() {
         "identity over number[] should roundtrip"
     );
 }
+
+#[test]
+fn identity_mapped_only_rewrites_first_rest_of_multi_rest_tuple() {
+    // GUARD: the per-position rule is only safe for the FIRST rest element,
+    // whose prefix is all fixed. A tuple with a second rest (e.g. from a
+    // generic variadic spread `[string, ...U, ...boolean[]]`) must NOT use
+    // positional indexing for the later rest, since `tuple_index_literal`
+    // short-circuits on the first rest it meets. Here we synthesize two
+    // array rests directly: the first must map precisely to `number[]`; the
+    // later rest must fall back to the original behavior (no crash, stays a
+    // rest element) rather than borrowing the first rest's index.
+    let interner = TypeInterner::new();
+    let source = interner.tuple(vec![
+        req_elem(TypeId::STRING),
+        rest_elem(interner.array(TypeId::NUMBER)),
+        rest_elem(interner.array(TypeId::BOOLEAN)),
+    ]);
+
+    let result = eval_identity_mapped(&interner, "I", source);
+    let Some(TypeData::Tuple(list_id)) = interner.lookup(result) else {
+        panic!("expected tuple result, got {:?}", interner.lookup(result));
+    };
+    let elements = interner.tuple_list(list_id);
+    assert_eq!(elements.len(), 3);
+    assert!(elements[1].rest && elements[2].rest);
+    assert_eq!(
+        elements[1].type_id,
+        interner.array(TypeId::NUMBER),
+        "first rest must map precisely to number[] via the per-position rule"
+    );
+    // The later rest keeps the original (union-based) behavior; we only assert
+    // it remains a rest element rather than pinning the legacy union shape.
+}


### PR DESCRIPTION
## Summary

Fixes #9699.

**Structural rule:** When a homomorphic mapped type `{ [I in keyof X]: F<X[I]> }` is instantiated over a tuple, the **first** rest element `...E[]` must be mapped by binding `I` to that rest position's index (every preceding position is fixed, so `X[i]` resolves unambiguously to `E`), then re-wrapped as an array. Binding `I` to `X[number]` instead — as the old `evaluate_mapped_array` reuse did — yields the union of **every** tuple element, so `Identity<[string, ...number[]]>` produced a rest member of `string | number` and even the identity mapping failed to round-trip (false-positive **TS2322**).

The fix adds a `map_template_at_index` helper (shared with the fixed-element path) and applies the per-position rule **only to the first rest element**. Any later rest (only reachable via a generic variadic spread, e.g. `[string, ...U, ...boolean[]]`) keeps the original behavior, because `tuple_index_literal` short-circuits on the first rest it meets and cannot place positions after an earlier spread. Nested fixed-tuple spreads (`...[A, B]`) still recurse. All other behavior (optional-modifier handling on the rest slot) is unchanged from the original.

## Owner layer

Solver — `crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs`. Pure type-semantic evaluation of mapped types over tuple shapes; no checker changes.

## Adjacent-case test matrix (`crates/tsz-solver/tests/mapped_comprehensive_tests.rs`)

1. `Identity<[string, ...number[]]>` round-trips; rest member pinned to `number[]` (reported repro).
2. `{ [I in keyof X]: [X[I]] }` over `[string, ...number[]]` → `[[string], ...[number][]]` (rest member `[number]`, not `[string | number]`).
3. Labeled variadic `[a: string, ...b: number[]]` round-trips.
4. Multi-element prefix `[string, symbol, ...number[]]` round-trips (rest member `number`).
5. Iteration variable renamed (`I`/`Idx`/`P`) — behavior unchanged, proving the rule is structural.
6. **Guard:** multi-rest tuple `[string, ...number[], ...boolean[]]` — first rest maps to `number[]`; the later rest keeps the original behavior (no positional borrow).
7. CONTROLS: fixed tuple `[string, number]` and plain array `number[]` still round-trip.

## Verification

- `cargo test -p tsz-solver --lib mapped_comprehensive` — 37 passed (5 new).
- Local conformance (pinned corpus): **variadicTuples 3/3**, **tuple 37/37**. mappedType's only failures are the two pre-existing accepted regressions (`mappedTypeRelationships`, `mappedTypeInferenceFromApparentType`).
- `cargo clippy -p tsz-solver --all-targets` — clean.
- CLI repro `tsz --noEmit --strict` on the issue's cases (incl. labeled variant, `T[1]` probe) and on the `variadicTuples1` multi-rest shape — exits 0.

## Project Corpus Impact

- Row: n/a
- Bug family: homomorphic mapped type over variadic tuple (false-positive TS2322); distinct from #9651 (readonly drop) and #9675 (conditional infer over variadic).
- Evidence: solver unit tests + local conformance (variadicTuples/tuple at 100%).

## Known unsupported shapes / fallback

Only the **first** rest element gets per-position mapping. Later rests (generic variadic spreads) and nested fixed-tuple spreads (`...[A, B]`) retain the original behavior. This is intentional: positional indexing is only sound when the rest's prefix is entirely fixed.

## Coordination Notes

AgentName: tuple-hunter
Track: conformance / solver
Invariant: solver is the single source of truth for mapped-type evaluation; per-position index binding for the first rest preserves variadic shape without disturbing generic-spread deferral.
Scope: one solver function + a shared helper + unit tests; no checker/emitter changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ytbfArXTAMMsYmPk2FzTk)_