### PR TITLE
refactor(checker): route duplicate declaration relation guards

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifier_relation_helpers.rs
@@ -1,0 +1,28 @@
+//! Relation helpers for duplicate declaration diagnostics.
+
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn duplicate_decl_types_match(&mut self, left: TypeId, right: TypeId) -> bool {
+        self.diagnostic_relation_boolean_guard(left, right)
+            && self.diagnostic_relation_boolean_guard(right, left)
+    }
+
+    pub(super) fn duplicate_decl_type_matches_index(
+        &mut self,
+        property_type: TypeId,
+        index_type: TypeId,
+    ) -> bool {
+        self.diagnostic_relation_boolean_guard(property_type, index_type)
+    }
+
+    pub(super) fn duplicate_index_types_overlap(
+        &mut self,
+        local_type: TypeId,
+        existing_type: TypeId,
+    ) -> bool {
+        self.diagnostic_relation_boolean_guard(local_type, existing_type)
+            || self.diagnostic_relation_boolean_guard(existing_type, local_type)
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -2692,10 +2692,9 @@ impl<'a> CheckerState<'a> {
                                 if !self.type_contains_error(*property_type)
                                     && !self.type_contains_error(existing_type)
                                 {
-                                    let compatible_both_ways = self
-                                        .is_assignable_to(existing_type, *property_type)
-                                        && self.is_assignable_to(*property_type, existing_type);
-                                    if !compatible_both_ways {
+                                    if !self
+                                        .duplicate_decl_types_match(existing_type, *property_type)
+                                    {
                                         let existing_type_str = self.format_type(existing_type);
                                         let property_type_str = self.format_type(*property_type);
                                         self.error_at_node_msg(
@@ -2727,10 +2726,7 @@ impl<'a> CheckerState<'a> {
                             {
                                 continue;
                             }
-                            let compatible_both_ways = self
-                                .is_assignable_to(existing_type, *property_type)
-                                && self.is_assignable_to(*property_type, existing_type);
-                            if !compatible_both_ways {
+                            if !self.duplicate_decl_types_match(existing_type, *property_type) {
                                 let existing_type_str = self.format_type(existing_type);
                                 let property_type_str = self.format_type(*property_type);
                                 self.error_at_node_msg(
@@ -2747,7 +2743,7 @@ impl<'a> CheckerState<'a> {
 
                     if *is_numeric
                         && let Some(number_index) = local_number_index.or(merged_number_index)
-                        && !self.is_assignable_to(*property_type, number_index)
+                        && !self.duplicate_decl_type_matches_index(*property_type, number_index)
                     {
                         let index_type_str = self.format_type(number_index);
                         self.error_at_node_msg(
@@ -2763,7 +2759,7 @@ impl<'a> CheckerState<'a> {
                     }
 
                     if let Some(string_index) = local_string_index.or(merged_string_index)
-                        && !self.is_assignable_to(*property_type, string_index)
+                        && !self.duplicate_decl_type_matches_index(*property_type, string_index)
                     {
                         let index_type_str = self.format_type(string_index);
                         self.error_at_node_msg(
@@ -2811,9 +2807,7 @@ impl<'a> CheckerState<'a> {
 
                     let local_str = self.format_type(local_number);
                     let existing_str = self.format_type(existing_number);
-                    if !self.is_assignable_to(local_number, existing_number)
-                        && !self.is_assignable_to(existing_number, local_number)
-                    {
+                    if !self.duplicate_index_types_overlap(local_number, existing_number) {
                         self.error_at_node_msg(
                             local_number_index_node,
                             diagnostic_codes::INDEX_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
@@ -2843,9 +2837,7 @@ impl<'a> CheckerState<'a> {
 
                     let local_str = self.format_type(local_string);
                     let existing_str = self.format_type(existing_string);
-                    if !self.is_assignable_to(local_string, existing_string)
-                        && !self.is_assignable_to(existing_string, local_string)
-                    {
+                    if !self.duplicate_index_types_overlap(local_string, existing_string) {
                         self.error_at_node_msg(
                             local_string_index_node,
                             diagnostic_codes::INDEX_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -2691,18 +2691,16 @@ impl<'a> CheckerState<'a> {
                                 // against the method's function type.
                                 if !self.type_contains_error(*property_type)
                                     && !self.type_contains_error(existing_type)
-                                {
-                                    if !self
+                                    && !self
                                         .duplicate_decl_types_match(existing_type, *property_type)
-                                    {
-                                        let existing_type_str = self.format_type(existing_type);
-                                        let property_type_str = self.format_type(*property_type);
-                                        self.error_at_node_msg(
-                                            *name_idx,
-                                            diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
-                                            &[name, &existing_type_str, &property_type_str],
-                                        );
-                                    }
+                                {
+                                    let existing_type_str = self.format_type(existing_type);
+                                    let property_type_str = self.format_type(*property_type);
+                                    self.error_at_node_msg(
+                                        *name_idx,
+                                        diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
+                                        &[name, &existing_type_str, &property_type_str],
+                                    );
                                 }
                             }
                             continue;

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -17,6 +17,7 @@ mod cross_file_conflicts;
 mod declarations;
 mod declarations_utils;
 mod duplicate_identifier_conflict_kinds;
+mod duplicate_identifier_relation_helpers;
 mod duplicate_identifiers;
 mod duplicate_identifiers_ambient_default;
 mod duplicate_identifiers_constructor;


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10140.

## Invariant
When merged declaration diagnostics compare duplicate property and index-signature value types, TS2717/TS2374 follow-up diagnostics still come from the same checker diagnostic path, but the boolean relation predicates route through the shared diagnostic relation guard.

## Scope
- Added `types::type_checking::duplicate_identifier_relation_helpers` for duplicate declaration diagnostic relation predicates.
- Replaced raw `is_assignable_to` checks in `duplicate_identifiers.rs` for TS2717 property compatibility and duplicate index-signature value compatibility.
- Kept diagnostic messages, anchors, and reporting conditions unchanged.

## Project Corpus Impact
Row: n/a

Bug family: checker relation diagnostics routing / #8227 raw diagnostic assignability predicates

Evidence: refactor-only helper extraction; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-jsdoc-import-constraint-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10140 at base head `faee2cf8441d616b7c6bcf8c505f8c72ea9315f8`.
- Current head: `11ac5b7df0085b3d8709860b426179e8e409bec6`.
- Rebased from prior base `f7a52514cc8a80c5081f563cf9629669dc2705c2`; replay was clean across the existing two commits.
- Removes the remaining raw diagnostic assignability predicates from `types/type_checking/duplicate_identifiers.rs`; the file is still oversized at 2916 lines, but this slice reduces it and isolates the relation boundary in a 28-line helper.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
