### PR TITLE
fix(checker): use structural protected intersection owner

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -934,6 +934,10 @@ name = "fresh_intersection_display_tests"
 path = "tests/fresh_intersection_display_tests.rs"
 
 [[test]]
+name = "protected_intersection_owner_display_tests"
+path = "tests/protected_intersection_owner_display_tests.rs"
+
+[[test]]
 name = "intersection_signatures"
 path = "tests/intersection_signatures.rs"
 

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -591,14 +591,13 @@ impl<'a> CheckerState<'a> {
         object_type: tsz_solver::TypeId,
         property_name: &str,
     ) -> Option<String> {
-        if self.receiver_property_visibility(object_type, property_name)
-            != Some(tsz_solver::Visibility::Protected)
-        {
-            return None;
-        }
-
-        let display = self.format_type_diagnostic(object_type);
-        display.contains(" & ").then_some(display)
+        let owner_type =
+            crate::query_boundaries::property_access::protected_intersection_owner_type(
+                self.ctx.types,
+                object_type,
+                property_name,
+            )?;
+        Some(self.format_type_diagnostic(owner_type))
     }
 
     fn intersection_has_unrelated_public_property_member(

--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -28,6 +28,22 @@ pub(crate) fn receiver_property_visibility(
     tsz_solver::type_queries::receiver_property_visibility(db, object_type, property_name)
 }
 
+pub(crate) fn protected_intersection_owner_type(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+    property_name: &str,
+) -> Option<TypeId> {
+    let intersection_type = db
+        .get_display_alias(object_type)
+        .filter(|alias| intersection_members(db, *alias).is_some())
+        .unwrap_or(object_type);
+    let members = intersection_members(db, intersection_type)?;
+    (members.len() >= 2
+        && receiver_property_visibility(db, intersection_type, property_name)
+            == Some(tsz_solver::Visibility::Protected))
+    .then_some(intersection_type)
+}
+
 pub(crate) fn resolve_property_access_with_options(
     db: &dyn QueryDatabase,
     obj_type: TypeId,

--- a/crates/tsz-checker/tests/protected_intersection_owner_display_tests.rs
+++ b/crates/tsz-checker/tests/protected_intersection_owner_display_tests.rs
@@ -1,0 +1,30 @@
+use tsz_checker::test_utils::check_source_code_messages;
+
+#[test]
+fn protected_intersection_owner_display_is_structural_for_renamed_classes() {
+    let diagnostics = check_source_code_messages(
+        r#"
+class Alpha {
+    protected slot: string = "";
+}
+class Beta {
+    protected slot: string = "";
+}
+declare var value: Alpha & Beta;
+value.slot;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2445
+                && message.contains("Property 'slot' is protected")
+                && message.contains("Alpha & Beta")
+        }),
+        "expected TS2445 against the renamed protected intersection owner, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2339),
+        "renamed protected intersection member should not fall back to missing property, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
M1-C checker diagnostic display cleanup.

## Invariant
Diagnostic decisions must not inspect rendered type strings. The checker may render the owner name only after a structural query boundary has selected the owner `TypeId`.

## Scope
- Replace the protected-intersection owner `display.contains(" & ")` decision in `property_checker` with a property-access boundary helper.
- Teach the boundary helper to prefer an intersection display alias when the access receiver has been normalized to a constituent type.
- Add focused coverage for renamed protected classes so the decision is structural, not tied to a specific class spelling.

## Project Corpus Impact
- Row: n/a
- Bug family: rendered diagnostic display string decisions (#8775 / #8228)
- Evidence: checker-only diagnostic display path; local `cargo check -p tsz-checker`, architecture guard, and focused nextest coverage passed.

## Verification
- `cargo fmt --all -- --check`
- `python3 scripts/arch/arch_guard.py`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo check -p tsz-checker`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-checker --test protected_intersection_owner_display_tests --no-fail-fast`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/.target cargo nextest run -p tsz-checker --lib intersection_all_protected_property_stays_protected --no-fail-fast`

## Coordination Notes
- AgentName: M1-C
- Ready for review on head `62da6aaf7edcee8b65c80c1a5f0d0f5bad72400a`; fresh ready-review CI is green, including `CI Summary`.
- `Queue Tested` remains pending, so auto-merge stays off until the exact head has a complete green required-check picture.
- This does not touch alias-display (#9272), recursive-heritage display (#10041), nominal call suppression (#10045), keyof constraint gate (#10048), optional mapped undefined (#10062), numeric union display (#10082), or rest-any callable display (#10084).