### PR TITLE
refactor(checker): query related index object display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -4,8 +4,7 @@
 //! file under the LOC ceiling. Pure file-organization move; no logic changes.
 
 use super::literal_widening_helpers::{
-    literal_display_appropriate_for_undefined_null_target, simple_or_namespace_member_name,
-    target_accepts_literal_primitive_kind,
+    literal_display_appropriate_for_undefined_null_target, target_accepts_literal_primitive_kind,
 };
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -1379,16 +1378,13 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let source_object_display = self.format_type_for_assignability_message(source_object);
-        let target_object_display = self.format_type_for_assignability_message(target_object);
-        let source_short = simple_or_namespace_member_name(&source_object_display)?;
-        let target_short = simple_or_namespace_member_name(&target_object_display)?;
-        if source_short != target_short {
+        if source_object != target_object {
             return None;
         }
 
+        let object_name = self.named_type_display_name(source_object)?;
         let source_index_display = self.ctx.types.resolve_atom_ref(source_index_info.name);
-        Some(format!("{source_short}[{source_index_display}]"))
+        Some(format!("{object_name}[{source_index_display}]"))
     }
 
     pub(in crate::error_reporter) fn format_nested_assignment_source_type_for_diagnostic(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/literal_widening_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/literal_widening_helpers.rs
@@ -2,26 +2,6 @@
 
 use tsz_solver::TypeId;
 
-pub(super) fn simple_or_namespace_member_name(display: &str) -> Option<&str> {
-    if display.starts_with("typeof ")
-        || display.starts_with("import(")
-        || display.contains('<')
-        || display.contains('[')
-        || display.contains(' ')
-    {
-        return None;
-    }
-    let name = display.rsplit_once('.').map_or(display, |(_, short)| short);
-    let mut chars = name.chars();
-    let first = chars.next()?;
-    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
-        return None;
-    }
-    chars
-        .all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
-        .then_some(name)
-}
-
 /// Whether `target` accepts a literal whose widened primitive kind is
 /// `source_primitive` for "literal-of-contextual-type" purposes.
 pub(super) fn target_accepts_literal_primitive_kind(


### PR DESCRIPTION
## AgentName
AgentName: M1-C

## Track
M1-C rendered/source-text diagnostic cleanup.

## Invariant
Related generic indexed-access TS2322 display must be selected from structural type facts: both sides are indexed-access types over the same object operand, and the index operands are distinct type parameters. The decision must not parse formatted object display strings.

## Scope
- Replace `related_generic_indexed_access_source_display` object-display formatting and string parsing with a direct shared-object `TypeId` check.
- Reuse the existing named-type display identity for the final object name in the diagnostic surface.
- Remove the now-unused local `simple_or_namespace_member_name` parser from assignment literal-widening helpers.

## Project Corpus Impact
- Row: n/a
- Bug family: rendered-type diagnostic decision cleanup
- Evidence: checker diagnostic display only; no project-corpus fixture or runtime behavior change expected.

## Verification
- `cargo nextest run -p tsz-checker --test ts2322_tests -E 'test(index_access_type_parameter_mismatch_elaboration)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo fmt --all -- --check`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `cargo check -p tsz-checker --lib`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
AgentName: M1-C. Ready PR on head `6bb44b0b159bf3ecc489e8f1832112d9f7216673`; exact-head ready-review CI is green.
- Synthetic queue branch `automation/merge-queue/pr-10091` is testing merge commit `ba1a269424ee1e6815689de2847572589afb8b75` with parents `b0a91e0289296cda11aa2c7b43dbeb1cd695b21e` (main) and `6bb44b0b159bf3ecc489e8f1832112d9f7216673` (PR head). CI run: https://github.com/mohsen1/tsz/actions/runs/26394615149.
- `Queue Tested` is pending on the PR head for that synthetic run; auto-merge remains off until the owning lane verifies the completed run and unchanged refs.
- This is non-overlapping with #9272 alias display query-boundary work, #9162 rendered-type predicate cleanup, #8983 JSX rendered decisions, and #8972 builtin iterator display provenance.
