### PR TITLE
refactor(checker): query JSX ElementType constraint surface

### DIFF
--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -634,11 +634,12 @@ impl<'a> CheckerState<'a> {
         if self.indexed_access_into_object_uniformly_satisfies_constraint(type_arg, constraint) {
             return;
         }
-        if constraint_str.starts_with("ElementType<")
-            && type_str.contains("ComponentType<any>")
-            && (type_str.contains("IntrinsicElementsKeys")
-                || type_str.contains("keyof IntrinsicElements"))
-        {
+        if crate::query_boundaries::checkers::generic::jsx_element_type_constraint_accepts_component_or_intrinsic_keys(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            type_arg,
+            constraint,
+        ) {
             return;
         }
         self.error_at_node_msg(

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -1,5 +1,5 @@
-use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{DefinitionStore, TypeId};
 
 pub(crate) use super::super::common::{
     callable_shape_for_type, contains_free_type_parameters, contains_generic_type_parameters,
@@ -60,6 +60,122 @@ pub(crate) fn contains_named_or_bound_type_parameter(
 /// Get the operand of a `keyof T` type.
 pub(crate) fn keyof_operand(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::type_queries::keyof_inner_type(db, type_id)
+}
+
+pub(crate) fn jsx_element_type_constraint_accepts_component_or_intrinsic_keys(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_arg: TypeId,
+    constraint: TypeId,
+) -> bool {
+    surface_contains_def_name(db, def_store, constraint, "ElementType", &mut Vec::new())
+        && surface_contains_component_type_application(db, def_store, type_arg, &mut Vec::new())
+        && surface_contains_intrinsic_element_keys(db, def_store, type_arg, &mut Vec::new())
+}
+
+fn surface_contains_component_type_application(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    visited: &mut Vec<TypeId>,
+) -> bool {
+    if visited.contains(&type_id) {
+        return false;
+    }
+    visited.push(type_id);
+
+    if let Some(app) = crate::query_boundaries::common::type_application(db, type_id)
+        && type_has_def_name(db, def_store, app.base, "ComponentType")
+    {
+        return true;
+    }
+
+    surface_children(db, type_id)
+        .into_iter()
+        .any(|child| surface_contains_component_type_application(db, def_store, child, visited))
+}
+
+fn surface_contains_intrinsic_element_keys(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    visited: &mut Vec<TypeId>,
+) -> bool {
+    if visited.contains(&type_id) {
+        return false;
+    }
+    visited.push(type_id);
+
+    if type_has_def_name(db, def_store, type_id, "IntrinsicElementsKeys") {
+        return true;
+    }
+
+    if let Some(operand) = keyof_operand(db, type_id)
+        && surface_contains_def_name(db, def_store, operand, "IntrinsicElements", &mut Vec::new())
+    {
+        return true;
+    }
+
+    surface_children(db, type_id)
+        .into_iter()
+        .any(|child| surface_contains_intrinsic_element_keys(db, def_store, child, visited))
+}
+
+fn surface_contains_def_name(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    expected: &str,
+    visited: &mut Vec<TypeId>,
+) -> bool {
+    if visited.contains(&type_id) {
+        return false;
+    }
+    visited.push(type_id);
+
+    if type_has_def_name(db, def_store, type_id, expected) {
+        return true;
+    }
+
+    surface_children(db, type_id)
+        .into_iter()
+        .any(|child| surface_contains_def_name(db, def_store, child, expected, visited))
+}
+
+fn surface_children(db: &dyn TypeDatabase, type_id: TypeId) -> Vec<TypeId> {
+    let mut children = Vec::new();
+    if let Some(members) = crate::query_boundaries::common::union_members(db, type_id) {
+        children.extend(members);
+    }
+    if let Some(members) = crate::query_boundaries::common::intersection_members(db, type_id) {
+        children.extend(members);
+    }
+    if let Some(app) = crate::query_boundaries::common::type_application(db, type_id) {
+        children.push(app.base);
+        children.extend(app.args.iter().copied());
+    }
+    if let Some((object, index)) = index_access_components(db, type_id) {
+        children.push(object);
+        children.push(index);
+    }
+    if let Some(operand) = keyof_operand(db, type_id) {
+        children.push(operand);
+    }
+    children
+}
+
+fn type_has_def_name(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    expected: &str,
+) -> bool {
+    let candidate = crate::query_boundaries::common::type_application(db, type_id)
+        .map_or(type_id, |app| app.base);
+    crate::query_boundaries::common::lazy_def_id(db, candidate)
+        .or_else(|| def_store.find_def_for_type(candidate))
+        .and_then(|def_id| def_store.get_name(def_id))
+        .is_some_and(|name| db.resolve_atom_ref(name).as_ref() == expected)
 }
 
 /// Get the extends type and false type of a conditional type.

--- a/crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs
@@ -286,6 +286,72 @@ function wrap<T extends (props: {}) => React.ReactElement<any>>(Component: T) {
     );
 }
 
+#[test]
+fn jsx_element_type_constraint_accepts_component_type_or_intrinsic_key_alias() {
+    let source = r#"
+declare namespace React {
+    interface ReactElement<P = any> {}
+    type ComponentType<Props = any> = (props: Props) => ReactElement<any>;
+}
+declare global {
+    namespace JSX {
+        interface Element extends React.ReactElement<any> {}
+        interface IntrinsicElements { div: { id?: string }; span: {}; }
+    }
+}
+type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+type ElementType<Props = any, Tag extends IntrinsicElementsKeys = IntrinsicElementsKeys> =
+    | { [K in Tag]: Props extends JSX.IntrinsicElements[K] ? K : never }[Tag]
+    | React.ComponentType<Props>;
+type RequiresElementType<T extends ElementType<any>> = T;
+type Probe = RequiresElementType<React.ComponentType<any> | IntrinsicElementsKeys>;
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2344),
+        "React-style ElementType constraint should accept ComponentType or intrinsic-key alias without TS2344. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn jsx_element_type_constraint_accepts_component_type_or_keyof_intrinsic_elements() {
+    let source = r#"
+declare namespace React {
+    interface ReactElement<P = any> {}
+    type ComponentType<Input = any> = (props: Input) => ReactElement<any>;
+}
+declare global {
+    namespace JSX {
+        interface Element extends React.ReactElement<any> {}
+        interface IntrinsicElements { article: { title?: string }; aside: {}; }
+    }
+}
+type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+type ElementType<Input = any, Name extends IntrinsicElementsKeys = IntrinsicElementsKeys> =
+    | { [Tag in Name]: Input extends JSX.IntrinsicElements[Tag] ? Tag : never }[Name]
+    | React.ComponentType<Input>;
+type RequiresElementType<T extends ElementType<any>> = T;
+type Probe = RequiresElementType<React.ComponentType<any> | keyof JSX.IntrinsicElements>;
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2344),
+        "React-style ElementType constraint should accept ComponentType or keyof IntrinsicElements without TS2344. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn jsx_element_type_constraint_suppression_does_not_read_rendered_type_strings() {
+    let generics_src = include_str!("../error_reporter/generics.rs");
+    assert!(
+        !generics_src.contains("constraint_str.starts_with(\"ElementType<\")")
+            && !generics_src.contains("type_str.contains(\"ComponentType<any>\")")
+            && !generics_src.contains("type_str.contains(\"IntrinsicElementsKeys\")")
+            && !generics_src.contains("type_str.contains(\"keyof IntrinsicElements\")"),
+        "JSX ElementType TS2344 suppression must use query-boundary facts, not rendered type substrings"
+    );
+}
+
 /// Return compatibility alone is not enough: a source callable that requires
 /// more parameters than the `ElementType` callable arm is not a valid JSX
 /// component.


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
M1-C rendered-type/source-text diagnostic cleanup

## Invariant
JSX ElementType TS2344 suppression must decide from TypeId surface structure and definition identities, not from rendered type strings such as `ElementType<`, `ComponentType<any>`, or `keyof IntrinsicElements`.

## Scope
- Replace the rendered-string JSX ElementType TS2344 carve-out in `error_reporter/generics.rs` with a `query_boundaries::checkers::generic` helper.
- The helper walks union, intersection, application, indexed-access, and `keyof` surfaces and resolves JSX/React alias identities through `DefinitionStore`.
- Add focused JSX ElementType tests for both `IntrinsicElementsKeys` alias and direct `keyof JSX.IntrinsicElements` surfaces, plus a guard against restoring the old rendered-substring decision.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display policy cleanup
- Evidence: checker-only TS2344 diagnostic-decision refactor; no project-corpus row is directly targeted.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n 'constraint_str\.starts_with\("ElementType<"\)|type_str\.contains\("ComponentType<any>"\)|type_str\.contains\("IntrinsicElementsKeys"\)|type_str\.contains\("keyof IntrinsicElements"\)' crates/tsz-checker/src/error_reporter/generics.rs crates/tsz-checker/src/query_boundaries/checkers/generic.rs crates/tsz-checker/src/tests/jsx_element_type_constraint_tests.rs` exits 1 with no matches
- `cargo check -p tsz-checker --lib`
- `cargo nextest run -p tsz-checker --lib -E 'test(jsx_element_type_constraint_accepts_component_type_or_intrinsic_key_alias) or test(jsx_element_type_constraint_accepts_component_type_or_keyof_intrinsic_elements) or test(jsx_element_type_constraint_suppression_does_not_read_rendered_type_strings)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`

## Coordination Notes
- AgentName: M1-C
- Started after sweeping M1-C owned PRs: no red checks were actionable; drafts #10123/#10119 and ready #10114 still had queued/in-progress CI, while older ready PRs sampled were mergeable but blocked on `Queue Tested=PENDING`.
- Non-overlap: this targets the JSX ElementType TS2344 string carve-out in `error_reporter/generics.rs`, separate from #10123 JSX props anonymous target, #10119 JSX children display aliases, #10114 unknown type args, and active optional/iterator/callable/indexed display PRs.
- Updated body to the strict PR template shape before promotion.
- Ready-review CI is green on exact head `9414a0d8cb47488e14fa2a7f3971137b95d30bfb`; live GitHub state currently has auto-merge off. #10131 landed as `3fa8f324d436fc367171b55826a1a0799b24813e`. This PR is now the active serial synthetic queue: run `26387675511` is queued on merge commit `f8165e3473486a4e25c76a0e114a52c3bb5a0eb4` with parents current `main` `3fa8f324d436fc367171b55826a1a0799b24813e` and PR head `9414a0d8cb47488e14fa2a7f3971137b95d30bfb`.

