### PR TITLE
perf(checker): lower indexed type-literal alias values

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -233,12 +233,8 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::INDEXED_ACCESS_TYPE => {
                 arena.get_indexed_access_type(node).is_some_and(|indexed| {
-                    Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
-                        arena,
-                        binder,
-                        indexed.object_type,
-                        type_param_names,
-                        seen,
+                    Self::source_file_indexed_access_object_is_generic_local_alias_application_lowerable(
+                        arena, binder, indexed.object_type, type_param_names, seen,
                     ) && Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
                         arena,
                         binder,
@@ -437,7 +433,7 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::INDEXED_ACCESS_TYPE => {
                 arena.get_indexed_access_type(node).is_some_and(|indexed| {
-                    Self::source_file_type_node_is_local_alias_chain_lowerable(
+                    Self::source_file_indexed_access_object_is_local_alias_chain_lowerable(
                         arena,
                         binder,
                         indexed.object_type,
@@ -570,10 +566,89 @@ impl<'a> CheckerState<'a> {
                 ))
     }
 
+    fn source_file_indexed_access_object_is_generic_local_alias_application_lowerable(
+        arena: &NodeArena,
+        binder: &BinderState,
+        node_idx: NodeIndex,
+        type_param_names: &[String],
+        seen: &mut AliasCycleTracker,
+    ) -> bool {
+        if let Some(node) = arena.get(node_idx)
+            && node.kind == syntax_kind_ext::TYPE_LITERAL
+        {
+            return Self::source_file_type_literal_has_lowerable_properties(
+                arena,
+                binder,
+                node,
+                type_param_names,
+                seen,
+            );
+        }
+        Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
+            arena,
+            binder,
+            node_idx,
+            type_param_names,
+            seen,
+        )
+    }
+
+    fn source_file_indexed_access_object_is_local_alias_chain_lowerable(
+        arena: &NodeArena,
+        binder: &BinderState,
+        node_idx: NodeIndex,
+        seen: &mut AliasCycleTracker,
+    ) -> bool {
+        if let Some(node) = arena.get(node_idx)
+            && node.kind == syntax_kind_ext::TYPE_LITERAL
+        {
+            return Self::source_file_type_literal_has_lowerable_properties(
+                arena,
+                binder,
+                node,
+                &[],
+                seen,
+            );
+        }
+        Self::source_file_type_node_is_local_alias_chain_lowerable(arena, binder, node_idx, seen)
+    }
+
     fn source_file_type_literal_has_generic_scope_independent_properties(
         arena: &NodeArena,
         node: &tsz_parser::parser::node::Node,
         type_param_names: &[String],
+    ) -> bool {
+        Self::source_file_type_literal_properties_are_lowerable(arena, node, |type_node| {
+            Self::source_file_type_node_is_generic_scope_independent(
+                arena,
+                type_node,
+                type_param_names,
+            )
+        })
+    }
+
+    fn source_file_type_literal_has_lowerable_properties(
+        arena: &NodeArena,
+        binder: &BinderState,
+        node: &tsz_parser::parser::node::Node,
+        type_param_names: &[String],
+        seen: &mut AliasCycleTracker,
+    ) -> bool {
+        Self::source_file_type_literal_properties_are_lowerable(arena, node, |type_node| {
+            Self::source_file_type_node_is_generic_local_alias_application_lowerable_with_seen(
+                arena,
+                binder,
+                type_node,
+                type_param_names,
+                seen,
+            )
+        })
+    }
+
+    fn source_file_type_literal_properties_are_lowerable(
+        arena: &NodeArena,
+        node: &tsz_parser::parser::node::Node,
+        mut value_is_lowerable: impl FnMut(NodeIndex) -> bool,
     ) -> bool {
         let Some(type_literal) = arena.get_type_literal(node) else {
             return false;
@@ -605,11 +680,7 @@ impl<'a> CheckerState<'a> {
                 {
                     return false;
                 }
-                Self::source_file_type_node_is_generic_scope_independent(
-                    arena,
-                    signature.type_annotation,
-                    type_param_names,
-                )
+                value_is_lowerable(signature.type_annotation)
             })
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
@@ -334,6 +334,25 @@ fn direct_source_file_type_alias_lowers_indexed_type_literal_with_local_alias_va
 }
 
 #[test]
+fn direct_source_file_type_alias_lowers_type_literal_property_local_alias_application() {
+    with_two_file_state(
+        "type Leaf<X> = X | null;\ntype Pick<X> = X extends unknown ? 1 : 0;\nexport type Select<T> = { 1: Leaf<T>, 0: never }[Pick<T>];",
+        "import { Select } from './target';",
+        |state, target_binder| {
+            let select_sym = target_binder.file_locals.get("Select").expect("Select");
+            let (ty, params) = state
+                .direct_source_file_type_alias_result(select_sym, Some(1), true)
+                .expect(
+                    "type-literal property values with safe local alias applications should lower",
+                );
+            assert_ne!(ty, TypeId::UNKNOWN);
+            assert_ne!(ty, TypeId::ERROR);
+            assert_eq!(params.len(), 1, "Select should preserve its type parameter");
+        },
+    );
+}
+
+#[test]
 fn direct_source_file_type_alias_rejects_type_literal_with_computed_name() {
     with_two_file_state(
         "declare const key: unique symbol;\nexport type Box<T> = { [key]: T };",
@@ -345,6 +364,23 @@ fn direct_source_file_type_alias_rejects_type_literal_with_computed_name() {
                     .direct_source_file_type_alias_result(box_sym, Some(1), true)
                     .is_none(),
                 "computed property names must stay on the child-checker path",
+            );
+        },
+    );
+}
+
+#[test]
+fn direct_source_file_type_alias_rejects_type_literal_property_typeof_alias_application() {
+    with_two_file_state(
+        "const value = 1;\ntype Leaf<X> = X | typeof value;\ntype Pick<X> = X extends unknown ? 1 : 0;\nexport type Select<T> = { 1: Leaf<T>, 0: never }[Pick<T>];",
+        "import { Select } from './target';",
+        |state, target_binder| {
+            let select_sym = target_binder.file_locals.get("Select").expect("Select");
+            assert!(
+                state
+                    .direct_source_file_type_alias_result(select_sym, Some(1), true)
+                    .is_none(),
+                "flow-sensitive local alias applications in type-literal properties must stay on the child-checker path",
             );
         },
     );


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance / source-file alias delegation fast path

## Invariant
When an exported source-file type alias is an indexed access over an inline type literal, and each property value is a lowerable local alias application while the index side is also lowerable, tsz can lower the alias directly into the parent checker type universe. Flow-sensitive local aliases, computed property names, root type-literal local-alias values, cycles, and `typeof`-dependent bodies still stay on the child-checker path.

## Scope
- Extend the direct source-file alias proof for indexed-access object type literals only.
- Reuse one property-walk helper for conservative type-literal value checks.
- Add adjacent positive and negative checker unit tests for lowerable local alias values and `typeof`-dependent rejection.

## Project Corpus Impact
- Row: ts-toolbelt-project source-file alias residue family
- Bug family: `DelegateCrossArenaSymbol` source-file type-alias residues for indexed type-literal alias values
- Evidence: focused checker unit coverage for the structural fast path; no wall-time claim from this PR

## Performance Evidence
- Measurement mode: attribution/structural proof only; timing mode not claimed.
- Before/after command protecting the invariant: `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`.
- Counter note: a two-file CLI micro fixture compiled with `TSZ_PERF_COUNTERS=1` and `--perf-counters-json`, but it did not exercise the source-alias counter path, so this PR does not claim a counter delta.
- Semantic invariant: the fast path remains syntax-structural and rejects flow-sensitive or value-dependent local alias bodies before skipping child-checker delegation.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib direct_source_file_type_alias`
- `scripts/safe-run.sh --limit 75% -- cargo run -p tsz-cli --features perf-tools --bin tsz -- --noEmit --extendedDiagnostics --perf-counters-json /tmp/tsz-source-alias-branch.json -p /tmp/tsz-source-alias-j0u63m/tsconfig.json` (0 diagnostics; counter path not exercised)

## Coordination Notes
- Owns branch `codex/m1-a-source-alias-type-literal-values-20260526` under AgentName M1-A.
- Remote body and `agent:M1-A` label verified before marking ready.
