### PR TITLE
ci: annotate ownership duplicate clusters

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -87,6 +87,17 @@ function titleScope(title) {
     .trim();
 }
 
+function prSummary(report, number, prefix = "#") {
+  const pr = report.prs.find((candidate) => candidate.number === number);
+  if (!pr) {
+    return `${prefix}${number}`;
+  }
+  const state = pr.draft ? "draft" : "ready";
+  const wip = pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title) ? ", WIP" : "";
+  const owner = pr.agentName ?? "no AgentName";
+  return `${prefix}${number} (${state}${wip}, ${owner})`;
+}
+
 function makeReport(pulls) {
   const normalized = pulls.map((pr) => ({
     number: pr.number,
@@ -188,7 +199,7 @@ function printMarkdown(report) {
     console.log("- none");
   } else {
     for (const duplicate of report.duplicateTitleScopes) {
-      console.log(`- ${duplicate.scope}: ${duplicate.prs.map((pr) => `#${pr}`).join(", ")}`);
+      console.log(`- ${duplicate.scope}: ${duplicate.prs.map((pr) => prSummary(report, pr)).join(", ")}`);
     }
   }
   console.log("");
@@ -203,7 +214,7 @@ function printMarkdown(report) {
     console.log("- none");
   } else {
     for (const duplicate of issueDuplicates) {
-      console.log(`- #${duplicate.issue}: ${duplicate.prs.map((pr) => `PR #${pr}`).join(", ")}`);
+      console.log(`- #${duplicate.issue}: ${duplicate.prs.map((pr) => prSummary(report, pr, "PR #")).join(", ")}`);
     }
   }
 }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -91,9 +91,12 @@ withTempDir((dir) => {
   assert.match(result.stdout, /Open PR Ownership Report/);
   assert.match(result.stdout, /agent\/mapped-a: root #10; children #12/);
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
-  assert.match(result.stdout, /fix\(checker\): preserve mapped access: #10, #11/);
-  assert.match(result.stdout, /#42: PR #10, PR #11/);
-  assert.doesNotMatch(result.stdout, /#42: PR #10, PR #11, PR #42/);
+  assert.match(
+    result.stdout,
+    /fix\(checker\): preserve mapped access: #10 \(draft, WIP, alpha\), #11 \(draft, WIP, beta\), #42 \(draft, delta\)/,
+  );
+  assert.match(result.stdout, /#42: PR #10 \(draft, WIP, alpha\), PR #11 \(draft, WIP, beta\)/);
+  assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Metadata reports should make PR ownership and WIP state legible without changing compiler behavior or taking over another lane's implementation PR.

## Scope
- Annotate duplicate title and duplicate issue sections in `scripts/ci/pr-ownership-report.mjs` with each PR's draft/ready state, WIP marker, and AgentName.
- Update `scripts/ci/test-pr-ownership-report.mjs` fixture assertions for the richer markdown output.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report formatting; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs`

## Coordination Notes
- M1-A direct owned PR queue was empty before this change.
- This helps cleanup agents triage duplicate draft clusters from the report output without opening every PR for owner/state context.
- No WIP state was changed and no other lane PR was taken over.