### PR TITLE
ci: show active queue run age

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -256,6 +256,25 @@ function shortDate(value) {
   return value ? String(value).slice(0, 10) : "unknown";
 }
 
+function elapsedAge(startedAt, now) {
+  const startedMs = Date.parse(startedAt || "");
+  const nowMs = Date.parse(now || "");
+  if (!Number.isFinite(startedMs) || !Number.isFinite(nowMs)) return "unknown";
+
+  const totalMinutes = Math.max(0, Math.floor((nowMs - startedMs) / 60_000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (totalHours < 24) {
+    return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
+  }
+
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours ? `${days}d ${hours}h` : `${days}d`;
+}
+
 export function activeBranchQueueRun(runs) {
   return (runs || []).find((run) => queueRunIsActive(run)) || null;
 }
@@ -945,11 +964,18 @@ export function formatResult(result, options) {
       }
     }
     if (options.verbose && result.activeRuns?.length) {
-      lines.push("", "### Active Queue Runs", "", "| Branch | PR | Owner | Run | Status | Started |", "|--------|----|-------|-----|--------|---------|");
+      const now = result.now || new Date().toISOString();
+      lines.push(
+        "",
+        "### Active Queue Runs",
+        "",
+        "| Branch | PR | Owner | Run | Status | Started | Age |",
+        "|--------|----|-------|-----|--------|---------|-----|",
+      );
       for (const run of result.activeRuns.slice(0, 50)) {
         const runId = run.runId || "(unknown)";
         const runLink = run.url ? `[${runId}](${run.url})` : runId;
-        lines.push(`| \`${run.branch}\` | #${run.number} | ${run.owner || "(unknown)"} | ${runLink} | ${String(run.status || "unknown").toLowerCase()} | ${shortDateTime(run.startedAt)} |`);
+        lines.push(`| \`${run.branch}\` | #${run.number} | ${run.owner || "(unknown)"} | ${runLink} | ${String(run.status || "unknown").toLowerCase()} | ${shortDateTime(run.startedAt)} | ${elapsedAge(run.startedAt, now)} |`);
       }
     }
     if (options.verbose && result.skips?.length) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -291,6 +291,7 @@ const cleanupActiveRunFormat = formatResult({
   skippedOpen: 0,
   skippedUnrecognized: 0,
   supersededOpen: 0,
+  now: "2026-05-26T05:05:00Z",
   skips: [
     {
       branch: "automation/merge-queue/pr-9515",
@@ -317,7 +318,7 @@ assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue
 assert.match(cleanupActiveRunFormat, /### Active Queue Runs/);
 assert.match(
   cleanupActiveRunFormat,
-  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| agent:M4-A \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \|/,
+  /\| `automation\/merge-queue\/pr-9515` \| #9515 \| agent:M4-A \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \| 1h 29m \|/,
 );
 assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue-branch cleanup reports should make active synthetic run staleness visible without changing queue selection, status posting, branch cleanup deletion, or merge behavior.

## Scope
- Add an `Age` column to verbose `Active Queue Runs` rows.
- Compute elapsed age from the run `startedAt` timestamp, with `unknown` for missing or invalid timestamps.
- Keep the age calculation deterministic in formatter tests by injecting a fixed `now` value.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- Direct `agent:M1-A` PR queue was empty at cycle start.
- Live queue dry-run still showed no queue-ready auto-merge PR.
- The cleanup dry-run now exposes active queue-run elapsed age next to started time for stale-run handoff.
