### PR TITLE
refactor(checker): query keyof constraint structure

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1243,9 +1243,11 @@ impl<'a> CheckerState<'a> {
                             && self.type_arg_has_explicit_constraint_in_ast(arg_idx)
                         {
                             let constraint_resolved = self.resolve_lazy_type(constraint);
-                            if self
-                                .format_type_diagnostic(constraint_resolved)
-                                .starts_with("keyof ")
+                            if query::keyof_operand(
+                                self.ctx.types.as_type_database(),
+                                constraint_resolved,
+                            )
+                            .is_some()
                             {
                                 self.error_type_constraint_not_satisfied(
                                     type_arg,

--- a/crates/tsz-checker/tests/ts2344_infer_conditional_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_infer_conditional_constraint.rs
@@ -284,6 +284,30 @@ export type RemoveIdxSgn<T> = Pick<T, KeysWithoutStringIndex<T>>;
 }
 
 #[test]
+fn test_mapped_key_infer_subset_satisfies_keyof_constraint_renamed() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Select<Obj, Key extends keyof Obj> = { [Member in Key]: Obj[Member] };
+type KeysWithoutWideString<Source> =
+    { [Property in keyof Source]: string extends Property ? never : Property } extends { [_Name in keyof Source]: infer Candidate }
+    ? Candidate
+    : never;
+
+export type RemoveWideStringIndex<Source> = Select<Source, KeysWithoutWideString<Source>>;
+"#,
+    );
+
+    let ts2344_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert!(
+        ts2344_errors.is_empty(),
+        "Renamed mapped key infer result should be accepted as a keyof subset. Got: {ts2344_errors:?}"
+    );
+}
+
+#[test]
 fn test_react_component_props_with_ref_accepts_conditional_element_type() {
     let diagnostics = compile_and_get_diagnostics(
         r#"


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track: M1-C rendered/source decision cleanup
PR type: refactor

## Invariant
Generic constraint validation must classify `keyof` constraints from solver/query-boundary structure, not from diagnostic display strings.

## Scope
- Replaces `format_type_diagnostic(constraint_resolved).starts_with("keyof ")` in generic constraint validation with `query::keyof_operand`.
- Keeps checker orchestration thin by reusing the existing solver-backed generic query boundary.
- Adds a renamed mapped-key infer/keyof regression so the accepted subset path is independent of binder-chosen names.

## Project Corpus Impact
- Row: n/a
- Bug family: rendered-type generic constraint decision cleanup
- Evidence: checker-only TS2344 constraint-validation refactor; no benchmark project row behavior is intentionally changed.

## Verification
- `cargo fmt --all -- --check`
- `cargo nextest run -p tsz-checker --test ts2344_infer_conditional_constraint -E 'test(test_mapped_key_infer_subset_satisfies_keyof_constraint) or test(test_mapped_key_infer_subset_satisfies_keyof_constraint_renamed)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo check -p tsz-checker --lib`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `rg -n "format_type_diagnostic\\(constraint_resolved\\)|starts_with\\(\\\"keyof \\\"\\)" crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs` returned no matches
- `cargo nextest run -p tsz-checker --lib -E 'test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
AgentName: M1-C
Head SHA: 03097b1d1fd1150f0cf4ad62fc72968d89992d3d
Base: `origin/main` at branch creation (`531210fa9b`).
Non-overlap: separate from #9272 alias display cleanup, #10097 Parameters/ConstructorParameters indexed-access syntax cleanup, #10093 indexed annotation AST cleanup, #10091 related indexed display cleanup, #10090 builtin iterator intrinsic alias syntax, and the optional-undefined/callable/numeric display PRs. This slice only removes the `keyof` rendered-string decision in `generic_checker/constraint_validation.rs`.
Auto-merge: off. Opened as draft for light CI first; mark ready only after draft checks are clean and the current head is intentionally reviewed.
