### PR TITLE
ci: skip active merge queue runs

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -226,6 +226,12 @@ export function activeBranchQueueRun(runs) {
   return (runs || []).find((run) => queueRunIsActive(run)) || null;
 }
 
+export function activeSyntheticQueueRun(runs, headSha) {
+  return (runs || []).find((run) => (
+    queueRunIsActive(run) && (!headSha || run.headSha === headSha)
+  )) || null;
+}
+
 function activePendingQueueRun(repository, pr, options) {
   const pendingRun = pendingQueueRun(pr, options.statusContext);
   if (pendingRun) {
@@ -320,7 +326,7 @@ function readBranchWorkflowRuns(repository, branch) {
     "--repo", repository,
     "--branch", branch,
     "--limit", "20",
-    "--json", "databaseId,status,conclusion,url",
+    "--json", "databaseId,status,conclusion,headSha,url",
   ]);
 }
 
@@ -451,15 +457,26 @@ function commitStatusRollup(repository, sha) {
   ];
 }
 
-function waitForSyntheticChecks(repository, mergeOid, options) {
+function waitForSyntheticChecks(repository, synthetic, options) {
   for (let attempt = 0; attempt < options.waitAttempts; attempt += 1) {
     const state = requiredCheckState(
-      commitStatusRollup(repository, mergeOid),
+      commitStatusRollup(repository, synthetic.mergeOid),
       options.mergeRequiredChecks,
     );
     if (state.kind === "passed") return state;
     if (state.kind === "failed") throw new Error(state.reason);
     if (attempt + 1 < options.waitAttempts) sleep(options.waitIntervalMs);
+  }
+  const activeRun = activeSyntheticQueueRun(
+    readBranchWorkflowRuns(repository, synthetic.branch),
+    synthetic.mergeOid,
+  );
+  if (activeRun) {
+    return {
+      kind: "pending",
+      reason: `timed out while synthetic run ${activeRun.databaseId || "(unknown)"} is still active`,
+      activeRun,
+    };
   }
   throw new Error(`timed out waiting for synthetic merge check(s): ${options.mergeRequiredChecks.join(", ")}`);
 }
@@ -491,7 +508,18 @@ function processOne(repository, options) {
     invalidatePullRequest(repository, pr, options);
     try {
       const synthetic = prepareSyntheticMerge(repository, pr, baseOid, options);
-      waitForSyntheticChecks(repository, synthetic.mergeOid, options);
+      const syntheticState = waitForSyntheticChecks(repository, synthetic, options);
+      if (syntheticState.activeRun) {
+        postStatus(
+          repository,
+          pr.headRefOid,
+          "pending",
+          options.statusContext,
+          `Waiting for synthetic run ${syntheticState.activeRun.databaseId || synthetic.mergeOid.slice(0, 12)}`,
+          syntheticState.activeRun.url || "",
+        );
+        return { selected: pr, pendingSynthetic: true, synthetic, activeRun: syntheticState.activeRun, skips };
+      }
       const refreshed = readPullRequest(repository, pr.number);
       const currentBase = readBranchOid(repository, options.base);
       if (currentBase !== baseOid) {
@@ -564,6 +592,10 @@ export function formatResult(result, options) {
     lines.push(`Retest needed for #${result.selected.number}: base moved from \`${result.oldBaseOid.slice(0, 12)}\` to \`${result.newBaseOid.slice(0, 12)}\`.`);
   } else if (result.headMoved) {
     lines.push(`Retest needed for #${result.selected.number}: PR head moved during queue test.`);
+  } else if (result.pendingSynthetic) {
+    const runId = result.activeRun?.databaseId || "(unknown)";
+    const runUrl = result.activeRun?.url ? ` (${result.activeRun.url})` : "";
+    lines.push(`Preserved #${result.selected.number}: synthetic run ${runId}${runUrl} is still active after the queue wait window.`);
   } else if (result.failed) {
     lines.push(`Failed #${result.selected.number}: ${result.reason}`);
   }

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -209,6 +209,21 @@ export function pendingQueueRun(pr, statusContext) {
   return runId ? { runId, targetUrl: status.targetUrl } : null;
 }
 
+export function queueRunIsActive(run) {
+  return normalize(run?.status) !== "COMPLETED";
+}
+
+function activePendingQueueRun(repository, pr, statusContext) {
+  const pendingRun = pendingQueueRun(pr, statusContext);
+  if (!pendingRun) return null;
+  const run = readWorkflowRun(repository, pendingRun.runId);
+  if (!queueRunIsActive(run)) return null;
+  return {
+    ...pendingRun,
+    url: run.url || pendingRun.targetUrl,
+  };
+}
+
 export function queueSkipReason(pr, requiredState, base) {
   if (pr.baseRefName !== base) return `base is ${pr.baseRefName || "(unknown)"}, not ${base}`;
   if (pr.isDraft) return "draft PR";
@@ -308,7 +323,10 @@ function postComment(repository, number, body) {
 }
 
 function invalidatePullRequest(repository, pr, options) {
-  if (options.dryRun) return;
+  if (options.dryRun) return { invalidated: false, skipped: false };
+  const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
+  const activeRun = activePendingQueueRun(repository, detailed, options.statusContext);
+  if (activeRun) return { invalidated: false, skipped: true, activeRun };
   postStatus(
     repository,
     pr.headRefOid,
@@ -316,12 +334,19 @@ function invalidatePullRequest(repository, pr, options) {
     options.statusContext,
     `Waiting for ${options.base} synthetic merge test`,
   );
+  return { invalidated: true, skipped: false };
 }
 
 function invalidateOpen(repository, options) {
   const prs = readPullRequests(repository, options.base, options.maxPrs);
-  for (const pr of prs) invalidatePullRequest(repository, pr, options);
-  return { invalidated: prs.length };
+  let invalidated = 0;
+  let skippedActiveRuns = 0;
+  for (const pr of prs) {
+    const result = invalidatePullRequest(repository, pr, options);
+    if (result?.invalidated) invalidated += 1;
+    if (result?.skipped) skippedActiveRuns += 1;
+  }
+  return { invalidated, skippedActiveRuns };
 }
 
 function readQueueCandidates(repository, options) {
@@ -334,15 +359,12 @@ function readQueueCandidates(repository, options) {
       const requiredState = requiredCheckState(detailed.statusCheckRollup, options.prRequiredChecks);
       const detailedSkipReason = queueSkipReason(detailed, requiredState, options.base);
       if (detailedSkipReason) return { pr: detailed, skipReason: detailedSkipReason };
-      const pendingRun = pendingQueueRun(detailed, options.statusContext);
-      if (pendingRun) {
-        const run = readWorkflowRun(repository, pendingRun.runId);
-        if (normalize(run.status) !== "COMPLETED") {
-          return {
-            pr: detailed,
-            skipReason: `queue test already running (${run.url || pendingRun.targetUrl})`,
-          };
-        }
+      const activeRun = activePendingQueueRun(repository, detailed, options.statusContext);
+      if (activeRun) {
+        return {
+          pr: detailed,
+          skipReason: `queue test already running (${activeRun.url})`,
+        };
       }
       return {
         pr: detailed,
@@ -498,6 +520,9 @@ export function formatResult(result, options) {
   ];
   if (result.invalidated !== undefined) {
     lines.push(`Invalidated ${result.invalidated} open PR head(s).`);
+    if (result.skippedActiveRuns) {
+      lines.push(`Preserved ${result.skippedActiveRuns} active queue run status(es).`);
+    }
   } else if (!result.selected) {
     lines.push("No queue-ready auto-merge PR found.");
   } else if (result.dryRun) {
@@ -526,8 +551,11 @@ function main() {
   let result;
   if (options.invalidatePr !== null) {
     const pr = readPullRequest(options.repository, options.invalidatePr);
-    invalidatePullRequest(options.repository, pr, options);
-    result = { invalidated: 1 };
+    const invalidation = invalidatePullRequest(options.repository, pr, options);
+    result = {
+      invalidated: invalidation?.invalidated ? 1 : 0,
+      skippedActiveRuns: invalidation?.skipped ? 1 : 0,
+    };
   } else if (options.invalidateOpen) {
     result = invalidateOpen(options.repository, options);
   } else {

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -193,6 +193,22 @@ export function requiredCheckState(checks, requiredNames) {
   return { kind: "passed", reason: "required checks passed" };
 }
 
+function actionsRunIdFromUrl(url) {
+  const match = String(url || "").match(/\/actions\/runs\/(\d+)(?:\D|$)/);
+  return match ? match[1] : null;
+}
+
+export function pendingQueueRun(pr, statusContext) {
+  const status = (pr.statusCheckRollup || []).find((check) => (
+    check.__typename === "StatusContext"
+      && check.context === statusContext
+      && normalize(check.state) === "PENDING"
+  ));
+  if (!status?.targetUrl) return null;
+  const runId = actionsRunIdFromUrl(status.targetUrl);
+  return runId ? { runId, targetUrl: status.targetUrl } : null;
+}
+
 export function queueSkipReason(pr, requiredState, base) {
   if (pr.baseRefName !== base) return `base is ${pr.baseRefName || "(unknown)"}, not ${base}`;
   if (pr.isDraft) return "draft PR";
@@ -254,6 +270,14 @@ function readPullRequest(repository, number) {
   ]);
 }
 
+function readWorkflowRun(repository, runId) {
+  return runGhJson([
+    "run", "view", runId,
+    "--repo", repository,
+    "--json", "status,conclusion,url",
+  ]);
+}
+
 function readBranchOid(repository, branch) {
   return runGhJson([
     "api",
@@ -307,13 +331,22 @@ function readQueueCandidates(repository, options) {
       const skipReason = queueSkipReason(pr, { kind: "passed" }, options.base);
       if (skipReason) return { pr, skipReason };
       const detailed = readPullRequest(repository, pr.number);
+      const requiredState = requiredCheckState(detailed.statusCheckRollup, options.prRequiredChecks);
+      const detailedSkipReason = queueSkipReason(detailed, requiredState, options.base);
+      if (detailedSkipReason) return { pr: detailed, skipReason: detailedSkipReason };
+      const pendingRun = pendingQueueRun(detailed, options.statusContext);
+      if (pendingRun) {
+        const run = readWorkflowRun(repository, pendingRun.runId);
+        if (normalize(run.status) !== "COMPLETED") {
+          return {
+            pr: detailed,
+            skipReason: `queue test already running (${run.url || pendingRun.targetUrl})`,
+          };
+        }
+      }
       return {
         pr: detailed,
-        skipReason: queueSkipReason(
-          detailed,
-          requiredCheckState(detailed.statusCheckRollup, options.prRequiredChecks),
-          options.base,
-        ),
+        skipReason: null,
       };
     });
 }

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -209,18 +209,39 @@ export function pendingQueueRun(pr, statusContext) {
   return runId ? { runId, targetUrl: status.targetUrl } : null;
 }
 
+export function hasPendingPlaceholderQueueStatus(pr, statusContext) {
+  return (pr.statusCheckRollup || []).some((check) => (
+    check.__typename === "StatusContext"
+      && check.context === statusContext
+      && normalize(check.state) === "PENDING"
+      && !check.targetUrl
+  ));
+}
+
 export function queueRunIsActive(run) {
   return normalize(run?.status) !== "COMPLETED";
 }
 
-function activePendingQueueRun(repository, pr, statusContext) {
-  const pendingRun = pendingQueueRun(pr, statusContext);
-  if (!pendingRun) return null;
-  const run = readWorkflowRun(repository, pendingRun.runId);
-  if (!queueRunIsActive(run)) return null;
+export function activeBranchQueueRun(runs) {
+  return (runs || []).find((run) => queueRunIsActive(run)) || null;
+}
+
+function activePendingQueueRun(repository, pr, options) {
+  const pendingRun = pendingQueueRun(pr, options.statusContext);
+  if (pendingRun) {
+    const run = readWorkflowRun(repository, pendingRun.runId);
+    if (!queueRunIsActive(run)) return null;
+    return {
+      ...pendingRun,
+      url: run.url || pendingRun.targetUrl,
+    };
+  }
+  if (!hasPendingPlaceholderQueueStatus(pr, options.statusContext)) return null;
+  const run = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranch(options, pr)));
+  if (!run) return null;
   return {
-    ...pendingRun,
-    url: run.url || pendingRun.targetUrl,
+    runId: String(run.databaseId || ""),
+    url: run.url,
   };
 }
 
@@ -289,7 +310,17 @@ function readWorkflowRun(repository, runId) {
   return runGhJson([
     "run", "view", runId,
     "--repo", repository,
-    "--json", "status,conclusion,url",
+    "--json", "databaseId,status,conclusion,url",
+  ]);
+}
+
+function readBranchWorkflowRuns(repository, branch) {
+  return runGhJson([
+    "run", "list",
+    "--repo", repository,
+    "--branch", branch,
+    "--limit", "20",
+    "--json", "databaseId,status,conclusion,url",
   ]);
 }
 
@@ -325,7 +356,7 @@ function postComment(repository, number, body) {
 function invalidatePullRequest(repository, pr, options) {
   if (options.dryRun) return { invalidated: false, skipped: false };
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
-  const activeRun = activePendingQueueRun(repository, detailed, options.statusContext);
+  const activeRun = activePendingQueueRun(repository, detailed, options);
   if (activeRun) return { invalidated: false, skipped: true, activeRun };
   postStatus(
     repository,
@@ -359,7 +390,7 @@ function readQueueCandidates(repository, options) {
       const requiredState = requiredCheckState(detailed.statusCheckRollup, options.prRequiredChecks);
       const detailedSkipReason = queueSkipReason(detailed, requiredState, options.base);
       if (detailedSkipReason) return { pr: detailed, skipReason: detailedSkipReason };
-      const activeRun = activePendingQueueRun(repository, detailed, options.statusContext);
+      const activeRun = activePendingQueueRun(repository, detailed, options);
       if (activeRun) {
         return {
           pr: detailed,

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -4,6 +4,7 @@ import {
   formatResult,
   pendingQueueRun,
   parseArgs,
+  queueRunIsActive,
   queueSkipReason,
   requiredCheckState,
 } from "./poor-mans-merge-queue.mjs";
@@ -80,6 +81,9 @@ assert.equal(
   }), "Queue Tested"),
   null,
 );
+assert.equal(queueRunIsActive({ status: "queued" }), true);
+assert.equal(queueRunIsActive({ status: "in_progress" }), true);
+assert.equal(queueRunIsActive({ status: "completed", conclusion: "cancelled" }), false);
 
 assert.equal(queueSkipReason(pr({ isDraft: true }), { kind: "passed" }, "main"), "draft PR");
 assert.equal(queueSkipReason(pr({ autoMergeRequest: null }), { kind: "passed" }, "main"), "auto-merge is not armed");
@@ -96,6 +100,14 @@ assert.match(
     skips: [],
   }, parseArgs(["--repository", "owner/repo", "--dry-run"])),
   /Would synthetic-test and merge #42/,
+);
+
+assert.match(
+  formatResult({
+    invalidated: 12,
+    skippedActiveRuns: 2,
+  }, parseArgs(["--repository", "owner/repo", "--invalidate-open"])),
+  /Preserved 2 active queue run status/,
 );
 
 assert.match(

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   activeBranchQueueRun,
+  activeSyntheticQueueRun,
   formatResult,
   hasPendingPlaceholderQueueStatus,
   pendingQueueRun,
@@ -124,6 +125,19 @@ assert.equal(
   ]),
   null,
 );
+assert.deepEqual(
+  activeSyntheticQueueRun([
+    { databaseId: 1, status: "queued", conclusion: "", headSha: "a".repeat(40), url: "https://github.example/runs/1" },
+    { databaseId: 2, status: "queued", conclusion: "", headSha: "b".repeat(40), url: "https://github.example/runs/2" },
+  ], "b".repeat(40)),
+  { databaseId: 2, status: "queued", conclusion: "", headSha: "b".repeat(40), url: "https://github.example/runs/2" },
+);
+assert.equal(
+  activeSyntheticQueueRun([
+    { databaseId: 1, status: "completed", conclusion: "success", headSha: "b".repeat(40), url: "https://github.example/runs/1" },
+  ], "b".repeat(40)),
+  null,
+);
 
 assert.equal(queueSkipReason(pr({ isDraft: true }), { kind: "passed" }, "main"), "draft PR");
 assert.equal(queueSkipReason(pr({ autoMergeRequest: null }), { kind: "passed" }, "main"), "auto-merge is not armed");
@@ -170,6 +184,17 @@ assert.match(
     skips: [],
   }, parseArgs(["--repository", "owner/repo"])),
   /Retest needed/,
+);
+
+assert.match(
+  formatResult({
+    selected: pr(),
+    pendingSynthetic: true,
+    synthetic: { mergeOid: "c".repeat(40) },
+    activeRun: { databaseId: 123, url: "https://github.example/runs/123" },
+    skips: [],
+  }, parseArgs(["--repository", "owner/repo"])),
+  /synthetic run 123.*still active/,
 );
 
 console.log("poor man's merge queue tests passed");

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   formatResult,
+  pendingQueueRun,
   parseArgs,
   queueSkipReason,
   requiredCheckState,
@@ -51,6 +52,34 @@ assert.equal(requiredCheckState([check({ conclusion: "FAILURE" })], ["CI Summary
 assert.equal(requiredCheckState([], ["CI Summary"]).kind, "missing");
 assert.equal(requiredCheckState([{ context: "Queue Tested", state: "SUCCESS" }], ["Queue Tested"]).kind, "passed");
 assert.equal(requiredCheckState([{ context: "Queue Tested", state: "PENDING" }], ["Queue Tested"]).kind, "pending");
+assert.deepEqual(
+  pendingQueueRun(pr({
+    statusCheckRollup: [
+      {
+        __typename: "StatusContext",
+        context: "Queue Tested",
+        state: "PENDING",
+        targetUrl: "https://github.com/owner/repo/actions/runs/123456789",
+      },
+    ],
+  }), "Queue Tested"),
+  {
+    runId: "123456789",
+    targetUrl: "https://github.com/owner/repo/actions/runs/123456789",
+  },
+);
+assert.equal(
+  pendingQueueRun(pr({
+    statusCheckRollup: [
+      {
+        __typename: "StatusContext",
+        context: "Queue Tested",
+        state: "PENDING",
+      },
+    ],
+  }), "Queue Tested"),
+  null,
+);
 
 assert.equal(queueSkipReason(pr({ isDraft: true }), { kind: "passed" }, "main"), "draft PR");
 assert.equal(queueSkipReason(pr({ autoMergeRequest: null }), { kind: "passed" }, "main"), "auto-merge is not armed");

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import {
+  activeBranchQueueRun,
   formatResult,
+  hasPendingPlaceholderQueueStatus,
   pendingQueueRun,
   parseArgs,
   queueRunIsActive,
@@ -81,9 +83,47 @@ assert.equal(
   }), "Queue Tested"),
   null,
 );
+assert.equal(
+  hasPendingPlaceholderQueueStatus(pr({
+    statusCheckRollup: [
+      {
+        __typename: "StatusContext",
+        context: "Queue Tested",
+        state: "PENDING",
+      },
+    ],
+  }), "Queue Tested"),
+  true,
+);
+assert.equal(
+  hasPendingPlaceholderQueueStatus(pr({
+    statusCheckRollup: [
+      {
+        __typename: "StatusContext",
+        context: "Queue Tested",
+        state: "PENDING",
+        targetUrl: "https://github.com/owner/repo/actions/runs/123456789",
+      },
+    ],
+  }), "Queue Tested"),
+  false,
+);
 assert.equal(queueRunIsActive({ status: "queued" }), true);
 assert.equal(queueRunIsActive({ status: "in_progress" }), true);
 assert.equal(queueRunIsActive({ status: "completed", conclusion: "cancelled" }), false);
+assert.deepEqual(
+  activeBranchQueueRun([
+    { databaseId: 1, status: "completed", conclusion: "cancelled", url: "https://github.example/runs/1" },
+    { databaseId: 2, status: "queued", conclusion: "", url: "https://github.example/runs/2" },
+  ]),
+  { databaseId: 2, status: "queued", conclusion: "", url: "https://github.example/runs/2" },
+);
+assert.equal(
+  activeBranchQueueRun([
+    { databaseId: 1, status: "completed", conclusion: "cancelled", url: "https://github.example/runs/1" },
+  ]),
+  null,
+);
 
 assert.equal(queueSkipReason(pr({ isDraft: true }), { kind: "passed" }, "main"), "draft PR");
 assert.equal(queueSkipReason(pr({ autoMergeRequest: null }), { kind: "passed" }, "main"), "auto-merge is not armed");


### PR DESCRIPTION
AgentName: M1-A

## Track
Track 0 / M1-A PR readiness and merge-queue hygiene.

## Invariant
The poor-man merge queue should not repeatedly select or restart a PR while an exact-head synthetic queue run is already active for its `Queue Tested` status.

## Scope
- Detect pending `Queue Tested` statuses that point at GitHub Actions run URLs.
- Preserve those run-linked pending statuses during `--invalidate-open` and `--invalidate-pr` when the referenced workflow run is still active.
- Inspect the referenced workflow run and skip the PR while that run is not completed.
- Keep placeholder pending statuses without a run URL queueable only when there is no active synthetic CI run on the PR queue branch.
- Inspect active `automation/merge-queue/pr-<number>` workflow runs so placeholder statuses do not cause duplicate queue attempts.
- Preserve a linked pending `Queue Tested` status when the queue controller wait window expires but the exact synthetic run is still active.
- Add focused Node coverage for extracting active queue-run status data, placeholder-status branch-run fallback behavior, and active-run timeout preservation.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-tooling-only change in `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, benchmark, emit, checker, solver, parser, binder, LSP, or WASM behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/check-wip-state-comments.mjs --repository mohsen1/tsz --window-hours 24 --advisory`

## Coordination Notes
- AgentName: M1-A
- This came from the live queue state where #10029 already had `Queue Tested` pending for workflow run `26375446234`, but the dry-run still selected it for another synthetic test.
- The same stale-run race repeated after older queue attempts overwrote #9912 and #9933 run-linked `Queue Tested` statuses with push-lease failures while their workflow-dispatch runs were still queued.
- Current queue state after the first refresh: #10078 run `26375361829` was still queued with a run-linked `Queue Tested` status; #10029 run `26375708818` canceled and #10029 was back to placeholder `Queue Tested` pending; #9933 merged after the queue race was resolved.
- Pushed follow-up head `45a76c81c329d83194b526e5f498b42f83123097` to preserve active run-linked statuses during invalidation. Exact-head CI was green, including `CI Summary`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `project-corpus-pr-body`, `gate`, and GitGuardian.
- Pushed follow-up head `21ee674f4d9b8a63604aa1e32d63cfbc19255e66` to also detect active synthetic queue runs from placeholder `Queue Tested` statuses by checking the `automation/merge-queue/pr-<number>` branch. Local verification: `node scripts/ci/test-poor-mans-merge-queue.mjs`, `git diff --check`, and `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose` now reports no queue-ready PR while #10089 run `26376938904` is active.
- Exact-head CI for `21ee674f4d9b8a63604aa1e32d63cfbc19255e66` is green. Squash auto-merge was re-armed at 2026-05-25 00:52 UTC, and `Queue Tested` is pending via synthetic queue run https://github.com/mohsen1/tsz/actions/runs/26377708249 on `automation/merge-queue/pr-10089` after refreshing the stale queue-branch lease.
- AgentName: M1-A update 2026-05-25: Disabled squash auto-merge while required `Queue Tested` is still pending. Synthetic queue run https://github.com/mohsen1/tsz/actions/runs/26377708249 remains `pending` with no jobs; the queue dry-run reports no queue-ready auto-merge PR, so #10089 is not being duplicated while the active queue state is pending. Next owner/action: wait for a terminal queue result, then re-arm/merge only if every required current-head check is complete and green; inspect failed logs and repair/comment if it fails.
- AgentName: M1-A update 2026-05-25: Cancelled stale older queue run https://github.com/mohsen1/tsz/actions/runs/26376938904 on obsolete synthetic SHA `0897b4173379` because it was occupying the queue branch concurrency group. Current synthetic run https://github.com/mohsen1/tsz/actions/runs/26377708249 on `8a017b925014` now has jobs and is queued/running. Auto-merge remains off until `Queue Tested` reaches a terminal green state.
- AgentName: M1-A update 2026-05-25: Pushed follow-up head `bf935a6b82f9` after live queue run `26377697597` posted a false red `Queue Tested` timeout while synthetic run `26377708249` for exact queue SHA `8a017b925014` was still active. The queue script now preserves a linked pending status instead of failing the PR when the exact synthetic run is still active after the wait window. Local verification: `node scripts/ci/test-poor-mans-merge-queue.mjs`, `git diff --check`, `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`, and the WIP advisory. Auto-merge remains off until exact-head CI and a fresh queue test are complete and green.