### PR TITLE
ci: export duplicate draft cleanup targets

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -208,6 +208,10 @@ function makeReport(pulls) {
     })
     .sort((a, b) => a.issue - b.issue);
 
+  const duplicateDraftCleanupTargets = duplicateIssueRefs.filter(
+    (entry) => entry.draftCount > 1 && entry.unstackedDraftCount > 0,
+  );
+
   const agentLabelMismatches = normalized
     .filter((pr) => pr.agentLabels.length === 1 && pr.agentName !== null && pr.agentName !== pr.agentLabels[0])
     .map((pr) => ({
@@ -233,6 +237,7 @@ function makeReport(pulls) {
     stacks,
     duplicateTitleScopes,
     duplicateIssueRefs,
+    duplicateDraftCleanupTargets,
     agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
@@ -284,11 +289,10 @@ function printMarkdown(report) {
   }
   console.log("");
   console.log("## Duplicate Draft Cleanup Targets");
-  const issueCleanupTargets = issueDuplicates.filter((entry) => entry.unstackedDraftCount > 0);
-  if (issueCleanupTargets.length === 0) {
+  if (report.duplicateDraftCleanupTargets.length === 0) {
     console.log("- none");
   } else {
-    for (const duplicate of issueCleanupTargets) {
+    for (const duplicate of report.duplicateDraftCleanupTargets) {
       console.log(
         `- #${duplicate.issue} (${duplicate.draftStackState}; unstacked drafts: ${
           duplicate.unstackedDraftCount

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -138,6 +138,16 @@ withTempDir((dir) => {
       draftStackState: "mixed stacked/unstacked drafts",
     },
   ]);
+  assert.deepEqual(report.duplicateDraftCleanupTargets, [
+    {
+      issue: 42,
+      prs: [10, 11],
+      draftCount: 2,
+      stackedDraftCount: 1,
+      unstackedDraftCount: 1,
+      draftStackState: "mixed stacked/unstacked drafts",
+    },
+  ]);
   assert.deepEqual(report.agentLabelMismatches, [{ number: 11, agentName: "beta", label: "agent:omega" }]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
   assert.deepEqual(report.prs.find((pr) => pr.number === 10).agentLabels, ["alpha"]);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
Ownership reports should expose the same cleanup targets in markdown and JSON without mutating another lane’s PR state or changing compiler behavior.

## Scope
- Add `duplicateDraftCleanupTargets` to `scripts/ci/pr-ownership-report.mjs` JSON output.
- Reuse that report field for the markdown `Duplicate Draft Cleanup Targets` section.
- Extend the ownership report fixture test for the new JSON field.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-script-only ownership report data shape; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-json-targets.json`
- `jq '.duplicateDraftCleanupTargets' /tmp/m1a-ownership-report-json-targets.json`

## Coordination Notes
- Direct `agent:M1-A` PR and issue queues were empty before this change.
- The live JSON now exposes the same five duplicate-draft cleanup targets shown in markdown.
- No WIP state was changed and no other lane PR was taken over.