### PR TITLE
refactor(checker): route index key relation guards

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -18,10 +18,10 @@ impl<'a> CheckerState<'a> {
             let members: Vec<TypeId> = self.ctx.types.type_list(list_id).to_vec();
             return members
                 .into_iter()
-                .all(|member| self.is_assignable_to(member, index_value_type));
+                .all(|member| self.diagnostic_relation_boolean_guard(member, index_value_type));
         }
 
-        self.is_assignable_to(prop_type, index_value_type)
+        self.diagnostic_relation_boolean_guard(prop_type, index_value_type)
     }
 
     pub(crate) fn format_ts2411_type(&mut self, type_id: TypeId) -> String {

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -494,6 +494,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "state"
             / "state_checking_members"
+            / "index_signature_key_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "state_checking_members"
             / "statement_helpers.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10103.

## Invariant
Index-signature key helpers compare property types against index value types only to decide whether the existing TS2411 diagnostic path is satisfied. Diagnostic-only relations now route through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route two index-signature key helper probes in `crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs` through `diagnostic_relation_boolean_guard`.
- Add `index_signature_key_helpers.rs` to the #8227 raw diagnostic assignability predicate arch guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-recursive-heritage-constraint-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `bcfdfc9eede974b99014f6aadccc3a83bea73b2a` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10103 (`codex/m1b-recursive-heritage-constraint-relation-guard-20260525`) at base head `863daf08406a41389049570381e85b4f213f2b56`.
- Current head: `bcfdfc9eede974b99014f6aadccc3a83bea73b2a`.
- Rebased after #10103 moved from `a0a797f72df1846120bfa10e8ffa266cd5c3b017` to `863daf08406a41389049570381e85b4f213f2b56`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: CLEAN`.
- Keep #10104 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-index-key-helper-relation-guards-20260525` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
