### PR TITLE
docs(agents): refresh M1-D lane queue

### DIFF
--- a/docs/plan/agents/M1-D.md
+++ b/docs/plan/agents/M1-D.md
@@ -24,19 +24,30 @@ scripts/agents/list-owned-work.sh M1-D
 
 - Initial priority: land, close, or clearly hand off existing PRs in this lane
   before claiming issue backlog.
-- Issue context: `#8780`, `#8424`.
-- Related PRs to inspect: `#8919`, `#8903`, `#8982`, `#8661`, `#8470`.
 - Track: roadmap Track 6.
-- Next concrete step: determine whether the destructured-discriminant work has
-  a live owner. If not, take the smallest repro path and preserve the rule with
-  a checker or solver test.
+- Current owned PR queue:
+  - `#10075`: ready refactor PR; wait for exact-head required CI, then land or
+    fix any failing check.
+  - `#9933`: ready conditional-break narrowing PR; wait for exact-head heavy
+    CI/queue, then land or fix any failing check.
+  - `#9937`: draft enum equality narrowing PR; promote only after exact-head
+    draft-light CI is clean, then let ready-review CI be the landing authority.
+  - `#9889`: draft do-while narrowing PR stacked on `#9933`; keep parked until
+    `#9933` lands or the stack is otherwise resolved, then rebase onto `main`
+    and mark ready after focused verification.
+- Historical issue context: `#8780` and `#8424` are closed; related PRs
+  `#8919`, `#8903`, `#8982`, and `#8470` are merged, while `#8661` was closed.
+- Next concrete step after the owned PR queue is clear: search for an open
+  Track 6 narrowing or flow-predicate issue with no live owner. If one exists,
+  take the smallest structural repro path and preserve the rule with checker or
+  solver tests.
 
 ## Existing Work To Inspect First
 
-- `#8919` and `#8903` both touch destructured or aliased discriminant
-  behavior.
-- `#8982` handles class property initializer narrowing reset.
-- `#8661` handles `Symbol.hasInstance`-aware `instanceof` narrowing.
+- Inspect the current `agent:M1-D` PRs first; they are the active ownership
+  surface for this lane.
+- Treat `#8919`, `#8903`, `#8982`, `#8661`, and `#8470` as historical context
+  only unless a new open issue explicitly depends on them.
 
 ## Non-Overlap Rules
 


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Track 6 lane coordination / docs-only agent goal refresh.

## Invariant
When the lane-control file names stale closed issues as the next action, future M1-D cycles can duplicate completed work instead of draining the active PR queue. This PR updates the M1-D goal file so agents inspect and act on the current owned PRs before searching for new narrowing backlog.

## Scope
- `docs/plan/agents/M1-D.md`: replace the closed destructured-discriminant next step with the current M1-D PR queue and move the old issue/PR list to historical context.

## Verification
- `git diff --check` -> passed.
- `wc -l docs/plan/agents/M1-D.md` -> 65 lines.
- Pre-commit formatting hook ran during commit; no staged Rust files changed.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-control update; no compiler, harness, fixture, or project corpus behavior changes.

## Coordination Notes
- The active M1-D queue remains #10075, #9937, #9933, and #9889.
- #9937 was marked ready after exact-head draft-light CI passed; ready-review CI is now pending and remains the landing authority.
- No issue ownership label is applied, per M1-D instruction to keep `agent:M1-D` labels on PRs only for now.
