### PR TITLE
fix(emit): capture async array literal prefixes

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -917,6 +917,13 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_label,
             ) {
                 lowered_call
+            } else if let Some(lowered_array) = self.lower_array_literal_before_suspension(
+                idx,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_array
             } else if let Some(lowered_access) = self.lower_element_access_object_before_suspension(
                 idx,
                 cases,
@@ -2632,6 +2639,15 @@ impl<'a> AsyncES5Transformer<'a> {
                                 current_label,
                             ) {
                             lowered_call
+                        } else if let Some(lowered_array) = self
+                            .lower_array_literal_before_suspension(
+                                ret.expression,
+                                cases,
+                                current_statements,
+                                current_label,
+                            )
+                        {
+                            lowered_array
                         } else if let Some(lowered_access) = self
                             .lower_element_access_object_before_suspension(
                                 ret.expression,
@@ -2875,6 +2891,15 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_statements,
                 current_label,
             ) {
+                return;
+            }
+            if let Some(lowered_array) = self.lower_array_literal_before_suspension(
+                idx,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                current_statements.push(IRNode::ExpressionStatement(Box::new(lowered_array)));
                 return;
             }
             if let Some(lowered_access) = self.lower_element_access_object_before_suspension(
@@ -3329,6 +3354,22 @@ impl<'a> AsyncES5Transformer<'a> {
 
                 // Emit the yield for the nested await
                 if let Some(lowered_init) = self.lower_call_callee_before_suspension(
+                    decl.initializer,
+                    cases,
+                    current_statements,
+                    current_label,
+                ) {
+                    current_statements.push(IRNode::ExpressionStatement(Box::new(
+                        IRNode::BinaryExpr {
+                            left: Box::new(IRNode::Identifier(name.into())),
+                            operator: "=".to_string().into(),
+                            right: Box::new(lowered_init),
+                        },
+                    )));
+                    return;
+                }
+
+                if let Some(lowered_init) = self.lower_array_literal_before_suspension(
                     decl.initializer,
                     cases,
                     current_statements,

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -3076,7 +3076,7 @@ impl<'a> AsyncES5Transformer<'a> {
         None
     }
 
-    fn emit_nested_suspension(
+    pub(super) fn emit_nested_suspension(
         &mut self,
         idx: NodeIndex,
         cases: &mut Vec<IRGeneratorCase>,
@@ -3327,24 +3327,12 @@ impl<'a> AsyncES5Transformer<'a> {
                     initializer: None,
                 });
 
-                if let Some((temp, initial_obj, lowered_init)) =
-                    self.lower_object_literal_es5_after_computed_suspension(decl.initializer)
-                {
-                    current_statements.push(IRNode::HoistedVarGroupBreak);
-                    current_statements.push(IRNode::VarDecl {
-                        name: temp.clone().into(),
-                        initializer: None,
-                    });
-                    current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
-                        IRNode::id(temp),
-                        initial_obj,
-                    ))));
-                    self.emit_nested_suspension(
-                        decl.initializer,
-                        cases,
-                        current_statements,
-                        current_label,
-                    );
+                if let Some(lowered_init) = self.lower_object_literal_before_suspension(
+                    decl.initializer,
+                    cases,
+                    current_statements,
+                    current_label,
+                ) {
                     current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
                         IRNode::Identifier(name.into()),
                         lowered_init,
@@ -4436,7 +4424,8 @@ impl<'a> AsyncES5Transformer<'a> {
             | IRNode::LogicalAnd { .. }
             | IRNode::ConditionalExpr { .. }
             | IRNode::CommaExpr(_)
-            | IRNode::CommaExprMultiline(_) => IRNode::Parenthesized(Box::new(condition)),
+            | IRNode::CommaExprMultiline(_)
+            | IRNode::CommaExprMultilineFlat(_) => IRNode::Parenthesized(Box::new(condition)),
             _ => condition,
         };
         IRNode::PrefixUnaryExpr {

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs
@@ -6,6 +6,324 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> AsyncES5Transformer<'a> {
+    pub(super) fn lower_array_literal_before_suspension(
+        &mut self,
+        idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let node = self.arena.get(idx)?;
+        match node.kind {
+            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
+                self.lower_suspended_array_literal(idx, cases, current_statements, current_label)
+            }
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                let binary = self.arena.get_binary_expr(node)?;
+                if self.get_operator_text(binary.operator_token) != "=" {
+                    return None;
+                }
+                let left = self.arena.get(binary.left)?;
+                if left.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+                    return None;
+                }
+                let right = self.lower_array_literal_before_suspension(
+                    binary.right,
+                    cases,
+                    current_statements,
+                    current_label,
+                )?;
+                Some(IRNode::assign(self.expression_to_ir(binary.left), right))
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                let paren = self.arena.get_parenthesized(node)?;
+                self.lower_array_literal_before_suspension(
+                    paren.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+                .map(|expr| IRNode::Parenthesized(Box::new(expr)))
+            }
+            k if k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                let assertion = self.arena.get_type_assertion(node)?;
+                self.lower_array_literal_before_suspension(
+                    assertion.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+            }
+            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
+                let unary = self.arena.get_unary_expr_ex(node)?;
+                self.lower_array_literal_before_suspension(
+                    unary.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+            }
+            _ => None,
+        }
+    }
+
+    fn lower_suspended_array_literal(
+        &mut self,
+        idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let node = self.arena.get(idx)?;
+        let array = self.arena.get_literal_expr(node)?;
+        let elements = &array.elements.nodes;
+        let first_suspension_index = elements
+            .iter()
+            .position(|&element| self.contains_await_recursive(element))?;
+
+        if self.args_contain_spread(elements) {
+            return self.lower_suspended_spread_array_literal(
+                elements,
+                first_suspension_index,
+                cases,
+                current_statements,
+                current_label,
+            );
+        }
+
+        self.lower_suspended_plain_array_literal(
+            elements,
+            first_suspension_index,
+            cases,
+            current_statements,
+            current_label,
+        )
+    }
+
+    fn lower_suspended_plain_array_literal(
+        &mut self,
+        elements: &[NodeIndex],
+        first_suspension_index: usize,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let suspension_indices = elements
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &element)| self.contains_await_recursive(element).then_some(index))
+            .collect::<Vec<_>>();
+        if suspension_indices.len() == 1 && first_suspension_index == 0 {
+            self.emit_nested_suspension(
+                elements[first_suspension_index],
+                cases,
+                current_statements,
+                current_label,
+            );
+            return Some(IRNode::ArrayLiteral(
+                elements
+                    .iter()
+                    .map(|&element| self.expression_to_ir(element))
+                    .collect(),
+            ));
+        }
+
+        let temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: temp.clone().into(),
+            initializer: None,
+        });
+        let mut temp_initialized = false;
+        if first_suspension_index > 0 {
+            current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                IRNode::id(temp.clone()),
+                IRNode::ArrayLiteral(
+                    elements[..first_suspension_index]
+                        .iter()
+                        .map(|&element| self.expression_to_ir(element))
+                        .collect(),
+                ),
+            ))));
+            temp_initialized = true;
+        }
+
+        for (position, &suspension_index) in suspension_indices.iter().enumerate() {
+            self.emit_nested_suspension(
+                elements[suspension_index],
+                cases,
+                current_statements,
+                current_label,
+            );
+
+            let next_suspension_index = suspension_indices.get(position + 1).copied();
+            let segment_end = next_suspension_index.unwrap_or(elements.len());
+            let segment = IRNode::ArrayLiteral(
+                elements[suspension_index..segment_end]
+                    .iter()
+                    .map(|&element| self.expression_to_ir(element))
+                    .collect(),
+            );
+
+            if next_suspension_index.is_some() {
+                let value = if temp_initialized {
+                    IRNode::call(
+                        IRNode::prop(IRNode::id(temp.clone()), "concat"),
+                        vec![segment],
+                    )
+                } else {
+                    segment
+                };
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::id(temp.clone()),
+                    value,
+                ))));
+                temp_initialized = true;
+            } else if temp_initialized {
+                return Some(IRNode::call(
+                    IRNode::prop(IRNode::id(temp), "concat"),
+                    vec![segment],
+                ));
+            } else {
+                return Some(segment);
+            }
+        }
+
+        None
+    }
+
+    fn lower_suspended_spread_array_literal(
+        &mut self,
+        elements: &[NodeIndex],
+        first_suspension_index: usize,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let suspension_indices = elements
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &element)| self.contains_await_recursive(element).then_some(index))
+            .collect::<Vec<_>>();
+        if suspension_indices.len() != 1 {
+            return None;
+        }
+
+        self.helpers_needed.mark_spread_array();
+        let suspension_is_spread = self.is_spread_arg(elements[first_suspension_index]);
+        let needs_prefix_temp = first_suspension_index > 0 || suspension_is_spread;
+        let prefix_temp = needs_prefix_temp.then(|| self.generate_hoisted_temp());
+
+        if let Some(temp) = &prefix_temp {
+            current_statements.push(IRNode::VarDecl {
+                name: temp.clone().into(),
+                initializer: None,
+            });
+            current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                IRNode::id(temp.clone()),
+                IRNode::ArrayLiteral(vec![
+                    self.spread_array_base_array(&elements[..first_suspension_index]),
+                ]),
+            ))));
+        }
+
+        self.emit_nested_suspension(
+            elements[first_suspension_index],
+            cases,
+            current_statements,
+            current_label,
+        );
+
+        let current = if let Some(temp) = prefix_temp {
+            let resumed = if suspension_is_spread {
+                IRNode::Parenthesized(Box::new(IRNode::GeneratorSent))
+            } else {
+                IRNode::ArrayLiteral(vec![IRNode::GeneratorSent])
+            };
+            let pack = IRNode::BooleanLiteral(suspension_is_spread);
+            self.spread_array_apply(IRNode::CallExpr {
+                callee: Box::new(IRNode::prop(IRNode::id(temp), "concat")),
+                arguments: vec![IRNode::ArrayLiteral(vec![resumed, pack])],
+            })
+        } else {
+            IRNode::ArrayLiteral(vec![IRNode::GeneratorSent])
+        };
+
+        Some(self.append_spread_array_suffix(current, &elements[first_suspension_index + 1..]))
+    }
+
+    fn append_spread_array_suffix(&mut self, mut current: IRNode, suffix: &[NodeIndex]) -> IRNode {
+        let mut segment = Vec::new();
+        for &element in suffix {
+            if self.is_spread_arg(element) {
+                if !segment.is_empty() {
+                    current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                        current,
+                        IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        IRNode::BooleanLiteral(false),
+                    ]));
+                }
+                current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                    current,
+                    self.spread_arg_expression_to_ir(element),
+                    IRNode::BooleanLiteral(true),
+                ]));
+            } else {
+                segment.push(self.expression_to_ir(element));
+            }
+        }
+        if !segment.is_empty() {
+            current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                current,
+                IRNode::ArrayLiteral(segment),
+                IRNode::BooleanLiteral(false),
+            ]));
+        }
+        current
+    }
+
+    fn spread_array_base_array(&mut self, elements: &[NodeIndex]) -> IRNode {
+        if elements.is_empty() || !self.args_contain_spread(elements) {
+            return IRNode::ArrayLiteral(
+                elements
+                    .iter()
+                    .map(|&element| self.expression_to_ir(element))
+                    .collect(),
+            );
+        }
+
+        let mut current = IRNode::ArrayLiteral(Vec::new());
+        let mut segment = Vec::new();
+        for &element in elements {
+            if self.is_spread_arg(element) {
+                if !segment.is_empty() {
+                    current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                        current,
+                        IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        IRNode::BooleanLiteral(false),
+                    ]));
+                }
+                current = self.spread_array_call(
+                    current,
+                    self.spread_arg_expression_to_ir(element),
+                    true,
+                );
+            } else {
+                segment.push(self.expression_to_ir(element));
+            }
+        }
+        if !segment.is_empty() {
+            current = self.spread_array_apply(IRNode::ArrayLiteral(vec![
+                current,
+                IRNode::ArrayLiteral(segment),
+                IRNode::BooleanLiteral(false),
+            ]));
+        }
+        current
+    }
+
     pub(super) fn lower_call_callee_before_suspension(
         &mut self,
         idx: NodeIndex,
@@ -821,15 +1139,17 @@ impl<'a> AsyncES5Transformer<'a> {
                     current = self.spread_array_call(
                         current,
                         IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        false,
                     );
                 }
-                current = self.spread_array_call(current, self.spread_arg_expression_to_ir(arg));
+                current =
+                    self.spread_array_call(current, self.spread_arg_expression_to_ir(arg), false);
             } else {
                 segment.push(self.expression_to_ir(arg));
             }
         }
         if !segment.is_empty() {
-            current = self.spread_array_call(current, IRNode::ArrayLiteral(segment));
+            current = self.spread_array_call(current, IRNode::ArrayLiteral(segment), false);
         }
         current
     }
@@ -947,24 +1267,26 @@ impl<'a> AsyncES5Transformer<'a> {
                     current = self.spread_array_call(
                         current,
                         IRNode::ArrayLiteral(std::mem::take(&mut segment)),
+                        false,
                     );
                 }
-                current = self.spread_array_call(current, self.spread_arg_expression_to_ir(arg));
+                current =
+                    self.spread_array_call(current, self.spread_arg_expression_to_ir(arg), false);
             } else {
                 segment.push(self.expression_to_ir(arg));
             }
         }
         if !segment.is_empty() {
-            current = self.spread_array_call(current, IRNode::ArrayLiteral(segment));
+            current = self.spread_array_call(current, IRNode::ArrayLiteral(segment), false);
         }
         current
     }
 
-    fn spread_array_call(&mut self, to: IRNode, from: IRNode) -> IRNode {
+    fn spread_array_call(&mut self, to: IRNode, from: IRNode, pack: bool) -> IRNode {
         self.helpers_needed.mark_spread_array();
         IRNode::CallExpr {
             callee: Box::new(IRNode::RuntimeHelper("__spreadArray".into())),
-            arguments: vec![to, from, IRNode::BooleanLiteral(false)],
+            arguments: vec![to, from, IRNode::BooleanLiteral(pack)],
         }
     }
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_for_of.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_for_of.rs
@@ -598,6 +598,7 @@ impl<'a> AsyncES5Transformer<'a> {
                     kind: crate::transforms::ir::IRPropertyKind::Init,
                 }],
                 source_range: None,
+                extra_indent: 0,
             },
         )));
         current_statements.push(Self::generator_break_statement(end_label));

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
@@ -1,7 +1,9 @@
 //! Object-literal helpers for the async ES5 IR converter.
 
 use crate::transforms::async_es5_ir::AsyncES5Transformer;
-use crate::transforms::ir::{IRNode, IRParam, IRProperty, IRPropertyKey, IRPropertyKind};
+use crate::transforms::ir::{
+    IRGeneratorCase, IRNode, IRParam, IRProperty, IRPropertyKey, IRPropertyKind,
+};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::MethodDeclData;
 use tsz_parser::parser::syntax_kind_ext;
@@ -100,48 +102,245 @@ impl AsyncES5Transformer<'_> {
         Some((temp, IRNode::CommaExpr(parts)))
     }
 
-    pub(super) fn lower_object_literal_es5_after_computed_suspension(
-        &self,
+    pub(super) fn lower_object_literal_before_suspension(
+        &mut self,
         idx: NodeIndex,
-    ) -> Option<(String, IRNode, IRNode)> {
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
         let node = self.arena.get(idx)?;
-        if node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
-            return None;
-        }
-        let literal = self.arena.get_literal_expr(node)?;
-        let first_suspending_computed_idx =
-            literal.elements.nodes.iter().position(|&elem_idx| {
-                let Some(elem_node) = self.arena.get(elem_idx) else {
-                    return false;
-                };
-                if elem_node.kind != syntax_kind_ext::PROPERTY_ASSIGNMENT {
-                    return false;
+        match node.kind {
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
+                self.lower_suspended_object_literal(idx, cases, current_statements, current_label)
+            }
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                let binary = self.arena.get_binary_expr(node)?;
+                if self.get_operator_text(binary.operator_token) != "=" {
+                    return None;
                 }
-                self.arena
-                    .get_property_assignment(elem_node)
-                    .is_some_and(|prop| self.computed_property_name_contains_await(prop.name))
-            })?;
+                let right = self.lower_object_literal_before_suspension(
+                    binary.right,
+                    cases,
+                    current_statements,
+                    current_label,
+                )?;
+                Some(IRNode::assign(self.expression_to_ir(binary.left), right))
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                let paren = self.arena.get_parenthesized(node)?;
+                self.lower_object_literal_before_suspension(
+                    paren.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+                .map(|expr| IRNode::Parenthesized(Box::new(expr)))
+            }
+            k if k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                let assertion = self.arena.get_type_assertion(node)?;
+                self.lower_object_literal_before_suspension(
+                    assertion.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+            }
+            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
+                let unary = self.arena.get_unary_expr_ex(node)?;
+                self.lower_object_literal_before_suspension(
+                    unary.expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                )
+            }
+            _ => None,
+        }
+    }
 
-        let temp = self.generate_hoisted_temp();
-        let initial_obj =
-            IRNode::object(self.convert_object_properties(
-                &literal.elements.nodes[..first_suspending_computed_idx],
-            ));
-
-        let mut parts = Vec::new();
-        for &elem_idx in literal
-            .elements
-            .nodes
+    fn lower_suspended_object_literal(
+        &mut self,
+        idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> Option<IRNode> {
+        let node = self.arena.get(idx)?;
+        let literal = self.arena.get_literal_expr(node)?;
+        let elements = &literal.elements.nodes;
+        let first_suspension_index = elements
             .iter()
-            .skip(first_suspending_computed_idx)
-        {
-            if let Some(assignment) = self.lower_object_property_es5(elem_idx, &temp) {
+            .position(|&element| self.object_element_contains_suspension(element))?;
+        let first_suspension = elements[first_suspension_index];
+        let first_property = self.suspending_property_assignment(first_suspension)?;
+        let first_property_name = first_property.name;
+        let first_property_initializer = first_property.initializer;
+        let first_key_suspends = self.computed_property_name_contains_await(first_property_name);
+        let first_value_suspends = self.body_contains_await(first_property_initializer);
+        let first_key_needs_temp = first_value_suspends
+            && (first_key_suspends || self.object_property_name_is_computed(first_property_name));
+        let first_key_temp = first_key_needs_temp.then(|| self.generate_hoisted_temp());
+        let split_object_var_group = first_key_temp.is_some()
+            || first_key_suspends
+            || elements[..first_suspension_index]
+                .iter()
+                .any(|&element| self.object_element_needs_computed_lowering(element));
+
+        if let Some(temp) = &first_key_temp {
+            current_statements.push(IRNode::VarDecl {
+                name: temp.clone().into(),
+                initializer: None,
+            });
+        }
+        if split_object_var_group {
+            current_statements.push(IRNode::HoistedVarGroupBreak);
+        }
+
+        let object_temp = self.generate_hoisted_temp();
+        current_statements.push(IRNode::VarDecl {
+            name: object_temp.clone().into(),
+            initializer: None,
+        });
+        self.emit_object_literal_prefix_before_suspension(
+            &elements[..first_suspension_index],
+            &object_temp,
+            Some((node.pos, node.end)),
+            split_object_var_group,
+            current_statements,
+        );
+
+        if let Some(key_temp) = &first_key_temp {
+            if first_key_suspends {
+                let key_expression = self.computed_property_expression(first_property_name)?;
+                self.emit_nested_suspension(
+                    key_expression,
+                    cases,
+                    current_statements,
+                    current_label,
+                );
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::id(key_temp.clone()),
+                    IRNode::GeneratorSent,
+                ))));
+            } else {
+                let key_expression = self.computed_property_expression(first_property_name)?;
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::id(key_temp.clone()),
+                    self.expression_to_ir(key_expression),
+                ))));
+            }
+        }
+
+        let first_value_is_resume = if first_value_suspends {
+            self.emit_nested_suspension(
+                first_property_initializer,
+                cases,
+                current_statements,
+                current_label,
+            );
+            true
+        } else if first_key_suspends {
+            let key_expression = self.computed_property_expression(first_property_name)?;
+            self.emit_nested_suspension(key_expression, cases, current_statements, current_label);
+            false
+        } else {
+            return None;
+        };
+
+        let suffix = &elements[first_suspension_index + 1..];
+        let suffix_needs_computed_lowering = suffix
+            .iter()
+            .any(|&element| self.object_element_needs_computed_lowering(element));
+        let result_temp = suffix_needs_computed_lowering.then(|| self.generate_hoisted_temp());
+        if let Some(temp) = &result_temp {
+            current_statements.push(IRNode::HoistedVarGroupBreak);
+            current_statements.push(IRNode::VarDecl {
+                name: temp.clone().into(),
+                initializer: None,
+            });
+        }
+
+        let key = if let Some(key_temp) = &first_key_temp {
+            IRNode::elem(
+                IRNode::id(object_temp.clone()),
+                IRNode::id(key_temp.clone()),
+            )
+        } else if first_key_suspends {
+            IRNode::elem(IRNode::id(object_temp.clone()), IRNode::GeneratorSent)
+        } else {
+            self.convert_property_key_to_element_access(first_property_name, &object_temp)?
+        };
+        let value = if first_value_is_resume {
+            IRNode::GeneratorSent
+        } else {
+            self.expression_to_ir(first_property_initializer)
+        };
+        let first_assignment = IRNode::assign(key, value);
+
+        if let Some(result_temp) = result_temp {
+            let mut parts = vec![IRNode::assign(
+                IRNode::id(result_temp.clone()),
+                IRNode::CommaExprMultilineFlat(vec![first_assignment, IRNode::id(object_temp)]),
+            )];
+            for &element in suffix {
+                if let Some(assignment) = self.lower_object_property_es5(element, &result_temp) {
+                    parts.push(assignment);
+                }
+            }
+            parts.push(IRNode::id(result_temp));
+            return Some(IRNode::CommaExprMultiline(parts));
+        }
+
+        let mut parts = vec![first_assignment];
+        for &element in suffix {
+            if let Some(assignment) = self.lower_object_property_es5(element, &object_temp) {
                 parts.push(assignment);
             }
         }
-        parts.push(IRNode::id(temp.clone()));
+        parts.push(IRNode::id(object_temp));
 
-        Some((temp, initial_obj, IRNode::CommaExpr(parts)))
+        Some(IRNode::CommaExprMultiline(parts))
+    }
+
+    fn emit_object_literal_prefix_before_suspension(
+        &self,
+        elements: &[NodeIndex],
+        temp: &str,
+        source_range: Option<(u32, u32)>,
+        extra_indent: bool,
+        current_statements: &mut Vec<IRNode>,
+    ) {
+        let first_computed_idx = elements
+            .iter()
+            .position(|&element| self.object_element_needs_computed_lowering(element))
+            .unwrap_or(elements.len());
+        let initial_assignment = IRNode::assign(
+            IRNode::id(temp.to_string()),
+            IRNode::ObjectLiteral {
+                properties: self.convert_object_properties(&elements[..first_computed_idx]),
+                source_range,
+                extra_indent: u8::from(extra_indent),
+            },
+        );
+
+        if first_computed_idx < elements.len() {
+            let mut parts = vec![initial_assignment];
+            for &element in &elements[first_computed_idx..] {
+                if let Some(assignment) = self.lower_object_property_es5(element, temp) {
+                    parts.push(assignment);
+                }
+            }
+            current_statements.push(IRNode::ExpressionStatement(Box::new(
+                IRNode::CommaExprMultiline(parts),
+            )));
+            return;
+        }
+
+        current_statements.push(IRNode::ExpressionStatement(Box::new(initial_assignment)));
     }
 
     fn object_element_needs_computed_lowering(&self, elem_idx: NodeIndex) -> bool {
@@ -163,6 +362,33 @@ impl AsyncES5Transformer<'_> {
         false
     }
 
+    fn object_element_contains_suspension(&self, elem_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(elem_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+            return self
+                .arena
+                .get_property_assignment(node)
+                .is_some_and(|prop| {
+                    self.computed_property_name_contains_await(prop.name)
+                        || self.body_contains_await(prop.initializer)
+                });
+        }
+        false
+    }
+
+    fn suspending_property_assignment(
+        &self,
+        elem_idx: NodeIndex,
+    ) -> Option<&tsz_parser::parser::node::PropertyAssignmentData> {
+        let node = self.arena.get(elem_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ASSIGNMENT {
+            return None;
+        }
+        self.arena.get_property_assignment(node)
+    }
+
     fn object_property_name_is_computed(&self, name_idx: NodeIndex) -> bool {
         self.arena
             .get(name_idx)
@@ -179,6 +405,16 @@ impl AsyncES5Transformer<'_> {
         self.arena
             .get_computed_property(name_node)
             .is_some_and(|computed| self.body_contains_await(computed.expression))
+    }
+
+    fn computed_property_expression(&self, name_idx: NodeIndex) -> Option<NodeIndex> {
+        let name_node = self.arena.get(name_idx)?;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        self.arena
+            .get_computed_property(name_node)
+            .map(|computed| computed.expression)
     }
 
     fn lower_object_property_es5(&self, elem_idx: NodeIndex, temp: &str) -> Option<IRNode> {

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -1807,6 +1807,7 @@ impl<'a> AstToIr<'a> {
             IRNode::ObjectLiteral {
                 properties: props,
                 source_range: Some((node.pos, node.end)),
+                extra_indent: 0,
             }
         } else {
             IRNode::ASTRef(idx)
@@ -2029,6 +2030,7 @@ impl<'a> AstToIr<'a> {
             IRNode::ObjectLiteral {
                 properties: Vec::new(),
                 source_range: None,
+                extra_indent: 0,
             }
         };
         comma_parts.push(IRNode::BinaryExpr {
@@ -2122,6 +2124,7 @@ impl<'a> AstToIr<'a> {
                         IRNode::ObjectLiteral {
                             properties: descriptor_props,
                             source_range: None,
+                            extra_indent: 0,
                         },
                     ],
                 })

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -132,6 +132,11 @@ pub enum IRNode {
     /// ```
     CommaExprMultiline(Vec<Self>),
 
+    /// Multiline comma expression whose continuation lines reuse the current
+    /// indentation level. Used when a comma expression is nested inside another
+    /// multiline comma expression.
+    CommaExprMultilineFlat(Vec<Self>),
+
     /// Array literal: `[a, b, c]`
     ArrayLiteral(Vec<Self>),
 
@@ -143,6 +148,9 @@ pub enum IRNode {
         properties: Vec<IRProperty>,
         /// Source range (pos, end) for single-line vs multiline detection
         source_range: Option<(u32, u32)>,
+        /// Extra continuation indentation for object literals that TypeScript
+        /// emits as part of downlevel computed-property temporaries.
+        extra_indent: u8,
     },
 
     /// Function expression: `function name(params) { body }`
@@ -920,6 +928,7 @@ impl IRNode {
             }
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)
+            | Self::CommaExprMultilineFlat(nodes)
             | Self::ArrayLiteral(nodes)
             | Self::VarDeclList(nodes)
             | Self::Block(nodes)
@@ -1238,6 +1247,7 @@ impl IRNode {
             }
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)
+            | Self::CommaExprMultilineFlat(nodes)
             | Self::ArrayLiteral(nodes)
             | Self::VarDeclList(nodes)
             | Self::Block(nodes)
@@ -1485,6 +1495,7 @@ impl IRNode {
         Self::ObjectLiteral {
             properties: props,
             source_range: None,
+            extra_indent: 0,
         }
     }
 
@@ -1493,6 +1504,7 @@ impl IRNode {
         Self::ObjectLiteral {
             properties: Vec::new(),
             source_range: None,
+            extra_indent: 0,
         }
     }
 

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -856,6 +856,24 @@ impl<'a> IRPrinter<'a> {
                 self.indent_level -= 1;
                 self.write(")");
             }
+            IRNode::CommaExprMultilineFlat(exprs) => {
+                self.write("(");
+                for (i, expr) in exprs.iter().enumerate() {
+                    if i > 0 {
+                        if self.last_emit_ended_with_line_comment {
+                            self.write_line();
+                            self.write_indent();
+                        }
+                        self.last_emit_ended_with_line_comment = false;
+                        self.write(",");
+                        self.write_line();
+                        self.write_indent();
+                    }
+                    self.last_emit_ended_with_line_comment = false;
+                    self.emit_node(expr);
+                }
+                self.write(")");
+            }
             IRNode::ArrayLiteral(elements) => {
                 self.write("[");
                 self.emit_comma_separated(elements);
@@ -868,6 +886,7 @@ impl<'a> IRPrinter<'a> {
             IRNode::ObjectLiteral {
                 properties,
                 source_range,
+                extra_indent,
             } => {
                 if properties.is_empty() {
                     self.write("{}");
@@ -885,7 +904,8 @@ impl<'a> IRPrinter<'a> {
                     // Multiline format
                     self.write("{");
                     self.write_line();
-                    self.indent_level += 1;
+                    let extra_indent = u32::from(*extra_indent);
+                    self.indent_level += 1 + extra_indent;
                     for (i, prop) in properties.iter().enumerate() {
                         self.write_indent();
                         self.emit_property(prop);
@@ -897,6 +917,7 @@ impl<'a> IRPrinter<'a> {
                     self.indent_level -= 1;
                     self.write_indent();
                     self.write("}");
+                    self.indent_level -= extra_indent;
                 } else {
                     // Single-line format
                     self.write("{ ");
@@ -1058,6 +1079,27 @@ impl<'a> IRPrinter<'a> {
                 self.write(";");
             }
             IRNode::ExpressionStatement(expr) => {
+                if let IRNode::CommaExprMultiline(exprs) = expr.as_ref() {
+                    self.indent_level += 1;
+                    for (i, expr) in exprs.iter().enumerate() {
+                        if i > 0 {
+                            if self.last_emit_ended_with_line_comment {
+                                self.write_line();
+                                self.write_indent_level(self.indent_level.saturating_sub(1));
+                            }
+                            self.last_emit_ended_with_line_comment = false;
+                            self.write(",");
+                            self.write_line();
+                            self.write_indent();
+                        }
+                        self.last_emit_ended_with_line_comment = false;
+                        self.emit_node(expr);
+                    }
+                    self.indent_level -= 1;
+                    self.write(";");
+                    return;
+                }
+
                 // Wrap function/object expressions in parens when in statement
                 // position to prevent declaration/block ambiguity.
                 let needs_paren = matches!(
@@ -1084,6 +1126,7 @@ impl<'a> IRPrinter<'a> {
                     if let IRNode::ObjectLiteral {
                         properties,
                         source_range: None,
+                        extra_indent: 0,
                     } = &**e
                         && Self::is_done_value_object_literal(properties)
                     {

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -783,6 +783,7 @@ impl<'a> NamespaceES5Transformer<'a> {
                 },
             ],
             source_range: None,
+            extra_indent: 0,
         }
     }
 
@@ -1809,6 +1810,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             }
             IRNode::CommaExpr(items)
             | IRNode::CommaExprMultiline(items)
+            | IRNode::CommaExprMultilineFlat(items)
             | IRNode::ArrayLiteral(items)
             | IRNode::VarDeclList(items)
             | IRNode::Block(items)

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -1059,6 +1059,7 @@ pub(super) fn rewrite_exported_var_refs(
         }
         IRNode::CommaExpr(exprs)
         | IRNode::CommaExprMultiline(exprs)
+        | IRNode::CommaExprMultilineFlat(exprs)
         | IRNode::ArrayLiteral(exprs) => {
             for expr in exprs.iter_mut() {
                 rewrite_exported_var_refs(expr, ns_name, names);

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -537,6 +537,61 @@ fn count_substring(haystack: &str, needle: &str) -> usize {
 }
 
 #[test]
+fn generator_object_literal_prefix_before_yield_is_captured_before_resume() {
+    let output = transform_generator_and_print(
+        "function* f() { var x = { before: 1, value: yield 2, after: 3 }; }",
+    );
+
+    assert!(
+        output.contains("var x, _a;"),
+        "The object temp should be hoisted with the local declaration.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = { before: 1 };") && output.contains("return [4 /*yield*/, 2];"),
+        "Properties before the suspending value must be assigned before yielding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x = (_a.value = _b.sent(),\n                    _a.after = 3,\n                    _a);"),
+        "After resume, the saved object should be mutated and returned from the comma expression.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn generator_object_literal_computed_key_before_yield_is_captured() {
+    let output =
+        transform_generator_and_print("function* f() { var x = { before: 1, [key()]: yield 2 }; }");
+
+    assert!(
+        output.contains("var x, _a;\n    var _b;"),
+        "A computed key temp and object temp should use tsc's split hoist groups.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_b = { before: 1 };\n                _a = key();\n                return [4 /*yield*/, 2];"),
+        "The computed key must be evaluated before yielding the property value.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x = (_b[_a] = _c.sent(),\n                    _b);"),
+        "The resumed value should assign through the captured computed key.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn generator_object_literal_computed_suffix_uses_result_temp_after_resume() {
+    let output = transform_generator_and_print(
+        "function* f() { var x = { before: 1, value: yield 2, [key()]: 3 }; }",
+    );
+
+    assert!(
+        output.contains("var x, _a;\n    var _b;"),
+        "A suffix computed property should allocate a result temp after the saved object temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x = (_b = (_a.value = _c.sent(),\n                    _a),\n                    _b[key()] = 3,\n                    _b);"),
+        "The computed suffix should operate on the resumed object temp, matching tsc's comma expression shape.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn test_simple_async_function() {
     let output = transform_and_print("async function foo() { }");
     assert!(

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -218,6 +218,56 @@ fn new_expression_with_suspended_element_constructor_index_captures_object() {
     );
 }
 
+#[test]
+fn array_literal_prefix_before_await_is_captured_before_yield() {
+    let output = transform_and_print("async function f() { x = [head, await tail, after]; }");
+
+    assert!(
+        output.contains("var _a;"),
+        "A prefix temp should be hoisted before the generator body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = [head];\n                    return [4 /*yield*/, tail];"),
+        "Array elements before the suspending element must be evaluated before yielding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x = _a.concat([_b.sent(), after]);"),
+        "After resume, the saved prefix should be concatenated with the sent value and suffix.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn array_literal_multiple_awaits_accumulates_prefix_between_yields() {
+    let output =
+        transform_and_print("async function f() { x = [await first, middle, await last]; }");
+
+    assert!(
+        output
+            .contains("_a = [_b.sent(), middle];\n                    return [4 /*yield*/, last];"),
+        "The resumed first await and intervening elements should be captured before the second yield.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("x = _a.concat([_b.sent()]);"),
+        "The final resume should append to the accumulated prefix temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn spread_array_literal_with_suspending_spread_uses_spread_array_apply() {
+    let output = transform_and_print("async function f() { x = [...(await values), z]; }");
+
+    assert!(
+        output.contains("_a = [[]];\n                    return [4 /*yield*/, values];"),
+        "A suspending first spread still needs a captured spread-argument prefix.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "x = __spreadArray.apply(void 0, [__spreadArray.apply(void 0, _a.concat([(_b.sent()), true])), [z], false]);"
+        ),
+        "Spread array recomposition after resume should use the ES5 __spreadArray helper shape.\nOutput:\n{output}"
+    );
+}
+
 // Structural rule: when an async ES5 function contains a try statement where
 // any region (try, catch, finally) suspends on `await`, the generator state
 // machine must emit a 4-tuple `_a.trys.push([start, catch, finally, end])`

--- a/crates/tsz-emitter/tests/ir_tests.rs
+++ b/crates/tsz-emitter/tests/ir_tests.rs
@@ -498,9 +498,11 @@ fn test_ir_object_literal_builder_default_source_range() {
         IRNode::ObjectLiteral {
             properties,
             source_range,
+            extra_indent,
         } => {
             assert_eq!(properties.len(), 1);
             assert!(source_range.is_none());
+            assert_eq!(extra_indent, 0);
         }
         _ => panic!("Expected ObjectLiteral"),
     }
@@ -514,9 +516,11 @@ fn test_ir_empty_object_is_empty() {
         IRNode::ObjectLiteral {
             properties,
             source_range,
+            extra_indent,
         } => {
             assert!(properties.is_empty());
             assert!(source_range.is_none());
+            assert_eq!(extra_indent, 0);
         }
         _ => panic!("Expected empty ObjectLiteral"),
     }


### PR DESCRIPTION
AgentName: StuduiEmit

## Summary
- Adds ES5 async/generator IR lowering for array literals that suspend after earlier elements.
- Captures array prefix segments into hoisted temps before yielding, then recombines after resume with `concat` or `__spreadArray`.
- Covers plain arrays, repeated awaits, assignment expressions, wrappers, and the single-suspending-spread array shapes in the TypeScript baseline.

## Structural Rule
When ES5 async/generator array literal lowering sees a suspending element after earlier elements, tsc evaluates and saves the prefix before the yield, then resumes by appending the sent value and suffix; when the array includes spread elements, tsc recomposes through `__spreadArray` without leaving ESNext spread syntax in ES5 output.

## Owner Layer
Owner: `crates/tsz-emitter/src/transforms/async_es5_ir_calls.rs` plus call sites in `crates/tsz-emitter/src/transforms/async_es5_ir.rs`.

This is output lowering only. It uses parser/AST structure and existing async IR suspension handling; it does not add semantic validation, checker calls, or output string surgery.

## Adjacent Cases
- Prefix before await: `[head, await tail, after]` saves `[head]` before yielding.
- Multiple awaits: `[await first, middle, await last]` accumulates the resumed first value and intervening elements before the second yield.
- Suspending first spread: `[...(await values), z]` uses `__spreadArray.apply` after resume.
- Prefix spread before await: `[...y, await z]` preserves array-spread `pack=true` for the saved prefix.

Known unsupported/fallback shape: spread arrays with multiple suspending elements still fall through to the existing generic async IR path.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit, ES5 async array-literal suspension lowering

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter array_literal_prefix_before_await_is_captured_before_yield array_literal_multiple_awaits_accumulates_prefix_between_yields spread_array_literal_with_suspending_spread_uses_spread_array_apply --no-fail-fast`
- `./scripts/emit/run.sh --filter=es5-asyncFunctionArrayLiterals --js-only --verbose --timeout=30000 --json-out=/tmp/studui-asyncArrayLiterals-after.json`
- `git diff --check`