### PR TITLE
refactor(checker): route for-in relation guard

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -599,7 +599,7 @@ impl<'a> CheckerState<'a> {
             if var_type != TypeId::STRING
                 && var_type != TypeId::ANY
                 && var_type != TypeId::UNKNOWN
-                && !self.is_assignable_to(element_type, var_type)
+                && !self.diagnostic_relation_boolean_guard(element_type, var_type)
             {
                 self.error_at_node(
                     initializer,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -497,6 +497,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "crates"
             / "tsz-checker"
             / "src"
+            / "state"
+            / "variable_checking"
+            / "for_loop.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
             / "checkers"
             / "call_checker"
             / "diagnostics.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10053.

## Invariant
When a `for-in` LHS diagnostic uses a boolean assignability probe only to decide TS2405 emission, tsz should route that probe through the shared diagnostic relation guard while preserving the same `element_type -> var_type` relation and diagnostic anchor. Behavior is unchanged.

## Scope
- Route the `for-in` LHS TS2405 probe in `crates/tsz-checker/src/state/variable_checking/for_loop.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `for_loop.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-import-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10053 (`codex/m1b-import-relation-guards-20260524`) at rebased base head `8d7f9ce970c6117f9335f4f2b85087df3fc6cd60`.
- Current head: `fc2cf47c98094345e103f052aeb6fd802dc3ddb7`.
- Rebased this child after #10053 moved from `230ce2e4e3b5a73351402096d97faa5a6258d18d` to `8d7f9ce970c6117f9335f4f2b85087df3fc6cd60` using `--onto` so only this PR's `for-in` guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `fc2cf47c98094345e103f052aeb6fd802dc3ddb7`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10055 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
