### PR TITLE
refactor(checker): route generator callback relation guard

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_display.rs
+++ b/crates/tsz-checker/src/types/computation/call_display.rs
@@ -140,7 +140,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if !self.is_assignable_to_with_env(source_return, target_return) {
+        if !self.diagnostic_relation_boolean_guard_with_env(source_return, target_return) {
             return false;
         }
 
@@ -149,7 +149,7 @@ impl<'a> CheckerState<'a> {
             self.get_generator_next_type_argument(target_return_type),
         ) {
             (Some(source_next), Some(target_next)) => {
-                self.is_assignable_to_with_env(target_next, source_next)
+                self.diagnostic_relation_boolean_guard_with_env(target_next, source_next)
             }
             _ => true,
         }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10135.

## Invariant
The generator `never` yield callback exception remains an error-emission-only relation check, but its return and next-type comparisons route through the shared diagnostic relation boundary with environment resolution preserved.

## Scope
- Routed `is_assignable_via_generator_never_yield_callback` return and next-type checks through `diagnostic_relation_boolean_guard_with_env`.
- Left `is_assignable_via_contextual_signatures` unchanged because it is also used by call inference, not just diagnostics.

## Project Corpus Impact
Row: n/a

Bug family: checker call-error diagnostic relation routing / #8227 raw diagnostic assignability predicates

Evidence: behavior-preserving diagnostic relation routing only; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-constraint-validation-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10135 at base head `b1d58e945ad7ba2b7088fe7dc538b0ebf67ef8e7`.
- Current head: `db9338a81c4c191ea0a11331348379a8de6e9bfb`.
- Rebased from prior base `b8500341aa1eea2a077c786688006496880eb095`; replay was clean and kept only this PR's generator-callback routing delta.
- `call_display.rs` still contains raw relation calls in `is_assignable_via_contextual_signatures`; those are intentionally left alone because that helper is used by call inference as well as diagnostics.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
