### PR TITLE
ci: list WIP PR ownership

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -121,7 +121,7 @@ function prSummary(report, number, prefix = "#") {
     return `${prefix}${number}`;
   }
   const state = pr.draft ? "draft" : "ready";
-  const wip = pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title) ? ", WIP" : "";
+  const wip = isWipPr(pr) ? ", WIP" : "";
   const owner = pr.agentName ?? "no AgentName";
   const stack = pr.stackRole ? `, ${pr.stackRole}` : "";
   return `${prefix}${number} (${state}${wip}, ${owner}${stack})`;
@@ -163,6 +163,21 @@ function ownerOf(pr) {
     return `agent:${pr.agentLabels[0]}`;
   }
   return pr.agentName || "unowned";
+}
+
+function isWipPr(pr) {
+  return pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title);
+}
+
+function wipMarkers(pr) {
+  const markers = [];
+  if (pr.labels.includes("WIP")) {
+    markers.push("label");
+  }
+  if (/^\[wip\]/i.test(pr.title)) {
+    markers.push("title");
+  }
+  return markers;
 }
 
 function makeReport(pulls) {
@@ -294,6 +309,21 @@ function makeReport(pulls) {
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
   const conflictingMainOwnerCounts = ownerCounts(conflictingMainPrs);
 
+  const wipPrs = normalized
+    .filter(isWipPr)
+    .map((pr) => ({
+      number: pr.number,
+      draft: pr.draft,
+      agentName: pr.agentName,
+      agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+      base: pr.base,
+      stackRole: pr.stackRole,
+      markers: wipMarkers(pr),
+      title: pr.title,
+    }))
+    .sort((a, b) => ownerOf(a).localeCompare(ownerOf(b)) || a.number - b.number);
+  const wipOwnerCounts = ownerCounts(wipPrs);
+
   const ownerSummaries = [...normalized
     .reduce((summaries, pr) => {
       const owner = ownerOf(pr);
@@ -317,7 +347,7 @@ function makeReport(pulls) {
       } else {
         summary.ready += 1;
       }
-      if (pr.labels.includes("WIP") || /^\[wip\]/i.test(pr.title)) {
+      if (isWipPr(pr)) {
         summary.wip += 1;
       }
       if (pr.stackRole === "stack child" || pr.stackRole === "stack middle") {
@@ -359,6 +389,8 @@ function makeReport(pulls) {
     blockedReadyMainOwnerCounts,
     conflictingMainPrs,
     conflictingMainOwnerCounts,
+    wipPrs,
+    wipOwnerCounts,
     agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
@@ -474,6 +506,25 @@ function printMarkdown(report) {
       console.log(
         `- #${pr.number}: ${owner}; ${state}; ${pr.mergeStateStatus}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`,
       );
+    }
+  }
+  console.log("");
+  console.log("## WIP PRs");
+  if (report.wipPrs.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log("Owner counts:");
+    for (const entry of report.wipOwnerCounts) {
+      console.log(`- ${entry.owner}: ${entry.count}`);
+    }
+    console.log("");
+    console.log("PRs:");
+    for (const pr of report.wipPrs) {
+      const owner = ownerOf(pr);
+      const state = pr.draft ? "draft" : "ready";
+      const stack = pr.stackRole ? `; ${pr.stackRole}` : "";
+      console.log(`- #${pr.number}: ${owner}; ${state}; ${pr.markers.join("+")}${stack}; ${pr.title}`);
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -172,6 +172,10 @@ withTempDir((dir) => {
     result.stdout,
     /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
+  assert.match(
+    result.stdout,
+    /WIP PRs[\s\S]*Owner counts:[\s\S]*agent:alpha: 1[\s\S]*agent:omega: 1[\s\S]*PRs:[\s\S]*#10: agent:alpha; draft; label; stack root; fix\(checker\): preserve mapped access \(#42\)[\s\S]*#11: agent:omega; draft; label\+title; \[WIP\] fix\(checker\): preserve mapped access \(#42\)/,
+  );
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(report.counts, {
@@ -341,6 +345,32 @@ withTempDir((dir) => {
   assert.deepEqual(report.conflictingMainOwnerCounts, [
     { owner: "agent:delta", count: 1 },
     { owner: "agent:zeta", count: 1 },
+  ]);
+  assert.deepEqual(report.wipPrs, [
+    {
+      number: 10,
+      draft: true,
+      agentName: "alpha",
+      agentLabel: "agent:alpha",
+      base: "main",
+      stackRole: "stack root",
+      markers: ["label"],
+      title: "fix(checker): preserve mapped access (#42)",
+    },
+    {
+      number: 11,
+      draft: true,
+      agentName: "beta",
+      agentLabel: "agent:omega",
+      base: "main",
+      stackRole: null,
+      markers: ["label", "title"],
+      title: "[WIP] fix(checker): preserve mapped access (#42)",
+    },
+  ]);
+  assert.deepEqual(report.wipOwnerCounts, [
+    { owner: "agent:alpha", count: 1 },
+    { owner: "agent:omega", count: 1 },
   ]);
   assert.deepEqual(report.prs.find((pr) => pr.number === 42).issueRefs, []);
   assert.deepEqual(report.prs.find((pr) => pr.number === 15).issueRefs, [9694, 9712, 9826]);


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The ownership report should expose the actual WIP PR rows behind owner-level WIP counts so cleanup agents can inspect and hand off stale WIP state directly.

## Scope

- Add a `WIP PRs` markdown section to `scripts/ci/pr-ownership-report.mjs`.
- Export `wipPrs` and `wipOwnerCounts` JSON fields.
- Show WIP marker source (`label`, `title`, or both), draft/ready state, owner, stack role, and title.
- Extend the ownership-report fixture test for label-only and label+title WIP rows.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-wip-summary.json`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes

- AgentName: M1-A
- Live WIP rows currently surface under M4-A, Studio-C, and Studio-E; this PR only improves reporting and does not change WIP state.
