### PR TITLE
ci: surface duplicate draft cleanup targets

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -283,6 +283,20 @@ function printMarkdown(report) {
     }
   }
   console.log("");
+  console.log("## Duplicate Draft Cleanup Targets");
+  const issueCleanupTargets = issueDuplicates.filter((entry) => entry.unstackedDraftCount > 0);
+  if (issueCleanupTargets.length === 0) {
+    console.log("- none");
+  } else {
+    for (const duplicate of issueCleanupTargets) {
+      console.log(
+        `- #${duplicate.issue} (${duplicate.draftStackState}; unstacked drafts: ${
+          duplicate.unstackedDraftCount
+        }): ${duplicate.prs.map((pr) => prSummary(report, pr, "PR #")).join(", ")}`,
+      );
+    }
+  }
+  console.log("");
   console.log("## AgentName / Label Mismatches");
   if (report.agentLabelMismatches.length === 0) {
     console.log("- none");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -100,6 +100,10 @@ withTempDir((dir) => {
     result.stdout,
     /#42 \(mixed stacked\/unstacked drafts\): PR #10 \(draft, WIP, alpha, stack root\), PR #11 \(draft, WIP, beta\)/,
   );
+  assert.match(
+    result.stdout,
+    /Duplicate Draft Cleanup Targets[\s\S]*#42 \(mixed stacked\/unstacked drafts; unstacked drafts: 1\): PR #10 \(draft, WIP, alpha, stack root\), PR #11 \(draft, WIP, beta\)/,
+  );
   assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
 


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Ownership reports should make cleanup targets legible without mutating another lane’s PR state or changing compiler behavior.

## Scope
- Add a `Duplicate Draft Cleanup Targets` section to `scripts/ci/pr-ownership-report.mjs`.
- Filter that section to duplicate issue clusters with at least one unstacked draft PR.
- Extend the ownership report fixture test for the new markdown section.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report formatting; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-duplicate-targets.json`

## Coordination Notes
- Direct `agent:M1-A` PR and issue queues were empty before this change.
- The live report now surfaces five duplicate-draft cleanup targets separately from stacked-only draft chains.
- No WIP state was changed and no other lane PR was taken over.