### PR TITLE
refactor(checker): route jsdoc assertion overlap guard

### DIFF
--- a/crates/tsz-checker/src/dispatch.rs
+++ b/crates/tsz-checker/src/dispatch.rs
@@ -747,8 +747,12 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                 jsdoc_type,
                             );
                         if should_check {
-                            let fwd = self.checker.is_assignable_to(expr_type, jsdoc_type);
-                            let rev = self.checker.is_assignable_to(jsdoc_type, expr_type);
+                            let fwd = self
+                                .checker
+                                .is_assignable_for_type_assertion_overlap(expr_type, jsdoc_type);
+                            let rev = self
+                                .checker
+                                .is_assignable_for_type_assertion_overlap(jsdoc_type, expr_type);
                             if !fwd && !rev {
                                 // Check union member overlap (same as `as` expressions):
                                 // if expr is a union, check if any member overlaps with target.
@@ -757,8 +761,13 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                     query::union_members(self.checker.ctx.types, expr_type)
                                 {
                                     for member in members {
-                                        if self.checker.is_assignable_to(member, jsdoc_type)
-                                            || self.checker.is_assignable_to(jsdoc_type, member)
+                                        if self.checker.is_assignable_for_type_assertion_overlap(
+                                            member, jsdoc_type,
+                                        ) || self
+                                            .checker
+                                            .is_assignable_for_type_assertion_overlap(
+                                                jsdoc_type, member,
+                                            )
                                         {
                                             have_overlap = true;
                                             break;

--- a/crates/tsz-checker/src/tests/jsdoc_cast_and_define_property_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_cast_and_define_property_widening_tests.rs
@@ -103,3 +103,16 @@ take(c);
         "Expected TS2345 (string passed where number required), got codes: {codes:?}\nDiagnostics: {diags:#?}",
     );
 }
+
+#[test]
+fn jsdoc_type_cast_reports_ts2352_for_non_overlapping_primitives() {
+    let source = "\
+const r = /** @type {number} */(\"abc\");
+";
+    let diags = diags_for_strict_js(source);
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        codes.contains(&2352),
+        "Expected TS2352 for incompatible JSDoc type cast, got codes: {codes:?}\nDiagnostics: {diags:#?}",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only checker relation routing for #8227. Stacked on #10144.

## Invariant
When a JSDoc `@type` cast checks TS2352-style assertion overlap, checker should use the same assertion-overlap relation helper as `as` / angle-bracket assertions instead of raw boolean assignability probes. The diagnostic behavior is preserved while the relation probe is routed through the shared assertion-overlap boundary.

## Scope
- Route JSDoc `@type` cast forward/reverse overlap probes through `is_assignable_for_type_assertion_overlap`.
- Route JSDoc cast union-member overlap probes through the same helper.
- Add a focused JS unit test that verifies non-overlapping JSDoc casts still report TS2352.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics routing for JSDoc assertion casts / #8227 raw diagnostic assignability predicates
- Evidence: local targeted unit, architecture guards, checker compile, and narrow checker clippy passed; no project corpus fixture, semantic policy, baseline, or emitted output change.

## Verification
- `git diff --check codex/m1b-overlap-relation-guards-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `cargo nextest run -p tsz-checker --lib jsdoc_type_cast_reports_ts2352_for_non_overlapping_primitives`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `wc -l crates/tsz-checker/src/dispatch.rs crates/tsz-checker/src/tests/jsdoc_cast_and_define_property_widening_tests.rs`
- `rg -n "is_assignable_to\\(" crates/tsz-checker/src/dispatch.rs crates/tsz-checker/src/tests/jsdoc_cast_and_define_property_widening_tests.rs`

## Coordination Notes
- Stacked above #10144 at base head `a8b57cae0788b73981762b30600f64df3aa82c2f`.
- Current head: `d1e44372a8c95dda8c2f4d64be579084241123b4`.
- Rebased cleanly from prior base `820d97076e54f9e747c6406272c094f3d34b22fe`.
- `dispatch.rs` remains under the 2000-line file limit at 1963 lines.
- `rg -n "is_assignable_to\\("` found no hits in the touched dispatch/test files.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until the lower stack is ready and green.
