### PR TITLE
fix(emit): lower private destructuring targets

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -1294,7 +1294,7 @@ impl<'a> Printer<'a> {
             }
 
             // If no super() call exists, emit prologue before first body statement
-            if !prologue_emitted && super_call_idx.is_none() && stmt_i == 0 {
+            if !prologue_emitted && super_call_idx.is_none() && stmt_i == directive_prologue_count {
                 self.emit_constructor_prologue(param_props, field_inits, auto_accessor_inits);
                 prologue_emitted = true;
             }
@@ -1359,19 +1359,6 @@ impl<'a> Printer<'a> {
             self.write(".add(this);");
             self.write_line();
         }
-        // Emit private field WeakMap.set inits
-        let private_inits = self.pending_private_field_constructor_inits.clone();
-        for (weakmap_name, has_initializer, initializer) in &private_inits {
-            self.write(weakmap_name);
-            self.write(".set(this, ");
-            if *has_initializer {
-                self.emit_expression(*initializer);
-            } else {
-                self.write("void 0");
-            }
-            self.write(");");
-            self.write_line();
-        }
         // When useDefineForClassFields is true and fields are being lowered to
         // the constructor (target < ES2022), parameter properties should use
         // Object.defineProperty to match tsc's emit semantics.
@@ -1403,6 +1390,20 @@ impl<'a> Printer<'a> {
                 self.write(name);
                 self.write(";");
             }
+            self.write_line();
+        }
+        // Emit private field WeakMap.set inits after parameter properties. They
+        // are instance field initializers for ordering purposes.
+        let private_inits = self.pending_private_field_constructor_inits.clone();
+        for (weakmap_name, has_initializer, initializer) in &private_inits {
+            self.write(weakmap_name);
+            self.write(".set(this, ");
+            if *has_initializer {
+                self.emit_expression(*initializer);
+            } else {
+                self.write("void 0");
+            }
+            self.write(");");
             self.write_line();
         }
         for (name, init_idx, init_end, leading_comments, trailing_comments) in field_inits {

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -4,6 +4,7 @@ use tsz_parser::parser::{NodeIndex, NodeList, node::Node, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
 /// Result of extracting a private field access from a (possibly parenthesized) node.
+#[derive(Clone)]
 struct PrivateFieldAccess {
     /// The receiver expression node index (e.g., `this` or `A.getInstance()`)
     expression: NodeIndex,
@@ -11,6 +12,13 @@ struct PrivateFieldAccess {
     clean_name: String,
     /// The weakmap variable name
     weakmap_name: String,
+}
+
+struct PrivateDestructuringTarget {
+    target: NodeIndex,
+    access: PrivateFieldAccess,
+    receiver_temp: String,
+    setter_value: String,
 }
 
 enum OptionalChainSegment {
@@ -128,6 +136,230 @@ impl<'a> Printer<'a> {
             }
         }
         self.write(")");
+    }
+
+    fn collect_private_destructuring_targets(
+        &self,
+        idx: NodeIndex,
+        targets: &mut Vec<(NodeIndex, PrivateFieldAccess)>,
+    ) {
+        if idx.is_none() {
+            return;
+        }
+        if let Some(access) = self.try_extract_private_field_access(idx) {
+            targets.push((idx, access));
+            return;
+        }
+
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                if let Some(paren) = self.arena.get_parenthesized(node) {
+                    self.collect_private_destructuring_targets(paren.expression, targets);
+                }
+            }
+            k if k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                if let Some(assertion) = self.arena.get_type_assertion(node) {
+                    self.collect_private_destructuring_targets(assertion.expression, targets);
+                }
+            }
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                if let Some(binary) = self.arena.get_binary_expr(node)
+                    && binary.operator_token == SyntaxKind::EqualsToken as u16
+                {
+                    self.collect_private_destructuring_targets(binary.left, targets);
+                }
+            }
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+            {
+                if let Some(literal) = self.arena.get_literal_expr(node) {
+                    for &element in &literal.elements.nodes {
+                        self.collect_private_destructuring_targets(element, targets);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
+            {
+                if let Some(pattern) = self.arena.get_binding_pattern(node) {
+                    for &element in &pattern.elements.nodes {
+                        self.collect_private_destructuring_targets(element, targets);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                if let Some(prop) = self.arena.get_property_assignment(node) {
+                    self.collect_private_destructuring_targets(prop.initializer, targets);
+                }
+            }
+            k if k == syntax_kind_ext::SPREAD_ELEMENT
+                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                if let Some(spread) = self.arena.get_spread(node) {
+                    self.collect_private_destructuring_targets(spread.expression, targets);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn emit_private_destructuring_setter_target(&mut self, target: &PrivateDestructuringTarget) {
+        self.write("({ set value(");
+        self.write(&target.setter_value);
+        self.write(") { ");
+        self.write_helper("__classPrivateFieldSet");
+        self.write("(");
+        self.write(&target.receiver_temp);
+        self.write(", ");
+        self.emit_private_state_var(&target.access.weakmap_name, &target.access.clean_name);
+        self.write(", ");
+        self.write(&target.setter_value);
+        self.emit_private_field_set_close(&target.access.clean_name);
+        self.write("; } }).value");
+    }
+
+    fn emit_private_destructuring_pattern(
+        &mut self,
+        idx: NodeIndex,
+        targets: &[PrivateDestructuringTarget],
+    ) {
+        if let Some(target) = targets.iter().find(|target| target.target == idx) {
+            self.emit_private_destructuring_setter_target(target);
+            return;
+        }
+
+        let Some(node) = self.arena.get(idx) else {
+            return;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                if let Some(paren) = self.arena.get_parenthesized(node) {
+                    self.write("(");
+                    self.emit_private_destructuring_pattern(paren.expression, targets);
+                    self.write(")");
+                }
+            }
+            k if k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                if let Some(assertion) = self.arena.get_type_assertion(node) {
+                    self.emit_private_destructuring_pattern(assertion.expression, targets);
+                }
+            }
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                if let Some(binary) = self.arena.get_binary_expr(node)
+                    && binary.operator_token == SyntaxKind::EqualsToken as u16
+                {
+                    self.emit_private_destructuring_pattern(binary.left, targets);
+                    self.write(" = ");
+                    self.emit(binary.right);
+                    return;
+                }
+                self.emit(idx);
+            }
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => {
+                if let Some(literal) = self.arena.get_literal_expr(node) {
+                    self.write("{ ");
+                    for (i, &element) in literal.elements.nodes.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.emit_private_destructuring_pattern(element, targets);
+                    }
+                    self.write(" }");
+                }
+            }
+            k if k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
+                if let Some(literal) = self.arena.get_literal_expr(node) {
+                    self.write("[");
+                    for (i, &element) in literal.elements.nodes.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        if !element.is_none() {
+                            self.emit_private_destructuring_pattern(element, targets);
+                        }
+                    }
+                    self.write("]");
+                }
+            }
+            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                if let Some(prop) = self.arena.get_property_assignment(node) {
+                    let name_node = self.arena.get(prop.name);
+                    if name_node.is_some_and(|n| {
+                        n.kind == tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                    }) {
+                        self.emit(prop.name);
+                    } else {
+                        self.emit_property_key_name(prop.name);
+                    }
+                    self.write(": ");
+                    self.emit_private_destructuring_pattern(prop.initializer, targets);
+                }
+            }
+            k if k == syntax_kind_ext::SPREAD_ELEMENT
+                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                if let Some(spread) = self.arena.get_spread(node) {
+                    self.write("...");
+                    self.emit_private_destructuring_pattern(spread.expression, targets);
+                }
+            }
+            _ => self.emit(idx),
+        }
+    }
+
+    fn emit_private_field_destructuring_assignment(
+        &mut self,
+        left: NodeIndex,
+        right: NodeIndex,
+    ) -> bool {
+        let Some(left_node) = self.arena.get(left) else {
+            return false;
+        };
+        if !matches!(
+            left_node.kind,
+            syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                | syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                | syntax_kind_ext::ARRAY_BINDING_PATTERN
+                | syntax_kind_ext::OBJECT_BINDING_PATTERN
+        ) {
+            return false;
+        }
+
+        let mut raw_targets = Vec::new();
+        self.collect_private_destructuring_targets(left, &mut raw_targets);
+        if raw_targets.is_empty() {
+            return false;
+        }
+
+        let targets = raw_targets
+            .into_iter()
+            .map(|(target, access)| PrivateDestructuringTarget {
+                target,
+                access,
+                receiver_temp: self.make_unique_name_hoisted_assignment(),
+                setter_value: self.make_unique_name_fresh(),
+            })
+            .collect::<Vec<_>>();
+
+        for target in &targets {
+            self.write(&target.receiver_temp);
+            self.write(" = ");
+            self.emit_private_receiver(target.access.expression, &target.access.clean_name);
+            self.write(", ");
+        }
+        self.emit_private_destructuring_pattern(left, &targets);
+        self.write(" = ");
+        self.emit(right);
+        true
     }
 
     /// Emit a private field unary mutation (++ or --).
@@ -469,6 +701,15 @@ impl<'a> Printer<'a> {
                 self.emit_private_field_set_close(&clean_name);
                 return;
             }
+        }
+
+        // ES2015+ can keep native destructuring syntax, but private field
+        // assignment targets still need to route writes through the SET helper.
+        if !self.ctx.target_es5
+            && binary.operator_token == SyntaxKind::EqualsToken as u16
+            && self.emit_private_field_destructuring_assignment(binary.left, binary.right)
+        {
+            return;
         }
 
         // ES2015-ES2017: lower object rest assignment patterns.

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -954,6 +954,83 @@ class RegularClass {\n    accessor shouldError: string;\n}\n";
     }
 
     #[test]
+    fn es2015_private_field_destructuring_assignment_uses_setter_target() {
+        let source = "class C {\n    #value: string;\n    m(arg: { key: string }) {\n        ({ key: this.#value } = arg);\n    }\n}\n";
+
+        let (parser, root) = parse_test_source(source);
+        let options = PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        };
+        let ctx = EmitContext::with_options(options.clone());
+        let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+        let mut printer =
+            EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        assert!(
+            output.contains("var __classPrivateFieldSet ="),
+            "Private-field destructuring writes should schedule the SET helper.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains("m(arg) {\n        var _a;"),
+            "The private receiver temp should be hoisted in the method body.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains("(_a = this, { key: ({ set value(_b) { __classPrivateFieldSet(_a, _C_value, _b, \"f\"); } }).value } = arg);"),
+            "Native destructuring should use a setter proxy target for private-field writes.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("{ key: __classPrivateFieldGet(this, _C_value, \"f\") } = arg"),
+            "The private field target must not be emitted as a private-field read.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn es2015_constructor_private_destructuring_keeps_prologue_order() {
+        let source = "class C {\n    #secret: string;\n    constructor(arg: { key: string }, public exposed: number) {\n        \"prologue\";\n        ({ key: this.#secret } = arg);\n    }\n}\n";
+
+        let (parser, root) = parse_test_source(source);
+        let options = PrinterOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        };
+        let ctx = EmitContext::with_options(options.clone());
+        let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+        let mut printer =
+            EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+        printer.set_source_text(source);
+        printer.emit(root);
+        let output = printer.get_output().to_string();
+
+        let directive_pos = output
+            .find("\"prologue\";")
+            .expect("constructor directive should be emitted");
+        let temp_pos = output
+            .find("var _a;")
+            .expect("private receiver temp should be hoisted after the directive");
+        let param_pos = output
+            .find("this.exposed = exposed;")
+            .expect("parameter property assignment should be emitted");
+        let private_init_pos = output
+            .find("_C_secret.set(this, void 0);")
+            .expect("private field initialization should be emitted");
+        let destructure_pos = output
+            .find("(_a = this, { key: ({ set value(_b) { __classPrivateFieldSet(_a, _C_secret, _b, \"f\"); } }).value } = arg);")
+            .expect("private-field destructuring setter target should be emitted");
+
+        assert!(
+            directive_pos < temp_pos
+                && temp_pos < param_pos
+                && param_pos < private_init_pos
+                && private_init_pos < destructure_pos,
+            "Constructor directives, temps, parameter properties, private initializers, and body statements should stay in tsc order.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
     fn esnext_legacy_class_fields_hoist_auto_accessors_in_source_order() {
         let source = "// order comment\n\
 class C {\n\

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -583,6 +583,111 @@ impl<'a> LoweringPass<'a> {
             .is_some_and(|name_n| name_n.kind == SyntaxKind::PrivateIdentifier as u16)
     }
 
+    fn assignment_pattern_contains_private_field_access(
+        &self,
+        pattern_idx: NodeIndex,
+        needle: NodeIndex,
+    ) -> bool {
+        let pattern_idx = self.unwrap_parens_and_types(pattern_idx);
+        if pattern_idx == needle && self.is_private_field_access(pattern_idx) {
+            return true;
+        }
+
+        let Some(node) = self.arena.get(pattern_idx) else {
+            return false;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+                self.arena.get_binary_expr(node).is_some_and(|binary| {
+                    binary.operator_token == SyntaxKind::EqualsToken as u16
+                        && self
+                            .assignment_pattern_contains_private_field_access(binary.left, needle)
+                })
+            }
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+            {
+                self.arena.get_literal_expr(node).is_some_and(|literal| {
+                    literal.elements.nodes.iter().any(|&element| {
+                        self.assignment_pattern_contains_private_field_access(element, needle)
+                    })
+                })
+            }
+            k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
+            {
+                self.arena.get_binding_pattern(node).is_some_and(|pattern| {
+                    pattern.elements.nodes.iter().any(|&element| {
+                        self.assignment_pattern_contains_private_field_access(element, needle)
+                    })
+                })
+            }
+            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => self
+                .arena
+                .get_property_assignment(node)
+                .is_some_and(|prop| {
+                    self.assignment_pattern_contains_private_field_access(prop.initializer, needle)
+                }),
+            k if k == syntax_kind_ext::SPREAD_ELEMENT
+                || k == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                self.arena.get_spread(node).is_some_and(|spread| {
+                    self.assignment_pattern_contains_private_field_access(spread.expression, needle)
+                })
+            }
+            _ => false,
+        }
+    }
+
+    fn assignment_pattern_has_private_field_access(&self, pattern_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(pattern_idx) else {
+            return false;
+        };
+        let start = node.pos;
+        let end = node.end;
+        for i in 0..self.arena.len() {
+            let nidx = NodeIndex(i as u32);
+            let Some(candidate) = self.arena.get(nidx) else {
+                continue;
+            };
+            if candidate.pos < start || candidate.end > end {
+                continue;
+            }
+            if self.is_private_field_access(nidx)
+                && self.assignment_pattern_contains_private_field_access(pattern_idx, nidx)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn collect_private_field_accesses_in_assignment_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        consumed: &mut std::collections::HashSet<u32>,
+    ) {
+        let Some(node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let start = node.pos;
+        let end = node.end;
+        for i in 0..self.arena.len() {
+            let nidx = NodeIndex(i as u32);
+            let Some(candidate) = self.arena.get(nidx) else {
+                continue;
+            };
+            if candidate.pos < start || candidate.end > end {
+                continue;
+            }
+            if self.is_private_field_access(nidx)
+                && self.assignment_pattern_contains_private_field_access(pattern_idx, nidx)
+            {
+                consumed.insert(nidx.0);
+            }
+        }
+    }
+
     /// Unwrap parenthesized expressions to get the inner expression.
     fn unwrap_parens(&self, mut idx: NodeIndex) -> NodeIndex {
         loop {
@@ -886,7 +991,9 @@ impl<'a> LoweringPass<'a> {
                         continue;
                     }
                     let left = self.unwrap_parens_and_types(bin.left);
-                    if self.is_private_field_access(left) {
+                    if self.is_private_field_access(left)
+                        || self.assignment_pattern_has_private_field_access(bin.left)
+                    {
                         return true;
                     }
                 }
@@ -947,7 +1054,9 @@ impl<'a> LoweringPass<'a> {
                     if bin.operator_token == SyntaxKind::EqualsToken as u16 {
                         // Unwrap parens AND type assertions to find the actual LHS
                         let left = self.unwrap_parens_and_types(bin.left);
-                        if left == nidx {
+                        if left == nidx
+                            || self.assignment_pattern_contains_private_field_access(bin.left, nidx)
+                        {
                             is_write_only = true;
                             break;
                         }
@@ -1014,6 +1123,10 @@ impl<'a> LoweringPass<'a> {
                     if self.is_private_field_access(left) {
                         consumed_pa.insert(left.0);
                     }
+                    self.collect_private_field_accesses_in_assignment_pattern(
+                        bin.left,
+                        &mut consumed_pa,
+                    );
                 }
                 if (n.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
                     || n.kind == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION)
@@ -1044,7 +1157,9 @@ impl<'a> LoweringPass<'a> {
                     )
                 {
                     let left = self.unwrap_parens(bin.left);
-                    if self.is_private_field_access(left) {
+                    let lhs_has_private_pattern =
+                        self.assignment_pattern_has_private_field_access(bin.left);
+                    if self.is_private_field_access(left) || lhs_has_private_pattern {
                         let is_plain_assign = bin.operator_token == SyntaxKind::EqualsToken as u16;
                         if earliest_pos.is_none() || n.pos < earliest_pos.unwrap() {
                             earliest_pos = Some(n.pos);


### PR DESCRIPTION
AgentName: StuduiEmit

## Summary
- Rewrites native ES2015 destructuring assignment targets that write to private fields into setter-proxy targets backed by `__classPrivateFieldSet`.
- Teaches helper planning that private-field accesses inside destructuring assignment patterns are writes, not reads.
- Keeps constructor directives, hoisted receiver temps, parameter properties, private field initializers, and body statements in tsc order.

## Structural Rule
When native destructuring syntax is preserved but an assignment target inside the pattern is a lowered private field, tsc captures the receiver once, writes through a synthetic setter target, and schedules `__classPrivateFieldSet`; tsz should do the same without treating the target as a private-field read.

## Owner Layer
Owner: `crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs` for private-field target lowering, `crates/tsz-emitter/src/lowering/helpers.rs` for helper planning, and the constructor prologue owner for ordering.

This is output lowering only. It operates on AST shape and existing private-field lowering state; it does not add checker calls, semantic validation, or output string surgery.

## Adjacent Cases
- Reported shape: constructor parameter property plus private-field destructuring target after a directive.
- Generic method shape: `{ key: this.#value } = arg` outside constructors schedules SET and uses a setter proxy.
- Constructor ordering shape: directive prologue, hoisted private receiver temp, parameter property assignment, private field init, then user body statement.
- Parameter-property smoke: existing constructor parameter-property baselines remain green.

Known unsupported/fallback: ES5 destructuring patterns still use the existing ES5 assignment-destructuring path; this PR targets native ES2015+ destructuring where the private-field target itself needs lowering.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit, private-field assignment targets in native destructuring patterns

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter es2015_private_field_destructuring_assignment_uses_setter_target es2015_constructor_private_destructuring_keeps_prologue_order --no-fail-fast`
- `./scripts/emit/run.sh --filter=constructorWithParameterPropertiesAndPrivateFields --js-only --verbose --timeout=30000 --json-out=/tmp/studui-private-param-rebased.json`
- `./scripts/emit/run.sh --filter=constructorParameterProperties --js-only --verbose --timeout=30000 --json-out=/tmp/studui-constructor-paramprops-rebased.json`
- `cargo fmt --check`
- `git diff --check`