### PR TITLE
refactor(checker): route destructuring relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -428,7 +428,7 @@ impl<'a> CheckerState<'a> {
         if self.should_suppress_assignability_for_parse_recovery(spread_expr, spread_expr) {
             return;
         }
-        if self.is_assignable_to(source, rest_target_type) {
+        if self.diagnostic_relation_boolean_guard(source, rest_target_type) {
             return;
         }
 
@@ -554,7 +554,10 @@ impl<'a> CheckerState<'a> {
                                             || target_type == TypeId::ERROR
                                             || default_type == TypeId::ANY
                                             || default_type == TypeId::ERROR
-                                            || self.is_assignable_to(default_type, target_type);
+                                            || self.diagnostic_relation_boolean_guard(
+                                                default_type,
+                                                target_type,
+                                            );
                                         if default_assignable {
                                             // Default is fine but property type might not be.
                                             self.check_destructuring_leaf_assignability_with_default(
@@ -736,7 +739,7 @@ impl<'a> CheckerState<'a> {
                         {
                             self.ensure_relation_input_ready(check_type);
                             self.ensure_relation_input_ready(target_type);
-                            if !self.is_assignable_to(check_type, target_type) {
+                            if !self.diagnostic_relation_boolean_guard(check_type, target_type) {
                                 // Emit TS2322 directly with pre-resolved types.
                                 // The standard error pipeline would re-derive
                                 // the source type from the anchor node's parent
@@ -850,7 +853,7 @@ impl<'a> CheckerState<'a> {
                 .unwrap_or_else(|| self.get_type_of_node(default_expr));
             if default_type != TypeId::ANY
                 && default_type != TypeId::ERROR
-                && !self.is_assignable_to(default_type, target_type)
+                && !self.diagnostic_relation_boolean_guard(default_type, target_type)
             {
                 if self.try_report_object_default_property_mismatch(
                     default_expr,
@@ -932,7 +935,7 @@ impl<'a> CheckerState<'a> {
         // Ensure both types are fully resolved before relation checking.
         self.ensure_relation_input_ready(prop_type);
         self.ensure_relation_input_ready(target_type);
-        if self.is_assignable_to(prop_type, target_type) {
+        if self.diagnostic_relation_boolean_guard(prop_type, target_type) {
             return;
         }
         // Emit TS2322 directly. Format source type from the TypeId rather
@@ -998,7 +1001,7 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            if self.is_assignable_to(source_type, target_prop_type) {
+            if self.diagnostic_relation_boolean_guard(source_type, target_prop_type) {
                 continue;
             }
             let source_for_display = {

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -453,6 +453,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "assignability"
             / "assignability_diagnostics.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "assignability"
+            / "assignment_checker"
+            / "destructuring.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "assignability" / "nullish_error_targets.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation boundary cleanup. Stacked on #10044.

## Invariant
When destructuring assignment diagnostic code only needs a boolean assignability result to decide whether to emit or suppress TS2322-family diagnostics, it should route through the checker diagnostic relation guard while relation semantics remain in the shared assignability path. Behavior is unchanged.

## Scope
- Route destructuring assignment diagnostic-only `is_assignable_to` probes through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `assignment_checker/destructuring.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only helper routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-polymorphic-this-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10044 (`codex/m1b-polymorphic-this-relation-guard-20260524`) at rebased base head `d313cde07207e80cc2d39b17e23716f0ab191876`.
- Current head: `8419c7fa20b70698576fa07ba8a15cf4f3b125e8`.
- Rebased this child after #10044 moved from `c7c76a84ca65575744ab99cced568733a39c3d88` to `d313cde07207e80cc2d39b17e23716f0ab191876` using `--onto` so only this PR's destructuring guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `8419c7fa20b70698576fa07ba8a15cf4f3b125e8`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10046 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
