### PR TITLE
fix(checker): report TS2693 for imported pure types

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -718,7 +718,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        let Some(mut current_sym_id) = exports_table.get(export_name).copied() else {
+        let Some(mut current_sym_id) = exports_table.get(export_name) else {
             return false;
         };
 

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -588,6 +588,12 @@ impl<'a> CheckerState<'a> {
                     {
                         return Some(kind);
                     }
+                    if self.is_intrinsic_type_only_export_across_binders(
+                        module_specifier,
+                        &export_name,
+                    ) {
+                        continue;
+                    }
                     // Record the hit but keep iterating other aliases. A
                     // later alias (e.g. a local `import type { ... }`)
                     // may expose a direct marker that we prefer.
@@ -671,6 +677,9 @@ impl<'a> CheckerState<'a> {
                 .get_symbol_with_libs(target_id, &lib_binders)
             && target_symbol.is_type_only
         {
+            if Self::symbol_is_intrinsic_type_only_without_value(target_symbol) {
+                return None;
+            }
             return Some(TypeOnlyKind::Export);
         }
 
@@ -684,6 +693,71 @@ impl<'a> CheckerState<'a> {
         }
 
         None
+    }
+
+    fn is_intrinsic_type_only_export_across_binders(
+        &self,
+        module_specifier: &str,
+        export_name: &str,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        let Some(target_file_idx) = self.ctx.resolve_import_target(module_specifier) else {
+            return false;
+        };
+        let Some(target_binder) = self.ctx.get_binder_for_file(target_file_idx) else {
+            return false;
+        };
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let Some(target_file_name) = target_arena.source_files.first().map(|f| &f.file_name) else {
+            return false;
+        };
+        let Some(exports_table) = self
+            .ctx
+            .module_exports_for_module(target_binder, target_file_name)
+        else {
+            return false;
+        };
+        let Some(mut current_sym_id) = exports_table.get(export_name).copied() else {
+            return false;
+        };
+
+        let mut visited = AliasCycleTracker::new();
+        while !visited.contains(&current_sym_id) {
+            visited.push(current_sym_id);
+
+            let Some(symbol) = target_binder
+                .get_symbol(current_sym_id)
+                .or_else(|| self.ctx.binder.get_symbol(current_sym_id))
+            else {
+                return false;
+            };
+
+            if Self::symbol_is_intrinsic_type_only_without_value(symbol) {
+                return true;
+            }
+
+            if !symbol.has_any_flags(symbol_flags::ALIAS) {
+                return false;
+            }
+
+            let Some(next_sym_id) = target_binder.resolve_import_symbol(current_sym_id) else {
+                return false;
+            };
+            if next_sym_id == current_sym_id {
+                return false;
+            }
+            current_sym_id = next_sym_id;
+        }
+
+        false
+    }
+
+    fn symbol_is_intrinsic_type_only_without_value(symbol: &tsz_binder::Symbol) -> bool {
+        use tsz_binder::symbol_flags;
+
+        symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)
+            && !symbol.has_any_flags(symbol_flags::VALUE)
     }
 
     /// Prefer the nearest lexical alias's own `type` marker before following
@@ -848,11 +922,13 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            // Non-alias type-only symbol (e.g. a symbol cloned for
-            // `export type { X as Y }` — its declarations point at the
-            // original non-type-only source, so the walk cannot reach
-            // the `export type` specifier). Default to TS1362: the
-            // type-only-ness originated on the export side.
+            // Non-alias pure types (interface/type alias) use ordinary
+            // TS2693. Other non-alias type-only symbols may be clones for
+            // `export type { X as Y }` whose declarations point at the
+            // original value source, so default those to TS1362.
+            if Self::symbol_is_intrinsic_type_only_without_value(sym) {
+                return None;
+            }
             return Some(TypeOnlyKind::Export);
         }
 

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -753,7 +753,7 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    fn symbol_is_intrinsic_type_only_without_value(symbol: &tsz_binder::Symbol) -> bool {
+    const fn symbol_is_intrinsic_type_only_without_value(symbol: &tsz_binder::Symbol) -> bool {
         use tsz_binder::symbol_flags;
 
         symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)

--- a/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
+++ b/crates/tsz-checker/tests/ts1361_chain_attribution_tests.rs
@@ -120,6 +120,78 @@ new B();
 }
 
 #[test]
+fn imported_interface_used_as_value_reports_ts2693_not_ts1362() {
+    let a = r#"
+export interface Animal {
+  legs: number;
+}
+"#;
+    let b = r#"
+import { Animal } from "./a";
+const x = Animal;
+"#;
+
+    let diagnostics = compile_module_files(&[("./a.ts", a), ("./b.ts", b)], 1);
+
+    let ts2693 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2693)
+        .collect::<Vec<_>>();
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 1362)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ts2693.len(),
+        1,
+        "Expected TS2693 for imported interface used as a value. \
+         Got TS2693={ts2693:?}, TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+    assert!(
+        ts1362.is_empty(),
+        "An intrinsic type-only export should not be attributed to `export type`. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+}
+
+#[test]
+fn imported_type_alias_used_as_value_reports_ts2693_not_ts1362() {
+    let a = r#"
+export type Animal = {
+  legs: number;
+};
+"#;
+    let b = r#"
+import { Animal } from "./a";
+const x = Animal;
+"#;
+
+    let diagnostics = compile_module_files(&[("./a.ts", a), ("./b.ts", b)], 1);
+
+    let ts2693 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2693)
+        .collect::<Vec<_>>();
+    let ts1362 = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 1362)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        ts2693.len(),
+        1,
+        "Expected TS2693 for imported type alias used as a value. \
+         Got TS2693={ts2693:?}, TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+    assert!(
+        ts1362.is_empty(),
+        "A type alias declaration should not be attributed to `export type`. \
+         Got TS1362={ts1362:?}, all={diagnostics:?}",
+    );
+}
+
+#[test]
 fn import_type_equals_require_value_use_reports_ts1361() {
     let foo = r#"
 class Foo {


### PR DESCRIPTION
AgentName: M4-D

## Track

checker diagnostics / M4-D lane

## Invariant

- Pure type declarations imported into value positions must report TS2693 (`only refers to a type`) rather than TS1362.
- Explicit `import type` / `export type` markers remain the attribution source for TS1361/TS1362.
- Class/value symbols blocked by `export type` continue to report TS1362.

## Scope

- Adjust `get_type_only_import_export_kind` / cross-file type-only attribution to recognize marker-less intrinsic type exports (`interface`, `type`) with no value meaning.
- Add focused multi-file regression tests for imported interface and imported type alias value use.
- Keep the existing class-through-`export type` control in the same test target.
- Follow-up commit fixes the cross-file export probe to use `SymbolTable::get`'s copied `SymbolId` return directly.
- Follow-up commit marks the intrinsic type-only helper `const fn` to satisfy CI clippy.

## Project Corpus Impact

- Row: n/a
- Bug family: checker diagnostic attribution for type/value namespace mismatch
- Evidence: issue #9753 minimal repro; unit regression tests added in `ts1361_chain_attribution_tests.rs`.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `CARGO_TARGET_DIR=/Users/mohsen/.codex/worktrees/911c/tsz/target cargo nextest run -p tsz-checker --test ts1361_chain_attribution_tests` (5 passed)
- 2026-05-24 lint repair on head `011670d17d`: `cargo fmt --all --check`, `git diff --check`, `cargo clippy -p tsz-checker --lib -- -D warnings`, and `cargo nextest run -p tsz-checker --test ts1361_chain_attribution_tests` passed locally.
- Draft-light CI passed on exact head `011670d17dbb358862d715242f3a6a06509d0236`: `CI Light Summary`, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, gate, and project-row-drift.

## Coordination Notes

- AgentName: M4-D
- Addresses #9753.
- No changes to M4-C-owned PR labels or branches.
- Existing M4-D PR #9634 remains draft/off-auto and blocked by #9904; this is independent checker diagnostic work.
- Draft-light lint failed on the previous head because `symbol_is_intrinsic_type_only_without_value` needed to be `const fn`; fixed and pushed in `011670d17d`.
- Ready-review promotion is appropriate after exact-head draft-light CI passed; auto-merge remains off until ready-review heavy CI is clean.
