### PR TITLE
fix(emit): keep type-only named imports from import star

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests.rs
@@ -63,6 +63,52 @@ export const x = <div />;
 }
 
 #[test]
+fn commonjs_classic_jsx_default_import_ignores_type_only_named_imports() {
+    let source = r#"import React, { ComponentPropsWithRef, ElementType, ReactNode } from "react";
+
+type ButtonBaseProps<T extends ElementType> = ComponentPropsWithRef<T> & { children?: ReactNode };
+
+export function Component<T extends ElementType = "span">(props: ButtonBaseProps<T>) {
+    return <></>;
+}
+"#;
+
+    let mut parser = ParserState::new("test.tsx".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        jsx: JsxEmit::React,
+        es_module_interop: true,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    let output = printer.get_output().to_string();
+
+    assert!(
+        output.contains("var __importDefault = "),
+        "Classic JSX default factory import should request __importDefault.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__importStar"),
+        "Type-only named imports beside a JSX default factory must not force __importStar.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("const react_1 = __importDefault(require(\"react\"));"),
+        "Default import should lower as default-only when named imports are type-only.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return react_1.default.createElement(react_1.default.Fragment, null);"),
+        "Classic JSX should still use the default import as the factory root.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn esmodule_es5_default_class_exports_after_iife() {
     let source = r#"export default class A {
     method() { return 1; }

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -893,7 +893,13 @@ impl<'a> Printer<'a> {
                 if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
                     has_value_binding = true;
                 } else {
-                    let value_specs = self.collect_value_specifiers(&named_imports.elements);
+                    let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
+                    if self.ctx.options.type_only_nodes.is_empty()
+                        && !self.source_is_js_file
+                        && !self.ctx.options.verbatim_module_syntax
+                    {
+                        value_specs = self.filter_value_specs_by_usage(node, &value_specs);
+                    }
                     if !value_specs.is_empty() {
                         has_value_binding = true;
                     }
@@ -952,7 +958,9 @@ impl<'a> Printer<'a> {
         // counter values on imports that use their own namespace name.
         let module_var = self.next_commonjs_module_var(&module_spec);
         self.register_commonjs_named_import_substitutions(node, &module_var);
-        let is_default_only_ast = clause.name.is_some() && clause.named_bindings.is_none();
+        let has_runtime_named_bindings =
+            self.import_clause_has_runtime_named_bindings(node, clause);
+        let is_default_only_ast = clause.name.is_some() && !has_runtime_named_bindings;
         let mut is_named_default_only_ast = false;
         if clause.name.is_none()
             && clause.named_bindings.is_some()
@@ -960,7 +968,13 @@ impl<'a> Printer<'a> {
             && let Some(named_imports) = self.arena.get_named_imports(bindings_node)
             && named_imports.name.is_none()
         {
-            let value_specs = self.collect_value_specifiers(&named_imports.elements);
+            let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
+            if self.ctx.options.type_only_nodes.is_empty()
+                && !self.source_is_js_file
+                && !self.ctx.options.verbatim_module_syntax
+            {
+                value_specs = self.filter_value_specs_by_usage(node, &value_specs);
+            }
             is_named_default_only_ast = !value_specs.is_empty()
                 && value_specs.iter().all(|&spec_idx| {
                     self.arena.get(spec_idx).is_some_and(|spec_node| {
@@ -1004,15 +1018,7 @@ impl<'a> Printer<'a> {
         // With esModuleInterop, this requires __importStar to wrap the require call
         // so both .default and named exports are accessible.
         let has_default = clause.name.is_some();
-        let has_named_bindings = clause.named_bindings.is_some()
-            && self.arena.get(clause.named_bindings).is_some_and(|n| {
-                n.kind != syntax_kind_ext::NAMESPACE_IMPORT
-                    && self
-                        .arena
-                        .get_named_imports(n)
-                        .is_some_and(|ni| ni.name.is_none() || !ni.elements.nodes.is_empty())
-            });
-        let use_import_star = es_module_interop && has_default && has_named_bindings;
+        let use_import_star = es_module_interop && has_default && has_runtime_named_bindings;
 
         // Emit: const module_1 = __importStar(require("module"));
         // OR:   const module_1 = require("module");
@@ -1066,16 +1072,21 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        for &spec_idx in &named_imports.elements.nodes {
+        let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
+        if self.ctx.options.type_only_nodes.is_empty()
+            && !self.source_is_js_file
+            && !self.ctx.options.verbatim_module_syntax
+        {
+            value_specs = self.filter_value_specs_by_usage(node, &value_specs);
+        }
+
+        for spec_idx in value_specs {
             let Some(spec_node) = self.arena.get(spec_idx) else {
                 continue;
             };
             let Some(spec) = self.arena.get_specifier(spec_node) else {
                 continue;
             };
-            if spec.is_type_only {
-                continue;
-            }
             let Some(local_name_node) = self.arena.get(spec.name) else {
                 continue;
             };
@@ -1114,6 +1125,36 @@ impl<'a> Printer<'a> {
             self.commonjs_named_import_substitutions
                 .insert(local_ident.escaped_text.to_string(), substitution);
         }
+    }
+
+    fn import_clause_has_runtime_named_bindings(
+        &self,
+        node: &Node,
+        clause: &tsz_parser::parser::node::ImportClauseData,
+    ) -> bool {
+        if clause.named_bindings.is_none() {
+            return false;
+        }
+        let Some(bindings_node) = self.arena.get(clause.named_bindings) else {
+            return false;
+        };
+        if bindings_node.kind == syntax_kind_ext::NAMESPACE_IMPORT {
+            return true;
+        }
+        let Some(named_imports) = self.arena.get_named_imports(bindings_node) else {
+            return true;
+        };
+        if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
+            return true;
+        }
+        let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
+        if self.ctx.options.type_only_nodes.is_empty()
+            && !self.source_is_js_file
+            && !self.ctx.options.verbatim_module_syntax
+        {
+            value_specs = self.filter_value_specs_by_usage(node, &value_specs);
+        }
+        !value_specs.is_empty()
     }
 
     pub(in crate::emitter) fn emit_import_equals_declaration(&mut self, node: &Node) {

--- a/crates/tsz-emitter/src/import_usage.rs
+++ b/crates/tsz-emitter/src/import_usage.rs
@@ -741,9 +741,10 @@ fn is_var_type_annotation_colon(line: &str, colon_pos: usize) -> bool {
     true
 }
 
-/// Check if `<` at position `i` starts a generic type argument list.
+/// Check if `<` at position `i` starts a generic type argument/parameter list.
 /// Heuristic: try to find matching `>` with balanced nesting, followed by `(`.
-/// This distinguishes `f<T>()` (generic call) from `a < b` (comparison).
+/// This distinguishes `f<T>()` / `function f<T = U>()` from `a < b`
+/// (comparison).
 fn is_generic_type_args(bytes: &[u8], start: usize) -> bool {
     let len = bytes.len();
     let mut depth = 0u32;
@@ -764,8 +765,9 @@ fn is_generic_type_args(bytes: &[u8], start: usize) -> bool {
                     return k < len && matches!(bytes[k], b'(' | b')' | b',' | b'>' | b';');
                 }
             }
-            // If we hit something that can't be in a type argument, it's a comparison
-            b'{' | b'}' | b';' | b'=' => return false,
+            // If we hit something that can't be in a type argument, it's a comparison.
+            // `=` is allowed for defaulted type parameters, e.g. `<T = U>()`.
+            b'{' | b'}' | b';' => return false,
             _ => {}
         }
         j += 1;

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -407,9 +407,10 @@ impl<'a> LoweringPass<'a> {
                     && self.arena.get(clause.named_bindings).is_some_and(|n| {
                         // Check for true named bindings (not namespace import)
                         n.kind != syntax_kind_ext::NAMESPACE_IMPORT
-                            && self.arena.get_named_imports(n).is_some_and(|ni| {
-                                ni.name.is_none() || !ni.elements.nodes.is_empty()
-                            })
+                            && self
+                                .arena
+                                .get_named_imports(n)
+                                .is_some_and(|ni| self.named_imports_have_value_usage(node, &ni))
                     });
 
                 // Combined default + named import (e.g., `import foo, {bar} from "mod"`)
@@ -660,6 +661,93 @@ impl<'a> LoweringPass<'a> {
         }
         self.ctx.target_es5
             && self.async_return_type_uses_imported_promise_constructor_after_node(node, &names)
+    }
+
+    fn named_imports_have_value_usage(
+        &self,
+        node: &Node,
+        named_imports: &tsz_parser::parser::node::NamedImportsData,
+    ) -> bool {
+        if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
+            return true;
+        }
+
+        named_imports.elements.nodes.iter().any(|&spec_idx| {
+            let Some(spec_node) = self.arena.get(spec_idx) else {
+                return true;
+            };
+            let Some(spec) = self.arena.get_specifier(spec_node) else {
+                return true;
+            };
+            if spec.is_type_only || self.ctx.options.type_only_nodes.contains(&spec_idx) {
+                return false;
+            }
+            let local_name = emit_utils::identifier_text_or_empty(self.arena, spec.name);
+            if local_name.is_empty() {
+                return true;
+            }
+            if self
+                .classic_jsx_factory_roots()
+                .iter()
+                .any(|root| root == &local_name)
+            {
+                return true;
+            }
+            let Some(source_text) = self.current_source_text else {
+                return true;
+            };
+            let haystack = self.source_after_import_statement(node, source_text);
+            let value_haystack = crate::import_usage::strip_type_only_content(haystack);
+            let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+                &value_haystack,
+                &self.ctx.options.external_const_enum_bindings,
+            );
+            if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name) {
+                return true;
+            }
+            if self.ctx.options.emit_decorator_metadata
+                && crate::import_usage::name_appears_in_decorator_metadata_type(
+                    haystack,
+                    &local_name,
+                )
+            {
+                return true;
+            }
+            self.ctx.target_es5
+                && self.async_return_type_uses_imported_promise_constructor_after_node(
+                    node,
+                    &[local_name],
+                )
+        })
+    }
+
+    fn source_after_import_statement<'b>(&self, node: &Node, source_text: &'b str) -> &'b str {
+        let mut start = if let Some(import_decl) = self.arena.get_import_decl(node)
+            && let Some(module_node) = self.arena.get(import_decl.module_specifier)
+        {
+            module_node.end as usize
+        } else {
+            node.end as usize
+        };
+        start = start.min(source_text.len());
+        let bytes = source_text.as_bytes();
+        while start < bytes.len() {
+            match bytes[start] {
+                b'\n' => {
+                    start += 1;
+                    break;
+                }
+                b'\r' => {
+                    start += 1;
+                    if start < bytes.len() && bytes[start] == b'\n' {
+                        start += 1;
+                    }
+                    break;
+                }
+                _ => start += 1,
+            }
+        }
+        &source_text[start..]
     }
 
     fn async_return_type_uses_imported_promise_constructor_after_node(


### PR DESCRIPTION
AgentName: Studio-C

Original runner metadata: `StuduiEmit`.

## Structural Rule
When a CommonJS `esModuleInterop` import has a default binding used as the classic JSX factory and named bindings that are used only in type positions, `tsc` emits a default-only `__importDefault(require(...))` import. This PR makes tsz classify the runtime named-binding set before choosing `__importStar`.

## Owner Layer
This is `tsz-emitter` import lowering and helper planning. CommonJS import emit now reuses the existing value-usage filtering for named specifiers before choosing the module helper and before registering named substitutions. Lowering mirrors that runtime named-binding decision so helper definitions are planned up front. The shared import-usage stripper also treats defaulted type-parameter lists as type-only text, so type-only generic constraints do not masquerade as runtime imports.

## Adjacent Cases
- Default classic JSX factory import remains preserved even when the identifier is only implicit in JSX syntax.
- Namespace classic JSX factory imports still survive with JSX.
- Unused namespace imports named like the JSX factory still elide when the file has no JSX.
- Named imports used only in type aliases, type annotations, or defaulted type parameters no longer force `__importStar`.

## Known Unsupported / Fallback
If source text or AST shape is unavailable, the existing conservative behavior remains: keep the binding/helper rather than accidentally eliding a runtime import.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit / CommonJS JSX import interop (`genericInferenceDefaultTypeParameterJsxReact`)

## Verification
- `./scripts/emit/run.sh --filter=genericInferenceDefaultTypeParameterJsxReact --js-only --verbose --timeout=30000 --json-out=/tmp/studui-js-genericInferenceDefaultTypeParameterJsxReact-after-rebase.json`
- `cargo nextest run -p tsz-emitter --lib commonjs_classic_jsx_default_import_ignores_type_only_named_imports`
- `cargo nextest run -p tsz-emitter --lib commonjs_unused_classic_jsx_factory_name_elides_namespace_import_without_jsx commonjs_classic_jsx_factory_namespace_import_survives_with_jsx commonjs_classic_jsx_default_import_ignores_type_only_named_imports`
- `cargo nextest run -p tsz-emitter --test import_use_before_decl_3597_tests`
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p tsz-emitter`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`


Project Corpus Impact: Emit-only import-star/type-only named import preservation fix. No project-corpus fixture or dependency changes are expected; ready-review CI should rerun the normal project gates on this exact head before auto-merge is re-armed.

