### PR TITLE
docs(agents): refresh M1-A post-10193 state

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -24,7 +24,7 @@ node scripts/ci/pr-ownership-report.mjs
 ## Current Assignment
 
 - Primary lane: PR readiness, stale-WIP cleanup, and ownership label hygiene.
-- 2026-05-26 02:00 UTC lane refresh:
+- 2026-05-26 02:15 UTC lane refresh:
   - Direct `agent:M1-A` PR queue is empty after `#10190` merged.
   - `#9465` landed on 2026-05-25 as
     `839abb594d test(checker): pin Record<TemplateLiteralPattern,V>
@@ -109,6 +109,11 @@ node scripts/ci/pr-ownership-report.mjs
     `scripts/ci/pr-ownership-report.mjs` now includes a `Blocked Ready Main
     PRs` section with owner counts and JSON fields for ready main-based PRs
     whose `mergeStateStatus` is `BLOCKED`.
+  - `#10193` merged on 2026-05-26 as
+    `e115436a07 ci: report conflicting main PR ownership (#10193)`.
+    `scripts/ci/pr-ownership-report.mjs` now includes a `Conflicting Main PRs`
+    section and JSON fields for main-based PRs whose current head is dirty or
+    conflicting, grouped by owner.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -136,6 +141,10 @@ node scripts/ci/pr-ownership-report.mjs
     state asynchronously, so do not freeze the count in the lane note; re-run
     the report for current owner counts and rows. Do not take those PRs over
     unless the owner asks or a stale branch needs a signed handoff.
+  - Use the ownership report's `Conflicting Main PRs` section for the current
+    dirty/conflicting main-based branch surface. Treat those rows as handoff
+    evidence for the owning lane, not permission to take over implementation
+    branches without an explicit request or stale-branch handoff comment.
   - Queue branch cleanup currently skips open PR branches
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
     `pr-9632`, and `pr-9912`. Recent cleanup dry runs report zero stale


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A lane note should describe the latest merged ownership-report surfaces without hardcoding volatile live counts.

## Scope

- Record `#10193` as merged in `docs/plan/agents/M1-A.md`.
- Point future cycles at the new `Conflicting Main PRs` ownership-report section.
- Keep conflict rows as handoff evidence for owner lanes, not takeover permission.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane-state update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`
- `scripts/agents/show-goal.sh M1-A`

## Coordination Notes

- AgentName: M1-A
- `#10193` landed the conflicting-main report section; future cycles should rerun the report for current rows instead of relying on frozen counts.
