### PR TITLE
ci: summarize active queue run status by owner

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -529,6 +529,23 @@ export function skipOwnerReasonCounts(skips) {
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner) || a.reason.localeCompare(b.reason));
 }
 
+export function activeRunOwnerStatusCounts(runs) {
+  const counts = new Map();
+  for (const run of runs || []) {
+    const owner = String(run.owner || "(unknown)");
+    const status = String(run.status || "unknown").toLowerCase();
+    const key = `${owner}\0${status}`;
+    const current = counts.get(key) || { owner, status, count: 0, oldestStartedAt: null };
+    current.count += 1;
+    if (run.startedAt && (!current.oldestStartedAt || run.startedAt < current.oldestStartedAt)) {
+      current.oldestStartedAt = run.startedAt;
+    }
+    counts.set(key, current);
+  }
+  return [...counts.values()]
+    .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner) || a.status.localeCompare(b.status));
+}
+
 function pushSkipOwnerCounts(lines, skips) {
   const ownerSummary = skipOwnerCounts(skips);
   const hasOldestUpdated = ownerSummary.some((entry) => entry.oldestUpdatedAt);
@@ -562,6 +579,21 @@ function pushSkipOwnerReasonCounts(lines, skips) {
     const owner = entry.owner.replace(/\|/g, "\\|");
     const reason = entry.reason.replace(/\|/g, "\\|");
     lines.push(`| ${entry.count} | ${owner} | ${reason} |`);
+  }
+}
+
+function pushActiveRunOwnerStatusCounts(lines, runs, now) {
+  lines.push(
+    "",
+    "### Active Queue Run Owner Status Counts",
+    "",
+    "| Count | Owner | Status | Oldest started | Oldest age |",
+    "|-------|-------|--------|----------------|------------|",
+  );
+  for (const entry of activeRunOwnerStatusCounts(runs)) {
+    const owner = entry.owner.replace(/\|/g, "\\|");
+    const status = entry.status.replace(/\|/g, "\\|");
+    lines.push(`| ${entry.count} | ${owner} | ${status} | ${shortDateTime(entry.oldestStartedAt)} | ${elapsedAge(entry.oldestStartedAt, now)} |`);
   }
 }
 
@@ -995,6 +1027,7 @@ export function formatResult(result, options) {
     }
     if (options.verbose && result.activeRuns?.length) {
       const now = result.now || new Date().toISOString();
+      pushActiveRunOwnerStatusCounts(lines, result.activeRuns, now);
       lines.push(
         "",
         "### Active Queue Runs",

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   activeBranchQueueRun,
+  activeRunOwnerStatusCounts,
   activeSyntheticQueueRun,
   failureCommentBody,
   formatResult,
@@ -238,6 +239,19 @@ assert.deepEqual(
   ],
 );
 assert.deepEqual(
+  activeRunOwnerStatusCounts([
+    { owner: "agent:M4-A", status: "in_progress", startedAt: "2026-05-26T03:35:21Z" },
+    { owner: "agent:M4-A", status: "queued", startedAt: "2026-05-26T03:40:00Z" },
+    { owner: "agent:M4-A", status: "queued", startedAt: "2026-05-26T03:20:00Z" },
+    { owner: "agent:M1-C", status: "queued", startedAt: "2026-05-26T03:45:00Z" },
+  ]),
+  [
+    { owner: "agent:M4-A", status: "queued", count: 2, oldestStartedAt: "2026-05-26T03:20:00Z" },
+    { owner: "agent:M1-C", status: "queued", count: 1, oldestStartedAt: "2026-05-26T03:45:00Z" },
+    { owner: "agent:M4-A", status: "in_progress", count: 1, oldestStartedAt: "2026-05-26T03:35:21Z" },
+  ],
+);
+assert.deepEqual(
   skipOwnerCounts([
     { owner: "agent:M4-A", updatedAt: "2026-05-25T10:00:00Z", reason: "draft PR" },
     { owner: "agent:M4-B", updatedAt: "2026-05-24T09:00:00Z", reason: "auto-merge is not armed" },
@@ -300,10 +314,19 @@ const cleanupActiveRunFormat = formatResult({
       status: "in_progress",
       startedAt: "2026-05-26T03:35:21Z",
     },
+    {
+      branch: "automation/merge-queue/pr-10084",
+      number: 10084,
+      owner: "agent:M1-C",
+      runId: 26423420118,
+      url: "https://github.example/runs/26423420118",
+      status: "queued",
+      startedAt: "2026-05-26T04:45:00Z",
+    },
   ],
   deletions: [],
   dryRun: true,
-  skippedActiveRuns: 1,
+  skippedActiveRuns: 2,
   skippedOpen: 0,
   skippedUnrecognized: 0,
   supersededOpen: 0,
@@ -330,11 +353,18 @@ const cleanupActiveRunFormat = formatResult({
   ],
   wouldDelete: 0,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
-assert.match(cleanupActiveRunFormat, /Preserved 1 branch\(es\) with active queue runs/);
+assert.match(cleanupActiveRunFormat, /Preserved 2 branch\(es\) with active queue runs/);
+assert.match(cleanupActiveRunFormat, /### Active Queue Run Owner Status Counts/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M1-C \| queued \| 2026-05-26 04:45Z \| 20m \|/);
+assert.match(cleanupActiveRunFormat, /\| 1 \| agent:M4-A \| in_progress \| 2026-05-26 03:35Z \| 1h 29m \|/);
 assert.match(cleanupActiveRunFormat, /### Active Queue Runs/);
 assert.match(
   cleanupActiveRunFormat,
   /\| `automation\/merge-queue\/pr-9515` \| #9515 \| agent:M4-A \| \[26423420117\]\(https:\/\/github\.example\/runs\/26423420117\) \| in_progress \| 2026-05-26 03:35Z \| 1h 29m \|/,
+);
+assert.match(
+  cleanupActiveRunFormat,
+  /\| `automation\/merge-queue\/pr-10084` \| #10084 \| agent:M1-C \| \[26423420118\]\(https:\/\/github\.example\/runs\/26423420118\) \| queued \| 2026-05-26 04:45Z \| 20m \|/,
 );
 assert.match(cleanupActiveRunFormat, /### Skip Reason Counts/);
 assert.match(cleanupActiveRunFormat, /\| 2 \| open PR branch \|/);


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue-branch cleanup reports should show active synthetic run status by lane without changing queue selection, status posting, branch cleanup deletion, or merge behavior.

## Scope
- Add an `Active Queue Run Owner Status Counts` table to verbose cleanup reports.
- Group active queue runs by canonical owner label and run status.
- Include oldest started time and oldest age for each owner/status group.
- Keep the existing active-run detail table and skip summaries intact.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`
- `REPOSITORY=mohsen1/tsz node scripts/ci/check-wip-state-comments.mjs`

## Coordination Notes
- Direct `agent:M1-A` PR queue was empty at cycle start.
- Live queue dry-run still showed no queue-ready auto-merge PR.
- The cleanup dry-run now exposes queued vs in-progress active queue blockers per lane before the detailed run list.
