### PR TITLE
perf(solver): avoid object spread union temp vec

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -943,19 +943,15 @@ impl<'a> QueryCache<'a> {
                 // contribute no properties. Properties that don't appear in
                 // every non-nullish member become optional.
                 let has_nullish = members.iter().any(|m| m.is_nullable());
-                let non_nullish: Vec<TypeId> = members
-                    .iter()
-                    .copied()
-                    .filter(|m| !m.is_nullable())
-                    .collect();
+                let non_nullish_count = members.iter().filter(|m| !m.is_nullable()).count();
 
-                if non_nullish.is_empty() {
+                if non_nullish_count == 0 {
                     return Vec::new();
                 }
 
                 // Collect properties per member
-                let mut all_props: Vec<Vec<PropertyInfo>> = Vec::with_capacity(non_nullish.len());
-                for &member in &non_nullish {
+                let mut all_props: Vec<Vec<PropertyInfo>> = Vec::with_capacity(non_nullish_count);
+                for &member in members.iter().filter(|m| !m.is_nullable()) {
                     all_props.push(self.collect_object_spread_properties_inner(member, visited));
                 }
 
@@ -982,7 +978,7 @@ impl<'a> QueryCache<'a> {
                 merged
                     .into_iter()
                     .map(|(name, (type_id, was_optional, count))| {
-                        let optional = was_optional || has_nullish || count < non_nullish.len();
+                        let optional = was_optional || has_nullish || count < non_nullish_count;
                         PropertyInfo {
                             name,
                             type_id,


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
Object spread over union types still ignores nullish members, returns no properties when every member is nullish, and marks merged properties optional when they are absent from any non-nullish member or when a nullish member is present.

## Scope
- Remove the temporary Vec<TypeId> collected for non-nullish union members in object-spread property collection.
- Keep the same recursion, visited-set behavior, property merge count, and optionality decision.

## Project Corpus Impact
- Row: n/a
- Bug family: solver object-spread union micro-allocation
- Evidence: behavior-preserving storage change only; local solver check, clippy, focused nextest, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-solver/src/caches/query_cache.rs -> 1952
- cargo check -p tsz-solver
- cargo clippy -p tsz-solver --lib -- -D warnings
- cargo nextest run -p tsz-solver query_cache_caches_object_spread_properties
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no non-M1-A PR touching crates/tsz-solver/src/caches/query_cache.rs.
- This is independent of M1-A PRs #10246 and #10247.
