### PR TITLE
bench: report 2x target gaps

### DIFF
--- a/docs/plan/PERFORMANCE_PLAN.md
+++ b/docs/plan/PERFORMANCE_PLAN.md
@@ -57,6 +57,11 @@ Record the following in the PR body when the PR is performance-motivated:
 For red/yellow rows, record the first correctness blocker and leave timing
 claims blank unless runtime, OOM, timeout, or residency is the blocker.
 
+The benchmark `*.tsgo-winners.json` companion report is also the 2x-target
+gap report. Its `two_x_target` summary and `target_gaps` rows are the canonical
+artifact fields for green rows where `tsz` is not at least `2x` faster than
+`tsgo`.
+
 ## Preferred Commands
 
 Use the narrowest command that answers the question:

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -155,6 +155,22 @@ withTempDir((dir) => {
   assert.equal(report.totals.green_tsgo_winners_with_attribution, 1);
   assert.deepEqual(report.totals.missing_attribution_rows, ["single-file-loss", "vite-vanilla-ts-app"]);
   assert.equal(report.totals.incomplete_compat_excluded, 0);
+  assert.deepEqual(report.two_x_target, {
+    tsz_speedup_target: 2,
+    eligible_green_rows: 4,
+    project_eligible_green_rows: 2,
+    rows_meeting_target: 1,
+    rows_below_target: 3,
+    project_rows_below_target: 2,
+    worst_gap: report.target_gaps[0],
+  });
+  assert.deepEqual(
+    report.target_gaps.map((row) => row.name),
+    ["ts-toolbelt-project", "vite-vanilla-ts-app", "single-file-loss"],
+  );
+  assert.equal(report.target_gaps[0].semantic_owner_family, "recursive type evaluation pressure");
+  assert.equal(report.target_gaps[0].tsz_speedup_vs_tsgo, 106.15 / 873.92);
+  assert.equal(report.target_gaps[0].target_gap_factor, 2 / (106.15 / 873.92));
   assert.deepEqual(report.measurement_profile, {
     present: true,
     mode: "release-pgo",
@@ -255,6 +271,11 @@ withTempDir((dir) => {
     "200 classes",
     "BCT candidates=200",
   ]);
+  assert.deepEqual(
+    report.target_gaps.map((row) => row.name),
+    ["BCT candidates=200", "200 classes"],
+  );
+  assert.equal(report.two_x_target.rows_below_target, 2);
 });
 
 // Duplicate known project rows make the green-tsgo-winner summary non-authoritative.
@@ -345,6 +366,12 @@ withTempDir((dir) => {
   assert.deepEqual(report.totals.missing_loss_closure_rows, ["complete-project", "single-file-win"]);
   assert.equal(report.totals.green_tsgo_winners_with_attribution, 0);
   assert.deepEqual(report.totals.missing_attribution_rows, ["complete-project", "single-file-win"]);
+  assert.equal(report.two_x_target.eligible_green_rows, 2);
+  assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.deepEqual(
+    report.target_gaps.map((row) => row.name),
+    ["complete-project", "single-file-win"],
+  );
   assert.deepEqual(report.measurement_profile, {
     present: false,
     mode: null,
@@ -355,6 +382,36 @@ withTempDir((dir) => {
   assert.deepEqual(
     report.rows.map((r) => r.name),
     ["complete-project", "single-file-win"],
+  );
+});
+
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  const output = path.join(dir, "report.json");
+  writeJson(input, {
+    results: [
+      { name: "target-met", winner: "tsz", factor: 2.5, tsz_ms: 10, tsgo_ms: 25 },
+      { name: "target-short", winner: "tsz", factor: 1.5, tsz_ms: 10, tsgo_ms: 15 },
+      { name: "tsgo-win", winner: "tsgo", factor: 3, tsz_ms: 30, tsgo_ms: 10 },
+    ],
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /2x target gaps: 2\/3/);
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.two_x_target.rows_meeting_target, 1);
+  assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.deepEqual(
+    report.target_gaps.map((row) => [row.name, row.tsz_speedup_vs_tsgo]),
+    [
+      ["tsgo-win", 10 / 30],
+      ["target-short", 15 / 10],
+    ],
   );
 });
 

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -5,6 +5,8 @@ import { pathToFileURL } from "node:url";
 import { PROJECT_ROWS_BY_NAME } from "./project-rows.mjs";
 import { isGreen, isIncompleteCompat } from "./row-utils.mjs";
 
+const TARGET_TSZ_SPEEDUP = 2;
+
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
@@ -92,6 +94,20 @@ function lossClosureForRow(row) {
   return LOSS_CLOSURE_BY_ROW.get(row.name) ?? null;
 }
 
+function tszSpeedupVsTsgo(row) {
+  const tszMs = asNumber(row?.tsz_ms);
+  const tsgoMs = asNumber(row?.tsgo_ms);
+  if (tszMs != null && tsgoMs != null && tszMs > 0 && tsgoMs > 0) {
+    return tsgoMs / tszMs;
+  }
+
+  const factor = asNumber(row?.factor ?? row?.ratio);
+  if (factor == null || factor <= 0) return null;
+  if (row?.winner === "tsz") return factor;
+  if (row?.winner === "tsgo") return 1 / factor;
+  return null;
+}
+
 function measurementProfileStatus(input) {
   const profile = input?.measurement_profile;
   if (!profile || typeof profile !== "object") {
@@ -166,6 +182,15 @@ function hasCompleteAttribution(status) {
   return Boolean(status?.present && status?.dominant_subsystem);
 }
 
+function targetGapFactor(speedup) {
+  if (speedup == null || speedup <= 0) return null;
+  return TARGET_TSZ_SPEEDUP / speedup;
+}
+
+function targetGapForSort(value) {
+  return value ?? -Infinity;
+}
+
 // Null factors sort last (treated as the lowest possible value) so that rows
 // with a real factor always appear before rows with an unknown factor.
 function factorForSort(value) {
@@ -182,6 +207,12 @@ function compareFamiliesByWorstFactorDesc(a, b) {
   const factorDelta = factorForSort(b.worst_factor) - factorForSort(a.worst_factor);
   if (factorDelta !== 0) return factorDelta;
   return a.family.localeCompare(b.family);
+}
+
+function compareTargetGaps(a, b) {
+  const gapDelta = targetGapForSort(b.target_gap_factor) - targetGapForSort(a.target_gap_factor);
+  if (gapDelta !== 0) return gapDelta;
+  return String(a.name).localeCompare(String(b.name));
 }
 
 function duplicateProjectRows(rows) {
@@ -207,6 +238,33 @@ export function createTsgoWinnerReport(input, inputPath) {
   const duplicateRows = duplicateProjectRows(rows);
   const duplicateNames = new Set(duplicateRows.map((row) => row.name));
   const incompleteCompatExcluded = rows.filter(isIncompleteCompat).length;
+  const eligibleRows = rows
+    .filter((row) => isGreen(row) && !duplicateNames.has(row?.name))
+    .map((row) => {
+      const speedup = tszSpeedupVsTsgo(row);
+      const gapFactor = speedup == null ? null : targetGapFactor(speedup);
+      return {
+        name: row.name,
+        winner: row.winner ?? null,
+        factor: asNumber(row.factor),
+        tsz_speedup_vs_tsgo: speedup,
+        target_gap_factor: gapFactor,
+        tsz_ms: asNumber(row.tsz_ms),
+        tsgo_ms: asNumber(row.tsgo_ms),
+        lines: asNumber(row.lines),
+        kb: asNumber(row.kb),
+        project_files: asNumber(row.project_files),
+        files_reached: asNumber(row.compatibility?.files_reached ?? row.project_files),
+        peak_memory_bytes: asNumber(row.compatibility?.peak_memory_bytes),
+        exit_class: row.compatibility?.exit_class ?? null,
+        semantic_owner_family: row.compatibility?.semantic_owner_family ?? null,
+        loss_closure: lossClosureForRow(row),
+        attribution_status: attributionStatusForRow(row),
+      };
+    });
+  const targetGapRows = eligibleRows
+    .filter((row) => row.tsz_speedup_vs_tsgo == null || row.tsz_speedup_vs_tsgo < TARGET_TSZ_SPEEDUP)
+    .sort(compareTargetGaps);
 
   const winners = rows
     .filter((row) => row?.winner === "tsgo" && isGreen(row) && !duplicateNames.has(row?.name))
@@ -270,8 +328,18 @@ export function createTsgoWinnerReport(input, inputPath) {
       missing_attribution_rows: missingAttributionRows,
       incomplete_compat_excluded: incompleteCompatExcluded,
     },
+    two_x_target: {
+      tsz_speedup_target: TARGET_TSZ_SPEEDUP,
+      eligible_green_rows: eligibleRows.length,
+      project_eligible_green_rows: eligibleRows.filter((row) => row.semantic_owner_family).length,
+      rows_meeting_target: eligibleRows.length - targetGapRows.length,
+      rows_below_target: targetGapRows.length,
+      project_rows_below_target: targetGapRows.filter((row) => row.semantic_owner_family).length,
+      worst_gap: targetGapRows[0] ?? null,
+    },
     measurement_profile: measurementProfileStatus(input),
     duplicate_rows: duplicateRows,
+    target_gaps: targetGapRows,
     worst: winners[0] ?? null,
     by_owner_family: [...byOwnerFamily.values()].sort(compareFamiliesByWorstFactorDesc),
     rows: winners,
@@ -298,6 +366,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     [
       `green tsgo winners: ${report.totals.green_tsgo_winners}`,
       `project green tsgo winners: ${report.totals.project_green_tsgo_winners}`,
+      `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
       `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
     ].join("\n"),
   );


### PR DESCRIPTION
AgentName: M1-A

## Track
Track 10 performance measurement: benchmark artifact/reporting contract.

## Invariant
When a benchmark row is green, `tsz` speed target accounting is derived from timing data only after correctness gating; this PR reports rows where direct `tsgo_ms / tsz_ms` is below `2x` without changing compiler behavior.

## Scope
- Add `two_x_target` summary data and `target_gaps` rows to `scripts/bench/tsgo-winner-report.mjs`.
- Keep the existing green `tsgo` winner report fields intact for current dashboards and alerts.
- Extend `scripts/bench/test-tsgo-winner-report.mjs` for the new 2x-target reporting contract.
- Document the `*.tsgo-winners.json` companion artifact as the canonical 2x-target gap report in `docs/plan/PERFORMANCE_PLAN.md`.

## Project Corpus Impact
- Row: benchmark artifact/reporting only
- Bug family: n/a
- Evidence: `scripts/bench/tsgo-winner-report.mjs` consumes already-green `bench-vs-tsgo.sh` artifacts and changes report schema only; no compiler, fixture, diagnostic, emit, project-compile, or project-corpus runner behavior changes.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `node scripts/bench/test-perf-hotspots.mjs`
- `git diff --check`

## Coordination Notes
- Current head: `724a75e9642ffdd03ad0c10c27c353b4669bfa2a`.
- Ready for review with no WIP label or title marker.
- Non-overlap: current Studio-F performance-counter stack is untouched; this PR only extends the existing winner report schema.
- No `ROADMAP.md` update: this does not change active sequencing or public metric claims.
- Auto-merge is off; land only after the required exact-head checks are green.