### PR TITLE
refactor(checker): inspect unknown type args structurally

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -426,10 +426,7 @@ fn load_json_weights(path: &Path) -> Option<ShardWeights> {
             else {
                 continue;
             };
-            weights
-                .path_weights
-                .entry(file.replace('\\', "/"))
-                .or_insert(weight);
+            weights.path_weights.insert(file.replace('\\', "/"), weight);
         }
     }
 
@@ -1922,6 +1919,31 @@ mod tests {
         assert!(is_appledouble_file(Path::new("._bar.js")));
         assert!(!is_appledouble_file(Path::new("foo.ts")));
         assert!(!is_appledouble_file(Path::new("dir/regular.js")));
+    }
+
+    #[test]
+    fn result_timings_override_stale_path_weights() {
+        let file = tempfile::NamedTempFile::new().expect("weights file");
+        std::fs::write(
+            file.path(),
+            serde_json::json!({
+                "path_weights": {
+                    "TypeScript/tests/cases/compiler/foo.ts": 10_000.0
+                },
+                "results": [{
+                    "file": "TypeScript/tests/cases/compiler/foo.ts",
+                    "elapsed_ms": 25.0
+                }]
+            })
+            .to_string(),
+        )
+        .expect("write weights");
+
+        let weights = load_json_weights(file.path()).expect("weights should load");
+        let path = Path::new("/repo/TypeScript/tests/cases/compiler/foo.ts");
+        let test_dir = Path::new("/repo/TypeScript/tests/cases");
+
+        assert_eq!(historical_path_weight(&weights, path, test_dir), Some(25.0));
     }
 
     fn with_temp_cwd<F, T>(create_fast_binary: bool, f: F) -> T

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
@@ -9,16 +9,13 @@ use tsz_solver::{TypeId, TypeParamInfo};
 
 impl<'a> CheckerState<'a> {
     pub(super) fn type_arg_is_unknown_keyword(&self, type_arg_idx: NodeIndex) -> bool {
-        self.node_text(type_arg_idx)
-            .is_some_and(|text| text.trim() == "unknown")
+        self.ctx
+            .arena
+            .get(type_arg_idx)
+            .is_some_and(|node| node.kind == SyntaxKind::UnknownKeyword as u16)
             || self
                 .type_arg_identifier_name(type_arg_idx)
                 .is_some_and(|name| name == "unknown")
-            || self
-                .ctx
-                .arena
-                .get(type_arg_idx)
-                .is_some_and(|node| node.kind == SyntaxKind::UnknownKeyword as u16)
     }
 
     pub(super) fn syntax_instantiated_type_arg_satisfies_constraint(
@@ -224,5 +221,23 @@ impl<'a> CheckerState<'a> {
             &substitution,
         );
         (instantiated != type_arg).then_some(instantiated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn unknown_type_arg_detection_does_not_read_source_text() {
+        let source = include_str!("constraint_syntax_instantiation.rs");
+        for forbidden in [
+            ["node_text", "(type_arg_idx)"].join(""),
+            ["text.trim()", " == ", "\"unknown\""].join(""),
+        ] {
+            assert!(
+                !source.contains(&forbidden),
+                "`unknown` type-argument detection must use syntax/name facts, \
+                 not source text: found {forbidden}"
+            );
+        }
     }
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -514,6 +514,9 @@ mod generic_spread_iterability_tests;
 #[path = "../tests/generic_tests.rs"]
 mod generic_tests;
 #[cfg(test)]
+#[path = "tests/generic_unknown_type_arg_tests.rs"]
+mod generic_unknown_type_arg_tests;
+#[cfg(test)]
 #[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
 mod in_narrow_bare_type_param_chained_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generic_unknown_type_arg_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_unknown_type_arg_tests.rs
@@ -1,0 +1,28 @@
+use crate::test_utils::check_source_diagnostics;
+
+#[test]
+fn unknown_type_arg_constraint_uses_keyword_syntax_with_trivia() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Need<T extends string> = T;
+type Bad = Need</* preserved trivia */ unknown>;
+"#,
+    );
+
+    let matches = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2344)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS2344 for unknown type argument, got: {diagnostics:?}"
+    );
+    assert!(
+        matches[0]
+            .message_text
+            .contains("Type 'unknown' does not satisfy the constraint 'string'."),
+        "expected TS2344 to report the unknown keyword and string constraint, got: {:?}",
+        matches[0]
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -4,21 +4,18 @@
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
 TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
 TypeScript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
-TypeScript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/jsxElementType.tsx
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
-TypeScript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts
 TypeScript/tests/cases/compiler/spyComparisonChecking.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/compiler/thislessFunctionsNotContextSensitive3.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 8/10 refactor: burn down source-text diagnostic decisions.

## Invariant
Generic type-argument constraint handling should recognize the `unknown` keyword from parser syntax/name facts, not by slicing and trimming source text for the type-argument node. Conformance CI shard planning and execution must use the same weighted timing precedence so aggregate coverage reflects the tests actually selected by each shard.

## Scope
- Replace `node_text(type_arg_idx).trim() == "unknown"` in generic constraint syntax instantiation with the parsed `UnknownKeyword` node kind plus existing identifier-name fallback.
- Add a focused TS2344 regression using trivia before `unknown` to preserve behavior.
- Add a local guard that rejects reintroducing the exact source-text decision in this helper.
- Align `scripts/conformance/conformance-accepted-regressions.txt` with the 31 unique accepted failures observed in CI run 26378394156.
- Fix weighted conformance runner timing precedence so fresh `results` entries override stale `path_weights`, matching the CI planner and preventing stale outliers from collapsing a shard to one selected test.

## Project Corpus Impact
- Row: n/a
- Bug family: source-text diagnostic decision debt plus conformance harness weighted-shard planning drift
- Evidence: checker-only TS2344 constraint validation refactor and conformance-harness-only CI coverage fix; no benchmark project row behavior is intentionally changed.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'node_text\\(type_arg_idx\\)|text\\.trim\\(\\) == "unknown"' crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs` exits 1 with no matches
- `timeout 240 cargo nextest run -p tsz-checker -E 'test(unknown_type_arg_constraint_uses_keyword_syntax_with_trivia) or test(unknown_type_arg_detection_does_not_read_source_text)'` compiled successfully but timed out after the `cargo-nextest` parent stalled before launching test binaries
- `.target/debug/deps/tsz_checker-e98fc976493a887f --exact checkers_domain::generic_checker::constraint_syntax_instantiation::tests::unknown_type_arg_detection_does_not_read_source_text`
- `.target/debug/deps/tsz_checker-e98fc976493a887f --exact generic_unknown_type_arg_tests::unknown_type_arg_constraint_uses_keyword_syntax_with_trivia`
- CI run 26378394156: all conformance shards passed; aggregate failed before allowlist comparison with coverage `12534 < 12757`.
- Local artifact check after `8fe61f5cfbd9c4881f20a7e20adb0c758f7ef228`: accepted list has 31 entries, observed CI failures have 31 entries, stale/unlisted sets are empty.
- `cargo nextest run -p tsz-conformance result_timings_override_stale_path_weights`

## Coordination Notes
- AgentName: M1-C
- Current head `533692dadfcd88da1017cfaa3ef903e788f27d78` includes the conformance weighted-timing precedence fix after CI run 26380679735 failed aggregate coverage with shard 0 reporting `0/1` actual tests against `563/563` expected.
- Root cause from run 26380679735: the Python planner lets cached timing `results` override older `path_weights`; the Rust runner kept the older path weight via `or_insert`, so stale outlier weights could make the runner select a different shard than the planner.
- Non-overlap: separate from #9272 alias display, #10048 keyof constraint surface, #10093/#10097 indexed-access syntax, #10106 interface heritage `typeof` syntax, #10090 iterator intrinsic syntax, and the optional-undefined/callable/numeric rendered-decision PRs. The semantic slice only changes generic `unknown` type-argument detection; the added harness fix is limited to weighted conformance sharding.
- Auto-merge remains off while CI reruns on the new head.
- #10119 landed as `50cad1f819d70a778f59e83697f910dd79c84e13`; this PR is now the active serial synthetic queue.
- Synthetic queue run `26391925757` is in progress on merge commit `55363b61045742b3e0e454d29d5f522839d4c660` with parents current `main` `50cad1f819d70a778f59e83697f910dd79c84e13` and PR head `533692dadfcd88da1017cfaa3ef903e788f27d78`.