### PR TITLE
refactor(checker): inspect parameters index syntax structurally

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1,6 +1,7 @@
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
@@ -198,10 +199,45 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
     ) -> bool {
         crate::query_boundaries::common::number_literal_value(self.ctx.types, index_type).is_some()
-            && self.node_text(object_type_node).is_some_and(|text| {
-                let text = text.trim();
-                text.starts_with("Parameters<") || text.starts_with("ConstructorParameters<")
-            })
+            && self.type_node_is_parameters_utility_reference(object_type_node)
+    }
+
+    fn type_node_is_parameters_utility_reference(&self, type_node: NodeIndex) -> bool {
+        let type_node = self.unwrap_parenthesized_type_node(type_node);
+        let Some(node) = self.ctx.arena.get(type_node) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        let Some(name) = self
+            .ctx
+            .arena
+            .get_identifier_at(type_ref.type_name)
+            .map(|ident| ident.escaped_text.as_str())
+        else {
+            return false;
+        };
+        matches!(name, "Parameters" | "ConstructorParameters")
+    }
+
+    fn unwrap_parenthesized_type_node(&self, mut type_node: NodeIndex) -> NodeIndex {
+        for _ in 0..8 {
+            let Some(node) = self.ctx.arena.get(type_node) else {
+                return type_node;
+            };
+            if node.kind != PARENTHESIZED_TYPE {
+                return type_node;
+            }
+            let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) else {
+                return type_node;
+            };
+            type_node = wrapped.type_node;
+        }
+        type_node
     }
 
     pub(super) fn index_constraint_keyof_matches_mapped_constraint(

--- a/crates/tsz-checker/tests/tuple_index_access_tests.rs
+++ b/crates/tsz-checker/tests/tuple_index_access_tests.rs
@@ -30,6 +30,36 @@ const result = apply((x: number) => x.toString(), 42);
 }
 
 #[test]
+fn parameters_utility_numeric_index_detection_is_syntactic() {
+    let source = r#"
+type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
+type ConstructorParameters<T extends new (...args: any) => any> =
+  T extends new (...args: infer P) => any ? P : never;
+
+function call<T extends (x: any) => any>(fn: T, arg: Parameters <T>[0]) {
+  return fn(arg);
+}
+
+class Box {
+  constructor(value: string) {}
+}
+function make<C extends new (value: any) => any>(ctor: C, value: (ConstructorParameters <C>)[0]) {
+  return new ctor(value);
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2536: Vec<_> = diagnostics.iter().filter(|d| d.code == 2536).collect();
+    assert!(
+        ts2536.is_empty(),
+        "Expected spaced Parameters/ConstructorParameters numeric indexes to avoid TS2536. Got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn readonly_variadic_tuple_to_mutable_variadic_tuple_emits_ts4104() {
     let diagnostics = check_source_diagnostics(
         r"


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track: M1-C rendered/source decision cleanup
PR type: refactor

## Invariant
Replace source-text decisions in checker logic with parser/AST structure while preserving TypeScript parity and keeping indexed-access behavior routed through existing checker orchestration.

## Scope
- Replaces `Parameters<` / `ConstructorParameters<` source-prefix detection for numeric indexed access with AST inspection of the object type node.
- Handles parenthesized utility references without consulting rendered/source snippets.
- Adds a focused checker test for spaced `Parameters <T>[0]` and parenthesized `ConstructorParameters <C>[0]` forms that the old source-prefix check missed.

## Project Corpus Impact
- Row: n/a
- Bug family: source-text diagnostic/type-checking decision cleanup
- Evidence: checker-only refactor plus focused tuple indexed-access test; no benchmark project row behavior is intentionally changed.

## Verification
- `cargo fmt --all -- --check`
- `cargo nextest run -p tsz-checker --test tuple_index_access_tests -E 'test(parameters_utility_numeric_index_detection_is_syntactic) or test(parameters_of_generic_function_allows_numeric_index)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo check -p tsz-checker --lib`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
AgentName: M1-C
Head SHA: `47098aa8725d77f17a8e243f00124e80ef985af5`.
Base: `origin/main` at branch creation (`531210fa9b`).
Non-overlap: separate from #9272 alias display cleanup, #10093 indexed annotation AST cleanup, #10091 related indexed display cleanup, #10090 builtin iterator intrinsic alias syntax, and the optional-undefined rendered-decision cleanup PRs. This slice only touches the `Parameters`/`ConstructorParameters` numeric indexed-access guard.
Ready state: PR is ready for review, non-draft, non-WIP, and has only the `agent:M1-C` label as of the 2026-05-25 M1-C cycle.
Queue status: active serial synthetic queue after #10106 landed as `7497688bfbcc954ada24f2884bcddf302d03c6a3`. Queue run `26393214425` is queued on merge commit `ac385a7f3df35d430d5bc7678bbed570ff89a876` with parents current `main` `7497688bfbcc954ada24f2884bcddf302d03c6a3` and PR head `47098aa8725d77f17a8e243f00124e80ef985af5`.