### PR TITLE
docs(agents): refresh M1-A post-10187 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 01:24 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10185` merged.
+- 2026-05-26 01:39 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10187` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -99,12 +99,14 @@ node scripts/ci/pr-ownership-report.mjs
     `41fdc94314 ci: show active queue runs in cleanup report (#10185)`.
     Verbose queue-branch cleanup dry runs now include an `Active Queue Runs`
     table with branch, PR, run id, and run URL for preserved active runs.
-    The latest live cleanup dry run preserved active run `26426750402` on
-    `automation/merge-queue/pr-10084`.
+  - `#10187` merged on 2026-05-26 as
+    `61f7b41458 ci: summarize cleanup queue branch skips (#10187)`.
+    Verbose queue-branch cleanup dry runs now include cleanup-specific
+    `Skip Reason Counts`, grouping detailed rows such as open PR branches and
+    active queue runs without losing per-branch evidence.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
-    longer matches current `main`; the latest dry run reports zero stale queue
-    branches and preserves no active queue runs.
+    longer matches current `main`.
   - `#9889` landed through the poor-man queue during M1-A queue drain. Its
     stale synthetic queue branch was deleted after merge.
   - `#9875` was selected by the queue but conflicted with current `main`.
@@ -131,7 +133,9 @@ node scripts/ci/pr-ownership-report.mjs
     stale branch needs a signed handoff.
   - Queue branch cleanup currently skips open PR branches
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
-    `pr-9632`, and `pr-9912`. The stale merged-PR queue branches for `#9848`,
+    `pr-9632`, and `pr-9912`. The latest cleanup dry run reports zero stale
+    branches, five open PR branch skips, and one active queue run
+    (`#9515`/`26427174368`). The stale merged-PR queue branches for `#9848`,
     `#9889`, `#10160`, and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A goal file should describe the current queue cleanup signal and the latest direct M1-A landing state.

## Scope

- Refresh `docs/plan/agents/M1-A.md` after #10187 merged.
- Record that the direct M1-A PR queue is empty again.
- Record the new cleanup `Skip Reason Counts` signal and current live cleanup branch state.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose > /tmp/m1a-cleanup-skip-counts-post-10187.txt`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10187-doc.json`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes

- AgentName: M1-A
- #10187 merged as `61f7b41458`; this PR only updates the lane note so future M1-A cycles start from the current queue cleanup picture.
