### PR TITLE
refactor(checker): route explicit alias constraint relation guard

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
@@ -29,7 +29,7 @@ impl<'a> CheckerState<'a> {
         let explicit_base_resolved = self.resolve_lazy_members_in_union(explicit_base);
         let explicit_base_for_check = self.evaluate_type_for_assignability(explicit_base_resolved);
         let inst_constraint_for_check = self.evaluate_type_for_assignability(inst_constraint);
-        self.is_assignable_to(explicit_base_for_check, inst_constraint_for_check)
+        self.diagnostic_relation_boolean_guard(explicit_base_for_check, inst_constraint_for_check)
             || self.base_union_members_satisfy_constraint(
                 explicit_base_for_check,
                 inst_constraint_for_check,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -522,6 +522,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "declaration.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "generic_checker"
+            / "explicit_alias_constraint_helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "parameter_checker.rs",
             ROOT


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10074.

## Invariant
Explicit alias type-parameter constraint validation uses a boolean assignability probe only to decide whether the existing TS2344-style constraint path is satisfied. The diagnostic-only relation now routes through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the explicit-alias constraint satisfaction probe in `crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs` through `diagnostic_relation_boolean_guard`.
- Add `explicit_alias_constraint_helpers.rs` to the #8227 raw diagnostic assignability predicate arch guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-index-signature-relation-guards-20260524...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `3d4e5b156a4af3d0e8cd93de2a29e071e0a62fb7` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10074 (`codex/m1b-index-signature-relation-guards-20260524`) at base head `926ce2124e774951d47997faa12b7217dab2b1dd`.
- Current head: `3d4e5b156a4af3d0e8cd93de2a29e071e0a62fb7`.
- Rebased after #10074 moved from `cc4755dc340f9c08a7fabf11eb784078b2a8a6f1` to `926ce2124e774951d47997faa12b7217dab2b1dd`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10092 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-explicit-alias-constraint-relation-guard-20260525` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
