### PR TITLE
refactor(checker): inspect interface heritage typeof syntax

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_display.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_display.rs
@@ -30,8 +30,10 @@ impl<'a> CheckerState<'a> {
             return self.format_type_diagnostic(evaluated);
         }
 
-        if let Some(alias_text) = self.type_alias_target_text_for_symbol(base_sym_id) {
-            if alias_text.starts_with("typeof ") {
+        if let Some((alias_text, alias_kind)) =
+            self.type_alias_target_text_and_kind_for_symbol(base_sym_id)
+        {
+            if alias_kind == syntax_kind_ext::TYPE_QUERY {
                 return alias_text;
             }
             if Self::is_array_or_tuple_alias_text(&alias_text) {
@@ -42,8 +44,8 @@ impl<'a> CheckerState<'a> {
             return alias_text;
         }
 
-        if let Some(text) = self.node_text(expr_idx)
-            && text.starts_with("typeof ")
+        if self.type_node_is_type_query_through_parens(expr_idx)
+            && let Some(text) = self.node_text(expr_idx)
         {
             return text.trim().to_string();
         }
@@ -55,6 +57,14 @@ impl<'a> CheckerState<'a> {
         &self,
         sym_id: tsz_binder::SymbolId,
     ) -> Option<String> {
+        self.type_alias_target_text_and_kind_for_symbol(sym_id)
+            .map(|(text, _)| text)
+    }
+
+    fn type_alias_target_text_and_kind_for_symbol(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> Option<(String, u16)> {
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         for &decl_idx in &symbol.declarations {
             let decl_arena =
@@ -78,7 +88,10 @@ impl<'a> CheckerState<'a> {
             let start = start as usize;
             let end = end as usize;
             if start < end && end <= source.len() {
-                return Some(Self::clean_alias_target_text(&source[start..end]));
+                return Some((
+                    Self::clean_alias_target_text(&source[start..end]),
+                    type_node.kind,
+                ));
             }
         }
         None
@@ -100,6 +113,25 @@ impl<'a> CheckerState<'a> {
 
     fn clean_alias_target_text(text: &str) -> String {
         text.trim().trim_end_matches(';').trim_end().to_string()
+    }
+
+    fn type_node_is_type_query_through_parens(&self, mut type_node: NodeIndex) -> bool {
+        for _ in 0..8 {
+            let Some(node) = self.ctx.arena.get(type_node) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::TYPE_QUERY {
+                return true;
+            }
+            if node.kind != syntax_kind_ext::PARENTHESIZED_TYPE {
+                return false;
+            }
+            let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) else {
+                return false;
+            };
+            type_node = wrapped.type_node;
+        }
+        false
     }
 
     fn format_interface_heritage_type_argument(&mut self, arg_idx: NodeIndex) -> String {

--- a/crates/tsz-checker/tests/interface_heritage_display_tests.rs
+++ b/crates/tsz-checker/tests/interface_heritage_display_tests.rs
@@ -28,6 +28,34 @@ interface I10 extends TCX {
 }
 
 #[test]
+fn interface_extends_typeof_alias_display_uses_type_query_syntax() {
+    let source = r#"
+declare class CX { static a: string }
+type TCX = typeof
+    CX;
+interface I11 extends TCX {
+    a: number;
+}
+"#;
+    let messages: Vec<_> = diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2430)
+        .map(|(_, message)| message)
+        .collect();
+
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.contains("Interface 'I11' incorrectly extends interface 'typeof")),
+        "TS2430 should display the typeof alias target from TYPE_QUERY syntax. Got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|msg| msg.contains("interface 'TCX'")),
+        "TS2430 should not fall back to the local alias name. Got: {messages:?}"
+    );
+}
+
+#[test]
 fn interface_extends_generic_intersection_argument_preserves_surface_text() {
     let source = r#"
 type T1 = { a: number };


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track: M1-C rendered/source decision cleanup
PR type: refactor

## Invariant
Interface heritage diagnostics should decide whether a base is a `typeof` type query from parser syntax, not from source text prefixes. Source text may still be used as the display surface after the AST has selected that path.

## Scope
- Replaces `alias_text.starts_with("typeof ")` in interface heritage display with the alias target node kind.
- Replaces direct heritage `node_text(expr_idx).starts_with("typeof ")` with a `TYPE_QUERY` syntax check that looks through parenthesized type nodes.
- Adds a TS2430 regression where a `typeof` alias body is split across a newline, which should still display the `typeof` target rather than the local alias name.

## Project Corpus Impact
- Row: n/a
- Bug family: source-text diagnostic display decision cleanup
- Evidence: checker-only interface heritage diagnostic display refactor; no benchmark project row behavior is intentionally changed.

## Verification
- `cargo fmt --all -- --check`
- `cargo nextest run -p tsz-checker --test interface_heritage_display_tests -E 'test(interface_extends_typeof_alias_displays_target_type) or test(interface_extends_typeof_alias_display_uses_type_query_syntax)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo check -p tsz-checker --lib`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
AgentName: M1-C
Head SHA: `18fc4d51809690c3d51ebf4cf80c7665b2848384`.
Base: `origin/main` at branch creation (`531210fa9b`).
Non-overlap: separate from #9272 alias display, #10077 `typeof` operator result typing, #10090 builtin iterator intrinsic syntax, #10093/#10097 indexed-access syntax, #10091 related-index display, #10048 keyof constraint gate, and the optional-undefined/callable/numeric rendered-decision PRs. This slice only touches `classes/interface_heritage_display.rs` and its focused interface heritage display tests.
Ready state: PR is ready for review, non-draft, non-WIP, and has only the `agent:M1-C` label as of the 2026-05-25 M1-C cycle.
Queue status: active serial synthetic queue after #10114 landed as `4786d346607d1241b94dcf40eecd9260a4cd2863`. Queue run `26392632366` is pending on merge commit `985bd9128c9600fac8a3749708e934ff64e78c00` with parents current `main` `4786d346607d1241b94dcf40eecd9260a4cd2863` and PR head `18fc4d51809690c3d51ebf4cf80c7665b2848384`. Queue ref was created with the Git refs API after HTTPS git push uploaded the commit object but GitHub rejected the ref update server-side.