### PR TITLE
chore(arch): correct query boundary common cap

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -513,7 +513,7 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Bumped by 2 for the deferred-conditional diagnostic-display fix
         # (`is_conditional_type` guards in the assignment-target display path,
         # matching the existing direct-call pattern in type_display.rs).
-        3375,
+        3377,
     ),
 ]
 

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -25,8 +25,8 @@ import {
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
 import {
+  hasCompletePhaseMetadata,
   isGreen,
-  isIncompleteCompat,
 } from "./row-utils.mjs";
 
 const args = process.argv.slice(2);
@@ -53,10 +53,11 @@ function loadArtifact() {
 function rowState(row, duplicate = false) {
   if (!row) return "missing";
   if (duplicate) return "gray";
-  if (row.status) return "red";
-  if (isIncompleteCompat(row)) return "gray";
+  if (row.artifact_missing === true) return "gray";
   const compat = row.compatibility;
   if (!compat) return "gray";
+  if (!hasCompletePhaseMetadata(compat)) return "gray";
+  if (row.status) return "red";
   if (isGreen(row)) return "green";
   if (compat.state === "yellow" || compat.state === "red") return compat.state;
   return "gray";

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -327,6 +327,31 @@ withTempDir((dir) => {
 console.log("✅ partial yellow compatibility is gray");
 
 // ---------------------------------------------------------------------------
+// Test: status text must not turn missing/incomplete project metadata into an
+// authoritative red row.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const incompleteStatusRow = makeRow(REQUIRED_PROJECT_ROWS[0], "red", {
+    errorStatus: "tsz crashed before compatibility artifact",
+  });
+  delete incompleteStatusRow.compatibility;
+  incompleteStatusRow.artifact_missing = true;
+  const rows = REQUIRED_PROJECT_ROWS.map((name, i) =>
+    i === 0 ? incompleteStatusRow : makeRow(name, "green"),
+  );
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json"]);
+  assert.equal(result.status, 0, `status-only incomplete metadata should not fail readiness:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.red, 0, "status-only incomplete row must not count as red");
+  assert.equal(parsed.gray, 1, "status-only incomplete row should count as gray/incomplete");
+  assert.equal(parsed.rows[0].state, "gray", "status-only incomplete row should render as gray");
+  assert.equal(parsed.rows[0].exit_class, null, "status-only incomplete row should not invent exit metadata");
+});
+console.log("✅ status-only incomplete project metadata is gray");
+
+// ---------------------------------------------------------------------------
 // Test: duplicate required rows are ambiguous, not authoritative green rows.
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1: Project Corpus Dashboard And Fixture Truth / architecture guard runway unblocker

## Invariant
Project-corpus readiness must not report correctness without complete blocker metadata, and the query-boundary common ratchet must match the exact live debt introduced by merged checker diagnostic work. This stacked landing keeps both facts explicit: no new query-boundary common references beyond the accepted live count, and incomplete benchmark compatibility artifacts stay gray instead of authoritative red.

## Scope
- Correct `scripts/arch/arch_guard.py` common-reference cap from 3375 to the exact live count, 3377.
- Teach `scripts/bench/check-artifact-readiness.mjs` to classify `artifact_missing`, missing compatibility objects, and incomplete phase metadata before consulting benchmark `status` text.
- Add focused coverage for a status-only project row whose compatibility artifact is missing.

## Project Corpus Impact
- Row: required project readiness summary rows
- Bug family: dashboard correctness/readiness metadata
- Evidence: `node scripts/bench/test-check-artifact-readiness.mjs` verifies status-only incomplete project metadata renders gray rather than red.

## Verification
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `git diff --check`

## Coordination Notes
- #10033 was stacked on this branch and merged into the stack base, so this PR now carries both the architecture-cap unblocker and the benchmark readiness guard.
- No compiler behavior changes.
- No broad benchmark, conformance, emit, or fourslash suites run locally.
- References #8225; this does not expand the migration surface beyond the merged checker diagnostic calls described by the existing comment.
- Rebasing after `#10001` and `#10008` changed the live query-boundary common count from 3376 to 3377; the no-slack arch guard test now passes at 3377.
