### PR TITLE
ci: report blocked ready PR ownership

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -38,6 +38,9 @@ function normalizePr(raw) {
     isDraft: Boolean(raw.isDraft),
     baseRefName: String(raw.baseRefName || "main"),
     headRefName: String(raw.headRefName || ""),
+    mergeStateStatus: String(raw.mergeStateStatus || "UNKNOWN"),
+    mergeable: String(raw.mergeable || "UNKNOWN"),
+    autoMergeArmed: Boolean(raw.autoMergeRequest),
     labels,
     body: String(raw.body ?? ""),
   };
@@ -58,7 +61,7 @@ function loadPulls(fixture) {
       "--limit",
       "500",
       "--json",
-      "number,title,isDraft,baseRefName,headRefName,labels,body",
+      "number,title,isDraft,baseRefName,headRefName,labels,body,mergeStateStatus,mergeable,autoMergeRequest",
     ],
     { encoding: "utf8" },
   );
@@ -147,6 +150,9 @@ function makeReport(pulls) {
     draft: pr.isDraft,
     base: pr.baseRefName,
     head: pr.headRefName,
+    mergeStateStatus: pr.mergeStateStatus,
+    mergeable: pr.mergeable,
+    autoMergeArmed: pr.autoMergeArmed,
     labels: pr.labels.sort(),
     agentName: agentNameFrom(pr.body),
     agentLabels: agentLabelsFrom(pr.labels),
@@ -238,6 +244,27 @@ function makeReport(pulls) {
     }))
     .sort((a, b) => a.number - b.number);
 
+  const blockedReadyMainPrs = normalized
+    .filter((pr) => !pr.draft && pr.base === "main" && pr.mergeStateStatus === "BLOCKED")
+    .map((pr) => ({
+      number: pr.number,
+      agentName: pr.agentName,
+      agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+      autoMergeArmed: pr.autoMergeArmed,
+      mergeable: pr.mergeable,
+      title: pr.title,
+    }))
+    .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
+  const blockedReadyMainOwnerCounts = [...blockedReadyMainPrs
+    .reduce((counts, pr) => {
+      const owner = pr.agentLabel || pr.agentName || "unowned";
+      counts.set(owner, (counts.get(owner) || 0) + 1);
+      return counts;
+    }, new Map())
+    .entries()]
+    .map(([owner, count]) => ({ owner, count }))
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+
   return {
     generatedAt: new Date().toISOString(),
     counts: {
@@ -255,6 +282,8 @@ function makeReport(pulls) {
     duplicateTitleScopes,
     duplicateIssueRefs,
     duplicateDraftCleanupTargets,
+    blockedReadyMainPrs,
+    blockedReadyMainOwnerCounts,
     agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
@@ -315,6 +344,24 @@ function printMarkdown(report) {
           duplicate.unstackedDraftCount
         }): ${duplicate.prs.map((pr) => prSummary(report, pr, "PR #")).join(", ")}`,
       );
+    }
+  }
+  console.log("");
+  console.log("## Blocked Ready Main PRs");
+  if (report.blockedReadyMainPrs.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log("Owner counts:");
+    for (const entry of report.blockedReadyMainOwnerCounts) {
+      console.log(`- ${entry.owner}: ${entry.count}`);
+    }
+    console.log("");
+    console.log("PRs:");
+    for (const pr of report.blockedReadyMainPrs) {
+      const owner = pr.agentLabel || pr.agentName || "unowned";
+      const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
+      console.log(`- #${pr.number}: ${owner}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -99,6 +99,18 @@ withTempDir((dir) => {
       labels: ["agent:zeta"],
       body: "AgentName: zeta\n\nAddresses #9694\n",
     },
+    {
+      number: 17,
+      title: "fix(checker): ready but blocked",
+      isDraft: false,
+      baseRefName: "main",
+      headRefName: "agent/blocked-ready",
+      mergeStateStatus: "BLOCKED",
+      mergeable: "MERGEABLE",
+      autoMergeRequest: null,
+      labels: ["agent:epsilon"],
+      body: "AgentName: epsilon\n",
+    },
   ]);
 
   const result = spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, "--json", output], {
@@ -124,19 +136,23 @@ withTempDir((dir) => {
   );
   assert.doesNotMatch(result.stdout, /#42: PR #10 .*PR #11 .*PR #42/);
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
+  assert.match(
+    result.stdout,
+    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1[\s\S]*PRs:[\s\S]*#17: agent:epsilon; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
+  );
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {
-    open: 8,
+    open: 9,
     draft: 7,
-    ready: 1,
+    ready: 2,
     stacked: 2,
     missingAgentName: 2,
     agentLabelMismatches: 1,
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
-    { base: "main", prs: [10, 11, 14, 15, 16, 42] },
+    { base: "main", prs: [10, 11, 14, 15, 16, 17, 42] },
     { base: "unknown-base", prs: [13] },
   ]);
   assert.deepEqual(report.stacks, [
@@ -167,6 +183,17 @@ withTempDir((dir) => {
     },
   ]);
   assert.deepEqual(report.agentLabelMismatches, [{ number: 11, agentName: "beta", label: "agent:omega" }]);
+  assert.deepEqual(report.blockedReadyMainPrs, [
+    {
+      number: 17,
+      agentName: "epsilon",
+      agentLabel: "agent:epsilon",
+      autoMergeArmed: false,
+      mergeable: "MERGEABLE",
+      title: "fix(checker): ready but blocked",
+    },
+  ]);
+  assert.deepEqual(report.blockedReadyMainOwnerCounts, [{ owner: "agent:epsilon", count: 1 }]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
   assert.deepEqual(report.prs.find((pr) => pr.number === 15).issueRefs, [9694, 9712, 9826]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 15).claimedIssueRefs, [9712]);


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A ownership reporting.

## Invariant

Ownership reports should make ready main-based PRs that are blocked from landing visible by owner, without requiring agents to scan the full open PR list manually.

## Scope

- Add `mergeStateStatus`, `mergeable`, and auto-merge metadata to the ownership-report input model.
- Add a `Blocked Ready Main PRs` markdown section and JSON fields for ready main PRs with `mergeStateStatus=BLOCKED`.
- Include owner counts before detailed blocked-ready PR rows.
- Extend the ownership-report fixture coverage for the new section and JSON shape.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change in `scripts/ci/pr-ownership-report.mjs`; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-blocked-ready.json`

## Coordination Notes

- AgentName: M1-A
- Live report currently surfaces 41 blocked ready main PRs by owner, led by `agent:M1-C: 10`, `agent:M4-A: 9`, and `agent:M4-C: 6`. This is read-only reporting; no other lane PR state was changed.
