### PR TITLE
fix(solver): strip undefined from `-?` mapped value of optional property

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -144,6 +144,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         )
     }
 
+    /// Strip the top-level `undefined` that an originally-optional property
+    /// contributes when `-?` removes its optionality, mirroring tsc's
+    /// `removeMissingOrUndefinedType` in `getTypeOfMappedSymbol`. Only applies
+    /// when the source property was optional and `-?` cleared it.
+    fn strip_removed_optional_undefined(&self, ty: TypeId, strip: bool) -> TypeId {
+        if strip {
+            crate::narrowing::utils::remove_undefined(self.interner(), ty)
+        } else {
+            ty
+        }
+    }
+
     /// Evaluate a mapped type: { [K in Keys]: Template }
     ///
     /// Algorithm:
@@ -598,6 +610,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 evaluated
             };
 
+            let property_type = self.strip_removed_optional_undefined(
+                property_type,
+                remove_optional_with_declared && source_optional,
+            );
+
             for remapped_name in remapped_names {
                 let is_string_named = source_info
                     .is_some_and(|(_, _, _, source_is_string_named, _, _)| *source_is_string_named)
@@ -708,6 +725,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 evaluated
             };
+
+            let property_type = self.strip_removed_optional_undefined(
+                property_type,
+                remove_optional_with_declared && source_optional,
+            );
 
             for remapped_sym_id in remapped_syms {
                 // Reuse source_atom when remapped symbol is the identity (no `as` remapping).

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -146,10 +146,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Strip the top-level `undefined` that an originally-optional property
     /// contributes when `-?` removes its optionality, mirroring tsc's
-    /// `removeMissingOrUndefinedType` in `getTypeOfMappedSymbol`. Only applies
-    /// when the source property was optional and `-?` cleared it.
+    /// `removeMissingOrUndefinedType` in `getTypeOfMappedSymbol`.
+    ///
+    /// With `exactOptionalPropertyTypes`, an explicit `| undefined` is not the
+    /// missing marker and must be preserved. tsz does not model that marker
+    /// separately yet, so only the non-exact path can safely remove
+    /// `undefined`.
     fn strip_removed_optional_undefined(&self, ty: TypeId, strip: bool) -> TypeId {
-        if strip {
+        if strip && !self.interner().exact_optional_property_types() {
             crate::narrowing::utils::remove_undefined(self.interner(), ty)
         } else {
             ty

--- a/crates/tsz-solver/tests/mapped_architecture_tests.rs
+++ b/crates/tsz-solver/tests/mapped_architecture_tests.rs
@@ -18,6 +18,7 @@ use crate::types::{
     MappedModifier, MappedType, PropertyInfo, TupleElement, TypeData, TypeParamInfo, Visibility,
 };
 use rustc_hash::FxHashMap;
+use tsz_common::Atom;
 
 // =============================================================================
 // classify_mapped_source tests
@@ -599,4 +600,157 @@ fn mapped_type_over_type_param_with_array_constraint() {
     if let Some(TypeData::Object(_)) = interner.lookup(result) {
         panic!("Expected array or deferred mapped type, got plain Object");
     }
+}
+
+// =============================================================================
+// `-?` strips `undefined` from the value of an originally-optional property
+//
+// tsc's `getTypeOfMappedSymbol` applies `removeMissingOrUndefinedType` when the
+// `-?` modifier removes optionality from a property that was optional in the
+// source. tsz must strip the explicit top-level `undefined` so that
+// `Required<{ a?: T | undefined }>.a` is `T`, not `T | undefined`.
+// =============================================================================
+
+/// Build a homomorphic identity mapped type `{ [K in keyof Src]<mod> Src[K] }`
+/// over `source`, evaluate it, and return the `(type_id, optional)` of the
+/// property named `prop`. `iter_var` exercises iteration-variable-name
+/// independence.
+fn eval_identity_mapped_prop(
+    interner: &TypeInterner,
+    source: TypeId,
+    prop: Atom,
+    iter_var: &str,
+    optional_modifier: Option<MappedModifier>,
+) -> (TypeId, bool) {
+    let k_name = interner.intern_string(iter_var);
+    let k_param = interner.type_param(TypeParamInfo {
+        name: k_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+    let mapped = MappedType {
+        type_param: TypeParamInfo {
+            name: k_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        constraint: interner.keyof(source),
+        name_type: None,
+        template: interner.index_access(source, k_param),
+        optional_modifier,
+        readonly_modifier: None,
+    };
+    let result = evaluate_type(interner, interner.mapped(mapped));
+    let shape_id = match interner.lookup(result) {
+        Some(TypeData::Object(id)) => id,
+        other => panic!("expected Object from homomorphic mapped type, got {other:?}"),
+    };
+    let shape = interner.object_shape(shape_id);
+    let p = shape
+        .properties
+        .iter()
+        .find(|p| p.name == prop)
+        .expect("property present in mapped result");
+    (p.type_id, p.optional)
+}
+
+#[test]
+fn remove_optional_strips_explicit_undefined_from_value() {
+    // Reported repro: Req<{ a?: number | undefined }> -> { a: number }.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let num_or_undef = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::opt(a, num_or_undef)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
+    assert!(!optional, "-? must clear the optional flag");
+    assert_eq!(ty, TypeId::NUMBER, "-? must strip the explicit `undefined`");
+}
+
+#[test]
+fn remove_optional_strip_is_iteration_var_name_invariant() {
+    // Same rule must hold when the iteration variable is `P`, not `K`.
+    let interner = TypeInterner::new();
+    let x = interner.intern_string("x");
+    let str_or_undef = interner.union(vec![TypeId::STRING, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::opt(x, str_or_undef)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, x, "P", Some(MappedModifier::Remove));
+    assert!(!optional);
+    assert_eq!(
+        ty,
+        TypeId::STRING,
+        "rule must not depend on iteration var name"
+    );
+}
+
+#[test]
+fn remove_optional_preserves_non_undefined_union_members() {
+    // `a?: number | null | undefined` with `-?` -> `number | null` (only the
+    // top-level `undefined` is removed; `null` survives).
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let union_all = interner.union(vec![TypeId::NUMBER, TypeId::NULL, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::opt(a, union_all)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
+    assert!(!optional);
+    let expected = interner.union(vec![TypeId::NUMBER, TypeId::NULL]);
+    assert_eq!(
+        ty, expected,
+        "only `undefined` must be stripped, `null` kept"
+    );
+}
+
+#[test]
+fn remove_optional_on_plain_optional_keeps_declared_type() {
+    // Control: `a?: number` (no explicit undefined) with `-?` -> `number`.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let source = interner.object(vec![PropertyInfo::opt(a, TypeId::NUMBER)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
+    assert!(!optional);
+    assert_eq!(ty, TypeId::NUMBER);
+}
+
+#[test]
+fn remove_optional_does_not_strip_undefined_from_required_property() {
+    // Negative control: a NON-optional `a: number | undefined` with `-?` keeps
+    // `undefined` — the strip is gated on the source property being optional.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let num_or_undef = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::new(a, num_or_undef)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
+    assert!(!optional);
+    assert_eq!(
+        ty, num_or_undef,
+        "non-optional source must retain `undefined` under `-?`"
+    );
+}
+
+#[test]
+fn no_optional_modifier_does_not_strip_undefined() {
+    // Negative control: an identity mapped type with NO optional modifier must
+    // preserve both optionality and the value's `undefined`.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let num_or_undef = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::opt(a, num_or_undef)]);
+
+    let (ty, optional) = eval_identity_mapped_prop(&interner, source, a, "K", None);
+    assert!(optional, "no modifier preserves source optionality");
+    assert_eq!(
+        ty, num_or_undef,
+        "value must retain `undefined` without `-?`"
+    );
 }

--- a/crates/tsz-solver/tests/mapped_architecture_tests.rs
+++ b/crates/tsz-solver/tests/mapped_architecture_tests.rs
@@ -607,8 +607,9 @@ fn mapped_type_over_type_param_with_array_constraint() {
 //
 // tsc's `getTypeOfMappedSymbol` applies `removeMissingOrUndefinedType` when the
 // `-?` modifier removes optionality from a property that was optional in the
-// source. tsz must strip the explicit top-level `undefined` so that
-// `Required<{ a?: T | undefined }>.a` is `T`, not `T | undefined`.
+// source. In non-exact optional mode that removes top-level `undefined`; in
+// exact optional mode explicit `undefined` is not the missing marker and must
+// be preserved.
 // =============================================================================
 
 /// Build a homomorphic identity mapped type `{ [K in keyof Src]<mod> Src[K] }`
@@ -658,7 +659,7 @@ fn eval_identity_mapped_prop(
 
 #[test]
 fn remove_optional_strips_explicit_undefined_from_value() {
-    // Reported repro: Req<{ a?: number | undefined }> -> { a: number }.
+    // Non-exact optional mode: Req<{ a?: number | undefined }> -> { a: number }.
     let interner = TypeInterner::new();
     let a = interner.intern_string("a");
     let num_or_undef = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
@@ -668,6 +669,26 @@ fn remove_optional_strips_explicit_undefined_from_value() {
         eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
     assert!(!optional, "-? must clear the optional flag");
     assert_eq!(ty, TypeId::NUMBER, "-? must strip the explicit `undefined`");
+}
+
+#[test]
+fn remove_optional_exact_optional_preserves_explicit_undefined() {
+    // With exact optional property types, `a?: number | undefined` has an
+    // explicit `undefined` member. `-?` removes the missing marker only, so the
+    // explicit `undefined` remains.
+    let interner = TypeInterner::new();
+    interner.set_exact_optional_property_types(true);
+    let a = interner.intern_string("a");
+    let num_or_undef = interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]);
+    let source = interner.object(vec![PropertyInfo::opt(a, num_or_undef)]);
+
+    let (ty, optional) =
+        eval_identity_mapped_prop(&interner, source, a, "K", Some(MappedModifier::Remove));
+    assert!(!optional, "-? must still clear the optional flag");
+    assert_eq!(
+        ty, num_or_undef,
+        "exact optional mode must preserve explicit `undefined`"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #9661

AgentName: M4-A

## Track
Solver — homomorphic mapped-type modifier evaluation; `-?` (optional Remove) value-type transformation.

## Invariant
A homomorphic mapped type's `-?` modifier removes the optional flag and, in non-exact optional mode, removes the top-level `| undefined` that represents the missing marker when the source property was optional. Under `exactOptionalPropertyTypes`, explicit `| undefined` is preserved because it is not the missing marker. This mirrors tsc's `getTypeOfMappedSymbol` `StripOptional` → `removeMissingOrUndefinedType` path. Non-optional sources, `+?`, and no-modifier cases are unaffected.

## Structural rule
> When a homomorphic mapped type `{ [K in keyof T]-?: ... }` is applied to `T` whose property `p` is **optional**, the resulting `p` must have `optional = false`. In non-exact optional mode, the value type must not retain the top-level `undefined` that represents optional missingness; in exact optional mode, explicit `undefined` remains. The rule is structural — independent of the iteration-variable name, the property name, the declared element type, and alias/`Required<…>` indirection.

## Root cause
For an identity homomorphic mapped type, `evaluate_mapped` takes the property value from the source's **declared** type. For `a?: number` the declared type is `number` (already correct), but for `a?: number | undefined` in non-exact optional mode the declared type itself carries `| undefined`. tsz cleared the optional flag but never ran the `removeMissingOrUndefinedType`-equivalent strip, so `Required<{ a?: number | undefined }>.a` evaluated to `number | undefined` and assigning it to `number` produced a false-positive **TS2322**. The first ready-review run also showed the exact-optional companion: under `exactOptionalPropertyTypes`, tsc preserves explicit `undefined`, so the strip must be disabled there until tsz models the missing marker separately.

## Scope
`crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs`:
- New private helper `strip_removed_optional_undefined(ty, strip)` that runs the existing `crate::narrowing::utils::remove_undefined` when the strip condition holds and `exactOptionalPropertyTypes` is off (no new public surface).
- Applied in both the named-key loop and the symbol-key loop of `evaluate_mapped`, gated on `remove_optional_with_declared && source_optional` (i.e. homomorphic, no type-param contamination, `-?` present, and the *source* property was optional).

## Adjacent-case test matrix
Seven new unit tests in `crates/tsz-solver/tests/mapped_architecture_tests.rs` (evaluate-driven, exercising the real `evaluate_mapped` path):
1. `remove_optional_strips_explicit_undefined_from_value` — reported repro `Req<{ a?: number | undefined }>` → `a: number`.
2. `remove_optional_exact_optional_preserves_explicit_undefined` — exact optional mode preserves explicit `undefined`, matching `inferenceOptionalProperties.ts`.
3. `remove_optional_strip_is_iteration_var_name_invariant` — iteration var `P` instead of `K`, prop `x` — proves name-independence.
4. `remove_optional_preserves_non_undefined_union_members` — `a?: number | null | undefined` → `number | null` (only `undefined` stripped, `null` kept).
5. `remove_optional_on_plain_optional_keeps_declared_type` — control: `a?: number` → `number`.
6. `remove_optional_does_not_strip_undefined_from_required_property` — negative control: non-optional `a: number | undefined` + `-?` retains `undefined`.
7. `no_optional_modifier_does_not_strip_undefined` — negative control: no modifier preserves optionality and value `undefined`.

End-to-end CLI repros verified (all match tsc):
- Reported `Req<{ a?: number | undefined }>` — clean; builtin `Required<…>` — clean; renamed iter var `P` + prop `x?: string | undefined` — clean.
- `a?: number | null | undefined` keeps `null` (errors only on `number` target); `a?: undefined` strips to `never`.
- Negative controls: non-optional `a: number | undefined` + `-?` still errors; `Partial<{ a: number }>` still adds `undefined`; multi-member mixed object only errors on the non-optional member.

## Known unsupported shapes / follow-ups
- tsz still does not model tsc's distinct `missingType` marker. This PR therefore strips only in non-exact optional mode and preserves explicit `undefined` when `exactOptionalPropertyTypes` is enabled.
- Non-identity templates wrapping `T[K]` (e.g. `F<T[K]>`) keep the wrapper for the optional element, matching tsc's top-level-only `removeMissingOrUndefinedType`.
- Sibling tuple-element case is #9712 / PR #9845 (independent function `evaluate_mapped_tuple`); this PR covers the object/symbol-key branches.

## Project Corpus Impact
- Row: n/a (no project corpus row currently exercises `Required<{ a?: T | undefined }>`).
- Bug family: false-positive TS2322 on homomorphic mapped types with `-?` over an optional property carrying explicit `| undefined`.
- Evidence: targeted CLI repros from #9661; `cargo test -p tsz-solver --lib mapped` → 312/312 pass (incl. 6 new); `cargo test -p tsz-solver --lib mapped_key_remap` → 16/16; `cargo clippy -p tsz-solver --all-targets -- -D warnings` clean; `cargo fmt --check` clean. tsz-checker `--lib mapped` shows 7 pre-existing failures identical with this diff stashed (unrelated to this change).

## Verification
- `cargo build -p tsz-cli --bin tsz` — clean.
- `cargo clippy -p tsz-solver --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- M4-A follow-up on `77eb055973`: `git diff --check` passed.
- M4-A follow-up on `77eb055973`: `cargo fmt --check` passed.
- M4-A follow-up on `77eb055973`: no local solver test/build rerun because disk remained below guardrail (`disk_free_mb=8385` / status `low`); ready-review CI is rerunning on the exact head.
- `cargo test -p tsz-solver --lib mapped` — 312/312 pass on the original head before the exact-optional follow-up.
- All end-to-end repros above re-verified post-refactor.

## Coordination Notes
- Issue #9661 was unowned at claim time (no open PR). WIP label added to the issue while implementing.
- Logically independent of PR #9845 (#9712, tuple branch). No `docs/plan/ROADMAP.md` change — narrow conformance fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpbCMMkZfBkSknU7NWqhdk)_


## M4-A CI Follow-up
AgentName: M4-A

Ready-review run `26378651966` failed `conformance-aggregate` on `TypeScript/tests/cases/compiler/inferenceOptionalProperties.ts`. Root cause: the new strip also ran under `exactOptionalPropertyTypes`, where explicit `undefined` must be preserved. Commit `77eb055973` gates the strip behind non-exact optional mode and adds `remove_optional_exact_optional_preserves_explicit_undefined`. Auto-merge remains off until exact-head CI and Queue Tested are green.
