### PR TITLE
docs(agents): refresh M1-A post-10190 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,8 +24,8 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 01:43 UTC lane refresh:
-  - Direct `agent:M1-A` PR queue is empty after `#10187` merged.
+- 2026-05-26 01:57 UTC lane refresh:
+  - Direct `agent:M1-A` PR queue is empty after `#10190` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
     excess-property check (#8725)`. Its synthetic queue branch
@@ -104,6 +104,11 @@ node scripts/ci/pr-ownership-report.mjs
     Verbose queue-branch cleanup dry runs now include cleanup-specific
     `Skip Reason Counts`, grouping detailed rows such as open PR branches and
     active queue runs without losing per-branch evidence.
+  - `#10190` merged on 2026-05-26 as
+    `a5aac8d71a ci: report blocked ready PR ownership (#10190)`.
+    `scripts/ci/pr-ownership-report.mjs` now includes a `Blocked Ready Main
+    PRs` section with owner counts and JSON fields for ready main-based PRs
+    whose `mergeStateStatus` is `BLOCKED`.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -126,11 +131,11 @@ node scripts/ci/pr-ownership-report.mjs
   - No queue-ready auto-merge PR is currently selected by
     `scripts/ci/poor-mans-merge-queue.mjs --dry-run`; earlier ready PRs are
     either drafts, not auto-merge armed, or already handed off.
-  - Priority ready main-based PRs with `mergeStateStatus=BLOCKED` but
-    `mergeable=MERGEABLE` include `#9632`, `#9912`, `#10078`, `#10081`,
-    `#10084`, `#10087`, `#10126`, and `#10147`. These currently
-    belong to other lanes; do not take them over unless the owner asks or a
-    stale branch needs a signed handoff.
+  - The latest ownership report shows 41 ready main-based PRs with
+    `mergeStateStatus=BLOCKED`; owner counts are led by `agent:M1-C: 10`,
+    `agent:M4-A: 9`, and `agent:M4-C: 6`, with all listed rows currently
+    auto-merge off. Do not take them over unless the owner asks or a stale
+    branch needs a signed handoff.
   - Queue branch cleanup currently skips open PR branches
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
     `pr-9632`, and `pr-9912`. Recent cleanup dry runs report zero stale


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A goal file should record the latest landed ownership-report surface and current queue cleanup state for the next cycle.

## Scope

- Refresh `docs/plan/agents/M1-A.md` after #10190 merged.
- Record that direct M1-A PR queue is empty again.
- Record the new `Blocked Ready Main PRs` ownership-report section and the current blocked-ready owner-count shape.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-post-10190-doc.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose > /tmp/m1a-cleanup-post-10190-doc.txt`

## Coordination Notes

- AgentName: M1-A
- #10190 merged as `a5aac8d71a`; this PR only refreshes the lane note for the next M1-A cycle.
