### PR TITLE
fix(solver): widen literal members of spread-mixed array literals during T[] inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -86,6 +86,10 @@ name = "async_return_widening_tests"
 path = "tests/async_return_widening_tests.rs"
 
 [[test]]
+name = "spread_array_literal_widening_inference_tests"
+path = "tests/spread_array_literal_widening_inference_tests.rs"
+
+[[test]]
 name = "object_literal_getter_widening_tests"
 path = "tests/object_literal_getter_widening_tests.rs"
 

--- a/crates/tsz-checker/tests/spread_array_literal_widening_inference_tests.rs
+++ b/crates/tsz-checker/tests/spread_array_literal_widening_inference_tests.rs
@@ -1,0 +1,167 @@
+//! Tests for literal widening of non-spread elements in a spread-containing
+//! array literal during `T[]` inference (issue #9741).
+//!
+//! Structural rule: when inferring the element type `T` of `arr: T[]` from a
+//! fresh array literal, the non-spread literal elements are widened to their
+//! base primitive (ordinary array-literal element widening), regardless of
+//! whether the literal also contains a spread. tsc's `getWidenedLiteralType`
+//! recurses into the candidate union and widens each fresh literal member
+//! independently, so a non-literal member injected by a spread of `number[]`
+//! must NOT suppress widening of its literal siblings.
+//!
+//! Before the fix tsz only widened when *every* union member was a literal, so
+//! `f([...numberArray, "x"])` inferred `T = number | "x"` instead of
+//! `T = string | number`, masking a `TS2322` (false negative).
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+fn ts2322(source: &str) -> Vec<String> {
+    get_diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+#[test]
+fn spread_then_literal_widens_during_array_inference() {
+    // Reported repro: `T` must widen to `string | number`, so assigning the
+    // result to the narrower `number | "x"` is a TS2322.
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x"]);
+const c: number | "x" = r;
+"#;
+    let errs = ts2322(source);
+    assert!(
+        !errs.is_empty(),
+        "expected TS2322 (T widened to string | number, not number | \"x\"), got none"
+    );
+}
+
+#[test]
+fn spread_then_literal_accepts_widened_target() {
+    // The widened inference (`string | number`) must be accepted by the
+    // widened annotation — no spurious error on the boundary control.
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x"]);
+const c: string | number = r;
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "string | number target must accept the widened result, got: {:#?}",
+        ts2322(source)
+    );
+}
+
+#[test]
+fn literal_then_spread_widens_position_independent() {
+    // Spread position must not matter: leading literal + trailing spread.
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f(["x", ...base]);
+const c: number | "x" = r;
+"#;
+    assert!(
+        !ts2322(source).is_empty(),
+        "expected TS2322 with spread last (position independent), got none"
+    );
+}
+
+#[test]
+fn spread_then_multiple_literals_widen() {
+    // Multiple trailing literals all widen.
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const base = [1, 2];
+const r = f([...base, "x", "y"]);
+const c: number | "x" | "y" = r;
+"#;
+    assert!(
+        !ts2322(source).is_empty(),
+        "expected TS2322 with multiple trailing literals, got none"
+    );
+}
+
+#[test]
+fn renamed_param_with_number_literal_member_widens() {
+    // Anti-hardcoding: rename the type parameter and use a number literal
+    // alongside a string spread. The rule is structural (a literal union
+    // member from a fresh array element widens), not tied to a name or to the
+    // `string`/`number` spelling in the repro.
+    let source = r#"
+declare function combine<Elem>(xs: Elem[]): Elem;
+const seed = ["a", "b"];
+const out = combine([...seed, 1]);
+const bad: string | 1 = out;
+"#;
+    assert!(
+        !ts2322(source).is_empty(),
+        "expected TS2322 with renamed param + widened number literal, got none"
+    );
+}
+
+#[test]
+fn renamed_param_widened_target_accepted() {
+    let source = r#"
+declare function combine<Elem>(xs: Elem[]): Elem;
+const seed = ["a", "b"];
+const out = combine([...seed, 1]);
+const ok: string | number = out;
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "string | number target must accept widened result, got: {:#?}",
+        ts2322(source)
+    );
+}
+
+#[test]
+fn plain_literal_array_still_widens_control() {
+    // Control: a plain array literal (no spread) already widened correctly and
+    // must keep widening — `T = string`, so the literal-union annotation errors.
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const r = f(["x", "y"]);
+const c: "x" | "y" = r;
+"#;
+    assert!(
+        !ts2322(source).is_empty(),
+        "plain array literal must still widen to string (T != \"x\" | \"y\"), got none"
+    );
+}
+
+#[test]
+fn plain_literal_array_accepts_string_control() {
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const r = f(["x", "y"]);
+const c: string = r;
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "plain array literal widened to string must accept `string`, got: {:#?}",
+        ts2322(source)
+    );
+}
+
+#[test]
+fn spread_only_literal_array_widens_control() {
+    // Control: spread of a literal array with no extra literal element still
+    // widens to the element primitive (the trigger is a non-spread literal
+    // *alongside* a spread, not the spread alone).
+    let source = r#"
+declare function f<T>(arr: T[]): T;
+const r = f([...["a", "b"]]);
+const c: string = r;
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "spread-only literal array must widen to string and accept `string`, got: {:#?}",
+        ts2322(source)
+    );
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -14,7 +14,7 @@ use crate::construction::TypeDatabase;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{InferencePriority, TemplateSpan, TypeData, TypeId};
-use crate::visitor::{is_literal_type, is_union_of_fresh_literals};
+use crate::visitor::{is_literal_type, union_contains_literal_member};
 use ena::unify::{InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -1243,7 +1243,7 @@ impl<'a> InferenceContext<'a> {
             is_fresh_literal: (!context.from_object_property || context.source_is_fresh)
                 && (is_literal_type(self.interner, ty)
                     || (self.in_array_element_context
-                        && is_union_of_fresh_literals(self.interner, ty)))
+                        && union_contains_literal_member(self.interner, ty)))
                 && !self.source_is_type_annotation,
             from_object_property: context.from_object_property,
             from_index_signature: context.from_index_signature,

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -2270,7 +2270,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                     let should_widen = crate::visitor::is_literal_type(db, result)
                                         && (!return_preserves_direct_literal
                                             || infer_ctx.all_candidates_from_array_elements(var))
-                                        || crate::visitor::is_union_of_fresh_literals(db, result);
+                                        || crate::visitor::union_contains_literal_member(
+                                            db, result,
+                                        );
                                     if should_widen {
                                         widening::widen_literal_type(db, result)
                                     } else {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -74,19 +74,21 @@ pub fn is_literal_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     matches!(types.lookup(type_id), Some(TypeData::Literal(_)))
 }
 
-/// Check if a type is a union whose every member is a fresh literal.
+/// Check if a type is a union with at least one literal member (e.g. `number | "x"`).
 ///
-/// Returns `true` for `"a" | "b" | "c"`, `1 | 2 | 3`, `true | false`, etc.
-/// Returns `false` for scalar `Literal` types, primitives, and any union that
-/// contains at least one non-literal member.
-pub fn is_union_of_fresh_literals(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+/// Gates widening of inference candidates from fresh array-literal elements. tsc's
+/// `getWidenedLiteralType` widens each fresh literal member of a union
+/// independently, so a non-literal member injected by a spread (the `number` in
+/// `[...numberArr, "x"]`) must not suppress widening of its literal siblings — an
+/// all-members check would wrongly preserve `"x"`.
+pub fn union_contains_literal_member(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id.is_intrinsic() {
         return false;
     }
     match types.lookup(type_id) {
         Some(TypeData::Union(list_id)) => {
             let members = types.type_list(list_id);
-            !members.is_empty() && members.iter().all(|&m| is_literal_type(types, m))
+            members.iter().any(|&m| is_literal_type(types, m))
         }
         _ => false,
     }


### PR DESCRIPTION
## Summary

Fixes #9741.

When inferring the element type `T` of `arr: T[]` from a **fresh array literal that mixes a spread with non-spread literal elements** (e.g. `[...numberArr, "x"]`), tsz preserved the literal types of the non-spread elements (`T = number | "x"`) instead of widening them like tsc (`T = string | number`). The wrong inferred type masked a `TS2322` (false negative).

```ts
declare function f<T>(arr: T[]): T;
const base = [1, 2];
const r = f([...base, "x"]);
const c: number | "x" = r;   // tsc: TS2322; tsz (before): accepted
```

## Structural rule

> When resolving an inference candidate sourced from a fresh array-literal element position, fresh literal **members** of the candidate union are widened to their base primitive — matching tsc's `getWidenedLiteralType`, which recurses into a union and widens each fresh literal member independently. A non-literal member injected by a spread (the `number` in `[...numberArr, "x"]`) must not suppress widening of its literal siblings.

## Owner layer & root cause

Solver inference. The array-literal checker collapses `[...base, "x"]` into a single union candidate `number | "x"` and adds it as the `T[]` element evidence. The widening decision is gated by candidate freshness (`is_fresh_literal`), set in `infer.rs` via `is_union_of_fresh_literals` — an **all-members** check. The spread injects a non-literal (`number`), so the all-members check fails and the literal sibling `"x"` is never widened.

The fix generalizes that predicate to `union_contains_literal_member` (**any** literal member) and uses it at both widening gates (candidate freshness marking in `inference/infer.rs`, and the noinfer widening gate in `operations/generic_call/resolve.rs`). The existing `widen_literal_type` already widens union members individually and leaves non-literal members untouched, so no further logic was required. This is a strict broadening of the old all-members predicate.

## Test matrix (`crates/tsz-checker/tests/spread_array_literal_widening_inference_tests.rs`, 9 tests)

1. `f([...base, "x"])` reported repro → `T = string | number`, narrow target errors.
2. Same repro → widened target `string | number` accepted (no spurious error).
3. `f(["x", ...base])` spread first → reproduces (position-independent).
4. `f([...base, "x", "y"])` multiple trailing literals → widened.
5. Anti-hardcoding: renamed type param + `number` literal (`combine([...seed, 1])`) → `string | 1` errors (proves the rule is structural, not the `string`/`number` spelling or param name).
6. Renamed-param widened target accepted.
7. Control: plain `f(["x","y"])` still widens to `string` (literal-union target errors).
8. Control: plain widened result accepts `string`.
9. Control: spread-only `f([...["a","b"]])` widens to `string`.

All nine match `tsc`.

## Project Corpus Impact

- Row: n/a (micro false-negative; no project-corpus row maps to it).
- Bug family: generic inference literal widening / `getWidenedLiteralType` over array-literal element candidates (missing `TS2322`).
- Evidence: solver/checker unit suites show **0 new** failures — the 13 pre-existing `tsz-solver` failures (10 `conditional_comprehensive_tests::equal_any*`, 3 `solver_file_size_ceiling_tests`) and the pre-existing `generic_call_inference_tests` (5) / `operator_literal_annotation_widen_tests` (2) checker failures reproduce **identically on clean `main`** (verified via `git stash`). Authoritative conformance/emit/fourslash gates run on this ready head in CI.

## Verification

- New target: 9/9 pass; all match `tsc` via the local `tsz` CLI.
- `cargo test -p tsz-solver`: 6162 passed, 13 failed — identical to clean `main` (0 new).
- Targeted checker widening/inference targets: 0 new failures vs. clean `main`.
- `cargo clippy -p tsz-solver`: clean.

## Coordination Notes

AgentName: gen-hunter-opus47
Track: conformance (false-negative)
Invariant: solver is the single source of truth for inference; the fix is gated on a structural predicate (`union_contains_literal_member`) over `TypeId` shapes — never on identifier names, file names, or printer output.

https://claude.ai/code/session_01Ee95RSuBmxCpCVEGBjjfMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee95RSuBmxCpCVEGBjjfMa)_