### PR TITLE
refactor(checker): route variable initializer relation guards

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -524,11 +524,13 @@ impl<'a> CheckerState<'a> {
                             let elaborated_obj =
                                 self.initializer_reaches_object_literal_through_wrappers(
                                     facts.initializer,
-                                ) && !self.is_assignable_to(checked_init_type, declared_type)
-                                    && self.try_elaborate_object_literal_properties_for_var_init(
-                                        facts.initializer,
-                                        declared_type,
-                                    );
+                                ) && !self.diagnostic_relation_boolean_guard(
+                                    checked_init_type,
+                                    declared_type,
+                                ) && self.try_elaborate_object_literal_properties_for_var_init(
+                                    facts.initializer,
+                                    declared_type,
+                                );
                             if !elaborated_obj {
                                 let skip_generic_outer_error = self
                                     .ctx
@@ -582,7 +584,10 @@ impl<'a> CheckerState<'a> {
                                         declared_type,
                                     )))
                                 && !(initializer_is_function
-                                    && !self.is_assignable_to(checked_init_type, declared_type)
+                                    && !self.diagnostic_relation_boolean_guard(
+                                        checked_init_type,
+                                        declared_type,
+                                    )
                                     && self.try_elaborate_assignment_source_error(
                                         facts.initializer,
                                         declared_type,
@@ -605,13 +610,14 @@ impl<'a> CheckerState<'a> {
                                     // contextual-typing decisions (`callsOnComplexSignatures`).
                                     if !(self.initializer_reaches_object_literal_through_wrappers(
                                         facts.initializer,
-                                    ) && !self
-                                        .is_assignable_to(checked_init_type, declared_type)
-                                        && self
-                                            .try_elaborate_object_literal_properties_for_var_init(
-                                                facts.initializer,
-                                                declared_type,
-                                            ))
+                                    ) && !self.diagnostic_relation_boolean_guard(
+                                        checked_init_type,
+                                        declared_type,
+                                    ) && self
+                                        .try_elaborate_object_literal_properties_for_var_init(
+                                            facts.initializer,
+                                            declared_type,
+                                        ))
                                     {
                                         // Disable callable-with-type-params suppression
                                         // for variable declarations. The suppression is
@@ -622,8 +628,10 @@ impl<'a> CheckerState<'a> {
                                         // (e.g., (cb: (x: string, ...rest: T) => void) => void
                                         //   vs (cb: (...args: never) => void) => void)
                                         if jsdoc_new_expression_relation
-                                            && !self
-                                                .is_assignable_to(checked_init_type, declared_type)
+                                            && !self.diagnostic_relation_boolean_guard(
+                                                checked_init_type,
+                                                declared_type,
+                                            )
                                         {
                                             self.error_type_not_assignable_generic_at(
                                                 checked_init_type,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -482,6 +482,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "crates"
             / "tsz-checker"
             / "src"
+            / "state"
+            / "variable_checking"
+            / "initializer_policy.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
             / "checkers"
             / "call_checker"
             / "diagnostics.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10047.

## Invariant
When variable initializer diagnostics use a boolean assignability probe only to choose TS2322 elaboration or generic fallback, tsz should route that probe through the shared diagnostic relation guard while preserving the same source/target relation and diagnostic ordering. Behavior is unchanged.

## Scope
- Route variable-initializer diagnostic probes in `crates/tsz-checker/src/state/variable_checking/initializer_policy.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `initializer_policy.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-assignment-ops-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10047 (`codex/m1b-assignment-ops-relation-guards-20260524`) at rebased base head `e8c214fae44d46799770ba570bb208ea60fe93be`.
- Current head: `2a78cebcd6fe0053c3e2d499228747aa1ca197b9`.
- Rebased this child after #10047 moved from `468614ea472c0bca3c96e9896dd0a2f2a656bb35` to `e8c214fae44d46799770ba570bb208ea60fe93be` using `--onto` so only this PR's variable-initializer guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `2a78cebcd6fe0053c3e2d499228747aa1ca197b9`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10051 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
