### PR TITLE
ci: summarize queue skip owners

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -470,6 +470,17 @@ export function skipReasonCounts(skips) {
     .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
 }
 
+export function skipOwnerCounts(skips) {
+  const counts = new Map();
+  for (const skip of skips || []) {
+    const owner = String(skip.owner || "(unknown)");
+    counts.set(owner, (counts.get(owner) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([owner, count]) => ({ owner, count }))
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
+
 function invalidatePullRequest(repository, pr, options) {
   if (options.dryRun) return { invalidated: false, skipped: false };
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
@@ -861,6 +872,11 @@ export function formatResult(result, options) {
       for (const entry of summary) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
+      const ownerSummary = skipOwnerCounts(result.skips);
+      lines.push("", "### Skip Owner Counts", "", "| Count | Owner |", "|-------|-------|");
+      for (const entry of ownerSummary) {
+        lines.push(`| ${entry.count} | ${entry.owner.replace(/\|/g, "\\|")} |`);
+      }
       lines.push("", "### Skips", "", "| Branch | Owner | Reason |", "|--------|-------|--------|");
       for (const skip of result.skips.slice(0, 50)) {
         lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
@@ -891,6 +907,11 @@ export function formatResult(result, options) {
     lines.push("", "### Skip Reason Counts", "", "| Count | Reason |", "|-------|--------|");
     for (const entry of summary) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
+    }
+    const ownerSummary = skipOwnerCounts(result.skips);
+    lines.push("", "### Skip Owner Counts", "", "| Count | Owner |", "|-------|-------|");
+    for (const entry of ownerSummary) {
+      lines.push(`| ${entry.count} | ${entry.owner.replace(/\|/g, "\\|")} |`);
     }
     lines.push("", "### Skips", "", "| PR | Owner | Reason |", "|----|-------|--------|");
     for (const skip of result.skips.slice(0, 25)) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -13,6 +13,7 @@ import {
   queueRunIsActive,
   queueSkipReason,
   requiredCheckState,
+  skipOwnerCounts,
   skipReasonCounts,
   supersededOpenQueueBranchReason,
 } from "./poor-mans-merge-queue.mjs";
@@ -209,6 +210,17 @@ assert.deepEqual(
     { reason: "active queue run", count: 1 },
   ],
 );
+assert.deepEqual(
+  skipOwnerCounts([
+    { owner: "agent:M4-A", reason: "draft PR" },
+    { owner: "agent:M4-B", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
+  ]),
+  [
+    { owner: "agent:M4-A", count: 2 },
+    { owner: "agent:M4-B", count: 1 },
+  ],
+);
 assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
 assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
@@ -299,6 +311,9 @@ assert.match(
 assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);
 assert.match(cleanupActiveRunFormat, /\| 1 \| active queue run \|/);
+assert.match(cleanupActiveRunFormat, /### Skip Owner Counts/);
+assert.match(cleanupActiveRunFormat, /\| 2 \| agent:M4-A \|/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M4-C \|/);
 assert.match(cleanupActiveRunFormat, /\| Branch \| Owner \| Reason \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| agent:M4-A \| active queue run 26423420117 \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9912` \| agent:M4-C \| PR #9912 is open \|/);
@@ -314,6 +329,9 @@ const queueSkipFormat = formatResult({
 assert.match(queueSkipFormat, /### Skip Reason Counts/);
 assert.match(queueSkipFormat, /\| 18 \| auto-merge is not armed \|/);
 assert.match(queueSkipFormat, /\| 9 \| draft PR \|/);
+assert.match(queueSkipFormat, /### Skip Owner Counts/);
+assert.match(queueSkipFormat, /\| 14 \| agent:M1-A \|/);
+assert.match(queueSkipFormat, /\| 13 \| agent:M4-B \|/);
 assert.match(queueSkipFormat, /\| PR \| Owner \| Reason \|/);
 assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| \.\.\. \|  \| 2 more skipped PR\(s\) omitted \|/);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue reports should summarize skipped PR ownership completely even when detailed skip rows are capped, without changing queue selection, status posting, cleanup deletion, or merge behavior.

## Scope
- Add `Skip Owner Counts` summaries to verbose queue dry-run reports.
- Add the same owner summary to verbose queue-branch cleanup skip reports.
- Preserve existing skip reason counts and detailed row caps.
- Extend focused queue script tests for owner-count summaries.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`

## Coordination Notes
- Live reports still show no queue-ready auto-merge PR and zero stale queue branches to delete.
- Owner-count summaries make the capped skip tables actionable by lane.