### PR TITLE
refactor(checker): route jsdoc heritage relation guard

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -246,7 +246,7 @@ impl<'a> CheckerState<'a> {
             };
             let arg_eval = self.evaluate_type_for_assignability(arg_prop.type_id);
             let constraint_eval = self.evaluate_type_for_assignability(constraint_prop.type_id);
-            if !self.is_assignable_to(arg_eval, constraint_eval) {
+            if !self.diagnostic_relation_boolean_guard(arg_eval, constraint_eval) {
                 return true;
             }
         }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -481,6 +481,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "state"
             / "state_checking_members"
             / "statement_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "classes"
+            / "class_implements_checker"
+            / "jsdoc_heritage.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "classes" / "interface_heritage_index.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10067.

## Invariant
When JSDoc heritage constraint validation compares object-shape property types only to decide whether to emit TS2344, the checker should route that diagnostic-only relation through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the JSDoc heritage object-constraint diagnostic probe through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `classes/class_implements_checker/jsdoc_heritage.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-interface-heritage-index-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `701f236ecabc12447d66bf27cf09cb521b7e1891` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10067 (`codex/m1b-interface-heritage-index-relation-guard-20260524`) at base head `6dec8a2e3eacd0559fe0e7b471e401e518d74f11`.
- Current head: `701f236ecabc12447d66bf27cf09cb521b7e1891`.
- Rebased this child after #10067 moved from `5837e00e3bd23e38c9955e7baacea1745cfd7b97` to `6dec8a2e3eacd0559fe0e7b471e401e518d74f11` using `--onto` so only this PR's JSDoc heritage guard patch replayed.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10069 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
