### PR TITLE
perf(checker): keep call argument anchors inline

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors_anchors.rs
@@ -3,6 +3,7 @@
 //! These helpers locate the precise AST node to anchor a diagnostic on
 //! when reporting overload and literal argument mismatch errors.
 use crate::state::CheckerState;
+use smallvec::SmallVec;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 use tsz_solver::computation::ContextualTypeContext;
@@ -17,16 +18,22 @@ impl<'a> CheckerState<'a> {
     /// the call-result handler. Treating tagged templates uniformly here keeps
     /// overload/argument anchor logic from collapsing onto the tag callee when
     /// the offending node is actually a substitution expression.
-    pub(super) fn logical_call_argument_nodes(&self, idx: NodeIndex) -> Option<Vec<NodeIndex>> {
+    pub(super) fn logical_call_argument_nodes(
+        &self,
+        idx: NodeIndex,
+    ) -> Option<SmallVec<[NodeIndex; 4]>> {
         use tsz_parser::parser::syntax_kind_ext;
 
         let node = self.ctx.arena.get(idx)?;
         if let Some(call) = self.ctx.arena.get_call_expr(node) {
-            return call.arguments.as_ref().map(|args| args.nodes.to_vec());
+            return call
+                .arguments
+                .as_ref()
+                .map(|args| args.nodes.iter().copied().collect());
         }
         if node.kind == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION {
             let tagged = self.ctx.arena.get_tagged_template(node)?.clone();
-            let mut nodes = Vec::with_capacity(4);
+            let mut nodes = SmallVec::new();
             nodes.push(tagged.template);
             if let Some(template_node) = self.ctx.arena.get(tagged.template)
                 && template_node.kind == syntax_kind_ext::TEMPLATE_EXPRESSION


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance micro-allocation.

## Invariant
Call error anchor resolution returns the same logical argument nodes in the same order for plain calls and tagged templates. The change only stores those short-lived argument lists in inline `SmallVec` storage for the common small-call case instead of eagerly allocating a heap `Vec`.

## Scope
- `crates/tsz-checker/src/error_reporter/call_errors_anchors.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: micro-allocation in checker call diagnostic anchoring
- Evidence: behavior-preserving temporary argument-list storage change; no project-row speed claim.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l crates/tsz-checker/src/error_reporter/call_errors_anchors.rs` -> 522

## Coordination Notes
- AgentName: M1-A.
- Open-PR overlap scan showed no active PR touching `crates/tsz-checker/src/error_reporter/call_errors_anchors.rs`.
- Independent of M1-A PRs #10243 and #10244, which are waiting on CI/queue state.
