### PR TITLE
refactor(checker): route jsdoc import constraint relation guard

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1531,15 +1531,17 @@ impl<'a> CheckerState<'a> {
                                 Self::parse_jsdoc_import_type(import_base)
                         {
                             self.report_jsdoc_import_type_constraint_error(
-                                expr,
-                                angle_idx,
-                                &arg_strs,
-                                &module_specifier,
-                                &member_name,
-                                &typedef_info,
-                                comment.pos,
-                                comment.end,
-                                &source_text,
+                                crate::jsdoc::diagnostics_import_type_constraints::JsdocImportTypeConstraintDiagnostic {
+                                    expr,
+                                    angle_idx,
+                                    arg_strs: &arg_strs,
+                                    module_specifier: &module_specifier,
+                                    member_name: &member_name,
+                                    typedef_info: &typedef_info,
+                                    comment_pos: comment.pos,
+                                    comment_end: comment.end,
+                                    source_text: &source_text,
+                                },
                             );
                         }
                         continue;

--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1530,107 +1530,17 @@ impl<'a> CheckerState<'a> {
                             && let Some((module_specifier, Some(member_name))) =
                                 Self::parse_jsdoc_import_type(import_base)
                         {
-                            // Register template params in scope for resolving type args
-                            let factory = self.ctx.types.factory();
-                            let mut scope_updates = Vec::new();
-                            for tp in &typedef_info.template_params {
-                                let constraint = tp
-                                    .constraint
-                                    .as_deref()
-                                    .and_then(|c| self.resolve_jsdoc_type_str(c));
-                                let atom = self.ctx.types.intern_string(&tp.name);
-                                let param = tsz_solver::TypeParamInfo {
-                                    name: atom,
-                                    constraint,
-                                    default: None,
-                                    is_const: false,
-                                };
-                                let type_id = factory.type_param(param);
-                                let previous = self
-                                    .ctx
-                                    .type_parameter_scope
-                                    .insert(tp.name.clone(), type_id);
-                                scope_updates.push((tp.name.clone(), previous));
-                            }
-
-                            // Try symbol-based resolution first (for TS exports),
-                            // then fall back to cross-file JSDoc typedef resolution
-                            // (for types defined via @typedef in JS files).
-                            let mut type_params = self
-                                .resolve_jsdoc_import_member(&module_specifier, &member_name)
-                                .map(|sym_id| self.type_reference_symbol_type_with_params(sym_id).1)
-                                .unwrap_or_default();
-                            if type_params.is_empty() {
-                                type_params = self.resolve_import_typedef_type_params(
-                                    &module_specifier,
-                                    &member_name,
-                                );
-                            }
-
-                            if !type_params.is_empty() {
-                                let comment_text = &source_text[comment.pos as usize
-                                    ..(comment.end as usize).min(source_text.len())];
-                                let type_expr_offset = comment_text.find(expr).unwrap_or(0);
-                                let mut arg_search_offset = angle_idx + 1;
-                                for (arg_str, param) in arg_strs.iter().zip(type_params.iter()) {
-                                    let Some(constraint) = param.constraint else {
-                                        arg_search_offset += arg_str.len() + 1;
-                                        continue;
-                                    };
-                                    let Some(type_arg) =
-                                        self.resolve_jsdoc_type_str(arg_str.trim())
-                                    else {
-                                        arg_search_offset += arg_str.len() + 1;
-                                        continue;
-                                    };
-                                    if type_arg == tsz_solver::TypeId::ERROR {
-                                        arg_search_offset += arg_str.len() + 1;
-                                        continue;
-                                    }
-                                    if self.is_assignable_to(type_arg, constraint) {
-                                        arg_search_offset += arg_str.len() + 1;
-                                        continue;
-                                    }
-                                    let widened_arg =
-                                        crate::query_boundaries::common::widen_literal_type(
-                                            self.ctx.types,
-                                            type_arg,
-                                        );
-                                    use crate::diagnostics::{
-                                        diagnostic_codes as dc, diagnostic_messages as dm,
-                                        format_message as fmt_msg,
-                                    };
-                                    let message = fmt_msg(
-                                        dm::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
-                                        &[
-                                            &self.format_type_diagnostic(widened_arg),
-                                            &self.format_type_diagnostic(constraint),
-                                        ],
-                                    );
-                                    let arg_rel =
-                                        expr[arg_search_offset..].find(arg_str.trim()).unwrap_or(0);
-                                    let arg_pos = comment.pos as usize
-                                        + type_expr_offset
-                                        + arg_search_offset
-                                        + arg_rel;
-                                    self.ctx.error(
-                                        arg_pos as u32,
-                                        arg_str.trim().len() as u32,
-                                        message,
-                                        dc::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
-                                    );
-                                    break;
-                                }
-                            }
-
-                            // Restore scope
-                            for (name, previous) in scope_updates.into_iter().rev() {
-                                if let Some(previous) = previous {
-                                    self.ctx.type_parameter_scope.insert(name, previous);
-                                } else {
-                                    self.ctx.type_parameter_scope.remove(&name);
-                                }
-                            }
+                            self.report_jsdoc_import_type_constraint_error(
+                                expr,
+                                angle_idx,
+                                &arg_strs,
+                                &module_specifier,
+                                &member_name,
+                                &typedef_info,
+                                comment.pos,
+                                comment.end,
+                                &source_text,
+                            );
                         }
                         continue;
                     }

--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -4,19 +4,34 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::jsdoc::types::JsdocTypedefInfo;
 use crate::state::CheckerState;
 
+pub(super) struct JsdocImportTypeConstraintDiagnostic<'a> {
+    pub(super) expr: &'a str,
+    pub(super) angle_idx: usize,
+    pub(super) arg_strs: &'a [&'a str],
+    pub(super) module_specifier: &'a str,
+    pub(super) member_name: &'a str,
+    pub(super) typedef_info: &'a JsdocTypedefInfo,
+    pub(super) comment_pos: u32,
+    pub(super) comment_end: u32,
+    pub(super) source_text: &'a str,
+}
+
 impl<'a> CheckerState<'a> {
     pub(super) fn report_jsdoc_import_type_constraint_error(
         &mut self,
-        expr: &str,
-        angle_idx: usize,
-        arg_strs: &[&str],
-        module_specifier: &str,
-        member_name: &str,
-        typedef_info: &JsdocTypedefInfo,
-        comment_pos: u32,
-        comment_end: u32,
-        source_text: &str,
+        request: JsdocImportTypeConstraintDiagnostic<'_>,
     ) {
+        let JsdocImportTypeConstraintDiagnostic {
+            expr,
+            angle_idx,
+            arg_strs,
+            module_specifier,
+            member_name,
+            typedef_info,
+            comment_pos,
+            comment_end,
+            source_text,
+        } = request;
         let factory = self.ctx.types.factory();
         let mut scope_updates = Vec::new();
         for tp in &typedef_info.template_params {

--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -1,0 +1,102 @@
+//! JSDoc import type constraint diagnostics.
+
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::jsdoc::types::JsdocTypedefInfo;
+use crate::state::CheckerState;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn report_jsdoc_import_type_constraint_error(
+        &mut self,
+        expr: &str,
+        angle_idx: usize,
+        arg_strs: &[&str],
+        module_specifier: &str,
+        member_name: &str,
+        typedef_info: &JsdocTypedefInfo,
+        comment_pos: u32,
+        comment_end: u32,
+        source_text: &str,
+    ) {
+        let factory = self.ctx.types.factory();
+        let mut scope_updates = Vec::new();
+        for tp in &typedef_info.template_params {
+            let constraint = tp
+                .constraint
+                .as_deref()
+                .and_then(|c| self.resolve_jsdoc_type_str(c));
+            let atom = self.ctx.types.intern_string(&tp.name);
+            let param = tsz_solver::TypeParamInfo {
+                name: atom,
+                constraint,
+                default: None,
+                is_const: false,
+            };
+            let type_id = factory.type_param(param);
+            let previous = self
+                .ctx
+                .type_parameter_scope
+                .insert(tp.name.clone(), type_id);
+            scope_updates.push((tp.name.clone(), previous));
+        }
+
+        let mut type_params = self
+            .resolve_jsdoc_import_member(module_specifier, member_name)
+            .map(|sym_id| self.type_reference_symbol_type_with_params(sym_id).1)
+            .unwrap_or_default();
+        if type_params.is_empty() {
+            type_params = self.resolve_import_typedef_type_params(module_specifier, member_name);
+        }
+
+        if !type_params.is_empty() {
+            let comment_text =
+                &source_text[comment_pos as usize..(comment_end as usize).min(source_text.len())];
+            let type_expr_offset = comment_text.find(expr).unwrap_or(0);
+            let mut arg_search_offset = angle_idx + 1;
+            for (arg_str, param) in arg_strs.iter().zip(type_params.iter()) {
+                let Some(constraint) = param.constraint else {
+                    arg_search_offset += arg_str.len() + 1;
+                    continue;
+                };
+                let Some(type_arg) = self.resolve_jsdoc_type_str(arg_str.trim()) else {
+                    arg_search_offset += arg_str.len() + 1;
+                    continue;
+                };
+                if type_arg == tsz_solver::TypeId::ERROR {
+                    arg_search_offset += arg_str.len() + 1;
+                    continue;
+                }
+                if self.diagnostic_relation_boolean_guard(type_arg, constraint) {
+                    arg_search_offset += arg_str.len() + 1;
+                    continue;
+                }
+
+                let widened_arg =
+                    crate::query_boundaries::common::widen_literal_type(self.ctx.types, type_arg);
+                let message = format_message(
+                    diagnostic_messages::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
+                    &[
+                        &self.format_type_diagnostic(widened_arg),
+                        &self.format_type_diagnostic(constraint),
+                    ],
+                );
+                let arg_rel = expr[arg_search_offset..].find(arg_str.trim()).unwrap_or(0);
+                let arg_pos = comment_pos as usize + type_expr_offset + arg_search_offset + arg_rel;
+                self.ctx.error(
+                    arg_pos as u32,
+                    arg_str.trim().len() as u32,
+                    message,
+                    diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
+                );
+                break;
+            }
+        }
+
+        for (name, previous) in scope_updates.into_iter().rev() {
+            if let Some(previous) = previous {
+                self.ctx.type_parameter_scope.insert(name, previous);
+            } else {
+                self.ctx.type_parameter_scope.remove(&name);
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/src/jsdoc/mod.rs
+++ b/crates/tsz-checker/src/jsdoc/mod.rs
@@ -36,6 +36,7 @@
 //! - New data structures → `types.rs`
 
 pub(crate) mod diagnostics;
+pub(crate) mod diagnostics_import_type_constraints;
 pub(crate) mod diagnostics_imports;
 pub(crate) mod diagnostics_templates;
 pub(crate) mod lookup;


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10139.

## Invariant
When a JSDoc import type argument is checked against an imported generic constraint, TS2344 remains owned by the JSDoc diagnostic path and the boolean relation decision routes through the shared checker diagnostic relation guard.

## Scope
- Extracted JSDoc import type constraint-argument diagnostics into `jsdoc::diagnostics_import_type_constraints`.
- Replaced the local raw `is_assignable_to` predicate in that path with `diagnostic_relation_boolean_guard`.
- Kept TS2344 message rendering and source positioning unchanged.

## Project Corpus Impact
Row: n/a

Bug family: checker relation diagnostics routing / #8227 raw diagnostic assignability predicates

Evidence: refactor-only helper extraction; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-type-param-default-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10139 at base head `afd4f475940408b72055c93a819a62fd717efc88`.
- Current head: `faee2cf8441d616b7c6bcf8c505f8c72ea9315f8`.
- Rebased from prior base `bb4a148b83dec1ec834bdf7f2b3506ba379aa2f0`; replay was clean across the existing two commits.
- This removes one raw diagnostic assignability predicate from `jsdoc/diagnostics.rs` and reduces that oversized file by roughly 100 lines without changing behavior; `diagnostics_import_type_constraints.rs` is 117 lines.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
