### PR TITLE
docs(agents): refresh M1-A post-10183 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 01:01 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10181` merged.
+- 2026-05-26 01:12 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10183` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -89,6 +89,12 @@ node scripts/ci/pr-ownership-report.mjs
     entries, and zero AgentName/label mismatches, and now reports no duplicate
     draft cleanup targets because the previous five were incidental
     coordination references rather than duplicate issue claims.
+  - `#10183` merged on 2026-05-26 as
+    `0495520fb1 ci: summarize merge queue skip reasons (#10183)`.
+    Verbose `scripts/ci/poor-mans-merge-queue.mjs --dry-run` output now shows
+    a full `Skip Reason Counts` table before the capped per-PR details. The
+    latest live dry run reports 44 PRs skipped because auto-merge is not armed
+    and 16 skipped as draft PRs, with no queue-ready auto-merge candidate.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`; the latest dry run reports zero stale queue


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A goal file should describe the current queue state and the queue-report signals future M1-A cycles should trust.

## Scope

- Refresh `docs/plan/agents/M1-A.md` after #10183 merged.
- Record that the direct M1-A PR queue is empty again.
- Record the new verbose poor-man queue skip reason summary and the current live distribution.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --verbose > /tmp/m1a-queue-skip-summary-post-10183.txt`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10183-doc.json`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes

- AgentName: M1-A
- #10183 merged as `0495520fb1`; this PR only updates the lane note to preserve that state for the next M1-A cycle.