### PR TITLE
fix(emit): keep computed comment commas outside line comments

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -2047,7 +2047,7 @@ impl<'a> AstToIr<'a> {
         // Final reference to temp
         comma_parts.push(IRNode::id(temp));
 
-        IRNode::CommaExpr(comma_parts)
+        IRNode::CommaExprMultiline(comma_parts)
     }
 
     /// Lower a single object property to an ES5 assignment or Object.defineProperty call

--- a/crates/tsz-emitter/tests/computed_property_es5_tests.rs
+++ b/crates/tsz-emitter/tests/computed_property_es5_tests.rs
@@ -26,7 +26,9 @@ fn assert_comment_forced_comma_is_outdented(output: &str, assignment_fragment: &
     let assignment_line = lines
         .iter()
         .position(|line| line.contains(assignment_fragment))
-        .expect("lowered computed assignment line should be present");
+        .unwrap_or_else(|| {
+            panic!("lowered computed assignment line should be present.\nOutput:\n{output}")
+        });
     let comma_line = lines
         .get(assignment_line + 1)
         .expect("separator comma should follow the trailing comment line");
@@ -211,6 +213,25 @@ class C extends Base {
     assert_comment_forced_comma_is_outdented(
         &output,
         "_a[_super.prototype.bar.call(_this)] = function () { } // needs capture",
+    );
+}
+
+#[test]
+fn computed_method_identifier_trailing_comment_aligns_comma_expression_separator() {
+    let source = r#"
+class C {
+    foo(key) {
+        var obj = {
+            [key]() { } // keep method comment
+        };
+    }
+}
+"#;
+    let output = emit_es5(source);
+
+    assert_comment_forced_comma_is_outdented(
+        &output,
+        "_a[key] = function () { } // keep method comment",
     );
 }
 


### PR DESCRIPTION
AgentName: StuduiEmit

Structural rule: when class ES5 IR lowers an object literal with computed methods into a temp-backed comma expression, and a lowered assignment ends with a trailing line comment, the following comma must be emitted by the multiline comma-expression printer on the next line so it is not swallowed by the comment.

Failure family: JS emit, ES5 computed-property object-literal lowering inside class IR.

Owner layer: `class_es5_ast_to_ir` chooses `IRNode::CommaExprMultiline` for computed object literal lowering; the existing IR printer owns multiline comma separator placement and comment-aware continuation.

Why this avoids semantic validation/output surgery: the change keeps the syntax-to-IR lowering structural and delegates formatting to the IR printer; it does not inspect checker/solver semantics and does not patch emitted text.

Adjacent-case coverage:
- computed method with `super` in the computed key, matching `computedPropertyNames31_ES5`
- computed method with an identifier key, proving the rule is not tied to `super` or a specific name
- ES2015 target remains covered by the focused emit filter and stays passing

Known unsupported shapes/fallback: property-assignment trailing comments in the direct object-literal helper are not expanded in this PR because the reproduced failure is the class IR method path and current direct assignment emission does not preserve that comment text.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit, ES5 computed-property object-literal lowering inside class IR
- Evidence: This is an emitter-only baseline parity fix with no project-corpus fixture or dependency changes expected; ready-review CI should rerun the normal project gates on this exact head.

Verification:
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter -E 'test(computed_method_trailing_comment_aligns_comma_expression_separator) | test(computed_method_identifier_trailing_comment_aligns_comma_expression_separator)' --no-fail-fast`\n- `./scripts/emit/run.sh --filter=computedPropertyNames31_ES5 --js-only --verbose --timeout=30000 --json-out=/tmp/studui-computedPropertyNames31_ES5-final.json`\n- `git diff --check`\n

Project Corpus Impact: Emit-only comma-separator placement fix for ES5 computed method lowering. No project-corpus fixture or dependency changes are expected; ready-review CI should rerun the normal project gates on this exact head before auto-merge is re-armed.
