### PR TITLE
docs(agents): refresh M1-A after cleanup owner report

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -157,6 +157,11 @@ node scripts/ci/pr-ownership-report.mjs
     Verbose queue dry runs now include the canonical `agent:*` owner label in
     skipped-PR rows, so `auto-merge off` and `draft PR` blocks can be handed
     off by lane without cross-referencing the ownership report.
+  - `#10213` merged on 2026-05-26 as
+    `93c86a9b1f ci: show owners in cleanup queue skips (#10213)`.
+    Verbose queue-branch cleanup dry runs now include owner labels in
+    preserved open-branch and active-run rows, so cleanup blockers can be
+    handed off by lane from the cleanup report alone.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -206,10 +211,10 @@ node scripts/ci/pr-ownership-report.mjs
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
     `pr-9632`, and `pr-9912`. Recent cleanup dry runs report zero stale
     branches and group the six preserved branches as open PR branch skips or
-    active queue runs with status/start time; the exact active-run subset
-    changes as synthetic runs complete, so re-run the cleanup dry-run for
-    current run ids and ages. The stale merged-PR queue branches for `#9848`,
-    `#9889`, `#10160`, and `#10163` were deleted.
+    active queue runs with owner labels and status/start time; the exact
+    active-run subset changes as synthetic runs complete, so re-run the
+    cleanup dry-run for current owners, run ids, and ages. The stale merged-PR
+    queue branches for `#9848`, `#9889`, `#10160`, and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / lane coordination docs

## Invariant
The M1-A lane note should reflect newly landed queue-cleanup reporting affordances so later cycles can use the current tooling without rediscovery.

## Scope
- Record #10213 as merged in the M1-A lane history.
- Note that verbose queue-branch cleanup dry-runs now include owner labels for preserved open branches and active runs.
- Keep the existing live-count guidance intact; no frozen queue counts added.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only update to `docs/plan/agents/M1-A.md`.

## Verification
- `git diff --check`

## Coordination Notes
- Follow-up to #10213 after it merged as `93c86a9b1f`.
- No compiler or CI script behavior changes in this PR.
