### PR TITLE
refactor(checker): route indexed access helper relation guards

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -506,9 +506,10 @@ impl<'a> CheckerState<'a> {
             let Some(value_keyof) = self.type_literal_keyof_from_node(sig.type_annotation) else {
                 return false;
             };
-            if !self.is_assignable_to(index_for_check, value_keyof)
-                && !constraint_for_check
-                    .is_some_and(|constraint| self.is_assignable_to(constraint, value_keyof))
+            if !self.diagnostic_relation_boolean_guard(index_for_check, value_keyof)
+                && !constraint_for_check.is_some_and(|constraint| {
+                    self.diagnostic_relation_boolean_guard(constraint, value_keyof)
+                })
             {
                 return false;
             }
@@ -565,7 +566,7 @@ impl<'a> CheckerState<'a> {
         let nested_index_for_check = nested_index_constraint.unwrap_or(nested_index_type);
         let nested_index_for_check = self.evaluate_type_with_env(nested_index_for_check);
 
-        self.is_assignable_to(nested_index_for_check, nested_base_keyof)
+        self.diagnostic_relation_boolean_guard(nested_index_for_check, nested_base_keyof)
             && self.type_literal_member_values_accept_index(
                 nested.object_type,
                 outer_index_type,
@@ -758,7 +759,7 @@ impl<'a> CheckerState<'a> {
         };
 
         members.iter().all(|&member| {
-            self.is_assignable_to(member, keyof_object)
+            self.diagnostic_relation_boolean_guard(member, keyof_object)
                 || self
                     .get_index_key_kind(member)
                     .is_some_and(|(wants_string, wants_number)| {
@@ -783,7 +784,7 @@ impl<'a> CheckerState<'a> {
         {
             let mapped = self.ctx.types.mapped_type(mapped_id);
             let template_keyof = self.ctx.types.evaluate_keyof(mapped.template);
-            return self.is_assignable_to(index_type, template_keyof);
+            return self.diagnostic_relation_boolean_guard(index_type, template_keyof);
         }
 
         let Some(constraint) =
@@ -802,7 +803,7 @@ impl<'a> CheckerState<'a> {
         if matches!(values, TypeId::ERROR | TypeId::UNDEFINED) {
             return false;
         }
-        self.is_assignable_to(index_type, self.ctx.types.evaluate_keyof(values))
+        self.diagnostic_relation_boolean_guard(index_type, self.ctx.types.evaluate_keyof(values))
     }
 
     pub(super) fn mapped_object_index_matches_own_key_constraint(
@@ -835,8 +836,8 @@ impl<'a> CheckerState<'a> {
 
         index_type == constraint_type
             || index_type_for_check == constraint_eval
-            || (self.is_assignable_to(index_type_for_check, constraint_eval)
-                && self.is_assignable_to(constraint_eval, index_type_for_check))
+            || (self.diagnostic_relation_boolean_guard(index_type_for_check, constraint_eval)
+                && self.diagnostic_relation_boolean_guard(constraint_eval, index_type_for_check))
     }
 
     pub(super) fn simple_type_reference_name(&self, node_idx: NodeIndex) -> Option<String> {
@@ -894,6 +895,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         let string_or_number = self.ctx.types.union2(TypeId::STRING, TypeId::NUMBER);
-        self.is_assignable_to(index_type_for_check, string_or_number)
+        self.diagnostic_relation_boolean_guard(index_type_for_check, string_or_number)
     }
 }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -556,6 +556,14 @@ REGEX_LINE_COUNT_CHECKS = [
             / "tsz-checker"
             / "src"
             / "types"
+            / "type_checking"
+            / "indexed_access"
+            / "indexed_access_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
             / "property_access_type"
             / "helpers.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "jsdoc" / "lookup.rs",


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10113.

Invariant:
Diagnostic-only indexed-access helper predicates route through the shared checker relation boolean guard. Behavior is unchanged; this is a boundary-routing refactor.

Scope:
- Replaced raw `is_assignable_to` predicates in `crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs` with `diagnostic_relation_boolean_guard`.
- Added the indexed-access helper file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no project corpus behavior intended.

Verification:
- `git diff --check codex/m1b-infer-conditional-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `4450fb5989284c57ecdef1e6663a7548349042a7` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `queue-one-pr`, `gate`, `CI Light Summary`).
- `Queue Tested` is still pending for the synthetic main merge; no auto-merge is enabled.

Coordination Notes:
- Stacked above #10113 (`codex/m1b-infer-conditional-relation-guards-20260525`) at base head `20628805d93a6ed81c3a8b82b8710278bd273b61`.
- Current head: `4450fb5989284c57ecdef1e6663a7548349042a7`.
- Rebased from prior base `84254f197d6a66191618b0de2468e827757a3b82`; conflict state cleared by replaying only this PR's two-file routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: UNSTABLE` only because `Queue Tested` is pending.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
