### PR TITLE
ci: report ownership AgentName mismatches

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -73,6 +73,13 @@ function agentNameFrom(body) {
   return match?.[1] ?? null;
 }
 
+function agentLabelsFrom(labels) {
+  return labels
+    .filter((label) => label.startsWith("agent:"))
+    .map((label) => label.slice("agent:".length))
+    .sort();
+}
+
 function issueRefsFrom(text) {
   return [...String(text).matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
 }
@@ -107,6 +114,7 @@ function makeReport(pulls) {
     head: pr.headRefName,
     labels: pr.labels.sort(),
     agentName: agentNameFrom(pr.body),
+    agentLabels: agentLabelsFrom(pr.labels),
     issueRefs: [...new Set(issueRefsFrom(`${pr.title}\n${pr.body}`).filter((issue) => issue !== pr.number))].sort(
       (a, b) => a - b,
     ),
@@ -153,6 +161,15 @@ function makeReport(pulls) {
     .map(([issue, prs]) => ({ issue, prs: prs.sort((a, b) => a - b) }))
     .sort((a, b) => a.issue - b.issue);
 
+  const agentLabelMismatches = normalized
+    .filter((pr) => pr.agentLabels.length === 1 && pr.agentName !== null && pr.agentName !== pr.agentLabels[0])
+    .map((pr) => ({
+      number: pr.number,
+      agentName: pr.agentName,
+      label: `agent:${pr.agentLabels[0]}`,
+    }))
+    .sort((a, b) => a.number - b.number);
+
   return {
     generatedAt: new Date().toISOString(),
     counts: {
@@ -161,6 +178,7 @@ function makeReport(pulls) {
       ready: normalized.filter((pr) => !pr.draft).length,
       stacked: stacks.reduce((sum, stack) => sum + stack.children.length, 0),
       missingAgentName: normalized.filter((pr) => pr.agentName === null).length,
+      agentLabelMismatches: agentLabelMismatches.length,
     },
     byBase: [...byBase.entries()]
       .map(([base, prs]) => ({ base, prs: prs.sort((a, b) => a - b) }))
@@ -168,6 +186,7 @@ function makeReport(pulls) {
     stacks,
     duplicateTitleScopes,
     duplicateIssueRefs,
+    agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
 }
@@ -176,7 +195,7 @@ function printMarkdown(report) {
   console.log("# Open PR Ownership Report");
   console.log("");
   console.log(
-    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}`,
+    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
   );
   console.log("");
   console.log("## Base Branches");
@@ -215,6 +234,15 @@ function printMarkdown(report) {
   } else {
     for (const duplicate of issueDuplicates) {
       console.log(`- #${duplicate.issue}: ${duplicate.prs.map((pr) => prSummary(report, pr, "PR #")).join(", ")}`);
+    }
+  }
+  console.log("");
+  console.log("## AgentName / Label Mismatches");
+  if (report.agentLabelMismatches.length === 0) {
+    console.log("- none");
+  } else {
+    for (const mismatch of report.agentLabelMismatches) {
+      console.log(`- #${mismatch.number}: AgentName ${mismatch.agentName}; label ${mismatch.label}`);
     }
   }
 }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -33,7 +33,7 @@ withTempDir((dir) => {
       isDraft: true,
       baseRefName: "main",
       headRefName: "agent/mapped-a",
-      labels: [{ name: "WIP" }, { name: "checker" }],
+      labels: [{ name: "WIP" }, { name: "checker" }, { name: "agent:alpha" }],
       body: "AgentName: alpha\n\nRefs #42\n",
     },
     {
@@ -42,7 +42,7 @@ withTempDir((dir) => {
       isDraft: true,
       baseRefName: "main",
       headRefName: "agent/mapped-b",
-      labels: ["WIP"],
+      labels: ["WIP", "agent:omega"],
       body: "AgentName: beta\n",
     },
     {
@@ -51,7 +51,7 @@ withTempDir((dir) => {
       isDraft: false,
       baseRefName: "agent/mapped-a",
       headRefName: "agent/relation-child",
-      labels: [],
+      labels: ["agent:gamma"],
       body: "AgentName: gamma\nDepends on #10\n",
     },
     {
@@ -89,6 +89,7 @@ withTempDir((dir) => {
   });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Open PR Ownership Report/);
+  assert.match(result.stdout, /AgentName\/label mismatches: 1/);
   assert.match(result.stdout, /agent\/mapped-a: root #10; children #12/);
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
   assert.match(
@@ -97,6 +98,7 @@ withTempDir((dir) => {
   );
   assert.match(result.stdout, /#42: PR #10 \(draft, WIP, alpha\), PR #11 \(draft, WIP, beta\)/);
   assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
+  assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {
@@ -105,6 +107,7 @@ withTempDir((dir) => {
     ready: 1,
     stacked: 2,
     missingAgentName: 2,
+    agentLabelMismatches: 1,
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
@@ -121,7 +124,9 @@ withTempDir((dir) => {
   assert.deepEqual(report.duplicateIssueRefs, [
     { issue: 42, prs: [10, 11] },
   ]);
+  assert.deepEqual(report.agentLabelMismatches, [{ number: 11, agentName: "beta", label: "agent:omega" }]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
+  assert.deepEqual(report.prs.find((pr) => pr.number === 10).agentLabels, ["alpha"]);
   assert.equal(report.prs.find((pr) => pr.number === 13).agentName, null);
   assert.equal(report.prs.find((pr) => pr.number === 14).agentName, null);
 });


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Ownership reports should make mismatched PR coordination metadata visible without changing compiler behavior or mutating another lane's PR state.

## Scope
- Add `agent:*` label extraction to `scripts/ci/pr-ownership-report.mjs`.
- Report open PRs whose body `AgentName` disagrees with their single canonical `agent:*` label.
- Extend the ownership report fixture test to cover mismatch counts, markdown output, and JSON fields.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report formatting; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs`

## Coordination Notes
- M1-A direct owned PR queue was empty before this change.
- Live report currently surfaces 15 AgentName/label mismatches, mostly runner-generated AgentName values on canonical lane labels.
- No WIP state was changed and no other lane PR was taken over.