### PR TITLE
refactor(checker): route syntax constraint relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
@@ -71,10 +71,13 @@ impl<'a> CheckerState<'a> {
             let db = self.ctx.types.as_type_database();
             return query::is_callable_type(db, syntax_instantiated_type_arg)
                 || query::callable_shape_for_type(db, syntax_instantiated_type_arg).is_some()
-                || self.is_assignable_to(syntax_instantiated_type_arg, inst_constraint);
+                || self.diagnostic_relation_boolean_guard(
+                    syntax_instantiated_type_arg,
+                    inst_constraint,
+                );
         }
 
-        self.is_assignable_to(syntax_instantiated_type_arg, inst_constraint)
+        self.diagnostic_relation_boolean_guard(syntax_instantiated_type_arg, inst_constraint)
             || self.base_union_members_satisfy_constraint(
                 syntax_instantiated_type_arg,
                 inst_constraint,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -542,6 +542,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "checkers"
             / "generic_checker"
+            / "constraint_syntax_instantiation.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "generic_checker"
             / "union_constraint_helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "parameter_checker.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10096.

## Invariant
Syntax-guided type-argument instantiation uses boolean assignability probes only to decide whether the existing TS2344-style constraint path is satisfied. Diagnostic-only relations now route through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route two syntax-instantiated type-argument constraint probes in `crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs` through `diagnostic_relation_boolean_guard`.
- Add `constraint_syntax_instantiation.rs` to the #8227 raw diagnostic assignability predicate arch guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-merged-interface-constraint-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `2a5a4b4a7318256a4228fc45aa5dd700297af77e` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10096 (`codex/m1b-merged-interface-constraint-relation-guard-20260525`) at base head `ff48cdea04d16df33a1278815697d4bf25e5de48`.
- Current head: `2a5a4b4a7318256a4228fc45aa5dd700297af77e`.
- Rebased after #10096 moved from `a4affd787276cb38014d1030b0437d65fceeb719` to `ff48cdea04d16df33a1278815697d4bf25e5de48`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: CLEAN`.
- Keep #10098 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-syntax-constraint-relation-guard-20260525` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
