### PR TITLE
perf(checker): avoid jsx signature filter vecs

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -1216,11 +1216,13 @@ impl<'a> CheckerState<'a> {
             // G4: Skip overloaded SFCs — we don't do JSX overload resolution.
             // Picking the first non-generic overload would produce wrong errors
             // when later overloads match the provided attributes.
-            let non_generic: Vec<_> = sigs.iter().filter(|s| s.type_params.is_empty()).collect();
-            if non_generic.len() != 1 {
+            let mut non_generic = sigs.iter().filter(|s| s.type_params.is_empty());
+            let Some(sig) = non_generic.next() else {
+                return None;
+            };
+            if non_generic.next().is_some() {
                 return None;
             }
-            let sig = non_generic[0];
             let props = sig
                 .params
                 .first()
@@ -1455,11 +1457,14 @@ impl<'a> CheckerState<'a> {
         let first_sig = if sigs.len() == 1 {
             sigs.first()?
         } else {
-            let with_props: Vec<_> = sigs.iter().filter(|sig| !sig.params.is_empty()).collect();
-            match with_props.len() {
-                1 => with_props[0],
-                _ => return None,
+            let mut with_props = sigs.iter().filter(|sig| !sig.params.is_empty());
+            let Some(sig) = with_props.next() else {
+                return None;
+            };
+            if with_props.next().is_some() {
+                return None;
             }
+            sig
         };
 
         let inferred_sig = Some(first_sig.clone())

--- a/crates/tsz-checker/src/checkers/jsx/extraction.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction.rs
@@ -1217,9 +1217,7 @@ impl<'a> CheckerState<'a> {
             // Picking the first non-generic overload would produce wrong errors
             // when later overloads match the provided attributes.
             let mut non_generic = sigs.iter().filter(|s| s.type_params.is_empty());
-            let Some(sig) = non_generic.next() else {
-                return None;
-            };
+            let sig = non_generic.next()?;
             if non_generic.next().is_some() {
                 return None;
             }
@@ -1458,9 +1456,7 @@ impl<'a> CheckerState<'a> {
             sigs.first()?
         } else {
             let mut with_props = sigs.iter().filter(|sig| !sig.params.is_empty());
-            let Some(sig) = with_props.next() else {
-                return None;
-            };
+            let sig = with_props.next()?;
             if with_props.next().is_some() {
                 return None;
             }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 performance micro-allocation.

## Invariant
JSX props extraction keeps the same overload decisions: it accepts exactly one non-generic callable props signature and exactly one props-taking constructor signature. The change only replaces temporary filtered `Vec`s with iterator probes that detect zero, one, or multiple matches without heap allocation.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: micro-allocation in checker JSX props extraction
- Evidence: behavior-preserving temporary signature-filter allocation removal; no project-row speed claim.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l crates/tsz-checker/src/checkers/jsx/extraction.rs` -> 1718

## Coordination Notes
- AgentName: M1-A.
- Open-PR overlap scan showed no active PR touching `crates/tsz-checker/src/checkers/jsx/extraction.rs`.
- Independent of M1-A PRs #10243, #10244, and #10245, which are waiting on CI/queue state.
