### PR TITLE
refactor(checker): route assignment operation relation guards

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -1004,7 +1004,9 @@ impl<'a> CheckerState<'a> {
                             || op == SyntaxKind::GreaterThanGreaterThanToken as u16
                             || op == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16;
 
-                        if is_compound_like && self.is_assignable_to(right_type, widened_left) {
+                        if is_compound_like
+                            && self.diagnostic_relation_boolean_guard(right_type, widened_left)
+                        {
                             check_assignability = false;
                         }
                     }
@@ -1733,7 +1735,7 @@ impl<'a> CheckerState<'a> {
             self.deferred_generic_element_write_target(left_idx, source_type)
         {
             if (source_type != generic_target
-                && !self.is_assignable_to(source_type, generic_target))
+                && !self.diagnostic_relation_boolean_guard(source_type, generic_target))
                 || (source_type != generic_target
                     && !crate::query_boundaries::common::contains_type_parameters(
                         self.ctx.types,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -460,6 +460,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "assignability"
             / "assignment_checker"
             / "destructuring.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "assignability"
+            / "assignment_checker"
+            / "assignment_ops.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "assignability" / "nullish_error_targets.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation boundary cleanup. Stacked on #10046.

## Invariant
When assignment-operation diagnostic orchestration only needs a boolean assignability result to decide whether to emit or suppress TS2322-family diagnostics, it should route through the checker diagnostic relation guard while relation semantics remain in the shared assignability path. Behavior is unchanged.

## Scope
- Route assignment-operation diagnostic-only `is_assignable_to` probes through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `assignment_checker/assignment_ops.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only helper routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-destructuring-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10046 (`codex/m1b-destructuring-relation-guards-20260524`) at rebased base head `8419c7fa20b70698576fa07ba8a15cf4f3b125e8`.
- Current head: `e8c214fae44d46799770ba570bb208ea60fe93be`.
- Rebased this child after #10046 moved from `0bc088bf6fe7de0a7aebfbb8e4a04580dbfa21f0` to `8419c7fa20b70698576fa07ba8a15cf4f3b125e8` using `--onto` so only this PR's assignment-operation guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `e8c214fae44d46799770ba570bb208ea60fe93be`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10047 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
