### PR TITLE
docs(agents): refresh M1-A after owner age summary

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -142,6 +142,11 @@ node scripts/ci/pr-ownership-report.mjs
     `Blocked Ready Main PRs` rows now show `updated YYYY-MM-DD`, and
     blocked-ready JSON rows include `updatedAt` so stale blocked-ready
     handoffs have the same quick age signal as conflicting-ready handoffs.
+  - `#10207` merged on 2026-05-26 as
+    `c5108c4623 ci: show oldest updated owner counts (#10207)`.
+    Blocked-ready, conflicting-ready, and conflicting-main owner-count rows now
+    show `oldest updated YYYY-MM-DD`, and their JSON owner-count rows include
+    `oldestUpdatedAt` for owner-level stale-handoff triage.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -164,8 +169,9 @@ node scripts/ci/pr-ownership-report.mjs
   - Use the ownership report's `Owner Summary` section for the current
     owner-by-owner workload and handoff view. Counts are live GitHub state and
     should be re-run each cycle, not copied into this lane note. The
-    `Conflicting ready` column is the quick owner-level view of non-draft PRs
-    that still need conflict handoff before queueing.
+    `Conflicting ready` column is the quick owner-level count of non-draft PRs
+    that still need conflict handoff before queueing; the blocked/conflicting
+    owner-count sections now show oldest-update dates for age triage.
   - Use the ownership report's `WIP PRs` section for the current WIP marker
     rows and owner counts before adding, removing, or handing off WIP state.
   - No queue-ready auto-merge PR is currently selected by


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / lane coordination.

## Invariant
Keep the M1-A lane note aligned with landed PR-garden tooling without changing compiler behavior or queue state.

## Scope
- Record that #10207 merged and added oldest-update owner-count summaries to the ownership report.
- Clarify that blocked/conflicting owner-count sections now show oldest-update dates for age triage.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only update to `docs/plan/agents/M1-A.md`; no compiler, conformance, emit, or project-corpus behavior changed.

## Verification
- `git diff --check`

## Coordination Notes
Direct `agent:M1-A` PR queue is empty after #10207 merged. Post-merge audits showed labels clean, WIP comments clean, no duplicate draft cleanup targets, and no queue-ready auto-merge PR.
