### PR TITLE
docs(agents): refresh M1-A AgentName cleanup state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,7 +24,7 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-25 23:53 UTC lane refresh:
+- 2026-05-25 23:58 UTC lane refresh:
   - Direct `agent:M1-A` PR queue is empty after `#10170` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
@@ -52,7 +52,8 @@ node scripts/ci/pr-ownership-report.mjs
     `24936e167a ci: report ownership AgentName mismatches (#10170)`.
     `scripts/ci/pr-ownership-report.mjs` now reports open PRs where the body
     `AgentName` disagrees with the single canonical `agent:*` label; the latest
-    live report surfaced 15 such mismatches.
+    live report now shows zero such mismatches after M1-A normalized the 15
+    mismatched PR body `AgentName` lines to their existing canonical labels.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / M1-A lane state

## Invariant
The M1-A goal file should reflect current PR-garden cleanup state without changing compiler behavior.

## Scope
- Record that M1-A normalized the 15 AgentName/label mismatches surfaced by #10170.
- Update the latest live ownership report note to zero AgentName/label mismatches.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state refresh; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`
- `scripts/agents/list-owned-work.sh M1-A`
- `node scripts/ci/pr-ownership-report.mjs`

## Coordination Notes
- Metadata cleanup only changed PR body `AgentName:` lines to match existing canonical `agent:*` labels.
- No labels, WIP state, branches, or implementation contents were changed.
- No other lane PR was taken over.