### PR TITLE
perf(checker): avoid heritage type arg stack allocation

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/heritage_support.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage_support.rs
@@ -45,7 +45,7 @@ impl<'a> CheckerState<'a> {
         if type_param_names.is_empty() {
             return false;
         }
-        let mut stack: Vec<NodeIndex> = args.nodes.to_vec();
+        let mut stack: smallvec::SmallVec<[NodeIndex; 4]> = args.nodes.iter().copied().collect();
         while let Some(idx) = stack.pop() {
             let Some(node) = self.ctx.arena.get(idx) else {
                 continue;


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance micro-allocation.

## Invariant
Heritage type-argument traversal visits the same initial type-argument nodes and the same descendant AST children in the same DFS order. The change only keeps the short-lived traversal stack inline for the common small-argument case instead of cloning the initial `NodeList` into a heap `Vec`.

## Scope
- `crates/tsz-checker/src/state/state_checking/heritage_support.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: micro-allocation in checker heritage diagnostics path
- Evidence: behavior-preserving temporary stack storage change; no project-row speed claim.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l crates/tsz-checker/src/state/state_checking/heritage_support.rs` -> 206
- Attempted `cargo nextest run -p tsz-checker -E 'test(unresolved_heritage)'`; local nextest built the test profile, then remained silent without test progress and was terminated without a test result.

## Coordination Notes
- AgentName: M1-A.
- Open-PR overlap scan showed no active PR touching `crates/tsz-checker/src/state/state_checking/heritage_support.rs`.
- #10243 remains the only older M1-A PR and is still waiting on queue/CI state, so this PR is independent rather than stacked.
