### PR TITLE
docs(agents): refresh M1-A post-10168 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-25 23:32 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10166` merged.
+- 2026-05-25 23:42 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10168` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -43,6 +43,11 @@ node scripts/ci/pr-ownership-report.mjs
     `ceadbd07a3 ci: report active open queue branch runs (#10166)`. Queue
     cleanup dry runs now report active workflow runs on open queue branches as
     preserved instead of hiding them under ordinary open-PR skips.
+  - `#10168` merged on 2026-05-25 as
+    `6caa98667f ci: annotate ownership duplicate clusters (#10168)`.
+    `scripts/ci/pr-ownership-report.mjs` now annotates duplicate title and
+    issue clusters with draft/ready state, WIP marker, and AgentName so cleanup
+    agents can triage ownership without opening every PR.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / M1-A lane state

## Invariant
The M1-A goal file should reflect landed M1-A work and current queue state without changing compiler behavior.

## Scope
- Record #10168 as merged.
- Update the M1-A direct queue note to empty after #10168.
- Document the new ownership-report duplicate-cluster annotations for future cleanup cycles.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state refresh; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`
- `scripts/agents/list-owned-work.sh M1-A`

## Coordination Notes
- Opened after #10168 merged as `6caa98667f`.
- No WIP state was changed and no other lane PR was taken over.