### PR TITLE
ci: report active open queue branch runs

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -496,6 +496,17 @@ function cleanupQueueBranches(repository, options) {
         ? supersededOpenQueueBranchReason(queueBranchInfo.branch, currentBaseOid, options.queueBranchPrefix)
         : null;
       if (!supersededReason) {
+        const activeRun = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranchInfo.branch));
+        if (activeRun) {
+          skippedActiveRuns += 1;
+          if (options.verbose) {
+            skips.push({
+              branch: queueBranchInfo.branch,
+              reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
+            });
+          }
+          continue;
+        }
         skippedOpen += 1;
         if (options.verbose) {
           skips.push({ branch: queueBranchInfo.branch, reason: `PR #${number} is open` });

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -226,6 +226,22 @@ assert.match(cleanupFormat, /Included 1 superseded open PR branch/);
 assert.match(cleanupFormat, /open superseded/);
 assert.doesNotMatch(cleanupFormat, /\| #undefined \|/);
 
+const cleanupActiveRunFormat = formatResult({
+  cleanupQueueBranches: true,
+  deletions: [],
+  dryRun: true,
+  skippedActiveRuns: 1,
+  skippedOpen: 0,
+  skippedUnrecognized: 0,
+  supersededOpen: 0,
+  skips: [
+    { branch: "automation/merge-queue/pr-9515", reason: "active queue run 26423420117" },
+  ],
+  wouldDelete: 0,
+}, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
+assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue runs/);
+assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| active queue run 26423420117 \|/);
+
 assert.match(
   formatResult({
     selected: pr(),


### PR DESCRIPTION
AgentName: M1-A

## Track

M1-A PR garden / queue cleanup reporting.

## Invariant

Queue cleanup dry-runs should not hide active synthetic runs on open PR queue branches. Operators need to know which branches are deliberately preserved because CI is still running and which are just ordinary open-PR skips.

## Scope

- Check open, non-superseded queue branches for active workflow runs before counting them as ordinary open-PR skips.
- Report those branches through the existing active-run preservation path and verbose skip table.
- Add a focused formatter assertion for active open queue branch evidence.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI-tooling-only change in `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, checker, solver, emitter, LSP, WASM, or project corpus behavior changes.

## Verification

- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `AGENT_NAME=M1-A node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-superseded-open-queue-branches --dry-run --verbose`

## Coordination Notes

- AgentName: M1-A
- This came from the current cleanup dry-run: `automation/merge-queue/pr-9515` and `automation/merge-queue/pr-10084` both had active queue runs, but the previous summary only counted open-PR skips.
- Draft first for light CI. No compiler suites were run locally.
