### PR TITLE
ci: show cleanup skip owner staleness

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -409,7 +409,7 @@ function readPullRequestState(repository, number) {
     "api",
     `repos/${repository}/pulls/${number}`,
     "--jq",
-    "{number: .number, state: .state, merged: (.merged_at != null)}",
+    "{number: .number, state: .state, merged: (.merged_at != null), updatedAt: .updated_at}",
   ]);
 }
 
@@ -598,6 +598,7 @@ function cleanupQueueBranches(repository, options) {
               owner,
               reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
               summaryReason: "active queue run",
+              updatedAt: pullRequest.updatedAt || "",
             });
           }
           continue;
@@ -609,6 +610,7 @@ function cleanupQueueBranches(repository, options) {
             owner,
             reason: `PR #${number} is open`,
             summaryReason: "open PR branch",
+            updatedAt: pullRequest.updatedAt || "",
           });
         }
         continue;

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -329,6 +329,44 @@ assert.match(cleanupActiveRunFormat, /\| Branch \| Owner \| Reason \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| agent:M4-A \| active queue run 26423420117 \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9912` \| agent:M4-C \| PR #9912 is open \|/);
 
+const cleanupOwnerDateFormat = formatResult({
+  cleanupQueueBranches: true,
+  activeRuns: [],
+  deletions: [],
+  dryRun: true,
+  skippedActiveRuns: 0,
+  skippedOpen: 3,
+  skippedUnrecognized: 0,
+  supersededOpen: 0,
+  skips: [
+    {
+      branch: "automation/merge-queue/pr-9515",
+      owner: "agent:M4-A",
+      reason: "PR #9515 is open",
+      summaryReason: "open PR branch",
+      updatedAt: "2026-05-25T10:00:00Z",
+    },
+    {
+      branch: "automation/merge-queue/pr-9632",
+      owner: "agent:M4-A",
+      reason: "PR #9632 is open",
+      summaryReason: "open PR branch",
+      updatedAt: "2026-05-24T09:00:00Z",
+    },
+    {
+      branch: "automation/merge-queue/pr-9912",
+      owner: "agent:M4-C",
+      reason: "PR #9912 is open",
+      summaryReason: "open PR branch",
+      updatedAt: "2026-05-23T08:00:00Z",
+    },
+  ],
+  wouldDelete: 0,
+}, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
+assert.match(cleanupOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
+assert.match(cleanupOwnerDateFormat, /\| 2 \| agent:M4-A \| 2026-05-24 \|/);
+assert.match(cleanupOwnerDateFormat, /\| 1 \| agent:M4-C \| 2026-05-23 \|/);
+
 const queueSkipFormat = formatResult({
   selected: null,
   skips: Array.from({ length: 27 }, (_, index) => ({


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue cleanup reporting

## Invariant
Verbose queue-branch cleanup reports should show lane-level stale age for preserved open-PR queue branches when GitHub exposes PR update timestamps, without changing branch deletion, queue selection, status posting, or merge behavior.

## Scope
- Include PR `updated_at` in queue-branch cleanup PR-state reads.
- Carry that timestamp into verbose cleanup skip rows for open PR branches and active open-PR queue runs.
- Reuse the existing `Skip Owner Counts` oldest-updated column when cleanup skips include timestamps.
- Add focused formatter coverage for timestamped cleanup owner summaries.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- Live queue cleanup dry-run still finds zero stale branches to delete.
- Cleanup owner summaries now show oldest-update dates for preserved open PR queue branches.