### PR TITLE
refactor(checker): route class own member relation guards

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -430,7 +430,7 @@ pub(crate) fn should_report_own_member_type_mismatch(
     // source vs `IteratorResult<T, void>` target — `any` is a universal sink
     // for the standard relation but the strict path keeps the args nominally
     // distinct). tsc does not emit TS2416 here.
-    if checker.is_assignable_to(source, target) {
+    if checker.diagnostic_relation_boolean_guard(source, target) {
         return false;
     }
     if source_this_parameter_is_acceptable_for_target_without_this(checker, source, target) {
@@ -511,7 +511,9 @@ fn is_coinductive_return_type_cycle(
         }
         // Check each param for assignability
         for (sp, tp) in s_params.iter().zip(t_params.iter()) {
-            if sp.type_id != tp.type_id && !checker.is_assignable_to(tp.type_id, sp.type_id) {
+            if sp.type_id != tp.type_id
+                && !checker.diagnostic_relation_boolean_guard(tp.type_id, sp.type_id)
+            {
                 return false;
             }
         }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 4 / Track 10: refactor-only checker relation routing for #8227. Stacked on #10145.

## Invariant
When checker decides whether to suppress class/interface member diagnostics such as TS2416 for own members or coinductive return cycles, checker owns the diagnostic decision and relation probes should go through the shared diagnostic relation guard. Behavior is unchanged; the relation calls become grep-distinct from diagnostic-bearing `RelationOutcome` paths.

## Scope
- Route the standard own-member TS2416 fallback probe in `query_boundaries::class` through `diagnostic_relation_boolean_guard`.
- Route the coinductive-cycle parameter compatibility probe through the same diagnostic guard.
- Preserve the existing no-erase-generics strict path and suppression ordering.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics routing for class member compatibility / #8227 raw diagnostic assignability predicates
- Evidence: refactor-only routing; no project corpus fixture, semantic policy, baseline, or emitted output change.

## Verification
- `git diff --check codex/m1b-jsdoc-assertion-overlap-relation-guard-20260525...HEAD`
- `cargo fmt --check`
- `python3 -m py_compile scripts/arch/arch_guard.py scripts/arch/arch_guard_config.py scripts/arch/arch_guard_projects.py`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_flags_raw_diagnostic_assignability_predicates scripts.arch.test_arch_guard.ArchGuardRegexLineCountTests.test_scan_regex_line_count_accepts_file_roots`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo check -p tsz-checker --lib`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `wc -l crates/tsz-checker/src/query_boundaries/class.rs`
- `rg -n "is_assignable_to\\(|diagnostic_relation_boolean_guard" crates/tsz-checker/src/query_boundaries/class.rs`

## Coordination Notes
- Stacked above #10145 at base head `d1e44372a8c95dda8c2f4d64be579084241123b4`.
- Current head: `d9a4a7f7d91b5f7a6de95aa45b886170a8d1fa47`.
- Rebased cleanly from prior base `8a6305cd8c4f1689e7cf28bf7f28c308a9cc7de6`.
- `class.rs` remains small at 708 lines.
- `class.rs` has no remaining raw `is_assignable_to(` hits; the grep shows only `diagnostic_relation_boolean_guard` calls.
- Non-overlap: no solver policy/cache/request/M4-B changes.
- Draft/off-auto with `agent:M1-B` only; keep draft until the lower stack is ready and green.
