### PR TITLE
ci: clean suffixed merge queue branches

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -360,7 +360,7 @@ function readRemoteQueueBranches(options) {
 
 export function queueBranchPrNumber(branch, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
   const escapedPrefix = queueBranchPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = String(branch || "").match(new RegExp(`^${escapedPrefix}/pr-(\\d+)$`));
+  const match = String(branch || "").match(new RegExp(`^${escapedPrefix}/pr-(\\d+)(?:-[^/]+)?$`));
   return match ? Number.parseInt(match[1], 10) : null;
 }
 

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -62,7 +62,10 @@ assert.deepEqual(
 );
 assert.equal(parseArgs(["--invalidate-pr", "123"]).invalidatePr, 123);
 assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123"), 123);
-assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-extra"), null);
+assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-extra"), 123);
+assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-a56115a-m4c"), 123);
+assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123/extra"), null);
+assert.equal(queueBranchPrNumber("automation/merge-queue/not-pr-123"), null);
 assert.equal(queueBranchPrNumber("custom/queue/pr-456", "custom/queue"), 456);
 
 assert.equal(requiredCheckState([check()], ["CI Summary"]).kind, "passed");


### PR DESCRIPTION
AgentName: M1-A

## Track
M1-A PR hygiene / merge queue cleanup.

## Invariant
Poor man's merge queue cleanup must recognize stale synthetic queue branches that encode the PR number plus a suffix, while still preserving branches for open PRs and active queue runs.

## Scope
- Recognize `automation/merge-queue/pr-<number>-<suffix>` as belonging to PR `<number>` during cleanup.
- Keep malformed slash-suffixed queue names unrecognized.
- Extend focused Node coverage for exact, suffixed, custom-prefix, and malformed queue branch names.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only queue hygiene change; no compiler, checker, solver, emitter, conformance, or project corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- Live dry run before cleanup showed 7 suffixed stale branches would be deleted and open PR queue branches skipped.
- Applied cleanup deleted 7 stale suffixed queue branches for merged PRs #10151 and #9200.
- Live dry run after cleanup reports 0 stale queue branches and 14 open PR branches skipped.
- Follow-up live dry run on 2026-05-25 showed 2 suffixed stale branches for merged PR #10095; applied cleanup deleted both.
- Follow-up live dry run after that cleanup reports 0 stale queue branches and 15 open PR branches skipped.
- Live dry run on 2026-05-25 showed 1 suffixed stale branch for merged PR #10083; applied cleanup deleted it.
- Follow-up live dry run after #10083 cleanup reports 0 stale queue branches and 17 open PR branches skipped.
- Live dry run on 2026-05-25 showed 1 stale queue branch for merged PR #10082; applied cleanup deleted it.
- Follow-up live dry run after #10082 cleanup reports 0 stale queue branches and 17 open PR branches skipped.
- Live dry run on 2026-05-25 showed 5 stale queue branches for merged PR #9205 while preserving active queue run 26402342827; applied cleanup deleted the stale branches.
- Follow-up live dry run after #9205 cleanup reports 0 stale queue branches, 13 open PR branches skipped, and active queue run 26402342827 preserved.
- Follow-up live dry run after run 26402342827 completed showed 1 remaining stale queue branch for merged PR #9205; applied cleanup deleted it.
- Follow-up live dry run after final #9205 cleanup reports 0 stale queue branches and 14 open PR branches skipped.
- Draft CI/light checks passed on head `34c0c66f5f4045323030fb2aa50d56539a21b376`.
- Ready-review CI passed on head `34c0c66f5f4045323030fb2aa50d56539a21b376`.
- Previous synthetic merge test `576d7fb21caa85f2c09d1053126190dd24271caa` / run https://github.com/mohsen1/tsz/actions/runs/26400337450 was cancelled as stale after `origin/main` advanced from `5ea33f694b39f52e058dbedb9d7d9f2772cd83e4` to `b22fe34556bb2cc92bb55f875deb93326e4fa2bc`.
- Previous synthetic merge test `84fd2013017c7c47850ee90beb0f996864ebd9a7` / run https://github.com/mohsen1/tsz/actions/runs/26400602968 was cancelled as stale after `origin/main` advanced from `b22fe34556bb2cc92bb55f875deb93326e4fa2bc` to `0d3f55dcf67d35d034aa3e97eddb3dfe285ad2f5`.
- Previous synthetic merge test `81f672b7f726bae4916cdd7761c389dfbf4319cd` / run https://github.com/mohsen1/tsz/actions/runs/26401649919 was cancelled as stale after `origin/main` advanced from `0d3f55dcf67d35d034aa3e97eddb3dfe285ad2f5` to `4d8177f346347c473da2cb67c9b90c78e317d0a9`.
- Previous synthetic merge test `a3d13f99d0435ccb0dccee13de2fdacc809471bb` / run https://github.com/mohsen1/tsz/actions/runs/26402265519 was cancelled as stale after `origin/main` advanced from `4d8177f346347c473da2cb67c9b90c78e317d0a9` to `6f1bd866b2e3b5e1e96b84b1a0816278072d7e46`.
- Current synthetic merge test against main `6f1bd866b2e3b5e1e96b84b1a0816278072d7e46` is queued on merge commit `3888400cf9a337be2a20ab3e4eebaca1728e012f`: https://github.com/mohsen1/tsz/actions/runs/26403527426

## Coordination Notes
Ready-review checks are green. `Queue Tested` is pending with target https://github.com/mohsen1/tsz/actions/runs/26403527426. If the synthetic `CI Summary` passes and main/head are unchanged, post `Queue Tested` success for head `34c0c66f5f4045323030fb2aa50d56539a21b376` and merge with `--match-head-commit`. Auto-merge remains off.