### PR TITLE
refactor(checker): route mapped constraint relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
@@ -51,8 +51,8 @@ impl<'a> CheckerState<'a> {
     /// Substitute every in-scope type parameter in `type_id` with its declared
     /// constraint (or `unknown` when the parameter is unconstrained). The
     /// result is used to give a concrete instantiation of a generic-reference
-    /// type argument so that `is_assignable_to(concrete, target_constraint)`
-    /// can be evaluated without ambiguity. (#3063)
+    /// type argument so the target constraint relation can be evaluated
+    /// without ambiguity. (#3063)
     pub(super) fn scoped_type_param_substituted_form(&self, type_id: TypeId) -> TypeId {
         if self.ctx.type_parameter_scope.is_empty() {
             return type_id;
@@ -123,8 +123,8 @@ impl<'a> CheckerState<'a> {
         let true_base_evaluated = self.evaluate_type_for_assignability(true_base_resolved);
         let constraint_evaluated = self.evaluate_type_for_assignability(constraint_resolved);
         true_base_evaluated == constraint_evaluated
-            || self.is_assignable_to(true_base_evaluated, constraint_evaluated)
-            || self.is_assignable_to(true_base_resolved, constraint_resolved)
+            || self.diagnostic_relation_boolean_guard(true_base_evaluated, constraint_evaluated)
+            || self.diagnostic_relation_boolean_guard(true_base_resolved, constraint_resolved)
     }
 
     pub(super) fn constraint_check_base_type(&mut self, type_id: TypeId) -> TypeId {
@@ -258,7 +258,7 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_input_ready(type_arg_resolved);
         let type_arg_evaluated = self.evaluate_type_with_resolution(type_arg_resolved);
         type_arg_evaluated == source
-            || self.is_assignable_to(type_arg_evaluated, source)
+            || self.diagnostic_relation_boolean_guard(type_arg_evaluated, source)
             || self.type_satisfies_required_source_properties(type_arg_resolved, &properties)
             || (type_arg_evaluated != type_arg_resolved
                 && self.type_satisfies_required_source_properties(type_arg_evaluated, &properties))
@@ -330,7 +330,7 @@ impl<'a> CheckerState<'a> {
             if arg_prop.type_id != source_prop.type_id {
                 let arg_type = self.evaluate_type_for_assignability(arg_prop.type_id);
                 let source_type = self.evaluate_type_for_assignability(source_prop.type_id);
-                if !self.is_assignable_to(arg_type, source_type) {
+                if !self.diagnostic_relation_boolean_guard(arg_type, source_type) {
                     return false;
                 }
             }
@@ -367,7 +367,9 @@ impl<'a> CheckerState<'a> {
 
             let arg_type = self.get_type_from_type_node(arg_type_node);
             let source_type = self.get_type_from_type_node(source_type_node);
-            if arg_type != source_type && !self.is_assignable_to(arg_type, source_type) {
+            if arg_type != source_type
+                && !self.diagnostic_relation_boolean_guard(arg_type, source_type)
+            {
                 return false;
             }
         }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -556,6 +556,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "checkers"
             / "generic_checker"
+            / "mapped_constraint_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "generic_checker"
             / "union_constraint_helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "iterable_checker.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "parameter_checker.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10099.

## Invariant
Mapped-utility constraint helpers use boolean assignability probes only to decide whether existing TS2344-style constraint shortcuts are satisfied. Diagnostic-only relations now route through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route five mapped-constraint helper probes in `crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs` through `diagnostic_relation_boolean_guard`.
- Update one nearby doc comment so it no longer names the raw assignability helper.
- Add `mapped_constraint_helpers.rs` to the #8227 raw diagnostic assignability predicate arch guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-conditional-constraint-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `7f2a8c9cb0e27e79f6a085c1ad104078f3838bd2` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10099 (`codex/m1b-conditional-constraint-relation-guard-20260525`) at base head `fd084b542e48787a722de862deea8e4744d0ddd6`.
- Current head: `7f2a8c9cb0e27e79f6a085c1ad104078f3838bd2`.
- Rebased after #10099 moved from `036c0d8eaaa511caa9f08408c88955e7489bd92e` to `fd084b542e48787a722de862deea8e4744d0ddd6`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10100 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-mapped-constraint-relation-guard-20260525` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
