### PR TITLE
refactor(checker): route rest parameter relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1300,8 +1300,9 @@ impl<'a> CheckerState<'a> {
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
 
-                    if !self.is_assignable_to(declared_type, readonly_any_array)
-                        && !self.is_assignable_to(array_check_type, readonly_any_array)
+                    if !self.diagnostic_relation_boolean_guard(declared_type, readonly_any_array)
+                        && !self
+                            .diagnostic_relation_boolean_guard(array_check_type, readonly_any_array)
                     {
                         // tsc anchors TS2370 at the parameter (including the
                         // `...` token) rather than at its type annotation or
@@ -1332,7 +1333,7 @@ impl<'a> CheckerState<'a> {
                     let factory = self.ctx.types.factory();
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
-                    if !self.is_assignable_to(init_type, readonly_any_array) {
+                    if !self.diagnostic_relation_boolean_guard(init_type, readonly_any_array) {
                         self.error_at_node(
                             param_idx,
                             "A rest parameter must be of an array type.",

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -455,6 +455,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "parameter_checker.rs",
             ROOT
             / "crates"
             / "tsz-checker"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227. Stacked on #10037.

## Invariant
When rest-parameter diagnostic validation uses assignability only to decide whether to emit TS2370, tsz should route those pure boolean relation probes through the checker diagnostic boolean guard. Behavior is unchanged; the raw assignability calls become grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/checkers/parameter_checker.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing plus architecture guard coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check codex/m1b-callback-param-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10037 (`codex/m1b-callback-param-relation-guard-20260524`) at rebased base head `8512450da8bc5a3d95c967a2edc4200bf67602ea`.
- Current head: `ea515fec3499d8bf6ce37d0cc505d0c4098b5a5c`.
- Rebased this child from prior parent `238bc3bda0332f239b11b6802353f7081d17be20` after #10037 moved to `8512450da8bc5a3d95c967a2edc4200bf67602ea`; replayed only this PR's rest-parameter guard patch.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `ea515fec3499d8bf6ce37d0cc505d0c4098b5a5c`.
- Keep #10038 draft/off-auto until #9922 lands or is explicitly handed off and #10037 is promoted in order.
- Non-overlap: does not touch solver relation policy, relation cache keys, relation request construction, or M4-B-owned relation internals.
