### PR TITLE
ci: annotate ownership report stack roles

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -102,7 +102,8 @@ function prSummary(report, number, prefix = "#") {
   const state = pr.draft ? "draft" : "ready";
   const wip = pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title) ? ", WIP" : "";
   const owner = pr.agentName ?? "no AgentName";
-  return `${prefix}${number} (${state}${wip}, ${owner})`;
+  const stack = pr.stackRole ? `, ${pr.stackRole}` : "";
+  return `${prefix}${number} (${state}${wip}, ${owner}${stack})`;
 }
 
 function makeReport(pulls) {
@@ -150,6 +151,22 @@ function makeReport(pulls) {
       return { base, root, children: children.sort((a, b) => a - b) };
     })
     .sort((a, b) => a.base.localeCompare(b.base));
+
+  const stackRoots = new Set(stacks.map((stack) => stack.root).filter((root) => root !== null));
+  const stackChildren = new Set(stacks.flatMap((stack) => stack.children));
+  for (const pr of normalized) {
+    const root = stackRoots.has(pr.number);
+    const child = stackChildren.has(pr.number);
+    if (root && child) {
+      pr.stackRole = "stack middle";
+    } else if (root) {
+      pr.stackRole = "stack root";
+    } else if (child) {
+      pr.stackRole = "stack child";
+    } else {
+      pr.stackRole = null;
+    }
+  }
 
   const duplicateTitleScopes = [...byScope.entries()]
     .filter(([, prs]) => prs.length > 1)

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -94,9 +94,9 @@ withTempDir((dir) => {
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
   assert.match(
     result.stdout,
-    /fix\(checker\): preserve mapped access: #10 \(draft, WIP, alpha\), #11 \(draft, WIP, beta\), #42 \(draft, delta\)/,
+    /fix\(checker\): preserve mapped access: #10 \(draft, WIP, alpha, stack root\), #11 \(draft, WIP, beta\), #42 \(draft, delta\)/,
   );
-  assert.match(result.stdout, /#42: PR #10 \(draft, WIP, alpha\), PR #11 \(draft, WIP, beta\)/);
+  assert.match(result.stdout, /#42: PR #10 \(draft, WIP, alpha, stack root\), PR #11 \(draft, WIP, beta\)/);
   assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
 
@@ -129,4 +129,7 @@ withTempDir((dir) => {
   assert.deepEqual(report.prs.find((pr) => pr.number === 10).agentLabels, ["alpha"]);
   assert.equal(report.prs.find((pr) => pr.number === 13).agentName, null);
   assert.equal(report.prs.find((pr) => pr.number === 14).agentName, null);
+  assert.equal(report.prs.find((pr) => pr.number === 10).stackRole, "stack root");
+  assert.equal(report.prs.find((pr) => pr.number === 12).stackRole, "stack child");
+  assert.equal(report.prs.find((pr) => pr.number === 11).stackRole, null);
 });


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Ownership reports should separate intentional stacked PR chains from duplicate stale work without mutating another lane's PR state or changing compiler behavior.

## Scope
- Add stack role classification (`stack root`, `stack middle`, `stack child`) to PR summaries in duplicate-cluster output.
- Extend `scripts/ci/test-pr-ownership-report.mjs` to cover stack role markdown and JSON fields.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report formatting; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs`

## Coordination Notes
- M1-A direct owned PR queue was empty before this change.
- The live report now marks stacked duplicate issue clusters, making intentional stacks easier to distinguish from duplicate stale drafts.
- No WIP state was changed and no other lane PR was taken over.