### PR TITLE
ci: distinguish claimed issue refs in ownership report

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -84,6 +84,24 @@ function issueRefsFrom(text) {
   return [...String(text).matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
 }
 
+function uniqueIssueRefs(refs, prNumber) {
+  return [...new Set(refs.filter((issue) => issue !== prNumber))].sort((a, b) => a - b);
+}
+
+function claimedIssueRefsFromBody(body) {
+  const refs = [];
+  for (const match of String(body).matchAll(
+    /\b(?:addresses?|closes?|fix(?:es)?|resolves?)\b[^\r\n.]*/gi,
+  )) {
+    refs.push(...issueRefsFrom(match[0]));
+  }
+  return refs;
+}
+
+function claimedIssueRefsFrom(pr) {
+  return uniqueIssueRefs([...issueRefsFrom(pr.title), ...claimedIssueRefsFromBody(pr.body)], pr.number);
+}
+
 function titleScope(title) {
   return String(title)
     .toLowerCase()
@@ -132,9 +150,8 @@ function makeReport(pulls) {
     labels: pr.labels.sort(),
     agentName: agentNameFrom(pr.body),
     agentLabels: agentLabelsFrom(pr.labels),
-    issueRefs: [...new Set(issueRefsFrom(`${pr.title}\n${pr.body}`).filter((issue) => issue !== pr.number))].sort(
-      (a, b) => a - b,
-    ),
+    issueRefs: uniqueIssueRefs(issueRefsFrom(`${pr.title}\n${pr.body}`), pr.number),
+    claimedIssueRefs: claimedIssueRefsFrom(pr),
     titleScope: titleScope(pr.title),
   }));
 
@@ -152,7 +169,7 @@ function makeReport(pulls) {
     }
     byScope.get(pr.titleScope).push(pr.number);
 
-    for (const issue of pr.issueRefs) {
+    for (const issue of pr.claimedIssueRefs) {
       if (!byIssue.has(issue)) {
         byIssue.set(issue, []);
       }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -81,6 +81,24 @@ withTempDir((dir) => {
       labels: [],
       body: "AgentName:\n\n## Track\ncoordination\n",
     },
+    {
+      number: 15,
+      title: "fix(solver): strip optional tuple undefined",
+      isDraft: true,
+      baseRefName: "main",
+      headRefName: "agent/optional-tuple",
+      labels: ["agent:delta"],
+      body: "AgentName: delta\n\nFixes #9712\n\nCoordination Notes: PR #9826 (Issue #9694) touches the same helper.\n",
+    },
+    {
+      number: 16,
+      title: "fix(solver): preserve variadic tuple shape",
+      isDraft: true,
+      baseRefName: "main",
+      headRefName: "agent/variadic-tuple",
+      labels: ["agent:zeta"],
+      body: "AgentName: zeta\n\nAddresses #9694\n",
+    },
   ]);
 
   const result = spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, "--json", output], {
@@ -109,8 +127,8 @@ withTempDir((dir) => {
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {
-    open: 6,
-    draft: 5,
+    open: 8,
+    draft: 7,
     ready: 1,
     stacked: 2,
     missingAgentName: 2,
@@ -118,7 +136,7 @@ withTempDir((dir) => {
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
-    { base: "main", prs: [10, 11, 14, 42] },
+    { base: "main", prs: [10, 11, 14, 15, 16, 42] },
     { base: "unknown-base", prs: [13] },
   ]);
   assert.deepEqual(report.stacks, [
@@ -150,6 +168,10 @@ withTempDir((dir) => {
   ]);
   assert.deepEqual(report.agentLabelMismatches, [{ number: 11, agentName: "beta", label: "agent:omega" }]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
+  assert.deepEqual(report.prs.find((pr) => pr.number === 15).issueRefs, [9694, 9712, 9826]);
+  assert.deepEqual(report.prs.find((pr) => pr.number === 15).claimedIssueRefs, [9712]);
+  assert.deepEqual(report.prs.find((pr) => pr.number === 16).issueRefs, [9694]);
+  assert.deepEqual(report.prs.find((pr) => pr.number === 16).claimedIssueRefs, [9694]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 10).agentLabels, ["alpha"]);
   assert.equal(report.prs.find((pr) => pr.number === 13).agentName, null);
   assert.equal(report.prs.find((pr) => pr.number === 14).agentName, null);


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / ownership report accuracy.

## Invariant

Duplicate draft cleanup targets should identify PRs that actually claim the same issue, not PRs that only mention another issue or PR in coordination notes. Raw body/title issue references remain visible in each PR row for audit context.

## Scope

- Teach `scripts/ci/pr-ownership-report.mjs` to keep raw `issueRefs` while grouping duplicate issue work by `claimedIssueRefs`.
- Treat title issue refs and body claim phrases (`Addresses`, `Fixes`, `Closes`, `Resolves`) as claim refs.
- Add a fixture case matching the live false-positive shape where one PR fixes its own issue while mentioning a related PR/issue in coordination notes.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only ownership metadata change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-claim-refs-final.json`
- `git diff --check`

## Coordination Notes

- AgentName: M1-A
- Live report before this change listed five duplicate-draft cleanup targets driven by incidental coordination references such as PR #9845 mentioning Issue #9694 while claiming #9712, and M4-D stack notes mentioning #9634/#9904 while claiming different issues.
- Live report after this change still shows 64 open PRs, 20 drafts, 44 ready PRs, 4 stacked children, zero missing `AgentName`, and zero AgentName/label mismatches, but `Duplicate Draft Cleanup Targets` is now `none` because there are no current duplicate claim refs.