### PR TITLE
perf(checker): avoid switch clause index scratch vec

### DIFF
--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -630,17 +630,12 @@ impl<'a> CheckerState<'a> {
             return true;
         };
 
-        let mut has_default = false;
-        let mut clause_indices = Vec::new();
-        for &clause_idx in &case_block.statements.nodes {
-            let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
-                continue;
-            };
-            if clause_node.kind == syntax_kind_ext::DEFAULT_CLAUSE {
-                has_default = true;
-            }
-            clause_indices.push(clause_idx);
-        }
+        let has_default = case_block.statements.nodes.iter().any(|&clause_idx| {
+            self.ctx
+                .arena
+                .get(clause_idx)
+                .is_some_and(|clause_node| clause_node.kind == syntax_kind_ext::DEFAULT_CLAUSE)
+        });
 
         // Without a default clause, unmatched discriminants can skip the switch
         // body unless case coverage is exhaustive.
@@ -653,7 +648,7 @@ impl<'a> CheckerState<'a> {
         let mut falls_from_next = true;
         let mut any_entry_falls_through = false;
 
-        for &clause_idx in clause_indices.iter().rev() {
+        for &clause_idx in case_block.statements.nodes.iter().rev() {
             let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
                 continue;
             };


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance: allocation-only checker reachability cleanup.

## Invariant
When a switch statement is analyzed for fall-through, tsz must preserve the same default-clause detection and reverse clause analysis. This PR changes only temporary storage in checker reachability.

## Scope
- `crates/tsz-checker/src/flow/reachability_checker.rs`: remove the temporary `Vec<NodeIndex>` used only to reverse-iterate switch clauses in `switch_falls_through`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: allocation-only checker fall-through iteration cleanup; no project fixture behavior or timing claim.

## Performance Evidence
No timing claim. The change avoids one temporary clause-index vector allocation/copy per analyzed switch by iterating the existing case-block slice directly.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- Attempted: `/opt/homebrew/bin/timeout 90s cargo nextest run -p tsz-checker test_unreachable_code_in_switch_fallthrough` and a 60s retry after build; both timed out after the test profile finished building in this workspace, so nextest is not counted as passed.

## Coordination Notes
- AgentName: M1-A
- Fresh branch from `origin/main` at `896d62402c`.
- No file overlap with owned PRs #10235, #10236, or #10237.
- Open PR scan showed optional-chain/mapped-type work in other lanes; this PR stays in switch reachability only.