### PR TITLE
ci: show active queue runs in cleanup report

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -484,6 +484,7 @@ function cleanupQueueBranches(repository, options) {
   let skippedActiveRuns = 0;
   let skippedUnrecognized = 0;
   let supersededOpen = 0;
+  const activeRuns = [];
   const deletions = [];
   const skips = [];
   const currentBaseOid = options.cleanupSupersededOpenQueueBranches
@@ -510,6 +511,12 @@ function cleanupQueueBranches(repository, options) {
         const activeRun = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranchInfo.branch));
         if (activeRun) {
           skippedActiveRuns += 1;
+          activeRuns.push({
+            branch: queueBranchInfo.branch,
+            number,
+            runId: activeRun.databaseId || null,
+            url: activeRun.url || "",
+          });
           if (options.verbose) {
             skips.push({
               branch: queueBranchInfo.branch,
@@ -529,6 +536,12 @@ function cleanupQueueBranches(repository, options) {
     const activeRun = activeBranchQueueRun(readBranchWorkflowRuns(repository, queueBranchInfo.branch));
     if (activeRun) {
       skippedActiveRuns += 1;
+      activeRuns.push({
+        branch: queueBranchInfo.branch,
+        number,
+        runId: activeRun.databaseId || null,
+        url: activeRun.url || "",
+      });
       if (options.verbose) {
         skips.push({
           branch: queueBranchInfo.branch,
@@ -558,6 +571,7 @@ function cleanupQueueBranches(repository, options) {
 
   return {
     cleanupQueueBranches: true,
+    activeRuns,
     deleted,
     deletions,
     dryRun: options.dryRun,
@@ -785,6 +799,14 @@ export function formatResult(result, options) {
           ? "open superseded"
           : deletion.merged ? "merged" : String(deletion.state || "closed").toLowerCase();
         lines.push(`| \`${deletion.branch}\` | #${deletion.number} | ${state} |`);
+      }
+    }
+    if (options.verbose && result.activeRuns?.length) {
+      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Run |", "|--------|----|-----|");
+      for (const run of result.activeRuns.slice(0, 50)) {
+        const runId = run.runId || "(unknown)";
+        const runLink = run.url ? `[${runId}](${run.url})` : runId;
+        lines.push(`| \`${run.branch}\` | #${run.number} | ${runLink} |`);
       }
     }
     if (options.verbose && result.skips?.length) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -240,6 +240,14 @@ assert.doesNotMatch(cleanupFormat, /\| #undefined \|/);
 
 const cleanupActiveRunFormat = formatResult({
   cleanupQueueBranches: true,
+  activeRuns: [
+    {
+      branch: "automation/merge-queue/pr-9515",
+      number: 9515,
+      runId: 26423420117,
+      url: "https://github.example/runs/26423420117",
+    },
+  ],
   deletions: [],
   dryRun: true,
   skippedActiveRuns: 1,
@@ -252,6 +260,11 @@ const cleanupActiveRunFormat = formatResult({
   wouldDelete: 0,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
 assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue runs/);
+assert.match(cleanupActiveRunFormat, /### Active Queue Runs/);
+assert.match(
+  cleanupActiveRunFormat,
+  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \|/,
+);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| active queue run 26423420117 \|/);
 
 const queueSkipFormat = formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / poor-man merge queue cleanup observability.

## Invariant

Queue branch cleanup dry-runs should make preserved active workflow runs actionable without requiring another GitHub lookup per skipped branch.

## Scope

- Carry structured active queue-run metadata out of `cleanupQueueBranches`.
- In verbose cleanup output, print an `Active Queue Runs` table with branch, PR number, run id, and run URL.
- Preserve the existing skip table and cleanup counts.
- Cover the active-run table in `scripts/ci/test-poor-mans-merge-queue.mjs`.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only queue cleanup observability change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose > /tmp/m1a-cleanup-active-runs.txt`
- `git diff --check`

## Coordination Notes

- AgentName: M1-A
- Live cleanup dry-run now shows one preserved active queue run directly: `automation/merge-queue/pr-10084` / run `26426750402`.