### PR TITLE
docs(agents): refresh M1-A post-10181 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 00:43 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10179` merged.
+- 2026-05-26 01:01 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10181` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -79,6 +79,16 @@ node scripts/ci/pr-ownership-report.mjs
     `duplicateDraftCleanupTargets`, so follow-up automation can consume the
     unstacked/mixed duplicate-draft target list without recomputing the
     markdown filter.
+  - `#10181` merged on 2026-05-26 as
+    `352ccabeef ci: distinguish claimed issue refs in ownership report
+    (#10181)`. `scripts/ci/pr-ownership-report.mjs` now keeps raw
+    `issueRefs` for audit context but groups duplicate issue work by
+    `claimedIssueRefs` from PR titles plus `Addresses`/`Fixes`/`Closes`/
+    `Resolves` body claims. The latest live report still shows 64 open PRs,
+    20 drafts, 44 ready PRs, 4 stacked children, zero missing `AgentName`
+    entries, and zero AgentName/label mismatches, and now reports no duplicate
+    draft cleanup targets because the previous five were incidental
+    coordination references rather than duplicate issue claims.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A goal file should describe the current landing state and the ownership-report signals that future PR-garden agents should trust.

## Scope

- Refresh `docs/plan/agents/M1-A.md` after #10181 merged.
- Record that the direct M1-A PR queue is empty again.
- Record that duplicate draft cleanup targets now use `claimedIssueRefs`, and the latest live report has no duplicate draft cleanup targets.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10181-doc.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes

- AgentName: M1-A
- #10181 merged as `352ccabeef`; this PR only updates the lane note to preserve that state for the next M1-A cycle.