### PR TITLE
refactor(checker): route import relation guards

### DIFF
--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -45,7 +45,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if the specifier type is assignable to `string`
-        if !self.is_assignable_to(arg_type, TypeId::STRING) {
+        if !self.diagnostic_relation_boolean_guard(arg_type, TypeId::STRING) {
             let type_str = self.format_type(arg_type);
             let message = format_message(
                 diagnostic_messages::DYNAMIC_IMPORTS_SPECIFIER_MUST_BE_OF_TYPE_STRING_BUT_HERE_HAS_TYPE,
@@ -172,7 +172,7 @@ impl<'a> CheckerState<'a> {
         // For import attribute options (`with` / `assert`), prefer a top-level
         // TS2322 anchored at the options object, matching tsc fingerprints.
         if self.import_options_has_attribute_property(options_idx) {
-            if !self.is_assignable_to(options_type, import_call_options_type) {
+            if !self.diagnostic_relation_boolean_guard(options_type, import_call_options_type) {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
                 let source_str = self.format_type(options_type);
                 let message = format_message(

--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -699,7 +699,7 @@ impl<'a> CheckerState<'a> {
 
         // Emit top-level TS2322 at the attributes object (matching tsc fingerprint
         // parity for import attribute shape mismatches).
-        if !self.is_assignable_to(source_type, import_attributes_type) {
+        if !self.diagnostic_relation_boolean_guard(source_type, import_attributes_type) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
             let source_str = self.format_type(source_type);
             let message = format_message(

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -474,6 +474,14 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "assignability"
             / "polymorphic_this_diagnostics.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "declarations" / "dynamic_import_checker.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "declarations"
+            / "import"
+            / "declaration.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10051.

## Invariant
When import-related diagnostics use boolean assignability probes only to decide TS7036 or TS2322 emission, tsz should route those probes through the shared diagnostic relation guard while preserving the same source/target relation and diagnostic anchoring. Behavior is unchanged.

## Scope
- Route dynamic import specifier and import options probes in `crates/tsz-checker/src/declarations/dynamic_import_checker.rs` through `diagnostic_relation_boolean_guard`.
- Route import attribute shape probe in `crates/tsz-checker/src/declarations/import/declaration.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding those files to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-var-init-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10051 (`codex/m1b-var-init-relation-guards-20260524`) at rebased base head `2a78cebcd6fe0053c3e2d499228747aa1ca197b9`.
- Current head: `8d7f9ce970c6117f9335f4f2b85087df3fc6cd60`.
- Rebased this child after #10051 moved from `6bdac23cc2cf33bf7e9e674caf85b74e7d977e3e` to `2a78cebcd6fe0053c3e2d499228747aa1ca197b9` using `--onto` so only this PR's import guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `8d7f9ce970c6117f9335f4f2b85087df3fc6cd60`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10053 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
