### PR TITLE
ci: show owners in queue skip report

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -170,6 +170,10 @@ function labelNames(labels) {
     : [];
 }
 
+function agentLabel(labels) {
+  return labelNames(labels).find((label) => label.startsWith("agent:")) || "";
+}
+
 function normalize(value) {
   return String(value || "").toUpperCase();
 }
@@ -717,7 +721,12 @@ function processOne(repository, options) {
 
   for (const { pr, skipReason } of candidates) {
     if (skipReason) {
-      if (options.verbose) skips.push({ number: pr.number, reason: skipReason, url: pr.url });
+      if (options.verbose) skips.push({
+        number: pr.number,
+        owner: agentLabel(pr.labels),
+        reason: skipReason,
+        url: pr.url,
+      });
       continue;
     }
 
@@ -868,12 +877,12 @@ export function formatResult(result, options) {
     for (const entry of summary) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
     }
-    lines.push("", "### Skips", "", "| PR | Reason |", "|----|--------|");
+    lines.push("", "### Skips", "", "| PR | Owner | Reason |", "|----|-------|--------|");
     for (const skip of result.skips.slice(0, 25)) {
-      lines.push(`| #${skip.number} | ${skip.reason.replace(/\|/g, "\\|")} |`);
+      lines.push(`| #${skip.number} | ${skip.owner || "(none)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
     }
     if (result.skips.length > 25) {
-      lines.push(`| ... | ${result.skips.length - 25} more skipped PR(s) omitted |`);
+      lines.push(`| ... |  | ${result.skips.length - 25} more skipped PR(s) omitted |`);
     }
   }
   return `${lines.join("\n")}\n`;

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -293,13 +293,16 @@ const queueSkipFormat = formatResult({
   selected: null,
   skips: Array.from({ length: 27 }, (_, index) => ({
     number: index + 1,
+    owner: index % 2 === 0 ? "agent:M1-A" : "agent:M4-B",
     reason: index % 3 === 0 ? "draft PR" : "auto-merge is not armed",
   })),
 }, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
 assert.match(queueSkipFormat, /### Skip Reason Counts/);
 assert.match(queueSkipFormat, /\| 18 \| auto-merge is not armed \|/);
 assert.match(queueSkipFormat, /\| 9 \| draft PR \|/);
-assert.match(queueSkipFormat, /\| \.\.\. \| 2 more skipped PR\(s\) omitted \|/);
+assert.match(queueSkipFormat, /\| PR \| Owner \| Reason \|/);
+assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
+assert.match(queueSkipFormat, /\| \.\.\. \|  \| 2 more skipped PR\(s\) omitted \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Queue dry-runs must make skipped PR ownership visible without changing queue selection, status posting, or merge behavior.

## Scope
- Add the canonical `agent:*` owner label to verbose poor-man merge queue skipped-PR rows.
- Preserve existing skip reason counts and selection behavior.
- Extend the focused queue script test to cover the owner column and omitted-row formatting.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`

## Coordination Notes
- Live dry-run still reports no queue-ready auto-merge PR.
- The skip table now shows owner labels, making the current 44 auto-merge-off and 16 draft skips easier to hand off by lane.
