### PR TITLE
ci: show queue skip updated dates

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -516,6 +516,54 @@ function pushSkipOwnerCounts(lines, skips) {
   }
 }
 
+function pushCleanupSkipRows(lines, skips) {
+  const hasUpdatedAt = (skips || []).some((skip) => skip.updatedAt);
+  lines.push(
+    "",
+    "### Skips",
+    "",
+    hasUpdatedAt ? "| Branch | Owner | Updated | Reason |" : "| Branch | Owner | Reason |",
+    hasUpdatedAt ? "|--------|-------|---------|--------|" : "|--------|-------|--------|",
+  );
+  for (const skip of skips.slice(0, 50)) {
+    const reason = skip.reason.replace(/\|/g, "\\|");
+    if (hasUpdatedAt) {
+      lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${shortDate(skip.updatedAt)} | ${reason} |`);
+    } else {
+      lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${reason} |`);
+    }
+  }
+  if (skips.length > 50) {
+    lines.push(hasUpdatedAt
+      ? `| ... |  |  | ${skips.length - 50} more skipped branch(es) omitted |`
+      : `| ... |  | ${skips.length - 50} more skipped branch(es) omitted |`);
+  }
+}
+
+function pushQueueSkipRows(lines, skips) {
+  const hasUpdatedAt = (skips || []).some((skip) => skip.updatedAt);
+  lines.push(
+    "",
+    "### Skips",
+    "",
+    hasUpdatedAt ? "| PR | Owner | Updated | Reason |" : "| PR | Owner | Reason |",
+    hasUpdatedAt ? "|----|-------|---------|--------|" : "|----|-------|--------|",
+  );
+  for (const skip of skips.slice(0, 25)) {
+    const reason = skip.reason.replace(/\|/g, "\\|");
+    if (hasUpdatedAt) {
+      lines.push(`| #${skip.number} | ${skip.owner || "(none)"} | ${shortDate(skip.updatedAt)} | ${reason} |`);
+    } else {
+      lines.push(`| #${skip.number} | ${skip.owner || "(none)"} | ${reason} |`);
+    }
+  }
+  if (skips.length > 25) {
+    lines.push(hasUpdatedAt
+      ? `| ... |  |  | ${skips.length - 25} more skipped PR(s) omitted |`
+      : `| ... |  | ${skips.length - 25} more skipped PR(s) omitted |`);
+  }
+}
+
 function invalidatePullRequest(repository, pr, options) {
   if (options.dryRun) return { invalidated: false, skipped: false };
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
@@ -911,13 +959,7 @@ export function formatResult(result, options) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
       pushSkipOwnerCounts(lines, result.skips);
-      lines.push("", "### Skips", "", "| Branch | Owner | Reason |", "|--------|-------|--------|");
-      for (const skip of result.skips.slice(0, 50)) {
-        lines.push(`| \`${skip.branch}\` | ${skip.owner || "(unknown)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
-      }
-      if (result.skips.length > 50) {
-        lines.push(`| ... |  | ${result.skips.length - 50} more skipped branch(es) omitted |`);
-      }
+      pushCleanupSkipRows(lines, result.skips);
     }
   } else if (!result.selected) {
     lines.push("No queue-ready auto-merge PR found.");
@@ -943,13 +985,7 @@ export function formatResult(result, options) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
     }
     pushSkipOwnerCounts(lines, result.skips);
-    lines.push("", "### Skips", "", "| PR | Owner | Reason |", "|----|-------|--------|");
-    for (const skip of result.skips.slice(0, 25)) {
-      lines.push(`| #${skip.number} | ${skip.owner || "(none)"} | ${skip.reason.replace(/\|/g, "\\|")} |`);
-    }
-    if (result.skips.length > 25) {
-      lines.push(`| ... |  | ${result.skips.length - 25} more skipped PR(s) omitted |`);
-    }
+    pushQueueSkipRows(lines, result.skips);
   }
   return `${lines.join("\n")}\n`;
 }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -366,6 +366,8 @@ const cleanupOwnerDateFormat = formatResult({
 assert.match(cleanupOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
 assert.match(cleanupOwnerDateFormat, /\| 2 \| agent:M4-A \| 2026-05-24 \|/);
 assert.match(cleanupOwnerDateFormat, /\| 1 \| agent:M4-C \| 2026-05-23 \|/);
+assert.match(cleanupOwnerDateFormat, /\| Branch \| Owner \| Updated \| Reason \|/);
+assert.match(cleanupOwnerDateFormat, /\| `automation\/merge-queue\/pr-9632` \| agent:M4-A \| 2026-05-24 \| PR #9632 is open \|/);
 
 const queueSkipFormat = formatResult({
   selected: null,
@@ -396,6 +398,8 @@ const queueSkipOwnerDateFormat = formatResult({
 assert.match(queueSkipOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
 assert.match(queueSkipOwnerDateFormat, /\| 2 \| agent:M1-A \| 2026-05-23 \|/);
 assert.match(queueSkipOwnerDateFormat, /\| 1 \| agent:M4-B \| 2026-05-24 \|/);
+assert.match(queueSkipOwnerDateFormat, /\| PR \| Owner \| Updated \| Reason \|/);
+assert.match(queueSkipOwnerDateFormat, /\| #2 \| agent:M1-A \| 2026-05-23 \| auto-merge is not armed \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue reports should preserve per-row staleness evidence in capped skip detail tables when timestamp data is available, without changing queue selection, status posting, branch cleanup deletion, or merge behavior.

## Scope
- Add conditional `Updated` columns to verbose queue skipped-PR detail rows when `updatedAt` is present.
- Add conditional `Updated` columns to verbose queue-branch cleanup skip rows when preserved branch skips carry PR timestamps.
- Preserve the existing two-column/three-column detail tables when timestamps are unavailable.
- Extend focused queue formatter tests for timestamped queue and cleanup details.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- PR #9559 is merged and no longer an active M1-A landing target.
- Live queue dry-run still shows no queue-ready auto-merge PR.
- Detailed skip rows now expose the same date signal as owner summaries when timestamps are available.
