### PR TITLE
refactor(checker): route class static side relation guard

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -309,49 +309,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Collect the names of a symbol's namespace exports (merged `namespace X { ... }`
-    /// declarations). Used to decide whether a class-namespace merge could
-    /// shadow or conflict with a base class's static members for the TS2417
-    /// static-side compatibility check.
-    fn collect_namespace_export_names_for_symbol(
-        &self,
-        sym_id: tsz_binder::SymbolId,
-    ) -> rustc_hash::FxHashSet<String> {
-        let mut names = rustc_hash::FxHashSet::default();
-        if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && let Some(exports) = symbol.exports.as_ref()
-        {
-            for (name, _sym_id) in exports.iter() {
-                if !name.is_empty() {
-                    names.insert(name.clone());
-                }
-            }
-        }
-        names
-    }
-
-    /// Collect all property names from a type via the solver query boundary API.
-    /// Used for type-level override checking when the base class is a complex
-    /// expression (function call, intersection constructor).
-    fn collect_property_names_from_type(
-        &mut self,
-        type_id: TypeId,
-    ) -> rustc_hash::FxHashSet<String> {
-        // Resolve Lazy types through the checker's type environment first
-        let resolved = self.resolve_lazy_type(type_id);
-        // Use the query boundary function which properly traverses Object/Intersection/Union
-        let atoms =
-            crate::query_boundaries::diagnostics::collect_property_name_atoms_for_diagnostics(
-                self.ctx.types,
-                resolved,
-                5, // max_depth sufficient for class hierarchies
-            );
-        atoms
-            .into_iter()
-            .map(|atom| self.ctx.types.resolve_atom_ref(atom).to_string())
-            .collect()
-    }
-
     /// Check override members against a type-level base class (when AST resolution fails).
     /// Used for complex heritage expressions: function calls, intersection constructors, etc.
     /// Also checks property type compatibility (TS2416) when `base_instance_type` is provided.
@@ -2263,52 +2220,13 @@ impl<'a> CheckerState<'a> {
         // namespace exports. This avoids false positives for classes that simply
         // don't replicate namespace exports from their base class.
         if !class_extends_error_reported && let Some(base_sym) = base_sym_for_ns_static_check {
-            let derived_sym = self.ctx.binder.get_node_symbol(class_idx);
-            if let Some(derived_sym) = derived_sym {
-                let derived_symbol_flags = self
-                    .ctx
-                    .binder
-                    .get_symbol(derived_sym)
-                    .map_or(0, |s| s.flags);
-                let derived_has_namespace = derived_symbol_flags
-                    & (tsz_binder::symbol_flags::NAMESPACE_MODULE
-                        | tsz_binder::symbol_flags::VALUE_MODULE)
-                    != 0;
-                if derived_has_namespace {
-                    let derived_ctor_type = self.get_type_of_symbol(derived_sym);
-                    let base_ctor_type = self.get_type_of_symbol(base_sym);
-                    // Only flag TS2417 when derived's namespace exports a name
-                    // that already exists on base's static (constructor) side.
-                    // Without such overlap, the namespace merge cannot shadow
-                    // a base static member, so the structural check would
-                    // otherwise over-fire on self-referential clodule generics
-                    // (e.g. `class C extends B<typeof C.X> { } ;
-                    // namespace C { export const X = ... }`) where
-                    // is_assignable_to rejects a technically-compatible
-                    // constructor pair purely because of the self-reference.
-                    let derived_ns_names =
-                        self.collect_namespace_export_names_for_symbol(derived_sym);
-                    let base_static_names = self.collect_property_names_from_type(base_ctor_type);
-                    let has_name_overlap = derived_ns_names
-                        .iter()
-                        .any(|n| base_static_names.contains(n));
-                    if has_name_overlap
-                        && derived_ctor_type != TypeId::UNKNOWN
-                        && derived_ctor_type != TypeId::ERROR
-                        && base_ctor_type != TypeId::UNKNOWN
-                        && base_ctor_type != TypeId::ERROR
-                        && !self.is_assignable_to(derived_ctor_type, base_ctor_type)
-                    {
-                        self.error_at_node(
-                                class_data.name,
-                                &format!(
-                                    "Class static side 'typeof {derived_class_name}' incorrectly extends base class static side 'typeof {base_class_name}'."
-                                ),
-                                diagnostic_codes::CLASS_STATIC_SIDE_INCORRECTLY_EXTENDS_BASE_CLASS_STATIC_SIDE,
-                            );
-                    }
-                }
-            }
+            self.report_namespace_merged_static_side_mismatch(
+                class_idx,
+                class_data.name,
+                &derived_class_name,
+                &base_class_name,
+                base_sym,
+            );
         }
 
         self.pop_type_parameters(derived_type_param_updates);

--- a/crates/tsz-checker/src/classes/class_static_side_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_static_side_helpers.rs
@@ -1,0 +1,96 @@
+//! Static-side class diagnostics for namespace-merged declarations.
+
+use crate::diagnostics::diagnostic_codes;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn report_namespace_merged_static_side_mismatch(
+        &mut self,
+        class_idx: NodeIndex,
+        class_name: NodeIndex,
+        derived_class_name: &str,
+        base_class_name: &str,
+        base_sym: tsz_binder::SymbolId,
+    ) {
+        let Some(derived_sym) = self.ctx.binder.get_node_symbol(class_idx) else {
+            return;
+        };
+        let derived_symbol_flags = self
+            .ctx
+            .binder
+            .get_symbol(derived_sym)
+            .map_or(0, |s| s.flags);
+        let derived_has_namespace = derived_symbol_flags
+            & (tsz_binder::symbol_flags::NAMESPACE_MODULE | tsz_binder::symbol_flags::VALUE_MODULE)
+            != 0;
+        if !derived_has_namespace {
+            return;
+        }
+
+        let derived_ctor_type = self.get_type_of_symbol(derived_sym);
+        let base_ctor_type = self.get_type_of_symbol(base_sym);
+        let derived_ns_names = self.collect_namespace_export_names_for_symbol(derived_sym);
+        let base_static_names = self.collect_property_names_from_type(base_ctor_type);
+        let has_name_overlap = derived_ns_names
+            .iter()
+            .any(|n| base_static_names.contains(n));
+        if has_name_overlap
+            && derived_ctor_type != TypeId::UNKNOWN
+            && derived_ctor_type != TypeId::ERROR
+            && base_ctor_type != TypeId::UNKNOWN
+            && base_ctor_type != TypeId::ERROR
+            && !self.diagnostic_relation_boolean_guard(derived_ctor_type, base_ctor_type)
+        {
+            self.error_at_node(
+                class_name,
+                &format!(
+                    "Class static side 'typeof {derived_class_name}' incorrectly extends base class static side 'typeof {base_class_name}'."
+                ),
+                diagnostic_codes::CLASS_STATIC_SIDE_INCORRECTLY_EXTENDS_BASE_CLASS_STATIC_SIDE,
+            );
+        }
+    }
+
+    /// Collect the names of a symbol's namespace exports (merged `namespace X { ... }`
+    /// declarations). Used to decide whether a class-namespace merge could
+    /// shadow or conflict with a base class's static members for the TS2417
+    /// static-side compatibility check.
+    fn collect_namespace_export_names_for_symbol(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> rustc_hash::FxHashSet<String> {
+        let mut names = rustc_hash::FxHashSet::default();
+        if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
+            && let Some(exports) = symbol.exports.as_ref()
+        {
+            for (name, _sym_id) in exports.iter() {
+                if !name.is_empty() {
+                    names.insert(name.clone());
+                }
+            }
+        }
+        names
+    }
+
+    /// Collect all property names from a type via the solver query boundary API.
+    /// Used for type-level override checking when the base class is a complex
+    /// expression (function call, intersection constructor).
+    pub(super) fn collect_property_names_from_type(
+        &mut self,
+        type_id: TypeId,
+    ) -> rustc_hash::FxHashSet<String> {
+        let resolved = self.resolve_lazy_type(type_id);
+        let atoms =
+            crate::query_boundaries::diagnostics::collect_property_name_atoms_for_diagnostics(
+                self.ctx.types,
+                resolved,
+                5,
+            );
+        atoms
+            .into_iter()
+            .map(|atom| self.ctx.types.resolve_atom_ref(atom).to_string())
+            .collect()
+    }
+}

--- a/crates/tsz-checker/src/classes/mod.rs
+++ b/crates/tsz-checker/src/classes/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod class_helpers;
 pub(crate) mod class_implements_checker;
 pub(crate) mod class_implements_helpers;
 pub mod class_inheritance;
+pub(crate) mod class_static_side_helpers;
 pub(crate) mod class_summary;
 pub mod constructor_checker;
 pub(crate) mod interface_heritage_display;


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10141.

## Invariant
When a namespace-merged derived class shadows base static exports, TS2417 remains reported from checker class diagnostics at the same location and message, while the constructor-side compatibility predicate routes through the shared diagnostic relation guard.

## Scope
- Extracted namespace-merged class static-side TS2417 diagnostics into `classes::class_static_side_helpers`.
- Replaced the raw `is_assignable_to` predicate for the constructor-side check with `diagnostic_relation_boolean_guard`.
- Moved static-side namespace/property-name collection helpers out of `class_checker.rs` without changing reporting conditions.

## Project Corpus Impact
Row: n/a

Bug family: checker relation diagnostics routing / #8227 raw diagnostic assignability predicates

Evidence: refactor-only helper extraction; no project-corpus row, fixture metadata, emitted-output behavior, or solver relation policy changed.

## Verification
- `git diff --check codex/m1b-duplicate-decl-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- Stacked above #10141 at base head `11ac5b7df0085b3d8709860b426179e8e409bec6`.
- Current head: `9b3809ac3495988b334b47e16ab8074e5533b030`.
- Rebased from prior base `a5c3bdabb98c278c28b78495fa39e5121df686c8`; replay was clean.
- Removes the raw diagnostic assignability predicate from `classes/class_checker.rs` and reduces that oversized file to 2808 lines; `class_static_side_helpers.rs` is 96 lines.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until #9922/lower stack is ready/green.
