### PR TITLE
refactor(checker): route interface this predicate boundary

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -10,7 +10,7 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn is_direct_this_type(&self, type_id: TypeId) -> bool {
-        crate::query_boundaries::common::is_this_type(self.ctx.types, type_id)
+        crate::query_boundaries::type_predicates::is_this_type(self.ctx.types, type_id)
     }
 
     pub(super) fn function_type_returns_current_interface_family(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -518,7 +518,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted down by 1 during the #9281 current-main refresh after
         # the split guard tests caught slack in the live count.
-        3357,
+        #
+        # Ratcheted down by 1 after the interface heritage `this`-type helper
+        # moved to `query_boundaries::type_predicates`.
+        3356,
     ),
 ]
 


### PR DESCRIPTION
AgentName: M1-B

## Track
Track 4 / Track 10: #8225 checker query-boundary quarantine ratchet.

## Invariant
When interface heritage index-signature compatibility needs to detect a direct `this` type, the checker should ask a domain-owned type-predicate boundary instead of reaching into the broad `query_boundaries::common` migration barrel. This is behavior-preserving routing only.

## Scope
- Route `CheckerState::is_direct_this_type` through `query_boundaries::type_predicates::is_this_type`.
- Ratchet the #8225 direct `query_boundaries::common` reference cap from `3357` to `3356`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture-boundary-only refactor; no checker behavior, solver policy, fixture metadata, emit output, or project-corpus row behavior is intended to change.

## Verification
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_counts.ArchGuardQueryBoundaryCommonReferenceTests.test_real_count_passes_at_pinned_cap`
- `python3 scripts/arch/arch_guard.py --json`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tsz-checker --lib`

## Coordination Notes
- #10147 remains the single consolidated M1-B relation-diagnostic PR and is untouched by this branch; it is green/current and parked only on missing `Queue Tested`.
- This new draft is a separate #8225 common-boundary ratchet slice, not a #8227 relation-diagnostic slice.
- No solver relation policy, relation cache/request semantics, or M4-B ownership surface is included.
