### PR TITLE
refactor(checker): route property index value relation guards

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -518,7 +518,7 @@ impl<'a> CheckerState<'a> {
 
                 if let Some(string_index) = &shape.string_index {
                     any_member_has_string_index = true;
-                    if Self::index_value_type_is_deferred(self.ctx.types, string_index.value_type)
+                    if self.index_value_type_is_deferred(string_index.value_type)
                         || crate::query_boundaries::common::contains_type_parameters(
                             self.ctx.types,
                             resolved_target,
@@ -619,7 +619,7 @@ impl<'a> CheckerState<'a> {
                                 }
                                 source_props.iter().any(|source_prop| {
                                     source_prop.name == target_prop.name
-                                        && self.is_assignable_to(
+                                        && self.diagnostic_relation_boolean_guard(
                                             source_prop.type_id,
                                             target_prop.type_id,
                                         )
@@ -2057,24 +2057,30 @@ impl<'a> CheckerState<'a> {
                     ) {
                         continue;
                     }
-                    if Self::index_value_type_is_deferred(self.ctx.types, string_index.value_type) {
+                    if self.index_value_type_is_deferred(string_index.value_type) {
                         has_deferred_index_value_type = true;
                         continue;
                     }
                     applicable_index_value_types.push(string_index.value_type);
-                    if self.is_assignable_to(source_prop.type_id, string_index.value_type) {
+                    if self.diagnostic_relation_boolean_guard(
+                        source_prop.type_id,
+                        string_index.value_type,
+                    ) {
                         accepted_by_index = true;
                         break;
                     }
                 }
 
                 if is_numeric_name && let Some(number_index) = &shape.number_index {
-                    if Self::index_value_type_is_deferred(self.ctx.types, number_index.value_type) {
+                    if self.index_value_type_is_deferred(number_index.value_type) {
                         has_deferred_index_value_type = true;
                         continue;
                     }
                     applicable_index_value_types.push(number_index.value_type);
-                    if self.is_assignable_to(source_prop.type_id, number_index.value_type) {
+                    if self.diagnostic_relation_boolean_guard(
+                        source_prop.type_id,
+                        number_index.value_type,
+                    ) {
                         accepted_by_index = true;
                         break;
                     }
@@ -2100,7 +2106,7 @@ impl<'a> CheckerState<'a> {
             ) {
                 continue;
             }
-            if self.is_assignable_to(source_prop.type_id, target_value_type) {
+            if self.diagnostic_relation_boolean_guard(source_prop.type_id, target_value_type) {
                 continue;
             }
 
@@ -2183,14 +2189,6 @@ impl<'a> CheckerState<'a> {
         }
 
         self.ctx.diagnostics.len() > diag_count_before
-    }
-
-    fn index_value_type_is_deferred(
-        types: &dyn tsz_solver::construction::TypeDatabase,
-        type_id: TypeId,
-    ) -> bool {
-        crate::query_boundaries::common::is_index_access_type(types, type_id)
-            || crate::query_boundaries::common::contains_type_parameters(types, type_id)
     }
 
     fn try_emit_nested_discriminated_union_assignability_error(

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -33,4 +33,9 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::create_string_literal_type(self.ctx.types, prop_name);
         self.diagnostic_relation_boolean_guard(prop_literal, key_type)
     }
+
+    pub(super) fn index_value_type_is_deferred(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::is_index_access_type(self.ctx.types, type_id)
+            || crate::query_boundaries::common::contains_type_parameters(self.ctx.types, type_id)
+    }
 }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -755,6 +755,13 @@ REGEX_LINE_COUNT_CHECKS = [
             / "crates"
             / "tsz-checker"
             / "src"
+            / "state"
+            / "state_checking"
+            / "property.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
             / "checkers"
             / "generic_checker"
             / "constraint_indexed_access_helpers.rs",


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10137.

## Invariant
Excess-property union index-signature value checks keep the same candidate values and deferred-type skips, but all property/index value relation decisions route through the shared diagnostic relation boundary.

## Scope
- Routed the remaining raw relation predicates in `state_checking/property.rs` through `diagnostic_relation_boolean_guard`.
- Moved `index_value_type_is_deferred` into `property_index_key_helpers.rs` so `property.rs` continues shrinking while this routing lands.
- Added `property.rs` to the raw diagnostic assignability architecture ratchet now that it is clear of raw diagnostic relation calls.

## Project Corpus Impact
Row: n/a

Bug family: checker excess-property diagnostic relation routing / #8227 raw diagnostic assignability predicates

Evidence: behavior-preserving diagnostic relation routing only; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-property-index-key-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10137 at base head `2ad23b6d96079b7ee4c52a26697a5a7e5cdbab17`.
- Current head: `ab02d56a97123a6d1b3548b7eb860516f43897c5`.
- Rebased from prior base `884a009d53caf96c739bd651e7f6af7a9ca015b9`; replay was clean and kept only this PR's property-index-value routing delta.
- `property.rs` is now clear of raw diagnostic assignability calls and covered by the guard, but it remains oversized; further work should split additional helpers before touching more property-checking behavior.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
