### PR TITLE
test(bench): add type-fest reduction fixtures

### DIFF
--- a/docs/plan/agents/Studio-A.md
+++ b/docs/plan/agents/Studio-A.md
@@ -27,11 +27,12 @@ scripts/agents/list-owned-work.sh Studio-A
 - Related PRs to inspect: `#9277`, `#9253`, `#9251`, `#9249`, `#9237`,
   `#9235`, `#9223`, `#9215`, `#9063`, `#9034`, `#8980`, `#8912`, `#8901`.
 - Track: roadmap Track 1.
-- Next concrete step: with the fixture-metadata sync guard landed in #9538,
-  do not reclaim the type-fest reduction backlog while Studio-D owns draft
-  PR #9229 for #8774. Look next for unowned dashboard-truth gaps where a
-  project row can misreport correctness, phase, first blocker family, runner
-  identity, or fixture metadata.
+- Next concrete step: with #10035 merged and Studio-D's #9229 closed unmerged,
+  Studio-A is reclaiming the unowned #8774 type-fest reduction-fixture backlog
+  on branch `codex/studio-a-typefest-reductions-20260524`. Do not duplicate
+  that slice while the Studio-A PR is open; after it lands, look next for
+  unowned dashboard-truth gaps where a project row can misreport correctness,
+  phase, first blocker family, runner identity, or fixture metadata.
 
 ## Existing Work To Inspect First
 
@@ -39,8 +40,9 @@ scripts/agents/list-owned-work.sh Studio-A
   current assumptions instead of reopening the Cloud Build timing-shard work.
 - `#9223` surfaces project compatibility measurements.
 - `#9215`, `#9063`, `#9034`, and `#8980` touch project compile guard shape.
-- `#9229` owns the current type-fest reduction backlog for `#8774`; coordinate
-  with Studio-D instead of adding parallel fixtures.
+- `#9229` was the previous Studio-D draft for `#8774`, but it is now closed
+  unmerged. The current type-fest reduction-fixture ownership is the Studio-A
+  branch named above.
 
 ## Non-Overlap Rules
 

--- a/tests/cases/reductions/type-fest/README.md
+++ b/tests/cases/reductions/type-fest/README.md
@@ -1,0 +1,15 @@
+# Type-Fest Project Reductions
+
+These fixtures capture the first type-fest project blocker families from
+issue #8774. They are intentionally small, self-contained `tsc` oracles rather
+than generated project snapshots.
+
+Run the oracle with:
+
+```sh
+tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false
+```
+
+Expected result: no diagnostics. Each fixture uses `Assert<Equal<...>>` aliases
+so a checker that widens the utility result, drops a key-space modifier, or
+fails a recursive reduction reports a concrete type error.

--- a/tests/cases/reductions/type-fest/any-never-unknown.ts
+++ b/tests/cases/reductions/type-fest/any-never-unknown.ts
@@ -1,0 +1,26 @@
+// Oracle: `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false`
+// reports no diagnostics. If `IsAny`, `IsNever`, or `IsUnknown` collapses to
+// `boolean`, one of the `Assert` aliases below fails.
+
+export {};
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+type IsUnknown<T> =
+  IsAny<T> extends true ? false
+    : unknown extends T
+      ? [keyof T] extends [never] ? true : false
+      : false;
+
+type AnyIsAny = Assert<Equal<IsAny<any>, true>>;
+type UnknownIsNotAny = Assert<Equal<IsAny<unknown>, false>>;
+type NeverIsNever = Assert<Equal<IsNever<never>, true>>;
+type UnionIsNotNever = Assert<Equal<IsNever<string | never>, false>>;
+type UnknownIsUnknown = Assert<Equal<IsUnknown<unknown>, true>>;
+type AnyIsNotUnknown = Assert<Equal<IsUnknown<any>, false>>;
+type ObjectIsNotUnknown = Assert<Equal<IsUnknown<{ value: string }>, false>>;

--- a/tests/cases/reductions/type-fest/case-conversions.ts
+++ b/tests/cases/reductions/type-fest/case-conversions.ts
@@ -1,0 +1,29 @@
+// Oracle: `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false`
+// reports no diagnostics. These cases force recursive template-literal
+// expansion through nested `infer`, `Lowercase`, and `Capitalize` applications.
+
+export {};
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+type CamelCase<S extends string> =
+  S extends `${infer Head}-${infer Tail}`
+    ? `${Lowercase<Head>}${Capitalize<CamelCase<Tail>>}`
+    : S extends `${infer Head}_${infer Tail}`
+      ? `${Lowercase<Head>}${Capitalize<CamelCase<Tail>>}`
+      : Lowercase<S>;
+
+type KebabCase<S extends string> =
+  S extends `${infer First}${infer Rest}`
+    ? Rest extends Uncapitalize<Rest>
+      ? `${Lowercase<First>}${KebabCase<Rest>}`
+      : `${Lowercase<First>}-${KebabCase<Rest>}`
+    : S;
+
+type CamelFromKebab = Assert<Equal<CamelCase<"user-profile-url">, "userProfileUrl">>;
+type CamelFromSnake = Assert<Equal<CamelCase<"USER_PROFILE_URL">, "userProfileUrl">>;
+type KebabFromCamel = Assert<Equal<KebabCase<"userProfileUrl">, "user-profile-url">>;
+type KebabFromPascal = Assert<Equal<KebabCase<"UserProfileUrl">, "user-profile-url">>;

--- a/tests/cases/reductions/type-fest/deep-get-path.ts
+++ b/tests/cases/reductions/type-fest/deep-get-path.ts
@@ -1,0 +1,43 @@
+// Oracle: `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false`
+// reports no diagnostics. The path parser and indexed-access reducer must keep
+// each recursive property hop precise.
+
+export {};
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+type PathSegments<Path extends string> =
+  Path extends `${infer Head}.${infer Tail}` ? [Head, ...PathSegments<Tail>] : [Path];
+
+type GetAt<T, Parts extends readonly string[]> =
+  Parts extends [infer Head extends string, ...infer Tail extends string[]]
+    ? Head extends keyof T
+      ? Tail extends []
+        ? T[Head]
+        : GetAt<T[Head], Tail>
+      : never
+    : T;
+
+type Get<T, Path extends string> = GetAt<T, PathSegments<Path>>;
+
+type Model = {
+  user: {
+    profile: {
+      name: string;
+      flags: {
+        active: boolean;
+      };
+    };
+  };
+  settings: {
+    theme: "dark" | "light";
+  };
+};
+
+type Name = Assert<Equal<Get<Model, "user.profile.name">, string>>;
+type Active = Assert<Equal<Get<Model, "user.profile.flags.active">, boolean>>;
+type Theme = Assert<Equal<Get<Model, "settings.theme">, "dark" | "light">>;
+type Missing = Assert<Equal<Get<Model, "user.profile.missing">, never>>;

--- a/tests/cases/reductions/type-fest/required-optional-keys.ts
+++ b/tests/cases/reductions/type-fest/required-optional-keys.ts
@@ -1,0 +1,50 @@
+// Oracle: `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false`
+// reports no diagnostics. The assertions exercise `+?` / `-?` mapped modifiers
+// so optionality is determined structurally, not by property spelling.
+
+export {};
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
+type RequiredKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T];
+
+type OptionalKeys<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? K : never
+}[keyof T];
+
+type SetRequired<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: T[P]
+};
+
+type SetOptional<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]+?: T[P]
+};
+
+type Source = {
+  required: string;
+  optional?: number;
+  readonly readonlyRequired: boolean;
+  readonly optionalReadonly?: Date;
+  valueOrUndefined: string | undefined;
+};
+
+type SourceRequired = Assert<
+  Equal<RequiredKeys<Source>, "required" | "readonlyRequired" | "valueOrUndefined">
+>;
+type SourceOptional = Assert<
+  Equal<OptionalKeys<Source>, "optional" | "optionalReadonly">
+>;
+
+type Promoted = SetRequired<Source, "optional" | "optionalReadonly">;
+type PromotedRequired = Assert<
+  Equal<RequiredKeys<Promoted>, keyof Source>
+>;
+type Demoted = SetOptional<Source, "required" | "valueOrUndefined">;
+type DemotedOptional = Assert<
+  Equal<OptionalKeys<Demoted>, "required" | "optional" | "optionalReadonly" | "valueOrUndefined">
+>;

--- a/tests/cases/reductions/type-fest/tsconfig.json
+++ b/tests/cases/reductions/type-fest/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true
+  },
+  "files": [
+    "any-never-unknown.ts",
+    "required-optional-keys.ts",
+    "case-conversions.ts",
+    "deep-get-path.ts"
+  ]
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 1: Project Corpus Dashboard And Fixture Truth / benchmark blocker reductions

## Invariant
When type-fest utility reductions depend on any/never/unknown detection, optionality key-space algebra, recursive template literal case conversion, or dotted-path indexed access, `tsc` accepts the focused oracle. This PR records those `tsc`-green oracles as reduction fixtures without changing compiler behavior.

## Scope
- Add `tests/cases/reductions/type-fest/` with focused fixtures for the #8774 utility families.
- Cover `IsAny`/`IsNever`/`IsUnknown`, `RequiredKeys`/`OptionalKeys`, `CamelCase`/`KebabCase`, and `Get<T, Path>`.
- Add a local `tsconfig.json` and README with the exact oracle command.
- Refresh `docs/plan/agents/Studio-A.md` now that #10035 merged and #9229 is closed unmerged.

## Project Corpus Impact
- Row: type-fest-project
- Bug family: mapped/conditional/key-space utility reductions
- Evidence: `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false` verifies the fixtures are accepted by `tsc`. No checker, solver, emitter, parser, binder, benchmark timing, or project fixture behavior changes.

## Verification
- `tsc -p tests/cases/reductions/type-fest/tsconfig.json --pretty false`
- `python3 -m json.tool tests/cases/reductions/type-fest/tsconfig.json`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- Exact-head draft-light CI passed on `b6f73cb7e96008fbcd1b4925565222f2950ef0d6`: `CI Light Summary`, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, project-row-drift, gate, and GitGuardian.

## Coordination Notes
- Claims #8774 after current-state audit found #9229 closed unmerged and no open successor PR for `type-fest` / `8774`.
- Reuses the focused fixture work from closed PR #9229 on a fresh Studio-A branch from current `origin/main`.
- Closes #8774.
- Marked ready after exact-head draft-light CI passed; no broad benchmark, conformance, emit, fourslash, or project compile suites were run locally.
- Auto-merge remains off until ready-review checks and queue state are complete and green on this exact head.
