### PR TITLE
refactor(checker): route polymorphic this relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs
@@ -135,14 +135,15 @@ impl<'a> CheckerState<'a> {
         }
 
         let receiver_type = self.get_type_of_node(access.expression);
-        if receiver_type == target || !self.is_assignable_to(receiver_type, target) {
+        if receiver_type == target || !self.diagnostic_relation_boolean_guard(receiver_type, target)
+        {
             return None;
         }
         if let Some(members) =
             crate::query_boundaries::common::intersection_members(self.ctx.types, receiver_type)
-            && let Some(member) = members
-                .into_iter()
-                .find(|&member| member != target && self.is_assignable_to(member, target))
+            && let Some(member) = members.into_iter().find(|&member| {
+                member != target && self.diagnostic_relation_boolean_guard(member, target)
+            })
         {
             return Some(member);
         }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -454,6 +454,12 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability"
             / "assignability_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "assignability" / "nullish_error_targets.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "assignability"
+            / "polymorphic_this_diagnostics.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only diagnostic relation guard cleanup for #8227. Stacked on #10043.

## Invariant
When polymorphic-this diagnostics compare receiver or intersection member types against the target only to decide whether the existing diagnostic path applies, tsz should route those pure boolean relation probes through the checker diagnostic boolean guard. Behavior is unchanged; the raw assignability calls become grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- `crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs`
- `scripts/arch/arch_guard_config.py`

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only relation guard routing plus architecture guard coverage; no semantic policy, project fixture behavior, or emitted output change.

## Verification
- `git diff --check codex/m1b-nullish-target-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10043 (`codex/m1b-nullish-target-relation-guard-20260524`) at rebased base head `88055e028465b8102a5d9ad0ac6072aa59e515b1`.
- Current head: `d313cde07207e80cc2d39b17e23716f0ab191876`.
- Rebased this child after #10043 moved from `f1d74fc7a88b62ebd94626c96f5d724994566dc9` to `88055e028465b8102a5d9ad0ac6072aa59e515b1` using `--onto` so only this PR's polymorphic-this guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `d313cde07207e80cc2d39b17e23716f0ab191876`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10044 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver relation policy, relation cache keys, relation request construction, or M4-B-owned relation internals.
