### PR TITLE
docs(agents): refresh M1-A post-10175 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 00:10 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10173` merged.
+- 2026-05-26 00:22 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10175` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -60,6 +60,13 @@ node scripts/ci/pr-ownership-report.mjs
     stacked PRs as `stack root`, `stack middle`, or `stack child`; the latest
     live report shows 64 open PRs, 20 drafts, 44 ready PRs, 4 stacked children,
     zero missing `AgentName` entries, and zero AgentName/label mismatches.
+  - `#10175` merged on 2026-05-26 as
+    `98a8bc656c ci: classify duplicate issue draft stacks (#10175)`.
+    The duplicate-issue section now classifies draft clusters as
+    `stacked-only drafts`, `mixed stacked/unstacked drafts`, or
+    `unstacked drafts`; the latest live report shows unstacked duplicate-draft
+    cleanup targets on `#9694`, `#9809`, and `#9886`, plus mixed clusters on
+    `#9634` and `#9904`.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
M1-A lane state should point at current landed work and current PR-garden topology so follow-up agents do not chase merged branches or stale report semantics.

## Scope
- Refresh `docs/plan/agents/M1-A.md` after #10175 landed.
- Record that duplicate issue draft clusters now show stacked-only, mixed, and unstacked draft classifications.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`
- `scripts/agents/list-owned-work.sh M1-A`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10175-doc.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run`

## Coordination Notes
- #10175 merged as 98a8bc656c before this docs refresh.
- Direct `agent:M1-A` PR and issue queues were empty before opening this PR.
- No WIP state was changed and no other lane PR was taken over.