### PR TITLE
refactor(checker): route decorator relation guards

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -147,7 +147,7 @@ impl<'a> CheckerState<'a> {
         let Some(function_type) = self.global_function_type_id() else {
             return false;
         };
-        self.is_assignable_to(decorator_type, function_type)
+        self.diagnostic_relation_boolean_guard(decorator_type, function_type)
     }
 
     fn global_function_type_id(&mut self) -> Option<TypeId> {
@@ -514,7 +514,7 @@ impl<'a> CheckerState<'a> {
         else {
             return;
         };
-        if !self.is_assignable_to(return_type, expected_return) {
+        if !self.diagnostic_relation_boolean_guard(return_type, expected_return) {
             let return_str = self.format_type_diagnostic(return_type);
             let expected_str = self.format_type_diagnostic(expected_return);
             let message = format_message(
@@ -654,7 +654,7 @@ impl<'a> CheckerState<'a> {
         if matches!(return_type, TypeId::ERROR | TypeId::ANY) {
             return;
         }
-        if !self.is_assignable_to(return_type, TypeId::VOID) {
+        if !self.diagnostic_relation_boolean_guard(return_type, TypeId::VOID) {
             let return_str = self.format_type_diagnostic(return_type);
             let message = format_message(
                 diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_BUT_IS_EXPECTED_TO_BE_VOID_OR_ANY,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -480,6 +480,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "state"
             / "state_checking_members"
+            / "decorator_signature_checks.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "state_checking_members"
             / "statement_helpers.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10072.

## Invariant
When decorator validation needs boolean assignability probes only to decide existing diagnostics, the checker should route those diagnostic-only relations through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route decorator global `Function` compatibility through `diagnostic_relation_boolean_guard`.
- Route method/accessor decorator return-type compatibility through `diagnostic_relation_boolean_guard`.
- Route legacy property decorator `void` return compatibility through `diagnostic_relation_boolean_guard`.
- Preserve the split architecture guard layout by adding `state_checking_members/decorator_signature_checks.rs` to the #8227 raw diagnostic assignability guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-access-index-relation-guard-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `4fec162d84bf79d88cab266ca101cb06a9264084` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10072 (`codex/m1b-access-index-relation-guard-20260524`) at base head `32588d1bb528fbfed6c0b46902a15b2429c4dd65`.
- Current head: `4fec162d84bf79d88cab266ca101cb06a9264084`.
- Rebased this child after #10072 moved from `61d8c61c36ef1e00c521dd93d24cd94f267d1b49` to `32588d1bb528fbfed6c0b46902a15b2429c4dd65` using `--onto` so only this PR's decorator guard patch replayed.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10073 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-decorator-relation-guards-20260524` exists locally/remotely but is not checked out in an active worktree; `/Users/mohsen/code/tsz-m1b-10073` now hosts a later M1-B branch.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
