### PR TITLE
docs(agents): refresh M1-A after blocked-ready dates

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -137,6 +137,11 @@ node scripts/ci/pr-ownership-report.mjs
     `f66f66cef0 ci: show conflicting ready update dates (#10203)`.
     `Conflicting Ready Main PRs` rows now show `updated YYYY-MM-DD`, and
     conflicting-main JSON rows include `updatedAt` for stale-handoff triage.
+  - `#10205` merged on 2026-05-26 as
+    `a7acc60e67 ci: show blocked ready update dates (#10205)`.
+    `Blocked Ready Main PRs` rows now show `updated YYYY-MM-DD`, and
+    blocked-ready JSON rows include `updatedAt` so stale blocked-ready
+    handoffs have the same quick age signal as conflicting-ready handoffs.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -170,7 +175,8 @@ node scripts/ci/pr-ownership-report.mjs
     ready main-based `mergeStateStatus=BLOCKED` surface. GitHub refreshes this
     state asynchronously, so do not freeze the count in the lane note; re-run
     the report for current owner counts and rows. Do not take those PRs over
-    unless the owner asks or a stale branch needs a signed handoff.
+    unless the owner asks or a stale branch needs a signed handoff. The
+    `updated` date in each row is the quick staleness signal.
   - Use the ownership report's `Conflicting Main PRs` section for the current
     dirty/conflicting main-based branch surface. Treat those rows as handoff
     evidence for the owning lane, not permission to take over implementation


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / lane coordination.

## Invariant
Keep the M1-A lane note aligned with landed PR-garden tooling without changing compiler behavior or queue state.

## Scope
- Record that #10205 merged and added blocked-ready update dates to the ownership report.
- Clarify that `Blocked Ready Main PRs` rows now use `updated` as the quick staleness signal.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only update to `docs/plan/agents/M1-A.md`; no compiler, conformance, emit, or project-corpus behavior changed.

## Verification
- `git diff --check`

## Coordination Notes
Direct `agent:M1-A` PR queue is empty after #10205 merged. Post-merge audits showed labels clean, WIP comments clean, no duplicate draft cleanup targets, and no queue-ready auto-merge PR.
