### PR TITLE
docs(agents): refresh M1-A post-10177 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 00:22 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10175` merged.
+- 2026-05-26 00:32 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10177` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -67,6 +67,12 @@ node scripts/ci/pr-ownership-report.mjs
     `unstacked drafts`; the latest live report shows unstacked duplicate-draft
     cleanup targets on `#9694`, `#9809`, and `#9886`, plus mixed clusters on
     `#9634` and `#9904`.
+  - `#10177` merged on 2026-05-26 as
+    `3d049d81c5 ci: surface duplicate draft cleanup targets (#10177)`.
+    `scripts/ci/pr-ownership-report.mjs` now has a dedicated
+    `Duplicate Draft Cleanup Targets` section that filters out stacked-only
+    draft chains and surfaces the five current unstacked/mixed cleanup targets
+    directly.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
M1-A lane state should point at current landed work and current PR-garden topology so follow-up agents do not chase merged branches or stale report semantics.

## Scope
- Refresh `docs/plan/agents/M1-A.md` after #10177 landed.
- Record that the ownership report now has a dedicated `Duplicate Draft Cleanup Targets` section.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`
- `scripts/agents/list-owned-work.sh M1-A`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10177-doc-verify.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run`

## Coordination Notes
- #10177 merged as 3d049d81c5 before this docs refresh.
- Direct `agent:M1-A` PR and issue queues were empty before opening this PR.
- No WIP state was changed and no other lane PR was taken over.