### PR TITLE
ci: show blocked ready update dates

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -294,6 +294,7 @@ function makeReport(pulls) {
       agentName: pr.agentName,
       agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
       autoMergeArmed: pr.autoMergeArmed,
+      updatedAt: pr.updatedAt,
       mergeable: pr.mergeable,
       title: pr.title,
     }))
@@ -505,7 +506,7 @@ function printMarkdown(report) {
     for (const pr of report.blockedReadyMainPrs) {
       const owner = ownerOf(pr);
       const autoMerge = pr.autoMergeArmed ? "auto-merge armed" : "auto-merge off";
-      console.log(`- #${pr.number}: ${owner}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
+      console.log(`- #${pr.number}: ${owner}; updated ${shortDate(pr.updatedAt)}; ${pr.mergeable}; ${autoMerge}; ${pr.title}`);
     }
   }
   console.log("");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -103,6 +103,7 @@ withTempDir((dir) => {
       number: 17,
       title: "fix(checker): ready but blocked",
       isDraft: false,
+      updatedAt: "2026-05-23T09:15:00Z",
       baseRefName: "main",
       headRefName: "agent/blocked-ready",
       mergeStateStatus: "BLOCKED",
@@ -167,7 +168,7 @@ withTempDir((dir) => {
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
   assert.match(
     result.stdout,
-    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1[\s\S]*PRs:[\s\S]*#17: agent:epsilon; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
+    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1[\s\S]*PRs:[\s\S]*#17: agent:epsilon; updated 2026-05-23; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
   );
   assert.match(
     result.stdout,
@@ -328,6 +329,7 @@ withTempDir((dir) => {
       agentName: "epsilon",
       agentLabel: "agent:epsilon",
       autoMergeArmed: false,
+      updatedAt: "2026-05-23T09:15:00Z",
       mergeable: "MERGEABLE",
       title: "fix(checker): ready but blocked",
     },


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership reporting.

## Invariant
Keep active PR handoff state legible without changing compiler behavior, WIP state, labels, or queue selection.

## Scope
- Include `updatedAt` in `blockedReadyMainPrs` JSON rows.
- Print `updated YYYY-MM-DD` in the `Blocked Ready Main PRs` markdown list.
- Extend the ownership report fixture test for the new blocked-ready date field.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-report-only change to `scripts/ci/pr-ownership-report.mjs`; no compiler, conformance, emit, or project-corpus behavior changed.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-blocked-dates.json`

## Coordination Notes
Direct `agent:M1-A` PR queue was empty at cycle start. The live report still shows no AgentName/label mismatches, no duplicate draft cleanup targets, and no WIP comment gaps. This PR only improves stale-handoff visibility for the current blocked-ready surface.
