### PR TITLE
fix(emit): preserve invalid let for recovery

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/control_flow.rs
+++ b/crates/tsz-emitter/src/emitter/statements/control_flow.rs
@@ -183,6 +183,10 @@ impl<'a> Printer<'a> {
             return;
         };
 
+        if self.try_emit_invalid_let_of_array_for_recovery(node, loop_stmt) {
+            return;
+        }
+
         // Check if the for initializer has `using` that needs lowering.
         // `for (using d1 = expr, d2 = expr2;;) { body }`
         // becomes:
@@ -412,7 +416,11 @@ impl<'a> Printer<'a> {
         } else {
             self.emit_for_header_initializer(for_in_of.initializer);
         }
-        self.write(" in ");
+        if self.for_in_invalid_let_header_needs_recovery_space(node) {
+            self.write("  in ");
+        } else {
+            self.write(" in ");
+        }
         self.emit(for_in_of.expression);
         // Map closing `)` — scan backward from body start
         if let Some(body_node) = self.arena.get(for_in_of.statement) {
@@ -1899,145 +1907,6 @@ impl<'a> Printer<'a> {
         // Close wrapping block
         self.decrease_indent();
         self.write("}");
-    }
-
-    /// Check if a statement list contains any `using`/`await using` declarations.
-    pub(in crate::emitter) fn block_has_using_declarations(&self, statements: &NodeList) -> bool {
-        for &stmt_idx in &statements.nodes {
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                continue;
-            };
-            if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
-                if self.variable_statement_source_using_flags(stmt_node) != 0 {
-                    return true;
-                }
-                let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
-                    continue;
-                };
-                for &decl_list_idx in &var_stmt.declarations.nodes {
-                    if let Some(decl_list_node) = self.arena.get(decl_list_idx)
-                        && let Some(decl_list) = self.arena.get_variable(decl_list_node)
-                    {
-                        let flags = decl_list.declarations.nodes.iter().fold(
-                            decl_list_node.flags as u32,
-                            |flags, &decl_idx| {
-                                flags | self.arena.get_variable_declaration_flags(decl_idx)
-                            },
-                        );
-                        if (flags & node_flags::USING) != 0 {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        false
-    }
-
-    pub(in crate::emitter) fn variable_statement_source_using_flags(&self, node: &Node) -> u32 {
-        if node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
-            return 0;
-        }
-        let Some(source_text) = self.source_text else {
-            return 0;
-        };
-        let start = (node.pos as usize).min(source_text.len());
-        let end = (node.end as usize).min(source_text.len());
-        let text = source_text[start..end].trim_start();
-        if text.starts_with("await using")
-            && text
-                .as_bytes()
-                .get("await using".len())
-                .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_' && *byte != b'$')
-        {
-            return node_flags::AWAIT_USING;
-        }
-        if text.starts_with("using")
-            && text
-                .as_bytes()
-                .get("using".len())
-                .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_' && *byte != b'$')
-        {
-            return node_flags::USING;
-        }
-        0
-    }
-
-    /// Check if a statement list contains any `await using` declarations.
-    pub(in crate::emitter) fn block_has_await_using(&self, statements: &NodeList) -> bool {
-        for &stmt_idx in &statements.nodes {
-            let Some(stmt_node) = self.arena.get(stmt_idx) else {
-                continue;
-            };
-            if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
-                let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
-                    continue;
-                };
-                for &decl_list_idx in &var_stmt.declarations.nodes {
-                    if let Some(decl_list_node) = self.arena.get(decl_list_idx)
-                        && (decl_list_node.flags as u32 & node_flags::AWAIT_USING)
-                            == node_flags::AWAIT_USING
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-
-    /// Emit just the `__addDisposableResource` calls for a using declaration,
-    /// without the try/catch/finally wrapper (used when block-level wrapping is active).
-    pub(crate) fn emit_using_addresource_only(
-        &mut self,
-        decl_list: &tsz_parser::parser::node::VariableData,
-        env_name: &str,
-        using_async: bool,
-    ) {
-        let initialized_decls: Vec<_> = decl_list
-            .declarations
-            .nodes
-            .iter()
-            .copied()
-            .filter(|&decl_idx| {
-                self.arena
-                    .get(decl_idx)
-                    .and_then(|n| self.arena.get_variable_declaration(n))
-                    .is_some_and(|d| d.initializer.is_some())
-            })
-            .collect();
-
-        // Block-level using: tsc emits `const/var d1 = __addDisposableResource(env, expr, false)`
-        // inside the try block. Uses `var` for ES5, `const` otherwise.
-        if !initialized_decls.is_empty() {
-            let kw = if self.ctx.target_es5 { "var" } else { "const" };
-            self.write(kw);
-            self.write(" ");
-            for (i, &decl_idx) in initialized_decls.iter().enumerate() {
-                if let Some(decl_node) = self.arena.get(decl_idx)
-                    && let Some(decl) = self.arena.get_variable_declaration(decl_node)
-                {
-                    self.emit(decl.name);
-                    self.write(" = ");
-                    self.write_helper("__addDisposableResource");
-                    self.write("(");
-                    self.write(env_name);
-                    self.write(", ");
-                    if !self
-                        .try_emit_object_literal_es5_inline_computed_expression(decl.initializer)
-                    {
-                        self.emit(decl.initializer);
-                    }
-                    self.write(", ");
-                    self.write(if using_async { "true" } else { "false" });
-                    self.write(")");
-                    if i + 1 < initialized_decls.len() {
-                        self.write(", ");
-                    }
-                }
-            }
-            self.write(";");
-        }
     }
 
     fn emit_static_block_await_labeled_jump_recovery(&mut self, stmt_idx: NodeIndex) -> bool {

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -47,10 +47,10 @@ impl<'a> Printer<'a> {
         if loop_stmt.initializer.is_some()
             || loop_stmt.condition.is_some()
             || loop_stmt.incrementor.is_some()
-            || !self
+            || self
                 .arena
                 .get(loop_stmt.statement)
-                .is_some_and(|stmt| stmt.kind == syntax_kind_ext::EMPTY_STATEMENT)
+                .is_none_or(|stmt| stmt.kind != syntax_kind_ext::EMPTY_STATEMENT)
         {
             return None;
         }

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -63,7 +63,7 @@ impl<'a> Printer<'a> {
         let inner = header[open_paren + 1..].trim_start();
         let after_let = keyword_tail(inner, "let")?.trim_start();
         let after_of = keyword_tail(after_let, "of")?.trim_start();
-        let array = after_of.strip_prefix('[')?.strip_suffix(']')?;
+        let array = recovered_array_elements_source(after_of)?;
         let elements = array
             .split(',')
             .map(str::trim)
@@ -92,4 +92,74 @@ fn is_keyword_followed_by(text: &str, first: &str, second: &str) -> bool {
         return false;
     };
     keyword_tail(tail.trim_start(), second).is_some()
+}
+
+fn recovered_array_elements_source(text: &str) -> Option<&str> {
+    let after_open = text.strip_prefix('[')?;
+    let close_offset = after_open.rfind(']')?;
+    let trailing = &after_open[close_offset + 1..];
+    if source_tail_is_trivia(trailing) {
+        Some(&after_open[..close_offset])
+    } else {
+        None
+    }
+}
+
+fn source_tail_is_trivia(mut text: &str) -> bool {
+    loop {
+        let trimmed = text.trim_start();
+        if trimmed.is_empty() {
+            return true;
+        }
+        if let Some(rest) = trimmed.strip_prefix("//") {
+            return !rest.contains('\n');
+        }
+        if let Some(rest) = trimmed.strip_prefix("/*") {
+            let Some(end) = rest.find("*/") else {
+                return false;
+            };
+            text = &rest[end + 2..];
+            continue;
+        }
+        return false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context::emit::EmitContext;
+    use crate::emitter::{Printer, PrinterOptions};
+    use crate::lowering::LoweringPass;
+    use tsz_common::ScriptTarget;
+
+    fn emit_es5(source: &str) -> String {
+        let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let options = PrinterOptions {
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        };
+        let ctx = EmitContext::with_options(options.clone());
+        let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+        let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+        printer.set_target_es5(ctx.target_es5);
+        printer.set_source_text(source);
+        printer.emit(root);
+        printer.get_output().to_string()
+    }
+
+    #[test]
+    fn invalid_let_of_array_for_recovery_accepts_trailing_header_trivia() {
+        for source in [
+            "for (let of [1, 2, 3] ) ;",
+            "for (let of [1, 2, 3] /* keep */) ;",
+        ] {
+            let output = emit_es5(source);
+
+            assert!(
+                output.contains("for (let of, []; 1, 2, 3; )"),
+                "Invalid `let of` recovery should ignore trailing header trivia.\nSource:\n{source}\nOutput:\n{output}"
+            );
+        }
+    }
 }

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -1,0 +1,95 @@
+use super::super::Printer;
+use tsz_parser::parser::node::{LoopData, Node};
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn try_emit_invalid_let_of_array_for_recovery(
+        &mut self,
+        node: &Node,
+        loop_stmt: &LoopData,
+    ) -> bool {
+        let Some(header) = self.invalid_let_of_array_for_header(node, loop_stmt) else {
+            return false;
+        };
+
+        self.write("for (");
+        self.write(&header);
+        self.write(")");
+        self.write_line();
+        self.increase_indent();
+        self.write(";");
+        self.decrease_indent();
+        true
+    }
+
+    pub(in crate::emitter) fn for_in_invalid_let_header_needs_recovery_space(
+        &self,
+        node: &Node,
+    ) -> bool {
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        let start = node.pos as usize;
+        if start >= text.len() {
+            return false;
+        }
+        let Some(header) = text[start..].split(')').next() else {
+            return false;
+        };
+        let Some(open_paren) = header.find('(') else {
+            return false;
+        };
+        let inner = header[open_paren + 1..].trim_start();
+        is_keyword_followed_by(inner, "let", "in")
+    }
+
+    fn invalid_let_of_array_for_header(&self, node: &Node, loop_stmt: &LoopData) -> Option<String> {
+        if loop_stmt.initializer.is_some()
+            || loop_stmt.condition.is_some()
+            || loop_stmt.incrementor.is_some()
+            || !self
+                .arena
+                .get(loop_stmt.statement)
+                .is_some_and(|stmt| stmt.kind == syntax_kind_ext::EMPTY_STATEMENT)
+        {
+            return None;
+        }
+
+        let text = self.source_text?;
+        let start = node.pos as usize;
+        let header_end = text.get(start..)?.find(')').map(|offset| start + offset)?;
+        let header = text.get(start..header_end)?;
+        let open_paren = header.find('(')?;
+        let inner = header[open_paren + 1..].trim_start();
+        let after_let = keyword_tail(inner, "let")?.trim_start();
+        let after_of = keyword_tail(after_let, "of")?.trim_start();
+        let array = after_of.strip_prefix('[')?.strip_suffix(']')?;
+        let elements = array
+            .split(',')
+            .map(str::trim)
+            .filter(|element| !element.is_empty())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("let of, []; {elements}; "))
+    }
+}
+
+fn keyword_tail<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
+    let tail = text.strip_prefix(keyword)?;
+    if tail
+        .chars()
+        .next()
+        .is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '$')
+    {
+        Some(tail)
+    } else {
+        None
+    }
+}
+
+fn is_keyword_followed_by(text: &str, first: &str, second: &str) -> bool {
+    let Some(tail) = keyword_tail(text, first) else {
+        return false;
+    };
+    keyword_tail(tail.trim_start(), second).is_some()
+}

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -112,7 +112,11 @@ fn source_tail_is_trivia(mut text: &str) -> bool {
             return true;
         }
         if let Some(rest) = trimmed.strip_prefix("//") {
-            return !rest.contains('\n');
+            let Some(line_end) = rest.find('\n') else {
+                return true;
+            };
+            text = &rest[line_end + 1..];
+            continue;
         }
         if let Some(rest) = trimmed.strip_prefix("/*") {
             let Some(end) = rest.find("*/") else {
@@ -153,6 +157,7 @@ mod tests {
         for source in [
             "for (let of [1, 2, 3] ) ;",
             "for (let of [1, 2, 3] /* keep */) ;",
+            "for (let of [1, 2, 3] // keep\n) ;",
         ] {
             let output = emit_es5(source);
 

--- a/crates/tsz-emitter/src/emitter/statements/mod.rs
+++ b/crates/tsz-emitter/src/emitter/statements/mod.rs
@@ -2,10 +2,12 @@ mod async_super_capture;
 mod control_flow;
 mod core;
 mod expression_statement_helpers;
+mod for_recovery;
 mod recovered_expression_statement_helpers;
 mod recovered_generated_member_helpers;
 mod static_block_await_recovery;
 mod try_statement;
+mod using_helpers;
 mod variable_statement_helpers;
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/emitter/statements/using_helpers.rs
+++ b/crates/tsz-emitter/src/emitter/statements/using_helpers.rs
@@ -1,0 +1,146 @@
+use super::super::Printer;
+use tsz_parser::parser::base::NodeList;
+use tsz_parser::parser::node::Node;
+use tsz_parser::parser::node_flags;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> Printer<'a> {
+    /// Check if a statement list contains any `using`/`await using` declarations.
+    pub(in crate::emitter) fn block_has_using_declarations(&self, statements: &NodeList) -> bool {
+        for &stmt_idx in &statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
+                if self.variable_statement_source_using_flags(stmt_node) != 0 {
+                    return true;
+                }
+                let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
+                    continue;
+                };
+                for &decl_list_idx in &var_stmt.declarations.nodes {
+                    if let Some(decl_list_node) = self.arena.get(decl_list_idx)
+                        && let Some(decl_list) = self.arena.get_variable(decl_list_node)
+                    {
+                        let flags = decl_list.declarations.nodes.iter().fold(
+                            decl_list_node.flags as u32,
+                            |flags, &decl_idx| {
+                                flags | self.arena.get_variable_declaration_flags(decl_idx)
+                            },
+                        );
+                        if (flags & node_flags::USING) != 0 {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    pub(in crate::emitter) fn variable_statement_source_using_flags(&self, node: &Node) -> u32 {
+        if node.kind != syntax_kind_ext::VARIABLE_STATEMENT {
+            return 0;
+        }
+        let Some(source_text) = self.source_text else {
+            return 0;
+        };
+        let start = (node.pos as usize).min(source_text.len());
+        let end = (node.end as usize).min(source_text.len());
+        let text = source_text[start..end].trim_start();
+        if text.starts_with("await using")
+            && text
+                .as_bytes()
+                .get("await using".len())
+                .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_' && *byte != b'$')
+        {
+            return node_flags::AWAIT_USING;
+        }
+        if text.starts_with("using")
+            && text
+                .as_bytes()
+                .get("using".len())
+                .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_' && *byte != b'$')
+        {
+            return node_flags::USING;
+        }
+        0
+    }
+
+    /// Check if a statement list contains any `await using` declarations.
+    pub(in crate::emitter) fn block_has_await_using(&self, statements: &NodeList) -> bool {
+        for &stmt_idx in &statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind == syntax_kind_ext::VARIABLE_STATEMENT {
+                let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
+                    continue;
+                };
+                for &decl_list_idx in &var_stmt.declarations.nodes {
+                    if let Some(decl_list_node) = self.arena.get(decl_list_idx)
+                        && (decl_list_node.flags as u32 & node_flags::AWAIT_USING)
+                            == node_flags::AWAIT_USING
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Emit just the `__addDisposableResource` calls for a using declaration,
+    /// without the try/catch/finally wrapper (used when block-level wrapping is active).
+    pub(crate) fn emit_using_addresource_only(
+        &mut self,
+        decl_list: &tsz_parser::parser::node::VariableData,
+        env_name: &str,
+        using_async: bool,
+    ) {
+        let initialized_decls: Vec<_> = decl_list
+            .declarations
+            .nodes
+            .iter()
+            .copied()
+            .filter(|&decl_idx| {
+                self.arena
+                    .get(decl_idx)
+                    .and_then(|n| self.arena.get_variable_declaration(n))
+                    .is_some_and(|d| d.initializer.is_some())
+            })
+            .collect();
+
+        // Block-level using: tsc emits `const`/`var d1 = __addDisposableResource(env, expr, false)`
+        // inside the try block. Uses `var` for ES5, `const` otherwise.
+        if !initialized_decls.is_empty() {
+            let kw = if self.ctx.target_es5 { "var" } else { "const" };
+            self.write(kw);
+            self.write(" ");
+            for (i, &decl_idx) in initialized_decls.iter().enumerate() {
+                if let Some(decl_node) = self.arena.get(decl_idx)
+                    && let Some(decl) = self.arena.get_variable_declaration(decl_node)
+                {
+                    self.emit(decl.name);
+                    self.write(" = ");
+                    self.write_helper("__addDisposableResource");
+                    self.write("(");
+                    self.write(env_name);
+                    self.write(", ");
+                    if !self
+                        .try_emit_object_literal_es5_inline_computed_expression(decl.initializer)
+                    {
+                        self.emit(decl.initializer);
+                    }
+                    self.write(", ");
+                    self.write(if using_async { "true" } else { "false" });
+                    self.write(")");
+                    if i + 1 < initialized_decls.len() {
+                        self.write(", ");
+                    }
+                }
+            }
+            self.write(";");
+        }
+    }
+}

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -77,6 +77,21 @@ fn invalid_jsx_closing_fragment_drops_recovered_slash() {
 }
 
 #[test]
+fn invalid_let_for_headers_preserve_tsc_recovery_emit() {
+    let source = "var let = 10;\nfor (let of [1,2,3]) {}\nfor (let in [1,2,3]) {}\n";
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("for (let of, []; 1, 2, 3; )\n    ;\n{ }"),
+        "`for (let of [...])` recovery should preserve tsc's split regular-for shape.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("for (let  in [1, 2, 3]) { }"),
+        "`for (let in ...)` recovery should preserve tsc's missing-binding spacing.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn js_satisfies_binary_expression_is_erased() {
     let output = parse_and_emit_strict_es2015("var v = undefined satisfies 1;", "a.js");
     assert_eq!(output.trim_end(), "\"use strict\";\nvar v = undefined;");


### PR DESCRIPTION
AgentName: Studio-C

## Track
Track 9 — JavaScript emit parity, parser-recovery-shaped `for` header output.

## Invariant
When the parser recovers invalid `for (let of [...])` and `for (let in ...)` headers, tsz should preserve the same JavaScript recovery shape as `tsc` without adding semantic validation to the emitter. Trailing whitespace or comments after the recovered array header must not change that recovery shape.

## Scope
- Preserve invalid `let` `for` headers through statement-level recovery emission.
- Split existing `using` statement helpers out of oversized `control_flow.rs` before adding the recovery helper.
- Keep the recovery rule scoped to parser recovery facts and source header structure.
- Accept trailing header trivia after recovered `let of [...]` array text before the closing paren.
- Emitter/parser recovery tests only; no checker, solver, or semantic validation changes.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit parser recovery for invalid `for` headers.
- Evidence: focused parser/emitter tests and `invalidLetInForOfAndForIn` emit filter below.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-emitter invalid_let_of_array_for_recovery_accepts_trailing_header_trivia invalid_let_for_headers_preserve_tsc_recovery_emit`
- `./scripts/emit/run.sh --filter=invalidLetInForOfAndForIn --js-only --verbose --timeout=30000 --json-out=/tmp/studio-c-10054-invalid-let-trivia.json` — 2/2 JS
- M1-A follow-up on `1ee7e727e4755031eb14436b2629112ada13a47e`: `cargo fmt --all --check`, `git diff --check`, `cargo nextest run -p tsz-emitter invalid_let_of_array_for_recovery_accepts_trailing_header_trivia invalid_let_for_headers_preserve_tsc_recovery_emit`, and `./scripts/emit/run.sh --filter=invalidLetInForOfAndForIn --js-only --verbose --timeout=30000 --json-out=/tmp/m1a-10054-invalid-let-line-comment.json` — 2/2 JS
- Earlier branch verification before the trivia follow-up: `cargo clippy -p tsz-emitter --all-targets -- -D warnings`, `cargo nextest run -p tsz-parser test_for_header_let_disambiguation_matches_invalid_for_of_recovery`, and exact-head draft-light CI at `7e5a9dff10aa08aa8fdc0bb2a2fe278dc89511e5`.

## Coordination Notes
- Current refreshed head: `1ee7e727e4755031eb14436b2629112ada13a47e`.
- Exact-head lint failure from the initial draft-light run was reproduced locally as `clippy::nonminimal_bool` in `for_recovery.rs` and fixed on the previous head.
- Studio-C addressed the first StudioManager reviewer follow-up by letting the recovered array header ignore trailing whitespace and block comments before `)`. M1-A then addressed the remaining line-comment-before-`)` edge on `1ee7e727e4755031eb14436b2629112ada13a47e`.
- The PR is draft with auto-merge off after StudioManager queue-safety review; Studio-C should re-promote only after this exact head has a complete green check picture.