### PR TITLE
refactor(checker): route interface overload relation guard

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
@@ -317,14 +317,17 @@ impl<'a> CheckerState<'a> {
             // overload signatures, allow the normal relation to fresh-instantiate
             // the method-local type params. Keep this gated to matching generic
             // shapes so ordinary TS2430 overload mismatches still report.
-            let strict_assignable =
-                self.is_assignable_to_no_erase_generics(derived_compare_sig, base_compare_sig);
-            let assignable = strict_assignable
-                || (can_use_fresh_generic_overload_assignability(
+            let assignable =
+                crate::query_boundaries::class::interface_overload_trailing_signature_assignable(
                     self,
                     derived_compare_sig,
                     base_compare_sig,
-                ) && self.is_assignable_to(derived_compare_sig, base_compare_sig));
+                    can_use_fresh_generic_overload_assignability(
+                        self,
+                        derived_compare_sig,
+                        base_compare_sig,
+                    ),
+                );
             if !assignable
                 && !self.should_suppress_assignability_for_parse_recovery(
                     derived_trailing_idx,

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -382,6 +382,21 @@ pub(crate) fn should_report_member_type_mismatch(
     true
 }
 
+/// Check interface trailing overload compatibility through the class relation boundary.
+///
+/// The strict path uses `no_erase_generics` to preserve overload compatibility
+/// behavior. The optional retry mirrors `tsc`'s fresh generic instantiation for
+/// equivalent method-local generic overload shapes.
+pub(crate) fn interface_overload_trailing_signature_assignable(
+    checker: &mut CheckerState<'_>,
+    source: TypeId,
+    target: TypeId,
+    allow_fresh_generic_retry: bool,
+) -> bool {
+    checker.is_assignable_to_no_erase_generics(source, target)
+        || (allow_fresh_generic_retry && checker.diagnostic_relation_boolean_guard(source, target))
+}
+
 /// Check if a DIRECT (own) member type mismatch should be reported (TS2416).
 ///
 /// Unlike `should_report_member_type_mismatch`, this variant uses a targeted

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -534,6 +534,12 @@ REGEX_LINE_COUNT_CHECKS = [
             / "tsz-checker"
             / "src"
             / "classes"
+            / "class_checker_compat_overloads.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "classes"
             / "class_implements_checker"
             / "core.rs",
             ROOT


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10120.

Invariant:
Diagnostic-only interface trailing overload compatibility checks route through the class relation boundary. The strict `no_erase_generics` path and fresh-generic retry preserve the existing relation behavior while removing raw relation predicates from the checker call site.

Scope:
- Added `interface_overload_trailing_signature_assignable` to `query_boundaries::class`.
- Replaced raw overload relation calls in `crates/tsz-checker/src/classes/class_checker_compat_overloads.rs` with that boundary helper.
- Added the overload checker file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker boundary routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-promise-this-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `3cb333b4c717f329d6698e9dfca60871e32f5181` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10120 (`codex/m1b-promise-this-relation-guard-20260525`) at base head `abc25b414114c5c378eaa1482edc6f7d4d90c647`.
- Current head: `3cb333b4c717f329d6698e9dfca60871e32f5181`.
- Rebased from prior base `dba09b7d350d8655287420161bdbdf68bf2f0b01`; replay was clean and kept only this PR's overload boundary routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
