### PR TITLE
perf(checker): lazily collect js prototype property names

### DIFF
--- a/crates/tsz-checker/src/types/function_type/js_prototype.rs
+++ b/crates/tsz-checker/src/types/function_type/js_prototype.rs
@@ -216,8 +216,6 @@ impl<'a> CheckerState<'a> {
             })?;
         let mut properties = rustc_hash::FxHashMap::default();
         self.collect_js_constructor_this_properties(body_idx, &mut properties, None, false);
-        let constructor_property_names: rustc_hash::FxHashSet<_> =
-            properties.keys().copied().collect();
         if let Some((func_name, sym_id)) = self.js_constructor_function_name_and_symbol(func_idx) {
             let PrototypeMembers {
                 method_bindings,
@@ -231,21 +229,25 @@ impl<'a> CheckerState<'a> {
             for (name, prop) in method_bindings {
                 properties.entry(name).or_insert(prop);
             }
-            for (name, mut prop) in this_props {
-                let factory = self.ctx.types.factory();
-                let widened_prop_type = factory.union2(prop.type_id, TypeId::UNDEFINED);
-                if let Some(existing) = properties.get_mut(&name) {
-                    if existing.write_type == TypeId::ANY {
-                        existing.type_id = factory.union2(existing.type_id, widened_prop_type);
-                    } else if !constructor_property_names.contains(&name) {
-                        let merged = factory.union2(existing.type_id, widened_prop_type);
-                        existing.type_id = merged;
-                        existing.write_type = merged;
+            if !this_props.is_empty() {
+                let constructor_property_names: rustc_hash::FxHashSet<_> =
+                    properties.keys().copied().collect();
+                for (name, mut prop) in this_props {
+                    let factory = self.ctx.types.factory();
+                    let widened_prop_type = factory.union2(prop.type_id, TypeId::UNDEFINED);
+                    if let Some(existing) = properties.get_mut(&name) {
+                        if existing.write_type == TypeId::ANY {
+                            existing.type_id = factory.union2(existing.type_id, widened_prop_type);
+                        } else if !constructor_property_names.contains(&name) {
+                            let merged = factory.union2(existing.type_id, widened_prop_type);
+                            existing.type_id = merged;
+                            existing.write_type = merged;
+                        }
+                    } else {
+                        prop.type_id = widened_prop_type;
+                        prop.write_type = prop.type_id;
+                        properties.insert(name, prop);
                     }
-                } else {
-                    prop.type_id = widened_prop_type;
-                    prop.write_type = prop.type_id;
-                    properties.insert(name, prop);
                 }
             }
         }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance: checker micro-allocation cleanup

## Invariant
JS constructor body instance-type inference preserves the same merge policy for constructor `this` properties, prototype method bindings, and prototype-method `this` properties. The existing constructor-property-name set is now built only when `this_props` is non-empty, which is the only path that reads it.

## Scope
- Update `crates/tsz-checker/src/types/function_type/js_prototype.rs` to avoid collecting `properties.keys()` into an `FxHashSet` when no prototype-method `this` properties are present.
- No semantic narrowing, diagnostics, cache keys, or project-row behavior changed.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: allocation-shape-only checker JS prototype helper cleanup; no timing claim made.

## Verification
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-checker/src/types/function_type/js_prototype.rs` -> 300
- Attempted `/opt/homebrew/bin/timeout 120s cargo nextest run -p tsz-checker test_plain_function_constructor_prototype_this_prop_has_undefined`; local nextest built the test profile but timed out without reporting the filtered test result, matching the current local nextest hang pattern.

## Coordination Notes
- M1-A follow-up after PRs #10235, #10236, #10237, #10238, #10239, and #10240; this touches a separate checker helper file and avoids their changed files.
- Open PR overlap check before coding found no active PR touching `crates/tsz-checker/src/types/function_type/js_prototype.rs`.
- Ready for CI; auto-merge is intentionally off until required checks complete on this exact head.
