### PR TITLE
refactor(checker): route jsdoc lookup relation guard

### DIFF
--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -1050,7 +1050,7 @@ impl<'a> CheckerState<'a> {
                 arg_search_offset += arg_str.len() + 1;
                 continue;
             };
-            if self.is_assignable_to(type_arg, constraint) {
+            if self.diagnostic_relation_boolean_guard(type_arg, constraint) {
                 arg_search_offset += arg_str.len() + 1;
                 continue;
             }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -488,6 +488,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "types"
             / "property_access_type"
             / "helpers.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "jsdoc" / "lookup.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "declarations" / "dynamic_import_checker.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10060.

## Invariant
When JSDoc generic-constraint validation needs a boolean assignability probe only to decide whether to emit TS2344, the checker should route that diagnostic-only relation through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the JSDoc lookup generic-constraint TS2344 probe through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `jsdoc/lookup.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-property-access-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10060 (`codex/m1b-property-access-relation-guard-20260524`) at rebased base head `ec3f047ff90aa19de09db3faae88d38bc8e71108`.
- Current head: `091e48c2449b41e0f597ebbba9f27478fe2bf1f4`.
- Rebased this child after #10060 moved from `c404885b1ef0b8e71cdfb8e81e7e29761847ac89` to `ec3f047ff90aa19de09db3faae88d38bc8e71108` using `--onto` so only this PR's JSDoc lookup guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `091e48c2449b41e0f597ebbba9f27478fe2bf1f4`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10065 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
- Skipped the similar raw probe in `jsdoc/diagnostics.rs` because that source file is already oversized; this PR keeps the slice to the smaller lookup module.
