### PR TITLE
refactor(checker): route function return branch relation guard

### DIFF
--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -2,13 +2,13 @@
 mod function_name_diagnostics;
 mod js_prototype;
 mod jsx_body_context;
+mod return_diagnostics;
 
 use crate::computation::complex::{
     expression_needs_contextual_return_type, is_contextually_sensitive,
 };
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
-use crate::diagnostics::format_message;
 use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_checking_utilities as type_query;
 use crate::state::CheckerState;
@@ -2284,50 +2284,12 @@ impl<'a> CheckerState<'a> {
                         // inference pass when the expected return still contains
                         // unresolved placeholders.
                     } else if use_generic_return_mismatch {
-                        let conditional_branch_mismatch = self
-                            .ctx
-                            .arena
-                            .get(body)
-                            .and_then(|body_node| self.ctx.arena.get_conditional_expr(body_node))
-                            .is_some_and(|cond| {
-                                let snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
-                                let return_req =
-                                    TypingRequest::with_contextual_type(expected_return_type);
-                                let mut when_true =
-                                    self.get_type_of_node_with_request(cond.when_true, &return_req);
-                                let mut when_false = self
-                                    .get_type_of_node_with_request(cond.when_false, &return_req);
-                                snap.rollback(&mut self.ctx.diagnostic_state());
-                                if is_async_for_context {
-                                    when_true =
-                                        self.unwrap_promise_type(when_true).unwrap_or(when_true);
-                                    when_false =
-                                        self.unwrap_promise_type(when_false).unwrap_or(when_false);
-                                }
-                                !self.is_assignable_to(when_true, expected_return_type)
-                                    || !self.is_assignable_to(when_false, expected_return_type)
-                            });
-                        if conditional_branch_mismatch
-                            && !self.is_nested_same_wrapper_application_assignment(
-                                actual_return,
-                                expected_return_type,
-                            )
-                            && let Some(loc) = self.get_source_location(body)
-                        {
-                            let src_str = self.format_type(actual_return);
-                            let tgt_str = self.format_type(expected_return_type);
-                            let message = format_message(
-                                    crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                                    &[&src_str, &tgt_str],
-                                );
-                            self.ctx.diagnostics.push(crate::diagnostics::Diagnostic::error(
-                                    self.ctx.file_name.clone(),
-                                    loc.start,
-                                    loc.length(),
-                                    message,
-                                    crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                                ));
-                        }
+                        self.emit_generic_conditional_return_mismatch(
+                            body,
+                            actual_return,
+                            expected_return_type,
+                            is_async_for_context,
+                        );
                     } else {
                         // For expression-bodied arrows/functions, use exact anchoring
                         // to prevent assignment_anchor_node from walking up to the

--- a/crates/tsz-checker/src/types/function_type/return_diagnostics.rs
+++ b/crates/tsz-checker/src/types/function_type/return_diagnostics.rs
@@ -1,0 +1,55 @@
+use crate::context::TypingRequest;
+use crate::context::speculation::DiagnosticSpeculationSnapshot;
+use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn emit_generic_conditional_return_mismatch(
+        &mut self,
+        body: NodeIndex,
+        actual_return: TypeId,
+        expected_return_type: TypeId,
+        is_async_for_context: bool,
+    ) {
+        let conditional_branch_mismatch = self
+            .ctx
+            .arena
+            .get(body)
+            .and_then(|body_node| self.ctx.arena.get_conditional_expr(body_node))
+            .is_some_and(|cond| {
+                let snap = DiagnosticSpeculationSnapshot::new(&self.ctx);
+                let return_req = TypingRequest::with_contextual_type(expected_return_type);
+                let mut when_true = self.get_type_of_node_with_request(cond.when_true, &return_req);
+                let mut when_false =
+                    self.get_type_of_node_with_request(cond.when_false, &return_req);
+                snap.rollback(&mut self.ctx.diagnostic_state());
+                if is_async_for_context {
+                    when_true = self.unwrap_promise_type(when_true).unwrap_or(when_true);
+                    when_false = self.unwrap_promise_type(when_false).unwrap_or(when_false);
+                }
+                !self.diagnostic_relation_boolean_guard(when_true, expected_return_type)
+                    || !self.diagnostic_relation_boolean_guard(when_false, expected_return_type)
+            });
+        if conditional_branch_mismatch
+            && !self
+                .is_nested_same_wrapper_application_assignment(actual_return, expected_return_type)
+            && let Some(loc) = self.get_source_location(body)
+        {
+            let src_str = self.format_type(actual_return);
+            let tgt_str = self.format_type(expected_return_type);
+            let message = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&src_str, &tgt_str],
+            );
+            self.ctx.diagnostics.push(Diagnostic::error(
+                self.ctx.file_name.clone(),
+                loc.start,
+                loc.length(),
+                message,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            ));
+        }
+    }
+}


### PR DESCRIPTION
AgentName: M1-B

Track: Track 10 / #8227 checker relation-boundary narrowing. Stacked on #10142.

Invariant: When a generic contextual function return uses a conditional expression body with a mismatching branch, TS2322 remains reported from checker function-return diagnostics at the same location/message while branch compatibility predicates route through the shared diagnostic relation guard.

Scope:
- Extract generic conditional return mismatch emission into `types::function_type::return_diagnostics`.
- Replace raw branch `is_assignable_to` predicates with `diagnostic_relation_boolean_guard`.
- Keep speculation rollback, async promise unwrapping, source span, and rendered TS2322 message unchanged.

Project Corpus Impact:
- Row: n/a
- Bug family: checker relation diagnostics routing / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only helper extraction; no project corpus row, fixture metadata, semantic policy, baseline, or emitted output change.

Verification:
- `git diff --check codex/m1b-class-static-side-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`

Coordination Notes:
- Stacked above #10142 at base head `9b3809ac3495988b334b47e16ab8074e5533b030`.
- Current head: `80370adfbe9517b18ea2f9586d22750489ddf43d`.
- Rebased cleanly from prior base `6f615d7170b1f0af64b13de7e50b5e1e87317d82`.
- Remaining raw calls in `types/function_type.rs` are contextual inference/semantic checks and intentionally left alone.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until the lower stack is ready and green.
