### PR TITLE
refactor(checker): route access index relation guard

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1481,7 +1481,8 @@ impl<'a> CheckerState<'a> {
                 // We should not defer this case to IndexAccess(T, ...).
                 if let Some(key_source) =
                     self.keyof_source_type_param(index_type, pre_resolution_object_type)
-                    && !self.is_assignable_to(pre_resolution_object_type, key_source)
+                    && !self
+                        .diagnostic_relation_boolean_guard(pre_resolution_object_type, key_source)
                     && !self.object_constraint_covers_keyof_source(
                         pre_resolution_object_type,
                         key_source,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -489,6 +489,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "class_implements_checker"
             / "jsdoc_heritage.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "classes" / "interface_heritage_index.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "types" / "computation" / "access.rs",
             ROOT
             / "crates"
             / "tsz-checker"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10069.

## Invariant
When indexed access computation reaches the TS2536 diagnostic gate for a generic index source, the boolean relation that decides whether to emit the diagnostic should route through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the indexed access TS2536 generic-key-source diagnostic probe through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `types/computation/access.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-jsdoc-heritage-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `32588d1bb528fbfed6c0b46902a15b2429c4dd65` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10069 (`codex/m1b-jsdoc-heritage-relation-guard-20260524`) at base head `701f236ecabc12447d66bf27cf09cb521b7e1891`.
- Current head: `32588d1bb528fbfed6c0b46902a15b2429c4dd65`.
- Rebased this child after #10069 moved from `f42f4f19891e8e2aa134b9509f1e14694abad961` to `701f236ecabc12447d66bf27cf09cb521b7e1891` using `--onto` so only this PR's indexed-access guard patch replayed.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10072 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
