### PR TITLE
ci: summarize merge queue skip reasons

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -438,6 +438,17 @@ export function failureCommentBody(agentName, reason) {
   ].join("\n");
 }
 
+export function skipReasonCounts(skips) {
+  const counts = new Map();
+  for (const skip of skips || []) {
+    const reason = String(skip.reason || "(unknown)");
+    counts.set(reason, (counts.get(reason) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+}
+
 function invalidatePullRequest(repository, pr, options) {
   if (options.dryRun) return { invalidated: false, skipped: false };
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
@@ -800,9 +811,17 @@ export function formatResult(result, options) {
     lines.push(`Failed #${result.selected.number}: ${result.reason}`);
   }
   if (!result.cleanupQueueBranches && options.verbose && result.skips?.length) {
+    const summary = skipReasonCounts(result.skips);
+    lines.push("", "### Skip Reason Counts", "", "| Count | Reason |", "|-------|--------|");
+    for (const entry of summary) {
+      lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
+    }
     lines.push("", "### Skips", "", "| PR | Reason |", "|----|--------|");
     for (const skip of result.skips.slice(0, 25)) {
       lines.push(`| #${skip.number} | ${skip.reason.replace(/\|/g, "\\|")} |`);
+    }
+    if (result.skips.length > 25) {
+      lines.push(`| ... | ${result.skips.length - 25} more skipped PR(s) omitted |`);
     }
   }
   return `${lines.join("\n")}\n`;

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -13,6 +13,7 @@ import {
   queueRunIsActive,
   queueSkipReason,
   requiredCheckState,
+  skipReasonCounts,
   supersededOpenQueueBranchReason,
 } from "./poor-mans-merge-queue.mjs";
 
@@ -186,6 +187,17 @@ assert.equal(queueSkipReason(pr({ labels: ["WIP"] }), { kind: "passed" }, "main"
 assert.equal(queueSkipReason(pr(), { kind: "pending", reason: "pending checks" }, "main"), "pending checks");
 assert.equal(queueSkipReason(pr(), { kind: "passed" }, "main"), null);
 assert.equal(queueSkipReason({ ...pr(), statusCheckRollup: undefined }, { kind: "passed" }, "main"), null);
+assert.deepEqual(
+  skipReasonCounts([
+    { number: 1, reason: "draft PR" },
+    { number: 2, reason: "auto-merge is not armed" },
+    { number: 3, reason: "draft PR" },
+  ]),
+  [
+    { reason: "draft PR", count: 2 },
+    { reason: "auto-merge is not armed", count: 1 },
+  ],
+);
 assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
 assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
@@ -241,6 +253,18 @@ const cleanupActiveRunFormat = formatResult({
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
 assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue runs/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| active queue run 26423420117 \|/);
+
+const queueSkipFormat = formatResult({
+  selected: null,
+  skips: Array.from({ length: 27 }, (_, index) => ({
+    number: index + 1,
+    reason: index % 3 === 0 ? "draft PR" : "auto-merge is not armed",
+  })),
+}, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
+assert.match(queueSkipFormat, /### Skip Reason Counts/);
+assert.match(queueSkipFormat, /\| 18 \| auto-merge is not armed \|/);
+assert.match(queueSkipFormat, /\| 9 \| draft PR \|/);
+assert.match(queueSkipFormat, /\| \.\.\. \| 2 more skipped PR\(s\) omitted \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / poor-man merge queue observability.

## Invariant

When the poor-man merge queue has no selectable PR, verbose output should explain the complete skip distribution, not only the first capped detail rows.

## Scope

- Add `skipReasonCounts` to summarize queue candidate skip reasons.
- In verbose queue selection output, print a `Skip Reason Counts` table before the capped per-PR skip rows.
- Add an omitted-row marker when the detailed skip table is truncated.
- Cover the summary and truncation behavior in `scripts/ci/test-poor-mans-merge-queue.mjs`.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only queue observability change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --verbose > /tmp/m1a-queue-skip-summary.txt`
- `git diff --check`

## Coordination Notes

- AgentName: M1-A
- Live verbose dry run now shows `44` PRs skipped because auto-merge is not armed and `16` skipped as draft PRs, while preserving the first 25 detailed rows and noting that 35 more were omitted.