### PR TITLE
perf(checker): keep interface signature keys inline

### DIFF
--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -13,6 +13,7 @@ use crate::query_boundaries::common::is_template_literal_type;
 use crate::state::CheckerState;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -39,14 +40,14 @@ fn dedup_call_signatures_keep_last(sigs: &mut Vec<tsz_solver::CallSignature>) {
     // Build a signature key from param types + return type for identity.
     // Walk from the end and record the last index for each unique key.
     // Then retain only those positions.
-    let key_of =
-        |sig: &tsz_solver::CallSignature| -> (Vec<tsz_solver::TypeId>, tsz_solver::TypeId) {
-            let param_types: Vec<_> = sig.params.iter().map(|p| p.type_id).collect();
-            (param_types, sig.return_type)
-        };
+    type SignatureKey = (SmallVec<[TypeId; 4]>, TypeId);
 
-    let mut seen: FxHashMap<(Vec<tsz_solver::TypeId>, tsz_solver::TypeId), usize> =
-        FxHashMap::default();
+    let key_of = |sig: &tsz_solver::CallSignature| -> SignatureKey {
+        let param_types = sig.params.iter().map(|p| p.type_id).collect();
+        (param_types, sig.return_type)
+    };
+
+    let mut seen: FxHashMap<SignatureKey, usize> = FxHashMap::default();
     // Record the LAST index for each key
     for (i, sig) in sigs.iter().enumerate() {
         seen.insert(key_of(sig), i);


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
Interface call-signature deduplication still keys signatures by the same ordered parameter TypeIds plus return TypeId and keeps the last duplicate occurrence.

## Scope
- Replace the heap-backed Vec used inside interface signature hash keys with SmallVec<[TypeId; 4]> so common short parameter lists stay inline during deduplication.
- No semantic relation, diagnostic, or ordering behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving storage change in `crates/tsz-checker/src/types/interface_type.rs`; no project-corpus behavior claim.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-checker/src/types/interface_type.rs -> 1532
- cargo check -p tsz-checker
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- AgentName: Gauss refreshed the Project Corpus Impact wording after the project-corpus-pr-body gate reported a stale failure.
- Open PR overlap check found no non-M1-A PR touching crates/tsz-checker/src/types/interface_type.rs.
- This is independent of M1-A PRs #10245 and #10246; M1-A PRs #10243 and #10244 have merged.
