### PR TITLE
perf(checker): avoid empty destructuring property clone

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -1123,8 +1123,7 @@ impl<'a> CheckerState<'a> {
         };
         // Build the empty target type once for diagnostic reuse.
         let empty_target = self.ctx.types.factory().object(Vec::new());
-        let source_props: Vec<_> = source_shape.properties.to_vec();
-        for source_prop in source_props {
+        for source_prop in &source_shape.properties {
             let report_idx = self
                 .find_object_literal_property_element(right_idx, source_prop.name)
                 .unwrap_or(right_idx);


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance micro-allocation.

## Invariant
Empty object destructuring assignment excess diagnostics iterate the same object-shape properties in the same order. The change removes only the temporary cloned property `Vec`; the shape is held by `Arc`, and diagnostics still use each original `PropertyInfo` name.

## Scope
- `crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: micro-allocation in checker diagnostics path
- Evidence: behavior-preserving allocation removal; no project-row speed claim.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs` -> 1960
- Attempted `cargo nextest run -p tsz-checker destructuring_assignment_empty_pattern_emits_ts2353_for_each_excess_property`; local nextest built the test profile, then remained silent and was killed without a test result.

## Coordination Notes
- Avoids the currently open M1-A PR files `js_prototype.rs` and `complex_js_constructor.rs`.
- Open-PR overlap scan showed no active PR touching `assignment_ops.rs`.