### PR TITLE
refactor(checker): route generic constraint relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -240,10 +240,10 @@ impl<'a> CheckerState<'a> {
                             }
                         }
                         if extends_type == constraint
-                            || (self.is_assignable_to(extends_type, constraint)
-                                && self.is_assignable_to(constraint, extends_type))
-                            || self.is_assignable_to(extends_resolved, constraint)
-                            || self.is_assignable_to(extends_evaluated, constraint)
+                            || (self.diagnostic_relation_boolean_guard(extends_type, constraint)
+                                && self.diagnostic_relation_boolean_guard(constraint, extends_type))
+                            || self.diagnostic_relation_boolean_guard(extends_resolved, constraint)
+                            || self.diagnostic_relation_boolean_guard(extends_evaluated, constraint)
                         {
                             return true;
                         }
@@ -283,7 +283,7 @@ impl<'a> CheckerState<'a> {
         // → intersection is `{a: string} & {b: number}` which satisfies `{a: string, b: number}`.
         if accumulated_extends.len() >= 2 {
             let intersection = self.ctx.types.intersection(accumulated_extends);
-            if self.is_assignable_to(intersection, constraint) {
+            if self.diagnostic_relation_boolean_guard(intersection, constraint) {
                 return true;
             }
         }
@@ -1011,14 +1011,14 @@ impl<'a> CheckerState<'a> {
                 } else {
                     evaluated_constraint
                 };
-            if self.is_assignable_to(type_arg, constraint_for_check) {
+            if self.diagnostic_relation_boolean_guard(type_arg, constraint_for_check) {
                 continue;
             }
             let base = self.constraint_check_base_type(type_arg);
             if base != type_arg && base != TypeId::UNKNOWN {
                 let base = self.resolve_lazy_members_in_union(base);
                 let base = self.evaluate_type_for_assignability(base);
-                if self.is_assignable_to(base, constraint_for_check)
+                if self.diagnostic_relation_boolean_guard(base, constraint_for_check)
                     || self.base_union_members_satisfy_constraint(base, constraint_for_check)
                 {
                     continue;
@@ -1030,7 +1030,7 @@ impl<'a> CheckerState<'a> {
             {
                 let base = self.resolve_lazy_members_in_union(base);
                 let base = self.evaluate_type_for_assignability(base);
-                if self.is_assignable_to(base, constraint_for_check)
+                if self.diagnostic_relation_boolean_guard(base, constraint_for_check)
                     || self.base_union_members_satisfy_constraint(base, constraint_for_check)
                 {
                     continue;

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -577,6 +577,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "checkers"
             / "generic_checker"
+            / "mod.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "generic_checker"
             / "recursive_heritage_constraint.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10104.

## Invariant
Generic checker constraint helpers compare type arguments, conditional-branch extends types, or derived base types only to decide whether an existing TS2344-style diagnostic path is satisfied. Diagnostic-only relations now route through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

## Scope
- Route the remaining raw relation probes in `crates/tsz-checker/src/checkers/generic_checker/mod.rs` through `diagnostic_relation_boolean_guard`.
- Add `generic_checker/mod.rs` to the #8227 raw diagnostic assignability predicate arch guard roots in `scripts/arch/arch_guard_config.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only diagnostic relation routing; no solver semantics, relation policy, project corpus behavior, or emitted output changes.

## Verification
- `git diff --check codex/m1b-index-key-helper-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI passed on head `15d9ad14ce2b1acab675e9939e698189c9fcfd63` (`CI Light Summary`, lint, unit, dist-binaries, cargo-deny, cargo-shear, gate, queue-one-pr, project-row-drift, unit-cloudbuild, GitGuardian Security Checks).
- Heavy ready-review suites are intentionally skipped while the PR remains draft.

## Coordination Notes
- Stacked above #10104 (`codex/m1b-index-key-helper-relation-guards-20260525`) at base head `bcfdfc9eede974b99014f6aadccc3a83bea73b2a`.
- Current head: `15d9ad14ce2b1acab675e9939e698189c9fcfd63`.
- Rebased after #10104 moved from `e572145528a49547501821950db4940201e110d0` to `bcfdfc9eede974b99014f6aadccc3a83bea73b2a`.
- Related older PR #9238 is closed and covered `error_reporter/generics.rs`; this PR covers `generic_checker/mod.rs`.
- Current PR state as of 2026-05-25: draft/off-auto, labeled only `agent:M1-B`, `mergeStateStatus: UNSTABLE` because `Queue Tested` is pending on the draft branch.
- Keep #10105 draft/off-auto until #9922 lands or is explicitly handed off and parent drafts are promoted in order.
- Local note: `codex/m1b-generic-mod-constraint-relation-guards-20260525` exists locally/remotely but is not checked out in an active worktree.
- Non-overlap: does not touch solver policy, relation caches, relation request construction, or relation semantics owned by M4-B.
