### PR TITLE
perf(checker): avoid child symbol cache preallocation

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -46,6 +46,7 @@ impl<'a> CheckerContext<'a> {
         file_name: String,
         compiler_options: CheckerOptions,
         capabilities: crate::query_boundaries::capabilities::EnvironmentCapabilities,
+        symbol_cache_capacity: usize,
     ) -> Self {
         let flow_graph = Some(FlowGraph::new(&binder.flow_nodes));
 
@@ -64,9 +65,9 @@ impl<'a> CheckerContext<'a> {
             no_implicit_override: false,
             types_extending_array: FxHashSet::default(),
             recovery_sites: RefCell::new(crate::recovery::RecoverySites::default()),
-            symbol_types: crate::context::SymbolTypeCache::with_capacity(binder.symbols.len()),
+            symbol_types: crate::context::SymbolTypeCache::with_capacity(symbol_cache_capacity),
             symbol_instance_types: crate::context::SymbolTypeCache::with_capacity(
-                binder.symbols.len(),
+                symbol_cache_capacity,
             ),
             enum_namespace_types: FxHashMap::default(),
             var_decl_types: FxHashMap::default(),
@@ -329,6 +330,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         // Create pre-populated DefinitionStore from binder's semantic_defs
         // using the solver-owned factory. This is the canonical identity
@@ -371,6 +373,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         ctx.definition_store = definition_store;
         // Eagerly warm local caches from the shared store so that
@@ -404,6 +407,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         ctx.definition_store = Arc::new(DefinitionStore::from_semantic_defs(
             &binder.semantic_defs,
@@ -449,6 +453,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         )
     }
 
@@ -502,6 +507,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         ctx.definition_store = Arc::new(DefinitionStore::from_semantic_defs(
             &binder.semantic_defs,
@@ -537,6 +543,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         ctx.definition_store = Arc::new(DefinitionStore::from_semantic_defs(
             &binder.semantic_defs,
@@ -574,6 +581,7 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            binder.symbols.len(),
         );
         ctx.definition_store = definition_store;
         ctx.warm_local_caches_from_shared_store();
@@ -607,6 +615,9 @@ impl<'a> CheckerContext<'a> {
             file_name,
             compiler_options,
             capabilities,
+            // Child contexts replace symbol caches with parent snapshots below;
+            // starting at zero avoids binder-sized preallocation per child.
+            0,
         );
 
         // Propagate parent state that is safe across arenas.


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance / checker child-constructor allocation cleanup

## Invariant
When `CheckerContext::with_parent_cache` creates a child context, the child inherits `symbol_types` and `symbol_instance_types` from the parent before use. Starting the child base context with zero symbol-cache capacity preserves the inherited cache contents while avoiding binder-sized preallocation that is immediately replaced.

## Scope
- Thread an explicit `symbol_cache_capacity` through `CheckerContext::base`.
- Keep normal/root contexts sized to `binder.symbols.len()`.
- Use capacity `0` only for `with_parent_cache`, where symbol caches are overwritten by parent snapshots.

## Project Corpus Impact
- Row: cross-file checker delegation hot paths, including ts-toolbelt-project residue families
- Bug family: repeated `with_parent_cache` child-constructor allocation overhead
- Evidence: existing perf-counter family records `with_parent_cache_constructed`; this PR removes two binder-sized symbol-cache preallocations per child construction without claiming wall-time

## Performance Evidence
- Measurement mode: structural allocation cleanup; timing mode not claimed.
- Before/after command protecting the build invariant: `cargo check -p tsz-checker`.
- Counter note: a local two-file CLI fixture compiled with `TSZ_PERF_COUNTERS=1` and `--perf-counters-json`, but it did not exercise `with_parent_cache`; the PR therefore does not claim a local counter delta.
- Semantic/cache invariant: child contexts still receive the same parent `symbol_types` and `symbol_instance_types` snapshots before resolution logic can use them.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-checker/src/context/constructors.rs` -> 753 lines

## Coordination Notes
- Owns branch `codex/m1-a-parent-cache-constructor-slice-20260526` under AgentName M1-A.
- Independent of #10235; touches `crates/tsz-checker/src/context/constructors.rs` only.
