### PR TITLE
refactor(checker): route call result relation guards

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -57,7 +57,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let param_union = self.ctx.types.factory().union(param_types);
-        if !self.is_assignable_to(actual, param_union) {
+        if !self.diagnostic_relation_boolean_guard(actual, param_union) {
             return None;
         }
 
@@ -210,7 +210,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if self.is_assignable_to(arg_types[2], target) {
+        if self.diagnostic_relation_boolean_guard(arg_types[2], target) {
             return false;
         }
         self.error_argument_not_assignable_preserving_param_display(arg_types[2], target, args[2]);
@@ -956,7 +956,10 @@ impl<'a> CheckerState<'a> {
                     let normalized_rest_expected =
                         self.rest_argument_element_type_with_env(expected);
                     if normalized_rest_expected != expected
-                        && self.is_assignable_to_with_env(actual, normalized_rest_expected)
+                        && self.diagnostic_relation_boolean_guard_with_env(
+                            actual,
+                            normalized_rest_expected,
+                        )
                     {
                         return if fallback_return != TypeId::ERROR {
                             fallback_return

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -729,6 +729,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "types"
             / "computation"
             / "call_finalize.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "computation"
+            / "call_result.rs",
         ],
         re.compile(
             r"\b(?:self|self\.ctx\.types|self\.interner)"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10127.

Invariant:
Diagnostic-only call result mismatch reporting and recovery predicates route through the checker diagnostic relation guards. Behavior is unchanged; this keeps call-result diagnostic decisions grep-distinct from semantic relation computation.

Scope:
- Replaced raw `self.is_assignable_to(...)` calls in `crates/tsz-checker/src/types/computation/call_result.rs` with `diagnostic_relation_boolean_guard(...)`.
- Replaced the environment-aware raw call-result relation predicate with `diagnostic_relation_boolean_guard_with_env(...)`.
- Covered correlated-union call recovery, polymorphic-this indexed conditional argument reporting, and spread/rest mismatch recovery.
- Added the call result file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-call-finalize-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `3958e3583fcd54621950a622b4d81b96ed260d2b` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10127 (`codex/m1b-call-finalize-relation-guards-20260525`) at base head `70006a313d2c1d2a1b97e9841374196e8aef46a2`.
- Current head: `3958e3583fcd54621950a622b4d81b96ed260d2b`.
- Rebased from prior base `9242416fa75bb7f3f896f02623e0c3838fb51138`; replay was clean and kept only this PR's call-result routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
