### PR TITLE
refactor(checker): query JSX children display aliases

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -1,6 +1,7 @@
 //! JSX children normalization: shape validation (TS2745/TS2746), spread child
 //! normalization, children prop type resolution, and multi-child assignability.
 
+use crate::query_boundaries::checkers::jsx as jsx_query;
 use crate::query_boundaries::common::{
     PropertyAccessResult, array_element_type, tuple_elements, unwrap_readonly,
 };
@@ -979,7 +980,7 @@ impl<'a> CheckerState<'a> {
                 .any(|&type_id| self.type_allows_multiple_children(type_id))
             || !element_types
                 .iter()
-                .any(|&type_id| self.format_type(type_id) == "ReactChild")
+                .any(|&type_id| self.jsx_type_has_declaration_name(type_id, "ReactChild"))
         {
             return false;
         }
@@ -1317,6 +1318,8 @@ impl<'a> CheckerState<'a> {
             Some(k) if k == syntax_kind_ext::ARROW_FUNCTION
                 || k == syntax_kind_ext::FUNCTION_EXPRESSION
         ) && target_is_single_callable;
+        let actual_child_is_jsx_element_type =
+            child_is_jsx_element_like && self.type_matches_jsx_element_type(actual_child_type);
         let assignable = if use_source_elaboration {
             self.check_assignable_or_report_at_exact_anchor(
                 actual_child_type,
@@ -1332,12 +1335,25 @@ impl<'a> CheckerState<'a> {
                 diag_node,
             )
         };
-        if !assignable
-            && child_is_jsx_element_like
-            && self.format_type(actual_child_type) == "Element"
-        {
+        if !assignable && actual_child_is_jsx_element_type {
             self.rewrite_recent_jsx_element_source_display(diagnostics_before);
         }
+    }
+
+    fn jsx_type_has_declaration_name(&self, type_id: TypeId, expected: &str) -> bool {
+        jsx_query::type_has_declaration_name(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            type_id,
+            expected,
+        )
+    }
+
+    fn type_matches_jsx_element_type(&mut self, type_id: TypeId) -> bool {
+        let Some(jsx_element_type) = self.get_jsx_element_type_for_check() else {
+            return false;
+        };
+        self.resolve_lazy_type(type_id) == self.resolve_lazy_type(jsx_element_type)
     }
 
     fn rewrite_recent_jsx_element_source_display(&mut self, diagnostics_start: usize) {
@@ -1744,5 +1760,23 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn jsx_children_display_policy_avoids_formatted_type_name_decisions() {
+        let source = include_str!("children.rs");
+        for forbidden in [
+            ["format_type(type_id)", " == ", "\"ReactChild\""].join(""),
+            ["format_type(actual_child_type)", " == ", "\"Element\""].join(""),
+        ] {
+            assert!(
+                !source.contains(&forbidden),
+                "JSX children display policy must use TypeId/query facts, \
+                 not formatted type-name comparisons: found {forbidden}"
+            );
+        }
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -162,6 +162,25 @@ pub(crate) fn single_arg_type_application(
     })
 }
 
+/// Return true when a type is a lazy alias/reference with the requested
+/// declaration name. Presentation policy uses this to avoid asking the type
+/// printer whether an alias happened to render with a particular spelling.
+pub(crate) fn type_has_declaration_name(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    expected: &str,
+) -> bool {
+    let reference_type = crate::query_boundaries::common::type_application(db, type_id)
+        .map_or(type_id, |app| app.base);
+    let Some(def_id) = crate::query_boundaries::common::lazy_def_id(db, reference_type) else {
+        return false;
+    };
+    def_store
+        .get_name(def_id)
+        .is_some_and(|name| db.resolve_atom_ref(name).as_ref() == expected)
+}
+
 pub(crate) fn contains_anonymous_object_surface(
     db: &dyn TypeDatabase,
     def_store: &DefinitionStore,


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
M1-C rendered-type-string cleanup

## Invariant
JSX children diagnostics must decide from TypeId, DefinitionStore, and JSX type facts, not from rendered type strings.

## Scope
- Replace the ReactChild ordering check with a JSX query-boundary helper that unwraps type applications and checks the lazy declaration name through DefinitionStore.
- Replace the JSX Element display rewrite guard with direct comparison to the resolved JSX.Element type.
- Add a focused guard test preventing the exact formatted-name display decisions from returning to children.rs.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display policy cleanup
- Evidence: checker-only refactor with focused JSX children guard and existing JSX children behavior test; no project-corpus row is directly targeted.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p tsz-checker --lib`
- `.target/debug/deps/tsz_checker-e98fc976493a887f --exact checkers_domain::jsx::children::tests::jsx_children_display_policy_avoids_formatted_type_name_decisions`
- `.target/debug/deps/tsz_checker-e98fc976493a887f --exact checkers_domain::jsx::tests::jsx_children_union_node_name_variant_no_ts2322`

## Coordination Notes
- AgentName: M1-C
- Started after refreshing #9272 and checking #10114/#10090 lane state.
- Non-overlap: this targets JSX children display-policy decisions in children.rs, separate from active M1-C PRs #9272, #10114, and the other ready lane PRs.
- `cargo nextest list -p tsz-checker` compiled the test binary but stalled during enumeration, so I killed that process and ran the exact built test binary directly.
- Updated PR body after ready-review `project-corpus-pr-body` reported the stricter template check; remote body now uses the required `## Project Corpus Impact` section and dashed `Row`/`Bug family` fields.
- Auto-merge remains off.
- #10123 landed as `86faea5c4d2a0aee13c6766fdf3decbfbd17362f`; this PR is now the active serial synthetic queue.
- Synthetic queue run `26390519260` is in progress on merge commit `5ed404603d3bf4cb83dcc6aaee7c83d8f14b7b23` with parents current `main` `86faea5c4d2a0aee13c6766fdf3decbfbd17362f` and PR head `467539c13dd0a9dad01025ec272ad653bac25467`.
- Prior synthetic run `26390519260` passed on `5ed404603d3bf4cb83dcc6aaee7c83d8f14b7b23`, but `main` advanced to `762ef80cfcfd6da080a1f96abff8e5ee14d20916` before merge, so that queue was stale and was not landed.
- Refreshed synthetic queue run `26391238539` is in progress on merge commit `3b039bd94b2d9e81c558909d9ae483d00a357e4b` with parents current `main` `762ef80cfcfd6da080a1f96abff8e5ee14d20916` and PR head `467539c13dd0a9dad01025ec272ad653bac25467`.