### PR TITLE
test(bench): keep incomplete readiness rows gray

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -25,8 +25,8 @@ import {
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
 import {
+  hasCompletePhaseMetadata,
   isGreen,
-  isIncompleteCompat,
 } from "./row-utils.mjs";
 
 const args = process.argv.slice(2);
@@ -53,10 +53,11 @@ function loadArtifact() {
 function rowState(row, duplicate = false) {
   if (!row) return "missing";
   if (duplicate) return "gray";
-  if (row.status) return "red";
-  if (isIncompleteCompat(row)) return "gray";
+  if (row.artifact_missing === true) return "gray";
   const compat = row.compatibility;
   if (!compat) return "gray";
+  if (!hasCompletePhaseMetadata(compat)) return "gray";
+  if (row.status) return "red";
   if (isGreen(row)) return "green";
   if (compat.state === "yellow" || compat.state === "red") return compat.state;
   return "gray";

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -327,6 +327,31 @@ withTempDir((dir) => {
 console.log("✅ partial yellow compatibility is gray");
 
 // ---------------------------------------------------------------------------
+// Test: status text must not turn missing/incomplete project metadata into an
+// authoritative red row.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const incompleteStatusRow = makeRow(REQUIRED_PROJECT_ROWS[0], "red", {
+    errorStatus: "tsz crashed before compatibility artifact",
+  });
+  delete incompleteStatusRow.compatibility;
+  incompleteStatusRow.artifact_missing = true;
+  const rows = REQUIRED_PROJECT_ROWS.map((name, i) =>
+    i === 0 ? incompleteStatusRow : makeRow(name, "green"),
+  );
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json"]);
+  assert.equal(result.status, 0, `status-only incomplete metadata should not fail readiness:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.red, 0, "status-only incomplete row must not count as red");
+  assert.equal(parsed.gray, 1, "status-only incomplete row should count as gray/incomplete");
+  assert.equal(parsed.rows[0].state, "gray", "status-only incomplete row should render as gray");
+  assert.equal(parsed.rows[0].exit_class, null, "status-only incomplete row should not invent exit metadata");
+});
+console.log("✅ status-only incomplete project metadata is gray");
+
+// ---------------------------------------------------------------------------
 // Test: duplicate required rows are ambiguous, not authoritative green rows.
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {


### PR DESCRIPTION
AgentName: Studio-A

## Track
Track 1: Project Corpus Dashboard And Fixture Truth

## Invariant
Benchmark readiness must not report a project row as authoritative red unless the row carries complete phase/exit compatibility metadata. Missing or incomplete compatibility artifacts stay gray so the dashboard cannot name a correctness state without the blocker facts Track 1 requires.

## Scope
- Teach `scripts/bench/check-artifact-readiness.mjs` to classify `artifact_missing`, missing compatibility objects, and incomplete phase metadata before consulting benchmark `status` text.
- Add focused coverage for a status-only project row whose compatibility artifact is missing.

## Project Corpus Impact
- Row: required project readiness summary rows
- Bug family: dashboard correctness/readiness metadata
- Evidence: `node scripts/bench/test-check-artifact-readiness.mjs` verifies status-only incomplete project metadata renders gray rather than red.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `git diff --check origin/codex/studio-a-query-common-cap-20260524...HEAD`

## Coordination Notes
- No compiler behavior changes.
- No broad benchmark, conformance, emit, or fourslash suites run locally.
- Stacked on #10035 (`codex/studio-a-query-common-cap-20260524`) while #10035 waits for the required `Queue Tested` status, so this PR can verify against the architecture-cap unblocker without duplicating that change.
- After #10035 lands, retarget/rebase this PR back to `main` if GitHub does not do so automatically, then inspect exact-head CI before merging.
