### PR TITLE
refactor(checker): route index signature relation guards

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -438,9 +438,11 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
 
-                let key_assignable = self.is_assignable_to(key_type, previous_key_type)
+                let key_assignable = self
+                    .diagnostic_relation_boolean_guard(key_type, previous_key_type)
                     || self.template_pattern_key_is_subset(key_type, previous_key_type);
-                let value_assignable = self.is_assignable_to(value_type, previous_value_type);
+                let value_assignable =
+                    self.diagnostic_relation_boolean_guard(value_type, previous_value_type);
                 if key_assignable && !value_assignable {
                     let key_type_str = self.format_type(key_type);
                     let value_type_str = self.format_type(value_type);
@@ -592,7 +594,8 @@ impl<'a> CheckerState<'a> {
         {
             // Only emit when we have own number index nodes to anchor the error,
             // OR when both signatures are inherited (anchor on container).
-            let is_assignable = self.is_assignable_to(number_idx.value_type, string_idx.value_type);
+            let is_assignable = self
+                .diagnostic_relation_boolean_guard(number_idx.value_type, string_idx.value_type);
             if !is_assignable {
                 let num_value_str = self.format_type(number_idx.value_type);
                 let str_value_str = self.format_type(string_idx.value_type);
@@ -645,7 +648,8 @@ impl<'a> CheckerState<'a> {
         if let (Some(static_num_type), Some(static_str_type)) =
             (static_number_value_type, static_string_value_type)
         {
-            let is_assignable = self.is_assignable_to(static_num_type, static_str_type);
+            let is_assignable =
+                self.diagnostic_relation_boolean_guard(static_num_type, static_str_type);
             if !is_assignable {
                 let num_value_str = self.format_type(static_num_type);
                 let str_value_str = self.format_type(static_str_type);

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -487,6 +487,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "state"
             / "state_checking_members"
+            / "index_signature_checks.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "state_checking_members"
             / "statement_helpers.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10073.

## Invariant
Index-signature validation boolean assignability probes for diagnostics such as TS2413 route through the diagnostic relation guard. Behavior is unchanged: this PR only centralizes the existing diagnostic relation decision path.

## Scope
- Route template-pattern index signature key/value checks through `diagnostic_relation_boolean_guard`.
- Route number/string index-signature value compatibility checks through `diagnostic_relation_boolean_guard`.
- Add `state/state_checking_members/index_signature_checks.rs` to the raw diagnostic assignability predicate arch guard roots.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-decorator-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `926ce2124e774951d47997faa12b7217dab2b1dd` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10073 (`codex/m1b-decorator-relation-guards-20260524`) at base head `4fec162d84bf79d88cab266ca101cb06a9264084`.
- Current head: `926ce2124e774951d47997faa12b7217dab2b1dd`.
- Rebased after #10073 moved from `9ee45a3424f1c4df19b0f1d6e439abe6fbb5c398` to `4fec162d84bf79d88cab266ca101cb06a9264084`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10074 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-index-signature-relation-guards-20260524` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
