### PR TITLE
refactor(checker): query typed array display names

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_tests.rs
@@ -86,6 +86,18 @@ arr_Int8Array = arr_Uint8Array;
 }
 
 #[test]
+fn typed_array_property_mismatch_display_does_not_read_rendered_prefixes() {
+    let renderer_src =
+        include_str!("../error_reporter/render_failure/nested_application_property_mismatch.rs");
+    assert!(
+        !renderer_src.contains("starts_with(\"Int8Array<\")")
+            && !renderer_src.contains("starts_with(\"Uint8Array<\")")
+            && !renderer_src.contains("starts_with(\"BigUint64Array<\")"),
+        "typed-array property mismatch rendering must use definition identities, not formatted type prefixes"
+    );
+}
+
+#[test]
 fn homomorphic_remap_missing_property_uses_specialized_source_display() {
     let diagnostics = diagnostics_for(
         r#"

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -34,7 +34,7 @@ impl<'a> CheckerState<'a> {
         let Some(base) = self.application_base_for_property_mismatch_display(type_id) else {
             return false;
         };
-        crate::query_boundaries::common::type_has_well_known_typed_array_name(
+        crate::query_boundaries::definition_identity::type_has_well_known_typed_array_name(
             self.ctx.types,
             &self.ctx.definition_store,
             base,
@@ -165,18 +165,16 @@ impl<'a> CheckerState<'a> {
             if !outer_is_structural
                 && let Some(tsz_solver::SubtypeFailureReason::LiteralTypeMismatch { .. }) =
                     nested_reason
-            {
-                if !(self.is_typed_array_application_property_mismatch_display(source)
+                && !(self.is_typed_array_application_property_mismatch_display(source)
                     && self.is_typed_array_application_property_mismatch_display(target))
-                {
-                    return self.render_failure_reason(
-                        nested_reason.expect("checked above"),
-                        source_property_type,
-                        target_property_type,
-                        idx,
-                        depth,
-                    );
-                }
+            {
+                return self.render_failure_reason(
+                    nested_reason.expect("checked above"),
+                    source_property_type,
+                    target_property_type,
+                    idx,
+                    depth,
+                );
             }
             let base = format_message(
                 diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -30,6 +30,17 @@ impl<'a> CheckerState<'a> {
         source_base == target_base
     }
 
+    fn is_typed_array_application_property_mismatch_display(&self, type_id: TypeId) -> bool {
+        let Some(base) = self.application_base_for_property_mismatch_display(type_id) else {
+            return false;
+        };
+        crate::query_boundaries::common::type_has_well_known_typed_array_name(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            base,
+        )
+    }
+
     fn nested_reason_reuses_enclosing_application_source(
         &self,
         nested_source: TypeId,
@@ -155,20 +166,9 @@ impl<'a> CheckerState<'a> {
                 && let Some(tsz_solver::SubtypeFailureReason::LiteralTypeMismatch { .. }) =
                     nested_reason
             {
-                let is_typed_array_display = |display: &str| {
-                    display.starts_with("Int8Array<")
-                        || display.starts_with("Uint8Array<")
-                        || display.starts_with("Uint8ClampedArray<")
-                        || display.starts_with("Int16Array<")
-                        || display.starts_with("Uint16Array<")
-                        || display.starts_with("Int32Array<")
-                        || display.starts_with("Uint32Array<")
-                        || display.starts_with("Float32Array<")
-                        || display.starts_with("Float64Array<")
-                        || display.starts_with("BigInt64Array<")
-                        || display.starts_with("BigUint64Array<")
-                };
-                if !(is_typed_array_display(&source_str) && is_typed_array_display(&target_str)) {
+                if !(self.is_typed_array_application_property_mismatch_display(source)
+                    && self.is_typed_array_application_property_mismatch_display(target))
+                {
                     return self.render_failure_reason(
                         nested_reason.expect("checked above"),
                         source_property_type,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -722,33 +722,6 @@ pub(crate) fn application_info(
     tsz_solver::type_queries::extended::get_application_info(db, type_id)
 }
 
-pub(crate) fn type_has_well_known_typed_array_name(
-    db: &dyn TypeDatabase,
-    def_store: &tsz_solver::DefinitionStore,
-    type_id: TypeId,
-) -> bool {
-    let Some(name) = lazy_def_id(db, type_id)
-        .or_else(|| def_store.find_def_for_type(type_id))
-        .and_then(|def_id| def_store.get_name(def_id))
-    else {
-        return false;
-    };
-    matches!(
-        db.resolve_atom_ref(name).as_ref(),
-        "Int8Array"
-            | "Uint8Array"
-            | "Uint8ClampedArray"
-            | "Int16Array"
-            | "Uint16Array"
-            | "Int32Array"
-            | "Uint32Array"
-            | "Float32Array"
-            | "Float64Array"
-            | "BigInt64Array"
-            | "BigUint64Array"
-    )
-}
-
 // ── Literal type classification ──
 
 pub(crate) use tsz_solver::type_queries::extended::LiteralTypeKind;

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -722,6 +722,33 @@ pub(crate) fn application_info(
     tsz_solver::type_queries::extended::get_application_info(db, type_id)
 }
 
+pub(crate) fn type_has_well_known_typed_array_name(
+    db: &dyn TypeDatabase,
+    def_store: &tsz_solver::DefinitionStore,
+    type_id: TypeId,
+) -> bool {
+    let Some(name) = lazy_def_id(db, type_id)
+        .or_else(|| def_store.find_def_for_type(type_id))
+        .and_then(|def_id| def_store.get_name(def_id))
+    else {
+        return false;
+    };
+    matches!(
+        db.resolve_atom_ref(name).as_ref(),
+        "Int8Array"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Int16Array"
+            | "Uint16Array"
+            | "Int32Array"
+            | "Uint32Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
+    )
+}
+
 // ── Literal type classification ──
 
 pub(crate) use tsz_solver::type_queries::extended::LiteralTypeKind;

--- a/crates/tsz-checker/src/query_boundaries/definition_identity.rs
+++ b/crates/tsz-checker/src/query_boundaries/definition_identity.rs
@@ -8,3 +8,30 @@ pub(crate) type DefId = tsz_solver::def::DefId;
 pub(crate) fn is_lazy_def_identity(db: &dyn TypeDatabase, type_id: TypeId, def_id: DefId) -> bool {
     tsz_solver::type_queries::get_lazy_def_id(db, type_id) == Some(def_id)
 }
+
+pub(crate) fn type_has_well_known_typed_array_name(
+    db: &dyn TypeDatabase,
+    def_store: &tsz_solver::DefinitionStore,
+    type_id: TypeId,
+) -> bool {
+    let Some(name) = tsz_solver::type_queries::get_lazy_def_id(db, type_id)
+        .or_else(|| def_store.find_def_for_type(type_id))
+        .and_then(|def_id| def_store.get_name(def_id))
+    else {
+        return false;
+    };
+    matches!(
+        db.resolve_atom_ref(name).as_ref(),
+        "Int8Array"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Int16Array"
+            | "Uint16Array"
+            | "Int32Array"
+            | "Uint32Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
+    )
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
M1-C rendered-type/source-text diagnostic cleanup

## Invariant
Typed-array nested property mismatch rendering must decide from TypeId application bases and definition identities, not from formatted type prefixes such as `Int8Array<` or `Uint8Array<`.

## Scope
- Replace the typed-array display-prefix check in `render_failure/nested_application_property_mismatch.rs` with a `query_boundaries::definition_identity` helper that resolves well-known typed-array definition names.
- Keep `query_boundaries/common.rs` below its architecture quarantine cap by moving the definition-name helper out of common.
- Preserve the existing TS2322 typed-array generic-argument display behavior.
- Add a focused guard preventing this renderer from reintroducing typed-array `starts_with("...<")` checks.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display policy cleanup
- Evidence: checker-only TS2322 diagnostic-rendering refactor; no project-corpus row is directly targeted.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `rg -n 'starts_with\("(Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array|BigInt64Array|BigUint64Array)<' crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs crates/tsz-checker/src/query_boundaries/common.rs crates/tsz-checker/src/assignability/assignment_checker_tests.rs` exits 1 with no matches
- `cargo check -p tsz-checker --lib`
- `cargo nextest run -p tsz-checker --lib -E 'test(typed_array_cross_assignment_preserves_generic_display) or test(typed_array_property_mismatch_display_does_not_read_rendered_prefixes) or test(test_rendered_type_decision_patterns_do_not_grow)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo nextest run -p tsz-checker --lib -E 'test(typed_array_cross_assignment_preserves_generic_display) | test(typed_array_property_mismatch_display_does_not_read_rendered_prefixes)' --status-level fail --final-status-level fail --failure-output immediate`
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

## Coordination Notes
- AgentName: M1-C
- Started after sweeping M1-C owned PRs. #10119 was promoted to ready after light CI passed; #10123 and #10128 were still draft-light queued, and sampled ready PRs were blocked on queued heavy CI or `Queue Tested=PENDING`.
- CI lint on head `8021e08c4d` failed the architecture guard because `query_boundaries/common.rs` grew to 1945 lines over the 1920-line quarantine cap.
- Commit `619e6129ec` moves the typed-array definition-name helper to `query_boundaries/definition_identity.rs` and keeps `common.rs` below the cap. Ready-review CI is green on exact head `619e6129ec0730674d3b44686be622f6419fb412`; live GitHub state currently has auto-merge off. #9272 landed as squash commit `4ef6b871791830adcd08ab1ebebe9720676b3e06`, so this PR is now the active serial synthetic queue. Queue run `26386707820` is running on merge commit `e913df5d636bdef7ad1527aa9ddec125c69b52a8` with parents current `main` `4ef6b871791830adcd08ab1ebebe9720676b3e06` and PR head `619e6129ec0730674d3b44686be622f6419fb412`.
- Non-overlap: this targets typed-array TS2322 nested property mismatch rendering, separate from active JSX, optional-undefined, iterator, callable, indexed-access, numeric, and alias-display M1-C PRs.

