### PR TITLE
docs(agents): refresh M1-A after owner summary update

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -129,6 +129,10 @@ node scripts/ci/pr-ownership-report.mjs
     `scripts/ci/pr-ownership-report.mjs` now includes a `Conflicting Ready
     Main PRs` section and `conflictingReadyMainPrs`/`conflictingReadyMainOwnerCounts`
     JSON for the ready-only subset of dirty or conflicting main-based PRs.
+  - `#10201` merged on 2026-05-26 as
+    `0b7d82391b ci: summarize conflicting ready ownership (#10201)`.
+    The ownership report's `Owner Summary` now includes a `Conflicting ready`
+    column and `ownerSummaries[].conflictingReadyMain` JSON field.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -150,7 +154,9 @@ node scripts/ci/pr-ownership-report.mjs
     Its stale synthetic branch was cleaned after merge.
   - Use the ownership report's `Owner Summary` section for the current
     owner-by-owner workload and handoff view. Counts are live GitHub state and
-    should be re-run each cycle, not copied into this lane note.
+    should be re-run each cycle, not copied into this lane note. The
+    `Conflicting ready` column is the quick owner-level view of non-draft PRs
+    that still need conflict handoff before queueing.
   - Use the ownership report's `WIP PRs` section for the current WIP marker
     rows and owner counts before adding, removing, or handing off WIP state.
   - No queue-ready auto-merge PR is currently selected by


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

The M1-A lane note should reflect recently landed ownership-report tooling so future cycles inspect the right live PR-garden surfaces.

## Scope

- Record #10201 as merged.
- Point future M1-A cycles at the owner summary's `Conflicting ready` column and JSON field.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: docs-only agent-lane note update; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `git diff --check`

## Coordination Notes

- AgentName: M1-A
- Follows the landed #10201 reporting change and does not alter PR ownership, WIP state, auto-merge, or queue behavior.
