### PR TITLE
ci: show active queue run status

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -244,6 +244,10 @@ export function queueRunIsActive(run) {
   return normalize(run?.status) !== "COMPLETED";
 }
 
+function shortDateTime(value) {
+  return value ? `${String(value).slice(0, 16).replace("T", " ")}Z` : "unknown";
+}
+
 export function activeBranchQueueRun(runs) {
   return (runs || []).find((run) => queueRunIsActive(run)) || null;
 }
@@ -262,6 +266,8 @@ function activePendingQueueRun(repository, pr, options) {
     return {
       ...pendingRun,
       url: run.url || pendingRun.targetUrl,
+      status: run.status || "",
+      startedAt: run.startedAt || run.createdAt || "",
     };
   }
   if (!hasPendingPlaceholderQueueStatus(pr, options.statusContext)) return null;
@@ -270,6 +276,8 @@ function activePendingQueueRun(repository, pr, options) {
   return {
     runId: String(run.databaseId || ""),
     url: run.url,
+    status: run.status || "",
+    startedAt: run.startedAt || run.createdAt || "",
   };
 }
 
@@ -338,7 +346,7 @@ function readWorkflowRun(repository, runId) {
   return runGhJson([
     "run", "view", runId,
     "--repo", repository,
-    "--json", "databaseId,status,conclusion,url",
+    "--json", "databaseId,status,conclusion,url,createdAt,startedAt,updatedAt",
   ]);
 }
 
@@ -348,7 +356,7 @@ function readBranchWorkflowRuns(repository, branch) {
     "--repo", repository,
     "--branch", branch,
     "--limit", "20",
-    "--json", "databaseId,status,conclusion,headSha,url",
+    "--json", "databaseId,status,conclusion,headSha,url,createdAt,startedAt,updatedAt",
   ]);
 }
 
@@ -520,6 +528,8 @@ function cleanupQueueBranches(repository, options) {
             number,
             runId: activeRun.databaseId || null,
             url: activeRun.url || "",
+            status: activeRun.status || "",
+            startedAt: activeRun.startedAt || activeRun.createdAt || "",
           });
           if (options.verbose) {
             skips.push({
@@ -550,6 +560,8 @@ function cleanupQueueBranches(repository, options) {
         number,
         runId: activeRun.databaseId || null,
         url: activeRun.url || "",
+        status: activeRun.status || "",
+        startedAt: activeRun.startedAt || activeRun.createdAt || "",
       });
       if (options.verbose) {
         skips.push({
@@ -812,11 +824,11 @@ export function formatResult(result, options) {
       }
     }
     if (options.verbose && result.activeRuns?.length) {
-      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Run |", "|--------|----|-----|");
+      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Run | Status | Started |", "|--------|----|-----|--------|---------|");
       for (const run of result.activeRuns.slice(0, 50)) {
         const runId = run.runId || "(unknown)";
         const runLink = run.url ? `[${runId}](${run.url})` : runId;
-        lines.push(`| \`${run.branch}\` | #${run.number} | ${runLink} |`);
+        lines.push(`| \`${run.branch}\` | #${run.number} | ${runLink} | ${String(run.status || "unknown").toLowerCase()} | ${shortDateTime(run.startedAt)} |`);
       }
     }
     if (options.verbose && result.skips?.length) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -257,6 +257,8 @@ const cleanupActiveRunFormat = formatResult({
       number: 9515,
       runId: 26423420117,
       url: "https://github.example/runs/26423420117",
+      status: "in_progress",
+      startedAt: "2026-05-26T03:35:21Z",
     },
   ],
   deletions: [],
@@ -280,7 +282,7 @@ assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue
 assert.match(cleanupActiveRunFormat, /### Active Queue Runs/);
 assert.match(
   cleanupActiveRunFormat,
-  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \|/,
+  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \|/,
 );
 assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / queue cleanup reporting.

## Invariant
Keep queue cleanup decisions legible without changing merge selection, WIP state, labels, or compiler behavior.

## Scope
- Include active queue-run `status` and start time in verbose cleanup `Active Queue Runs` rows.
- Request `createdAt`/`startedAt` fields when reading active workflow runs.
- Extend the poor-man merge queue fixture test for the new active-run columns.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-report-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, conformance, emit, or project-corpus behavior changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `GITHUB_REPOSITORY=mohsen1/tsz node scripts/ci/poor-mans-merge-queue.mjs --dry-run --cleanup-superseded-open-queue-branches --verbose`

## Coordination Notes
Direct `agent:M1-A` PR queue was empty at cycle start. The live cleanup dry-run preserved active queue run #26431049328 for #10084; this PR makes the active run status/start visible in the cleanup table.
