### PR TITLE
ci: sign merge queue failure comments

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -26,6 +26,7 @@ function usage() {
     "  --max-prs <n>                   Max open PRs to inspect",
     "  --status-context <name>         Required status context to post",
     "  --queue-branch-prefix <prefix>  Temporary branch namespace",
+    "  --agent-name <name>             AgentName for queue failure comments",
     "  --pr-required-check <name>      PR-head check required before queueing",
     "  --merge-required-check <name>   Synthetic merge check required before merge",
     "  --no-default-pr-required-checks",
@@ -48,6 +49,7 @@ function parsePositiveInt(flag, value) {
 
 export function parseArgs(argv) {
   const options = {
+    agentName: process.env.AGENT_NAME || "M1-A",
     base: process.env.BASE_BRANCH || DEFAULT_BASE,
     cleanupQueueBranches: false,
     dryRun: false,
@@ -80,6 +82,9 @@ export function parseArgs(argv) {
     } else if (arg === "--queue-branch-prefix") {
       options.queueBranchPrefix = argv[++index];
       if (!options.queueBranchPrefix) throw new Error("--queue-branch-prefix requires a branch prefix");
+    } else if (arg === "--agent-name") {
+      options.agentName = argv[++index];
+      if (!options.agentName) throw new Error("--agent-name requires an AgentName");
     } else if (arg === "--pr-required-check") {
       options.prRequiredChecks.push(argv[++index]);
     } else if (arg === "--merge-required-check") {
@@ -111,6 +116,13 @@ export function parseArgs(argv) {
   }
 
   return options;
+}
+
+function cleanAgentName(agentName) {
+  const trimmed = String(agentName || "").trim();
+  if (!trimmed) throw new Error("AgentName is required");
+  if (/[\r\n]/.test(trimmed)) throw new Error("AgentName must be a single line");
+  return trimmed;
 }
 
 function run(command, args, options = {}) {
@@ -394,6 +406,16 @@ function postComment(repository, number, body) {
   ]);
 }
 
+export function failureCommentBody(agentName, reason) {
+  return [
+    `AgentName: ${cleanAgentName(agentName)}`,
+    "",
+    "Poor man's merge queue could not land this PR.",
+    "",
+    `Reason: ${reason}`,
+  ].join("\n");
+}
+
 function invalidatePullRequest(repository, pr, options) {
   if (options.dryRun) return { invalidated: false, skipped: false };
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
@@ -656,13 +678,11 @@ function processOne(repository, options) {
         options.statusContext,
         error instanceof Error ? error.message : String(error),
       );
-      postComment(repository, pr.number, [
-        "AgentName: GPT-5.5",
-        "",
-        "Poor man's merge queue could not land this PR.",
-        "",
-        `Reason: ${error instanceof Error ? error.message : String(error)}`,
-      ].join("\n"));
+      postComment(
+        repository,
+        pr.number,
+        failureCommentBody(options.agentName, error instanceof Error ? error.message : String(error)),
+      );
       return { selected: pr, failed: true, reason: error instanceof Error ? error.message : String(error), skips };
     }
   }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   activeBranchQueueRun,
   activeSyntheticQueueRun,
+  failureCommentBody,
   formatResult,
   hasPendingPlaceholderQueueStatus,
   pendingQueueRun,
@@ -40,7 +41,16 @@ function pr(overrides = {}) {
   };
 }
 
+const originalAgentName = process.env.AGENT_NAME;
+delete process.env.AGENT_NAME;
 assert.equal(parseArgs(["--repository", "owner/repo"]).repository, "owner/repo");
+assert.equal(parseArgs(["--repository", "owner/repo"]).agentName, "M1-A");
+if (originalAgentName === undefined) {
+  delete process.env.AGENT_NAME;
+} else {
+  process.env.AGENT_NAME = originalAgentName;
+}
+assert.equal(parseArgs(["--repository", "owner/repo", "--agent-name", "M4-B"]).agentName, "M4-B");
 assert.equal(parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches"]).cleanupQueueBranches, true);
 assert.deepEqual(
   parseArgs(["--no-default-pr-required-checks", "--pr-required-check", "lint"]).prRequiredChecks,
@@ -150,6 +160,8 @@ assert.equal(queueSkipReason(pr({ labels: ["WIP"] }), { kind: "passed" }, "main"
 assert.equal(queueSkipReason(pr(), { kind: "pending", reason: "pending checks" }, "main"), "pending checks");
 assert.equal(queueSkipReason(pr(), { kind: "passed" }, "main"), null);
 assert.equal(queueSkipReason({ ...pr(), statusCheckRollup: undefined }, { kind: "passed" }, "main"), null);
+assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
+assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track
M1-A PR hygiene / merge queue coordination.

## Invariant
Poor man's merge queue comments must be signed with the active AgentName so WIP/blocker handoffs remain attributable.

## Scope
- Add `--agent-name` / `AGENT_NAME` support to `scripts/ci/poor-mans-merge-queue.mjs`.
- Replace the hardcoded queue failure comment signer with the configured AgentName.
- Add focused Node coverage for the default signer, override, generated failure body, and single-line validation.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only coordination fix; no compiler, checker, solver, emitter, conformance, or project corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- Draft CI/light checks on head `95875593f6774d279363493586015b3865943bdd`: `gate`, `project-row-drift`, `lint`, `cargo-deny`, `cargo-shear`, `queue-one-pr`, and GitGuardian passed.
- Ready-review CI on head `95875593f6774d279363493586015b3865943bdd`: `CI Summary`, `project-corpus-pr-body`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, and GitGuardian passed after the body bullet-format repair.
- Stale synthetic merge test against main `eb994fcb553015e0478246a5f6e3b72b90e9ca34` was canceled after main moved.
- Current synthetic merge test against main `b5244b0e8183e0e06568586174631386f3b1a0cf` is queued on merge commit `38dd5ce3938ee04b6ef11d8e7f852fa37f616121`: https://github.com/mohsen1/tsz/actions/runs/26398547079

## Coordination Notes
`Queue Tested` is pending with target https://github.com/mohsen1/tsz/actions/runs/26398547079. If the synthetic `CI Summary` passes and main/head are unchanged, post `Queue Tested` success for head `95875593f6774d279363493586015b3865943bdd` and merge with `--match-head-commit`. Auto-merge remains off.
