### PR TITLE
refactor(checker): route promise this relation guard

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -643,7 +643,7 @@ impl<'a> CheckerState<'a> {
         for sig in &sigs {
             if let Some(expected_this) = sig.this_type
                 && expected_this != TypeId::VOID
-                && !self.is_assignable_to(type_id, expected_this)
+                && !self.diagnostic_relation_boolean_guard(type_id, expected_this)
             {
                 rejected_this_type.get_or_insert(expected_this);
                 continue;

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -592,6 +592,7 @@ REGEX_LINE_COUNT_CHECKS = [
             / "declaration.rs",
             ROOT / "crates" / "tsz-checker" / "src" / "error_reporter",
             ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "call_context.rs",
+            ROOT / "crates" / "tsz-checker" / "src" / "checkers" / "promise_checker.rs",
             ROOT
             / "crates"
             / "tsz-checker"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10118.

Invariant:
Diagnostic-only Promise/thenable `this` rejection predicates route through the shared checker relation boolean guard. Behavior is unchanged; this is a boundary-routing refactor that keeps await/thenable diagnostic decisions on the relation-boundary migration path.

Scope:
- Replaced the raw `self.is_assignable_to(...)` call in `crates/tsz-checker/src/checkers/promise_checker.rs` with `diagnostic_relation_boolean_guard(...)`.
- Added the Promise checker file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-indexed-access-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `abc25b414114c5c378eaa1482edc6f7d4d90c647` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10118 (`codex/m1b-indexed-access-relation-guards-20260525`) at base head `1c3fde19c986d447852da61b6f2babc6518e4c2d`.
- Current head: `abc25b414114c5c378eaa1482edc6f7d4d90c647`.
- Rebased from prior base `75b65a7cc27d1f1f5a45db3e36ba148e606686c5`; replay was clean and kept only this PR's Promise checker routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
