### PR TITLE
refactor(checker): route core statement relation guards

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -203,7 +203,7 @@ impl<'a> CheckerState<'a> {
                                 contextual_type,
                             )
                         })))
-                && self.is_assignable_to(contextual_type, expected_type)
+                && self.diagnostic_relation_boolean_guard(contextual_type, expected_type)
             {
                 return_type = contextual_type;
             }
@@ -225,7 +225,7 @@ impl<'a> CheckerState<'a> {
             if request.contextual_type.is_some()
                 && self
                     .async_contextual_return_call_has_only_fixed_arguments(return_data.expression)
-                && !self.is_assignable_to(return_type, expected_type)
+                && !self.diagnostic_relation_boolean_guard(return_type, expected_type)
             {
                 self.invalidate_expression_for_contextual_retry(return_data.expression);
                 let mut raw_return_type = self
@@ -328,7 +328,9 @@ impl<'a> CheckerState<'a> {
             && !target_is_top_level_error
             && (!expected_contains_error_nested || allow_check_through_nested_error)
         {
-            if is_conditional_expr && !self.is_assignable_to(return_type, expected_type) {
+            if is_conditional_expr
+                && !self.diagnostic_relation_boolean_guard(return_type, expected_type)
+            {
                 // Per-branch error elaboration for conditional expressions.
                 // Instead of "Type '1 | 2' is not assignable to type '3'" at `return`,
                 // emit "Type '1' is not assignable to type '3'" at each failing branch.
@@ -964,7 +966,7 @@ impl<'a> CheckerState<'a> {
                         index_type,
                     )
                     .is_none_or(|constraint| {
-                        self.is_assignable_to(
+                        self.diagnostic_relation_boolean_guard(
                             constraint,
                             self.ctx.types.evaluate_keyof(object_type),
                         )
@@ -986,7 +988,7 @@ impl<'a> CheckerState<'a> {
                     )
                     .is_some_and(|constraint| {
                         let keyof_object = self.ctx.types.evaluate_keyof(object_type);
-                        !self.is_assignable_to(constraint, keyof_object)
+                        !self.diagnostic_relation_boolean_guard(constraint, keyof_object)
                     })
                 });
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -563,6 +563,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "src"
             / "types"
             / "type_checking"
+            / "core_statement_checks.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "type_checking"
             / "indexed_access.rs",
             ROOT
             / "crates"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10121.

Invariant:
Diagnostic-only return statement and mapped constraint predicates route through the shared checker relation boolean guard. Behavior is unchanged; this is a boundary-routing refactor that keeps core statement diagnostic decisions on the relation-boundary migration path.

Scope:
- Replaced raw `self.is_assignable_to(...)` calls in `crates/tsz-checker/src/types/type_checking/core_statement_checks.rs` with `diagnostic_relation_boolean_guard(...)`.
- Added the core statement checker file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-interface-overload-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `259b6407cbe92f62b9c20d29ea3c63183050aef2` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10121 (`codex/m1b-interface-overload-relation-guard-20260525`) at base head `3cb333b4c717f329d6698e9dfca60871e32f5181`.
- Current head: `259b6407cbe92f62b9c20d29ea3c63183050aef2`.
- Rebased from prior base `63052a8df78e84649f88c6746de8b7aee202ad78`; replay was clean and kept only this PR's core statement routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
