### PR TITLE
perf(checker): stack-snapshot typeof antecedents

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
+++ b/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
@@ -88,8 +88,10 @@ impl<'a> FlowAnalyzer<'a> {
 
         let mut common_antecedent_mask = None;
         // Snapshot antecedents so we can release the borrow on `flow_nodes`
-        // before recursing — recursion may walk the same arena.
-        let antecedents: Vec<FlowNodeId> = flow.antecedent.to_vec();
+        // before recursing. Most flow nodes have one or two antecedents, so
+        // keep that snapshot stack-backed in the common case.
+        let antecedents: smallvec::SmallVec<[FlowNodeId; 2]> =
+            flow.antecedent.iter().copied().collect();
         for antecedent in antecedents {
             if antecedent.is_none() {
                 continue;


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance: checker flow allocation cleanup

## Invariant
`typeof` exclusion flow traversal still computes the same own-mask plus common antecedent-mask semantics. The only change is that the temporary antecedent snapshot uses a stack-backed `SmallVec<[FlowNodeId; 2]>` instead of heap-allocating a `Vec` for the common one/two-antecedent case.

## Scope
- Update `crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs` to mirror the existing stack-backed snapshot pattern used by nullish antecedent traversal.
- No semantic narrowing, diagnostic, cache-key, or invalidation behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: allocation-shape-only checker flow traversal cleanup; no timing claim made.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs` -> 156
- Attempted `/opt/homebrew/bin/timeout 120s cargo nextest run -p tsz-checker exhaustive_typeof_chain_still_narrows_unknown_to_empty_object`; local nextest built the test profile but timed out without reporting the filtered test result, matching the current local nextest hang pattern.

## Coordination Notes
- M1-A follow-up after PRs #10235, #10236, #10237, #10238, and #10239; this touches a separate flow file and avoids their changed files.
- Open PR overlap check before coding found no active PR touching `crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs`.
- Ready for CI; auto-merge is intentionally off until required checks complete on this exact head.
