### PR TITLE
ci: summarize conflicting ready ownership

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -338,6 +338,7 @@ function makeReport(pulls) {
           wip: 0,
           stackedChildren: 0,
           blockedReadyMain: 0,
+          conflictingReadyMain: 0,
           conflictingMain: 0,
           autoMergeArmed: 0,
         });
@@ -357,6 +358,13 @@ function makeReport(pulls) {
       }
       if (!pr.draft && pr.base === "main" && pr.mergeStateStatus === "BLOCKED") {
         summary.blockedReadyMain += 1;
+      }
+      if (
+        !pr.draft &&
+        pr.base === "main" &&
+        (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY")
+      ) {
+        summary.conflictingReadyMain += 1;
       }
       if (pr.base === "main" && (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY")) {
         summary.conflictingMain += 1;
@@ -413,12 +421,14 @@ function printMarkdown(report) {
   } else {
     console.log("");
     console.log(
-      "| Owner | Open | Ready | Draft | WIP | Stacked children | Blocked ready main | Conflicting main | Auto-merge armed |",
+      "| Owner | Open | Ready | Draft | WIP | Stacked children | Blocked ready main | Conflicting ready | Conflicting main | Auto-merge armed |",
     );
-    console.log("|-------|------|-------|-------|-----|------------------|--------------------|------------------|------------------|");
+    console.log(
+      "|-------|------|-------|-------|-----|------------------|--------------------|-------------------|------------------|------------------|",
+    );
     for (const owner of report.ownerSummaries) {
       console.log(
-        `| ${owner.owner} | ${owner.open} | ${owner.ready} | ${owner.draft} | ${owner.wip} | ${owner.stackedChildren} | ${owner.blockedReadyMain} | ${owner.conflictingMain} | ${owner.autoMergeArmed} |`,
+        `| ${owner.owner} | ${owner.open} | ${owner.ready} | ${owner.draft} | ${owner.wip} | ${owner.stackedChildren} | ${owner.blockedReadyMain} | ${owner.conflictingReadyMain} | ${owner.conflictingMain} | ${owner.autoMergeArmed} |`,
       );
     }
   }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -146,7 +146,7 @@ withTempDir((dir) => {
   assert.match(result.stdout, /AgentName\/label mismatches: 1/);
   assert.match(
     result.stdout,
-    /Owner Summary[\s\S]*\| agent:delta \| 2 \| 0 \| 2 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| agent:zeta \| 2 \| 1 \| 1 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| unowned \| 2 \| 0 \| 2 \| 0 \| 1 \| 0 \| 0 \| 0 \|[\s\S]*\| delta \| 1 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \| 0 \|/,
+    /Owner Summary[\s\S]*\| agent:delta \| 2 \| 0 \| 2 \| 0 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| agent:zeta \| 2 \| 1 \| 1 \| 0 \| 0 \| 0 \| 1 \| 1 \| 0 \|[\s\S]*\| unowned \| 2 \| 0 \| 2 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \|[\s\S]*\| delta \| 1 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \| 0 \| 0 \|/,
   );
   assert.match(result.stdout, /agent\/mapped-a: root #10; children #12/);
   assert.match(result.stdout, /unknown-base: unknown root; children #13/);
@@ -204,6 +204,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 0,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 1,
       autoMergeArmed: 0,
     },
@@ -215,6 +216,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 0,
       blockedReadyMain: 0,
+      conflictingReadyMain: 1,
       conflictingMain: 1,
       autoMergeArmed: 0,
     },
@@ -226,6 +228,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 1,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },
@@ -237,6 +240,7 @@ withTempDir((dir) => {
       wip: 1,
       stackedChildren: 0,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },
@@ -248,6 +252,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 0,
       blockedReadyMain: 1,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },
@@ -259,6 +264,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 1,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },
@@ -270,6 +276,7 @@ withTempDir((dir) => {
       wip: 1,
       stackedChildren: 0,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },
@@ -281,6 +288,7 @@ withTempDir((dir) => {
       wip: 0,
       stackedChildren: 0,
       blockedReadyMain: 0,
+      conflictingReadyMain: 0,
       conflictingMain: 0,
       autoMergeArmed: 0,
     },


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The ownership report's high-level owner summary should expose ready-only conflict blockers so cleanup agents can see which owners have non-draft PRs that still cannot enter the queue.

## Scope

- Add a `Conflicting ready` column to the owner summary table.
- Export `conflictingReadyMain` in each `ownerSummaries` JSON row.
- Preserve the existing `Conflicting main` count for full draft/ready dirty-branch context.
- Extend the ownership-report fixture test for the new owner summary field.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-owner-conflicting-ready.json`

## Coordination Notes

- AgentName: M1-A
- Live owner summary currently reports conflicting-ready counts for M4-A and M4-C. This PR only improves reporting and does not change ownership, WIP state, auto-merge, or queue behavior.
