### PR TITLE
refactor(checker): route variable core relation guards

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -229,7 +229,7 @@ impl<'a> CheckerState<'a> {
             let value_type = self.resolve_lazy_type(value_type);
             if value_type == TypeId::ERROR
                 || value_type == TypeId::ANY
-                || self.is_assignable_to(value_type, enum_element_type)
+                || self.diagnostic_relation_boolean_guard(value_type, enum_element_type)
             {
                 continue;
             }
@@ -2197,7 +2197,7 @@ impl<'a> CheckerState<'a> {
         // Check if the init return type is Promise<T> where T is assignable
         // to the declared return type.
         if let Some(unwrapped) = self.unwrap_promise_type(init_ret) {
-            self.is_assignable_to(unwrapped, decl_ret)
+            self.diagnostic_relation_boolean_guard(unwrapped, decl_ret)
         } else {
             false
         }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -492,6 +492,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "state"
             / "variable_checking"
+            / "core.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "variable_checking"
             / "initializer_policy.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10055.

## Invariant
When variable-core diagnostic helpers use boolean assignability probes only to decide enum-element TS2322 emission or async JSDoc return suppression, tsz should route those probes through the shared diagnostic relation guard while preserving the same source/target relation and diagnostic anchoring. Behavior is unchanged.

## Scope
- Route enum-element object-literal TS2322 probe in `crates/tsz-checker/src/state/variable_checking/core.rs` through `diagnostic_relation_boolean_guard`.
- Route async JSDoc return suppression relation in `core.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `core.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-for-in-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10055 (`codex/m1b-for-in-relation-guard-20260524`) at rebased base head `fc2cf47c98094345e103f052aeb6fd802dc3ddb7`.
- Current head: `3942e9c5b6e690b8f036472f7bf838bdc3d421aa`.
- Rebased this child after #10055 moved from `8bf350323e60e0eae619101a5f929e14195c08b8` to `fc2cf47c98094345e103f052aeb6fd802dc3ddb7` using `--onto` so only this PR's variable-core guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `3942e9c5b6e690b8f036472f7bf838bdc3d421aa`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10057 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
