### PR TITLE
perf(solver): avoid direct inference temp vec

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -561,15 +561,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     pub(super) fn direct_inference_tracking_target(&self, ty: TypeId) -> Option<TypeId> {
         match self.interner.lookup(ty) {
             Some(TypeData::Union(members)) => {
-                let non_nullish: Vec<TypeId> = self
-                    .interner
-                    .type_list(members)
+                let member_list = self.interner.type_list(members);
+                let mut non_nullish = member_list
                     .iter()
                     .copied()
-                    .filter(|member| !member.is_nullable())
-                    .collect();
-                if non_nullish.len() == 1 {
-                    self.direct_inference_tracking_target(non_nullish[0])
+                    .filter(|member| !member.is_nullable());
+                let member = non_nullish.next()?;
+                if non_nullish.next().is_none() {
+                    self.direct_inference_tracking_target(member)
                 } else {
                     None
                 }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
Generic-call direct inference tracking still unwraps a union only when it has exactly one non-nullish member, recurses into that member, and returns None for zero or multiple non-nullish members.

## Scope
- Replace the temporary Vec<TypeId> used to count non-nullish union members with iterator probing in direct_inference_tracking_target.
- No inference rule, relation behavior, or contextual target behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver generic-call inference micro-allocation
- Evidence: behavior-preserving storage change only; local solver check, clippy, focused nextest, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-solver/src/operations/generic_call/inference_helpers.rs -> 1886
- cargo check -p tsz-solver
- cargo clippy -p tsz-solver --lib -- -D warnings
- cargo nextest run -p tsz-solver test_contextual_generic_call_union_preserves_literal
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no non-M1-A PR touching crates/tsz-solver/src/operations/generic_call/inference_helpers.rs.
- This is independent of M1-A PRs #10246 and #10248.
