### PR TITLE
ci: classify duplicate issue draft stacks

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -106,6 +106,22 @@ function prSummary(report, number, prefix = "#") {
   return `${prefix}${number} (${state}${wip}, ${owner}${stack})`;
 }
 
+function draftStackState(draftCount, stackedDraftCount) {
+  if (draftCount === 0) {
+    return "no draft PRs";
+  }
+  if (draftCount === 1) {
+    return stackedDraftCount === 1 ? "single stacked draft" : "single unstacked draft";
+  }
+  if (stackedDraftCount === 0) {
+    return "unstacked drafts";
+  }
+  if (stackedDraftCount === draftCount) {
+    return "stacked-only drafts";
+  }
+  return "mixed stacked/unstacked drafts";
+}
+
 function makeReport(pulls) {
   const normalized = pulls.map((pr) => ({
     number: pr.number,
@@ -173,9 +189,23 @@ function makeReport(pulls) {
     .map(([scope, prs]) => ({ scope, prs: prs.sort((a, b) => a - b) }))
     .sort((a, b) => a.scope.localeCompare(b.scope));
 
+  const prByNumber = new Map(normalized.map((pr) => [pr.number, pr]));
+
   const duplicateIssueRefs = [...byIssue.entries()]
     .filter(([, prs]) => prs.length > 1)
-    .map(([issue, prs]) => ({ issue, prs: prs.sort((a, b) => a - b) }))
+    .map(([issue, prs]) => {
+      const sortedPrs = prs.sort((a, b) => a - b);
+      const draftPrs = sortedPrs.map((number) => prByNumber.get(number)).filter((pr) => pr?.draft);
+      const stackedDraftCount = draftPrs.filter((pr) => pr.stackRole !== null).length;
+      return {
+        issue,
+        prs: sortedPrs,
+        draftCount: draftPrs.length,
+        stackedDraftCount,
+        unstackedDraftCount: draftPrs.length - stackedDraftCount,
+        draftStackState: draftStackState(draftPrs.length, stackedDraftCount),
+      };
+    })
     .sort((a, b) => a.issue - b.issue);
 
   const agentLabelMismatches = normalized
@@ -240,17 +270,16 @@ function printMarkdown(report) {
   }
   console.log("");
   console.log("## Multiple Drafts Against Same Issue");
-  const issueDuplicates = report.duplicateIssueRefs.filter((entry) => {
-    const prs = entry.prs
-      .map((number) => report.prs.find((pr) => pr.number === number))
-      .filter(Boolean);
-    return prs.filter((pr) => pr.draft).length > 1;
-  });
+  const issueDuplicates = report.duplicateIssueRefs.filter((entry) => entry.draftCount > 1);
   if (issueDuplicates.length === 0) {
     console.log("- none");
   } else {
     for (const duplicate of issueDuplicates) {
-      console.log(`- #${duplicate.issue}: ${duplicate.prs.map((pr) => prSummary(report, pr, "PR #")).join(", ")}`);
+      console.log(
+        `- #${duplicate.issue} (${duplicate.draftStackState}): ${duplicate.prs
+          .map((pr) => prSummary(report, pr, "PR #"))
+          .join(", ")}`,
+      );
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -96,7 +96,10 @@ withTempDir((dir) => {
     result.stdout,
     /fix\(checker\): preserve mapped access: #10 \(draft, WIP, alpha, stack root\), #11 \(draft, WIP, beta\), #42 \(draft, delta\)/,
   );
-  assert.match(result.stdout, /#42: PR #10 \(draft, WIP, alpha, stack root\), PR #11 \(draft, WIP, beta\)/);
+  assert.match(
+    result.stdout,
+    /#42 \(mixed stacked\/unstacked drafts\): PR #10 \(draft, WIP, alpha, stack root\), PR #11 \(draft, WIP, beta\)/,
+  );
   assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
 
@@ -122,7 +125,14 @@ withTempDir((dir) => {
     { scope: "fix(checker): preserve mapped access", prs: [10, 11, 42] },
   ]);
   assert.deepEqual(report.duplicateIssueRefs, [
-    { issue: 42, prs: [10, 11] },
+    {
+      issue: 42,
+      prs: [10, 11],
+      draftCount: 2,
+      stackedDraftCount: 1,
+      unstackedDraftCount: 1,
+      draftStackState: "mixed stacked/unstacked drafts",
+    },
   ]);
   assert.deepEqual(report.agentLabelMismatches, [{ number: 11, agentName: "beta", label: "agent:omega" }]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Ownership reports should make cleanup targets legible without mutating another lane’s PR state or changing compiler behavior.

## Scope
- Add duplicate-issue draft stack classification to `scripts/ci/pr-ownership-report.mjs`.
- Include draft counts, stacked draft counts, unstacked draft counts, and `draftStackState` in the JSON report.
- Print `stacked-only drafts`, `mixed stacked/unstacked drafts`, or `unstacked drafts` in the duplicate issue section.
- Extend the ownership report fixture test for the new markdown and JSON shape.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report formatting; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-draft-stack.json`
- `jq '.duplicateIssueRefs[] | select(.draftCount > 1) | {issue,draftStackState,draftCount,stackedDraftCount,unstackedDraftCount}' /tmp/m1a-ownership-report-draft-stack.json`

## Coordination Notes
- Direct `agent:M1-A` PR and issue queues were empty before this change.
- The live report still shows zero missing AgentName entries and zero AgentName/label mismatches.
- No WIP state was changed and no other lane PR was taken over.