### PR TITLE
perf(checker): lower indexed type-literal source aliases

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -257,6 +257,13 @@ impl<'a> CheckerState<'a> {
                     seen,
                 )
             }
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                Self::source_file_type_literal_has_generic_scope_independent_properties(
+                    arena,
+                    node,
+                    type_param_names,
+                )
+            }
             _ => false,
         }
     }
@@ -452,6 +459,13 @@ impl<'a> CheckerState<'a> {
                     seen,
                 )
             }
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                Self::source_file_type_literal_has_generic_scope_independent_properties(
+                    arena,
+                    node,
+                    &[],
+                )
+            }
             _ => false,
         }
     }
@@ -554,5 +568,48 @@ impl<'a> CheckerState<'a> {
                     &mapped_param_names,
                     seen,
                 ))
+    }
+
+    fn source_file_type_literal_has_generic_scope_independent_properties(
+        arena: &NodeArena,
+        node: &tsz_parser::parser::node::Node,
+        type_param_names: &[String],
+    ) -> bool {
+        let Some(type_literal) = arena.get_type_literal(node) else {
+            return false;
+        };
+        type_literal
+            .members
+            .nodes
+            .iter()
+            .copied()
+            .all(|member_idx| {
+                let Some(member_node) = arena.get(member_idx) else {
+                    return false;
+                };
+                if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+                    return false;
+                }
+                let Some(signature) = arena.get_signature(member_node) else {
+                    return false;
+                };
+                if signature.type_parameters.is_some()
+                    || signature.parameters.is_some()
+                    || signature.type_annotation.is_none()
+                {
+                    return false;
+                }
+                if arena
+                    .get(signature.name)
+                    .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+                {
+                    return false;
+                }
+                Self::source_file_type_node_is_generic_scope_independent(
+                    arena,
+                    signature.type_annotation,
+                    type_param_names,
+                )
+            })
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
@@ -313,6 +313,44 @@ fn direct_source_file_type_alias_lowers_renamed_mapped_type_with_local_value_ali
 }
 
 #[test]
+fn direct_source_file_type_alias_lowers_indexed_type_literal_with_local_alias_values() {
+    with_two_file_state(
+        "type Is<T, U> = T extends U ? 1 : 0;\nexport type Select<T, U> = T extends unknown ? { 1: T & U, 0: never }[Is<T, U>] : never;",
+        "import { Select } from './target';",
+        |state, target_binder| {
+            let select_sym = target_binder.file_locals.get("Select").expect("Select");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(select_sym, Some(1), true)
+                .expect("indexed type literals with safe property values should lower");
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(
+                params.len(),
+                2,
+                "Select should preserve its type parameters"
+            );
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_type_literal_with_computed_name() {
+    with_two_file_state(
+        "declare const key: unique symbol;\nexport type Box<T> = { [key]: T };",
+        "import { Box } from './target';",
+        |state, target_binder| {
+            let box_sym = target_binder.file_locals.get("Box").expect("Box");
+            assert!(
+                state
+                    .direct_source_file_type_alias_result(box_sym, Some(1), true)
+                    .is_none(),
+                "computed property names must stay on the child-checker path",
+            );
+        },
+    );
+}
+
+#[test]
 fn direct_source_file_type_alias_lowers_same_binder_export_alias_symbol() {
     let (arena, binder, types) =
         parse_bound_source("type Leaf = string;\nexport type Result = Alias;");


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker / source-file alias direct-lowering residue for `ts-toolbelt-project` after #9999.

## Invariant
When a source-file type alias body contains an indexed-access wrapper over a type-literal object whose property signatures have non-computed names and generic-scope-independent value types, tsz can use the existing direct source-file alias lowering path instead of constructing a child checker. The proof remains checker-local admission logic only: it does not change solver relation semantics, diagnostic rendering, or emitted output.

## Scope
- Extend the source-file alias direct-lowering proof to admit safe type-literal property signatures inside generic and non-generic source-file alias bodies.
- Keep computed property names, methods, call/index signatures, type parameters on members, parameterized members, and alias-dependent property values on the child-checker path.
- Add focused coverage for a `Select`-style `{ 1: T & U, 0: never }[Is<T, U>]` shape and a computed-name rejection.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: recursive type evaluation pressure / source-file alias direct-lowering residue
- Evidence: post-rebase quick row stayed green-compatible and the matching counter probe reduced source-alias child-checker pressure modestly while preserving `Errors: 0`.

## Verification
- Current head `ba4676a0fe` rebased onto `origin/main` `b0487b6e31`: `git diff --check origin/main..HEAD` -> passed.
- Current head `ba4676a0fe`: same two-file diff as prior verified heads; rebase only refreshed onto the newer `main` after `origin/main` advanced.
- Previous refreshed head `398c9ffd9f` on `origin/main`: no diff changes from flattened head; refreshed only to clear stale cancellation noise after the queue-safety draft conversion.
- Previous refreshed head `398c9ffd9f`: `git diff --check origin/main..HEAD` -> passed.
- Flattened head `0e02797dc3` on `origin/main` after #10035 landed and this PR was retargeted to `main`: `python3 scripts/arch/arch_guard.py` -> passed.
- Flattened head `0e02797dc3`: `cargo fmt --check` -> passed.
- Flattened head `0e02797dc3`: `git diff --check origin/main..HEAD` -> passed.
- Flattened head `0e02797dc3`: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias` -> 34 passed, 4993 skipped.
- Previous stacked head `367910b6de` on #10035 (`codex/studio-a-query-common-cap-20260524`): `python3 scripts/arch/arch_guard.py` -> passed.
- Previous stacked head `367910b6de`: `cargo fmt --check` -> passed.
- Previous stacked head `367910b6de`: `git diff --check origin/codex/studio-a-query-common-cap-20260524..HEAD` -> passed.
- Previous stacked head `367910b6de`: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias` -> 34 passed, 4993 skipped.
- Previous benchmark command: `scripts/safe-run.sh env BENCH_PGO=0 ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-toolbelt-project$' --rebuild --json-file artifacts/perf/studio-b-10036-ts-toolbelt-post-rebase-20260524.json`
  - Result: green compatibility; `tsz` 1230.89 ms, `tsgo` 130.97 ms, `tsgo` 9.40x faster.
- Previous counter command: `TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 scripts/safe-run.sh ./.target-bench/dist/tsz --extendedDiagnostics --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json > artifacts/perf/studio-b-10036-ts-toolbelt-post-rebase-20260524.perf.txt 2>&1`
  - Result: exit 0, `Errors: 0`, `Check: 1.12s`, `Total time: 1.25s`, `Memory used: 425616K`.
  - Counter deltas versus #9999 rebased evidence: `with_parent_cache` 636 -> 625, `DelegateCrossArenaSymbol` 565 -> 554, `body_not_direct_lowerable` 577 -> 562, `type_reference` 435 -> 433, `conditional_type` 77 -> 75, `indexed_access_type` 43 -> 39, `local_type_alias_with_arguments` 187 -> 183, `local_type_parameter` 2099 -> 2071, `unresolved_identifier` 364 -> 351.
- Earlier ready-review CI run https://github.com/mohsen1/tsz/actions/runs/26368289471 on exact head `30df54050c` failed `lint` because the architecture guard reported `query_boundaries::common` quarantine references in `crates/tsz-checker/src/assignability/...` (issue #8225), outside this PR's two-file diff. That blocker was resolved by merged #10035.

## Coordination Notes
- Follows merged #9979, #9984, #9999, and #10035; does not duplicate #9866's stable source-alias cache slice or #9502's builtin lib class cache slice.
- #10035 has landed, so this PR is no longer stacked and now targets `main` directly.
- Current head `ba4676a0fe` keeps the same two-file diff and exists to test against current `origin/main` after `main` advanced to `b0487b6e31`.
- Remaining `ts-toolbelt-project` work stays open under #8356/#7378. This is a small residue slice and does not claim to close the row.
- Auto-merge is intentionally off until exact-head ready-review CI completes successfully.
