### PR TITLE
fix(solver): emit TS2589 for bare-infer self-recursive type aliases

### DIFF
--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -7,6 +7,15 @@ impl<'a> CheckerContext<'a> {
         crate::query_boundaries::common::contains_lazy_def_id(self.types, type_id, def_id)
     }
 
+    /// Whether `type_id` references any type-alias `DefId` flagged as
+    /// unconditionally-infinite (TS2589). Such aliases are error types in tsc,
+    /// so assignments involving them must not produce structural mismatches.
+    pub(crate) fn type_involves_depth_poisoned_def(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::collect_lazy_def_ids(self.types, type_id)
+            .into_iter()
+            .any(|def_id| self.definition_store.is_depth_poisoned(def_id))
+    }
+
     pub(crate) fn lookup_env_eval_cache(&self, type_id: TypeId) -> Option<EnvEvalCacheEntry> {
         self.env_eval_cache.borrow().get(&type_id).copied()
     }

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -436,6 +436,15 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     ) -> Option<tsz_solver::TypeId> {
         use tsz_binder::symbol_flags;
 
+        // A type alias flagged as unconditionally-infinite (TS2589 at its
+        // definition) resolves to the error type for every use, mirroring tsc's
+        // collapse of the alias to the error type. This covers both the
+        // evaluator and the relation resolution paths, so use sites do not
+        // cascade into spurious assignability diagnostics.
+        if self.definition_store.is_depth_poisoned(def_id) {
+            return Some(tsz_solver::TypeId::ERROR);
+        }
+
         // Convert DefId to SymbolId using the reverse mapping.
         // Fallback: if the DefId was created by `interner.reference(SymbolRef(N))`,
         // the raw DefId value equals the SymbolId. In that case, use the SymbolId

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -526,15 +526,6 @@ impl<'a> CheckerState<'a> {
         self.ctx.push_diagnostic(base_diag);
     }
 
-    /// Whether `type_id` references any type-alias `DefId` flagged as
-    /// unconditionally-infinite (TS2589). Such aliases are error types in tsc,
-    /// so assignments involving them must not produce structural mismatches.
-    fn type_involves_depth_poisoned_def(&self, type_id: TypeId) -> bool {
-        crate::query_boundaries::common::collect_lazy_def_ids(self.ctx.types, type_id)
-            .into_iter()
-            .any(|def_id| self.ctx.definition_store.is_depth_poisoned(def_id))
-    }
-
     /// Diagnose why an assignment failed and report a detailed error.
     pub fn diagnose_assignment_failure(&mut self, source: TypeId, target: TypeId, idx: NodeIndex) {
         let anchor_idx =
@@ -560,8 +551,8 @@ impl<'a> CheckerState<'a> {
         // structural relation is meaningless, so suppress the TS2322 cascade.
         // Gated on the poison set so the common case pays nothing.
         if self.ctx.definition_store.has_any_depth_poisoned()
-            && (self.type_involves_depth_poisoned_def(source)
-                || self.type_involves_depth_poisoned_def(target))
+            && (self.ctx.type_involves_depth_poisoned_def(source)
+                || self.ctx.type_involves_depth_poisoned_def(target))
         {
             return;
         }

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -526,6 +526,15 @@ impl<'a> CheckerState<'a> {
         self.ctx.push_diagnostic(base_diag);
     }
 
+    /// Whether `type_id` references any type-alias `DefId` flagged as
+    /// unconditionally-infinite (TS2589). Such aliases are error types in tsc,
+    /// so assignments involving them must not produce structural mismatches.
+    fn type_involves_depth_poisoned_def(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::collect_lazy_def_ids(self.ctx.types, type_id)
+            .into_iter()
+            .any(|def_id| self.ctx.definition_store.is_depth_poisoned(def_id))
+    }
+
     /// Diagnose why an assignment failed and report a detailed error.
     pub fn diagnose_assignment_failure(&mut self, source: TypeId, target: TypeId, idx: NodeIndex) {
         let anchor_idx =
@@ -543,6 +552,17 @@ impl<'a> CheckerState<'a> {
     ) {
         // Same TypeId → no actual type mismatch (failure at a higher structural level).
         if source == target {
+            return;
+        }
+        // A type alias flagged as unconditionally-infinite (TS2589 at its
+        // definition) collapses to the error type in tsc, which is assignable in
+        // both directions. When either side involves such a poisoned alias, the
+        // structural relation is meaningless, so suppress the TS2322 cascade.
+        // Gated on the poison set so the common case pays nothing.
+        if self.ctx.definition_store.has_any_depth_poisoned()
+            && (self.type_involves_depth_poisoned_def(source)
+                || self.type_involves_depth_poisoned_def(target))
+        {
             return;
         }
         // Centralized suppression for TS2322 cascades on unresolved escape-hatch types.

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -378,6 +378,21 @@ impl<'a> CheckerState<'a> {
                 // Evaluate with TS2589 detection flag
                 let depth_exceeded = (has_stable_recursive_ref || has_recursive_wrapper_arg)
                     && self.evaluate_type_for_ts2589_check(body_type, def_id);
+                // A bare-`infer` self-recursive alias is unconditionally infinite.
+                // tsc collapses it to the error type so use sites do not cascade
+                // into spurious TS2322. Flag the def as depth-poisoned: the
+                // evaluator then resolves every `Alias<...>` application to the
+                // error type (assignable both ways). Scoped to this shape so the
+                // direct-recursion path, which anchors TS2589 at the use site,
+                // keeps its current behavior. Clearing the evaluation caches drops
+                // any unexpanded application that was cached before the flag.
+                if depth_exceeded
+                    && self
+                        .conditional_body_has_bare_infer_recursive_ref(alias.type_node, alias_sid)
+                {
+                    self.ctx.definition_store.mark_depth_poisoned(def_id);
+                    self.ctx.clear_type_evaluation_caches_for_def(def_id);
+                }
                 if depth_exceeded || has_unresolved_computed_recursive_ref {
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     // tsc anchors TS2589 at `currentNode` (the inner self-reference
@@ -761,6 +776,46 @@ impl<'a> CheckerState<'a> {
             .into_iter()
             .any(|child_idx| {
                 self.conditional_body_has_definite_recursive_alias_ref(child_idx, alias_sid)
+            })
+    }
+
+    /// True when the alias body contains a conditional whose `extends` clause is
+    /// a bare `infer X` and whose true branch re-applies the alias to itself
+    /// (e.g. `type A<T> = T extends infer X ? A<X & B> : never`).
+    ///
+    /// A bare `infer X` always matches, so the true branch is taken
+    /// unconditionally; if that branch re-applies the alias the instantiation is
+    /// infinite. tsc reports TS2589 and collapses the alias to the error type.
+    /// We use this to scope the error-type collapse to exactly this shape, so the
+    /// existing direct-recursion path (which anchors TS2589 at the use site) is
+    /// unaffected.
+    fn conditional_body_has_bare_infer_recursive_ref(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::CONDITIONAL_TYPE
+            && let Some(cond) = self.ctx.arena.get_conditional_type(node)
+            && self
+                .ctx
+                .arena
+                .kind_at(cond.extends_type)
+                .is_some_and(|kind| kind == syntax_kind_ext::INFER_TYPE)
+            && self.conditional_body_has_definite_recursive_alias_ref(cond.true_type, alias_sid)
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.conditional_body_has_bare_infer_recursive_ref(child_idx, alias_sid)
             })
     }
 

--- a/crates/tsz-checker/tests/ts2589_tests.rs
+++ b/crates/tsz-checker/tests/ts2589_tests.rs
@@ -1501,3 +1501,107 @@ type T = TrimRight<"hello   ">;
         "TrimRight<\"hello   \"> is bounded; must NOT emit TS2589. Got: {diags_trim:?}"
     );
 }
+
+mod issue_9784 {
+    //! Tests for <https://github.com/mohsen1/tsz/issues/9784>.
+    //!
+    //! Structural rule: a generic type alias whose body is `T extends infer X
+    //! ? <re-application of the alias> : ...` always takes the true branch (a
+    //! bare `infer X` matches unconditionally), so re-applying the alias is
+    //! infinite instantiation. tsc reports TS2589 and collapses the alias to
+    //! the error type; this makes tsz do the same so use sites do not cascade
+    //! into a spurious TS2322 against the unexpanded alias. The fix is keyed on
+    //! the structural shape, not on identifier names or the grown wrapper type.
+    use std::sync::{Arc, OnceLock};
+
+    use tsz_binder::lib_loader::LibFile;
+
+    use crate::context::CheckerOptions;
+    use crate::test_utils::{
+        check_source_with_libs, diagnostics_with_code, load_default_lib_files,
+    };
+
+    fn check_with_libs(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+        static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+        let libs = LIBS.get_or_init(load_default_lib_files);
+        check_source_with_libs(source, "test.ts", CheckerOptions::default(), libs)
+    }
+
+    fn codes(source: &str) -> Vec<u32> {
+        check_with_libs(source)
+            .into_iter()
+            .map(|d| d.code)
+            .collect()
+    }
+
+    #[test]
+    fn intersection_growth_emits_ts2589_no_cascade() {
+        let diags = check_with_libs(
+            "type Acc<T> = T extends infer X ? Acc<X & { k: 1 }> : never;\ntype R = Acc<{}>;\nconst r: R = { k: 1 };\n",
+        );
+        assert!(
+            !diagnostics_with_code(&diags, 2589).is_empty(),
+            "expected TS2589 for unbounded intersection growth; got: {diags:?}"
+        );
+        assert!(
+            diagnostics_with_code(&diags, 2322).is_empty(),
+            "poisoned alias must collapse to error type, no TS2322 cascade; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn renamed_alias_and_var_still_emits_ts2589() {
+        let diags = check_with_libs(
+            "type Grow<P> = P extends infer Y ? Grow<Y & { m: 2 }> : never;\ntype Q = Grow<{}>;\nconst q: Q = { m: 2 };\n",
+        );
+        assert!(
+            !diagnostics_with_code(&diags, 2589).is_empty(),
+            "renamed alias/var must still emit TS2589; got: {diags:?}"
+        );
+        assert!(
+            diagnostics_with_code(&diags, 2322).is_empty(),
+            "renamed alias must not cascade TS2322; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn direct_recursion_still_emits_ts2589() {
+        let diags = check_with_libs(
+            "type Foo<T> = T extends unknown ? Foo<T> : unknown;\ntype R = Foo<number>;\nconst r: R = { k: 1 };\n",
+        );
+        assert!(
+            !diagnostics_with_code(&diags, 2589).is_empty(),
+            "direct recursion must still emit TS2589; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn terminating_infer_alias_no_ts2589() {
+        let diags = check_with_libs(
+            "type Once<T> = T extends infer X ? { v: X } : never;\ntype R = Once<number>;\nconst ok: R = { v: 1 };\nconst bad: R = { v: 5 as unknown as string };\n",
+        );
+        assert!(
+            diagnostics_with_code(&diags, 2589).is_empty(),
+            "terminating infer alias must NOT emit TS2589; got: {diags:?}"
+        );
+        assert!(
+            !diagnostics_with_code(&diags, 2322).is_empty(),
+            "the real string-vs-number mismatch must still be reported; got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn guarded_infer_recursion_no_ts2589() {
+        let cs = codes(
+            "type Flatten<T> = T extends infer X ? (X extends readonly any[] ? Flatten<X[number]> : X) : never;\ntype R = Flatten<number[][]>;\nconst r: R = 5;\n",
+        );
+        assert!(
+            !cs.contains(&2589),
+            "guarded recursion that terminates must NOT emit TS2589; got: {cs:?}"
+        );
+        assert!(
+            !cs.contains(&2322),
+            "Flatten<number[][]> resolves to number, 5 is assignable; got: {cs:?}"
+        );
+    }
+}

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -607,6 +607,14 @@ pub struct DefinitionStore {
     /// `"a"|"b"` but tsc shows the expanded union, not `T2`).
     computed_alias_bodies: DefDashSet<TypeId>,
 
+    /// Set of type-alias `DefId`s whose instantiation is unconditionally
+    /// infinite (e.g. `type A<T> = T extends infer X ? A<X & B> : never`).
+    /// The checker records these when it emits TS2589 at the alias definition;
+    /// the evaluator then resolves every `Alias<...>` application of a poisoned
+    /// def to the error type so use sites do not cascade into spurious TS2322,
+    /// matching tsc's collapse of the alias to the error type.
+    depth_poisoned_defs: DefDashSet<DefId>,
+
     /// Reverse index: `file_id` -> `Vec<DefId>` for per-file definition lookups.
     ///
     /// Populated during `register()` when the `DefinitionInfo` has a `file_id`.
@@ -864,6 +872,7 @@ impl DefinitionStore {
             symbol_mappings_snapshot: Mutex::new(None),
             body_to_alias: DefDashMap::default(),
             computed_alias_bodies: DefDashSet::default(),
+            depth_poisoned_defs: DefDashSet::default(),
             shape_to_def: DefDashMap::default(),
             file_to_defs: DefDashMap::with_capacity_and_hasher(file_capacity, Default::default()),
             class_to_constructor: DefDashMap::with_capacity_and_hasher(
@@ -1079,6 +1088,27 @@ impl DefinitionStore {
             );
             self.bump_generation();
         }
+    }
+
+    /// Mark a type-alias `DefId` as having an unconditionally-infinite
+    /// instantiation (TS2589). Every later application of this def resolves to
+    /// the error type.
+    pub fn mark_depth_poisoned(&self, id: DefId) {
+        if self.depth_poisoned_defs.insert(id) {
+            self.bump_generation();
+        }
+    }
+
+    /// Whether the given `DefId` was flagged via [`mark_depth_poisoned`].
+    pub fn is_depth_poisoned(&self, id: DefId) -> bool {
+        self.depth_poisoned_defs.contains(&id)
+    }
+
+    /// Whether any def has been flagged via [`mark_depth_poisoned`]. Used as a
+    /// cheap guard so hot evaluation paths skip per-application poison checks
+    /// when nothing is poisoned (the overwhelmingly common case).
+    pub fn has_any_depth_poisoned(&self) -> bool {
+        !self.depth_poisoned_defs.is_empty()
     }
 
     /// Update the type parameters for a definition.

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -397,6 +397,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self
     }
 
+    /// True when this evaluator is running the TS2589 depth-detection pass
+    /// (see `with_flag_depth_on_app_cycle`). Callers in other modules use this
+    /// to drive self-referential recursion that normal evaluation defers.
+    pub(crate) const fn is_depth_detection_pass(&self) -> bool {
+        self.flag_depth_on_app_cycle
+    }
+
     /// Preserve evaluated application display aliases with already-expanded
     /// type arguments. This is declaration-emitter-only behavior; checker
     /// diagnostics keep the original alias origin to avoid recursive display

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -316,10 +316,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
 
             if let Some(TypeData::Infer(info)) = self.interner().lookup(extends_type) {
-                if matches!(
+                // A bare `infer X` extends clause always matches, so tsc takes the
+                // true branch with `X` bound to the check type. Normal evaluation
+                // defers when the check type is still a free type parameter (the
+                // conditional has no concrete input yet). During the TS2589
+                // depth-detection pass the alias body is evaluated with its type
+                // parameters left free, so deferring here hides unconditionally
+                // recursive aliases like `type A<T> = T extends infer X ? A<X & B>
+                // : never` from the recursion guard. In that pass, bind `X` to the
+                // free type parameter and follow the true branch so the guard can
+                // observe the re-applied alias and surface TS2589.
+                let check_is_unresolved_param = matches!(
                     self.interner().lookup(check_type),
                     Some(TypeData::TypeParameter(_) | TypeData::Infer(_))
-                ) {
+                );
+                let drive_recursion_for_depth_check = self.is_depth_detection_pass()
+                    && matches!(
+                        self.interner().lookup(check_type),
+                        Some(TypeData::TypeParameter(_))
+                    );
+                if check_is_unresolved_param && !drive_recursion_for_depth_check {
                     return self.interner().conditional(*cond);
                 }
 


### PR DESCRIPTION
## Summary

Closes #9784.

A generic type alias whose body is `T extends infer X ? Alias<X & ...> : ...`
always takes the true branch — a bare `infer X` matches unconditionally — so
re-applying the alias is **unconditionally infinite** instantiation. `tsc`
reports **TS2589** and collapses the alias to the error type. `tsz` previously
left the alias unexpanded and emitted no TS2589, then produced a spurious
**TS2322** at use sites.

**Root cause:** the TS2589 depth-detection pass evaluates the alias body with
its type parameters left *free*. The conditional `T extends infer X ? …`
deferred immediately (the check type is a free `TypeParameter`), so the
recursion guard never observed the re-applied alias — no TS2589, and the
unexpanded `Alias<…>` then drove a spurious TS2322.

## Structural rule

> When a generic type alias's body contains a conditional whose `extends`
> clause is a bare `infer X` and whose true branch re-applies the alias, the
> instantiation is unconditionally infinite; `tsc` emits TS2589 and resolves
> the alias to the error type. This change makes `tsz` do the same.

Keyed on the structural shape, not on identifier names, the grown wrapper type,
or rendered output — renaming the alias/iteration variable or changing the
intersection member does not bypass it.

## Owner layer & approach

- **`tsz_solver` `evaluate_conditional`** — during the depth-detection pass
  (`flag_depth_on_app_cycle`) only, bind the bare `infer` variable to the free
  type parameter and follow the true branch so the existing recursion guard
  observes the re-applied alias and surfaces TS2589. Normal evaluation still
  defers, so no hot-path/behaviour change outside detection.
- **`DefinitionStore`** — a `depth_poisoned_defs` set records aliases the
  checker flagged as infinite (set when TS2589 is emitted at the definition).
- **Checker `resolve_lazy`** — resolves every application of a poisoned def to
  the error type (covers evaluator and relation resolution paths).
- **Assignability error reporter** — suppresses TS2322 when either side
  involves a poisoned alias (the alias is an error type, assignable both ways),
  so use sites do not cascade.

Scoped to the bare-infer-recursive shape, so the existing direct-recursion path
(`type Foo<T> = T extends unknown ? Foo<T> : unknown`, which anchors TS2589 at
the use site) is unchanged.

## Adjacent-case test matrix (`tests/ts2589_tests.rs::issue_9784`)

1. Reported repro `Acc<T> = T extends infer X ? Acc<X & {k:1}> : never` → TS2589, no TS2322 cascade.
2. Renamed alias + iteration var + different element type → still TS2589 (structural, not name-dependent).
3. Regression: direct (non-`infer`) unbounded recursion still emits TS2589.
4. Negative: bounded `infer` alias that does not re-apply itself terminates; the real mismatch is still reported, no false TS2589.
5. Negative: guarded recursion (`Flatten<T>` with an inner conditional narrowing the bound var) terminates and is not flagged.

## Known unsupported shapes / fallback

- Tuple- and template-literal-growth behind an `infer` conditional (the `#9777`
  hang family) are out of scope; the bare-`infer` predicate only matches a
  conditional whose `extends` is a single `infer` node.

## Project Corpus Impact

- Row: n/a
- Bug family: false-negative (missing TS2589) + spurious TS2322 cascade on
  bare-infer self-recursive type aliases
- Evidence: new `tsz_checker` unit suite `ts2589_tests::issue_9784` (5 tests);
  CLI diff on the full issue repro matrix matches tsc. Full conformance/emit/
  fourslash/WASM run by ready-for-review CI.

## Verification

- `cargo test -p tsz-checker --lib issue_9784` → 5/5 pass
- Re-ran ts2589 / conditional / circular checker suites → green; all other
  failures in alias/mapped/infer suites confirmed pre-existing on the rebased
  `main` baseline (not introduced here).
- `cargo clippy --workspace --all-targets` → clean
- Manual `tsz` vs `tsc` diff on the issue repro + boundary controls → match

## Coordination Notes

AgentName: opus47-1m-claude-code
Track: conformance (solver/checker false-negative + false-positive)
Invariant: parity with tsc for TS2589 on unconditionally-infinite type aliases
Scope: solver conditional-evaluation depth detection; checker alias poisoning + diagnostic suppression; no emitter changes

https://claude.ai/code/session_01WxVaEqHmrkDL4hhQKBMJdq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxVaEqHmrkDL4hhQKBMJdq)_