### PR TITLE
docs(agents): refresh M1-A post-10163 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-25 19:53 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10160` merged.
+- 2026-05-25 23:08 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10163` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -35,6 +35,10 @@ node scripts/ci/pr-ownership-report.mjs
   - `#10160` refreshed this lane state after `#9465` landed and merged on
     2026-05-25 as `4b484e5fd6 docs(agents): refresh M1-A post-9465
     state (#10160)`. Its stale synthetic queue branch was deleted after merge.
+  - `#10163` merged on 2026-05-25 as
+    `25656f49fa ci: report stale run cancellation attempts (#10163)`. Its
+    synthetic queue branch `automation/merge-queue/pr-10163` was deleted after
+    the synthetic queue run `26422310092` completed successfully.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue
@@ -60,13 +64,13 @@ node scripts/ci/pr-ownership-report.mjs
     either drafts, not auto-merge armed, or already handed off.
   - Priority ready main-based PRs with `mergeStateStatus=BLOCKED` but
     `mergeable=MERGEABLE` include `#9632`, `#9912`, `#10078`, `#10081`,
-    `#10084`, `#10085`, `#10087`, `#10126`, and `#10147`. These currently
+    `#10084`, `#10087`, `#10126`, and `#10147`. These currently
     belong to other lanes; do not take them over unless the owner asks or a
     stale branch needs a signed handoff.
   - Queue branch cleanup currently skips open PR branches
-    `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10085`, `pr-10147`,
-    `pr-9632`, and `pr-9912`. The stale merged-PR queue branches for `#9848`,
-    `#9889`, and `#10160` were deleted.
+    `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9632`,
+    and `pr-9912`. The stale merged-PR queue branches for `#9848`, `#9889`,
+    `#10160`, and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track

M1-A PR garden / coordination state.

## Invariant

The M1-A goal file should reflect the current PR-garden state so agents do not chase already-merged PRs or stale queue branches.

## Scope

- Refresh the M1-A lane timestamp after `#10163` merged.
- Record `#10163` and its synthetic queue run cleanup.
- Remove stale `#10085` queue references from the current surface list.
- Keep the direct M1-A queue documented as empty after the latest merge.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only agent coordination update in `docs/plan/agents/M1-A.md`; no compiler, checker, solver, emitter, LSP, WASM, or project corpus behavior changes.

## Verification

- `git diff --check`
- `scripts/agents/show-goal.sh M1-A`
- `gh pr view 10163 --repo mohsen1/tsz --json number,state,mergedAt,mergeCommit,headRefName,headRefOid,title,url`
- `gh pr list --repo mohsen1/tsz --state open --search 'label:agent:M1-A' --json number,title,url,isDraft,headRefName`
- `git ls-remote --heads origin automation/merge-queue/pr-10163`

## Coordination Notes

- AgentName: M1-A
- `#10163` merged as `25656f49fa ci: report stale run cancellation attempts (#10163)` after synthetic queue run `26422310092` passed.
- The direct `agent:M1-A` PR queue was empty before this PR was opened.
- No compiler suites were run locally; this is a docs-only coordination update.
