### PR TITLE
ci: show ownership owner ages

### DIFF
--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -202,8 +202,33 @@ function shortDate(value) {
   return value ? value.slice(0, 10) : "unknown";
 }
 
-function ownerCountSummary(entry) {
-  const oldest = Object.hasOwn(entry, "oldestUpdatedAt") ? ` (oldest updated ${shortDate(entry.oldestUpdatedAt)})` : "";
+function reportNow() {
+  return process.env.TSZ_PR_OWNERSHIP_REPORT_NOW || new Date().toISOString();
+}
+
+function elapsedAge(updatedAt, now) {
+  const updatedMs = Date.parse(updatedAt || "");
+  const nowMs = Date.parse(now || "");
+  if (!Number.isFinite(updatedMs) || !Number.isFinite(nowMs)) return "unknown";
+
+  const totalMinutes = Math.max(0, Math.floor((nowMs - updatedMs) / 60_000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (totalHours < 24) {
+    return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
+  }
+
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours ? `${days}d ${hours}h` : `${days}d`;
+}
+
+function ownerCountSummary(entry, now) {
+  const oldest = Object.hasOwn(entry, "oldestUpdatedAt")
+    ? ` (oldest updated ${shortDate(entry.oldestUpdatedAt)}, oldest age ${elapsedAge(entry.oldestUpdatedAt, now)})`
+    : "";
   return `${entry.owner}: ${entry.count}${oldest}`;
 }
 
@@ -439,6 +464,7 @@ function makeReport(pulls) {
 }
 
 function printMarkdown(report) {
+  const now = reportNow();
   console.log("# Open PR Ownership Report");
   console.log("");
   console.log(
@@ -521,7 +547,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.blockedReadyMainOwnerCounts) {
-      console.log(`- ${ownerCountSummary(entry)}`);
+      console.log(`- ${ownerCountSummary(entry, now)}`);
     }
     console.log("");
     console.log("PRs:");
@@ -539,7 +565,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.conflictingReadyMainOwnerCounts) {
-      console.log(`- ${ownerCountSummary(entry)}`);
+      console.log(`- ${ownerCountSummary(entry, now)}`);
     }
     console.log("");
     console.log("PRs:");
@@ -559,7 +585,7 @@ function printMarkdown(report) {
     console.log("");
     console.log("Owner counts:");
     for (const entry of report.conflictingMainOwnerCounts) {
-      console.log(`- ${ownerCountSummary(entry)}`);
+      console.log(`- ${ownerCountSummary(entry, now)}`);
     }
     console.log("");
     console.log("PRs:");

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -143,6 +143,10 @@ withTempDir((dir) => {
   const result = spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, "--json", output], {
     cwd: ROOT,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      TSZ_PR_OWNERSHIP_REPORT_NOW: "2026-05-26T11:15:00Z",
+    },
   });
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Open PR Ownership Report/);
@@ -169,15 +173,15 @@ withTempDir((dir) => {
   assert.match(result.stdout, /#11: AgentName beta; label agent:omega/);
   assert.match(
     result.stdout,
-    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1 \(oldest updated 2026-05-23\)[\s\S]*PRs:[\s\S]*#17: agent:epsilon; updated 2026-05-23; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
+    /Blocked Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:epsilon: 1 \(oldest updated 2026-05-23, oldest age 3d 2h\)[\s\S]*PRs:[\s\S]*#17: agent:epsilon; updated 2026-05-23; MERGEABLE; auto-merge off; fix\(checker\): ready but blocked/,
   );
   assert.match(
     result.stdout,
-    /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1 \(oldest updated 2026-05-22\)[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24\)[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+    /Conflicting Main PRs[\s\S]*Owner counts:[\s\S]*agent:delta: 1 \(oldest updated 2026-05-22, oldest age 4d 3h\)[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24, oldest age 2d\)[\s\S]*PRs:[\s\S]*#19: agent:delta; draft; DIRTY; CONFLICTING; auto-merge off; fix\(checker\): conflicting draft branch[\s\S]*#18: agent:zeta; ready; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
   assert.match(
     result.stdout,
-    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24\)[\s\S]*PRs:[\s\S]*#18: agent:zeta; updated 2026-05-24; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
+    /Conflicting Ready Main PRs[\s\S]*Owner counts:[\s\S]*agent:zeta: 1 \(oldest updated 2026-05-24, oldest age 2d\)[\s\S]*PRs:[\s\S]*#18: agent:zeta; updated 2026-05-24; DIRTY; CONFLICTING; auto-merge off; fix\(solver\): conflicting ready branch/,
   );
   assert.match(
     result.stdout,


### PR DESCRIPTION
AgentName: M1-A

## Track
PR garden / ownership reporting

## Invariant
Ownership reporting should make stale owner handoffs readable without changing PR selection, labels, WIP state, queue behavior, or merge behavior.

## Scope
- Add relative `oldest age` text to owner-count rows that already show `oldest updated`.
- Cover blocked-ready, conflicting-ready, and conflicting-main owner-count summaries.
- Keep JSON fields, owner grouping, row sorting, and PR lists unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/reporting-only change to `scripts/ci/pr-ownership-report.mjs`; no compiler, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `git diff --check`
- `node scripts/ci/pr-ownership-report.mjs`

## Coordination Notes
- Direct `agent:M1-A` PR queue was empty at cycle start.
- WIP-state comment audit and agent label audit were clean.
- Live queue dry-run still showed no queue-ready auto-merge PR.
