### PR TITLE
docs(agents): refresh M1-A after owner reason counts

### DIFF
--- a/docs/plan/agents/M1-A.md
+++ b/docs/plan/agents/M1-A.md
@@ -189,6 +189,11 @@ node scripts/ci/pr-ownership-report.mjs
     Verbose queue-branch cleanup dry runs now add an `Age` column to
     `Active Queue Runs`, so stale in-progress or queued synthetic runs can be
     spotted from the cleanup report.
+  - `#10225` merged on 2026-05-26 as
+    `e4c078cbf4 ci: summarize skip reasons by owner (#10225)`.
+    Verbose queue and queue-branch cleanup dry runs now include
+    `Skip Owner Reason Counts`, so each lane can see whether its blockers are
+    drafts, auto-merge-off PRs, active queue runs, or open queue branches.
   - `#10156` merged the queue-cleanup improvement. The cleanup tool may now
     delete superseded suffixed queue branches for open PRs when the suffix no
     longer matches current `main`.
@@ -220,9 +225,10 @@ node scripts/ci/pr-ownership-report.mjs
     `scripts/ci/poor-mans-merge-queue.mjs --dry-run`; earlier ready PRs are
     either drafts, not auto-merge armed, or already handed off. Use
     `--verbose` when triaging this surface; `Skip Owner Counts` gives the full
-    lane summary with oldest-update dates when available, and skipped PR rows
-    include owner labels plus per-row updated dates for direct handoff when
-    timestamp data is available.
+    lane summary with oldest-update dates when available, `Skip Owner Reason
+    Counts` splits each lane by blocker type, and skipped PR rows include owner
+    labels plus per-row updated dates for direct handoff when timestamp data is
+    available.
   - Use the ownership report's `Blocked Ready Main PRs` section for the current
     ready main-based `mergeStateStatus=BLOCKED` surface. GitHub refreshes this
     state asynchronously, so do not freeze the count in the lane note; re-run
@@ -243,9 +249,10 @@ node scripts/ci/pr-ownership-report.mjs
     active queue runs with owner labels, status, start time, and age; the exact
     active-run subset changes as synthetic runs complete, so re-run the
     cleanup dry-run for current owner counts, oldest-update dates, run ids, and
-    ages. Detailed cleanup skip rows also include per-row updated dates when
-    timestamp data is available. The stale merged-PR queue branches for
-    `#9848`, `#9889`, `#10160`, and `#10163` were deleted.
+    ages. `Skip Owner Reason Counts` separates open-branch blockers from
+    active-run blockers by lane, and detailed cleanup skip rows also include
+    per-row updated dates when timestamp data is available. The stale merged-PR
+    queue branches for `#9848`, `#9889`, `#10160`, and `#10163` were deleted.
   - Queue branch cleanup dry runs should use
     `--cleanup-superseded-open-queue-branches` so obsolete suffixed open-PR
     branches do not accumulate.


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / coordination notes

## Invariant
The M1-A lane note should describe durable queue-reporting surfaces that future cycles rely on, without changing compiler behavior or queue execution.

## Scope
- Record merged PR #10225 in the M1-A lane refresh list.
- Update queue dry-run guidance to mention `Skip Owner Reason Counts` for per-lane blocker types.
- Update queue cleanup guidance to mention the same owner/reason blocker split for open branch vs active-run blockers.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only lane note update under `docs/plan/agents/M1-A.md`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `git diff --check`

## Coordination Notes
- Follows #10225, which merged as `e4c078cbf4 ci: summarize skip reasons by owner`.
- Direct `agent:M1-A` PR queue was empty at cycle start.
