### PR TITLE
fix(solver): include symbol in keyof mixed index signatures

### DIFF
--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -623,6 +623,24 @@ const _k2: K = someSym;
 }
 
 #[test]
+fn keyof_mixed_string_symbol_index_signature_includes_symbol() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+interface R {
+    [k: string]: number;
+    [k: symbol]: number;
+}
+declare const x: symbol;
+const k: keyof R = x;
+"#,
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "symbol should be assignable to keyof mixed string/symbol index signature, got {codes:?}",
+    );
+}
+
+#[test]
 fn object_literal_wide_symbol_key_is_structural_renamed_identifier_one() {
     // Different key-variable name — the rule is structural, not identifier-keyed.
     let codes = diagnostic_codes_for_ts(

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -35,7 +35,21 @@ use super::super::evaluate::{
 /// - Number-keyed signature (only when no string-slot signature is present):
 ///   contributes `number`, except for enum namespace types where tsc excludes
 ///   the implicit `[index: number]: string` from `keyof typeof E`.
+fn index_signature_key_includes_symbol(interner: &dyn TypeDatabase, key_type: TypeId) -> bool {
+    if key_type == TypeId::SYMBOL {
+        return true;
+    }
+    match interner.lookup(key_type) {
+        Some(TypeData::Union(members)) => interner
+            .type_list(members)
+            .iter()
+            .any(|&member| index_signature_key_includes_symbol(interner, member)),
+        _ => false,
+    }
+}
+
 fn extend_keyof_with_index_signature_keys(
+    interner: &dyn TypeDatabase,
     key_types: &mut Vec<TypeId>,
     string_or_symbol_index: Option<&IndexSignature>,
     number_index: Option<&IndexSignature>,
@@ -47,6 +61,9 @@ fn extend_keyof_with_index_signature_keys(
         } else {
             key_types.push(TypeId::STRING);
             key_types.push(TypeId::NUMBER);
+            if index_signature_key_includes_symbol(interner, idx.key_type) {
+                key_types.push(TypeId::SYMBOL);
+            }
         }
     } else if number_index.is_some() && !is_enum_namespace {
         key_types.push(TypeId::NUMBER);
@@ -475,6 +492,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .collect();
 
                     extend_keyof_with_index_signature_keys(
+                        self.interner(),
                         &mut key_types,
                         shape.string_index.as_ref(),
                         shape.number_index.as_ref(),
@@ -501,6 +519,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .collect();
 
                     extend_keyof_with_index_signature_keys(
+                        self.interner(),
                         &mut key_types,
                         shape.string_index.as_ref(),
                         shape.number_index.as_ref(),

--- a/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
@@ -430,6 +430,37 @@ fn test_keyof_object_with_string_index_includes_string_and_number() {
 }
 
 #[test]
+fn test_keyof_object_with_collapsed_string_symbol_index_includes_symbol() {
+    let interner = TypeInterner::new();
+    let string_or_symbol = interner.union2(TypeId::STRING, TypeId::SYMBOL);
+    let obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: string_or_symbol,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(obj));
+
+    let Some(TypeData::Union(members)) = interner.lookup(result) else {
+        panic!(
+            "Expected union for keyof mixed string/symbol index, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    let member_list = interner.type_list(members);
+    assert!(member_list.contains(&TypeId::STRING));
+    assert!(member_list.contains(&TypeId::NUMBER));
+    assert!(member_list.contains(&TypeId::SYMBOL));
+}
+
+#[test]
 fn test_keyof_object_with_number_index_includes_number() {
     let interner = TypeInterner::new();
     let obj_with_index = interner.object_with_index(ObjectShape {
@@ -610,6 +641,34 @@ fn test_keyof_callable_with_string_index_includes_string_and_number() {
             interner.lookup(result)
         );
     }
+}
+
+#[test]
+fn test_keyof_callable_with_collapsed_string_symbol_index_includes_symbol() {
+    let interner = TypeInterner::new();
+    let string_or_symbol = interner.union2(TypeId::STRING, TypeId::SYMBOL);
+    let callable = interner.callable(CallableShape {
+        string_index: Some(IndexSignature {
+            key_type: string_or_symbol,
+            value_type: TypeId::NUMBER,
+            readonly: true,
+            param_name: None,
+        }),
+        ..CallableShape::default()
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(callable));
+
+    let Some(TypeData::Union(members)) = interner.lookup(result) else {
+        panic!(
+            "Expected union for keyof callable mixed string/symbol index, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    let member_list = interner.type_list(members);
+    assert!(member_list.contains(&TypeId::STRING));
+    assert!(member_list.contains(&TypeId::NUMBER));
+    assert!(member_list.contains(&TypeId::SYMBOL));
 }
 
 #[test]


### PR DESCRIPTION
AgentName: M4-C

## Track
Roadmap Track 3: generic inference, contextual typing, constructor inference, and instantiation-session correctness.

## Invariant
When an object or callable shape carries a collapsed index-signature key type that includes both string-like keys and `symbol`, `keyof` must include `symbol` alongside `string | number`. This is a solver `keyof` evaluation rule, not a checker diagnostic special case.

## Scope
- Narrow replacement slice for #9772 and the broad draft #9908.
- Updates solver `keyof` index-signature key collection to detect `symbol` inside an existing collapsed union key type.
- Adds focused solver coverage for object and callable collapsed string/symbol index signatures.
- Adds a checker repro for the root hand-written mixed index signature false positive.
- Leaves the broader `ObjectShape::symbol_index` architecture branch in #9908 as a parked follow-up rather than landing its 114-file fan-out.

## Project Corpus Impact
- Row: n/a.
- Bug family: false-positive TS2322 for `symbol` assigned to `keyof` of mixed string/symbol index signatures.
- Evidence: focused solver and checker regression tests; no project corpus row is claimed for this bounded rule fix.

## Verification
- `cargo nextest run -p tsz-solver test_keyof_object_with_collapsed_string_symbol_index_includes_symbol test_keyof_callable_with_collapsed_string_symbol_index_includes_symbol` passed: 2 tests run, 2 passed.
- `cargo nextest run -p tsz-checker -E 'test(keyof_mixed_string_symbol_index_signature_includes_symbol)'` passed: 2 tests run, 2 passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.

## Coordination Notes
- Current owner: M4-C.
- Related issue: #9772.
- Related broad draft: #9908 remains draft/off-auto and should not be promoted from head `db320736d7d2d406507b9ed59fa200c761dcca1a`.
- This PR intentionally keeps the landed slice small: 3 files changed, no shape-model field migration, no broad test-shard churn.
- Keep draft until light CI completes on this exact head, then mark ready for the normal heavy gates if clean.
