### PR TITLE
refactor(checker): query JSX props anonymous target

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -1268,8 +1268,12 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            let display = self.format_type(member);
-            let is_anonymous = display.starts_with('{');
+            let is_anonymous =
+                crate::query_boundaries::checkers::jsx::contains_anonymous_object_surface(
+                    self.ctx.types,
+                    &self.ctx.definition_store,
+                    member,
+                );
             let property_count = shape.properties.len();
             let score = (is_anonymous, property_count, required_count);
             if score < best_score {
@@ -1900,5 +1904,27 @@ impl<'a> CheckerState<'a> {
             anchor_idx,
         );
         Some(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn jsx_props_target_selection_avoids_anonymous_display_prefix_decision() {
+        let source = include_str!("validation.rs");
+        for forbidden in [
+            ["format_type(member)", ".starts_with('{')"].join(""),
+            [
+                "let display = self.format_type(member);",
+                "let is_anonymous = display.starts_with('{');",
+            ]
+            .join("\n"),
+        ] {
+            assert!(
+                !source.contains(&forbidden),
+                "JSX props target selection must use TypeId/query facts, \
+                 not formatted anonymous-object display prefixes: found {forbidden}"
+            );
+        }
     }
 }

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -1912,8 +1912,11 @@ mod tests {
     #[test]
     fn jsx_props_target_selection_avoids_anonymous_display_prefix_decision() {
         let source = include_str!("validation.rs");
+        let formatted_member_call = ["format_type", "(member)"].join("");
+        let starts_with_object = [".starts_with", "('{')"].join("");
+        let inline_forbidden = format!("{formatted_member_call}{starts_with_object}");
         for forbidden in [
-            ["format_type(member)", ".starts_with('{')"].join(""),
+            inline_forbidden,
             [
                 "let display = self.format_type(member);",
                 "let is_anonymous = display.starts_with('{');",


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
M1-C rendered-type/source-text diagnostic cleanup

## Invariant
JSX props target selection must decide whether an intersection member is anonymous from TypeId/query-boundary facts, not from the formatted target string prefix.

## Scope
- Replace the `format_type(member).starts_with('{')` anonymous-object heuristic in JSX missing-props target selection with the existing `contains_anonymous_object_surface` query-boundary helper.
- Add a focused guard test that prevents this exact display-prefix decision from returning to `props/validation.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display policy cleanup
- Evidence: checker-only refactor for JSX props target selection; no project-corpus row is directly targeted.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p tsz-checker --lib`
- `cargo nextest run -p tsz-checker --lib -E 'test(jsx_props_target_selection_avoids_anonymous_display_prefix_decision) or test(jsx_component_type_missing_prop_display_uses_props_type_arg)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
- AgentName: M1-C
- Started after sweeping M1-C PRs; all open blockers were external CI queue, draft light-CI, or `Queue Tested` pending.
- Non-overlap: this targets JSX props missing-props target selection, separate from #10119 JSX children display aliases and the active optional/iterator/callable/indexed-display PRs.
- Updated body to the strict PR template shape before promotion.
- Ready-review CI is green on exact head `948710164bce231c05bc17e898b8e65b5a3403e4`; live GitHub state currently has auto-merge off.
- #10128 landed as `c59751232a0da88313590dd9aebfde545f8ca691`.
- Prior synthetic run `26388344114` passed on `3d325504962db4e410d959410ebb607cd210322c`, but `main` advanced before merge, so that queue was stale and was not landed.
- Prior synthetic run `26389061391` passed on `0476eacdebb2f84ea565b3a8576603377e914df4`, but `main` advanced to `23963a839eed6b45475f777572b6bb7b9c4b3dff` via #9786 before merge, so that queue was stale and was not landed.
- This PR is now the active serial synthetic queue: run `26389765779` is queued on merge commit `a50dd1eb397b3da3842a438cf57201088144eba6` with parents current `main` `23963a839eed6b45475f777572b6bb7b9c4b3dff` and PR head `948710164bce231c05bc17e898b8e65b5a3403e4`.