### PR TITLE
fix(checker): module-augmentation members don't conflict with imports (TS2440)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -2399,6 +2399,13 @@ impl<'a> CheckerState<'a> {
                                             {
                                                 return false;
                                             }
+                                            // `declare module "..." { ... }` augmentation members
+                                            // merge into the augmented module's export table, not
+                                            // the augmenting file's scope, so they can't conflict
+                                            // with an import. Mirrors the Check 1 skip above.
+                                            if self.is_inside_module_augmentation(decl_idx) {
+                                                return false;
+                                            }
                                             // `declare global { ... }` places declarations in
                                             // the global scope; they can't conflict with an
                                             // import living in the enclosing module scope.
@@ -2666,6 +2673,9 @@ impl<'a> CheckerState<'a> {
                 }
                 let has_local_decl = other_sym.declarations.iter().any(|&decl_idx| {
                     if self.ctx.binder.node_symbols.get(&decl_idx.0) != Some(&other_sym_id) {
+                        return false;
+                    }
+                    if self.is_inside_module_augmentation(decl_idx) {
                         return false;
                     }
                     if self.is_inside_global_augmentation(decl_idx) {

--- a/crates/tsz-checker/tests/ts2440_tests.rs
+++ b/crates/tsz-checker/tests/ts2440_tests.rs
@@ -437,3 +437,107 @@ export = qux;
         get_diagnostics(source)
     );
 }
+
+// =========================================================================
+// Module augmentation members (`declare module "base" { interface X {} }`)
+// are contributions to the augmented module's export table, not local
+// declarations in the augmenting file. Importing the same name from that
+// module must NOT report TS2440. (Mirrors Check 1 / Check 2 symmetry.)
+// =========================================================================
+
+fn multi_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    crate::test_utils::check_multi_file(files, entry, CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn test_augmentation_member_plus_import_of_same_name_no_ts2440() {
+    let base = r#"
+declare module "base" {
+  export interface Opts { a: number; }
+}
+"#;
+    let aug = r#"
+import "base";
+declare module "base" {
+  interface Opts { b: string; }
+}
+import { Opts } from "base";
+const o: Opts = { a: 1, b: "x" };
+"#;
+    let codes = multi_file_codes(&[("base.d.ts", base), ("aug.ts", aug)], "aug.ts");
+    assert!(
+        !codes.contains(&2440),
+        "Augmentation member + import of same name must NOT emit TS2440. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_augmentation_member_plus_import_renamed_no_ts2440() {
+    // Same shape, different name — proves the fix is structural, not hardcoded.
+    let base = r#"
+declare module "base" {
+  export interface Settings { a: number; }
+}
+"#;
+    let aug = r#"
+import "base";
+declare module "base" {
+  interface Settings { b: string; }
+}
+import { Settings } from "base";
+const s: Settings = { a: 1, b: "x" };
+"#;
+    let codes = multi_file_codes(&[("base.d.ts", base), ("aug.ts", aug)], "aug.ts");
+    assert!(
+        !codes.contains(&2440),
+        "Renamed augmentation member + import must NOT emit TS2440. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_augmentation_member_exported_plus_import_no_ts2440() {
+    // Augmentation member written with the `export` keyword (vs bare member).
+    let base = r#"
+declare module "base" {
+  export interface Opts { a: number; }
+}
+"#;
+    let aug = r#"
+import "base";
+declare module "base" {
+  export interface Opts { b: string; }
+}
+import { Opts } from "base";
+const o: Opts = { a: 1, b: "x" };
+"#;
+    let codes = multi_file_codes(&[("base.d.ts", base), ("aug.ts", aug)], "aug.ts");
+    assert!(
+        !codes.contains(&2440),
+        "Exported augmentation member + import must NOT emit TS2440. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_genuine_local_interface_plus_import_still_conflicts() {
+    // Negative control: a genuine top-level local interface (NOT inside an
+    // augmentation) colliding with a type-bearing import must still report
+    // TS2440. This proves the fix only relaxes augmentation-scoped members.
+    let base = r#"
+declare module "base" {
+  export interface Opts { a: number; }
+}
+"#;
+    let use_ts = r#"
+import { Opts } from "base";
+interface Opts { b: string; }
+const o: Opts = { a: 1, b: "x" };
+"#;
+    let codes = multi_file_codes(&[("base.d.ts", base), ("use.ts", use_ts)], "use.ts");
+    assert!(
+        codes.contains(&2440),
+        "Genuine local interface colliding with import must still emit TS2440. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #9731

AgentName: aug-symmetry-opus47
Track: Conformance / checker false-positive

## Structural rule
> When a same-name declaration lives inside a module augmentation (`declare module "x" { ... }`), it is a contribution to that module's export table — not a local binding in the augmenting file's scope — so it must not be treated as a conflicting local declaration for the import-vs-local TS2440/TS2865 conflict check. (This matches tsc, which merges augmentation members into the target module's symbol.)

## Invariant
The conflict check is a *diagnostic-location* decision (`WHERE`), so it stays in the checker. The existing `is_inside_module_augmentation` predicate (`declarations/import/context_helpers.rs`) already encodes the structural fact; the bug was that only one of three filter sites consulted it.

The import-vs-local TS2440/TS2865 logic in `crates/tsz-checker/src/declarations/import/declaration.rs` has three sites that decide what counts as a "local declaration":
1. **Check 1** — merged declarations on the import's own symbol. *Already skipped augmentations.*
2. **Check 2** — separate same-name symbols (the binder may split an augmentation member into a distinct symbol). **Did not skip augmentations** → false TS2440.
3. The **`isolatedModules`** separate-symbols path. **Did not skip augmentations** → same latent bug.

When an augmentation member and an `import { X }` of the same name are co-located in one file, the binder keeps them as distinct symbols, so Check 2 saw the augmentation interface as a phantom local declaration and reported TS2440. This PR adds the same `is_inside_module_augmentation` skip to Check 2 and the `isolatedModules` path so all three agree.

## Scope
~9 lines of behavior change across two filter sites; no binder/solver changes. The augmentation declarations remain in the symbol set (so TS2451/TS2300 cross-file augmentation selection is untouched) — they are simply not counted as import-conflicting local bindings.

## Test matrix (`crates/tsz-checker/tests/ts2440_tests.rs`)
- Reported repro: interface augmentation + `import { Opts }` of same name → no TS2440.
- **Renamed** member (`Settings`) — proves the fix is structural, not hardcoded to `Opts`.
- Augmentation member written with the `export` keyword (vs bare member).
- **Negative control:** a genuine top-level local `interface Opts` (not in an augmentation) colliding with the import **still** emits TS2440.

All 23 tests in the TS2440 suite pass. The 35 failures in the full `tsz-checker` lib run (zod/async/mapped-display/architecture-file-size) are pre-existing on `main` — verified by stashing this change and re-running the same tests on the clean tree.

## Project Corpus Impact
- Row: n/a (checker false-positive fix; no benchmark fixture targeted)
- Bug family: TS2440 false-positive on module-augmentation + same-name import
- Evidence: new unit tests in `ts2440_tests.rs` (repro + renamed + exported + negative control); full TS2440 suite green locally.

## Verification
- `cargo test -p tsz-checker --lib ts2440_tests` → 23 passed.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` → clean.
- Rebased on latest `main` (no conflicts).

## Coordination Notes
Considered a binder-side fix (not registering augmentation members as separate local symbols), but the codebase's accepted pattern is checker-side filtering via `is_inside_module_augmentation` (Check 1 already did this), and the TS2451/TS2300 cross-file augmentation tests rely on those declarations remaining present in the conflict set. The surgical, symmetry-restoring checker fix is the correct layer.

https://claude.ai/code/session_01XAPDKJjSRgUQuCuQpB1hSi