### PR TITLE
ci: show conflicting ready update dates

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -36,6 +36,7 @@ function normalizePr(raw) {
     number: Number(raw.number),
     title: String(raw.title ?? ""),
     isDraft: Boolean(raw.isDraft),
+    updatedAt: raw.updatedAt ? String(raw.updatedAt) : null,
     baseRefName: String(raw.baseRefName || "main"),
     headRefName: String(raw.headRefName || ""),
     mergeStateStatus: String(raw.mergeStateStatus || "UNKNOWN"),
@@ -61,7 +62,7 @@ function loadPulls(fixture) {
       "--limit",
       "500",
       "--json",
-      "number,title,isDraft,baseRefName,headRefName,labels,body,mergeStateStatus,mergeable,autoMergeRequest",
+      "number,title,isDraft,updatedAt,baseRefName,headRefName,labels,body,mergeStateStatus,mergeable,autoMergeRequest",
     ],
     { encoding: "utf8" },
   );
@@ -180,11 +181,16 @@ function wipMarkers(pr) {
   return markers;
 }
 
+function shortDate(value) {
+  return value ? value.slice(0, 10) : "unknown";
+}
+
 function makeReport(pulls) {
   const normalized = pulls.map((pr) => ({
     number: pr.number,
     title: pr.title,
     draft: pr.isDraft,
+    updatedAt: pr.updatedAt,
     base: pr.baseRefName,
     head: pr.headRefName,
     mergeStateStatus: pr.mergeStateStatus,
@@ -302,6 +308,7 @@ function makeReport(pulls) {
       agentName: pr.agentName,
       agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
       autoMergeArmed: pr.autoMergeArmed,
+      updatedAt: pr.updatedAt,
       mergeStateStatus: pr.mergeStateStatus,
       mergeable: pr.mergeable,
       title: pr.title,
@@ -517,7 +524,7 @@ function printMarkdown(report) {
       const owner = ownerOf(pr);
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
       console.log(
-        `- #${pr.number}: ${owner}; ${pr.mergeStateStatus}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`,
+        `- #${pr.number}: ${owner}; updated ${shortDate(pr.updatedAt)}; ${pr.mergeStateStatus}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`,
       );
     }
   }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -115,6 +115,7 @@ withTempDir((dir) => {
       number: 18,
       title: "fix(solver): conflicting ready branch",
       isDraft: false,
+      updatedAt: "2026-05-24T10:20:30Z",
       baseRefName: "main",
       headRefName: "agent/conflicting-ready",
       mergeStateStatus: "DIRTY",
@@ -174,7 +175,7 @@ withTempDir((dir) => {
   );
   assert.match(
     result.stdout,
-    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#18: agent:zeta; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#18: agent:zeta; updated 2026-05-24; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
   assert.match(
     result.stdout,
@@ -339,6 +340,7 @@ withTempDir((dir) => {
       agentName: "delta",
       agentLabel: "agent:delta",
       autoMergeArmed: false,
+      updatedAt: null,
       mergeStateStatus: "DIRTY",
       mergeable: "CONFLICTING",
       title: "fix(checker): conflicting draft branch",
@@ -349,6 +351,7 @@ withTempDir((dir) => {
       agentName: "zeta",
       agentLabel: "agent:zeta",
       autoMergeArmed: false,
+      updatedAt: "2026-05-24T10:20:30Z",
       mergeStateStatus: "DIRTY",
       mergeable: "CONFLICTING",
       title: "fix(solver): conflicting ready branch",
@@ -365,6 +368,7 @@ withTempDir((dir) => {
       agentName: "zeta",
       agentLabel: "agent:zeta",
       autoMergeArmed: false,
+      updatedAt: "2026-05-24T10:20:30Z",
       mergeStateStatus: "DIRTY",
       mergeable: "CONFLICTING",
       title: "fix(solver): conflicting ready branch",


### PR DESCRIPTION
AgentName: M1-A

## Track

PR garden / M1-A lane coordination.

## Invariant

Ready PRs whose main-based branches are dirty or conflicting should show enough handoff context to prioritize stale blockers without opening every PR.

## Scope

- Fetch `updatedAt` in `scripts/ci/pr-ownership-report.mjs`.
- Export `updatedAt` for conflicting main PR JSON rows.
- Show a short `updated YYYY-MM-DD` field in the `Conflicting Ready Main PRs` markdown rows.
- Extend the ownership-report fixture test for the displayed update date and JSON field.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change; no compiler, parser, checker, solver, emitter, LSP, WASM, conformance, or project-corpus behavior changes.

## Verification

- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-conflicting-ready-updated-at.json`

## Coordination Notes

- AgentName: M1-A
- Live report currently shows #9632, #9820, and #9910 in `Conflicting Ready Main PRs`, all last updated on 2026-05-25. This PR only improves reporting and does not change ownership, WIP state, auto-merge, or queue behavior.
