### PR TITLE
fix(solver): preserve readonly array/tuple element literals during inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1478,6 +1478,10 @@ name = "issue_9785_const_type_param_satisfies_repro"
 path = "tests/issue_9785_const_type_param_satisfies_repro.rs"
 
 [[test]]
+name = "issue_9730_readonly_array_element_inference_repro"
+path = "tests/issue_9730_readonly_array_element_inference_repro.rs"
+
+[[test]]
 name = "satisfies_object_property_position_tests"
 path = "tests/satisfies_object_property_position_tests.rs"
 

--- a/crates/tsz-checker/tests/issue_9730_readonly_array_element_inference_repro.rs
+++ b/crates/tsz-checker/tests/issue_9730_readonly_array_element_inference_repro.rs
@@ -1,0 +1,163 @@
+//! Regression test for #9730: type-parameter inference from a `readonly`
+//! array/tuple element position widened the element literals.
+//!
+//! ## Structural rule
+//!
+//! When a type parameter `T` is inferred from an element position of a
+//! `readonly` array or tuple source (e.g. an `as const` argument, or any
+//! `readonly T[]` / `readonly [..]` value), tsc treats the element literals
+//! as **non-fresh** and does NOT widen them. So `new Set([1, 2] as const)`
+//! infers `Set<1 | 2>`, not `Set<number>`. A *mutable* array source still
+//! widens its fresh element literals (`new Set([1, 2])` -> `Set<number>`),
+//! because only fresh literals widen.
+//!
+//! This is keyed on the structural readonly-ness of the source, not on any
+//! identifier spelling or on `Set`/`Map` specifically — it holds for any
+//! generic constructor or function whose parameter is a readonly array/tuple
+//! (see §25 ANTI-HARDCODING DIRECTIVE and §26 GENERALIZATION GATE). The tests
+//! below vary the type-parameter names (`T`, `E`, `K`, `V`) and the carrier
+//! shape (class constructor, free function, nested readonly tuple) to prove
+//! the rule is structural.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_lib_files};
+
+fn ts2322_diags(source: &str) -> Vec<String> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Reported repro shape: a generic constructor taking `readonly T[]` called
+/// with an `as const` array preserves the element literals.
+#[test]
+fn readonly_ctor_param_preserves_const_array_literals() {
+    let source = r#"
+declare class MySet<T> { constructor(values: readonly T[]); val: T; }
+const ms = new MySet([1, 2] as const);
+const bad: 1 = ms.val;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        !ds[0].contains("number") && ds[0].contains('1') && ds[0].contains('2'),
+        "element literals should be preserved as `1 | 2`, not widened: {ds:?}",
+    );
+}
+
+/// Renamed type parameter + string literals: the rule must not depend on the
+/// type-parameter name or the literal kind.
+#[test]
+fn readonly_ctor_param_preserves_const_array_literals_renamed() {
+    let source = r#"
+declare class MyBag<E> { constructor(items: readonly E[]); item: E; }
+const mb = new MyBag(["x", "y"] as const);
+const bad: "x" = mb.item;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        ds[0].contains("\"x\"") && ds[0].contains("\"y\""),
+        "string literals should be preserved as `\"x\" | \"y\"`: {ds:?}",
+    );
+}
+
+/// Nested readonly tuple (the `Map<K, V>` shape): a `readonly (readonly
+/// [K, V])[]` parameter against `[['a', 1]] as const` preserves both `K` and
+/// `V` element literals.
+#[test]
+fn readonly_nested_tuple_param_preserves_key_and_value_literals() {
+    let source = r#"
+declare class MyMap<K, V> { constructor(entries: readonly (readonly [K, V])[]); k: K; v: V; }
+const mm = new MyMap([["a", 1]] as const);
+const badKey: "z" = mm.k;
+const badVal: 9 = mm.v;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(
+        ds.len(),
+        2,
+        "expected two TS2322 (key + value), got: {ds:?}"
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("\"a\"")),
+        "key literal `\"a\"` should be preserved: {ds:?}",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("Type '1'")),
+        "value literal `1` should be preserved: {ds:?}",
+    );
+}
+
+/// Free function with a `readonly T[]` parameter — same rule, different
+/// carrier shape (no constructor / no class involved).
+#[test]
+fn readonly_function_param_preserves_const_array_literals() {
+    let source = r#"
+declare function pick<T>(xs: readonly T[]): T;
+const p = pick([10, 20] as const);
+const bad: 10 = p;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        !ds[0].contains("number") && ds[0].contains("10") && ds[0].contains("20"),
+        "element literals should be preserved as `10 | 20`: {ds:?}",
+    );
+}
+
+/// Negative control: a *mutable* array argument to a `readonly T[]` parameter
+/// still widens its fresh element literals, matching tsc.
+#[test]
+fn mutable_array_into_readonly_param_still_widens() {
+    let source = r#"
+declare function pick<T>(xs: readonly T[]): T;
+const p = pick([10, 20]);
+const bad: 10 = p;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        ds[0].contains("number"),
+        "mutable-array element literals should widen to `number`: {ds:?}",
+    );
+}
+
+/// Negative control: a fully mutable array argument to a mutable `T[]`
+/// parameter widens (the pre-existing, correct behavior).
+#[test]
+fn mutable_array_into_mutable_param_widens() {
+    let source = r#"
+declare class MySet<T> { constructor(values: readonly T[]); val: T; }
+const ms = new MySet([1, 2]);
+const bad: 1 = ms.val;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        ds[0].contains("number"),
+        "fresh element literals should widen to `number`: {ds:?}",
+    );
+}
+
+/// `Iterable<T>` carrier: an `as const` array is iterable, and inference from
+/// the iterator element position preserves the readonly element literals too.
+#[test]
+fn iterable_param_preserves_const_array_literals() {
+    let source = r#"
+interface Iterator2<T> { next(): { value: T; done: boolean }; }
+interface Iterable2<T> { [Symbol.iterator](): Iterator2<T>; }
+declare function takeIter<T>(x: Iterable2<T>): T;
+const it = takeIter([1, 2] as const);
+const bad: 1 = it;
+"#;
+    let ds = ts2322_diags(source);
+    assert_eq!(ds.len(), 1, "expected one TS2322, got: {ds:?}");
+    assert!(
+        !ds[0].contains("number") && ds[0].contains('1') && ds[0].contains('2'),
+        "iterable element literals should be preserved as `1 | 2`: {ds:?}",
+    );
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -327,6 +327,12 @@ pub(crate) struct InferenceContext<'a> {
     pub(crate) vars_with_substituted_candidates: FxHashSet<InferenceVar>,
     /// Set during array element inference so candidates get `from_array_element = true`.
     pub(crate) in_array_element_context: bool,
+    /// Set while inference is descending through a `readonly` array/tuple source
+    /// (e.g. from an `as const` argument or a `readonly T[]` annotation). Literal
+    /// candidates collected in this context are non-fresh — tsc does not widen the
+    /// element literals of a readonly array/tuple, so `new Set([1, 2] as const)`
+    /// infers `Set<1 | 2>` rather than `Set<number>`.
+    pub(crate) in_readonly_source_context: bool,
 }
 
 impl<'a> InferenceContext<'a> {
@@ -360,6 +366,7 @@ impl<'a> InferenceContext<'a> {
             top_level_in_return_type_unfixed: FxHashSet::default(),
             vars_with_substituted_candidates: FxHashSet::default(),
             in_array_element_context: false,
+            in_readonly_source_context: false,
         }
     }
 
@@ -385,6 +392,7 @@ impl<'a> InferenceContext<'a> {
             top_level_in_return_type_unfixed: FxHashSet::default(),
             vars_with_substituted_candidates: FxHashSet::default(),
             in_array_element_context: false,
+            in_readonly_source_context: false,
         }
     }
 
@@ -1154,7 +1162,8 @@ impl<'a> InferenceContext<'a> {
         let candidate = InferenceCandidate {
             type_id: ty,
             priority,
-            is_fresh_literal: is_literal_type(self.interner, ty),
+            is_fresh_literal: is_literal_type(self.interner, ty)
+                && !self.in_readonly_source_context,
             from_object_property: false,
             from_index_signature: false,
             object_property_index: None,
@@ -1244,7 +1253,8 @@ impl<'a> InferenceContext<'a> {
                 && (is_literal_type(self.interner, ty)
                     || (self.in_array_element_context
                         && is_union_of_fresh_literals(self.interner, ty)))
-                && !self.source_is_type_annotation,
+                && !self.source_is_type_annotation
+                && !self.in_readonly_source_context,
             from_object_property: context.from_object_property,
             from_index_signature: context.from_index_signature,
             object_property_index: context.object_property_index,

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -1257,6 +1257,24 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
     }
 
+    /// Whether `type_id` is a `readonly` array/tuple source (e.g. an `as const`
+    /// argument or a `readonly T[]` annotation). Element literals of such a source
+    /// are non-fresh in tsc and must not be widened during inference.
+    pub(super) fn source_is_readonly_array_like(&mut self, type_id: TypeId) -> bool {
+        match self.interner.lookup(type_id) {
+            Some(TypeData::ReadonlyType(_)) => true,
+            Some(TypeData::Application(_) | TypeData::Lazy(_)) => {
+                let evaluated = self.checker.evaluate_type(type_id);
+                evaluated != type_id
+                    && matches!(
+                        self.interner.lookup(evaluated),
+                        Some(TypeData::ReadonlyType(_))
+                    )
+            }
+            _ => false,
+        }
+    }
+
     pub(super) fn array_like_element_for_constraint(&mut self, type_id: TypeId) -> Option<TypeId> {
         if let Some(elem) = crate::type_queries::get_array_element_type(self.interner, type_id) {
             return Some(elem);

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -328,19 +328,30 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             self.array_like_element_for_constraint(target),
         ) {
             let prev = ctx.in_array_element_context;
+            let prev_ro = ctx.in_readonly_source_context;
             ctx.in_array_element_context = true;
+            ctx.in_readonly_source_context |= self.source_is_readonly_array_like(source);
             self.constrain_types(ctx, var_map, source_elem, target_elem, priority);
             ctx.in_array_element_context = prev;
+            ctx.in_readonly_source_context = prev_ro;
             return;
         }
 
         match (source_key, target_key) {
-            (Some(TypeData::ReadonlyType(s_inner)), Some(TypeData::ReadonlyType(t_inner)))
-            | (Some(TypeData::NoInfer(s_inner)), Some(TypeData::NoInfer(t_inner))) => {
+            (Some(TypeData::ReadonlyType(s_inner)), Some(TypeData::ReadonlyType(t_inner))) => {
+                let prev_ro = ctx.in_readonly_source_context;
+                ctx.in_readonly_source_context = true;
+                self.constrain_types(ctx, var_map, s_inner, t_inner, priority);
+                ctx.in_readonly_source_context = prev_ro;
+            }
+            (Some(TypeData::NoInfer(s_inner)), Some(TypeData::NoInfer(t_inner))) => {
                 self.constrain_types(ctx, var_map, s_inner, t_inner, priority);
             }
             (Some(TypeData::ReadonlyType(s_inner)), _) => {
+                let prev_ro = ctx.in_readonly_source_context;
+                ctx.in_readonly_source_context = true;
                 self.constrain_types(ctx, var_map, s_inner, target, priority);
+                ctx.in_readonly_source_context = prev_ro;
             }
             (_, Some(TypeData::ReadonlyType(t_inner))) => {
                 self.constrain_types(ctx, var_map, source, t_inner, priority);


### PR DESCRIPTION
AgentName: M4-C

## Track
Track 3: solver generic inference / readonly array and tuple element literal freshness.

## Invariant
Only fresh literals widen during inference. When a type parameter `T` is inferred from an element position of a readonly array/tuple source, including an `as const` argument or any `readonly T[]` / `readonly [..]` value, tsc treats those element literals as non-fresh and preserves them. Mutable array sources still widen their fresh element literals.

## Scope
- Solver inference in the constraint walker and candidate collection/resolution path.
- Adds `in_readonly_source_context` to `InferenceContext` while descending through readonly array/tuple sources.
- Marks scalar/union literal candidates collected under that context as non-fresh so `resolve_from_candidates` preserves literal unions such as `1 | 2`.
- Leaves target-only-readonly and mutable-array cases on the existing widening path.
- Known out of scope: per-element `as const` inside a mutable array, such as `new Set([1 as const, 2 as const])`, still needs separate checker-layer freshness tracking. The parallel `infer_matching.rs` engine is left for a follow-up split because extending it here would push that file over the 2000-line ceiling.

## Summary
Fixes #9730.

Before this branch, `new Set([1, 2] as const)` inferred `Set<number>` because the readonly array element literals were treated as fresh and widened. This branch preserves `Set<1 | 2>`, matching tsc, while keeping mutable-array negatives such as `new Set([1, 2])` widened to `number`.

## Root Cause
Generic-call inference runs through the constraint walker (`operations/constraints/walker.rs`), which collects element candidates from array/tuple sources with `in_array_element_context = true`. Scalar/union literal candidates were then marked fresh based only on shape (`is_literal_type` / `is_union_of_fresh_literals`), without knowing that the source was a readonly array/tuple whose literals are non-fresh. Fresh candidates are widened in `infer_resolve.rs`, collapsing `1 | 2` to `number`.

## Project Corpus Impact
- Row: n/a.
- Bug family: false-negative literal widening in readonly-array/iterable element inference.
- Evidence: owning-crate regression test `crates/tsz-checker/tests/issue_9730_readonly_array_element_inference_repro.rs` and manual `tsz --noEmit --strict` repros before/after; no project-corpus row is known to map to this library inference fix.

## Verification
Current head `b773479b3abce0fc345b80c0a69c16e05ffc9ea3`:

- Exact-head ready-review CI is green: `CI Summary`, `conformance-aggregate`, `fourslash-aggregate`, `emit`, `wasm`, `wasm-web`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, `conformance-snapshot-gate`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-corpus-pr-body`, `project-row-drift`, `gate`, and GitGuardian passed.
- `Queue Tested` remains pending with no target URL, so auto-merge remains off per lane rules.

Prior owner verification:

- `cargo fmt --check` passed.
- `cargo clippy -p tsz-solver --all-targets` passed.
- `cargo test -p tsz-checker --test issue_9730_readonly_array_element_inference_repro` passed, 7/7.
- Manual CLI repros confirmed `Set<1 | 2>`, `Map<"a", 1>`, custom `MySet`/function `readonly T[]`, and `Iterable<T>` preserve literals; mutable-array negatives (`new Set([1,2])`, `pick([10,20])`) still widen to `number`; `id(5)`/`[1,2]` widening unchanged.
- Pre-existing unrelated failures on the branch were recorded by the prior owner: `generic_call_inference_tests` (5), `conditional_comprehensive_tests::test_equal_any_*`, and stale file-size ceiling baselines for files this PR does not touch (`evaluate.rs`, `conditional.rs`, emitter). This PR is net-neutral on the solver oversized-file count.

## Coordination Notes
- Current owner: M4-C.
- Current state: ready/off-auto on exact head `b773479b3abce0fc345b80c0a69c16e05ffc9ea3`.
- Exact-head ready-review CI is green. Older `conformance-aggregate` / `CI Summary` failures belong to prior runs and are stale relative to the green exact-head run.
- Next owner/action: do not arm auto-merge while `Queue Tested` is pending. Once the queue-required status is clean/eligible on this exact head, this PR can move to the landing queue.
- Issue #9730 has been used to claim the work while this PR lands; no overlapping open PRs were found for `9730 in:body` during the prior owner pass. This work is distinct from the do-while narrowing work in #9889.

https://claude.ai/code/session_01NHsXm9Zc4iUrEeHcum2ioW


