### PR TITLE
fix(emit): lower async block returns

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -2384,6 +2384,45 @@ impl<'a> AsyncES5Transformer<'a> {
         (!name.is_empty()).then_some(name)
     }
 
+    fn block_to_ir_in_async(&self, block_idx: NodeIndex) -> IRNode {
+        let Some(node) = self.arena.get(block_idx) else {
+            return IRNode::Block(Vec::new());
+        };
+        let Some(block) = self.arena.get_block(node) else {
+            return IRNode::Block(Vec::new());
+        };
+        IRNode::Block(
+            block
+                .statements
+                .nodes
+                .iter()
+                .map(|&stmt| self.statement_to_ir_in_async_block(stmt))
+                .collect(),
+        )
+    }
+
+    fn statement_to_ir_in_async_block(&self, stmt_idx: NodeIndex) -> IRNode {
+        let Some(node) = self.arena.get(stmt_idx) else {
+            return IRNode::EmptyStatement;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::RETURN_STATEMENT => {
+                let value = self.arena.get_return_statement(node).and_then(|ret| {
+                    ret.expression
+                        .into_option()
+                        .map(|expr| Box::new(self.expression_to_ir(expr)))
+                });
+                IRNode::ReturnStatement(Some(Box::new(IRNode::GeneratorOp {
+                    opcode: opcodes::RETURN,
+                    value,
+                    comment: Some("return".to_string().into()),
+                })))
+            }
+            k if k == syntax_kind_ext::BLOCK => self.block_to_ir_in_async(stmt_idx),
+            _ => self.statement_to_ir(stmt_idx),
+        }
+    }
+
     fn loop_body_to_ir(&self, statement: NodeIndex) -> IRNode {
         let Some(node) = self.arena.get(statement) else {
             return IRNode::EmptyStatement;
@@ -2538,6 +2577,22 @@ impl<'a> AsyncES5Transformer<'a> {
                         current_statements,
                         current_label,
                     );
+                }
+            }
+
+            k if k == syntax_kind_ext::BLOCK => {
+                if self.contains_await_recursive(idx) {
+                    if let Some(block) = self.arena.get_block(node) {
+                        self.process_async_statement_list(
+                            &block.statements.nodes,
+                            cases,
+                            current_statements,
+                            current_label,
+                            &[],
+                        );
+                    }
+                } else {
+                    current_statements.push(self.block_to_ir_in_async(idx));
                 }
             }
 

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -54,6 +54,20 @@ fn element_access_with_suspended_index_captures_object_before_yield() {
 }
 
 #[test]
+fn block_return_inside_async_body_lowers_to_generator_return() {
+    let output = transform_and_print("async function f() { { return; } }");
+
+    assert!(
+        output.contains("{\n            return [2 /*return*/];\n        }"),
+        "Nested blocks in async ES5 bodies should preserve braces but lower bare returns to generator return ops.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return;\n            }"),
+        "Raw JS returns inside the generator callback would bypass the __generator protocol.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn labeled_while_continue_rewrite_uses_user_chosen_label() {
     let output = transform_and_print(
         "async function f() { retry: while (x) { await y; while (z) { continue retry; } } }",
@@ -84,6 +98,20 @@ fn return_element_access_with_suspended_index_captures_user_chosen_object() {
 }
 
 #[test]
+fn block_return_expression_inside_async_body_keeps_return_value() {
+    let output = transform_and_print("async function f() { { return value; } }");
+
+    assert!(
+        output.contains("return [2 /*return*/, value];"),
+        "Nested block returns with values should lower to generator return ops with that value.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return value;"),
+        "The original return expression must not be emitted raw inside the generator callback.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn variable_initializer_element_access_with_suspended_index_captures_object() {
     let output = transform_and_print("async function f() { var result = obj[await key]; }");
 
@@ -108,6 +136,21 @@ fn non_assignment_binary_with_suspended_element_index_keeps_normal_fallback() {
     assert!(
         output.contains("lhs() + obj[") && output.contains(".sent()]"),
         "Unsupported binary shapes should keep the existing expression fallback.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn block_return_await_inside_async_body_stays_on_state_machine_path() {
+    let output = transform_and_print("async function f() { { return await value; } }");
+
+    assert!(
+        output.contains("case 0: return [4 /*yield*/, value];")
+            && output.contains("case 1: return [2 /*return*/, _a.sent()];"),
+        "Blocks containing suspending returns should be lowered through the async state machine.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return await value;"),
+        "Suspending block returns must not fall back to raw JS block emission.\nOutput:\n{output}"
     );
 }
 


### PR DESCRIPTION
AgentName: StuduiEmit

## Structural rule
When a nested block is emitted inside an async ES5 generator body, block-contained returns must lower to generator return operations. If the block contains a suspension, it must stay on the async state-machine path rather than raw block emission.

## Owner layer
This belongs in `tsz-emitter` async ES5 IR statement lowering. It keeps the fix in output transformation code, avoids checker/solver semantic validation, and does not patch emitted text after the fact.

## Adjacent cases
- The reported TypeScript fixture `es5-asyncFunctionReturnStatements` now passes for ES2015 and ES5 JS emit.
- A bare return in a nested block preserves the block braces and lowers to `[2 /*return*/]`.
- A return expression in a nested block preserves the returned value.
- A return-await inside a nested block uses the async state-machine path and does not raw emit `return await ...`.

## Scope
This slice is intentionally limited to nested block-contained returns. Broader async conditional/loop control-flow lowering remains out of scope and overlaps older broad async-control-flow work.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit async ES5 block-contained return lowering
- Evidence: targeted TypeScript emit fixture now passes locally.

## Verification
- `cargo nextest run -p tsz-emitter block_return --no-fail-fast`
- `cargo nextest run -p tsz-emitter async_es5_ir --no-fail-fast`
- `./scripts/emit/run.sh --filter=es5-asyncFunctionReturnStatements --js-only --verbose --timeout=30000 --json-out=/tmp/studui-async-return-after.json`
- `cargo check -p tsz-emitter`
- `cargo clippy -p tsz-emitter --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `scripts/architecture-check.sh --quick` (existing grandfathered warnings only)