### PR TITLE
ci: show queue skip owner ages

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -546,20 +546,20 @@ export function activeRunOwnerStatusCounts(runs) {
     .sort((a, b) => b.count - a.count || a.owner.localeCompare(b.owner) || a.status.localeCompare(b.status));
 }
 
-function pushSkipOwnerCounts(lines, skips) {
+function pushSkipOwnerCounts(lines, skips, now) {
   const ownerSummary = skipOwnerCounts(skips);
   const hasOldestUpdated = ownerSummary.some((entry) => entry.oldestUpdatedAt);
   lines.push(
     "",
     "### Skip Owner Counts",
     "",
-    hasOldestUpdated ? "| Count | Owner | Oldest updated |" : "| Count | Owner |",
-    hasOldestUpdated ? "|-------|-------|----------------|" : "|-------|-------|",
+    hasOldestUpdated ? "| Count | Owner | Oldest updated | Oldest age |" : "| Count | Owner |",
+    hasOldestUpdated ? "|-------|-------|----------------|------------|" : "|-------|-------|",
   );
   for (const entry of ownerSummary) {
     const owner = entry.owner.replace(/\|/g, "\\|");
     if (hasOldestUpdated) {
-      lines.push(`| ${entry.count} | ${owner} | ${shortDate(entry.oldestUpdatedAt)} |`);
+      lines.push(`| ${entry.count} | ${owner} | ${shortDate(entry.oldestUpdatedAt)} | ${elapsedAge(entry.oldestUpdatedAt, now)} |`);
     } else {
       lines.push(`| ${entry.count} | ${owner} |`);
     }
@@ -1047,7 +1047,7 @@ export function formatResult(result, options) {
       for (const entry of summary) {
         lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
       }
-      pushSkipOwnerCounts(lines, result.skips);
+      pushSkipOwnerCounts(lines, result.skips, result.now || new Date().toISOString());
       pushSkipOwnerReasonCounts(lines, result.skips);
       pushCleanupSkipRows(lines, result.skips);
     }
@@ -1074,7 +1074,7 @@ export function formatResult(result, options) {
     for (const entry of summary) {
       lines.push(`| ${entry.count} | ${entry.reason.replace(/\|/g, "\\|")} |`);
     }
-    pushSkipOwnerCounts(lines, result.skips);
+    pushSkipOwnerCounts(lines, result.skips, result.now || new Date().toISOString());
     pushSkipOwnerReasonCounts(lines, result.skips);
     pushQueueSkipRows(lines, result.skips);
   }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -388,6 +388,7 @@ const cleanupOwnerDateFormat = formatResult({
   skippedOpen: 3,
   skippedUnrecognized: 0,
   supersededOpen: 0,
+  now: "2026-05-26T11:15:00Z",
   skips: [
     {
       branch: "automation/merge-queue/pr-9515",
@@ -413,9 +414,9 @@ const cleanupOwnerDateFormat = formatResult({
   ],
   wouldDelete: 0,
 }, parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches", "--dry-run", "--verbose"]));
-assert.match(cleanupOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
-assert.match(cleanupOwnerDateFormat, /\| 2 \| agent:M4-A \| 2026-05-24 \|/);
-assert.match(cleanupOwnerDateFormat, /\| 1 \| agent:M4-C \| 2026-05-23 \|/);
+assert.match(cleanupOwnerDateFormat, /\| Count \| Owner \| Oldest updated \| Oldest age \|/);
+assert.match(cleanupOwnerDateFormat, /\| 2 \| agent:M4-A \| 2026-05-24 \| 2d 2h \|/);
+assert.match(cleanupOwnerDateFormat, /\| 1 \| agent:M4-C \| 2026-05-23 \| 3d 3h \|/);
 assert.match(cleanupOwnerDateFormat, /\| Branch \| Owner \| Updated \| Reason \|/);
 assert.match(cleanupOwnerDateFormat, /\| `automation\/merge-queue\/pr-9632` \| agent:M4-A \| 2026-05-24 \| PR #9632 is open \|/);
 
@@ -441,6 +442,7 @@ assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| \.\.\. \|  \| 2 more skipped PR\(s\) omitted \|/);
 
 const queueSkipOwnerDateFormat = formatResult({
+  now: "2026-05-26T11:15:00Z",
   selected: null,
   skips: [
     { number: 1, owner: "agent:M1-A", reason: "draft PR", updatedAt: "2026-05-25T10:00:00Z" },
@@ -448,9 +450,9 @@ const queueSkipOwnerDateFormat = formatResult({
     { number: 3, owner: "agent:M4-B", reason: "auto-merge is not armed", updatedAt: "2026-05-24T09:00:00Z" },
   ],
 }, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
-assert.match(queueSkipOwnerDateFormat, /\| Count \| Owner \| Oldest updated \|/);
-assert.match(queueSkipOwnerDateFormat, /\| 2 \| agent:M1-A \| 2026-05-23 \|/);
-assert.match(queueSkipOwnerDateFormat, /\| 1 \| agent:M4-B \| 2026-05-24 \|/);
+assert.match(queueSkipOwnerDateFormat, /\| Count \| Owner \| Oldest updated \| Oldest age \|/);
+assert.match(queueSkipOwnerDateFormat, /\| 2 \| agent:M1-A \| 2026-05-23 \| 3d 3h \|/);
+assert.match(queueSkipOwnerDateFormat, /\| 1 \| agent:M4-B \| 2026-05-24 \| 2d 2h \|/);
 assert.match(queueSkipOwnerDateFormat, /\| PR \| Owner \| Updated \| Reason \|/);
 assert.match(queueSkipOwnerDateFormat, /\| #2 \| agent:M1-A \| 2026-05-23 \| auto-merge is not armed \|/);
 


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / merge queue reporting

## Invariant
Verbose queue dry-runs should make stale owner handoffs readable without changing queue selection, status posting, branch cleanup deletion, or merge behavior.

## Scope
- Add `Oldest age` to `Skip Owner Counts` whenever `Oldest updated` is available.
- Apply the same formatter to normal queue dry-runs and queue-branch cleanup dry-runs.
- Keep skip grouping, active-run summaries, queue selection, and cleanup behavior unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/poor-mans-merge-queue.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --verbose`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --cleanup-queue-branches --dry-run --verbose --cleanup-superseded-open-queue-branches`

## Coordination Notes
- Direct `agent:M1-A` PR queue was empty at cycle start.
- Live queue dry-run still showed no queue-ready auto-merge PR.
- The new age column is display-only and uses the existing queue-report `elapsedAge` helper.
