### PR TITLE
refactor(checker): route nullish target relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/nullish_error_targets.rs
+++ b/crates/tsz-checker/src/assignability/nullish_error_targets.rs
@@ -29,6 +29,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let (_, nullable_target) = self.split_nullish_type(target);
-        nullable_target.is_none_or(|nullable| !self.is_assignable_to(source, nullable))
+        nullable_target
+            .is_none_or(|nullable| !self.diagnostic_relation_boolean_guard(source, nullable))
     }
 }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -453,6 +453,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "assignability"
             / "assignability_diagnostics.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "assignability" / "nullish_error_targets.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227. Stacked on #10040.

## Invariant
When nullish assignability diagnostics compare a source type against a nullable target constituent only to decide whether the existing nullish-target diagnostic path applies, tsz should route that pure boolean relation probe through the checker diagnostic boolean guard. Behavior is unchanged; the raw assignability call becomes grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/assignability/nullish_error_targets.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing plus architecture guard coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check codex/m1b-iterable-next-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10040 (`codex/m1b-iterable-next-relation-guard-20260524`) at rebased base head `23f8b06587341e03df91b9c9fa135c908fa5a856`.
- Current head: `88055e028465b8102a5d9ad0ac6072aa59e515b1`.
- Rebased this child from prior parent `3713ca8c7614dd50798adbcbcbfe1fde4791746f` after #10040 moved to `23f8b06587341e03df91b9c9fa135c908fa5a856`; replayed only this PR's nullish-target guard patch.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `88055e028465b8102a5d9ad0ac6072aa59e515b1`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10043 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver relation policy, relation cache keys, relation request construction, or M4-B-owned relation internals.
