### PR TITLE
ci: report stale run cancellation attempts

### DIFF
--- a/scripts/ci/check-stale-ci-runs.mjs
+++ b/scripts/ci/check-stale-ci-runs.mjs
@@ -9,7 +9,7 @@ const ACTIVE_STATUSES = ["in_progress", "queued"];
 
 function usage() {
   return [
-    "usage: check-stale-ci-runs.mjs [--fixture path] [--repository owner/repo] [--stale-minutes n] [--max-runs n] [--now iso] [--advisory|--enforce]",
+    "usage: check-stale-ci-runs.mjs [--fixture path] [--repository owner/repo] [--stale-minutes n] [--max-runs n] [--now iso] [--advisory|--enforce] [--cancel-stale]",
     "",
     "Reports queued or in-progress workflow runs that have been active or",
     "unchanged long enough to look stale.",
@@ -19,6 +19,7 @@ function usage() {
 function parseArgs(argv) {
   const options = {
     advisory: true,
+    cancelStale: false,
     enforce: false,
     fixture: null,
     maxRuns: DEFAULT_MAX_RUNS,
@@ -72,6 +73,10 @@ function parseArgs(argv) {
       options.advisory = false;
       continue;
     }
+    if (arg === "--cancel-stale") {
+      options.cancelStale = true;
+      continue;
+    }
     if (arg === "--help" || arg === "-h") {
       console.log(usage());
       process.exit(0);
@@ -105,6 +110,30 @@ function runGhJson(args) {
     );
   }
   return JSON.parse(result.stdout);
+}
+
+function runGh(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    const command = `gh ${args.join(" ")}`;
+    if (result.error.code === "ENOBUFS") {
+      return {
+        status: 1,
+        stderr: `${command} exceeded ${DEFAULT_GH_MAX_BUFFER_BYTES} bytes of output`,
+        stdout: "",
+      };
+    }
+    return { status: 1, stderr: result.error.message, stdout: "" };
+  }
+  return {
+    status: result.status ?? 1,
+    stderr: result.stderr.trim(),
+    stdout: result.stdout.trim(),
+  };
 }
 
 function normalizeRuns(payload) {
@@ -229,8 +258,49 @@ function minuteLabel(value) {
   return value === null || value === undefined ? "unknown" : `${value}m`;
 }
 
+function cancelLabel(result) {
+  if (!result) return "";
+  if (result.status === "requested") return "requested";
+  if (result.status === "skipped") return `skipped: ${result.detail}`;
+  return `failed: ${result.detail}`;
+}
+
+export function cancelStaleRuns(findings, repository, runCommand = runGh) {
+  if (!repository) {
+    throw new Error("REPOSITORY or GITHUB_REPOSITORY is required to cancel stale runs");
+  }
+
+  return findings.map((finding) => {
+    if (!finding.id) {
+      return { id: "", status: "skipped", detail: "missing run id" };
+    }
+
+    const result = runCommand([
+      "api",
+      "-X",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/actions/runs/${finding.id}/cancel`,
+    ]);
+
+    if (result.status === 0) {
+      return { id: finding.id, status: "requested", detail: "" };
+    }
+
+    return {
+      id: finding.id,
+      status: "failed",
+      detail: result.stderr || result.stdout || `gh exited ${result.status}`,
+    };
+  });
+}
+
 export function formatReport(findings, options = {}) {
   const staleMinutes = options.staleMinutes ?? DEFAULT_STALE_MINUTES;
+  const cancelResults = options.cancelResults || [];
+  const cancelById = new Map(cancelResults.map((result) => [String(result.id), result]));
+  const includeCancelColumn = cancelResults.length > 0;
   const lines = [
     "## Stale CI Run Advisory",
     "",
@@ -243,21 +313,31 @@ export function formatReport(findings, options = {}) {
 
   lines.push(`Found ${findings.length} queued or in-progress workflow run(s) stale at ${staleMinutes} minutes.`);
   lines.push("");
-  lines.push("| Run | Status | Age | Last update | Branch | Reason | Title |");
-  lines.push("|-----|--------|-----|-------------|--------|--------|-------|");
+  lines.push(includeCancelColumn
+    ? "| Run | Status | Age | Last update | Branch | Reason | Cancel | Title |"
+    : "| Run | Status | Age | Last update | Branch | Reason | Title |");
+  lines.push(includeCancelColumn
+    ? "|-----|--------|-----|-------------|--------|--------|--------|-------|"
+    : "|-----|--------|-----|-------------|--------|--------|-------|");
   for (const finding of findings) {
     const runLabel = finding.url && finding.id
       ? `[#${finding.id}](${finding.url})`
       : escapeCell(finding.id || "unknown");
-    lines.push([
+    const cells = [
       runLabel,
       escapeCell(finding.status),
       minuteLabel(finding.ageMinutes),
       minuteLabel(finding.updatedMinutes),
       escapeCell(finding.branch),
       escapeCell(finding.reason),
+    ];
+    if (includeCancelColumn) {
+      cells.push(escapeCell(cancelLabel(cancelById.get(String(finding.id)))));
+    }
+    cells.push(
       escapeCell(finding.title),
-    ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+    );
+    lines.push(cells.join(" | ").replace(/^/, "| ").replace(/$/, " |"));
   }
 
   return lines.join("\n");
@@ -269,7 +349,13 @@ function main() {
     ? readFixture(options.fixture)
     : readActiveRuns(options.repository, options.maxRuns);
   const findings = staleRunFindings(runs, options);
-  console.log(formatReport(findings, options));
+  const cancelResults = options.cancelStale && findings.length > 0
+    ? cancelStaleRuns(findings, options.repository)
+    : [];
+  console.log(formatReport(findings, { ...options, cancelResults }));
+  if (cancelResults.some((result) => result.status === "failed")) {
+    process.exit(1);
+  }
   if (findings.length > 0 && options.enforce) {
     process.exit(1);
   }

--- a/scripts/ci/test-check-stale-ci-runs.mjs
+++ b/scripts/ci/test-check-stale-ci-runs.mjs
@@ -5,7 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { formatReport, readActiveRuns, staleRunFindings } from "./check-stale-ci-runs.mjs";
+import {
+  cancelStaleRuns,
+  formatReport,
+  readActiveRuns,
+  staleRunFindings,
+} from "./check-stale-ci-runs.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -155,6 +160,49 @@ assert.match(report, /Stale CI Run Advisory/);
 assert.match(report, /\[#12345\]\(https:\/\/github.example\/runs\/12345\)/);
 assert.match(report, /no recent update/);
 
+{
+  const findings = staleRunFindings([run()], { now: NOW, staleMinutes: 45 });
+  const cancelResults = cancelStaleRuns(findings, "owner/repo", (args) => {
+    assert.deepEqual(args, [
+      "api",
+      "-X",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "repos/owner/repo/actions/runs/12345/cancel",
+    ]);
+    return { status: 0, stdout: "", stderr: "" };
+  });
+  assert.deepEqual(cancelResults, [{ id: 12345, status: "requested", detail: "" }]);
+
+  const cancelReport = formatReport(findings, {
+    cancelResults,
+    staleMinutes: 45,
+  });
+  assert.match(cancelReport, /Cancel \| Title/);
+  assert.match(cancelReport, /requested/);
+}
+
+{
+  const findings = staleRunFindings([run()], { now: NOW, staleMinutes: 45 });
+  const cancelResults = cancelStaleRuns(findings, "owner/repo", () => ({
+    status: 1,
+    stdout: "",
+    stderr: "HTTP 500: Failed to cancel workflow run",
+  }));
+  assert.deepEqual(cancelResults, [{
+    id: 12345,
+    status: "failed",
+    detail: "HTTP 500: Failed to cancel workflow run",
+  }]);
+
+  const cancelReport = formatReport(findings, {
+    cancelResults,
+    staleMinutes: 45,
+  });
+  assert.match(cancelReport, /failed: HTTP 500: Failed to cancel workflow run/);
+}
+
 const advisory = runFixture([run()], ["--stale-minutes", "45"]);
 assert.equal(advisory.status, 0, advisory.stderr);
 assert.match(advisory.stdout, /Found 1 queued or in-progress workflow run/);
@@ -169,6 +217,74 @@ const clean = runFixture([run({
 })], ["--stale-minutes", "45"]);
 assert.equal(clean.status, 0, clean.stderr);
 assert.match(clean.stdout, /No queued or in-progress workflow runs are stale/);
+
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-cancel-"));
+  try {
+    const fakeGh = path.join(dir, "gh");
+    fs.writeFileSync(fakeGh, `#!/usr/bin/env node
+const endpoint = process.argv.find((arg) => arg.includes("/actions/runs/"));
+if (endpoint) {
+  process.exit(0);
+}
+console.error("unexpected gh args", process.argv.slice(2).join(" "));
+process.exit(1);
+`);
+    fs.chmodSync(fakeGh, 0o755);
+
+    const result = withFixture([run()], (fixture) => spawnSync(process.execPath, [
+      SCRIPT,
+      "--fixture",
+      fixture,
+      "--repository",
+      "owner/repo",
+      "--now",
+      NOW,
+      "--cancel-stale",
+    ], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    }));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /requested/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-cancel-fail-"));
+  try {
+    const fakeGh = path.join(dir, "gh");
+    fs.writeFileSync(fakeGh, `#!/usr/bin/env node
+console.error("HTTP 500: Failed to cancel workflow run");
+process.exit(1);
+`);
+    fs.chmodSync(fakeGh, 0o755);
+
+    const result = withFixture([run()], (fixture) => spawnSync(process.execPath, [
+      SCRIPT,
+      "--fixture",
+      fixture,
+      "--repository",
+      "owner/repo",
+      "--now",
+      NOW,
+      "--cancel-stale",
+    ], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    }));
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /failed: HTTP 500: Failed to cancel workflow run/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-gh-"));


### PR DESCRIPTION
AgentName: M1-A

## Track

M1-A PR garden / CI queue hygiene.

## Invariant

Stale CI run reporting must remain advisory by default, and any operator-triggered cancellation attempt must be visible in the command output, including GitHub API failures.

## Scope

- Add `--cancel-stale` to `scripts/ci/check-stale-ci-runs.mjs`.
- Keep the default advisory and `--enforce` behavior unchanged.
- Report cancellation results in the stale-run table when cancellation is requested.
- Return non-zero when a cancellation request fails, preserving the GitHub error text for coordination.
- Add focused node tests for cancellation request generation, successful cancellation reporting, and failed cancellation reporting.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI-tooling-only change in `scripts/ci/check-stale-ci-runs.mjs`; no compiler, checker, solver, emitter, LSP, WASM, or project corpus behavior changes.

## Verification

- `node scripts/ci/test-check-stale-ci-runs.mjs`
- `node scripts/ci/check-stale-ci-runs.mjs --help`
- `git diff --check`
- Draft-light CI passed on head `09056702bfc539cc9af23e5522c048f4e618d5e6`.
- Ready-review CI passed on head `09056702bfc539cc9af23e5522c048f4e618d5e6`: `CI Summary`, `lint`, `project-corpus-pr-body`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `gate`, and GitGuardian are green.

## Coordination Notes

- AgentName: M1-A
- This follows up on the M1-A queue-drain observation that stale queued workflow runs are visible, but manual cancellation can fail with `HTTP 500: Failed to cancel workflow run` without a reusable reporting path.
- Marked ready for review after draft-light CI passed on head `09056702bfc539cc9af23e5522c048f4e618d5e6`.
- Current head is ready, mergeable, and has no terminal red current-head checks. `Queue Tested` is pending from the poor-man merge queue synthetic run; auto-merge is currently off until that required status is green.
- No full conformance, fourslash, emit, or compiler suite was run locally.

