### PR TITLE
refactor(checker): route constraint validation relation guards

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -151,7 +151,8 @@ impl<'a> CheckerState<'a> {
                         }
                         let concrete_arg = self.resolve_lazy_type(concrete_arg);
                         let concrete_arg = self.evaluate_type_for_assignability(concrete_arg);
-                        if self.is_assignable_to(concrete_arg, constraint_resolved) {
+                        if self.diagnostic_relation_boolean_guard(concrete_arg, constraint_resolved)
+                        {
                             continue;
                         }
                         self.error_type_constraint_not_satisfied(
@@ -275,7 +276,7 @@ impl<'a> CheckerState<'a> {
                                 evaluated_arg,
                                 TypeId::UNKNOWN | TypeId::ERROR | TypeId::NEVER
                             )
-                            && (self.is_assignable_to_no_weak_checks(
+                            && (self.diagnostic_relation_boolean_guard_no_weak_checks(
                                 evaluated_arg,
                                 evaluated_constraint,
                             ) || self.satisfies_array_like_constraint(
@@ -547,13 +548,12 @@ impl<'a> CheckerState<'a> {
                                             // `unknown` infer bases fail constraints like `string`.
                                             let is_satisfied = inst_constraint == TypeId::UNKNOWN
                                                 || inst_constraint == TypeId::ANY
-                                                || self
-                                                    .is_assignable_to(infer_base, inst_constraint)
+                                                || self.diagnostic_relation_boolean_guard(infer_base, inst_constraint)
                                                 || {
                                                     let evaluated =
                                                         self.evaluate_type_for_assignability(type_arg);
                                                     evaluated != type_arg
-                                                        && self.is_assignable_to(
+                                                        && self.diagnostic_relation_boolean_guard(
                                                             evaluated,
                                                             inst_constraint,
                                                         )
@@ -620,10 +620,13 @@ impl<'a> CheckerState<'a> {
                                         let ext_resolved = self.resolve_lazy_type(cond_extends);
                                         let ext_evaluated =
                                             self.evaluate_type_for_assignability(ext_resolved);
-                                        if self.is_assignable_to(ext_evaluated, constraint_resolved)
-                                            || self
-                                                .is_assignable_to(ext_resolved, constraint_resolved)
-                                        {
+                                        if self.diagnostic_relation_boolean_guard(
+                                            ext_evaluated,
+                                            constraint_resolved,
+                                        ) || self.diagnostic_relation_boolean_guard(
+                                            ext_resolved,
+                                            constraint_resolved,
+                                        ) {
                                             continue;
                                         }
                                         // Extract-like pattern (? T : never) but the
@@ -947,21 +950,20 @@ impl<'a> CheckerState<'a> {
                             let base_for_check = self.resolve_lazy_members_in_union(base);
                             let base_for_check =
                                 self.evaluate_type_for_assignability(base_for_check);
-                            let mut is_satisfied = self
-                                .is_assignable_to(base_for_check, inst_constraint)
-                                || self.base_union_members_satisfy_constraint(
+                            let mut is_satisfied =
+                                self.diagnostic_relation_boolean_guard(
                                     base_for_check,
                                     inst_constraint,
-                                )
-                                || self.satisfies_array_like_constraint(
+                                ) || self.base_union_members_satisfy_constraint(
                                     base_for_check,
                                     inst_constraint,
-                                )
-                                || self.infer_result_satisfies_via_referenced_constraints(
+                                ) || self.satisfies_array_like_constraint(
+                                    base_for_check,
+                                    inst_constraint,
+                                ) || self.infer_result_satisfies_via_referenced_constraints(
                                     type_arg,
                                     inst_constraint,
-                                )
-                                || type_args_list.nodes.get(i).copied().is_some_and(|arg_idx| {
+                                ) || type_args_list.nodes.get(i).copied().is_some_and(|arg_idx| {
                                     self.type_arg_satisfies_via_hidden_infer_constraints(
                                         type_arg,
                                         arg_idx,
@@ -1060,10 +1062,9 @@ impl<'a> CheckerState<'a> {
                                         .unwrap_or(TypeId::UNKNOWN);
                                 let is_satisfied = inst_constraint == TypeId::UNKNOWN
                                     || inst_constraint == TypeId::ANY
-                                    || self.is_assignable_to(infer_base, inst_constraint)
+                                    || self.diagnostic_relation_boolean_guard(infer_base, inst_constraint)
                                     || (type_arg_evaluated != type_arg
-                                        && self
-                                            .is_assignable_to(type_arg_evaluated, inst_constraint))
+                                        && self.diagnostic_relation_boolean_guard(type_arg_evaluated, inst_constraint))
                                     || self.infer_result_satisfies_via_check_constraint(
                                         type_arg,
                                         (cond_check, cond_extends, cond_true),
@@ -1115,12 +1116,13 @@ impl<'a> CheckerState<'a> {
                                 // If false branch is `never` (Extract pattern) and the
                                 // extends type satisfies the constraint, skip TS2344.
                                 if false_type == TypeId::NEVER
-                                    && (self
-                                        .is_assignable_to(extends_evaluated, constraint_resolved)
-                                        || self.is_assignable_to(
-                                            extends_resolved,
-                                            constraint_resolved,
-                                        ))
+                                    && (self.diagnostic_relation_boolean_guard(
+                                        extends_evaluated,
+                                        constraint_resolved,
+                                    ) || self.diagnostic_relation_boolean_guard(
+                                        extends_resolved,
+                                        constraint_resolved,
+                                    ))
                                 {
                                     // Skip: Extract<T, C> always produces subtype of C
                                 } else {
@@ -1228,7 +1230,10 @@ impl<'a> CheckerState<'a> {
                             );
                             if inst_constraint == TypeId::UNKNOWN
                                 || inst_constraint == TypeId::ANY
-                                || self.is_assignable_to(positional_constraint, inst_constraint)
+                                || self.diagnostic_relation_boolean_guard(
+                                    positional_constraint,
+                                    inst_constraint,
+                                )
                             {
                                 continue;
                             }
@@ -1291,7 +1296,10 @@ impl<'a> CheckerState<'a> {
                                             self.ctx.types,
                                             inst_constraint,
                                         )
-                                        && !self.is_assignable_to(hidden_base, inst_constraint)
+                                        && !self.diagnostic_relation_boolean_guard(
+                                            hidden_base,
+                                            inst_constraint,
+                                        )
                                     {
                                         self.error_type_constraint_not_satisfied(
                                             type_arg,
@@ -1334,15 +1342,16 @@ impl<'a> CheckerState<'a> {
                             });
                             if is_checkable
                                 && base_for_check.is_none_or(|base_for_check| {
-                                    !self.is_assignable_to(base_for_check, inst_constraint)
-                                        && !self.base_union_members_satisfy_constraint(
-                                            base_for_check,
-                                            inst_constraint,
-                                        )
-                                        && !self.satisfies_array_like_constraint(
-                                            base_for_check,
-                                            inst_constraint,
-                                        )
+                                    !self.diagnostic_relation_boolean_guard(
+                                        base_for_check,
+                                        inst_constraint,
+                                    ) && !self.base_union_members_satisfy_constraint(
+                                        base_for_check,
+                                        inst_constraint,
+                                    ) && !self.satisfies_array_like_constraint(
+                                        base_for_check,
+                                        inst_constraint,
+                                    )
                                 })
                                 && let Some(&arg_idx) = type_args_list.nodes.get(i)
                                 && !self.type_argument_is_narrowed_by_conditional_true_branch(
@@ -1487,8 +1496,10 @@ impl<'a> CheckerState<'a> {
                                                 .as_ref()
                                                 .is_some_and(|m| m.contains(&primitive_key));
                                         in_base
-                                            && !self
-                                                .is_assignable_to(primitive_key, inst_constraint)
+                                            && !self.diagnostic_relation_boolean_guard(
+                                                primitive_key,
+                                                inst_constraint,
+                                            )
                                     })
                             }
                             && let Some(&arg_idx) = type_args_list.nodes.get(i)
@@ -1504,7 +1515,7 @@ impl<'a> CheckerState<'a> {
                         let base_for_check = self.resolve_lazy_members_in_union(base);
                         let base_for_check = self.evaluate_type_for_assignability(base_for_check);
                         let mut is_satisfied = self
-                            .is_assignable_to(base_for_check, inst_constraint)
+                            .diagnostic_relation_boolean_guard(base_for_check, inst_constraint)
                             || self.base_union_members_satisfy_constraint(
                                 base_for_check,
                                 inst_constraint,
@@ -1682,9 +1693,15 @@ impl<'a> CheckerState<'a> {
                                 type_arg,
                             )
                         {
-                            self.is_assignable_to(type_arg, instantiated_constraint)
+                            self.diagnostic_relation_boolean_guard(
+                                type_arg,
+                                instantiated_constraint,
+                            )
                         } else {
-                            self.is_assignable_to_no_weak_checks(type_arg, instantiated_constraint)
+                            self.diagnostic_relation_boolean_guard_no_weak_checks(
+                                type_arg,
+                                instantiated_constraint,
+                            )
                         });
                 // When the constraint is all-optional and the structural check
                 // passed (because all-optional types have no required properties),
@@ -1757,7 +1774,7 @@ impl<'a> CheckerState<'a> {
                             TypeId::UNKNOWN | TypeId::ERROR | TypeId::NEVER
                         )
                     {
-                        is_satisfied = self.is_assignable_to_no_weak_checks(
+                        is_satisfied = self.diagnostic_relation_boolean_guard_no_weak_checks(
                             evaluated_arg,
                             instantiated_constraint,
                         ) || self.satisfies_array_like_constraint(
@@ -1776,7 +1793,8 @@ impl<'a> CheckerState<'a> {
                 {
                     let base = self.resolve_lazy_members_in_union(base);
                     let base = self.evaluate_type_for_assignability(base);
-                    is_satisfied = self.is_assignable_to(base, instantiated_constraint)
+                    is_satisfied = self
+                        .diagnostic_relation_boolean_guard(base, instantiated_constraint)
                         || self
                             .base_union_members_satisfy_constraint(base, instantiated_constraint)
                         || self.satisfies_array_like_constraint(base, instantiated_constraint);

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -762,6 +762,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "crates"
             / "tsz-checker"
             / "src"
+            / "checkers"
+            / "generic_checker"
+            / "constraint_validation.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
             / "types"
             / "computation"
             / "complex_contextual_new.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10134.

## Invariant
TS2344 constraint validation decisions still use the same candidate types and no-weak-check policy, but the diagnostic relation predicates route through the shared relation boundary. This PR does not change solver relation policy.

## Scope
- Replaced the remaining raw assignability predicates in `constraint_validation.rs` with `diagnostic_relation_boolean_guard`.
- Preserved existing no-weak-check behavior by routing those checks through `diagnostic_relation_boolean_guard_no_weak_checks`.
- Added `constraint_validation.rs` to the raw diagnostic assignability architecture ratchet now that the file is clear.

## Project Corpus Impact
Row: n/a

Bug family: checker TS2344 constraint relation routing / #8227 raw diagnostic assignability predicates

Evidence: behavior-preserving diagnostic relation routing only; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-constraint-indexed-access-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10134 at base head `fa697e65d7d93c8422dfcbeff91e9b0986a07ac7`.
- Current head: `b1d58e945ad7ba2b7088fe7dc538b0ebf67ef8e7`.
- Rebased from prior base `854de4249e87a46c9d480319eb89bc4a5b750e80`; replay was clean and kept only this PR's constraint-validation routing delta.
- File-size guard context: `constraint_validation.rs` is 1878 lines.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
