### PR TITLE
refactor(checker): route callback parameter relation guard

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -476,7 +476,7 @@ impl<'a> CheckerState<'a> {
                         .expect("expected_params should not be empty")
                 });
                 // Parameter types conflict if the actual is NOT assignable to expected.
-                !self.is_assignable_to(actual_param_type, expected_param_type)
+                !self.diagnostic_relation_boolean_guard(actual_param_type, expected_param_type)
             })
     }
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -454,6 +454,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability"
             / "assignability_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
+            ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
             ROOT
             / "crates"
             / "tsz-checker"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227. Stacked on #9922.

## Invariant
When callback diagnostic suppression compares an explicitly annotated callback parameter against the expected callback parameter type only to decide whether to suppress an inner diagnostic, tsz should route that pure boolean relation probe through the checker diagnostic boolean guard. Behavior is unchanged; the raw assignability call becomes grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/checkers/call_context.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing plus architecture guard coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check codex/m1b-call-checker-diagnostic-relation-guard-20260521...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #9922 (`codex/m1b-call-checker-diagnostic-relation-guard-20260521`) at rebased base head `a9347e918e3e3faa1cd740830ec1d431063effdb`.
- Current head: `8512450da8bc5a3d95c967a2edc4200bf67602ea`.
- Rebased this child from prior parent `b0cc6adb82cd6ef71c667e7c31002a0e9974d508` after #9922 moved to `a9347e918e3e3faa1cd740830ec1d431063effdb`; replayed only this PR's callback-parameter guard patch.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `8512450da8bc5a3d95c967a2edc4200bf67602ea`.
- Keep #10037 draft/off-auto until #9922's required `Queue Tested` blocker is resolved and #9922 lands or is explicitly handed off, then promote the stack in order.
- Non-overlap: does not touch solver relation policy, relation cache keys, relation request construction, or M4-B-owned relation internals.
