### PR TITLE
fix(emit): lower async es5 new expressions

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -2904,6 +2904,15 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_statements.push(IRNode::ExpressionStatement(Box::new(lowered_call)));
                 return;
             }
+            if let Some(lowered_new) = self.lower_new_expression_before_suspension(
+                idx,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                current_statements.push(IRNode::ExpressionStatement(Box::new(lowered_new)));
+                return;
+            }
             if self.async_generator_mode
                 && (node.kind == syntax_kind_ext::YIELD_EXPRESSION
                     || self.node_text_contains_yield(idx))
@@ -3092,6 +3101,7 @@ impl<'a> AsyncES5Transformer<'a> {
             } else {
                 let operand = self
                     .lower_es5_call_spread(await_expr.expression)
+                    .or_else(|| self.lower_es5_new_spread(await_expr.expression))
                     .unwrap_or_else(|| self.expression_to_ir(await_expr.expression));
                 if self.async_generator_mode && node.kind == syntax_kind_ext::AWAIT_EXPRESSION {
                     Some(IRNode::CallExpr {

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
@@ -383,6 +383,490 @@ impl<'a> AsyncES5Transformer<'a> {
         })
     }
 
+    pub(super) fn lower_new_expression_before_suspension(
+        &mut self,
+        idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let node = self.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::NEW_EXPRESSION {
+            return None;
+        }
+        let new_expr = self.arena.get_call_expr(node)?;
+        if let Some(lowered) = self.lower_new_element_callee_index_before_suspension(
+            new_expr.expression,
+            new_expr
+                .arguments
+                .as_ref()
+                .map(|args| args.nodes.as_slice()),
+            cases,
+            current_statements,
+            current_label,
+        ) {
+            return Some(lowered);
+        }
+        if self.contains_await_recursive(new_expr.expression) {
+            self.emit_nested_suspension(
+                new_expr.expression,
+                cases,
+                current_statements,
+                current_label,
+            );
+            let args = new_expr.arguments.as_ref();
+            if let Some(args) = args
+                && self.args_contain_spread(&args.nodes)
+            {
+                let receiver_temp = self.generate_hoisted_temp();
+                current_statements.push(IRNode::VarDecl {
+                    name: receiver_temp.clone().into(),
+                    initializer: None,
+                });
+                let captured_receiver = IRNode::Parenthesized(Box::new(IRNode::assign(
+                    IRNode::id(receiver_temp.clone()),
+                    IRNode::Parenthesized(Box::new(IRNode::GeneratorSent)),
+                )));
+                let arg_array = self.spread_new_base_array(&args.nodes);
+                return Some(Self::new_from_bound_apply(
+                    IRNode::prop(captured_receiver, "bind"),
+                    IRNode::id(receiver_temp),
+                    arg_array,
+                ));
+            }
+            let args = args
+                .map(|args| {
+                    args.nodes
+                        .iter()
+                        .map(|&arg| self.expression_to_ir(arg))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let callee = self
+                .new_callee_after_suspension(new_expr.expression)
+                .unwrap_or_else(|| IRNode::Parenthesized(Box::new(IRNode::GeneratorSent)));
+            return Some(IRNode::NewExpr {
+                callee: Box::new(callee),
+                arguments: args,
+                explicit_arguments: new_expr.arguments.is_some(),
+            });
+        }
+
+        let args = new_expr.arguments.as_ref()?;
+        let suspension_arg_index = args
+            .nodes
+            .iter()
+            .position(|&arg| self.contains_await_recursive(arg))?;
+        let has_spread = self.args_contain_spread(&args.nodes);
+        let spread_capture = has_spread.then(|| {
+            self.capture_new_bind_apply_before_suspension(new_expr.expression, current_statements)
+        });
+        let bind_capture = (!has_spread).then(|| {
+            self.capture_new_bind_before_suspension(new_expr.expression, current_statements)
+        });
+        let arg_array = self.lower_suspended_new_arguments(
+            &args.nodes,
+            suspension_arg_index,
+            current_statements,
+        );
+
+        self.emit_nested_suspension(
+            args.nodes[suspension_arg_index],
+            cases,
+            current_statements,
+            current_label,
+        );
+
+        if let Some((bind_temp, apply_temp, receiver_args_temp)) = spread_capture {
+            return Some(Self::new_from_apply_apply(
+                IRNode::id(apply_temp),
+                IRNode::id(bind_temp),
+                IRNode::id(receiver_args_temp),
+                arg_array,
+            ));
+        }
+
+        let (bind_temp, receiver) = bind_capture?;
+        Some(Self::new_from_bound_apply(
+            IRNode::id(bind_temp),
+            receiver,
+            arg_array,
+        ))
+    }
+
+    fn lower_new_element_callee_index_before_suspension(
+        &mut self,
+        callee: NodeIndex,
+        args: Option<&[NodeIndex]>,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let callee_node = self.arena.get(callee)?;
+        if callee_node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        if self.contains_await_recursive(access.expression)
+            || !self.contains_await_recursive(access.name_or_argument)
+        {
+            return None;
+        }
+
+        let object_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: object_temp.clone().into(),
+            initializer: None,
+        });
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(object_temp.clone()),
+            self.expression_to_ir(access.expression),
+        ))));
+
+        self.emit_nested_suspension(
+            access.name_or_argument,
+            cases,
+            current_statements,
+            current_label,
+        );
+
+        let arguments = args
+            .map(|args| args.iter().map(|&arg| self.expression_to_ir(arg)).collect())
+            .unwrap_or_default();
+        Some(IRNode::NewExpr {
+            callee: Box::new(IRNode::ElementAccess {
+                object: Box::new(IRNode::id(object_temp)),
+                index: Box::new(IRNode::GeneratorSent),
+            }),
+            arguments,
+            explicit_arguments: args.is_some(),
+        })
+    }
+
+    fn new_callee_after_suspension(&self, callee: NodeIndex) -> Option<IRNode> {
+        let callee_node = self.arena.get(callee)?;
+        if callee_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(callee_node)?;
+            if self.contains_await_recursive(access.expression)
+                && !self.contains_await_recursive(access.name_or_argument)
+            {
+                let property = crate::transforms::emit_utils::identifier_text_or_empty(
+                    self.arena,
+                    access.name_or_argument,
+                );
+                return Some(IRNode::prop(
+                    IRNode::Parenthesized(Box::new(IRNode::GeneratorSent)),
+                    property,
+                ));
+            }
+        }
+        if callee_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(callee_node)?;
+            if self.contains_await_recursive(access.expression)
+                && !self.contains_await_recursive(access.name_or_argument)
+            {
+                return Some(IRNode::elem(
+                    IRNode::Parenthesized(Box::new(IRNode::GeneratorSent)),
+                    self.expression_to_ir(access.name_or_argument),
+                ));
+            }
+        }
+        None
+    }
+
+    pub(super) fn lower_es5_new_spread(&mut self, idx: NodeIndex) -> Option<IRNode> {
+        let node = self.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::NEW_EXPRESSION {
+            return None;
+        }
+        let new_expr = self.arena.get_call_expr(node)?;
+        let args = new_expr.arguments.as_ref()?;
+        if !self.args_contain_spread(&args.nodes) {
+            return None;
+        }
+        let callee = self.expression_to_ir(new_expr.expression);
+        let arg_array = self.spread_new_base_array(&args.nodes);
+        Some(Self::new_from_bound_apply(
+            IRNode::prop(callee.clone(), "bind"),
+            callee,
+            arg_array,
+        ))
+    }
+
+    fn capture_new_bind_before_suspension(
+        &mut self,
+        callee: NodeIndex,
+        current_statements: &mut Vec<IRNode>,
+    ) -> (String, IRNode) {
+        let Some(callee_node) = self.arena.get(callee) else {
+            return (String::new(), IRNode::Undefined);
+        };
+        if callee_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || callee_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            let constructor_temp = self.generate_hoisted_temp();
+            let bind_temp = self.generate_hoisted_temp();
+            current_statements.push(IRNode::VarDecl {
+                name: constructor_temp.clone().into(),
+                initializer: None,
+            });
+            current_statements.push(IRNode::VarDecl {
+                name: bind_temp.clone().into(),
+                initializer: None,
+            });
+            current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                IRNode::id(bind_temp.clone()),
+                IRNode::prop(
+                    IRNode::Parenthesized(Box::new(IRNode::assign(
+                        IRNode::id(constructor_temp.clone()),
+                        self.expression_to_ir(callee),
+                    ))),
+                    "bind",
+                ),
+            ))));
+            return (bind_temp, IRNode::id(constructor_temp));
+        }
+
+        let bind_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: bind_temp.clone().into(),
+            initializer: None,
+        });
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(bind_temp.clone()),
+            IRNode::prop(self.expression_to_ir(callee), "bind"),
+        ))));
+        (bind_temp, self.expression_to_ir(callee))
+    }
+
+    fn capture_new_bind_apply_before_suspension(
+        &mut self,
+        callee: NodeIndex,
+        current_statements: &mut Vec<IRNode>,
+    ) -> (String, String, String) {
+        let bind_temp = self.generate_hoisted_temp();
+        let apply_temp = self.generate_hoisted_temp();
+        let receiver_args_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: bind_temp.clone().into(),
+            initializer: None,
+        });
+        current_statements.push(IRNode::VarDecl {
+            name: apply_temp.clone().into(),
+            initializer: None,
+        });
+        current_statements.push(IRNode::VarDecl {
+            name: receiver_args_temp.clone().into(),
+            initializer: None,
+        });
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(apply_temp.clone()),
+            IRNode::prop(
+                IRNode::Parenthesized(Box::new(IRNode::assign(
+                    IRNode::id(bind_temp.clone()),
+                    IRNode::prop(self.expression_to_ir(callee), "bind"),
+                ))),
+                "apply",
+            ),
+        ))));
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(receiver_args_temp.clone()),
+            IRNode::ArrayLiteral(vec![self.expression_to_ir(callee)]),
+        ))));
+        (bind_temp, apply_temp, receiver_args_temp)
+    }
+
+    fn lower_suspended_new_arguments(
+        &mut self,
+        args: &[NodeIndex],
+        suspension_arg_index: usize,
+        current_statements: &mut Vec<IRNode>,
+    ) -> IRNode {
+        if self.args_contain_spread(args) {
+            return self.lower_suspended_spread_new_arguments(
+                args,
+                suspension_arg_index,
+                current_statements,
+            );
+        }
+
+        if suspension_arg_index == 0 {
+            let mut lowered_args = Vec::with_capacity(args.len() + 1);
+            lowered_args.push(IRNode::Undefined);
+            lowered_args.extend(args.iter().map(|&arg| self.expression_to_ir(arg)));
+            return IRNode::ArrayLiteral(lowered_args);
+        }
+
+        let prefix_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: prefix_temp.clone().into(),
+            initializer: None,
+        });
+        let mut prefix_args = Vec::with_capacity(suspension_arg_index + 1);
+        prefix_args.push(IRNode::Undefined);
+        prefix_args.extend(
+            args[..suspension_arg_index]
+                .iter()
+                .map(|&arg| self.expression_to_ir(arg)),
+        );
+        current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+            IRNode::id(prefix_temp.clone()),
+            IRNode::ArrayLiteral(prefix_args),
+        ))));
+
+        let suffix_args = args[suspension_arg_index..]
+            .iter()
+            .map(|&arg| self.expression_to_ir(arg))
+            .collect();
+        IRNode::CallExpr {
+            callee: Box::new(IRNode::prop(IRNode::id(prefix_temp), "concat")),
+            arguments: vec![IRNode::ArrayLiteral(suffix_args)],
+        }
+    }
+
+    fn lower_suspended_spread_new_arguments(
+        &mut self,
+        args: &[NodeIndex],
+        suspension_arg_index: usize,
+        current_statements: &mut Vec<IRNode>,
+    ) -> IRNode {
+        self.helpers_needed.mark_spread_array();
+        let prefix_base = self.spread_new_base_array(&args[..suspension_arg_index]);
+        let suspension_is_spread = self.is_spread_arg(args[suspension_arg_index]);
+        let has_prefix_spread = self.args_contain_spread(&args[..suspension_arg_index]);
+        let has_suffix_spread = self.args_contain_spread(&args[suspension_arg_index + 1..]);
+
+        let mut current = if suspension_is_spread || has_prefix_spread {
+            let prefix_temp = self.generate_hoisted_temp();
+            current_statements.push(IRNode::VarDecl {
+                name: prefix_temp.clone().into(),
+                initializer: None,
+            });
+            current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                IRNode::id(prefix_temp.clone()),
+                IRNode::ArrayLiteral(vec![prefix_base]),
+            ))));
+            let resumed = if suspension_is_spread {
+                IRNode::Parenthesized(Box::new(IRNode::GeneratorSent))
+            } else {
+                IRNode::ArrayLiteral(vec![IRNode::GeneratorSent])
+            };
+            self.spread_array_apply(IRNode::CallExpr {
+                callee: Box::new(IRNode::prop(IRNode::id(prefix_temp), "concat")),
+                arguments: vec![IRNode::ArrayLiteral(vec![
+                    resumed,
+                    IRNode::BooleanLiteral(false),
+                ])],
+            })
+        } else if has_suffix_spread {
+            let prefix_temp = self.generate_hoisted_temp();
+            current_statements.push(IRNode::VarDecl {
+                name: prefix_temp.clone().into(),
+                initializer: None,
+            });
+            current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                IRNode::id(prefix_temp.clone()),
+                prefix_base,
+            ))));
+            IRNode::CallExpr {
+                callee: Box::new(IRNode::prop(IRNode::id(prefix_temp), "concat")),
+                arguments: vec![IRNode::ArrayLiteral(vec![IRNode::GeneratorSent])],
+            }
+        } else {
+            IRNode::ArrayLiteral(vec![IRNode::Undefined, IRNode::GeneratorSent])
+        };
+
+        let mut segment = Vec::new();
+        for &arg in &args[suspension_arg_index + 1..] {
+            if self.is_spread_arg(arg) {
+                if !segment.is_empty() {
+                    current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                        current,
+                        IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        IRNode::BooleanLiteral(false),
+                    ]));
+                }
+                current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                    current,
+                    self.spread_arg_expression_to_ir(arg),
+                    IRNode::BooleanLiteral(false),
+                ]));
+            } else {
+                segment.push(self.expression_to_ir(arg));
+            }
+        }
+        if !segment.is_empty() {
+            current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                current,
+                IRNode::ArrayLiteral(segment),
+                IRNode::BooleanLiteral(false),
+            ]));
+        }
+        current
+    }
+
+    fn spread_new_base_array(&mut self, args: &[NodeIndex]) -> IRNode {
+        if !self.args_contain_spread(args) {
+            let mut lowered = Vec::with_capacity(args.len() + 1);
+            lowered.push(IRNode::Undefined);
+            lowered.extend(args.iter().map(|&arg| self.expression_to_ir(arg)));
+            return IRNode::ArrayLiteral(lowered);
+        }
+
+        let mut current = IRNode::ArrayLiteral(vec![IRNode::Undefined]);
+        let mut segment = Vec::new();
+        for &arg in args {
+            if self.is_spread_arg(arg) {
+                if !segment.is_empty() {
+                    current = self.spread_array_call(
+                        current,
+                        IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                    );
+                }
+                current = self.spread_array_call(current, self.spread_arg_expression_to_ir(arg));
+            } else {
+                segment.push(self.expression_to_ir(arg));
+            }
+        }
+        if !segment.is_empty() {
+            current = self.spread_array_call(current, IRNode::ArrayLiteral(segment));
+        }
+        current
+    }
+
+    fn new_from_bound_apply(bind: IRNode, receiver: IRNode, arg_array: IRNode) -> IRNode {
+        IRNode::NewExpr {
+            callee: Box::new(IRNode::Parenthesized(Box::new(IRNode::CallExpr {
+                callee: Box::new(IRNode::prop(bind, "apply")),
+                arguments: vec![receiver, arg_array],
+            }))),
+            arguments: Vec::new(),
+            explicit_arguments: true,
+        }
+    }
+
+    fn new_from_apply_apply(
+        apply_method: IRNode,
+        bind_function: IRNode,
+        receiver_args: IRNode,
+        arg_array: IRNode,
+    ) -> IRNode {
+        IRNode::NewExpr {
+            callee: Box::new(IRNode::Parenthesized(Box::new(IRNode::CallExpr {
+                callee: Box::new(IRNode::prop(apply_method, "apply")),
+                arguments: vec![
+                    bind_function,
+                    IRNode::CallExpr {
+                        callee: Box::new(IRNode::prop(receiver_args, "concat")),
+                        arguments: vec![IRNode::ArrayLiteral(vec![arg_array])],
+                    },
+                ],
+            }))),
+            arguments: Vec::new(),
+            explicit_arguments: true,
+        }
+    }
+
     fn args_contain_spread(&self, args: &[NodeIndex]) -> bool {
         args.iter().any(|&arg| self.is_spread_arg(arg))
     }

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -154,6 +154,70 @@ fn block_return_await_inside_async_body_stays_on_state_machine_path() {
     );
 }
 
+#[test]
+fn new_expression_with_suspended_constructor_yields_before_constructing() {
+    let output = transform_and_print("async function f() { new (await ctor)(arg); }");
+
+    assert!(
+        output.contains("case 0: return [4 /*yield*/, ctor];")
+            && output.contains("case 1:")
+            && output.contains("new (_a.sent())(arg);"),
+        "A suspended constructor expression must yield the constructor before emitting the `new` call.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn new_expression_with_suspended_argument_uses_bind_apply() {
+    let output = transform_and_print("async function f() { new Factory(prefix, await value); }");
+
+    assert!(
+        output.contains("var _a, _b;"),
+        "Suspended new-expression arguments should reserve temps for `.bind` and prefix args.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = Factory.bind;")
+            && output.contains("_b = [void 0, prefix];")
+            && output.contains("return [4 /*yield*/, value];"),
+        "The constructor bind and prefix arguments must be captured before yielding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("new (_a.apply(Factory, _b.concat([_c.sent()])))();"),
+        "The resumed constructor call should use tsc's bind/apply new-expression shape.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn awaited_new_expression_with_spread_lowers_to_bind_apply() {
+    let output = transform_and_print("async function f() { await new Factory(...args, tail); }");
+
+    assert!(
+        output.contains("new (Factory.bind.apply(Factory, __spreadArray(__spreadArray([void 0], args, false), [tail], false)))()"),
+        "Awaited ES5 new expressions with spread arguments must lower through constructor bind/apply before yielding.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("new Factory(...args"),
+        "Raw spread syntax must not survive in async ES5 output.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn new_expression_with_suspended_element_constructor_index_captures_object() {
+    let output = transform_and_print("async function f() { new registry[await key](arg); }");
+
+    assert!(
+        output.contains("var _a;"),
+        "Suspended constructor element indexes should reserve a temp for the constructor object.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = registry;") && output.contains("return [4 /*yield*/, key];"),
+        "The constructor object must be captured before yielding the computed key.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("new _a[_b.sent()](arg);"),
+        "The resumed constructor should index into the captured object.\nOutput:\n{output}"
+    );
+}
+
 // Structural rule: when an async ES5 function contains a try statement where
 // any region (try, catch, finally) suspends on `await`, the generator state
 // machine must emit a 4-tuple `_a.trys.push([start, catch, finally, end])`


### PR DESCRIPTION
## Agent
AgentName: StuduiEmit

## Track
Track 9 emit/DTS parity: JavaScript emit async ES5 lowering.

## Invariant
When an async ES5 state-machine path contains `new` with a suspended constructor, suspended computed constructor key, suspended constructor argument, or spread constructor arguments, `tsc` captures the constructor/value prefix before yielding and resumes through the downlevel `bind`/`apply` constructor shape; this PR makes tsz emit that through the async ES5 IR lowering owner.

## Project Corpus Impact
- Row: n/a
- Bug family: async ES5 new-expression emit lowering

## Scope
- Extends `async_es5_ir_calls` with structured `new`-expression suspension/spread lowering.
- Wires the async state-machine expression path to the new lowering helper.
- Adds focused async IR tests for suspended constructors, suspended constructor args, spread construction, and suspended element constructor keys.

## Owner Layer
Emitter transform IR planning. This stays in OUTPUT: no checker or solver semantic validation, and no output-string surgery.

## Coordination
Originally developed on top of #10014; rebased onto `main` after #10014 merged.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter new_expression_with_suspended_constructor_yields_before_constructing new_expression_with_suspended_argument_uses_bind_apply awaited_new_expression_with_spread_lowers_to_bind_apply new_expression_with_suspended_element_constructor_index_captures_object --no-fail-fast`
- `./scripts/emit/run.sh --filter=es5-asyncFunctionNewExpressions --js-only --verbose --timeout=30000 --json-out=/tmp/studui-async-new-after-main-rebase.json`
- `./scripts/emit/run.sh --filter=es5-asyncFunctionCallExpressions --js-only --verbose --timeout=30000 --json-out=/tmp/studui-async-call-after-main-rebase.json`
- `git diff --check`