### PR TITLE
docs(agents): refresh M1-A after cleanup staleness

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -173,6 +173,11 @@ node scripts/ci/pr-ownership-report.mjs
     Verbose queue dry runs now add `Oldest updated` to `Skip Owner Counts`
     when skipped PR timestamp data is available, so owner-level handoffs show
     both volume and stale age without opening each PR.
+  - `#10219` merged on 2026-05-26 as
+    `ff982c14b0 ci: show cleanup skip owner staleness (#10219)`.
+    Verbose queue-branch cleanup dry runs now carry open PR `updated_at` into
+    preserved branch skips, so cleanup `Skip Owner Counts` can also show
+    oldest-update dates for lane-level stale branch handoffs.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -225,9 +230,9 @@ node scripts/ci/pr-ownership-report.mjs
     branches and group the six preserved branches as open PR branch skips or
     active queue runs with owner labels and status/start time; the exact
     active-run subset changes as synthetic runs complete, so re-run the
-    cleanup dry-run for current owner counts, run ids, and ages. The stale
-    merged-PR queue branches for `#9848`, `#9889`, `#10160`, and `#10163` were
-    deleted.
+    cleanup dry-run for current owner counts, oldest-update dates, run ids, and
+    ages. The stale merged-PR queue branches for `#9848`, `#9889`, `#10160`,
+    and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / M1-A lane notes

## Invariant
The M1-A lane note should reflect landed PR-garden reporting changes and current triage surfaces without changing compiler behavior, queue cleanup behavior, or merge behavior.

## Scope
- Record merged #10219 and its queue cleanup skip-owner staleness summary.
- Point future cleanup triage at owner counts with oldest-update dates when available.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only change to `docs/plan/agents/M1-A.md`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, CI execution, or project-corpus behavior changes.

## Verification
- `git diff --check`

## Coordination Notes
- #10219 merged as `ff982c14b0 ci: show cleanup skip owner staleness (#10219)`.
- This keeps the M1-A lane note aligned with the current queue cleanup report output.