### PR TITLE
docs(agents): refresh M1-A post-10166 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-25 23:08 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10163` merged.
+- 2026-05-25 23:32 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10166` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -39,6 +39,10 @@ node scripts/ci/pr-ownership-report.mjs
     `25656f49fa ci: report stale run cancellation attempts (#10163)`. Its
     synthetic queue branch `automation/merge-queue/pr-10163` was deleted after
     the synthetic queue run `26422310092` completed successfully.
+  - `#10166` merged on 2026-05-25 as
+    `ceadbd07a3 ci: report active open queue branch runs (#10166)`. Queue
+    cleanup dry runs now report active workflow runs on open queue branches as
+    preserved instead of hiding them under ordinary open-PR skips.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue
@@ -68,9 +72,9 @@ node scripts/ci/pr-ownership-report.mjs
     belong to other lanes; do not take them over unless the owner asks or a
     stale branch needs a signed handoff.
   - Queue branch cleanup currently skips open PR branches
-    `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9632`,
-    and `pr-9912`. The stale merged-PR queue branches for `#9848`, `#9889`,
-    `#10160`, and `#10163` were deleted.
+    `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
+    `pr-9632`, and `pr-9912`. The stale merged-PR queue branches for `#9848`,
+    `#9889`, `#10160`, and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track

M1-A PR garden / coordination state.

## Invariant

The M1-A goal file should reflect the current PR-garden state so agents do not chase already-merged PRs or stale queue branch facts.

## Scope

- Refresh the M1-A lane timestamp after `#10166` merged.
- Record `#10166` and the queue-cleanup reporting improvement.
- Update the current queue-branch cleanup skip list to include `automation/merge-queue/pr-9515`.
- Keep the direct M1-A queue documented as empty after the latest merge.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only agent coordination update in `docs/plan/agents/M1-A.md`; no compiler, checker, solver, emitter, LSP, WASM, or project corpus behavior changes.

## Verification

- `git diff --check`
- `sed -n '24,78p' docs/plan/agents/M1-A.md`
- `gh pr view 10166 --repo mohsen1/tsz --json number,state,mergedAt,mergeCommit,headRefName,headRefOid,title,url`
- `scripts/agents/list-owned-work.sh M1-A`
- `AGENT_NAME=M1-A node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-superseded-open-queue-branches --dry-run --verbose`

## Coordination Notes

- AgentName: M1-A
- `#10166` merged as `ceadbd07a3 ci: report active open queue branch runs (#10166)`.
- The direct `agent:M1-A` PR queue was empty before this PR was opened.
- `scripts/agents/show-goal.sh M1-A` intentionally reads `origin/main` first, so local unmerged goal-file verification used direct file/diff reads instead.
- No compiler suites were run locally; this is a docs-only coordination update.
