### PR TITLE
docs(agents): refresh M1-A post-10179 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 00:32 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10177` merged.
+- 2026-05-26 00:43 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10179` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -73,6 +73,12 @@ node scripts/ci/pr-ownership-report.mjs
     `Duplicate Draft Cleanup Targets` section that filters out stacked-only
     draft chains and surfaces the five current unstacked/mixed cleanup targets
     directly.
+  - `#10179` merged on 2026-05-26 as
+    `965c5dd4d1 ci: export duplicate draft cleanup targets (#10179)`.
+    The JSON report now exposes the same cleanup list as
+    `duplicateDraftCleanupTargets`, so follow-up automation can consume the
+    unstacked/mixed duplicate-draft target list without recomputing the
+    markdown filter.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership hygiene

## Invariant
M1-A lane state should point at current landed work and current PR-garden topology so follow-up agents do not chase merged branches or stale report semantics.

## Scope
- Refresh `docs/plan/agents/M1-A.md` after #10179 landed.
- Record that `duplicateDraftCleanupTargets` is now available in ownership report JSON.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, conformance, emit, parser, checker, solver, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`
- `scripts/agents/list-owned-work.sh M1-A`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10179-doc-verify.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run`

## Coordination Notes
- #10179 merged as 965c5dd4d1 before this docs refresh.
- Direct `agent:M1-A` PR and issue queues were empty before opening this PR.
- No WIP state was changed and no other lane PR was taken over.