### PR TITLE
perf(checker): avoid optional chain key scratch allocation

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/optional_chain_cache.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_chain_cache.rs
@@ -3,6 +3,7 @@
 use crate::context::TypingRequest;
 use crate::query_boundaries::common::OptionalPropertyChainKey;
 use crate::state::CheckerState;
+use smallvec::SmallVec;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -27,7 +28,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let mut current = idx;
-        let mut reversed_properties: Vec<(Atom, bool)> = Vec::with_capacity(6);
+        let mut reversed_properties: SmallVec<[(Atom, bool); 6]> = SmallVec::new();
         let mut saw_optional = false;
         let root = loop {
             if reversed_properties.len() >= u64::BITS as usize {


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance / optional-property-chain cache key allocation cleanup

## Invariant
When building an `OptionalPropertyChainKey`, tsz must preserve the same ordered property atoms and optional mask. This PR changes only the temporary reversed-property scratch buffer from heap-backed `Vec` to inline `SmallVec`; the final cache key remains the same owned `Vec<Atom>`.

## Scope
- Use `SmallVec<[(Atom, bool); 6]>` for the temporary reversed optional-chain property list.
- Leave cache-key fields, request gating, JS/index-signature guards, and final key ownership unchanged.

## Project Corpus Impact
- Row: optional-property-chain-heavy checker paths in project rows such as Next/Vite-style applications
- Bug family: per-chain heap allocation while constructing optional property chain cache keys
- Evidence: structural allocation cleanup in the existing optional-chain cache path; no wall-time claim from this PR

## Performance Evidence
- Measurement mode: structural allocation cleanup; timing mode not claimed.
- Before/after command protecting build behavior: `cargo check -p tsz-checker`.
- Allocation invariant: optional chains of up to six property segments now keep the temporary reversed-property list inline instead of allocating a heap `Vec` before the final key is built.
- Known local test limitation: `cargo nextest` did not return even for a no-match probe in this workspace, so focused nextest coverage was not used for this slice; ready CI is expected to run the unit and heavy suites.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-checker/src/types/property_access_type/optional_chain_cache.rs` -> 99 lines

## Coordination Notes
- Owns branch `codex/m1-a-optional-chain-cache-smallvec-20260526` under AgentName M1-A.
- No file overlap with #10235, #10236, or M4-C #9875.
