### PR TITLE
docs(agents): avoid volatile M1-A run ids

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,7 +24,7 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 01:39 UTC lane refresh:
+- 2026-05-26 01:43 UTC lane refresh:
   - Direct `agent:M1-A` PR queue is empty after `#10187` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
@@ -133,10 +133,12 @@ node scripts/ci/pr-ownership-report.mjs
     stale branch needs a signed handoff.
   - Queue branch cleanup currently skips open PR branches
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
-    `pr-9632`, and `pr-9912`. The latest cleanup dry run reports zero stale
-    branches, five open PR branch skips, and one active queue run
-    (`#9515`/`26427174368`). The stale merged-PR queue branches for `#9848`,
-    `#9889`, `#10160`, and `#10163` were deleted.
+    `pr-9632`, and `pr-9912`. Recent cleanup dry runs report zero stale
+    branches and group the six preserved branches as open PR branch skips or
+    active queue runs; the exact active-run subset changes as synthetic runs
+    complete, so re-run the cleanup dry-run for current run ids. The stale
+    merged-PR queue branches for `#9848`, `#9889`, `#10160`, and `#10163` were
+    deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A goal file should avoid preserving volatile synthetic queue run ids that can become stale during the same cycle.

## Scope

- Refresh `docs/plan/agents/M1-A.md` to describe queue cleanup branch state in durable terms.
- Keep the six preserved queue branches visible while instructing future cycles to rerun cleanup dry-run for current active run ids.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state correction; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose > /tmp/m1a-cleanup-stable-post-10188.txt`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-stable-doc.json`

## Coordination Notes

- AgentName: M1-A
- After #10188 merged, the active-run subset changed again while final audits were running. This update removes exact ephemeral run ids from the living lane note.
