### PR TITLE
docs(agents): refresh M1-A after WIP report

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -119,6 +119,11 @@ node scripts/ci/pr-ownership-report.mjs
     `scripts/ci/pr-ownership-report.mjs` now includes an `Owner Summary`
     section and `ownerSummaries` JSON with per-owner open, ready, draft, WIP,
     stacked-child, blocked-ready, conflicting-main, and auto-merge counts.
+  - `#10197` merged on 2026-05-26 as
+    `006e6e596f ci: list WIP PR ownership (#10197)`.
+    `scripts/ci/pr-ownership-report.mjs` now includes a `WIP PRs` section and
+    `wipPrs`/`wipOwnerCounts` JSON so cleanup agents can inspect the exact WIP
+    rows behind owner-level WIP counts.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -141,6 +146,8 @@ node scripts/ci/pr-ownership-report.mjs
   - Use the ownership report's `Owner Summary` section for the current
     owner-by-owner workload and handoff view. Counts are live GitHub state and
     should be re-run each cycle, not copied into this lane note.
+  - Use the ownership report's `WIP PRs` section for the current WIP marker
+    rows and owner counts before adding, removing, or handing off WIP state.
   - No queue-ready auto-merge PR is currently selected by
     `scripts/ci/poor-mans-merge-queue.mjs --dry-run`; earlier ready PRs are
     either drafts, not auto-merge armed, or already handed off.


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A lane note should reflect recently landed ownership-report tooling so future cycles inspect the right live PR-garden surfaces.

## Scope

- Record #10197 as merged.
- Point future M1-A cycles at the ownership report's `WIP PRs` section and JSON fields.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only agent-lane note update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`

## Coordination Notes

- AgentName: M1-A
- Follows the landed #10197 reporting change and does not alter PR ownership, WIP state, or queue behavior.
