### PR TITLE
refactor(checker): route infer conditional relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
@@ -63,8 +63,8 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.is_assignable_to(restricted_evaluated, inst_constraint)
-            || self.is_assignable_to(restricted, inst_constraint)
+        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
+            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
     }
 
     fn infer_result_satisfies_via_mapped_key_subset(
@@ -140,8 +140,8 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.is_assignable_to(restricted_evaluated, inst_constraint)
-            || self.is_assignable_to(restricted, inst_constraint)
+        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
+            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
     }
 
     /// Some aliases compute a constrained result through a conditional `infer`
@@ -187,8 +187,8 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.is_assignable_to(restricted_evaluated, inst_constraint)
-            || self.is_assignable_to(restricted, inst_constraint)
+        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
+            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
     }
 
     pub(super) fn type_arg_satisfies_via_hidden_infer_constraints(
@@ -231,7 +231,7 @@ impl<'a> CheckerState<'a> {
             &substitution,
         );
         let restricted = self.resolve_lazy_type(restricted);
-        self.is_assignable_to(restricted, inst_constraint)
+        self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
             || self.base_union_members_satisfy_constraint(restricted, inst_constraint)
     }
 
@@ -261,7 +261,7 @@ impl<'a> CheckerState<'a> {
         };
 
         candidates.into_iter().any(|candidate| {
-            self.is_assignable_to_no_weak_checks(candidate, inst_constraint)
+            self.diagnostic_relation_boolean_guard_no_weak_checks(candidate, inst_constraint)
                 || self.base_union_members_satisfy_constraint(candidate, inst_constraint)
                 || self.conditional_array_element_infer_satisfies_constraint(
                     candidate,
@@ -425,7 +425,7 @@ impl<'a> CheckerState<'a> {
             .filter_map(|candidate| self.array_like_element_type(candidate))
             .collect::<Vec<_>>();
         elements.into_iter().any(|element| {
-            self.is_assignable_to_no_weak_checks(element, inst_constraint)
+            self.diagnostic_relation_boolean_guard_no_weak_checks(element, inst_constraint)
                 || self.base_union_members_satisfy_constraint(element, inst_constraint)
         })
     }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -603,6 +603,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "checkers"
             / "generic_checker"
+            / "infer_conditional_constraints.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "checkers"
+            / "generic_checker"
             / "conditional_constraint_helpers.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10112.

Invariant:
When infer-result conditional constraint helpers compare restricted or candidate type arguments against instantiated constraints only to decide whether existing TS2344 constraint diagnostics should report, route the diagnostic-only relation through the diagnostic relation guard. Behavior is unchanged; solver semantics and relation policy are unchanged.

Scope:
- Route infer conditional constraint relation probes through `diagnostic_relation_boolean_guard` / `diagnostic_relation_boolean_guard_no_weak_checks`.
- Add `generic_checker/infer_conditional_constraints.rs` to the raw diagnostic assignability arch-guard root set.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only; no semantic, project-corpus, or emitted-output behavior changes.

Verification:
- `git diff --check codex/m1b-overload-compat-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `20628805d93a6ed81c3a8b82b8710278bd273b61` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, `gate`, `CI Light Summary`).
- `Queue Tested` is still pending for the synthetic main merge; no auto-merge is enabled.

Coordination Notes:
- Stacked above #10112 (`codex/m1b-overload-compat-relation-guards-20260525`) at base head `93228f2137857db841a35fe9ce483a99635ef2b9`.
- Current head: `20628805d93a6ed81c3a8b82b8710278bd273b61`.
- Rebased from prior base `f0b42638670bd4a834182e85956fe81d36b00d96`; conflict state cleared by replaying only this PR's two-file routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: UNSTABLE` only because `Queue Tested` is pending.
- Non-overlap: does not touch solver policy, relation caches, request construction, or M4-B relation internals.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
