### PR TITLE
refactor(checker): route enum member relation guards

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -212,15 +212,15 @@ impl<'a> CheckerState<'a> {
             // assignable to number or string, tsc's evaluator would likely succeed
             // (the import resolves to a const with a literal value).
             if eval_result.is_none()
-                && (self.is_assignable_to(init_type, TypeId::NUMBER)
-                    || self.is_assignable_to(init_type, TypeId::STRING))
+                && (self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)
+                    || self.diagnostic_relation_boolean_guard(init_type, TypeId::STRING))
             {
                 continue;
             }
 
             // Evaluation would fail (or unknown with non-number/string type).
             // Emit TS18033 if the type is not assignable to number.
-            if !self.is_assignable_to(init_type, TypeId::NUMBER) {
+            if !self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER) {
                 // tsc displays widened types in TS18033: 'string' not '"bar"'
                 let widened =
                     crate::query_boundaries::common::widen_literal_type(self.ctx.types, init_type);

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -474,6 +474,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "assignability"
             / "polymorphic_this_diagnostics.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "state_checking_members"
+            / "statement_helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "declarations" / "dynamic_import_checker.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10057.

## Invariant
When computed enum member diagnostics use boolean assignability probes only to decide TS18033 emission or suppression, tsz should route those probes through the shared diagnostic relation guard while preserving the same `init_type -> number|string` relation and diagnostic anchor. Behavior is unchanged.

## Scope
- Route computed enum member TS18033 probes in `crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `statement_helpers.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-variable-core-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10057 (`codex/m1b-variable-core-relation-guards-20260524`) at rebased base head `3942e9c5b6e690b8f036472f7bf838bdc3d421aa`.
- Current head: `6c1bd0d3afad7870ff250e0ff95eea98553ae88b`.
- Rebased this child after #10057 moved from `553480c68f4b685e529806b411b9b6f7195f6221` to `3942e9c5b6e690b8f036472f7bf838bdc3d421aa` using `--onto` so only this PR's enum-member guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `6c1bd0d3afad7870ff250e0ff95eea98553ae88b`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10059 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
