### PR TITLE
ci: report conflicting main PR ownership

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -143,6 +143,18 @@ function draftStackState(draftCount, stackedDraftCount) {
   return "mixed stacked/unstacked drafts";
 }
 
+function ownerCounts(prs) {
+  return [...prs
+    .reduce((counts, pr) => {
+      const owner = pr.agentLabel || pr.agentName || "unowned";
+      counts.set(owner, (counts.get(owner) || 0) + 1);
+      return counts;
+    }, new Map())
+    .entries()]
+    .map(([owner, count]) => ({ owner, count }))
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
+
 function makeReport(pulls) {
   const normalized = pulls.map((pr) => ({
     number: pr.number,
@@ -255,15 +267,22 @@ function makeReport(pulls) {
       title: pr.title,
     }))
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
-  const blockedReadyMainOwnerCounts = [...blockedReadyMainPrs
-    .reduce((counts, pr) => {
-      const owner = pr.agentLabel || pr.agentName || "unowned";
-      counts.set(owner, (counts.get(owner) || 0) + 1);
-      return counts;
-    }, new Map())
-    .entries()]
-    .map(([owner, count]) => ({ owner, count }))
-    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+  const blockedReadyMainOwnerCounts = ownerCounts(blockedReadyMainPrs);
+
+  const conflictingMainPrs = normalized
+    .filter((pr) => pr.base === "main" && (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY"))
+    .map((pr) => ({
+      number: pr.number,
+      draft: pr.draft,
+      agentName: pr.agentName,
+      agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+      autoMergeArmed: pr.autoMergeArmed,
+      mergeStateStatus: pr.mergeStateStatus,
+      mergeable: pr.mergeable,
+      title: pr.title,
+    }))
+    .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
+  const conflictingMainOwnerCounts = ownerCounts(conflictingMainPrs);
 
   return {
     generatedAt: new Date().toISOString(),
@@ -284,6 +303,8 @@ function makeReport(pulls) {
     duplicateDraftCleanupTargets,
     blockedReadyMainPrs,
     blockedReadyMainOwnerCounts,
+    conflictingMainPrs,
+    conflictingMainOwnerCounts,
     agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
@@ -362,6 +383,27 @@ function printMarkdown(report) {
       const owner = pr.agentLabel || pr.agentName || "unowned";
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
       console.log(`- #${pr.number}: ${owner}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
+    }
+  }
+  console.log("");
+  console.log("## Conflicting Main PRs");
+  if (report.conflictingMainPrs.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log("Owner counts:");
+    for (const entry of report.conflictingMainOwnerCounts) {
+      console.log(`- ${entry.owner}: ${entry.count}`);
+    }
+    console.log("");
+    console.log("PRs:");
+    for (const pr of report.conflictingMainPrs) {
+      const owner = pr.agentLabel || pr.agentName || "unowned";
+      const state = pr.draft ? "draft" : "ready";
+      const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
+      console.log(
+        `- #${pr.number}: ${owner}; ${state}; ${pr.mergeStateStatus}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`,
+      );
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -111,6 +111,30 @@ withTempDir((dir) => {
       labels: ["agent:epsilon"],
       body: "AgentName: epsilon\n",
     },
+    {
+      number: 18,
+      title: "fix(solver): conflicting ready branch",
+      isDraft: false,
+      baseRefName: "main",
+      headRefName: "agent/conflicting-ready",
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      autoMergeRequest: null,
+      labels: ["agent:zeta"],
+      body: "AgentName: zeta\n",
+    },
+    {
+      number: 19,
+      title: "fix(checker): conflicting draft branch",
+      isDraft: true,
+      baseRefName: "main",
+      headRefName: "agent/conflicting-draft",
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      autoMergeRequest: null,
+      labels: ["agent:delta"],
+      body: "AgentName: delta\n",
+    },
   ]);
 
   const result = spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, "--json", output], {
@@ -140,19 +164,23 @@ withTempDir((dir) => {
     result.stdout,
     /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1[\s\S]*PRs:[\s\S]*#17: agent:epsilon; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
   );
+  assert.match(
+    result.stdout,
+    /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+  );
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {
-    open: 9,
-    draft: 7,
-    ready: 2,
+    open: 11,
+    draft: 8,
+    ready: 3,
     stacked: 2,
     missingAgentName: 2,
     agentLabelMismatches: 1,
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
-    { base: "main", prs: [10, 11, 14, 15, 16, 17, 42] },
+    { base: "main", prs: [10, 11, 14, 15, 16, 17, 18, 19, 42] },
     { base: "unknown-base", prs: [13] },
   ]);
   assert.deepEqual(report.stacks, [
@@ -194,6 +222,32 @@ withTempDir((dir) => {
     },
   ]);
   assert.deepEqual(report.blockedReadyMainOwnerCounts, [{ owner: "agent:epsilon", count: 1 }]);
+  assert.deepEqual(report.conflictingMainPrs, [
+    {
+      number: 19,
+      draft: true,
+      agentName: "delta",
+      agentLabel: "agent:delta",
+      autoMergeArmed: false,
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      title: "fix(checker): conflicting draft branch",
+    },
+    {
+      number: 18,
+      draft: false,
+      agentName: "zeta",
+      agentLabel: "agent:zeta",
+      autoMergeArmed: false,
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      title: "fix(solver): conflicting ready branch",
+    },
+  ]);
+  assert.deepEqual(report.conflictingMainOwnerCounts, [
+    { owner: "agent:delta", count: 1 },
+    { owner: "agent:zeta", count: 1 },
+  ]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
   assert.deepEqual(report.prs.find((pr) => pr.number === 15).issueRefs, [9694, 9712, 9826]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 15).claimedIssueRefs, [9712]);


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The ownership report should make handoff surfaces visible without requiring agents to scan every open PR manually.

## Scope

- Add `Conflicting Main PRs` markdown and JSON output to `scripts/ci/pr-ownership-report.mjs`.
- Reuse owner-count grouping for blocked-ready and conflicting-main report sections.
- Cover ready and draft conflicting main PRs in the ownership-report fixture test.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-conflicting-main.json`

## Coordination Notes

- AgentName: M1-A
- Live report currently surfaces conflicting main PRs #9632, #9820, #9852, #9875, and #9910 for their owning lanes; this PR only reports them and does not take ownership.
