### PR TITLE
fix(emit): keep function block bindings local

### DIFF
--- a/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
+++ b/crates/tsz-emitter/src/transforms/block_scoping_es5.rs
@@ -119,12 +119,14 @@ impl BlockScopeState {
         // block-scoped declarations that shadow it to avoid conflicts.
         let is_builtin_shadow = original_name == "arguments";
 
-        let needs_rename = is_builtin_shadow
-            || self.reserved_names.contains(original_name)
-            || self
+        let shadows_outer_generated_function_name = !at_function_level
+            && self
                 .function_scope_shadowed_names
                 .last()
-                .is_some_and(|names| names.contains(original_name))
+                .is_some_and(|names| names.contains(original_name));
+        let needs_rename = is_builtin_shadow
+            || self.reserved_names.contains(original_name)
+            || shadows_outer_generated_function_name
             || if at_function_level {
                 // At function body level: only check the current function scope itself
                 // (for redeclarations within the same scope)

--- a/crates/tsz-emitter/tests/block_scoping_es5.rs
+++ b/crates/tsz-emitter/tests/block_scoping_es5.rs
@@ -231,3 +231,26 @@ fn class_decl_at_loop_capture_function_level_keeps_local_name() {
     assert_eq!(state.get_emitted_name("row"), Some("row".to_string()));
     state.exit_scope();
 }
+
+#[test]
+fn function_level_shadowed_names_stay_local_nested_blocks_rename() {
+    let mut state = BlockScopeState::new();
+
+    state.enter_function_scope();
+    state.register_function_scope_shadowed_name("value");
+
+    assert_eq!(
+        state.register_variable("value"),
+        "value",
+        "Direct function-body block-scoped declarations lower to local var bindings"
+    );
+
+    state.enter_scope();
+    assert_eq!(
+        state.register_variable("value"),
+        "value_1",
+        "Nested block-scoped declarations must rename so the hoisted var does not capture later references"
+    );
+    state.exit_scope();
+    state.exit_scope();
+}


### PR DESCRIPTION
AgentName: StuduiEmit

## Structural Rule
When ES5 block-scope lowering runs inside a generated function body with outer names seeded for hoist safety, direct function-body `let`/`const` declarations lower to local `var` bindings and do not need to rename for those outer names. Nested block-scoped declarations still rename so their hoisted `var` does not capture references after the block.

## Owner Layer
Owner layer: emitter block-scope naming (`BlockScopeState`). This stays in output planning/name scheduling and does not add checker/solver semantic validation or output surgery.

## Adjacent Cases
- Direct generated function-body block binding with an outer seeded name keeps the source binding name.
- Nested block binding with the same outer seeded name still gets a suffix.
- Existing generated block-scope reserved-name behavior remains covered.
- Live `downlevelLetConst16` now passes for ES2015 and ES5.

## Verification
- `cargo check -p tsz-emitter`
- `cargo nextest run -p tsz-emitter --lib -E 'test(function_level_shadowed_names_stay_local_nested_blocks_rename) | test(test_block_scope_state) | test(generated_block_scope_names_are_reserved_after_scope_exit)' --no-fail-fast`
- `cargo nextest run -p tsz-emitter --lib -E 'test(es5_class_method_nested_block_keeps_outer_names_nameable) | test(es5_block_scoped_destructuring_uses_renamed_binding_targets)' --no-fail-fast`
- `./scripts/emit/run.sh --filter=downlevelLetConst16 --js-only --verbose --timeout=30000 --json-out=/tmp/studui-js-downlevelLetConst16-after.json`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --check`
- `git diff --check`

## Known Unsupported Shapes
This PR fixes the block-scope naming rule. It does not attempt the separate `classUsedBeforeInitializedVariables` formatter/comment/class-expression temp gaps.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit / ES5 block-scope naming

No project-corpus row is expected to change. This is a focused ES5 emit naming fix for block-scoped declarations inside generated function bodies.

Project Corpus Impact: Emit-only block-scope naming fix for ES5 downlevel output. No project-corpus fixture or dependency changes are expected; ready-review CI should rerun the normal project gates on this exact head before auto-merge is re-armed.
