### PR TITLE
refactor(checker): route indexed access relation guards

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -333,7 +333,7 @@ impl<'a> CheckerState<'a> {
             // Also check assignability: constraint might be
             // DistributedKeyOf<ObjT> which evaluates to keyof ObjT
             let keyof_object = self.ctx.types.evaluate_keyof(object_type_for_check);
-            if self.is_assignable_to(constraint_eval, keyof_object) {
+            if self.diagnostic_relation_boolean_guard(constraint_eval, keyof_object) {
                 return true;
             }
         }
@@ -654,7 +654,7 @@ impl<'a> CheckerState<'a> {
         {
             let check_index = index_constraint.unwrap_or(index_type);
             let check_index_eval = self.evaluate_type_with_env(check_index);
-            if self.is_assignable_to(check_index_eval, keyof_type) {
+            if self.diagnostic_relation_boolean_guard(check_index_eval, keyof_type) {
                 return;
             }
         }
@@ -871,7 +871,7 @@ impl<'a> CheckerState<'a> {
         // First check: raw index type against keyof.
         // This handles cases where keyof includes type parameters from mapped types
         // (e.g. keyof ({ [P in T]: P } & ...) = T | ...) and the index IS that parameter.
-        if self.is_assignable_to(index_type_for_check, keyof_object) {
+        if self.diagnostic_relation_boolean_guard(index_type_for_check, keyof_object) {
             return;
         }
         if self.conditional_result_branches_satisfy_constraint(index_type, keyof_object)
@@ -886,7 +886,7 @@ impl<'a> CheckerState<'a> {
         // constraint `keyof M` is found from the AST but not in the TypeId.
         if let Some(constraint) = index_constraint {
             let constraint_eval = self.evaluate_type_with_env(constraint);
-            if self.is_assignable_to(constraint_eval, keyof_object) {
+            if self.diagnostic_relation_boolean_guard(constraint_eval, keyof_object) {
                 return;
             }
         }
@@ -931,7 +931,7 @@ impl<'a> CheckerState<'a> {
             );
             let Some(next_constraint) = next else { break };
             let next_evaluated = self.evaluate_type_with_env(next_constraint);
-            if self.is_assignable_to(next_evaluated, keyof_object) {
+            if self.diagnostic_relation_boolean_guard(next_evaluated, keyof_object) {
                 return;
             }
             // If the constraint resolved to a deferred key space for THIS object,
@@ -975,7 +975,7 @@ impl<'a> CheckerState<'a> {
                 {
                     return;
                 }
-                if self.is_assignable_to(evaluated, keyof_object) {
+                if self.diagnostic_relation_boolean_guard(evaluated, keyof_object) {
                     return;
                 }
                 let next = crate::query_boundaries::common::type_parameter_constraint(
@@ -986,7 +986,7 @@ impl<'a> CheckerState<'a> {
                 chain_start = next_constraint;
             }
         }
-        if !self.is_assignable_to(index_type_for_check, keyof_object) {
+        if !self.diagnostic_relation_boolean_guard(index_type_for_check, keyof_object) {
             if let Some((wants_string, wants_number)) =
                 self.get_index_key_kind(index_type_for_check)
                 && !generic_constrained_index(
@@ -1055,11 +1055,12 @@ impl<'a> CheckerState<'a> {
                     )
                     .is_some_and(|constraint| {
                         let constraint = self.evaluate_type_with_env(constraint);
-                        self.is_assignable_to(constraint, constrained_base_keyof)
+                        self.diagnostic_relation_boolean_guard(constraint, constrained_base_keyof)
                     });
-                let nested_index_matches_constrained_base = self
-                    .is_assignable_to(nested_index_for_check, constrained_base_keyof)
-                    || nested_index_constraint_matches
+                let nested_index_matches_constrained_base = self.diagnostic_relation_boolean_guard(
+                    nested_index_for_check,
+                    constrained_base_keyof,
+                ) || nested_index_constraint_matches
                     || self.is_keyof_for_current_object(
                         nested_index_type,
                         constrained_base_type,
@@ -1188,7 +1189,10 @@ impl<'a> CheckerState<'a> {
                         // Fall back to keyof check for non-literal indices.
                         let constrained_keyof =
                             self.ctx.types.evaluate_keyof(constrained_object_type);
-                        if self.is_assignable_to(index_type_for_check, constrained_keyof) {
+                        if self.diagnostic_relation_boolean_guard(
+                            index_type_for_check,
+                            constrained_keyof,
+                        ) {
                             return;
                         }
                     }
@@ -1512,7 +1516,9 @@ impl<'a> CheckerState<'a> {
                     {
                         // Check if the index is a valid key of the values union
                         let keyof_values = self.ctx.types.evaluate_keyof(values_union);
-                        if self.is_assignable_to(index_type_for_check, keyof_values) {
+                        if self
+                            .diagnostic_relation_boolean_guard(index_type_for_check, keyof_values)
+                        {
                             return;
                         }
                         // Also try property access for string literal indices

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -557,6 +557,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "types"
             / "type_checking"
+            / "indexed_access.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "type_checking"
             / "indexed_access"
             / "indexed_access_helpers.rs",
             ROOT


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10117.

Invariant:
Diagnostic-only indexed-access TS2536 suppression predicates route through the shared checker relation boolean guard. Behavior is unchanged; this is a boundary-routing refactor that keeps indexed-access diagnostic decisions on the relation-boundary migration path.

Scope:
- Replaced raw `self.is_assignable_to(...)` calls in `crates/tsz-checker/src/types/type_checking/indexed_access.rs` with `diagnostic_relation_boolean_guard(...)`.
- Added the indexed-access checker file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-indexed-access-mapped-key-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `1c3fde19c986d447852da61b6f2babc6518e4c2d` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10117 (`codex/m1b-indexed-access-mapped-key-relation-guards-20260525`) at base head `a5ce164378f17ff2b0c079d740c218c96e5f064e`.
- Current head: `1c3fde19c986d447852da61b6f2babc6518e4c2d`.
- Rebased from prior base `90a9492e02b8927ffe7bd0bd54fc85205215f46a`; replay was clean and kept only this PR's two-file indexed-access routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
