### PR TITLE
refactor(checker): route interface heritage index relation guard

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index.rs
@@ -52,7 +52,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             if self.type_contains_error(prop_type)
-                || self.is_assignable_to(prop_type, string_index_value)
+                || self.diagnostic_relation_boolean_guard(prop_type, string_index_value)
             {
                 continue;
             }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -481,6 +481,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "state"
             / "state_checking_members"
             / "statement_helpers.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "classes" / "interface_heritage_index.rs",
             ROOT
             / "crates"
             / "tsz-checker"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10065.

## Invariant
When interface heritage index checking needs a boolean assignability probe only to decide whether to emit the property-to-index-type diagnostic, the checker should route that diagnostic-only relation through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the interface heritage index property/index diagnostic probe through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `classes/interface_heritage_index.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-jsdoc-lookup-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10065 (`codex/m1b-jsdoc-lookup-relation-guard-20260524`) at rebased base head `091e48c2449b41e0f597ebbba9f27478fe2bf1f4`.
- Current head: `6dec8a2e3eacd0559fe0e7b471e401e518d74f11`.
- Rebased this child after #10065 moved from `78f951a47167755b0bf6b2092566be7dfefe1817` to `091e48c2449b41e0f597ebbba9f27478fe2bf1f4` using `--onto` so only this PR's interface heritage index guard patch replayed.
- Current PR state: draft/off-auto, labeled only `agent:M1-B`, mergeable/clean, and draft-light CI is green on `6dec8a2e3eacd0559fe0e7b471e401e518d74f11`.
- GitHub reports `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on this draft branch; do not arm auto-merge as a queue watcher.
- Keep #10067 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
