### PR TITLE
refactor(checker): route private access relation guards

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -91,7 +91,7 @@ impl<'a> CheckerState<'a> {
                 {
                     return true;
                 }
-                if self.is_assignable_to(object_type, declaring_type) {
+                if self.diagnostic_relation_boolean_guard(object_type, declaring_type) {
                     return true;
                 }
                 // Last resort: check if the object type has the private property
@@ -105,7 +105,7 @@ impl<'a> CheckerState<'a> {
                 )
                 .is_success()
             }
-            _ => self.is_assignable_to(object_type, declaring_type),
+            _ => self.diagnostic_relation_boolean_guard(object_type, declaring_type),
         }
     }
 
@@ -699,7 +699,7 @@ impl<'a> CheckerState<'a> {
                 &property_name,
             )
         } else if self.types_have_same_private_brand(object_type_for_check, declaring_type)
-            || self.is_assignable_to(object_type_for_check, declaring_type)
+            || self.diagnostic_relation_boolean_guard(object_type_for_check, declaring_type)
         {
             true
         } else {
@@ -752,7 +752,7 @@ impl<'a> CheckerState<'a> {
                         } else if self.types_have_same_private_brand(object_type_for_check, ty) {
                             true
                         } else {
-                            self.is_assignable_to(object_type_for_check, ty)
+                            self.diagnostic_relation_boolean_guard(object_type_for_check, ty)
                         }
                     })
             });

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -744,6 +744,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "computation"
             / "call"
             / "tail_helpers.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "type_analysis"
+            / "computed_helpers_private.rs",
         ],
         re.compile(
             r"\b(?:self|self\.ctx\.types|self\.interner)"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10130.

Invariant:
Diagnostic-only private member access compatibility checks that decide TS2339/TS18014-style reporting route through the shared checker diagnostic relation guard. Behavior is unchanged; this keeps private access diagnostic decisions grep-distinct from semantic relation computation.

Scope:
- Replaced raw `self.is_assignable_to(...)` calls in `crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs` with `diagnostic_relation_boolean_guard(...)`.
- Added the private computed helper file to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-call-tail-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `a615455591eed9e3c47dc2e8e5ed155709961a75` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10130 (`codex/m1b-call-tail-relation-guards-20260525`) at base head `ea861ab816beb0515b8e768fb43384a10c2c1cbe`.
- Current head: `a615455591eed9e3c47dc2e8e5ed155709961a75`.
- Rebased from prior base `e8f5f5577f63ac7077cbe577568ad3f6a3534a72`; replay was clean and kept only this PR's private-access routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
