### PR TITLE
refactor(checker): route access helper relation guards

### DIFF
--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -469,7 +469,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        !self.is_assignable_to(index_type, string_index.key_type)
+        !self.diagnostic_relation_boolean_guard(index_type, string_index.key_type)
     }
 
     /// Check if an index type is "generic" — i.e., it cannot be resolved to a
@@ -930,7 +930,7 @@ impl<'a> CheckerState<'a> {
 
         let object_key_space = self.ctx.types.evaluate_keyof(object_constraint);
         let source_key_space = self.ctx.types.evaluate_keyof(key_source);
-        self.is_assignable_to(source_key_space, object_key_space)
+        self.diagnostic_relation_boolean_guard(source_key_space, object_key_space)
     }
 
     pub(crate) fn should_report_union_generic_key_mismatch_ts2536(
@@ -949,7 +949,7 @@ impl<'a> CheckerState<'a> {
 
         members.iter().any(|&member| {
             let member_keyof = self.ctx.types.evaluate_keyof(member);
-            !self.is_assignable_to(index_type, member_keyof)
+            !self.diagnostic_relation_boolean_guard(index_type, member_keyof)
         })
     }
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -562,6 +562,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "tsz-checker"
             / "src"
             / "types"
+            / "computation"
+            / "access_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
             / "type_checking"
             / "core_statement_checks.rs",
             ROOT


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10122.

Invariant:
Diagnostic-only access helper predicates route through the shared checker relation boolean guard. Behavior is unchanged; this is a boundary-routing refactor that keeps TS2536/TS7053-style access diagnostics on the relation-boundary migration path.

Scope:
- Replaced raw `self.is_assignable_to(...)` calls in `crates/tsz-checker/src/types/computation/access_helpers.rs` with `diagnostic_relation_boolean_guard(...)`.
- Covered narrow string-index rejection, keyof source coverage, and union generic key mismatch checks.
- Added the access helper file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-core-statement-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `a4406deed28884619bf78a5a8b978b74a2e5e20f` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10122 (`codex/m1b-core-statement-relation-guards-20260525`) at base head `259b6407cbe92f62b9c20d29ea3c63183050aef2`.
- Current head: `a4406deed28884619bf78a5a8b978b74a2e5e20f`.
- Rebased from prior base `efa989ebc2eb8e892af6a1b7682d799659b79ee0`; replay was clean and kept only this PR's access helper routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
