### PR TITLE
ci: summarize cleanup queue branch skips

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -441,7 +441,7 @@ export function failureCommentBody(agentName, reason) {
 export function skipReasonCounts(skips) {
   const counts = new Map();
   for (const skip of skips || []) {
-    const reason = String(skip.reason || "(unknown)");
+    const reason = String(skip.summaryReason || skip.reason || "(unknown)");
     counts.set(reason, (counts.get(reason) || 0) + 1);
   }
   return [...counts.entries()]
@@ -496,7 +496,11 @@ function cleanupQueueBranches(repository, options) {
     if (!metadata) {
       skippedUnrecognized += 1;
       if (options.verbose) {
-        skips.push({ branch: queueBranchInfo.branch, reason: "unrecognized queue branch name" });
+        skips.push({
+          branch: queueBranchInfo.branch,
+          reason: "unrecognized queue branch name",
+          summaryReason: "unrecognized queue branch name",
+        });
       }
       continue;
     }
@@ -521,13 +525,18 @@ function cleanupQueueBranches(repository, options) {
             skips.push({
               branch: queueBranchInfo.branch,
               reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
+              summaryReason: "active queue run",
             });
           }
           continue;
         }
         skippedOpen += 1;
         if (options.verbose) {
-          skips.push({ branch: queueBranchInfo.branch, reason: `PR #${number} is open` });
+          skips.push({
+            branch: queueBranchInfo.branch,
+            reason: `PR #${number} is open`,
+            summaryReason: "open PR branch",
+          });
         }
         continue;
       }
@@ -546,6 +555,7 @@ function cleanupQueueBranches(repository, options) {
         skips.push({
           branch: queueBranchInfo.branch,
           reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
+          summaryReason: "active queue run",
         });
       }
       continue;
@@ -810,9 +820,17 @@ export function formatResult(result, options) {
       }
     }
     if (options.verbose && result.skips?.length) {
+      const summary = skipReasonCounts(result.skips);
+      lines.push("", "### Skip Reason Counts", "", "| Count | Reason |", "|-------|--------|");
+      for (const entry of summary) {
+        lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
+      }
       lines.push("", "### Skips", "", "| Branch | Reason |", "|--------|--------|");
       for (const skip of result.skips.slice(0, 50)) {
         lines.push(`| \`${skip.branch}\` | ${skip.reason.replace(/\|/g, "\\|")} |`);
+      }
+      if (result.skips.length > 50) {
+        lines.push(`| ... | ${result.skips.length - 50} more skipped branch(es) omitted |`);
       }
     }
   } else if (!result.selected) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -198,6 +198,17 @@ assert.deepEqual(
     { reason: "auto-merge is not armed", count: 1 },
   ],
 );
+assert.deepEqual(
+  skipReasonCounts([
+    { reason: "PR #1 is open", summaryReason: "open PR branch" },
+    { reason: "PR #2 is open", summaryReason: "open PR branch" },
+    { reason: "active queue run 123", summaryReason: "active queue run" },
+  ]),
+  [
+    { reason: "open PR branch", count: 2 },
+    { reason: "active queue run", count: 1 },
+  ],
+);
 assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
 assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
@@ -255,7 +266,13 @@ const cleanupActiveRunFormat = formatResult({
   skippedUnrecognized: 0,
   supersededOpen: 0,
   skips: [
-    { branch: "automation/merge-queue/pr-9515", reason: "active queue run 26423420117" },
+    {
+      branch: "automation/merge-queue/pr-9515",
+      reason: "active queue run 26423420117",
+      summaryReason: "active queue run",
+    },
+    { branch: "automation/merge-queue/pr-9632", reason: "PR #9632 is open", summaryReason: "open PR branch" },
+    { branch: "automation/merge-queue/pr-9912", reason: "PR #9912 is open", summaryReason: "open PR branch" },
   ],
   wouldDelete: 0,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
@@ -265,6 +282,9 @@ assert.match(
   cleanupActiveRunFormat,
   /\| `automation\/merge-queue\/pr-9515` \| #9515 \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \|/,
 );
+assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
+assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| active queue run \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| active queue run 26423420117 \|/);
 
 const queueSkipFormat = formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A queue tooling.

## Invariant

Queue cleanup dry-runs should make the current PR-garden blocker shape visible without requiring agents to read every skipped branch row.

## Scope

- Add grouped `Skip Reason Counts` output to verbose queue-branch cleanup reports.
- Preserve detailed per-branch skip rows while grouping cleanup-specific summaries such as `open PR branch` and `active queue run`.
- Extend the existing poor-man merge queue unit coverage for summary reasons and cleanup formatting.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/tooling-only change in `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose`

## Coordination Notes

- AgentName: M1-A
- The live cleanup dry-run now reports grouped cleanup skip counts before detailed branch rows; latest observed summary was 4 open PR branches and 2 active queue runs, with no stale branch deletion candidate.
