### PR TITLE
perf(checker): prescan import typedef type params

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -535,6 +535,9 @@ impl<'a> CheckerState<'a> {
         };
 
         for source_file in &target_arena.source_files {
+            if !Self::source_file_has_jsdoc_typedef_named(source_file, member_name) {
+                continue;
+            }
             let comments = source_file.comments.clone();
             let source_text = source_file.text.to_string();
             // No cache fast-path on this delegate; every entry is a miss.


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance / import-type JSDoc typedef child-checker avoidance.

## Invariant
When resolving type parameters for `import('./file').Name<T>` where `Name` is a JSDoc typedef, tsz only needs a child checker for source files that structurally declare the requested typedef name. Files without that typedef cannot produce type parameters for it, so skipping them preserves the same empty-result behavior while avoiding source-text cloning and child-checker construction.

## Scope
- `crates/tsz-checker/src/state/type_resolution/import_type.rs`: reuse the existing `source_file_has_jsdoc_typedef_named` pre-scan in `resolve_import_typedef_type_params` before cloning comments/source text or constructing an `ImportType` child checker.

## Project Corpus Impact
- Row: JSDoc/import-type-heavy project rows and import-type constraint checks.
- Bug family: unnecessary `ImportType` child-checker construction on negative JSDoc typedef type-parameter lookups.
- Evidence: structural guard before the existing child-checker path; no wall-time claim from this PR.

## Performance Evidence
- Measurement mode: structural allocation/construction cleanup; timing mode not claimed.
- Avoids cloning source text and constructing a `with_parent_cache_attributed(..., ImportType)` checker for target source files that do not declare the requested typedef.
- Semantic invariant: the same pre-scan already guards `resolve_import_type_jsdoc_typedef`; when it is false, `resolve_jsdoc_typedef_info(member_name, ...)` would return `None` for that file, so the final result remains `Vec::new()` unless another source file declares the typedef.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-checker/src/state/type_resolution/import_type.rs` -> 1262 lines
- Attempted: `/opt/homebrew/bin/timeout 60s cargo nextest run -p tsz-checker jsdoc_typedef_in_js_module_suppresses_ts2694_on_import_type_member`; timed out in this workspace, so nextest is not counted as passed.

## Coordination Notes
- AgentName: M1-A
- Fresh branch from `origin/main` at `c9812de98e`.
- No file overlap with owned PRs #10235, #10236, #10237, or #10238.
- Open PR scan showed no active branch touching `crates/tsz-checker/src/state/type_resolution/import_type.rs`.