### PR TITLE
fix(ci): clean superseded open queue branches

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -34,6 +34,8 @@ function usage() {
     "  --invalidate-open               Mark open PR heads pending and exit",
     "  --invalidate-pr <number>        Mark one PR head pending and exit",
     "  --cleanup-queue-branches        Delete stale queue branches for closed PRs",
+    "  --cleanup-superseded-open-queue-branches",
+    "                                  Also delete inactive suffixed open-PR queue branches from older bases",
     "  --dry-run                       Report without pushing or merging",
     "  --verbose",
   ].join("\n");
@@ -52,6 +54,7 @@ export function parseArgs(argv) {
     agentName: process.env.AGENT_NAME || "M1-A",
     base: process.env.BASE_BRANCH || DEFAULT_BASE,
     cleanupQueueBranches: false,
+    cleanupSupersededOpenQueueBranches: false,
     dryRun: false,
     invalidateOpen: false,
     invalidatePr: null,
@@ -99,6 +102,9 @@ export function parseArgs(argv) {
       options.invalidatePr = parsePositiveInt("--invalidate-pr", argv[++index]);
     } else if (arg === "--cleanup-queue-branches") {
       options.cleanupQueueBranches = true;
+    } else if (arg === "--cleanup-superseded-open-queue-branches") {
+      options.cleanupQueueBranches = true;
+      options.cleanupSupersededOpenQueueBranches = true;
     } else if (arg === "--wait-attempts") {
       options.waitAttempts = parsePositiveInt("--wait-attempts", argv[++index]);
     } else if (arg === "--wait-interval-ms") {
@@ -359,9 +365,25 @@ function readRemoteQueueBranches(options) {
 }
 
 export function queueBranchPrNumber(branch, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
+  return queueBranchMetadata(branch, queueBranchPrefix)?.number ?? null;
+}
+
+export function queueBranchMetadata(branch, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
   const escapedPrefix = queueBranchPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = String(branch || "").match(new RegExp(`^${escapedPrefix}/pr-(\\d+)(?:-[^/]+)?$`));
-  return match ? Number.parseInt(match[1], 10) : null;
+  const match = String(branch || "").match(new RegExp(`^${escapedPrefix}/pr-(\\d+)(?:-([^/]+))?$`));
+  return match ? {
+    number: Number.parseInt(match[1], 10),
+    suffix: match[2] || "",
+  } : null;
+}
+
+export function supersededOpenQueueBranchReason(queueBranch, currentBaseOid, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
+  const metadata = queueBranchMetadata(queueBranch, queueBranchPrefix);
+  if (!metadata) return null;
+  if (!metadata.suffix) return null;
+  const basePrefix = String(currentBaseOid || "").slice(0, 7);
+  if (basePrefix && metadata.suffix.startsWith(basePrefix)) return null;
+  return `superseded open PR queue branch for older base (current ${basePrefix || "unknown"})`;
 }
 
 function readPullRequestState(repository, number) {
@@ -449,26 +471,36 @@ function cleanupQueueBranches(repository, options) {
   let skippedOpen = 0;
   let skippedActiveRuns = 0;
   let skippedUnrecognized = 0;
+  let supersededOpen = 0;
   const deletions = [];
   const skips = [];
+  const currentBaseOid = options.cleanupSupersededOpenQueueBranches
+    ? readBranchOid(repository, options.base)
+    : "";
 
   for (const queueBranchInfo of readRemoteQueueBranches(options)) {
-    const number = queueBranchPrNumber(queueBranchInfo.branch, options.queueBranchPrefix);
-    if (!number) {
+    const metadata = queueBranchMetadata(queueBranchInfo.branch, options.queueBranchPrefix);
+    if (!metadata) {
       skippedUnrecognized += 1;
       if (options.verbose) {
         skips.push({ branch: queueBranchInfo.branch, reason: "unrecognized queue branch name" });
       }
       continue;
     }
+    const { number } = metadata;
 
     const pullRequest = readPullRequestState(repository, number);
     if (String(pullRequest.state || "").toUpperCase() === "OPEN") {
-      skippedOpen += 1;
-      if (options.verbose) {
-        skips.push({ branch: queueBranchInfo.branch, reason: `PR #${number} is open` });
+      const supersededReason = options.cleanupSupersededOpenQueueBranches
+        ? supersededOpenQueueBranchReason(queueBranchInfo.branch, currentBaseOid, options.queueBranchPrefix)
+        : null;
+      if (!supersededReason) {
+        skippedOpen += 1;
+        if (options.verbose) {
+          skips.push({ branch: queueBranchInfo.branch, reason: `PR #${number} is open` });
+        }
+        continue;
       }
-      continue;
     }
 
     const activeRun = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranchInfo.branch));
@@ -483,11 +515,15 @@ function cleanupQueueBranches(repository, options) {
       continue;
     }
 
+    if (String(pullRequest.state || "").toUpperCase() === "OPEN") {
+      supersededOpen += 1;
+    }
     deletions.push({
       branch: queueBranchInfo.branch,
       number,
       state: pullRequest.state,
       merged: Boolean(pullRequest.merged),
+      supersededOpen: String(pullRequest.state || "").toUpperCase() === "OPEN",
     });
     if (options.dryRun) {
       wouldDelete += 1;
@@ -505,6 +541,7 @@ function cleanupQueueBranches(repository, options) {
     skippedActiveRuns,
     skippedOpen,
     skippedUnrecognized,
+    supersededOpen,
     skips,
     wouldDelete,
   };
@@ -712,13 +749,18 @@ export function formatResult(result, options) {
     }
     lines.push(`Skipped ${result.skippedOpen} open PR branch(es).`);
     lines.push(`Preserved ${result.skippedActiveRuns} branch(es) with active queue runs.`);
+    if (result.supersededOpen) {
+      lines.push(`Included ${result.supersededOpen} superseded open PR branch(es).`);
+    }
     if (result.skippedUnrecognized) {
       lines.push(`Skipped ${result.skippedUnrecognized} unrecognized queue branch name(s).`);
     }
     if (options.verbose && result.deletions?.length) {
       lines.push("", "### Queue Branches", "", "| Branch | PR | State |", "|--------|----|-------|");
       for (const deletion of result.deletions.slice(0, 50)) {
-        const state = deletion.merged ? "merged" : String(deletion.state || "closed").toLowerCase();
+        const state = deletion.supersededOpen
+          ? "open superseded"
+          : deletion.merged ? "merged" : String(deletion.state || "closed").toLowerCase();
         lines.push(`| \`${deletion.branch}\` | #${deletion.number} | ${state} |`);
       }
     }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -8,10 +8,12 @@ import {
   hasPendingPlaceholderQueueStatus,
   pendingQueueRun,
   parseArgs,
+  queueBranchMetadata,
   queueBranchPrNumber,
   queueRunIsActive,
   queueSkipReason,
   requiredCheckState,
+  supersededOpenQueueBranchReason,
 } from "./poor-mans-merge-queue.mjs";
 
 function check(overrides = {}) {
@@ -52,6 +54,10 @@ if (originalAgentName === undefined) {
 }
 assert.equal(parseArgs(["--repository", "owner/repo", "--agent-name", "M4-B"]).agentName, "M4-B");
 assert.equal(parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches"]).cleanupQueueBranches, true);
+assert.equal(
+  parseArgs(["--repository", "owner/repo", "--cleanup-superseded-open-queue-branches"]).cleanupSupersededOpenQueueBranches,
+  true,
+);
 assert.deepEqual(
   parseArgs(["--no-default-pr-required-checks", "--pr-required-check", "lint"]).prRequiredChecks,
   ["lint"],
@@ -67,6 +73,23 @@ assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-a56115a-m4c"), 1
 assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123/extra"), null);
 assert.equal(queueBranchPrNumber("automation/merge-queue/not-pr-123"), null);
 assert.equal(queueBranchPrNumber("custom/queue/pr-456", "custom/queue"), 456);
+assert.deepEqual(
+  queueBranchMetadata("automation/merge-queue/pr-123-a56115a-m4c"),
+  { number: 123, suffix: "a56115a-m4c" },
+);
+assert.equal(queueBranchMetadata("automation/merge-queue/pr-123").suffix, "");
+assert.equal(
+  supersededOpenQueueBranchReason("automation/merge-queue/pr-123-a56115a-m4c", "a56115afffffffffffffffffffffffffffffffffff"),
+  null,
+);
+assert.match(
+  supersededOpenQueueBranchReason("automation/merge-queue/pr-123-deadbee-m4c", "a56115afffffffffffffffffffffffffffffffffff"),
+  /superseded open PR queue branch/,
+);
+assert.equal(
+  supersededOpenQueueBranchReason("automation/merge-queue/pr-123", "a56115afffffffffffffffffffffffffffffffffff"),
+  null,
+);
 
 assert.equal(requiredCheckState([check()], ["CI Summary"]).kind, "passed");
 assert.equal(requiredCheckState([check({ status: "IN_PROGRESS", conclusion: "" })], ["CI Summary"]).kind, "pending");
@@ -188,15 +211,19 @@ const cleanupFormat = formatResult({
   cleanupQueueBranches: true,
   deletions: [
     { branch: "automation/merge-queue/pr-1", number: 1, state: "closed", merged: true },
+    { branch: "automation/merge-queue/pr-2-deadbee", number: 2, state: "open", supersededOpen: true },
   ],
   dryRun: true,
   skippedActiveRuns: 1,
   skippedOpen: 2,
   skippedUnrecognized: 1,
+  supersededOpen: 1,
   skips: [],
-  wouldDelete: 1,
+  wouldDelete: 2,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
-assert.match(cleanupFormat, /Would delete 1 stale queue branch/);
+assert.match(cleanupFormat, /Would delete 2 stale queue branch/);
+assert.match(cleanupFormat, /Included 1 superseded open PR branch/);
+assert.match(cleanupFormat, /open superseded/);
 assert.doesNotMatch(cleanupFormat, /\| #undefined \|/);
 
 assert.match(


### PR DESCRIPTION
AgentName: M1-A

Track: PR garden / queue hygiene

Invariant: Queue cleanup must not delete active queue runs or current open-PR queue evidence, but should be able to remove explicitly superseded stale open-PR queue branches.

Scope: Add an opt-in poor-mans-merge-queue flag to delete inactive suffixed open-PR queue branches whose suffix does not match current main, while preserving unsuffixed branches, current-main suffixed branches, and active runs. Also update focused queue-script tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI queue-maintenance script only; no compiler, checker, solver, conformance, emit, or project-corpus behavior changes.

Verification:
- node scripts/ci/test-poor-mans-merge-queue.mjs
- git diff --check
- REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --cleanup-superseded-open-queue-branches --dry-run --verbose
- Applied the new opt-in cleanup once: deleted stale open queue branches automation/merge-queue/pr-10081-0d3f55d-m4c, automation/merge-queue/pr-10081-4d8177f-m4c, automation/merge-queue/pr-10081-6f1bd86-m4c, and automation/merge-queue/pr-10150-ce8fbe.
- Re-ran the opt-in cleanup dry run after deletion: would delete 0 stale branches and preserved current open PR queue branches.

Coordination Notes:
- The default --cleanup-queue-branches behavior is unchanged for open PR branches.
- The new behavior requires --cleanup-superseded-open-queue-branches and only applies to inactive suffixed branches from older base prefixes.
- The current #10150 queue branch automation/merge-queue/pr-10150-52f60fe was preserved because its suffix matches current main.
