### PR TITLE
ci: summarize PR ownership by owner

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -146,13 +146,23 @@ function draftStackState(draftCount, stackedDraftCount) {
 function ownerCounts(prs) {
   return [...prs
     .reduce((counts, pr) => {
-      const owner = pr.agentLabel || pr.agentName || "unowned";
+      const owner = ownerOf(pr);
       counts.set(owner, (counts.get(owner) || 0) + 1);
       return counts;
     }, new Map())
     .entries()]
     .map(([owner, count]) => ({ owner, count }))
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
+
+function ownerOf(pr) {
+  if (pr.agentLabel) {
+    return pr.agentLabel;
+  }
+  if (Array.isArray(pr.agentLabels) && pr.agentLabels.length === 1) {
+    return `agent:${pr.agentLabels[0]}`;
+  }
+  return pr.agentName || "unowned";
 }
 
 function makeReport(pulls) {
@@ -284,6 +294,49 @@ function makeReport(pulls) {
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
   const conflictingMainOwnerCounts = ownerCounts(conflictingMainPrs);
 
+  const ownerSummaries = [...normalized
+    .reduce((summaries, pr) => {
+      const owner = ownerOf(pr);
+      if (!summaries.has(owner)) {
+        summaries.set(owner, {
+          owner,
+          open: 0,
+          ready: 0,
+          draft: 0,
+          wip: 0,
+          stackedChildren: 0,
+          blockedReadyMain: 0,
+          conflictingMain: 0,
+          autoMergeArmed: 0,
+        });
+      }
+      const summary = summaries.get(owner);
+      summary.open += 1;
+      if (pr.draft) {
+        summary.draft += 1;
+      } else {
+        summary.ready += 1;
+      }
+      if (pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title)) {
+        summary.wip += 1;
+      }
+      if (pr.stackRole === "stack child" || pr.stackRole === "stack middle") {
+        summary.stackedChildren += 1;
+      }
+      if (!pr.draft && pr.base === "main" && pr.mergeStateStatus === "BLOCKED") {
+        summary.blockedReadyMain += 1;
+      }
+      if (pr.base === "main" && (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY")) {
+        summary.conflictingMain += 1;
+      }
+      if (pr.autoMergeArmed) {
+        summary.autoMergeArmed += 1;
+      }
+      return summaries;
+    }, new Map())
+    .values()]
+    .sort((a, b) => b.open - a.open || a.owner.localeCompare(b.owner));
+
   return {
     generatedAt: new Date().toISOString(),
     counts: {
@@ -297,6 +350,7 @@ function makeReport(pulls) {
     byBase: [...byBase.entries()]
       .map(([base, prs]) => ({ base, prs: prs.sort((a, b) => a - b) }))
       .sort((a, b) => a.base.localeCompare(b.base)),
+    ownerSummaries,
     stacks,
     duplicateTitleScopes,
     duplicateIssueRefs,
@@ -316,6 +370,22 @@ function printMarkdown(report) {
   console.log(
     `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
   );
+  console.log("");
+  console.log("## Owner Summary");
+  if (report.ownerSummaries.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log(
+      "| Owner | Open | Ready | Draft | WIP | Stacked children | Blocked ready main | Conflicting main | Auto-merge armed |",
+    );
+    console.log("|-------|------|-------|-------|-----|------------------|--------------------|------------------|------------------|");
+    for (const owner of report.ownerSummaries) {
+      console.log(
+        `| ${owner.owner} | ${owner.open} | ${owner.ready} | ${owner.draft} | ${owner.wip} | ${owner.stackedChildren} | ${owner.blockedReadyMain} | ${owner.conflictingMain} | ${owner.autoMergeArmed} |`,
+      );
+    }
+  }
   console.log("");
   console.log("## Base Branches");
   for (const entry of report.byBase) {
@@ -380,7 +450,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("PRs:");
     for (const pr of report.blockedReadyMainPrs) {
-      const owner = pr.agentLabel || pr.agentName || "unowned";
+      const owner = ownerOf(pr);
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
       console.log(`- #${pr.number}: ${owner}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
     }
@@ -398,7 +468,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("PRs:");
     for (const pr of report.conflictingMainPrs) {
-      const owner = pr.agentLabel || pr.agentName || "unowned";
+      const owner = ownerOf(pr);
       const state = pr.draft ? "draft" : "ready";
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
       console.log(

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -144,6 +144,10 @@ withTempDir((dir) => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Open PR Ownership Report/);
   assert.match(result.stdout, /AgentName\/label mismatches: 1/);
+  assert.match(
+    result.stdout,
+    /Owner Summary[\s\S]*\| agent:delta \| 2 \| 0 \| 2 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| agent:zeta \| 2 \| 1 \| 1 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| unowned \| 2 \| 0 \| 2 \| 0 \| 1 \| 0 \| 0 \| 0 \|[\s\S]*\| delta \| 1 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \| 0 \|/,
+  );
   assert.match(result.stdout, /agent\/mapped-a: root #10; children #12/);
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
   assert.match(
@@ -182,6 +186,96 @@ withTempDir((dir) => {
     { base: "agent/mapped-a", prs: [12] },
     { base: "main", prs: [10, 11, 14, 15, 16, 17, 18, 19, 42] },
     { base: "unknown-base", prs: [13] },
+  ]);
+  assert.deepEqual(report.ownerSummaries, [
+    {
+      owner: "agent:delta",
+      open: 2,
+      ready: 0,
+      draft: 2,
+      wip: 0,
+      stackedChildren: 0,
+      blockedReadyMain: 0,
+      conflictingMain: 1,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "agent:zeta",
+      open: 2,
+      ready: 1,
+      draft: 1,
+      wip: 0,
+      stackedChildren: 0,
+      blockedReadyMain: 0,
+      conflictingMain: 1,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "unowned",
+      open: 2,
+      ready: 0,
+      draft: 2,
+      wip: 0,
+      stackedChildren: 1,
+      blockedReadyMain: 0,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "agent:alpha",
+      open: 1,
+      ready: 0,
+      draft: 1,
+      wip: 1,
+      stackedChildren: 0,
+      blockedReadyMain: 0,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "agent:epsilon",
+      open: 1,
+      ready: 1,
+      draft: 0,
+      wip: 0,
+      stackedChildren: 0,
+      blockedReadyMain: 1,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "agent:gamma",
+      open: 1,
+      ready: 1,
+      draft: 0,
+      wip: 0,
+      stackedChildren: 1,
+      blockedReadyMain: 0,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "agent:omega",
+      open: 1,
+      ready: 0,
+      draft: 1,
+      wip: 1,
+      stackedChildren: 0,
+      blockedReadyMain: 0,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
+    {
+      owner: "delta",
+      open: 1,
+      ready: 0,
+      draft: 1,
+      wip: 0,
+      stackedChildren: 0,
+      blockedReadyMain: 0,
+      conflictingMain: 0,
+      autoMergeArmed: 0,
+    },
   ]);
   assert.deepEqual(report.stacks, [
     { base: "agent/mapped-a", root: 10, children: [12] },


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The ownership report should expose owner-level PR workload and handoff signals without requiring agents to scan every detailed section.

## Scope

- Add an `Owner Summary` markdown table to `scripts/ci/pr-ownership-report.mjs`.
- Export `ownerSummaries` JSON with open, ready, draft, WIP, stacked-child, blocked-ready, conflicting-main, and auto-merge counts.
- Reuse owner normalization for existing blocked-ready and conflicting-main sections.
- Extend the ownership-report fixture test for canonical labels, AgentName-only rows, WIP, stacked children, blocked-ready, and conflicting-main counts.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-owner-summary.json`

## Coordination Notes

- AgentName: M1-A
- Live report now surfaces owner workload counts directly; current top rows are M4-A, M1-C, and M4-C. This PR only improves reporting and does not change ownership state.
