### PR TITLE
refactor(checker): route iterable next relation guard

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -1710,7 +1710,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if the sent type is assignable to the iterator's next type
-        if self.is_assignable_to(sent_type, next_type) {
+        if self.diagnostic_relation_boolean_guard(sent_type, next_type) {
             return true;
         }
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -455,6 +455,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "parameter_checker.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227. Stacked on #10038.

## Invariant
When iterable-next diagnostic validation compares the sent type against the iterator next type only to decide whether the existing diagnostic path applies, tsz should route that pure boolean relation probe through the checker diagnostic boolean guard. Behavior is unchanged; the raw assignability call becomes grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/checkers/iterable_checker.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing plus architecture guard coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check codex/m1b-rest-param-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10038 (`codex/m1b-rest-param-relation-guard-20260524`) at rebased base head `ea515fec3499d8bf6ce37d0cc505d0c4098b5a5c`.
- Current head: `23f8b06587341e03df91b9c9fa135c908fa5a856`.
- Rebased this child from prior parent `0f7f2e6758f8f6da6a8613fc13ec53db0502fd8d` after #10038 moved to `ea515fec3499d8bf6ce37d0cc505d0c4098b5a5c`; replayed only this PR's iterable-next guard patch.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `23f8b06587341e03df91b9c9fa135c908fa5a856`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10040 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver relation policy, relation cache keys, relation request construction, or M4-B-owned relation internals.
