### PR TITLE
docs(agents): add iteration workflow skills

### DIFF
--- a/.agents/skills/tsz-disk-cache-hygiene/SKILL.md
+++ b/.agents/skills/tsz-disk-cache-hygiene/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: tsz-disk-cache-hygiene
+description: Prevent TSZ machines and worktrees from running out of disk while preserving useful build caches. Use before creating worktrees, running large builds/tests, diagnosing low disk, cleaning artifacts, deciding whether to delete caches, or recovering space without slowing future Rust/TypeScript builds.
+---
+
+# TSZ Disk Cache Hygiene
+
+Use this skill whenever disk space or cleanup is part of the task. The priority
+order is: keep the machine usable, preserve hot build caches when possible, and
+avoid broad disk archaeology that burns time and terminal output.
+
+## Default Workflow
+
+1. Start with compact signals:
+
+   ```bash
+   df -h .
+   scripts/setup/disk-worktree-guard.sh
+   scripts/agents/disk-preflight.sh <AgentName>
+   git worktree list
+   ```
+
+2. Reuse an inactive worktree before creating a new one, especially when it
+   already has `.target`, `target`, `.target-bench`, or `TypeScript` state.
+3. If disk is low, run the cache-preserving ladder in order:
+
+   ```bash
+   scripts/setup/disk-worktree-guard.sh --auto-prune
+   scripts/setup/clean.sh --quiet
+   ```
+
+4. Rerun the compact guard to see whether enough space was recovered.
+5. Escalate only when the guard still reports low space.
+
+Read `references/cleanup-ladder.md` before deleting worktrees, running
+`scripts/setup/clean.sh --full`, or removing build directories manually.
+
+## Cache Policy
+
+Preserve by default:
+
+- `.target/`
+- `.target-bench/`
+- `target/`
+- populated or symlinked `TypeScript/`
+- package-manager caches unless the task is specifically about dependency
+  corruption
+
+These are expensive to rebuild and directly affect iteration speed. Do not run
+`cargo clean`, `rm -rf target`, or `scripts/setup/clean.sh --full` as routine
+hygiene.
+
+Safe routine cleanup:
+
+- stale Cargo `incremental` subdirectories older than seven days,
+- gitignored debris outside protected build caches,
+- abandoned worktrees after confirming their branch/PR owner and preserving
+  useful findings.
+
+## New Worktree Decision
+
+Before `git worktree add`, answer:
+
+- Is there an inactive sister worktree with the right cache shape?
+- Does the disk guard show enough free space?
+- Does the task need a real TypeScript corpus, or can it run without it?
+- Can a sibling worktree link to an existing TypeScript checkout instead of
+  creating another copy?
+
+Preferred new-worktree setup:
+
+```bash
+git worktree add ../tsz-<short-scope> -b codex/<short-scope>-<yyyymmdd> origin/main
+cd ../tsz-<short-scope>
+scripts/setup/link-ts-submodule.sh
+```
+
+## What To Report
+
+When cleanup or reuse affects the work, include:
+
+- the guard output summary before/after,
+- whether caches were preserved,
+- any abandoned worktree removed and why it was safe,
+- any deliberate cache destruction and why no safer option was enough.
+
+Do not include giant recursive size listings unless a targeted cleanup needs
+exact ownership.

--- a/.agents/skills/tsz-disk-cache-hygiene/agents/openai.yaml
+++ b/.agents/skills/tsz-disk-cache-hygiene/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TSZ Disk Cache Hygiene"
+  short_description: "Preserve caches while avoiding full disks."
+  default_prompt: "Use $tsz-disk-cache-hygiene before creating worktrees or running large TSZ builds."

--- a/.agents/skills/tsz-disk-cache-hygiene/references/cleanup-ladder.md
+++ b/.agents/skills/tsz-disk-cache-hygiene/references/cleanup-ladder.md
@@ -1,0 +1,80 @@
+# TSZ Cleanup Ladder
+
+Use this reference when compact cleanup did not recover enough space.
+
+## Level 0: Do Nothing Destructive
+
+Use when disk is not low:
+
+```bash
+scripts/setup/disk-worktree-guard.sh
+```
+
+Prefer reusing existing cached worktrees instead of cleaning.
+
+## Level 1: Auto-Prune Stale Incremental Cache
+
+Use when disk is low or before a large run on a tight machine:
+
+```bash
+scripts/setup/disk-worktree-guard.sh --auto-prune
+```
+
+This prunes old Cargo incremental directories while keeping built artifacts that
+make future compiles faster.
+
+## Level 2: Cache-Preserving Clean
+
+Use when Level 1 is not enough:
+
+```bash
+scripts/setup/clean.sh --quiet
+```
+
+This removes routine debris while preserving `.target`, `.target-bench`, and
+`target`.
+
+Preview first when unsure:
+
+```bash
+scripts/setup/clean.sh --dry-run
+```
+
+## Level 3: Remove Abandoned Worktrees
+
+Use only after confirming the branch/PR owner and preserving any useful
+findings in a PR comment, issue, or handoff note.
+
+Check:
+
+```bash
+git worktree list
+gh pr list --state open --limit 100 --json number,title,headRefName,labels,url
+```
+
+Prefer deleting worktrees that are inactive, merged, closed, duplicated, or
+explicitly handed off. Do not delete active sibling-agent work to free space.
+
+## Level 4: Full Cache Deletion
+
+Use only as a last resort when the machine cannot proceed and Levels 1-3 are
+insufficient.
+
+Examples of destructive commands requiring deliberate justification:
+
+```bash
+scripts/setup/clean.sh --full
+cargo clean
+rm -rf target .target .target-bench
+```
+
+Before doing this, state what will be lost, why cache-preserving cleanup was not
+enough, and which future build will pay the rebuild cost.
+
+## Never Start With
+
+- broad `du -sh *` dumps,
+- recursive sorted disk archaeology,
+- deleting `TypeScript/` copies without checking whether they are shared
+  symlinks,
+- deleting build caches just because a task is finished.

--- a/.agents/skills/tsz-iteration-audit/SKILL.md
+++ b/.agents/skills/tsz-iteration-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: tsz-iteration-audit
+description: Audit TSZ repo iteration speed and quality. Use when asked to deep-dive repo health, identify avoidable delays, improve agent workflows, reduce CI/PR churn, add guardrails, choose skills to install or create, or turn recurring TSZ process failures into focused tooling/docs PRs.
+---
+
+# TSZ Iteration Audit
+
+Use this skill to turn repo-health observations into small, useful changes.
+The output should be evidence-backed and PR-sized, not a new roadmap unless the
+durable project direction truly changes.
+
+## Audit Loop
+
+1. Read the current direction and coordination state:
+
+   ```bash
+   sed -n '1,320p' docs/plan/ROADMAP.md
+   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+   gh pr list --state merged --limit 30 --json number,title,headRefName,mergedAt,url
+   gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
+   ```
+
+2. Inventory existing guardrails before proposing new ones:
+
+   ```bash
+   find .agents/skills .claude/skills scripts/agents scripts/ci scripts/arch scripts/bench scripts/conformance scripts/emit -maxdepth 3 -type f | sort
+   ```
+
+3. Look for recurring iteration costs:
+
+   ```bash
+   find crates scripts .agents .claude .codex docs -type f \
+     \( -name '*.rs' -o -name '*.py' -o -name '*.mjs' -o -name '*.js' -o -name '*.sh' -o -name '*.md' \) \
+     -not -path '*/target/*' -not -path '*/.target/*' -print0 | xargs -0 wc -l | sort -nr | sed -n '1,60p'
+   rg -n "source_text\\.contains|rewrite_.*fingerprints|format_type_diagnostic|TypeData|CompatChecker|is_assignable_to" crates scripts
+   rg -n "WIP|stale|drift|queue|worktree|disk|allowlist|fingerprint" docs scripts .agents .claude .codex
+   ```
+
+4. Classify each finding:
+
+   - `workflow`: agents repeatedly start from stale state or lose coordination.
+   - `guardrail`: architecture, file-size, WIP, PR-body, or CI checks miss a
+     preventable class.
+   - `visibility`: useful data exists but is hard to find at decision time.
+   - `duplication`: the same policy lives in multiple scripts/docs/skills.
+   - `behavior debt`: compiler code violates an architecture rule and needs a
+     focused owner, not process cleanup.
+
+5. Choose the smallest aligned change:
+
+   - Create or refine a skill when the failure is procedural and repeatable.
+   - Add a script or test when the failure needs deterministic enforcement.
+   - Update an existing script when good tooling exists but misses one field.
+   - File an issue when the fix is real but outside the current PR scope.
+
+Use `references/2026-05-26-findings.md` as a starting evidence map. Replace it
+with fresher evidence when the repo state changes.
+
+## What Not To Do
+
+- Do not add a new plan file for routine status.
+- Do not update `docs/plan/ROADMAP.md` for ordinary cleanup or PR bookkeeping.
+- Do not broaden a process PR into compiler behavior changes.
+- Do not hide a behavior regression with snapshots, allowlists, or test skips.
+- Do not create another checker/solver workaround when the audit finds a
+  semantic bug. Route that to the owning TSZ skill and a focused issue or PR.
+
+## PR Shape
+
+For iteration-audit PRs, write:
+
+- the recurring cost found,
+- the evidence source,
+- the specific skill/script/doc change,
+- why it does not change compiler behavior,
+- the validation command,
+- the `AgentName`.
+
+The best audit PRs make the next agent faster within the first five minutes of
+their task.

--- a/.agents/skills/tsz-iteration-audit/agents/openai.yaml
+++ b/.agents/skills/tsz-iteration-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TSZ Iteration Audit"
+  short_description: "Find and prioritize TSZ repo iteration bottlenecks."
+  default_prompt: "Use $tsz-iteration-audit to inspect this TSZ repo and propose a focused improvement PR."

--- a/.agents/skills/tsz-iteration-audit/references/2026-05-26-findings.md
+++ b/.agents/skills/tsz-iteration-audit/references/2026-05-26-findings.md
@@ -1,0 +1,59 @@
+# TSZ Iteration Findings, 2026-05-26
+
+This is a point-in-time evidence map for process/tooling improvement work. Use
+current commands before treating any count as live truth.
+
+## What Could Have Been Avoided
+
+- Long-lived branches remained checked out after their PRs merged. This made new
+  work look 100+ commits ahead of the remote and increased the risk of pushing
+  unrelated history.
+- Useful coordination commands existed, but agents had to remember the sequence
+  from scattered docs: roadmap, lane goal, disk preflight, owned work, open PRs,
+  issue overlap, then branch selection.
+- PR body rules were strict and correct, but easy to miss during small process
+  PRs. The repo needs a reusable checklist, not another prose-only reminder.
+- Global generic skills for PR review, CI triage, and publishing were not
+  installed in `$CODEX_HOME/skills`, even though this repo spends substantial
+  time on PR feedback and CI queue handling.
+- Architecture and anti-hardcoding guardrails exist, but discoveries still
+  require manual search across `scripts/arch`, roadmap text, and repo skills.
+- File-size pressure remains visible in large tests and source modules. Some
+  oversized files are generated or data-like, but several hand-authored source
+  and test files are well above the 2000-line policy and need focused split
+  issues or PRs.
+- Open issues and PRs repeatedly cluster around the same semantic families:
+  mapped/indexed access, recursive conditionals, template literal inference,
+  unique-symbol identity, module/lib identity, relation false positives, and
+  emit/DTS output planning. Starting one branch per symptom would recreate the
+  backlog.
+
+## Useful Evidence Commands
+
+```bash
+gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
+scripts/agents/ensure-agent-labels.sh --audit
+scripts/ci/pr-ownership-report.mjs
+python3 scripts/arch/arch_guard.py
+python3 scripts/conformance/query-conformance.py --dashboard
+python3 scripts/emit/query-emit.py --dashboard
+```
+
+## Improvement Choices That Fit Small PRs
+
+- Add or refine skills that encode start-of-work, audit, and PR coordination
+  sequences.
+- Add one missing field to an existing report when it changes a real decision.
+- Split one oversized hand-authored file only when the owning issue/PR scope is
+  clear.
+- Convert a recurring manual search into an arch/CI script check.
+- Install global skills that reduce repeated review/CI/publish setup.
+
+## Improvement Choices That Need Separate Ownership
+
+- Compiler semantic fixes found during the audit.
+- Full conformance, emit, or fourslash runs.
+- Broad performance tuning before project rows are green.
+- Roadmap edits for routine status.
+- Closing old PRs merely to tidy the queue.

--- a/.agents/skills/tsz-performance-engineering/SKILL.md
+++ b/.agents/skills/tsz-performance-engineering/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: tsz-performance-engineering
+description: Use when planning, implementing, reviewing, or interpreting TSZ performance work, including benchmark regressions, cache/residency changes, timing claims, perf counters, hotspot investigations, OOM/timeout/stack-overflow blockers, or optimization PR evidence.
+---
+
+# TSZ Performance Engineering
+
+## Core Rule
+
+Performance work must preserve `tsc` parity and TSZ architecture. Speed claims are useful only after the row or behavior is correct, except when the first blocker is runtime, OOM, timeout, stack overflow, or residency.
+
+Before starting nontrivial perf work, read:
+
+- `docs/plan/ROADMAP.md`
+- `docs/plan/PERFORMANCE_PLAN.md`
+- `references/perf-mistakes.md` when diagnosing a regression, designing a cache, writing PR evidence, or changing residency/session behavior
+
+Also inspect open/recent PRs and issues for overlapping benchmark rows or perf tooling work.
+
+## Classify First
+
+Name the task class before coding:
+
+- `correctness blocker`: the row is red/yellow due to diagnostics, crash, missing metadata, or fixture drift. Fix correctness first; do not claim speed progress.
+- `runtime blocker`: OOM, timeout, stack overflow, excessive residency, or CI kill prevents the row from reaching a correctness result. Perf work is allowed with the runtime invariant stated.
+- `green-row speed`: row is correct and complete; before/after timing can be meaningful.
+- `cache/residency`: cache keys, invalidation, file sessions, project state, or memory growth. State the semantic identity and reset boundary.
+- `measurement/tooling`: counters, reports, dashboard interpretation, or benchmark scripts. Preserve schema stability and low overhead.
+- `micro-allocation`: clone, allocation, formatting, or buffer changes. Prove the hot path; do not overstate as project-row progress unless a row moves.
+
+## Evidence Workflow
+
+1. Record the affected project/benchmark row, bug family, and current correctness status.
+2. Pick the narrowest command that answers the question; avoid broad local suites.
+3. Separate timing mode from attribution mode. Do not compare attribution-mode TSZ to timing-mode `tsgo`.
+4. For cache or residency changes, document every behavior-affecting key field, invalidation/reset boundary, semantic mode, cycle/fuel interaction, memory-growth expectation, and cache-disabled behavior.
+5. For green-row speed claims, include before/after command, wall time, RSS/residency when relevant, cache/counter deltas, and noise sources.
+6. For runtime blockers, include the failure class before/after and the invariant that prevents recurrence.
+7. Add or update owning-crate tests for behavior changes. Let ready-for-review CI run heavy conformance, emit, fourslash, and WASM suites.
+
+## Preferred Local Commands
+
+Use filters and wrap long or memory-intensive runs with `scripts/safe-run.sh`.
+
+```bash
+python3 scripts/perf/cache-visibility-report.py --json
+python3 scripts/perf/visited-clone-report.py --json
+python3 scripts/perf/debug-print-report.py --json
+python3 scripts/perf/migration_callsite_counts.py --json
+python3 scripts/perf/query-perf-counters.py --json <artifact> --baseline <baseline>
+
+scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --quick --json-file /tmp/hotspots.json
+scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter '<row-or-fixture>' --json-file /tmp/bench.json
+```
+
+Use filtered project compile guard or focused `cargo nextest run -E 'test(...)'` when that is the shortest path to validate the change. Do not run full conformance, full emit, full fourslash, or broad project suites locally.
+
+## Cache And Identity Checks
+
+Before adding or widening a cache, answer:
+
+- What semantic question does this cache answer?
+- What stable identity is used? Avoid cross-file `NodeIndex` and do not compare `TypeId`s from different `TypeInterner`s.
+- Does the key include every mode that changes behavior: relation mode, variance, freshness/excess-property state, contextual typing, inference source, `any` propagation policy, target/module/options, request scope, cycle/fuel, and file/session generation as applicable?
+- Where is invalidation or reset performed?
+- What happens when the cache is absent, cold, disabled, or order-randomized?
+- Is size/residency bounded or observable?
+
+Move semantic fixes through solver/query boundaries. Do not add checker-local type algorithms, display-string heuristics, source-text shortcuts, or name-only allowlists.
+
+## PR Evidence Packet
+
+Every perf PR body or status comment should include:
+
+- `Project Corpus Impact`: row, bug family, correctness status, and evidence source
+- `Invariant`: semantic identity, cache key, invalidation/reset, request scope, or residency rule
+- `Verification`: exact local commands and any CI jobs relied on
+- before/after timing only for complete green rows
+- RSS/residency and failure-class evidence for runtime blockers
+- cache/counter deltas for cache work
+- noise sources and caveats
+- `AgentName` and coordination notes for overlapping rows/PRs
+
+Individual agents own their PR evidence and handoff notes. A manager or coordination agent should handle broad merge sequencing and cross-PR queue decisions.

--- a/.agents/skills/tsz-performance-engineering/agents/openai.yaml
+++ b/.agents/skills/tsz-performance-engineering/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TSZ Performance Engineering"
+  short_description: "Do TSZ performance work without breaking parity"
+  default_prompt: "Use $tsz-performance-engineering to plan or review TSZ performance work."

--- a/.agents/skills/tsz-performance-engineering/references/perf-mistakes.md
+++ b/.agents/skills/tsz-performance-engineering/references/perf-mistakes.md
@@ -1,0 +1,94 @@
+# TSZ Performance Mistakes And Guardrails
+
+Load this reference when planning or reviewing nontrivial performance work.
+
+## Current Strategy
+
+The durable plan is project-row first. Broad optimization waits until required
+rows are correct, except for runtime blockers where OOM, timeout, stack
+overflow, or residency prevents a correctness result. A performance change must
+state the invariant it preserves: semantic identity, cache key, invalidation,
+request scope, file/session residency, and fallback behavior.
+
+Do not treat a red/yellow row as a speed win. If diagnostics are wrong, metadata
+is incomplete, artifacts are missing, or fixture provenance is unclear, the row
+is not a timing target yet.
+
+## Mistakes Seen Before
+
+- **Faster but still wrong rows**: benchmark deltas were tempting before
+  diagnostics and metadata were complete. Keep correctness status beside every
+  timing number.
+- **Attribution/timing mode mixing**: counter-enabled TSZ runs are for
+  explanation, not direct comparison with timing-mode `tsgo`. Run timing and
+  attribution as separate experiments.
+- **Partial artifacts treated as truth**: memory-guard kills, missing
+  compatibility fields, duplicate rows, or local fixture drift can make a
+  dashboard row gray. Check row completeness before claiming movement.
+- **Stack tuning instead of recursion fixes**: large rows have hit stack
+  overflow from shape-specific unbounded recursion. Increasing stack size is
+  not a root-cause fix; find the missing depth/fuel/cycle guard.
+- **Cache keys missing modes**: relation mode, variance, freshness,
+  contextual typing, inference source, `any` policy, target/module/options,
+  cycle/fuel, or request scope can all change answers. Missing one creates
+  stale correctness bugs.
+- **Wrong identity**: `NodeIndex` is not cross-file semantic identity, and
+  `TypeId`s from different `TypeInterner`s are not comparable. Stable
+  cross-file reuse needs stable semantic facts.
+- **Checker-local shortcuts**: performance pressure has led to type-shape
+  recursion, display-string checks, source-text heuristics, and name-only lib
+  allowlists. These belong in solver/query boundaries or binder/global facts.
+- **Branch-local graph state explosions**: repeated `visited.clone()` traversal
+  can turn graph walks into path explosion. Prefer memoized DP, SCC/worklists,
+  or explicit bounds when the traversal is hot.
+- **Counters causing their own regression**: perf counters must be gated,
+  schema-stable, and cheap when disabled. Avoid production-cost atomics or
+  formatting in hot paths.
+- **Debug output in compiler internals**: `println!`, `eprintln!`, and `dbg!`
+  distort runs and fail lint policy. Use structured tracing and the existing
+  perf/debug-print reports.
+- **Micro wins overclaimed**: preallocation, clone removal, and formatting
+  fixes are valuable only when tied to a hot path or row movement. Keep claims
+  proportional.
+- **Stale coordination state**: old WIP text, issue notes, or PR labels may be
+  stale. Use current PR head, row state, and fresh signed comments before
+  taking ownership or publishing results.
+- **Counter-accessor sprawl**: perf counter accessors are moving toward a
+  declarative manifest. Do not duplicate accessor boilerplate; check the active
+  issue/PR stack before editing counter surfaces.
+
+## Tool Map
+
+- `docs/plan/PERFORMANCE_PLAN.md`: current performance contract, measurement
+  modes, evidence packet, and cache/residency rules.
+- `docs/plan/ROADMAP.md`: when performance work is allowed relative to project
+  rows and release gates.
+- `scripts/bench/project-rows.mjs`: source of truth for required/canary rows
+  and compatibility metadata.
+- `scripts/bench/row-utils.mjs`: what counts as a complete green row.
+- `scripts/bench/perf-hotspots.sh`: narrow hotspot suite for quick perf signal.
+- `scripts/bench/bench-vs-tsgo.sh`: filtered TSZ vs `tsgo` project timing.
+- `scripts/bench/tsgo-winner-report.mjs`: rows where `tsgo` is currently
+  faster and known closure/owner context.
+- `scripts/bench/project-winner-regression-report.mjs`: green rows that moved
+  from TSZ winner to `tsgo` winner.
+- `scripts/perf/query-perf-counters.py`: attribution artifact comparison.
+- `scripts/perf/cache-visibility-report.py`: cache-like maps and size/stat
+  observability gaps.
+- `scripts/perf/visited-clone-report.py`: traversal paths likely to clone
+  branch-local visited state.
+- `scripts/perf/debug-print-report.py`: ad-hoc compiler debug output.
+- `scripts/perf/migration_callsite_counts.py`: migration callsite counts for
+  selected checker performance projects.
+
+## Review Questions
+
+Ask these before approving a performance PR:
+
+1. Is the row correct and complete, or is this explicitly a runtime blocker?
+2. Is the measurement mode named, and are timing and attribution separated?
+3. Does the PR preserve `tsc` parity and architecture boundaries?
+4. Are cache key fields, invalidation/reset, request scope, and fallback behavior documented?
+5. Are RSS/residency or failure-class deltas included when memory/runtime is the point?
+6. Are claims limited to what the evidence proves?
+7. Did the agent check overlapping open/recent PRs and issues?

--- a/.agents/skills/tsz-pr-coordination/SKILL.md
+++ b/.agents/skills/tsz-pr-coordination/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: tsz-pr-coordination
-description: Create, refresh, and publish TSZ pull requests with correct coordination state. Use when opening a draft PR, updating a PR body, applying canonical agent labels, changing WIP/draft/ready state, acknowledging review, checking auto-merge readiness, or making sure a TSZ PR satisfies AgentName, Project Corpus Impact, verification, and overlap rules.
+description: Create, refresh, and publish TSZ pull requests with correct coordination state. Use when opening a draft PR, updating a PR body, applying canonical agent labels, changing WIP/draft/ready state, acknowledging review, handing off readiness to a manager agent, or making sure a TSZ PR satisfies AgentName, Project Corpus Impact, verification, and overlap rules.
 ---
 
 # TSZ PR Coordination
 
 Use this skill for TSZ PR state, especially before pushing a branch or changing
 draft/WIP/ready status. It complements `tsz-ci-pr`: use this skill for the
-coordination contract and `tsz-ci-pr` for check triage and landing.
+coordination contract and `tsz-ci-pr` for check triage. Merge and auto-merge
+coordination belongs to an explicit manager or queue-owner agent, not every
+implementation agent.
 
 ## Required Identity
 
@@ -17,6 +19,27 @@ such as `agent:claude-*` or typo labels such as `agnet:*`.
 
 Canonical ownership labels are documented in
 `docs/plan/agents/README.md`. Apply at most one `agent:*` label to a PR.
+
+## Role Split
+
+Individual implementation agents own only their own PRs. They should:
+
+- keep their PR body, labels, WIP/draft state, verification, and review replies
+  current,
+- mark their own PR ready only when implementation and verification are done and
+  the lane permits it,
+- leave a signed readiness or blocker note for the manager agent,
+- avoid queue sweeps, merge decisions, or auto-merge changes on unrelated PRs.
+
+Manager or queue-owner agents handle cross-PR coordination. They may:
+
+- inspect the full PR queue and ownership state,
+- decide merge order and dependency handoffs,
+- enable or disable auto-merge when policy and exact-head checks allow it,
+- merge ready PRs or leave signed blocker comments.
+
+If you are not acting as the manager/queue owner, do not merge PRs or use
+auto-merge as part of routine implementation work.
 
 ## Before Publishing
 
@@ -92,17 +115,19 @@ it is blocked, immediately leave a signed PR comment with:
 - next owner/action,
 - verification already run.
 
-## Ready And Auto-Merge
+## Ready Handoff
 
-Before marking ready:
+Before marking your own PR ready or handing it to the manager:
 
 1. Remove WIP markers only after implementation and verification are complete.
 2. Confirm the latest pushed head SHA is the one you reviewed.
-3. Confirm required checks for that head are green, not pending or missing.
-4. Confirm the PR body has current verification and Project Corpus Impact.
+3. Confirm the PR body has current verification and Project Corpus Impact.
+4. Comment with remaining risks, dependencies, or a clear "ready for manager
+   review/queue" note.
 
-Do not use auto-merge as a CI watcher. If checks are pending or failing, leave
-auto-merge off and comment with the blocker.
+Do not use auto-merge as a CI watcher. Unless you are the manager/queue owner,
+leave merge and auto-merge decisions to the manager after exact-head checks are
+complete.
 
 ## Review Responses
 

--- a/.agents/skills/tsz-pr-coordination/SKILL.md
+++ b/.agents/skills/tsz-pr-coordination/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: tsz-pr-coordination
+description: Create, refresh, and publish TSZ pull requests with correct coordination state. Use when opening a draft PR, updating a PR body, applying canonical agent labels, changing WIP/draft/ready state, acknowledging review, checking auto-merge readiness, or making sure a TSZ PR satisfies AgentName, Project Corpus Impact, verification, and overlap rules.
+---
+
+# TSZ PR Coordination
+
+Use this skill for TSZ PR state, especially before pushing a branch or changing
+draft/WIP/ready status. It complements `tsz-ci-pr`: use this skill for the
+coordination contract and `tsz-ci-pr` for check triage and landing.
+
+## Required Identity
+
+Use a stable `AgentName`. If assigned to a canonical lane, use that lane name
+in PR bodies and substantive comments. Do not create generated runner labels
+such as `agent:claude-*` or typo labels such as `agnet:*`.
+
+Canonical ownership labels are documented in
+`docs/plan/agents/README.md`. Apply at most one `agent:*` label to a PR.
+
+## Before Publishing
+
+1. Inspect scope:
+
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+
+2. Confirm the branch and overlap:
+
+   ```bash
+   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+   scripts/agents/ensure-agent-labels.sh --audit
+   ```
+
+3. Stage only files that belong to the requested PR. If dirty files are mixed,
+   leave unrelated files unstaged.
+
+## PR Body
+
+Use the repo template and fill every section. Never rely on `--fill` alone.
+Read `references/pr-body-checklist.md` when creating or materially editing a
+body.
+
+Minimum sections:
+
+```markdown
+## Agent
+AgentName: <AgentName>
+
+## Track
+<roadmap track and PR type>
+
+## Invariant
+When <condition>, <expected behavior>; this PR changes <owner/surface>.
+
+## Scope
+- <files or systems>
+
+## Project Corpus Impact
+- Row: n/a
+- Bug family: n/a
+- Evidence: <why n/a or affected row evidence>
+
+## Verification
+- <commands or CI gates>
+
+## Coordination Notes
+- <overlap, dependencies, WIP state, follow-ups>
+```
+
+After creating or editing the PR, verify the remote body:
+
+```bash
+gh pr view <number> --json body
+```
+
+## WIP And Draft State
+
+Treat a PR as WIP if it is draft, has a `WIP` label, starts with `[WIP]`, or
+declares a blocker in the body. Do not mark ready or enable auto-merge until the
+current head is genuinely ready.
+
+Whenever adding `WIP`, adding `[WIP]`, or converting a PR back to draft because
+it is blocked, immediately leave a signed PR comment with:
+
+- `AgentName`,
+- why the PR is WIP,
+- current blocker or active work,
+- next owner/action,
+- verification already run.
+
+## Ready And Auto-Merge
+
+Before marking ready:
+
+1. Remove WIP markers only after implementation and verification are complete.
+2. Confirm the latest pushed head SHA is the one you reviewed.
+3. Confirm required checks for that head are green, not pending or missing.
+4. Confirm the PR body has current verification and Project Corpus Impact.
+
+Do not use auto-merge as a CI watcher. If checks are pending or failing, leave
+auto-merge off and comment with the blocker.
+
+## Review Responses
+
+When a substantive review arrives:
+
+1. Read the comment or thread.
+2. React or reply so the reviewer knows it was seen.
+3. Leave a concise signed PR comment saying whether you fixed it, will fix it,
+   or disagree and why.
+4. Update the PR body when the review changes scope, risk, or verification.

--- a/.agents/skills/tsz-pr-coordination/agents/openai.yaml
+++ b/.agents/skills/tsz-pr-coordination/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TSZ PR Coordination"
+  short_description: "Keep TSZ pull requests coordinated."
+  default_prompt: "Use $tsz-pr-coordination to publish or refresh my TSZ pull request."

--- a/.agents/skills/tsz-pr-coordination/references/pr-body-checklist.md
+++ b/.agents/skills/tsz-pr-coordination/references/pr-body-checklist.md
@@ -14,7 +14,8 @@ Use this checklist before creating or materially updating a TSZ PR.
   and a concrete evidence line for docs, skills, or harness-only work.
 - `Verification`: targeted local commands and CI expectation.
 - `Coordination Notes`: overlap checks, dependency branches, WIP state,
-  follow-ups, and signed handoff facts.
+  follow-ups, signed handoff facts, and whether the PR is ready for a manager or
+  queue-owner agent to review.
 
 ## Body Validation
 

--- a/.agents/skills/tsz-pr-coordination/references/pr-body-checklist.md
+++ b/.agents/skills/tsz-pr-coordination/references/pr-body-checklist.md
@@ -1,0 +1,43 @@
+# TSZ PR Body Checklist
+
+Use this checklist before creating or materially updating a TSZ PR.
+
+## Required Sections
+
+- `AgentName`: stable identity, usually a canonical lane name when assigned.
+- `Track`: roadmap track and PR type, such as refactor-only, semantic campaign,
+  emit/DTS parity, benchmark blocker, or tooling/guardrail.
+- `Invariant`: structural rule for behavior work; iteration bottleneck and
+  affected surface for process work.
+- `Scope`: concrete files or systems touched.
+- `Project Corpus Impact`: always present. Use `Row: n/a`, `Bug family: n/a`,
+  and a concrete evidence line for docs, skills, or harness-only work.
+- `Verification`: targeted local commands and CI expectation.
+- `Coordination Notes`: overlap checks, dependency branches, WIP state,
+  follow-ups, and signed handoff facts.
+
+## Body Validation
+
+Run:
+
+```bash
+gh pr view <number> --json body
+```
+
+Confirm the remote body includes all required sections after GitHub stores it.
+If `project-corpus-pr-body` fails, fix the body before rerunning jobs.
+
+## Good Evidence Lines
+
+- `docs-only`
+- `agent-skill-only`
+- `test-harness-only`
+- `CI script only; no compiler behavior path`
+- `project row: utility-types; diagnostic false-positive family`
+
+## Bad Evidence Lines
+
+- blank `Evidence:`
+- `n/a` with no explanation
+- stale commands from a previous head
+- broad claims such as `tests pass` without naming the command or CI gate

--- a/.agents/skills/tsz-worktree-intake/SKILL.md
+++ b/.agents/skills/tsz-worktree-intake/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tsz-worktree-intake
+description: Start TSZ work safely in a crowded multi-agent checkout. Use when beginning a TSZ task, resuming a goal, switching or creating branches/worktrees, recovering from a merged or stale branch, checking disk/cache state, reading lane goals, or deciding whether local dirty files belong to the requested work.
+---
+
+# TSZ Worktree Intake
+
+Use this skill before non-trivial TSZ work. The goal is to avoid wasted cycles
+from stale branches, hidden dirty files, unowned PR overlap, missing TypeScript
+corpus state, and cache-destroying cleanup.
+
+## Fast Path
+
+1. Pick or confirm a stable `AgentName`.
+2. Refresh the remote truth:
+
+   ```bash
+   git fetch origin main
+   ```
+
+3. Read the durable direction and lane state:
+
+   ```bash
+   sed -n '1,260p' docs/plan/ROADMAP.md
+   scripts/agents/show-goal.sh <AgentName>
+   ```
+
+4. Check local workspace health:
+
+   ```bash
+   git status --short --branch
+   scripts/agents/disk-preflight.sh <AgentName>
+   git worktree list
+   ```
+
+5. Check coordination overlap before editing:
+
+   ```bash
+   scripts/agents/list-owned-work.sh <AgentName>
+   gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url
+   gh issue list --state open --limit 100 --json number,title,labels,updatedAt,url
+   ```
+
+Read `references/common-failure-modes.md` when any command reveals a stale
+merged branch, dirty workspace, low disk, missing TypeScript corpus, or
+overlapping active PR.
+
+## Branch Choice
+
+Use the current branch only when it is the active PR branch for the requested
+work. If the current branch's PR is merged, closed, unrelated, or heavily ahead
+of `origin/main`, create a fresh branch from `origin/main`.
+
+Prefer:
+
+```bash
+git switch -c codex/<short-scope>-<yyyymmdd> origin/main
+```
+
+If dirty files exist, inspect them before switching. Carry them only when they
+belong to the requested work; otherwise leave them unstaged and do not include
+them in the PR.
+
+## Worktree Choice
+
+Reuse an existing sister worktree when disk or TypeScript corpus state makes it
+cheaper. Create new worktrees beside the checkout, not inside it:
+
+```bash
+git worktree add ../tsz-<short-scope> -b codex/<short-scope>-<yyyymmdd> origin/main
+cd ../tsz-<short-scope>
+scripts/setup/link-ts-submodule.sh
+```
+
+Do not run broad `du` archaeology or `cargo clean` as a reflex. If disk is low,
+follow the cleanup ladder printed by `scripts/agents/disk-preflight.sh`.
+
+## Intake Decisions
+
+Before coding, state the next action in one sentence:
+
+- continue an existing PR,
+- start a fresh non-overlapping branch,
+- hand off or unblock an assigned draft,
+- file an issue instead of editing because the improvement is out of scope.
+
+For behavior work, also state the structural rule and owning layer before
+editing. For process or docs work, state the iteration bottleneck and the
+evidence that it is recurring.
+
+## Stop Conditions
+
+Pause and gather stronger evidence when:
+
+- more than one open PR claims the same issue or title scope,
+- the current branch is merged but still contains local-only changes,
+- local dirty files affect the same paths as the planned edit but their owner is
+  unclear,
+- the TypeScript corpus is missing and the task needs conformance, emit, or
+  fourslash source data,
+- a command would destroy caches or worktree state to solve a temporary problem.

--- a/.agents/skills/tsz-worktree-intake/SKILL.md
+++ b/.agents/skills/tsz-worktree-intake/SKILL.md
@@ -33,6 +33,9 @@ corpus state, and cache-destroying cleanup.
    git worktree list
    ```
 
+   If disk is low, cache state is unclear, or a new worktree might be needed,
+   use `tsz-disk-cache-hygiene` before cleaning or creating anything.
+
 5. Check coordination overlap before editing:
 
    ```bash

--- a/.agents/skills/tsz-worktree-intake/agents/openai.yaml
+++ b/.agents/skills/tsz-worktree-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TSZ Worktree Intake"
+  short_description: "Start TSZ work safely in a crowded multi-agent checkout."
+  default_prompt: "Use $tsz-worktree-intake to prepare this TSZ checkout for a new task."

--- a/.agents/skills/tsz-worktree-intake/references/common-failure-modes.md
+++ b/.agents/skills/tsz-worktree-intake/references/common-failure-modes.md
@@ -1,0 +1,68 @@
+# TSZ Intake Failure Modes
+
+Use this reference when the checkout is not obviously ready for the requested
+task.
+
+## Merged Branch Still Checked Out
+
+Symptom: `gh pr view` shows `state: MERGED`, while `git status --branch` shows a
+feature branch with many commits ahead of its remote.
+
+Preferred response:
+
+1. Inspect dirty files.
+2. Create a fresh branch from `origin/main`.
+3. Carry only dirty files that belong to the new work.
+4. Do not force-push or rewrite the merged branch.
+
+## Dirty Workspace
+
+Symptom: `git status --short` shows modified files before the task starts.
+
+Preferred response:
+
+1. Read the diff.
+2. Classify each file as requested work, sibling-agent/user work, generated
+   output, or unrelated drift.
+3. Stage explicitly by path.
+4. Mention excluded dirty files in the final or PR notes when they could confuse
+   review.
+
+Never revert dirty files you did not create unless the user explicitly asks.
+
+## Missing TypeScript Corpus
+
+Symptom: `scripts/agents/disk-preflight.sh` reports `typescript=missing` or
+`present-but-not-populated`.
+
+Preferred response:
+
+- If the task needs conformance, emit, fourslash, or TypeScript sources, link or
+  initialize the corpus before debugging.
+- In a sibling worktree, prefer `scripts/setup/link-ts-submodule.sh`.
+- If the task is docs, scripts, or skill-only, note that corpus setup was not
+  needed.
+
+## Low Disk
+
+Symptom: the disk guard reports low space.
+
+Preferred response:
+
+1. Reuse an existing worktree with cache state.
+2. Run `scripts/setup/disk-worktree-guard.sh --auto-prune`.
+3. Run `scripts/setup/clean.sh --quiet`.
+4. Delete only abandoned worktrees whose owner/PR is understood.
+5. Use full cleanup only as a deliberate last resort.
+
+## Overlapping PRs
+
+Symptom: open PR titles, issue references, or base/head branches indicate
+another agent already owns the same work.
+
+Preferred response:
+
+- Continue that PR if it is assigned to your lane.
+- Comment with a signed handoff if you find useful evidence but cannot take it.
+- Start a new PR only when the scope is clearly non-overlapping or stacked on
+  the dependency branch.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -294,6 +294,8 @@ matches their description:
 - `tsz-ci-pr`: GitHub PR status, CI triage, ready/merge handling, and landing.
 - `tsz-conformance`: conformance regressions, accepted-regression drift,
   fingerprint-only triage, and conformance issue creation.
+- `tsz-disk-cache-hygiene`: disk-space recovery, worktree reuse, and
+  cache-preserving cleanup before large builds or new worktrees.
 - `tsz-emit`: JavaScript/declaration emit and emit parity work.
 - `tsz-iteration-audit`: repo-health deep dives, iteration bottleneck triage,
   and focused process/tooling improvement PRs.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -299,6 +299,8 @@ matches their description:
 - `tsz-emit`: JavaScript/declaration emit and emit parity work.
 - `tsz-iteration-audit`: repo-health deep dives, iteration bottleneck triage,
   and focused process/tooling improvement PRs.
+- `tsz-performance-engineering`: performance/cache/residency/timing work,
+  evidence packets, and past perf mistake avoidance.
 - `tsz-project-bench`: benchmark/project-corpus rows, fixture metadata, PGO, and
   benchmark dashboard work.
 - `tsz-pr-coordination`: PR body, AgentName, WIP/draft/ready, labels, review

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -295,9 +295,15 @@ matches their description:
 - `tsz-conformance`: conformance regressions, accepted-regression drift,
   fingerprint-only triage, and conformance issue creation.
 - `tsz-emit`: JavaScript/declaration emit and emit parity work.
+- `tsz-iteration-audit`: repo-health deep dives, iteration bottleneck triage,
+  and focused process/tooling improvement PRs.
 - `tsz-project-bench`: benchmark/project-corpus rows, fixture metadata, PGO, and
   benchmark dashboard work.
+- `tsz-pr-coordination`: PR body, AgentName, WIP/draft/ready, labels, review
+  response, and auto-merge coordination.
 - `tsz-tracing`: tracing-driven debugging of checker/solver/binder behavior.
+- `tsz-worktree-intake`: safe task start, stale branch recovery, disk/cache
+  preflight, dirty workspace triage, and worktree reuse.
 
 Runtime-provided global skills may exist outside this checkout; do not document
 them as TSZ repo skills.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git pull --rebase origin main 2>/dev/null; cat \"$CLAUDE_PROJECT_DIR/AGENTS.md\""
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-${CODEX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}\"; git -C \"$root\" pull --rebase origin main 2>/dev/null || true; cat \"$root/AGENTS.md\""
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git pull --rebase origin main 2>/dev/null; cat \"$CLAUDE_PROJECT_DIR/AGENTS.md\""
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-${CODEX_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}\"; git -C \"$root\" pull --rebase origin main 2>/dev/null || true; cat \"$root/AGENTS.md\""
           }
         ]
       }


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 10 tooling/guardrail, agent-skill-only process improvement.

## Invariant
When agents start, audit, publish, hand off work, manage disk pressure, or plan performance work in this crowded TSZ repo, the repeated coordination and cleanup steps should be discoverable and reusable through repo-local skills; this PR adds those skills, clarifies that merge/auto-merge coordination belongs to an explicit manager or queue-owner agent, and makes session-start hooks robust across Claude/Codex project-dir variables without changing compiler behavior.

## Scope
- Add `.agents/skills/tsz-worktree-intake` for safe task start, stale branch recovery, dirty workspace triage, disk/cache checks, and worktree reuse.
- Add `.agents/skills/tsz-disk-cache-hygiene` for low-disk recovery that preserves useful Rust/TypeScript build caches and avoids broad disk archaeology.
- Add `.agents/skills/tsz-iteration-audit` for evidence-backed repo-health deep dives and PR-sized process/tooling improvements.
- Add `.agents/skills/tsz-pr-coordination` for PR body, AgentName, canonical label, WIP/draft/ready, review, and manager/queue-owner handoff.
- Add `.agents/skills/tsz-performance-engineering` for parity-preserving performance work, cache/residency invariants, timing-vs-attribution separation, and recurring past perf mistake avoidance.
- Clarify that individual implementation agents should maintain only their own PRs and leave queue sweeps, merge decisions, and auto-merge changes to a manager/queue-owner agent.
- Register the new repo-local skills in `.claude/CLAUDE.md` (and therefore `AGENTS.md` via symlink).
- Make `.claude/settings.json` and `.codex/hooks.json` resolve the repo root via `CLAUDE_PROJECT_DIR`, `CODEX_PROJECT_DIR`, or `git rev-parse` before reading `AGENTS.md`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-skill-only and hook/docs configuration only; no parser, binder, checker, solver, emitter, LSP, WASM, benchmark, or project-corpus behavior path is changed.

## Verification
- `python3 /Users/mohsen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tsz-worktree-intake`
- `python3 /Users/mohsen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tsz-disk-cache-hygiene`
- `python3 /Users/mohsen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tsz-iteration-audit`
- `python3 /Users/mohsen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tsz-pr-coordination`
- `python3 /Users/mohsen/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/tsz-performance-engineering`
- `python3 -m json.tool .claude/settings.json >/tmp/claude-settings.json`
- `python3 -m json.tool .codex/hooks.json >/tmp/codex-hooks.json`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Installed curated global skills with `$skill-installer`: `gh-address-comments`, `gh-fix-ci`, and `yeet`. Restart Codex to pick up new global skills.
- Current open PR label audit reported zero missing, duplicate, or noncanonical `agent:*` labels before publishing this branch.
- Incorporated user clarification that not all agents should participate in merging PRs; individual agents should focus on their own PRs and hand off to a manager/queue-owner agent.
- Incorporated user clarification that agents need a specific disk/cache hygiene workflow to avoid full disks without wasting caches that make builds faster.
- Incorporated user request for a performance-focused skill by grounding `tsz-performance-engineering` in `ROADMAP.md`, `PERFORMANCE_PLAN.md`, perf scripts, and prior perf PR/issue failure modes such as faster-but-wrong rows, attribution/timing mixing, partial artifacts, stack tuning for recursion bugs, stale cache keys, identity misuse, and overclaimed micro-wins.
- This is intentionally scoped away from compiler behavior, conformance baselines, emit baselines, and roadmap edits.
