### PR TITLE
ci: show oldest updated owner counts

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -156,6 +156,23 @@ function ownerCounts(prs) {
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
 }
 
+function ownerCountsWithOldestUpdated(prs) {
+  return [...prs
+    .reduce((counts, pr) => {
+      const owner = ownerOf(pr);
+      const current = counts.get(owner) || { count: 0, oldestUpdatedAt: null };
+      current.count += 1;
+      if (pr.updatedAt && (!current.oldestUpdatedAt || pr.updatedAt < current.oldestUpdatedAt)) {
+        current.oldestUpdatedAt = pr.updatedAt;
+      }
+      counts.set(owner, current);
+      return counts;
+    }, new Map())
+    .entries()]
+    .map(([owner, data]) => ({ owner, count: data.count, oldestUpdatedAt: data.oldestUpdatedAt }))
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
+
 function ownerOf(pr) {
   if (pr.agentLabel) {
     return pr.agentLabel;
@@ -183,6 +200,11 @@ function wipMarkers(pr) {
 
 function shortDate(value) {
   return value ? value.slice(0, 10) : "unknown";
+}
+
+function ownerCountSummary(entry) {
+  const oldest = Object.hasOwn(entry, "oldestUpdatedAt") ? ` (oldest updated ${shortDate(entry.oldestUpdatedAt)})` : "";
+  return `${entry.owner}: ${entry.count}${oldest}`;
 }
 
 function makeReport(pulls) {
@@ -299,7 +321,7 @@ function makeReport(pulls) {
       title: pr.title,
     }))
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
-  const blockedReadyMainOwnerCounts = ownerCounts(blockedReadyMainPrs);
+  const blockedReadyMainOwnerCounts = ownerCountsWithOldestUpdated(blockedReadyMainPrs);
 
   const conflictingMainPrs = normalized
     .filter((pr) => pr.base === "main" && (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY"))
@@ -315,9 +337,9 @@ function makeReport(pulls) {
       title: pr.title,
     }))
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
-  const conflictingMainOwnerCounts = ownerCounts(conflictingMainPrs);
+  const conflictingMainOwnerCounts = ownerCountsWithOldestUpdated(conflictingMainPrs);
   const conflictingReadyMainPrs = conflictingMainPrs.filter((pr) => !pr.draft);
-  const conflictingReadyMainOwnerCounts = ownerCounts(conflictingReadyMainPrs);
+  const conflictingReadyMainOwnerCounts = ownerCountsWithOldestUpdated(conflictingReadyMainPrs);
 
   const wipPrs = normalized
     .filter(isWipPr)
@@ -499,7 +521,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.blockedReadyMainOwnerCounts) {
-      console.log(`- ${entry.owner}: ${entry.count}`);
+      console.log(`- ${ownerCountSummary(entry)}`);
     }
     console.log("");
     console.log("PRs:");
@@ -517,7 +539,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.conflictingReadyMainOwnerCounts) {
-      console.log(`- ${entry.owner}: ${entry.count}`);
+      console.log(`- ${ownerCountSummary(entry)}`);
     }
     console.log("");
     console.log("PRs:");
@@ -537,7 +559,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.conflictingMainOwnerCounts) {
-      console.log(`- ${entry.owner}: ${entry.count}`);
+      console.log(`- ${ownerCountSummary(entry)}`);
     }
     console.log("");
     console.log("PRs:");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -129,6 +129,7 @@ withTempDir((dir) => {
       number: 19,
       title: "fix(checker): conflicting draft branch",
       isDraft: true,
+      updatedAt: "2026-05-22T08:00:00Z",
       baseRefName: "main",
       headRefName: "agent/conflicting-draft",
       mergeStateStatus: "DIRTY",
@@ -168,15 +169,15 @@ withTempDir((dir) => {
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
   assert.match(
     result.stdout,
-    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1[\s\S]*PRs:[\s\S]*#17: agent:epsilon; updated 2026-05-23; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
+    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1 \(oldest updated 2026-05-23\)[\s\S]*PRs:[\s\S]*#17: agent:epsilon; updated 2026-05-23; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
   );
   assert.match(
     result.stdout,
-    /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+    /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1 \(oldest updated 2026-05-22\)[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24\)[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
   assert.match(
     result.stdout,
-    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1[\s\S]*PRs:[\s\S]*#18: agent:zeta; updated 2026-05-24; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24\)[\s\S]*PRs:[\s\S]*#18: agent:zeta; updated 2026-05-24; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
   assert.match(
     result.stdout,
@@ -334,7 +335,9 @@ withTempDir((dir) => {
       title: "fix(checker): ready but blocked",
     },
   ]);
-  assert.deepEqual(report.blockedReadyMainOwnerCounts, [{ owner: "agent:epsilon", count: 1 }]);
+  assert.deepEqual(report.blockedReadyMainOwnerCounts, [
+    { owner: "agent:epsilon", count: 1, oldestUpdatedAt: "2026-05-23T09:15:00Z" },
+  ]);
   assert.deepEqual(report.conflictingMainPrs, [
     {
       number: 19,
@@ -342,7 +345,7 @@ withTempDir((dir) => {
       agentName: "delta",
       agentLabel: "agent:delta",
       autoMergeArmed: false,
-      updatedAt: null,
+      updatedAt: "2026-05-22T08:00:00Z",
       mergeStateStatus: "DIRTY",
       mergeable: "CONFLICTING",
       title: "fix(checker): conflicting draft branch",
@@ -360,8 +363,8 @@ withTempDir((dir) => {
     },
   ]);
   assert.deepEqual(report.conflictingMainOwnerCounts, [
-    { owner: "agent:delta", count: 1 },
-    { owner: "agent:zeta", count: 1 },
+    { owner: "agent:delta", count: 1, oldestUpdatedAt: "2026-05-22T08:00:00Z" },
+    { owner: "agent:zeta", count: 1, oldestUpdatedAt: "2026-05-24T10:20:30Z" },
   ]);
   assert.deepEqual(report.conflictingReadyMainPrs, [
     {
@@ -376,7 +379,9 @@ withTempDir((dir) => {
       title: "fix(solver): conflicting ready branch",
     },
   ]);
-  assert.deepEqual(report.conflictingReadyMainOwnerCounts, [{ owner: "agent:zeta", count: 1 }]);
+  assert.deepEqual(report.conflictingReadyMainOwnerCounts, [
+    { owner: "agent:zeta", count: 1, oldestUpdatedAt: "2026-05-24T10:20:30Z" },
+  ]);
   assert.deepEqual(report.wipPrs, [
     {
       number: 10,


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership reporting.

## Invariant
Keep stale PR handoff state visible without changing compiler behavior, WIP state, labels, or queue selection.

## Scope
- Add `oldestUpdatedAt` to blocked-ready, conflicting-ready, and conflicting-main owner-count JSON rows.
- Print `oldest updated YYYY-MM-DD` beside those owner-count rows in the markdown report.
- Extend the ownership report fixture test for the new summary dates.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-report-only change to `scripts/ci/pr-ownership-report.mjs`; no compiler, conformance, emit, or project-corpus behavior changed.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/m1a-ownership-report-oldest-updated.json`

## Coordination Notes
Direct `agent:M1-A` PR queue was empty at cycle start. The live report showed no AgentName/label mismatches, no duplicate draft cleanup targets, no WIP comment gaps, and no queue-ready auto-merge PR. This PR only improves stale-handoff visibility in owner summaries.
