### PR TITLE
refactor(checker): query function literal display shape

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1438,9 +1438,6 @@ impl<'a> CheckerState<'a> {
         if crate::query_boundaries::common::is_conditional_type(self.ctx.types, target) {
             return target_display;
         }
-        // Callable types use syntax like `{ (x: "foo"): number; }` which has `: "` pattern
-        // but these are parameter literals that should be preserved, not object property
-        // literals that should be widened. Skip rewriting for callable types.
         let evaluated = self.evaluate_type_for_assignability(target);
         let target_is_function_like = [target, evaluated].into_iter().any(|candidate| {
             is_function_like_for_literal_member_widening(self.ctx.types, candidate)

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -20,7 +20,8 @@ pub(crate) use super::assignability_type_helpers::{
 };
 pub(super) use super::assignability_type_helpers::{
     has_own_signature_type_params, is_builtin_wrapper_name, is_callable_application_type,
-    is_object_prototype_method, is_object_prototype_method_for_array_target,
+    is_function_like_for_literal_member_widening, is_object_prototype_method,
+    is_object_prototype_method_for_array_target,
 };
 
 impl<'a> CheckerState<'a> {
@@ -1307,7 +1308,9 @@ impl<'a> CheckerState<'a> {
 
         if self.is_literal_sensitive_assignment_target(target)
             || self.target_preserves_literal_surface(target)
-            || (source_display.contains("=>") && !target_is_constructor_like)
+            || ([source, evaluated_source].into_iter().any(|candidate| {
+                is_function_like_for_literal_member_widening(self.ctx.types, candidate)
+            }) && !target_is_constructor_like)
             || !Self::display_has_member_literals_assignability(&source_display)
         {
             return source_display;
@@ -1438,11 +1441,11 @@ impl<'a> CheckerState<'a> {
         // Callable types use syntax like `{ (x: "foo"): number; }` which has `: "` pattern
         // but these are parameter literals that should be preserved, not object property
         // literals that should be widened. Skip rewriting for callable types.
-        let is_callable_type =
-            crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, target)
-                .is_some();
-        if target_display.contains("=>")
-            || is_callable_type
+        let evaluated = self.evaluate_type_for_assignability(target);
+        let target_is_function_like = [target, evaluated].into_iter().any(|candidate| {
+            is_function_like_for_literal_member_widening(self.ctx.types, candidate)
+        });
+        if target_is_function_like
             || !Self::display_has_member_literals_assignability(&target_display)
         {
             return target_display;
@@ -1452,7 +1455,6 @@ impl<'a> CheckerState<'a> {
         if Self::type_displays_as_application(self.ctx.types, target) {
             return target_display;
         }
-        let evaluated = self.evaluate_type_for_assignability(target);
         let widened = crate::query_boundaries::common::widen_type(self.ctx.types, evaluated);
         let widened = self.widen_function_like_display_type(widened);
         let widened_display = self

--- a/crates/tsz-checker/src/error_reporter/assignability_type_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_type_helpers.rs
@@ -2,6 +2,14 @@
 
 use tsz_solver::TypeId;
 
+pub(super) fn is_function_like_for_literal_member_widening(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    crate::query_boundaries::common::function_shape_for_type(db, type_id).is_some()
+        || crate::query_boundaries::common::callable_shape_for_type(db, type_id).is_some()
+}
+
 /// Returns true if the formatted type name matches a built-in wrapper type
 /// (Boolean, Number, String, Object). These types inherit properties from Object
 /// and missing-property diagnostics should be suppressed in favor of TS2322.

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -2484,6 +2484,32 @@ fn test_numeric_literal_union_display_policy_avoids_rendered_union_separator_dec
     );
 }
 
+#[test]
+fn test_assignability_literal_widening_uses_function_shape_queries() {
+    let src = fs::read_to_string("src/error_reporter/assignability.rs")
+        .expect("failed to read assignability reporter source");
+    let helper_src = fs::read_to_string("src/error_reporter/assignability_type_helpers.rs")
+        .expect("failed to read assignability type helper source");
+
+    for forbidden in [
+        "source_display.contains(\"=>\")",
+        "target_display.contains(\"=>\")",
+    ] {
+        assert!(
+            !src.contains(forbidden),
+            "assignability literal-member widening must use TypeId function/callable \
+             facts, not rendered arrow text: found {forbidden}"
+        );
+    }
+
+    assert!(
+        src.contains("is_function_like_for_literal_member_widening")
+            && helper_src.contains("function_shape_for_type")
+            && helper_src.contains("callable_shape_for_type"),
+        "assignability literal-member widening should query function/callable shapes"
+    );
+}
+
 /// CLAUDE.md §4: Scanner must not import downstream crates (Parser/Binder/Checker/Solver).
 /// The scanner is the leaf of the pipeline; it only does lexing and string interning.
 #[test]


### PR DESCRIPTION
## AgentName
AgentName: M1-C

## Track
M1-C rendered type decision cleanup.

## Invariant
Assignability literal-member widening must preserve function/callable parameter and return literal surfaces based on TypeId function/callable facts, not rendered arrow text.

## Scope
- Replace source-display `contains("=>")` and target-display `contains("=>")` gates in assignability literal-member widening.
- Add `is_function_like_for_literal_member_widening` in assignability type helpers using existing query-boundary function/callable shape queries.
- Check original and evaluated TypeIds before deciding to skip literal-member text widening.
- Add an architecture guard preventing these rendered-arrow decisions from returning in `assignability.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: rendered-type diagnostic decision cleanup
- Evidence: checker diagnostic display-policy refactor only; focused function-literal display tests and architecture guard passed locally.

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p tsz-checker --lib`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_assignability_literal_widening_uses_function_shape_queries) | test(test_rendered_type_decision_patterns_do_not_grow)' --no-fail-fast`
- `cargo nextest run -p tsz-checker --test conformance_issues_features -E 'test(test_missing_property_messages_preserve_function_literal_return_type_display)' --no-fail-fast`
- `cargo nextest run -p tsz-checker --test conformance_issues_errors -E 'test(test_type_assertion_no_overlap_widens_function_literal_return_type) | test(test_ts2345_function_argument_display_widens_unannotated_literal_return)' --no-fail-fast`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib -- -D warnings`
- `git diff --check`
- Ready-review CI green on exact head `d3db8d983e9f1c97fda1eed3f37d53f9e6c157e2`: `CI Summary`, conformance aggregate, fourslash aggregate, emit, WASM, unit, lint, and project gates all succeeded in run `26377306897`.
- Synthetic queue run `26395958045` exposed the checker file-size guard after #10090 landed (`assignability.rs` at 2002 lines). Fixed by commit `62171f63f5c8083abab8844db1575364abe1b877`; local `cargo fmt --all -- --check`, `scripts/arch/check-checker-boundaries.sh`, and `git diff --check` passed.
- Synthetic queue run `26396382580` passed for merge commit `a8d0eca31a473156cb5c242e5a07e35bd77a9794`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26397072254` passed for merge commit `c7d426594050ba2245f9bb80890be8dc3bd45767`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26397732954` passed for merge commit `4f59135c63842f512350860e9949f2c68217af94`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26398577828` passed for merge commit `0b705736cd03e7f68dd8e00a2879831781936da4`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26399693153` passed for merge commit `762dc10977af901b082d0053da868b135ffcee49`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26400603330` passed for merge commit `bd569c610bec33137716e6175d09cda9554387e6`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26401841072` passed for merge commit `ceffd0940b757a30b5de64dfa1b01e01d65fe505`, but `main` advanced and then conflicted before landing, so that run is obsolete for merge.
- Rebasing PR head onto current `main` resolved the architecture guard test conflict by keeping both the numeric-union display guard and this function-shape guard; local `cargo fmt --all -- --check`, `scripts/arch/check-checker-boundaries.sh`, and `git diff --check` passed.
- Synthetic queue run `26402843171` passed for merge commit `73a54c5f052a873777aa1a2403239cdf405d8df7`, but `main` advanced before landing, so that run is obsolete for merge.
- Synthetic queue run `26404039182` for merge commit `b530d13f413281cf18c3b84d0d6190ab9acc2fee` is obsolete because `main` advanced before landing.
- Synthetic queue run `26404519319` for merge commit `127e402c28df6ba3ba5f1043623de9191f994584` is obsolete because `main` advanced before landing.
- Synthetic queue run pending for merge commit `18f2bff7fcf54c5bb00cfc4c288bb8302466d503` (parents current `main` `52f60feac90a15b1cba027908b6a7d51eeef5097` + `30de43759caca185f573fec6bc8f32bf11b58626`): https://github.com/mohsen1/tsz/actions/runs/26405211435

## Coordination Notes
AgentName: M1-C. Existing M1-C PRs were inspected first this cycle. On 2026-05-25, exact head `d3db8d983e9f1c97fda1eed3f37d53f9e6c157e2` had a complete green ready-review check picture. M1-C requested squash auto-merge, but GitHub cleared `autoMergeRequest` shortly after while leaving the PR open. This remains ready but branch-protection blocked; do not repeatedly re-arm auto-merge without a new blocker/fresh queue signal. This slice is non-overlapping with #9272 alias display, #10045 nominal call suppression, #10062 optional mapped undefined, #10071/#10076 optional undefined display, #10082 numeric union display, #10084 rest-any callable display, and #10085 callable missing-property suppression.

AgentName: M1-C queue note (2026-05-25): Rebuilt synthetic merge queue branch `automation/merge-queue/pr-10086` at `18f2bff7fcf54c5bb00cfc4c288bb8302466d503` against current main `52f60feac90a15b1cba027908b6a7d51eeef5097` after `main` moved again; local `cargo fmt --all -- --check`, `scripts/arch/check-checker-boundaries.sh`, and `git diff --check origin/main..HEAD` passed. CI run `26405211435` is pending and is the next landing gate.


