### PR TITLE
refactor(checker): route call finalize relation guards

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_finalize.rs
+++ b/crates/tsz-checker/src/types/computation/call_finalize.rs
@@ -263,8 +263,11 @@ impl<'a> CheckerState<'a> {
                         if aggregate_rest_mismatch {
                             let evaluated_param = self.evaluate_type_with_env(param.type_id);
                             let aggregate_assignable = self
-                                .is_assignable_to_with_env(actual, expected)
-                                || self.is_assignable_to_with_env(actual, evaluated_param);
+                                .diagnostic_relation_boolean_guard_with_env(actual, expected)
+                                || self.diagnostic_relation_boolean_guard_with_env(
+                                    actual,
+                                    evaluated_param,
+                                );
                             if aggregate_assignable {
                                 recovered_argument_mismatch = true;
                                 (

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -722,6 +722,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "computation"
             / "call"
             / "nominal_lib_object_callbacks.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "computation"
+            / "call_finalize.rs",
         ],
         re.compile(
             r"\b(?:self|self\.ctx\.types|self\.interner)"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10125.

Invariant:
Diagnostic-only aggregate-rest generic call mismatch recovery predicates route through the environment-aware checker diagnostic relation guard. Behavior is unchanged; this keeps environment-aware diagnostic recovery grep-distinct from semantic relation computation.

Scope:
- Replaced raw `self.is_assignable_to_with_env(...)` calls in `crates/tsz-checker/src/types/computation/call_finalize.rs` with `diagnostic_relation_boolean_guard_with_env(...)`.
- Added the call finalization file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-nominal-lib-callback-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `70006a313d2c1d2a1b97e9841374196e8aef46a2` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10125 (`codex/m1b-nominal-lib-callback-relation-guard-20260525`) at base head `73eda10737f14b706faca3c37d77a885ffd3bc46`.
- Current head: `70006a313d2c1d2a1b97e9841374196e8aef46a2`.
- Rebased from prior base `4fadf011a152289a9e7e4cf62a4884a65f7f6faa`; replay was clean and kept only this PR's call-finalize routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
