### PR TITLE
refactor(checker): route property index key relation guard

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking/mod.rs
@@ -13,6 +13,7 @@ mod mapped_object_literals;
 mod module_none;
 pub(crate) mod property;
 pub(crate) mod property_access;
+mod property_index_key_helpers;
 pub(crate) mod readonly;
 mod source_file;
 mod strict_names;

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -252,32 +252,6 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    fn string_index_key_accepts_property_name(
-        &mut self,
-        key_type: TypeId,
-        prop_name: &str,
-        is_symbol_named: bool,
-    ) -> bool {
-        if key_type == TypeId::SYMBOL {
-            return is_symbol_named
-                || prop_name.starts_with("[Symbol.")
-                || prop_name.starts_with("__unique_")
-                || prop_name.starts_with("__@");
-        }
-
-        if key_type == TypeId::STRING {
-            return true;
-        }
-
-        if is_symbol_named {
-            return false;
-        }
-
-        let prop_literal =
-            crate::query_boundaries::common::create_string_literal_type(self.ctx.types, prop_name);
-        self.is_assignable_to(prop_literal, key_type)
-    }
-
     fn union_member_has_type_parameter_for_excess_display(&self, member: TypeId) -> bool {
         query::is_type_parameter_like(self.ctx.types, member)
             || crate::query_boundaries::common::contains_generic_type_parameters(

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -1,0 +1,36 @@
+//! String index key helpers for excess-property diagnostics.
+//!
+//! Extracted from `property.rs` to keep the oversized state-checking file moving
+//! toward the repository line-count limit while routing diagnostic relation
+//! checks through the shared boundary.
+
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn string_index_key_accepts_property_name(
+        &mut self,
+        key_type: TypeId,
+        prop_name: &str,
+        is_symbol_named: bool,
+    ) -> bool {
+        if key_type == TypeId::SYMBOL {
+            return is_symbol_named
+                || prop_name.starts_with("[Symbol.")
+                || prop_name.starts_with("__unique_")
+                || prop_name.starts_with("__@");
+        }
+
+        if key_type == TypeId::STRING {
+            return true;
+        }
+
+        if is_symbol_named {
+            return false;
+        }
+
+        let prop_literal =
+            crate::query_boundaries::common::create_string_literal_type(self.ctx.types, prop_name);
+        self.diagnostic_relation_boolean_guard(prop_literal, key_type)
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10136.

## Invariant
Excess-property string-index key acceptance keeps the same structural rule, but its literal-key relation check routes through the shared diagnostic relation boundary. The oversized `property.rs` moves one helper into a dedicated sibling module rather than adding new size debt.

## Scope
- Extracted `string_index_key_accepts_property_name` from `property.rs` into `property_index_key_helpers.rs`.
- Routed the property-name string literal relation check through `diagnostic_relation_boolean_guard`.
- Registered the helper module under `state_checking`.

## Project Corpus Impact
Row: n/a

Bug family: checker excess-property diagnostic relation routing / #8227 raw diagnostic assignability predicates

Evidence: behavior-preserving diagnostic helper extraction only; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-generator-callback-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10136 at base head `db9338a81c4c191ea0a11331348379a8de6e9bfb`.
- Current head: `2ad23b6d96079b7ee4c52a26697a5a7e5cdbab17`.
- Rebased from prior base `4ec1226a840aed2939c1a95d7b7b5f6fc1eb3ce2`; replay was clean and kept only this PR's property-index-key helper extraction delta.
- `property.rs` remains over the repository line-count ceiling, but this PR reduces it by 26 lines and does not add new debt; `property_index_key_helpers.rs` is 36 lines.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
