### PR TITLE
fix(emit): lower jsx spread children

### DIFF
--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -186,13 +186,6 @@ impl<'a> Printer<'a> {
         result
     }
 
-    pub(super) fn bracketed<R>(&mut self, emit: impl FnOnce(&mut Self) -> R) -> R {
-        self.open_bracket();
-        let result = emit(self);
-        self.close_bracket();
-        result
-    }
-
     pub(super) fn braced<R>(&mut self, emit: impl FnOnce(&mut Self) -> R) -> R {
         self.open_brace();
         let result = emit(self);

--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -434,6 +434,19 @@ impl<'a> Printer<'a> {
         let filtered_children = self.collect_jsx_children(children);
         let has_spread = attrs_info.has_spread;
 
+        if self.ctx.target_es5 && self.jsx_children_have_spread(&filtered_children) {
+            self.emit_create_element_apply_call(
+                &factory,
+                tag_name,
+                &attrs_info,
+                attributes,
+                attribute_comment_end,
+                children,
+                &filtered_children,
+            );
+            return;
+        }
+
         self.emit_jsx_factory_call_target(&factory);
         self.write("(");
 
@@ -474,6 +487,129 @@ impl<'a> Printer<'a> {
         self.write(")");
         if multiline_children {
             self.decrease_indent();
+        }
+    }
+
+    fn emit_create_element_apply_call(
+        &mut self,
+        factory: &str,
+        tag_name: NodeIndex,
+        attrs_info: &JsxAttrsInfo,
+        attributes: NodeIndex,
+        attribute_comment_end: u32,
+        all_children: &[NodeIndex],
+        filtered_children: &[NodeIndex],
+    ) {
+        self.emit_jsx_factory_call_target(factory);
+        self.write(".apply(");
+        self.emit_jsx_factory_apply_this_arg(factory);
+        self.write(", ");
+        self.emit_jsx_classic_apply_args_array(
+            tag_name,
+            attrs_info,
+            attributes,
+            attribute_comment_end,
+            all_children,
+            filtered_children,
+        );
+        self.write(")");
+    }
+
+    fn emit_jsx_factory_apply_this_arg(&mut self, factory: &str) {
+        if let Some((receiver, _)) = factory.rsplit_once('.') {
+            self.emit_jsx_factory_reference(receiver);
+        } else {
+            self.write("void 0");
+        }
+    }
+
+    fn emit_jsx_classic_apply_args_array(
+        &mut self,
+        tag_name: NodeIndex,
+        attrs_info: &JsxAttrsInfo,
+        attributes: NodeIndex,
+        attribute_comment_end: u32,
+        all_children: &[NodeIndex],
+        filtered_children: &[NodeIndex],
+    ) {
+        enum Segment {
+            Elements(Vec<NodeIndex>),
+            Spread(NodeIndex),
+        }
+
+        let mut segments = Vec::new();
+        let mut pending_elements = Vec::new();
+        for &child in all_children {
+            if !filtered_children.contains(&child) {
+                if self.is_empty_jsx_expression(child)
+                    && let Some(node) = self.arena.get(child)
+                {
+                    self.skip_comments_for_empty_jsx_expr(node);
+                }
+                continue;
+            }
+
+            if let Some(spread_expr) = self.jsx_child_spread_expression(child) {
+                if !pending_elements.is_empty() {
+                    segments.push(Segment::Elements(std::mem::take(&mut pending_elements)));
+                }
+                segments.push(Segment::Spread(spread_expr));
+            } else {
+                pending_elements.push(child);
+            }
+        }
+        if !pending_elements.is_empty() {
+            segments.push(Segment::Elements(pending_elements));
+        }
+
+        let first_spread_segment = segments
+            .iter()
+            .position(|segment| matches!(segment, Segment::Spread(_)))
+            .unwrap_or(segments.len());
+        for _ in first_spread_segment..segments.len() {
+            self.write_helper("__spreadArray");
+            self.write("(");
+        }
+
+        self.write("[");
+        self.emit_jsx_tag_name_as_argument(tag_name);
+        self.write(", ");
+        if attrs_info.attrs.is_empty() && !attrs_info.has_spread {
+            self.write("null");
+        } else if attrs_info.has_spread {
+            self.emit_jsx_spread_attrs_classic(&attrs_info.attrs);
+        } else {
+            self.emit_jsx_attrs_as_object(&attrs_info.attrs);
+        }
+        self.skip_jsx_attribute_line_comments(attributes, attribute_comment_end);
+
+        for segment in &segments {
+            match segment {
+                Segment::Elements(elements) => {
+                    for &child in elements {
+                        self.write(", ");
+                        self.emit_jsx_child_as_expression(child);
+                    }
+                }
+                Segment::Spread(_) => {
+                    break;
+                }
+            }
+        }
+        self.write("]");
+
+        for segment in segments.iter().skip(first_spread_segment) {
+            self.write(", ");
+            match segment {
+                Segment::Elements(elements) => {
+                    self.emit_jsx_children_plain_array(elements);
+                    self.write(", false)");
+                }
+                Segment::Spread(expr) => {
+                    self.emit(self.unwrap_spread_argument(*expr));
+                    self.write(", false)");
+                }
+            }
         }
     }
 
@@ -521,7 +657,7 @@ impl<'a> Printer<'a> {
 
         let children: Vec<NodeIndex> = jsx.children.nodes.to_vec();
         let filtered_children = self.collect_jsx_children(&children);
-        let is_jsxs = filtered_children.len() > 1;
+        let is_jsxs = self.jsx_children_need_array(&filtered_children);
         let is_cjs = self.ctx.is_effectively_commonjs()
             && !matches!(self.ctx.original_module_kind, Some(ModuleKind::System));
         let is_dev = matches!(self.effective_jsx_emit(), JsxEmit::ReactJsxDev);
@@ -552,18 +688,7 @@ impl<'a> Printer<'a> {
         self.write(", { ");
         if !filtered_children.is_empty() {
             self.write("children: ");
-            let child_sep = if is_jsxs {
-                JsxChildSep::CommaBetween
-            } else {
-                JsxChildSep::None
-            };
-            if is_jsxs {
-                self.write("[");
-            }
-            self.emit_jsx_children_interleaved(&children, &filtered_children, child_sep);
-            if is_jsxs {
-                self.write("]");
-            }
+            self.emit_jsx_children_value(&children, &filtered_children, is_jsxs);
             self.write(" ");
         } else {
             self.skip_empty_jsx_children_comments(&children);
@@ -601,7 +726,7 @@ impl<'a> Printer<'a> {
 
         let attrs_info = self.collect_jsx_attributes_info(attributes);
         let filtered_children = self.collect_jsx_children(children);
-        let is_jsxs = filtered_children.len() > 1;
+        let is_jsxs = self.jsx_children_need_array(&filtered_children);
 
         // Extract key from attributes
         let key_attr = attrs_info
@@ -673,18 +798,7 @@ impl<'a> Printer<'a> {
                     self.write(", ");
                 }
                 self.write("children: ");
-                let child_sep = if is_jsxs {
-                    JsxChildSep::CommaBetween
-                } else {
-                    JsxChildSep::None
-                };
-                if is_jsxs {
-                    self.write("[");
-                }
-                self.emit_jsx_children_interleaved(children, &filtered_children, child_sep);
-                if is_jsxs {
-                    self.write("]");
-                }
+                self.emit_jsx_children_value(children, &filtered_children, is_jsxs);
             } else {
                 self.skip_empty_jsx_children_comments(children);
             }
@@ -1338,6 +1452,124 @@ impl<'a> Printer<'a> {
                 self.skip_comments_for_empty_jsx_expr(node);
             }
         }
+    }
+
+    pub(in super::super) fn jsx_children_need_array(&self, children: &[NodeIndex]) -> bool {
+        children.len() > 1 || self.jsx_children_have_spread(children)
+    }
+
+    pub(in super::super) fn jsx_children_have_spread(&self, children: &[NodeIndex]) -> bool {
+        children
+            .iter()
+            .any(|&child| self.jsx_child_is_spread_expression(child))
+    }
+
+    pub(in super::super) fn jsx_child_is_spread_expression(&self, child: NodeIndex) -> bool {
+        self.jsx_child_spread_expression(child).is_some()
+    }
+
+    fn jsx_child_spread_expression(&self, child: NodeIndex) -> Option<NodeIndex> {
+        let node = self.arena.get(child)?;
+        if node.kind != syntax_kind_ext::JSX_EXPRESSION {
+            return None;
+        }
+        let expr = self.arena.get_jsx_expression(node)?;
+        (expr.dot_dot_dot_token && expr.expression.is_some()).then_some(expr.expression)
+    }
+
+    pub(in super::super) fn emit_jsx_children_value(
+        &mut self,
+        all_children: &[NodeIndex],
+        filtered_children: &[NodeIndex],
+        as_array: bool,
+    ) {
+        if !as_array {
+            self.emit_jsx_children_interleaved(all_children, filtered_children, JsxChildSep::None);
+            return;
+        }
+
+        if self.ctx.target_es5 && self.jsx_children_have_spread(filtered_children) {
+            self.skip_empty_jsx_children_comments(all_children);
+            self.emit_jsx_children_array_es5(filtered_children);
+            return;
+        }
+
+        self.write("[");
+        self.emit_jsx_children_interleaved(
+            all_children,
+            filtered_children,
+            JsxChildSep::CommaBetween,
+        );
+        self.write("]");
+    }
+
+    fn emit_jsx_children_array_es5(&mut self, filtered_children: &[NodeIndex]) {
+        enum Segment {
+            Elements(Vec<NodeIndex>),
+            Spread(NodeIndex),
+        }
+
+        let mut segments = Vec::new();
+        let mut pending_elements = Vec::new();
+        for &child in filtered_children {
+            if let Some(spread_expr) = self.jsx_child_spread_expression(child) {
+                if !pending_elements.is_empty() {
+                    segments.push(Segment::Elements(std::mem::take(&mut pending_elements)));
+                }
+                segments.push(Segment::Spread(spread_expr));
+            } else {
+                pending_elements.push(child);
+            }
+        }
+        if !pending_elements.is_empty() {
+            segments.push(Segment::Elements(pending_elements));
+        }
+
+        let Some(first_segment) = segments.first() else {
+            self.write("[]");
+            return;
+        };
+
+        let first_is_spread = matches!(first_segment, Segment::Spread(_));
+        let wrapper_count = segments.len().saturating_sub(1) + usize::from(first_is_spread);
+        for _ in 0..wrapper_count {
+            self.write_helper("__spreadArray");
+            self.write("(");
+        }
+
+        match first_segment {
+            Segment::Elements(elements) => self.emit_jsx_children_plain_array(elements),
+            Segment::Spread(expr) => {
+                self.write("[], ");
+                self.emit(self.unwrap_spread_argument(*expr));
+                self.write(", true)");
+            }
+        }
+
+        for segment in segments.iter().skip(1) {
+            self.write(", ");
+            match segment {
+                Segment::Elements(elements) => {
+                    self.emit_jsx_children_plain_array(elements);
+                    self.write(", false)");
+                }
+                Segment::Spread(expr) => {
+                    self.emit(self.unwrap_spread_argument(*expr));
+                    self.write(", true)");
+                }
+            }
+        }
+    }
+
+    fn emit_jsx_children_plain_array(&mut self, children: &[NodeIndex]) {
+        self.write("[");
+        for (i, &child) in children.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.emit_jsx_child_as_expression(child);
+        }
+        self.write("]");
     }
 
     /// Emit a JSX child as an expression in the `createElement` args.

--- a/crates/tsz-emitter/src/emitter/jsx/transform.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/transform.rs
@@ -168,18 +168,7 @@ impl<'a> Printer<'a> {
                 self.write(", ");
             }
             self.write("children: ");
-            if is_jsxs {
-                self.bracketed(|emitter| {
-                    for (i, child) in children.iter().enumerate() {
-                        if i > 0 {
-                            emitter.write(", ");
-                        }
-                        emitter.emit_jsx_child_as_expression(*child);
-                    }
-                });
-            } else {
-                self.emit_jsx_child_as_expression(children[0]);
-            }
+            self.emit_jsx_children_value(children, children, is_jsxs);
         }
 
         self.write(" }");
@@ -228,18 +217,7 @@ impl<'a> Printer<'a> {
                     self.write(", ");
                 }
                 self.write("children: ");
-                if is_jsxs {
-                    self.bracketed(|emitter| {
-                        for (i, child) in children.iter().enumerate() {
-                            if i > 0 {
-                                emitter.write(", ");
-                            }
-                            emitter.emit_jsx_child_as_expression(*child);
-                        }
-                    });
-                } else {
-                    self.emit_jsx_child_as_expression(children[0]);
-                }
+                self.emit_jsx_children_value(children, children, is_jsxs);
             }
             self.write(" }");
             return;
@@ -313,18 +291,7 @@ impl<'a> Printer<'a> {
                 self.write(", ");
             }
             self.write("{ children: ");
-            if is_jsxs {
-                self.bracketed(|emitter| {
-                    for (i, child) in children.iter().enumerate() {
-                        if i > 0 {
-                            emitter.write(", ");
-                        }
-                        emitter.emit_jsx_child_as_expression(*child);
-                    }
-                });
-            } else {
-                self.emit_jsx_child_as_expression(children[0]);
-            }
+            self.emit_jsx_children_value(children, children, is_jsxs);
             self.write(" }");
         }
 
@@ -746,15 +713,18 @@ impl<'a> Printer<'a> {
                 }
                 if is_cjs {
                     let mut text = String::new();
+                    let decl_keyword = if self.ctx.target_es5 { "var" } else { "const" };
                     // Base module import for createElement fallback (key-after-spread)
                     if usage.needs_create_element {
                         let base_var = self.jsx_cjs_base_var();
-                        text.push_str(&format!("const {base_var} = require(\"{source}\");\n"));
+                        text.push_str(&format!(
+                            "{decl_keyword} {base_var} = require(\"{source}\");\n"
+                        ));
                     }
                     if usage.needs_jsx || usage.needs_jsxs || usage.needs_fragment {
                         let var_name = self.jsx_cjs_runtime_var();
                         text.push_str(&format!(
-                            "const {var_name} = require(\"{source}/jsx-runtime\");\n"
+                            "{decl_keyword} {var_name} = require(\"{source}/jsx-runtime\");\n"
                         ));
                     }
                     Some(text)
@@ -800,15 +770,18 @@ impl<'a> Printer<'a> {
                 let file_name_line = self.jsx_dev_file_name_text().unwrap_or_default();
                 if is_cjs {
                     let mut text = String::new();
+                    let decl_keyword = if self.ctx.target_es5 { "var" } else { "const" };
                     // Base module import for createElement fallback (key-after-spread)
                     if usage.needs_create_element {
                         let base_var = self.jsx_cjs_base_var();
-                        text.push_str(&format!("const {base_var} = require(\"{source}\");\n"));
+                        text.push_str(&format!(
+                            "{decl_keyword} {base_var} = require(\"{source}\");\n"
+                        ));
                     }
                     if usage.needs_jsx || usage.needs_jsxs || usage.needs_fragment {
                         let var_name = self.jsx_cjs_runtime_var();
                         text.push_str(&format!(
-                            "const {var_name} = require(\"{source}/jsx-dev-runtime\");\n"
+                            "{decl_keyword} {var_name} = require(\"{source}/jsx-dev-runtime\");\n"
                         ));
                     }
                     text.push_str(&file_name_line);
@@ -879,7 +852,7 @@ impl<'a> Printer<'a> {
                             usage.needs_create_element = true;
                         } else {
                             let children = self.collect_jsx_children(&jsx.children.nodes);
-                            if children.len() > 1 {
+                            if self.jsx_children_need_array(&children) {
                                 usage.needs_jsxs = true;
                             } else {
                                 usage.needs_jsx = true;
@@ -892,7 +865,7 @@ impl<'a> Printer<'a> {
                     // Fragments also use _jsx or _jsxs
                     if let Some(frag) = self.arena.get_jsx_fragment(node) {
                         let children = self.collect_jsx_children(&frag.children.nodes);
-                        if children.len() > 1 {
+                        if self.jsx_children_need_array(&children) {
                             usage.needs_jsxs = true;
                         } else {
                             usage.needs_jsx = true;

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests.rs
@@ -1003,6 +1003,112 @@ export const x = <span {...o} />;
 }
 
 #[test]
+fn es5_classic_jsx_spread_child_lowers_create_element_args() {
+    let source = r#"declare var React: any;
+declare var items: any;
+export const x = <div>{...items}</div>;
+"#;
+
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES5,
+        jsx: JsxEmit::React,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_target_es5(ctx.target_es5);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var __spreadArray = "),
+        "ES5 JSX spread children should request the __spreadArray helper.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "React.createElement.apply(React, __spreadArray([\"div\", null], items, false))"
+        ),
+        "Classic JSX spread children should lower createElement args through apply.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_classic_jsx_spread_child_preserves_adjacent_children() {
+    let source = r#"declare var React: any;
+declare var items: any;
+export const x = <div>{1}{...items}{2}</div>;
+"#;
+
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES5,
+        jsx: JsxEmit::React,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_target_es5(ctx.target_es5);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains(
+            "React.createElement.apply(React, __spreadArray(__spreadArray([\"div\", null, 1], items, false), [2], false))"
+        ),
+        "Classic JSX spread children should preserve regular children around the spread.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_automatic_jsx_spread_child_uses_jsxs_array_child() {
+    let source = r#"declare var items: any;
+export const x = <div>{...items}</div>;
+"#;
+
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES5,
+        jsx: JsxEmit::ReactJsx,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_target_es5(ctx.target_es5);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var jsx_runtime_1 = require(\"react/jsx-runtime\");"),
+        "ES5 automatic JSX runtime imports should be var declarations.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "(0, jsx_runtime_1.jsxs)(\"div\", { children: __spreadArray([], items, true) })"
+        ),
+        "Automatic JSX spread children should force jsxs with an ES5 array-spread child.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn commonjs_exported_destructuring_uses_binding_access_paths() {
     let source = r#"'use strict'
 // exported destructuring should read from the pattern source

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -754,6 +754,9 @@ impl<'a> LoweringPass<'a> {
             }
             k if k == syntax_kind_ext::JSX_EXPRESSION => {
                 if let Some(expr) = self.arena.get_jsx_expression(node) {
+                    if self.ctx.target_es5 && expr.dot_dot_dot_token {
+                        self.transforms.helpers_mut().mark_spread_array();
+                    }
                     self.visit(expr.expression);
                 }
             }


### PR DESCRIPTION
AgentName: StuduiEmit

## Structural Rule
When JSX children contain `{...expr}`, the child list is variadic rather than scalar: classic ES5 lowers `createElement` through `.apply`/`__spreadArray`, and automatic JSX treats the child prop as static array children (`jsxs`), lowering that array spread for ES5.

## Owner Layer
This belongs in `tsz-emitter` JSX direct emit and lowering helper scheduling. The change uses AST JSX child shape (`dot_dot_dot_token`) to choose emit structure, request helpers during lowering, and select the automatic JSX runtime entrypoint. It does not add checker/solver semantic validation and does not patch already-emitted output.

## Adjacent Cases
- Classic React ES2015 keeps the existing direct/native child spread path.
- Classic React ES5 emits `React.createElement.apply(...)` with `__spreadArray` for variadic children.
- Classic React ES5 preserves regular children before and after a spread child through nested `__spreadArray` calls.
- Automatic React JSX uses `jsxs` for a single spread child because the children prop is an array shape.
- Automatic React JSX ES5 requests `__spreadArray` and emits CommonJS runtime imports as `var` declarations.

## Known Unsupported / Fallback
Normal scalar children and ordinary multi-child JSX continue through the existing interleaved child emitter. Non-ES5 classic JSX keeps its existing native spread syntax path.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit / JSX spread children (`tsxSpreadChildrenInvalidType`)

## Verification
- `./scripts/emit/run.sh --filter=tsxSpreadChildrenInvalidType --js-only --verbose --timeout=30000 --json-out=/tmp/studui-js-tsxSpreadChildrenInvalidType-after-adjacent-test.json`
- `cargo nextest run -p tsz-emitter --lib es5_classic_jsx_spread_child_lowers_create_element_args es5_classic_jsx_spread_child_preserves_adjacent_children es5_automatic_jsx_spread_child_uses_jsxs_array_child`
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p tsz-emitter`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`


Project Corpus Impact: Emit-only JSX spread children lowering fix. No project-corpus fixture or dependency changes are expected; ready-review CI should rerun the normal project gates on this exact head before auto-merge is re-armed.
