### PR TITLE
fix(checker): resolve indexed access on intersections with mapped-alias members

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1154,6 +1154,10 @@ name = "deferred_keyof_index_access_assignability_tests"
 path = "tests/deferred_keyof_index_access_assignability_tests.rs"
 
 [[test]]
+name = "intersection_mapped_alias_indexed_access_tests"
+path = "tests/intersection_mapped_alias_indexed_access_tests.rs"
+
+[[test]]
 name = "cross_file_js_ts_class_merge_ts2451_suppression_tests"
 path = "tests/cross_file_js_ts_class_merge_ts2451_suppression_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -498,10 +498,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     && !is_index_access
                     && !object_has_type_params
                 {
+                    // Check property existence against the materialized object so
+                    // unevaluated mapped-alias intersection members contribute their
+                    // keys (see `evaluate_type_for_property_check`).
+                    let property_object = self.evaluate_type_for_property_check(resolved_object);
                     let prop_result =
                         crate::query_boundaries::property_access::resolve_property_access(
                             self.ctx.types,
-                            resolved_object,
+                            property_object,
                             &key,
                         );
 
@@ -595,6 +599,35 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             })
         } else {
             false
+        }
+    }
+
+    /// Materialize an intersection receiver before a property-existence check.
+    ///
+    /// An intersection member that is an unevaluated mapped-type alias
+    /// application (e.g. `Record<K, V>`, a user alias `M<…>`, or a wrapper around
+    /// one) is opaque to the bare property-access resolver, which cannot expand a
+    /// checker-owned `DefId`. Evaluating through the `TypeEnvironment` merges the
+    /// members into one object shape — as `keyof` and assignability already do —
+    /// so every member's keys are visible. Non-intersections and types that fail
+    /// to evaluate are returned unchanged.
+    fn evaluate_type_for_property_check(&self, object_type: TypeId) -> TypeId {
+        if !crate::query_boundaries::common::is_intersection_type(self.ctx.types, object_type) {
+            return object_type;
+        }
+        let evaluated = crate::query_boundaries::state::type_environment::evaluate_type_with_cache(
+            self.ctx.types,
+            &*self.ctx,
+            object_type,
+            std::iter::empty(),
+            false,
+            self.ctx.is_declaration_file() || self.ctx.emit_declarations(),
+        )
+        .result;
+        if evaluated == TypeId::ERROR {
+            object_type
+        } else {
+            evaluated
         }
     }
 

--- a/crates/tsz-checker/tests/intersection_mapped_alias_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/intersection_mapped_alias_indexed_access_tests.rs
@@ -1,0 +1,148 @@
+//! Tests for indexed access `(A & B)[K]` where the intersection member that
+//! contributes `K` is an *unevaluated mapped-type alias application* — a user
+//! alias `M<…> = { [P in K]: V }` (the lib `Record` is one instance of this
+//! shape), possibly behind a wrapper alias.
+//!
+//! Structural rule: `(A & B)[K]` must resolve `K` against the *evaluated* form
+//! of every intersection member, including mapped-type alias applications, the
+//! same materialization the `keyof` and assignability paths already perform.
+//! Before this fix, such a member was left opaque by the property-existence
+//! check (its checker-owned `DefId` could not be expanded by the bare
+//! property-access resolver), so the key was falsely reported missing (TS2339)
+//! and the indexed access collapsed to a deferred/never type.
+//!
+//! These tests use a user-defined mapped alias rather than the lib `Record`
+//! because the checker unit harness runs without lib definitions; the rule is
+//! the same for any mapped-type alias (issue #9648 explicitly notes it is not
+//! `Record`-specific). Regression coverage for issue #9648.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn count(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+fn assert_no_2339(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2339),
+        0,
+        "expected no TS2339; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+const REC: &str = "type Rec<K extends string, V> = { [P in K]: V };\n";
+
+/// `({} & Rec<"foo", number>)["foo"]` — empty sibling member.
+#[test]
+fn mapped_alias_member_empty_sibling_resolves_key() {
+    assert_no_2339(&format!(
+        "{REC}type A = ({{}} & Rec<\"foo\", number>)[\"foo\"];\nconst a: A = 42;\n"
+    ));
+}
+
+/// Order independence: `(Rec<"foo", number> & {})["foo"]`.
+#[test]
+fn mapped_alias_member_first_resolves_key() {
+    assert_no_2339(&format!(
+        "{REC}type A = (Rec<\"foo\", number> & {{}})[\"foo\"];\nconst a: A = 42;\n"
+    ));
+}
+
+/// Non-empty sibling literal member: `({ bar: string } & Rec<"foo", number>)["foo"]`.
+#[test]
+fn mapped_alias_member_nonempty_sibling_resolves_key() {
+    assert_no_2339(&format!(
+        "{REC}type A = ({{ bar: string }} & Rec<\"foo\", number>)[\"foo\"];\nconst a: A = 42;\n"
+    ));
+}
+
+/// The contributed key resolves to the correct value type, not `never`/deferred:
+/// a wrong assignment to `(... & Rec<"foo", number>)["foo"]` must emit TS2322.
+#[test]
+fn mapped_alias_member_key_resolves_to_value_type_not_never() {
+    let diags = check_source_diagnostics(&format!(
+        "{REC}type A = ({{ bar: string }} & Rec<\"foo\", number>)[\"foo\"];\nconst a: A = \"not a number\";\n"
+    ));
+    assert_eq!(count(&diags, 2339), 0, "no false TS2339");
+    assert_eq!(
+        count(&diags, 2322),
+        1,
+        "string assigned to a `number` member must emit TS2322; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Anti-hardcoding (§25): the iteration variable and type-parameter names must
+/// not matter. Same shape with `Key`/`Val`/`Q` instead of `K`/`V`/`P`.
+#[test]
+fn mapped_alias_member_renamed_params_resolves_key() {
+    assert_no_2339(
+        r#"
+type Rec2<Key extends string, Val> = { [Q in Key]: Val };
+type A = ({ bar: string } & Rec2<"foo", number>)["foo"];
+const a: A = 42;
+"#,
+    );
+}
+
+/// Wrapper alias around the mapped application: `Wrap<Rec<"foo", number>>`.
+#[test]
+fn wrapper_alias_around_mapped_application_resolves_key() {
+    assert_no_2339(&format!(
+        "{REC}type Wrap<T> = T;\ntype A = ({{ bar: string }} & Wrap<Rec<\"foo\", number>>)[\"foo\"];\nconst a: A = 42;\n"
+    ));
+}
+
+/// `keyof` / indexed-access internal consistency: both the key set and the
+/// per-key value type must agree on the mapped-alias member.
+#[test]
+fn keyof_and_indexed_access_agree_on_mapped_alias_member() {
+    assert_no_2339(&format!(
+        "{REC}type X = {{ bar: string }} & Rec<\"foo\", number>;\ntype V = X[\"foo\"];\nconst v: V = 5;\ntype K = keyof X;\nconst k: K = \"foo\";\n"
+    ));
+}
+
+/// Sibling literal-prop access must keep working (control).
+#[test]
+fn sibling_literal_property_access_still_resolves() {
+    assert_no_2339(&format!(
+        "{REC}type A = ({{ bar: string }} & Rec<\"foo\", number>)[\"bar\"];\nconst a: A = \"a string\";\n"
+    ));
+}
+
+/// Inline mapped member must keep working (control, never went through the
+/// alias-application path).
+#[test]
+fn inline_mapped_member_still_resolves() {
+    assert_no_2339(
+        r#"
+type A = ({} & { [K in "foo"]: number })["foo"];
+const a: A = 42;
+"#,
+    );
+}
+
+/// Negative/fallback: a genuinely absent key must STILL be reported missing —
+/// materializing the members must not silently accept unknown keys.
+#[test]
+fn genuinely_missing_key_still_reports_2339() {
+    let diags = check_source_diagnostics(&format!(
+        "{REC}type A = ({{ bar: string }} & Rec<\"foo\", number>)[\"baz\"];\ndeclare const a: A;\n"
+    ));
+    assert!(
+        count(&diags, 2339) >= 1,
+        "missing key `baz` must still emit TS2339; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Closes #9648.

AgentName: M4-C

(Ownership lane: `agent:M4-C`. Runner metadata: `opus47-remote`.)

## Structural rule

> When `(A & B)[K]` is resolved and the intersection member contributing `K` is an unevaluated mapped-type alias application (a `TypeData::Application` over a mapped body — `Record<…>`, a user alias `M<…> = { [P in K]: V }`, or a wrapper alias around one), tsc resolves `K` to that member's value type; this change makes tsz materialize every intersection member before the property-existence check so it does the same, instead of falsely emitting TS2339 and collapsing the access to `never`.

## Root cause

The TS2339 property-existence check for indexed-access type nodes
(`crates/tsz-checker/src/types/type_node_advanced.rs`) resolved the property
on the **raw** intersection via the bare property-access query boundary. That
resolver (`db.as_type_resolver()`) cannot expand a checker-owned `DefId`, so an
alias-application member such as `Record<"foo", number>` stayed opaque and its
property was reported missing — even though `keyof` and assignability already
evaluate the intersection through the `TypeEnvironment` and see the key. The
two paths disagreed, which is the defect described in #9648.

## Fix

Evaluate an intersection receiver through the `TypeEnvironment`
(`evaluate_type_with_cache`) before the property-existence lookup, so its
members are merged into a single object shape — exactly the materialization the
keyof/assignability paths already perform. Non-intersection receivers and
types that fail to evaluate are returned unchanged, keeping blast radius tight.
The error message still renders the original (un-evaluated) type, so display is
unaffected.

## Owner layer

Checker orchestration: the checker owns `DefId` stabilization and the
`TypeEnvironment` (`DefId -> TypeId`), and already evaluates types through it
elsewhere in this file. The fix routes the property-existence check through the
same env-backed evaluation rather than adding any ad-hoc type algorithm.

## Adjacent-case test matrix

New owning-crate suite
`crates/tsz-checker/tests/intersection_mapped_alias_indexed_access_tests.rs`
(uses a user-defined mapped alias because the checker unit harness runs without
lib; the rule is not `Record`-specific):

- empty sibling `({} & M<"foo", number>)["foo"]`
- order independence `(M<"foo", number> & {})["foo"]`
- non-empty sibling `({ bar: string } & M<"foo", number>)["foo"]`
- value-type resolution (wrong assignment must emit **TS2322**, proving the key
  resolves to `number`, not `never`)
- renamed iteration/type-param names (`Key`/`Val`/`Q` instead of `K`/`V`/`P`) —
  anti-hardcoding §25
- wrapper alias `Wrap<M<"foo", number>>`
- `keyof` / indexed-access internal consistency
- controls: sibling literal-prop access, inline mapped member
- negative/fallback: a genuinely absent key still emits **TS2339**

End-to-end (`tsz --noEmit --strict`, with lib) reproduces the issue's full
snippet set (A1–A4 + Ok1–Ok4, both orders, user alias, wrapper alias) clean.

## Known unsupported shapes / fallback

Only intersection receivers are materialized; other receiver kinds keep their
existing path. If env evaluation yields `ERROR` the original type is used, so
error-suppression behavior is preserved.

## Track
Conformance — checker false-positive (indexed access / intersections).

## Invariant
`(A & B)[K]` property existence and value type are determined from the
evaluated form of every intersection member, consistent with `keyof` and
assignability.

## Scope
Checker only: `type_node_advanced.rs` (one call site + a small helper) and the
new test target registration. No solver/emitter/binder changes.

## Project Corpus Impact
- Row: n/a
- Bug family: false-positive TS2339 on `(A & B)[K]` where a member is an
  unevaluated mapped-type alias application; indexed access collapses to `never`.
- Evidence: 10 new `tsz-checker` unit tests; end-to-end `tsz` repro of #9648 now
  clean; related indexed-access/intersection/keyof/mapped checker suites re-run
  green locally (see Verification). Full conformance/emit/fourslash run by
  ready-for-review CI.

## Verification
- `cargo test -p tsz-checker --test intersection_mapped_alias_indexed_access_tests` → 10/10
- Re-ran ~18 related targets green: `tuple_index_access_tests`,
  `enum_indexed_access_tests`, `element_access_structural_codes_tests`,
  `indexed_access_resolved_union_property_tests`,
  `indexed_access_unconstrained_param_tests`,
  `recursive_intersection_assignability_tests`,
  `excess_property_check_recursive_intersection_tests`,
  `lib_merge_indexed_access_no_cascade_tests`,
  `object_element_access_diagnostics_tests`,
  `global_this_property_access_diagnostics_tests`,
  `keyof_naked_priority_tests`, `keyof_mapped_as_clause_tests`,
  `mapped_type_interface_tests`, `homomorphic_mapped_union_distribution_tests`,
  `intersection_primitive_member_assignability_tests`,
  `deferred_keyof_index_access_assignability_tests`,
  `union_index_access_function_application_param_tests`,
  `indexed_access_callback_tests`.
- `cargo clippy -p tsz-checker --all-targets` → clean.
- `.target/debug/tsz repro.ts --noEmit --strict` → 0 errors on the full #9648 snippet set.

## Coordination Notes
Ownership lane: **M4-C** (canonical `agent:M4-C` label; assigned via queue-safety
handoff from M1-A — checker indexed-access/intersection/materialization work).
`opus47-remote` is the runner-generated name only, not an ownership lane.
Searched open/draft PRs for overlapping intersection/indexed-access work — none
target #9648 (#9908 is a separate symbol-index-signature `keyof` fix). Branch is
current with `main`; no conflicts. Follow-up file-split tracked in #10068
(`type_node_advanced.rs` at 1973/2000 lines). Auto-merge stays off until
exact-head required checks on `bb74878` are complete and green.

https://claude.ai/code/session_01MPGekEsT2HHo6MZHB6FEnE