### PR TITLE
docs(agents): refresh M1-A after active run age

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -184,6 +184,11 @@ node scripts/ci/pr-ownership-report.mjs
     `Updated` columns in capped skip detail tables when timestamp data is
     available, so individual stale rows can be handed off without opening each
     PR.
+  - `#10223` merged on 2026-05-26 as
+    `49100cecf9 ci: show active queue run age (#10223)`.
+    Verbose queue-branch cleanup dry runs now add an `Age` column to
+    `Active Queue Runs`, so stale in-progress or queued synthetic runs can be
+    spotted from the cleanup report.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -235,7 +240,7 @@ node scripts/ci/pr-ownership-report.mjs
     `automation/merge-queue/pr-10078`, `pr-10084`, `pr-10147`, `pr-9515`,
     `pr-9632`, and `pr-9912`. Recent cleanup dry runs report zero stale
     branches and group the six preserved branches as open PR branch skips or
-    active queue runs with owner labels and status/start time; the exact
+    active queue runs with owner labels, status, start time, and age; the exact
     active-run subset changes as synthetic runs complete, so re-run the
     cleanup dry-run for current owner counts, oldest-update dates, run ids, and
     ages. Detailed cleanup skip rows also include per-row updated dates when


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / coordination notes

## Invariant
The M1-A lane note should describe durable queue-reporting surfaces that future cycles rely on, without changing compiler behavior or queue execution.

## Scope
- Record merged PR #10223 in the M1-A lane refresh list.
- Update queue cleanup guidance to mention active queue-run age in the verbose cleanup report.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane note update under `docs/plan/agents/M1-A.md`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`

## Coordination Notes
- Follows #10223, which merged as `49100cecf9 ci: show active queue run age`.
- Direct `agent:M1-A` PR queue was empty at cycle start.
