### PR TITLE
refactor(checker): route type parameter default relation guards

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -80,7 +80,7 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    fn type_parameter_default_syntactically_satisfies_constraint(
+    pub(super) fn type_parameter_default_syntactically_satisfies_constraint(
         &self,
         param_idx: NodeIndex,
     ) -> bool {
@@ -1974,97 +1974,7 @@ impl<'a> CheckerState<'a> {
         // Build a constraint graph among type parameters in this list and detect cycles.
         self.check_indirect_circular_constraints(&params, &param_indices);
 
-        // Validate defaults against the stabilized constraints.
-        for (&param_idx, param) in param_indices.iter().zip(params.iter()) {
-            let Some(default_type) = param.default else {
-                continue;
-            };
-            let Some(constraint_type) = param.constraint else {
-                continue;
-            };
-            let constraint_has_type_params =
-                generic_query::contains_type_parameters(self.ctx.types, constraint_type);
-            let default_has_type_params =
-                generic_query::contains_type_parameters(self.ctx.types, default_type);
-            if constraint_has_type_params || default_has_type_params {
-                let is_other_bare_type_parameter = |type_id| {
-                    generic_query::is_bare_type_parameter(self.ctx.types, type_id)
-                        && generic_query::type_parameter_name(self.ctx.types, type_id)
-                            .is_some_and(|name| name != param.name)
-                };
-                if !is_other_bare_type_parameter(default_type)
-                    && !is_other_bare_type_parameter(constraint_type)
-                {
-                    continue;
-                }
-            }
-            if self
-                .empty_type_literal_satisfies_optional_mapped_constraint(param_idx, constraint_type)
-            {
-                continue;
-            }
-            // A default that is syntactically one branch of its constraint union
-            // satisfies the constraint by construction. This keeps default
-            // validation from depending on an early semantic copy of the same
-            // branch that may not have all lazy aliases stabilized yet.
-            if self.type_parameter_default_syntactically_satisfies_constraint(param_idx) {
-                continue;
-            }
-            let mut default_satisfies = self.is_assignable_to(default_type, constraint_type);
-            if !default_satisfies {
-                self.ensure_refs_resolved(default_type);
-                self.ensure_refs_resolved(constraint_type);
-                let evaluated_default = self.evaluate_type_for_assignability(default_type);
-                let evaluated_constraint = self.evaluate_type_for_assignability(constraint_type);
-                if evaluated_default != default_type
-                    && !matches!(
-                        evaluated_default,
-                        TypeId::UNKNOWN | TypeId::ERROR | TypeId::NEVER
-                    )
-                {
-                    default_satisfies = self
-                        .is_assignable_to(evaluated_default, evaluated_constraint)
-                        || self.satisfies_array_like_constraint(
-                            evaluated_default,
-                            evaluated_constraint,
-                        )
-                        || self.conditional_result_branches_satisfy_constraint(
-                            evaluated_default,
-                            evaluated_constraint,
-                        );
-                }
-            }
-            if !default_satisfies {
-                let Some(node) = self.ctx.arena.get(param_idx) else {
-                    continue;
-                };
-                let Some(data) = self.ctx.arena.get_type_parameter(node) else {
-                    continue;
-                };
-                if let Some(instantiated_default) =
-                    self.instantiate_type_ref_argument_from_syntax(default_type, data.default)
-                {
-                    let evaluated_default =
-                        self.evaluate_type_for_assignability(instantiated_default);
-                    default_satisfies = self.is_assignable_to(evaluated_default, constraint_type)
-                        || self.satisfies_array_like_constraint(evaluated_default, constraint_type)
-                        || self.conditional_result_branches_satisfy_constraint(
-                            evaluated_default,
-                            constraint_type,
-                        );
-                }
-                if default_satisfies {
-                    continue;
-                }
-                let type_str = self.format_type(default_type);
-                let constraint_str = self.format_type(constraint_type);
-                self.error_at_node_msg(
-                    data.default,
-                    crate::diagnostics::diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
-                    &[&type_str, &constraint_str],
-                );
-            }
-        }
+        self.validate_type_parameter_defaults_against_constraints(&param_indices, &params);
 
         self.ctx.leave_recursion();
         (params, updates)
@@ -2117,7 +2027,7 @@ impl<'a> CheckerState<'a> {
         type_id
     }
 
-    fn empty_type_literal_satisfies_optional_mapped_constraint(
+    pub(super) fn empty_type_literal_satisfies_optional_mapped_constraint(
         &mut self,
         param_idx: NodeIndex,
         constraint_type: TypeId,

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -27,3 +27,4 @@ mod cross_file_residue;
 mod cross_file_shared_cache;
 mod source_alias_attribution;
 mod symbol_type_helpers;
+mod type_param_defaults;

--- a/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
+++ b/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
@@ -1,0 +1,111 @@
+//! Type-parameter default validation helpers.
+//!
+//! Extracted from `core.rs` to reduce the oversized type-analysis module while
+//! routing default/constraint diagnostic relation checks through the shared
+//! boundary.
+
+use crate::query_boundaries::checkers::generic as generic_query;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn validate_type_parameter_defaults_against_constraints(
+        &mut self,
+        param_indices: &[NodeIndex],
+        params: &[tsz_solver::TypeParamInfo],
+    ) {
+        for (&param_idx, param) in param_indices.iter().zip(params.iter()) {
+            let Some(default_type) = param.default else {
+                continue;
+            };
+            let Some(constraint_type) = param.constraint else {
+                continue;
+            };
+            let constraint_has_type_params =
+                generic_query::contains_type_parameters(self.ctx.types, constraint_type);
+            let default_has_type_params =
+                generic_query::contains_type_parameters(self.ctx.types, default_type);
+            if constraint_has_type_params || default_has_type_params {
+                let is_other_bare_type_parameter = |type_id| {
+                    generic_query::is_bare_type_parameter(self.ctx.types, type_id)
+                        && generic_query::type_parameter_name(self.ctx.types, type_id)
+                            .is_some_and(|name| name != param.name)
+                };
+                if !is_other_bare_type_parameter(default_type)
+                    && !is_other_bare_type_parameter(constraint_type)
+                {
+                    continue;
+                }
+            }
+            if self
+                .empty_type_literal_satisfies_optional_mapped_constraint(param_idx, constraint_type)
+            {
+                continue;
+            }
+            // A default that is syntactically one branch of its constraint union
+            // satisfies the constraint by construction. This keeps default
+            // validation from depending on an early semantic copy of the same
+            // branch that may not have all lazy aliases stabilized yet.
+            if self.type_parameter_default_syntactically_satisfies_constraint(param_idx) {
+                continue;
+            }
+            let mut default_satisfies =
+                self.diagnostic_relation_boolean_guard(default_type, constraint_type);
+            if !default_satisfies {
+                self.ensure_refs_resolved(default_type);
+                self.ensure_refs_resolved(constraint_type);
+                let evaluated_default = self.evaluate_type_for_assignability(default_type);
+                let evaluated_constraint = self.evaluate_type_for_assignability(constraint_type);
+                if evaluated_default != default_type
+                    && !matches!(
+                        evaluated_default,
+                        TypeId::UNKNOWN | TypeId::ERROR | TypeId::NEVER
+                    )
+                {
+                    default_satisfies = self
+                        .diagnostic_relation_boolean_guard(evaluated_default, evaluated_constraint)
+                        || self.satisfies_array_like_constraint(
+                            evaluated_default,
+                            evaluated_constraint,
+                        )
+                        || self.conditional_result_branches_satisfy_constraint(
+                            evaluated_default,
+                            evaluated_constraint,
+                        );
+                }
+            }
+            if !default_satisfies {
+                let Some(node) = self.ctx.arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(data) = self.ctx.arena.get_type_parameter(node) else {
+                    continue;
+                };
+                if let Some(instantiated_default) =
+                    self.instantiate_type_ref_argument_from_syntax(default_type, data.default)
+                {
+                    let evaluated_default =
+                        self.evaluate_type_for_assignability(instantiated_default);
+                    default_satisfies = self
+                        .diagnostic_relation_boolean_guard(evaluated_default, constraint_type)
+                        || self.satisfies_array_like_constraint(evaluated_default, constraint_type)
+                        || self.conditional_result_branches_satisfy_constraint(
+                            evaluated_default,
+                            constraint_type,
+                        );
+                }
+                if default_satisfies {
+                    continue;
+                }
+                let type_str = self.format_type(default_type);
+                let constraint_str = self.format_type(constraint_type);
+                self.error_at_node_msg(
+                    data.default,
+                    crate::diagnostics::diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
+                    &[&type_str, &constraint_str],
+                );
+            }
+        }
+    }
+}

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -756,6 +756,20 @@ REGEX_LINE_COUNT_CHECKS = [
             / "tsz-checker"
             / "src"
             / "state"
+            / "type_analysis"
+            / "core.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
+            / "type_analysis"
+            / "type_param_defaults.rs",
+            ROOT
+            / "crates"
+            / "tsz-checker"
+            / "src"
+            / "state"
             / "state_checking"
             / "property.rs",
             ROOT


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10138.

## Invariant
Type-parameter default validation keeps the same stabilized default/constraint candidates and fallback checks, but its diagnostic relation predicates route through the shared diagnostic relation boundary. The oversized `type_analysis/core.rs` moves the default-validation loop into a dedicated helper module.

## Scope
- Extracted type-parameter default-vs-constraint validation from `state/type_analysis/core.rs` into `type_param_defaults.rs`.
- Routed the default/constraint relation checks through `diagnostic_relation_boolean_guard`.
- Added both `core.rs` and `type_param_defaults.rs` to the raw diagnostic assignability architecture ratchet now that this path is clear.

## Project Corpus Impact
Row: n/a

Bug family: checker type-parameter default diagnostic relation routing / #8227 raw diagnostic assignability predicates

Evidence: behavior-preserving diagnostic helper extraction only; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-property-index-value-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10138 at base head `ab02d56a97123a6d1b3548b7eb860516f43897c5`.
- Current head: `afd4f475940408b72055c93a819a62fd717efc88`.
- Rebased from prior base `7c3e85a3530d163a82381621864c841ba9d5ec47`; replay was clean and kept only this PR's type-parameter default extraction/routing delta.
- `type_analysis/core.rs` is still oversized at 2742 lines, but this PR reduces it by about 90 lines while avoiding new file-size debt; `type_param_defaults.rs` is 111 lines.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
