### PR TITLE
ci: add stale merge queue branch cleanup

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -32,6 +32,7 @@ function usage() {
     "  --no-default-merge-required-checks",
     "  --invalidate-open               Mark open PR heads pending and exit",
     "  --invalidate-pr <number>        Mark one PR head pending and exit",
+    "  --cleanup-queue-branches        Delete stale queue branches for closed PRs",
     "  --dry-run                       Report without pushing or merging",
     "  --verbose",
   ].join("\n");
@@ -48,6 +49,7 @@ function parsePositiveInt(flag, value) {
 export function parseArgs(argv) {
   const options = {
     base: process.env.BASE_BRANCH || DEFAULT_BASE,
+    cleanupQueueBranches: false,
     dryRun: false,
     invalidateOpen: false,
     invalidatePr: null,
@@ -90,6 +92,8 @@ export function parseArgs(argv) {
       options.invalidateOpen = true;
     } else if (arg === "--invalidate-pr") {
       options.invalidatePr = parsePositiveInt("--invalidate-pr", argv[++index]);
+    } else if (arg === "--cleanup-queue-branches") {
+      options.cleanupQueueBranches = true;
     } else if (arg === "--wait-attempts") {
       options.waitAttempts = parsePositiveInt("--wait-attempts", argv[++index]);
     } else if (arg === "--wait-interval-ms") {
@@ -330,6 +334,37 @@ function readBranchWorkflowRuns(repository, branch) {
   ]);
 }
 
+function readRemoteQueueBranches(options) {
+  const output = git(["ls-remote", "--heads", "origin", `${options.queueBranchPrefix}/pr-*`]);
+  return output.split("\n").flatMap((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return [];
+    const [oid, ref] = trimmed.split(/\s+/);
+    const prefix = "refs/heads/";
+    if (!oid || !ref?.startsWith(prefix)) return [];
+    return [{ oid, branch: ref.slice(prefix.length) }];
+  });
+}
+
+export function queueBranchPrNumber(branch, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
+  const escapedPrefix = queueBranchPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = String(branch || "").match(new RegExp(`^${escapedPrefix}/pr-(\\d+)$`));
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function readPullRequestState(repository, number) {
+  return runGhJson([
+    "api",
+    `repos/${repository}/pulls/${number}`,
+    "--jq",
+    "{number: .number, state: .state, merged: (.merged_at != null)}",
+  ]);
+}
+
+function deleteRemoteBranch(branch) {
+  git(["push", "origin", `:refs/heads/${branch}`], { stdio: "inherit" });
+}
+
 function readBranchOid(repository, branch) {
   return runGhJson([
     "api",
@@ -384,6 +419,73 @@ function invalidateOpen(repository, options) {
     if (result?.skipped) skippedActiveRuns += 1;
   }
   return { invalidated, skippedActiveRuns };
+}
+
+function cleanupQueueBranches(repository, options) {
+  let deleted = 0;
+  let wouldDelete = 0;
+  let skippedOpen = 0;
+  let skippedActiveRuns = 0;
+  let skippedUnrecognized = 0;
+  const deletions = [];
+  const skips = [];
+
+  for (const queueBranchInfo of readRemoteQueueBranches(options)) {
+    const number = queueBranchPrNumber(queueBranchInfo.branch, options.queueBranchPrefix);
+    if (!number) {
+      skippedUnrecognized += 1;
+      if (options.verbose) {
+        skips.push({ branch: queueBranchInfo.branch, reason: "unrecognized queue branch name" });
+      }
+      continue;
+    }
+
+    const pullRequest = readPullRequestState(repository, number);
+    if (String(pullRequest.state || "").toUpperCase() === "OPEN") {
+      skippedOpen += 1;
+      if (options.verbose) {
+        skips.push({ branch: queueBranchInfo.branch, reason: `PR #${number} is open` });
+      }
+      continue;
+    }
+
+    const activeRun = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranchInfo.branch));
+    if (activeRun) {
+      skippedActiveRuns += 1;
+      if (options.verbose) {
+        skips.push({
+          branch: queueBranchInfo.branch,
+          reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
+        });
+      }
+      continue;
+    }
+
+    deletions.push({
+      branch: queueBranchInfo.branch,
+      number,
+      state: pullRequest.state,
+      merged: Boolean(pullRequest.merged),
+    });
+    if (options.dryRun) {
+      wouldDelete += 1;
+    } else {
+      deleteRemoteBranch(queueBranchInfo.branch);
+      deleted += 1;
+    }
+  }
+
+  return {
+    cleanupQueueBranches: true,
+    deleted,
+    deletions,
+    dryRun: options.dryRun,
+    skippedActiveRuns,
+    skippedOpen,
+    skippedUnrecognized,
+    skips,
+    wouldDelete,
+  };
 }
 
 function readQueueCandidates(repository, options) {
@@ -582,6 +684,30 @@ export function formatResult(result, options) {
     if (result.skippedActiveRuns) {
       lines.push(`Preserved ${result.skippedActiveRuns} active queue run status(es).`);
     }
+  } else if (result.cleanupQueueBranches) {
+    if (result.dryRun) {
+      lines.push(`Would delete ${result.wouldDelete} stale queue branch(es).`);
+    } else {
+      lines.push(`Deleted ${result.deleted} stale queue branch(es).`);
+    }
+    lines.push(`Skipped ${result.skippedOpen} open PR branch(es).`);
+    lines.push(`Preserved ${result.skippedActiveRuns} branch(es) with active queue runs.`);
+    if (result.skippedUnrecognized) {
+      lines.push(`Skipped ${result.skippedUnrecognized} unrecognized queue branch name(s).`);
+    }
+    if (options.verbose && result.deletions?.length) {
+      lines.push("", "### Queue Branches", "", "| Branch | PR | State |", "|--------|----|-------|");
+      for (const deletion of result.deletions.slice(0, 50)) {
+        const state = deletion.merged ? "merged" : String(deletion.state || "closed").toLowerCase();
+        lines.push(`| \`${deletion.branch}\` | #${deletion.number} | ${state} |`);
+      }
+    }
+    if (options.verbose && result.skips?.length) {
+      lines.push("", "### Skips", "", "| Branch | Reason |", "|--------|--------|");
+      for (const skip of result.skips.slice(0, 50)) {
+        lines.push(`| \`${skip.branch}\` | ${skip.reason.replace(/\|/g, "\\|")} |`);
+      }
+    }
   } else if (!result.selected) {
     lines.push("No queue-ready auto-merge PR found.");
   } else if (result.dryRun) {
@@ -599,7 +725,7 @@ export function formatResult(result, options) {
   } else if (result.failed) {
     lines.push(`Failed #${result.selected.number}: ${result.reason}`);
   }
-  if (options.verbose && result.skips?.length) {
+  if (!result.cleanupQueueBranches && options.verbose && result.skips?.length) {
     lines.push("", "### Skips", "", "| PR | Reason |", "|----|--------|");
     for (const skip of result.skips.slice(0, 25)) {
       lines.push(`| #${skip.number} | ${skip.reason.replace(/\|/g, "\\|")} |`);
@@ -619,6 +745,8 @@ function main() {
       invalidated: invalidation?.invalidated ? 1 : 0,
       skippedActiveRuns: invalidation?.skipped ? 1 : 0,
     };
+  } else if (options.cleanupQueueBranches) {
+    result = cleanupQueueBranches(options.repository, options);
   } else if (options.invalidateOpen) {
     result = invalidateOpen(options.repository, options);
   } else {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -7,6 +7,7 @@ import {
   hasPendingPlaceholderQueueStatus,
   pendingQueueRun,
   parseArgs,
+  queueBranchPrNumber,
   queueRunIsActive,
   queueSkipReason,
   requiredCheckState,
@@ -40,6 +41,7 @@ function pr(overrides = {}) {
 }
 
 assert.equal(parseArgs(["--repository", "owner/repo"]).repository, "owner/repo");
+assert.equal(parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches"]).cleanupQueueBranches, true);
 assert.deepEqual(
   parseArgs(["--no-default-pr-required-checks", "--pr-required-check", "lint"]).prRequiredChecks,
   ["lint"],
@@ -49,6 +51,9 @@ assert.deepEqual(
   ["CI Summary"],
 );
 assert.equal(parseArgs(["--invalidate-pr", "123"]).invalidatePr, 123);
+assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123"), 123);
+assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-extra"), null);
+assert.equal(queueBranchPrNumber("custom/queue/pr-456", "custom/queue"), 456);
 
 assert.equal(requiredCheckState([check()], ["CI Summary"]).kind, "passed");
 assert.equal(requiredCheckState([check({ status: "IN_PROGRESS", conclusion: "" })], ["CI Summary"]).kind, "pending");
@@ -163,6 +168,21 @@ assert.match(
   }, parseArgs(["--repository", "owner/repo", "--invalidate-open"])),
   /Preserved 2 active queue run status/,
 );
+
+const cleanupFormat = formatResult({
+  cleanupQueueBranches: true,
+  deletions: [
+    { branch: "automation/merge-queue/pr-1", number: 1, state: "closed", merged: true },
+  ],
+  dryRun: true,
+  skippedActiveRuns: 1,
+  skippedOpen: 2,
+  skippedUnrecognized: 1,
+  skips: [],
+  wouldDelete: 1,
+}, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
+assert.match(cleanupFormat, /Would delete 1 stale queue branch/);
+assert.doesNotMatch(cleanupFormat, /\| #undefined \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track: M1-A PR garden / queue hygiene
PR type: CI tooling

## Invariant
Keep merge-queue cleanup explicit, reviewable, and safe: stale temporary queue branches may be deleted only when their PR is closed or merged, while branches for open PRs and branches with active queue runs are preserved.

## Scope
- Adds `--cleanup-queue-branches` to `scripts/ci/poor-mans-merge-queue.mjs`.
- Supports `--dry-run` and verbose reporting for cleanup candidates.
- Restricts cleanup to exact `automation/merge-queue/pr-<number>` branch names.
- Skips open PR queue branches and preserves branches with active queue runs.
- Extends the existing queue script test coverage for parsing and cleanup formatting.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI script/tooling-only change; no compiler, checker, solver, emit, or project corpus behavior is changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- Dry-run evidence before the formatting fix: `REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose` reported 44 stale exact queue branches, 13 open PR queue branches preserved, 0 active queue-run branches preserved, and 1 unrecognized queue branch skipped. No branches were deleted.
- After rebasing onto `origin/main` `cf000f5c9bcd59c4f6ed9d1887661cfaacf91a61`: `node scripts/ci/test-poor-mans-merge-queue.mjs` and `git diff --check`.
- Ready CI on prior head `c2dde48c6bae69bbc7bf8c3a7b9450a66fc333b3`: run `26393935932` completed successfully.
- Prior synthetic queue run `26394199204` passed, but tested old main parent `cf000f5c9bcd59c4f6ed9d1887661cfaacf91a61`; it was not used for landing after main advanced.
- After rebasing onto `origin/main` `b0a91e0289296cda11aa2c7b43dbeb1cd695b21e`: `node scripts/ci/test-poor-mans-merge-queue.mjs` and `git diff --check`.
- Ready CI on prior head `69021db4687a8f53d98b9de87811570114deb550`: run `26394796198` completed successfully.
- Prior synthetic queue run `26395052372` passed, but tested old main parent `b0a91e0289296cda11aa2c7b43dbeb1cd695b21e`; it was not used for landing after main advanced.
- After rebasing onto `origin/main` `e060e6a47fd870d29c63dd041d8599a630a079dc`: `node scripts/ci/test-poor-mans-merge-queue.mjs` and `git diff --check`.
- Ready CI on current head `127ca54f5b2cda122f45af888f1b14670828b184`: run `26395861990` completed successfully.

## Coordination Notes
AgentName: M1-A
Head SHA: `127ca54f5b2cda122f45af888f1b14670828b184`.
Base: `origin/main` `e060e6a47fd870d29c63dd041d8599a630a079dc` after #10091 landed; current synthetic queue branch uses newer main `a23d7b2b9bbcc6e04e216f9281b754640f30138c` after #10090 landed.
Queue status: active exact synthetic queue. Branch `automation/merge-queue/pr-10152` is at `d2f77d43c25ab34ee4031d8d8a395bc296cce3b7`, with parent1 current main `a23d7b2b9bbcc6e04e216f9281b754640f30138c` and parent2 PR head `127ca54f5b2cda122f45af888f1b14670828b184`. Queue run `26396115784` is running, and `Queue Tested` points at that run.
This PR only adds tooling and does not delete any remote branch by itself. Operators should run cleanup first with `--dry-run`, review the branch list, then rerun without `--dry-run` only when the output is expected.
