### PR TITLE
refactor(checker): route property access relation guard

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -1848,7 +1848,7 @@ impl<'a> CheckerState<'a> {
         let source_type = self.get_type_of_node(source_idx);
         let target_type =
             crate::query_boundaries::common::remove_undefined(self.ctx.types, declared_type);
-        if !self.is_assignable_to(source_type, target_type) {
+        if !self.diagnostic_relation_boolean_guard(source_type, target_type) {
             let _ = self.check_assignable_or_report_at_exact_anchor(
                 source_type,
                 target_type,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -481,6 +481,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "state"
             / "state_checking_members"
             / "statement_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "property_access_type"
+            / "helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "declarations" / "dynamic_import_checker.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10 refactor-only checker relation-boundary slice. Stacked on #10059.

## Invariant
When JS prototype property-access diagnostics use a boolean assignability probe only to decide whether to emit the existing exact-anchor TS2322 path, tsz should route that probe through the shared diagnostic relation guard while preserving the same source/target relation and diagnostic anchor. Behavior is unchanged.

## Scope
- Route the JS prototype property-access diagnostic precheck in `crates/tsz-checker/src/types/property_access_type/helpers.rs` through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `helpers.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-enum-member-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10059 (`codex/m1b-enum-member-relation-guards-20260524`) at rebased base head `6c1bd0d3afad7870ff250e0ff95eea98553ae88b`.
- Current head: `ec3f047ff90aa19de09db3faae88d38bc8e71108`.
- Rebased this child after #10059 moved from `cd2ef1ddb0f295504e97c997e4b1cc38bd91d6a9` to `6c1bd0d3afad7870ff250e0ff95eea98553ae88b` using `--onto` so only this PR's property-access guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `ec3f047ff90aa19de09db3faae88d38bc8e71108`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10060 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
