### PR TITLE
ci: show owners in cleanup queue skips

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -407,6 +407,15 @@ function readPullRequestState(repository, number) {
   ]);
 }
 
+function readPullRequestOwner(repository, number) {
+  const pr = runGhJson([
+    "pr", "view", String(number),
+    "--repo", repository,
+    "--json", "labels",
+  ]);
+  return agentLabel(pr.labels);
+}
+
 function deleteRemoteBranch(branch) {
   git(["push", "origin", `:refs/heads/${branch}`], { stdio: "inherit" });
 }
@@ -520,6 +529,7 @@ function cleanupQueueBranches(repository, options) {
 
     const pullRequest = readPullRequestState(repository, number);
     if (String(pullRequest.state || "").toUpperCase() === "OPEN") {
+      const owner = readPullRequestOwner(repository, number);
       const supersededReason = options.cleanupSupersededOpenQueueBranches
         ? supersededOpenQueueBranchReason(queueBranchInfo.branch, currentBaseOid, options.queueBranchPrefix)
         : null;
@@ -530,6 +540,7 @@ function cleanupQueueBranches(repository, options) {
           activeRuns.push({
             branch: queueBranchInfo.branch,
             number,
+            owner,
             runId: activeRun.databaseId || null,
             url: activeRun.url || "",
             status: activeRun.status || "",
@@ -538,6 +549,7 @@ function cleanupQueueBranches(repository, options) {
           if (options.verbose) {
             skips.push({
               branch: queueBranchInfo.branch,
+              owner,
               reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
               summaryReason: "active queue run",
             });
@@ -548,6 +560,7 @@ function cleanupQueueBranches(repository, options) {
         if (options.verbose) {
           skips.push({
             branch: queueBranchInfo.branch,
+            owner,
             reason: `PR #${number} is open`,
             summaryReason: "open PR branch",
           });
@@ -562,6 +575,7 @@ function cleanupQueueBranches(repository, options) {
       activeRuns.push({
         branch: queueBranchInfo.branch,
         number,
+        owner: "",
         runId: activeRun.databaseId || null,
         url: activeRun.url || "",
         status: activeRun.status || "",
@@ -570,6 +584,7 @@ function cleanupQueueBranches(repository, options) {
       if (options.verbose) {
         skips.push({
           branch: queueBranchInfo.branch,
+          owner: "",
           reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
           summaryReason: "active queue run",
         });
@@ -833,11 +848,11 @@ export function formatResult(result, options) {
       }
     }
     if (options.verbose && result.activeRuns?.length) {
-      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Run | Status | Started |", "|--------|----|-----|--------|---------|");
+      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Owner | Run | Status | Started |", "|--------|----|-------|-----|--------|---------|");
       for (const run of result.activeRuns.slice(0, 50)) {
         const runId = run.runId || "(unknown)";
         const runLink = run.url ? `[${runId}](${run.url})` : runId;
-        lines.push(`| \`${run.branch}\` | #${run.number} | ${runLink} | ${String(run.status || "unknown").toLowerCase()} | ${shortDateTime(run.startedAt)} |`);
+        lines.push(`| \`${run.branch}\` | #${run.number} | ${run.owner || "(unknown)"} | ${runLink} | ${String(run.status || "unknown").toLowerCase()} | ${shortDateTime(run.startedAt)} |`);
       }
     }
     if (options.verbose && result.skips?.length) {
@@ -846,12 +861,12 @@ export function formatResult(result, options) {
       for (const entry of summary) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
-      lines.push("", "### Skips", "", "| Branch | Reason |", "|--------|--------|");
+      lines.push("", "### Skips", "", "| Branch | Owner | Reason |", "|--------|-------|--------|");
       for (const skip of result.skips.slice(0, 50)) {
-        lines.push(`| \`${skip.branch}\` | ${skip.reason.replace(/\|/g, "\\|")} |`);
+        lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
       }
       if (result.skips.length > 50) {
-        lines.push(`| ... | ${result.skips.length - 50} more skipped branch(es) omitted |`);
+        lines.push(`| ... |  | ${result.skips.length - 50} more skipped branch(es) omitted |`);
       }
     }
   } else if (!result.selected) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -255,6 +255,7 @@ const cleanupActiveRunFormat = formatResult({
     {
       branch: "automation/merge-queue/pr-9515",
       number: 9515,
+      owner: "agent:M4-A",
       runId: 26423420117,
       url: "https://github.example/runs/26423420117",
       status: "in_progress",
@@ -270,11 +271,22 @@ const cleanupActiveRunFormat = formatResult({
   skips: [
     {
       branch: "automation/merge-queue/pr-9515",
+      owner: "agent:M4-A",
       reason: "active queue run 26423420117",
       summaryReason: "active queue run",
     },
-    { branch: "automation/merge-queue/pr-9632", reason: "PR #9632 is open", summaryReason: "open PR branch" },
-    { branch: "automation/merge-queue/pr-9912", reason: "PR #9912 is open", summaryReason: "open PR branch" },
+    {
+      branch: "automation/merge-queue/pr-9632",
+      owner: "agent:M4-A",
+      reason: "PR #9632 is open",
+      summaryReason: "open PR branch",
+    },
+    {
+      branch: "automation/merge-queue/pr-9912",
+      owner: "agent:M4-C",
+      reason: "PR #9912 is open",
+      summaryReason: "open PR branch",
+    },
   ],
   wouldDelete: 0,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
@@ -282,12 +294,14 @@ assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue
 assert.match(cleanupActiveRunFormat, /### Active Queue Runs/);
 assert.match(
   cleanupActiveRunFormat,
-  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \|/,
+  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| agent:M4-A \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \|/,
 );
 assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);
 assert.match(cleanupActiveRunFormat, /\| 1 \| active queue run \|/);
-assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| active queue run 26423420117 \|/);
+assert.match(cleanupActiveRunFormat, /\| Branch \| Owner \| Reason \|/);
+assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| agent:M4-A \| active queue run 26423420117 \|/);
+assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9912` \| agent:M4-C \| PR #9912 is open \|/);
 
 const queueSkipFormat = formatResult({
   selected: null,


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue cleanup reporting

## Invariant
Queue branch cleanup dry-runs should identify the owning lane for preserved open queue branches without changing deletion, queue selection, status posting, or merge behavior.

## Scope
- Add the canonical `agent:*` owner label to verbose queue-branch cleanup skip rows.
- Add the owner label to active queue-run rows for open PR queue branches.
- Preserve existing skip reason counts, deletion decisions, and active-run preservation behavior.
- Extend the focused queue script test for the owner columns.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`

## Coordination Notes
- Live cleanup dry-run still reports zero stale queue branches to delete.
- The open queue branch skip rows now show owner labels for direct handoff by lane.
