### PR TITLE
ci: show queue skip owner staleness

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -252,6 +252,10 @@ function shortDateTime(value) {
   return value ? `${String(value).slice(0, 16).replace("T", " ")}Z` : "unknown";
 }
 
+function shortDate(value) {
+  return value ? String(value).slice(0, 10) : "unknown";
+}
+
 export function activeBranchQueueRun(runs) {
   return (runs || []).find((run) => queueRunIsActive(run)) || null;
 }
@@ -320,6 +324,7 @@ function readPullRequests(repository, base, maxPrs) {
       "labels",
       "number",
       "title",
+      "updatedAt",
       "url",
     ].join(","),
   ]);
@@ -341,6 +346,7 @@ function readPullRequest(repository, number) {
       "number",
       "statusCheckRollup",
       "title",
+      "updatedAt",
       "url",
     ].join(","),
   ]);
@@ -474,11 +480,40 @@ export function skipOwnerCounts(skips) {
   const counts = new Map();
   for (const skip of skips || []) {
     const owner = String(skip.owner || "(unknown)");
-    counts.set(owner, (counts.get(owner) || 0) + 1);
+    const current = counts.get(owner) || { count: 0, oldestUpdatedAt: null };
+    current.count += 1;
+    if (skip.updatedAt && (!current.oldestUpdatedAt || skip.updatedAt < current.oldestUpdatedAt)) {
+      current.oldestUpdatedAt = skip.updatedAt;
+    }
+    counts.set(owner, current);
   }
   return [...counts.entries()]
-    .map(([owner, count]) => ({ owner, count }))
+    .map(([owner, data]) => {
+      const entry = { owner, count: data.count };
+      if (data.oldestUpdatedAt) entry.oldestUpdatedAt = data.oldestUpdatedAt;
+      return entry;
+    })
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
+}
+
+function pushSkipOwnerCounts(lines, skips) {
+  const ownerSummary = skipOwnerCounts(skips);
+  const hasOldestUpdated = ownerSummary.some((entry) => entry.oldestUpdatedAt);
+  lines.push(
+    "",
+    "### Skip Owner Counts",
+    "",
+    hasOldestUpdated ? "| Count | Owner | Oldest updated |" : "| Count | Owner |",
+    hasOldestUpdated ? "|-------|-------|----------------|" : "|-------|-------|",
+  );
+  for (const entry of ownerSummary) {
+    const owner = entry.owner.replace(/\|/g, "\\|");
+    if (hasOldestUpdated) {
+      lines.push(`| ${entry.count} | ${owner} | ${shortDate(entry.oldestUpdatedAt)} |`);
+    } else {
+      lines.push(`| ${entry.count} | ${owner} |`);
+    }
+  }
 }
 
 function invalidatePullRequest(repository, pr, options) {
@@ -751,6 +786,7 @@ function processOne(repository, options) {
         number: pr.number,
         owner: agentLabel(pr.labels),
         reason: skipReason,
+        updatedAt: pr.updatedAt,
         url: pr.url,
       });
       continue;
@@ -872,11 +908,7 @@ export function formatResult(result, options) {
       for (const entry of summary) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
-      const ownerSummary = skipOwnerCounts(result.skips);
-      lines.push("", "### Skip Owner Counts", "", "| Count | Owner |", "|-------|-------|");
-      for (const entry of ownerSummary) {
-        lines.push(`| ${entry.count} | ${entry.owner.replace(/\|/g, "\\|")} |`);
-      }
+      pushSkipOwnerCounts(lines, result.skips);
       lines.push("", "### Skips", "", "| Branch | Owner | Reason |", "|--------|-------|--------|");
       for (const skip of result.skips.slice(0, 50)) {
         lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
@@ -908,11 +940,7 @@ export function formatResult(result, options) {
     for (const entry of summary) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
     }
-    const ownerSummary = skipOwnerCounts(result.skips);
-    lines.push("", "### Skip Owner Counts", "", "| Count | Owner |", "|-------|-------|");
-    for (const entry of ownerSummary) {
-      lines.push(`| ${entry.count} | ${entry.owner.replace(/\|/g, "\\|")} |`);
-    }
+    pushSkipOwnerCounts(lines, result.skips);
     lines.push("", "### Skips", "", "| PR | Owner | Reason |", "|----|-------|--------|");
     for (const skip of result.skips.slice(0, 25)) {
       lines.push(`| #${skip.number} | ${skip.owner || "(none)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -221,6 +221,17 @@ assert.deepEqual(
     { owner: "agent:M4-B", count: 1 },
   ],
 );
+assert.deepEqual(
+  skipOwnerCounts([
+    { owner: "agent:M4-A", updatedAt: "2026-05-25T10:00:00Z", reason: "draft PR" },
+    { owner: "agent:M4-B", updatedAt: "2026-05-24T09:00:00Z", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-A", updatedAt: "2026-05-23T08:00:00Z", reason: "auto-merge is not armed" },
+  ]),
+  [
+    { owner: "agent:M4-A", count: 2, oldestUpdatedAt: "2026-05-23T08:00:00Z" },
+    { owner: "agent:M4-B", count: 1, oldestUpdatedAt: "2026-05-24T09:00:00Z" },
+  ],
+);
 assert.match(failureCommentBody("M1-A", "CI Summary failed"), /^AgentName: M1-A\n\nPoor man's merge queue/m);
 assert.throws(() => failureCommentBody("M1-A\nOther", "CI Summary failed"), /single line/);
 
@@ -335,6 +346,18 @@ assert.match(queueSkipFormat, /\| 13 \| agent:M4-B \|/);
 assert.match(queueSkipFormat, /\| PR \| Owner \| Reason \|/);
 assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| \.\.\. \|  \| 2 more skipped PR\(s\) omitted \|/);
+
+const queueSkipOwnerDateFormat = formatResult({
+  selected: null,
+  skips: [
+    { number: 1, owner: "agent:M1-A", reason: "draft PR", updatedAt: "2026-05-25T10:00:00Z" },
+    { number: 2, owner: "agent:M1-A", reason: "auto-merge is not armed", updatedAt: "2026-05-23T08:00:00Z" },
+    { number: 3, owner: "agent:M4-B", reason: "auto-merge is not armed", updatedAt: "2026-05-24T09:00:00Z" },
+  ],
+}, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
+assert.match(queueSkipOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
+assert.match(queueSkipOwnerDateFormat, /\| 2 \| agent:M1-A \| 2026-05-23 \|/);
+assert.match(queueSkipOwnerDateFormat, /\| 1 \| agent:M4-B \| 2026-05-24 \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue reports should identify not only which owner lanes are blocked, but also the oldest skipped PR update date for each lane when PR timestamp data is available. Queue selection, status posting, cleanup deletion, and merge behavior must remain unchanged.

## Scope
- Include `updatedAt` when reading queue PRs for skipped-PR reporting.
- Extend `Skip Owner Counts` to show `Oldest updated` for PR skip summaries that have timestamps.
- Keep queue-branch cleanup owner summaries stable when branch skips do not have PR update timestamps.
- Extend focused queue script tests for timestamped owner summaries.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- Live queue dry-run still shows no queue-ready auto-merge PR.
- Owner summaries now show stale owner lanes directly; cleanup branch summaries continue to show owner counts without dates.