### PR TITLE
refactor(checker): route contextual new relation guard

### DIFF
--- a/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
+++ b/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
@@ -29,7 +29,7 @@ impl<'a> CheckerState<'a> {
 
         contextual_actual != TypeId::ANY
             && contextual_actual != TypeId::ERROR
-            && self.is_assignable_to(contextual_actual, expected)
+            && self.diagnostic_relation_boolean_guard(contextual_actual, expected)
     }
 
     pub(crate) fn recover_new_expression_return_type_after_contextual_argument_match(

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -751,6 +751,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "state"
             / "type_analysis"
             / "computed_helpers_private.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "types"
+            / "computation"
+            / "complex_contextual_new.rs",
         ],
         re.compile(
             r"\b(?:self|self\.ctx\.types|self\.interner)"


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10132.

Invariant:
Diagnostic assignability decisions should route through the checker diagnostic relation boundary instead of raw checker relation predicates. Generic `new` contextual argument recovery stays grep-distinct from semantic relation computation.

Scope:
- Routed `generic_new_argument_accepts_contextual_parameter` through `diagnostic_relation_boolean_guard`.
- Added `crates/tsz-checker/src/types/computation/complex_contextual_new.rs` to the raw diagnostic assignability arch-guard root list.

Project Corpus Impact:
- Row: n/a
- Bug family: checker diagnostic-boundary refactor / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only checker helper routing; no semantic, project-corpus, or emitted-output behavior changes intended.

Verification:
- `git diff --check codex/m1b-private-access-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- Draft-light CI is green for head `b22448206825ee42a672bb6ed19bc448c68c2359` (`lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, `CI Light Summary`).

Coordination Notes:
- Stacked above #10132 (`codex/m1b-private-access-relation-guards-20260525`) at base head `a615455591eed9e3c47dc2e8e5ed155709961a75`.
- Current head: `b22448206825ee42a672bb6ed19bc448c68c2359`.
- Rebased from prior base `cdc5613e31c47954a4f0c48454d3504d25b89461`; replay was clean and kept only this PR's contextual-new routing delta.
- Current GitHub state: draft, auto-merge off, `mergeStateStatus: CLEAN`.
- Non-overlap: no solver policy, solver cache, request, or M4-B changes.
- Keep this PR draft/off-auto until #9922 lands and parent stack promotion is explicitly handled.
- Labeled only `agent:M1-B`; non-overlap with M4-B.
