### PR TITLE
ci: summarize skip reasons by owner

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -515,6 +515,20 @@ export function skipOwnerCounts(skips) {
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner));
 }
 
+export function skipOwnerReasonCounts(skips) {
+  const counts = new Map();
+  for (const skip of skips || []) {
+    const owner = String(skip.owner || "(unknown)");
+    const reason = String(skip.summaryReason || skip.reason || "(unknown)");
+    const key = `${owner}\0${reason}`;
+    const current = counts.get(key) || { owner, reason, count: 0 };
+    current.count += 1;
+    counts.set(key, current);
+  }
+  return [...counts.values()]
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner) || a.reason.localeCompare(b.reason));
+}
+
 function pushSkipOwnerCounts(lines, skips) {
   const ownerSummary = skipOwnerCounts(skips);
   const hasOldestUpdated = ownerSummary.some((entry) => entry.oldestUpdatedAt);
@@ -532,6 +546,22 @@ function pushSkipOwnerCounts(lines, skips) {
     } else {
       lines.push(`| ${entry.count} | ${owner} |`);
     }
+  }
+}
+
+function pushSkipOwnerReasonCounts(lines, skips) {
+  const ownerReasonSummary = skipOwnerReasonCounts(skips);
+  lines.push(
+    "",
+    "### Skip Owner Reason Counts",
+    "",
+    "| Count | Owner | Reason |",
+    "|-------|-------|--------|",
+  );
+  for (const entry of ownerReasonSummary) {
+    const owner = entry.owner.replace(/\|/g, "\\|");
+    const reason = entry.reason.replace(/\|/g, "\\|");
+    lines.push(`| ${entry.count} | ${owner} | ${reason} |`);
   }
 }
 
@@ -985,6 +1015,7 @@ export function formatResult(result, options) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
       pushSkipOwnerCounts(lines, result.skips);
+      pushSkipOwnerReasonCounts(lines, result.skips);
       pushCleanupSkipRows(lines, result.skips);
     }
   } else if (!result.selected) {
@@ -1011,6 +1042,7 @@ export function formatResult(result, options) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
     }
     pushSkipOwnerCounts(lines, result.skips);
+    pushSkipOwnerReasonCounts(lines, result.skips);
     pushQueueSkipRows(lines, result.skips);
   }
   return `${lines.join("\n")}\n`;

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -14,6 +14,7 @@ import {
   queueSkipReason,
   requiredCheckState,
   skipOwnerCounts,
+  skipOwnerReasonCounts,
   skipReasonCounts,
   supersededOpenQueueBranchReason,
 } from "./poor-mans-merge-queue.mjs";
@@ -222,6 +223,21 @@ assert.deepEqual(
   ],
 );
 assert.deepEqual(
+  skipOwnerReasonCounts([
+    { owner: "agent:M4-A", reason: "draft PR" },
+    { owner: "agent:M4-B", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-B", reason: "PR #10084 is open", summaryReason: "open PR branch" },
+  ]),
+  [
+    { owner: "agent:M4-A", reason: "auto-merge is not armed", count: 2 },
+    { owner: "agent:M4-A", reason: "draft PR", count: 1 },
+    { owner: "agent:M4-B", reason: "auto-merge is not armed", count: 1 },
+    { owner: "agent:M4-B", reason: "open PR branch", count: 1 },
+  ],
+);
+assert.deepEqual(
   skipOwnerCounts([
     { owner: "agent:M4-A", updatedAt: "2026-05-25T10:00:00Z", reason: "draft PR" },
     { owner: "agent:M4-B", updatedAt: "2026-05-24T09:00:00Z", reason: "auto-merge is not armed" },
@@ -326,6 +342,9 @@ assert.match(cleanupActiveRunFormat, /\| 1 \| active queue run \|/);
 assert.match(cleanupActiveRunFormat, /### Skip Owner Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| agent:M4-A \|/);
 assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M4-C \|/);
+assert.match(cleanupActiveRunFormat, /### Skip Owner Reason Counts/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M4-A \| active queue run \|/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M4-A \| open PR branch \|/);
 assert.match(cleanupActiveRunFormat, /\| Branch \| Owner \| Reason \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9515` \| agent:M4-A \| active queue run 26423420117 \|/);
 assert.match(cleanupActiveRunFormat, /\| `automation\/merge-queue\/pr-9912` \| agent:M4-C \| PR #9912 is open \|/);
@@ -384,6 +403,9 @@ assert.match(queueSkipFormat, /\| 9 \| draft PR \|/);
 assert.match(queueSkipFormat, /### Skip Owner Counts/);
 assert.match(queueSkipFormat, /\| 14 \| agent:M1-A \|/);
 assert.match(queueSkipFormat, /\| 13 \| agent:M4-B \|/);
+assert.match(queueSkipFormat, /### Skip Owner Reason Counts/);
+assert.match(queueSkipFormat, /\| 9 \| agent:M4-B \| auto-merge is not armed \|/);
+assert.match(queueSkipFormat, /\| 5 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| PR \| Owner \| Reason \|/);
 assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| \.\.\. \|  \| 2 more skipped PR\(s\) omitted \|/);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue reports should make each lane's blocker type visible without changing queue selection, status posting, branch cleanup deletion, or merge behavior.

## Scope
- Add a `Skip Owner Reason Counts` table to verbose queue skipped-PR reports.
- Add the same owner/reason breakdown to verbose queue-branch cleanup skip reports.
- Keep the existing reason totals, owner totals, and capped detail rows intact.
- Add focused formatter tests for the owner/reason cross-tab and rendered tables.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- Direct `agent:M1-A` PR queue was empty at cycle start.
- Live queue dry-run still showed no queue-ready auto-merge PR.
- The new table separates per-lane blockers such as `draft PR`, `auto-merge is not armed`, `active queue run`, and `open PR branch`.
