### PR TITLE
docs(agents): refresh M1-A post-9465 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,15 +24,18 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-25 15:55 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10157` merged.
+- 2026-05-25 18:55 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#9465` merged.
+  - `#9465` landed on 2026-05-25 as
+    `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
+    excess-property check (#8725)`. Its synthetic queue branch
+    `automation/merge-queue/pr-9465` was deleted after merge.
   - `#9559` is merged; the former M1-A JSX branch is no longer an active
     landing target.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
-    longer matches current `main`; the latest apply run deleted the merged
-    `#10157` queue branch `automation/merge-queue/pr-10157` and the superseded
-    open-PR branch `automation/merge-queue/pr-9281-49bd3b2`.
+    longer matches current `main`; the latest dry run reports zero stale queue
+    branches and preserves no active queue runs.
   - `#9230` merged on 2026-05-25 and is no longer an active queue unblocker.
   - The 2026-05-21 ready queue (`#9828`, `#9827`, `#9814`, `#9808`,
     `#9804`, `#9799`) is fully merged.
@@ -45,11 +48,13 @@ node scripts/ci/pr-ownership-report.mjs
   - `#10150` merged on 2026-05-25 and is no longer an active queue unblocker.
     Its stale synthetic branch was cleaned after merge.
   - Priority ready main-based PRs with `mergeStateStatus=BLOCKED` but
-    `mergeable=MERGEABLE`: `#9281`, `#9632`, `#9634`, `#9807`, `#9811`,
-    `#9912`, `#10078`, `#10081`, `#10084`, and `#10126`.
-  - `#9281` has an active synthetic queue run on
-    `automation/merge-queue/pr-9281-cb0458-49bd3b2`; do not take it over unless
-    the owner asks or it becomes stale and needs a signed handoff.
+    `mergeable=MERGEABLE` include `#9632`, `#9912`, `#10078`, `#10081`,
+    `#10084`, `#10085`, `#10087`, `#10126`, and `#10147`. These currently
+    belong to other lanes; do not take them over unless the owner asks or a
+    stale branch needs a signed handoff.
+  - Queue branch cleanup currently skips open PR branches
+    `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10085`, `pr-10147`,
+    `pr-9632`, `pr-9848`, and `pr-9912`.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A
Track: PR garden / agent coordination
Invariant: docs-only coordination update; no compiler, CI, or runtime behavior changes.

## Summary

Refresh the M1-A lane state after #9465 landed. The goal doc now records #9465 as merged, removes stale queue-branch details, and points future M1-A cycles at the current open-PR queue cleanup surfaces.

## Scope

- Update `docs/plan/agents/M1-A.md` only.
- No source, test, harness, or roadmap files changed.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only agent coordination update; no project corpus behavior path is touched.

## Verification

- `git fetch origin main`
- `scripts/agents/show-goal.sh M1-A`
- `scripts/agents/disk-preflight.sh M1-A`
- `scripts/agents/list-owned-work.sh M1-A`
- `node scripts/ci/pr-ownership-report.mjs`
- `AGENT_NAME=M1-A node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --cleanup-superseded-open-queue-branches --max-prs 300 --verbose`
- `git diff --check`

## Coordination Notes

#9465 is merged and the direct `agent:M1-A` queue is empty. Current queue cleanup dry run reports zero stale queue branches. Future M1-A cycles should inspect open PR ownership and queue hygiene before issue backlog, without taking over other lanes unless there is a signed stale handoff need.