### PR TITLE
ci: report conflicting ready PR ownership

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -308,6 +308,8 @@ function makeReport(pulls) {
     }))
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
   const conflictingMainOwnerCounts = ownerCounts(conflictingMainPrs);
+  const conflictingReadyMainPrs = conflictingMainPrs.filter((pr) => !pr.draft);
+  const conflictingReadyMainOwnerCounts = ownerCounts(conflictingReadyMainPrs);
 
   const wipPrs = normalized
     .filter(isWipPr)
@@ -387,6 +389,8 @@ function makeReport(pulls) {
     duplicateDraftCleanupTargets,
     blockedReadyMainPrs,
     blockedReadyMainOwnerCounts,
+    conflictingReadyMainPrs,
+    conflictingReadyMainOwnerCounts,
     conflictingMainPrs,
     conflictingMainOwnerCounts,
     wipPrs,
@@ -485,6 +489,26 @@ function printMarkdown(report) {
       const owner = ownerOf(pr);
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
       console.log(`- #${pr.number}: ${owner}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
+    }
+  }
+  console.log("");
+  console.log("## Conflicting Ready Main PRs");
+  if (report.conflictingReadyMainPrs.length === 0) {
+    console.log("- none");
+  } else {
+    console.log("");
+    console.log("Owner counts:");
+    for (const entry of report.conflictingReadyMainOwnerCounts) {
+      console.log(`- ${entry.owner}: ${entry.count}`);
+    }
+    console.log("");
+    console.log("PRs:");
+    for (const pr of report.conflictingReadyMainPrs) {
+      const owner = ownerOf(pr);
+      const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
+      console.log(
+        `- #${pr.number}: ${owner}; ${pr.mergeStateStatus}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`,
+      );
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -174,6 +174,10 @@ withTempDir((dir) => {
   );
   assert.match(
     result.stdout,
+    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#18: agent:zeta; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+  );
+  assert.match(
+    result.stdout,
     /WIP PRs[\s\S]*Owner counts:[\s\S]*agent:alpha: 1[\s\S]*agent:omega: 1[\s\S]*PRs:[\s\S]*#10: agent:alpha; draft; label; stack root; fix\(checker\): preserve mapped access \(#42\)[\s\S]*#11: agent:omega; draft; label\+title; \[WIP\] fix\(checker\): preserve mapped access \(#42\)/,
   );
 
@@ -346,6 +350,19 @@ withTempDir((dir) => {
     { owner: "agent:delta", count: 1 },
     { owner: "agent:zeta", count: 1 },
   ]);
+  assert.deepEqual(report.conflictingReadyMainPrs, [
+    {
+      number: 18,
+      draft: false,
+      agentName: "zeta",
+      agentLabel: "agent:zeta",
+      autoMergeArmed: false,
+      mergeStateStatus: "DIRTY",
+      mergeable: "CONFLICTING",
+      title: "fix(solver): conflicting ready branch",
+    },
+  ]);
+  assert.deepEqual(report.conflictingReadyMainOwnerCounts, [{ owner: "agent:zeta", count: 1 }]);
   assert.deepEqual(report.wipPrs, [
     {
       number: 10,


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

Ready PRs whose main-based branches are dirty or conflicting need a direct handoff surface because they are not landable even when they are non-draft and otherwise look queue-adjacent.

## Scope

- Add a `Conflicting Ready Main PRs` markdown section to `scripts/ci/pr-ownership-report.mjs`.
- Export `conflictingReadyMainPrs` and `conflictingReadyMainOwnerCounts` JSON fields.
- Keep the existing mixed `Conflicting Main PRs` section for full draft/ready context.
- Extend the ownership-report fixture test for the ready-only conflicting subset.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-conflicting-ready.json`

## Coordination Notes

- AgentName: M1-A
- Live report currently surfaces ready conflicting PRs #9632, #9820, and #9910; this PR only improves reporting and does not change ownership, WIP state, auto-merge, or queue behavior.
