### PR TITLE
perf(solver): avoid nested lazy union temp vec

### DIFF
--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -264,11 +264,13 @@ pub fn widen_if_recursive_intersection_member(
     }
 
     if let Some(union_members) = crate::type_queries::get_union_members(db, nested_target) {
-        let non_undef: Vec<TypeId> = union_members
+        let mut non_undef = union_members
             .into_iter()
-            .filter(|&m| m != TypeId::UNDEFINED)
-            .collect();
-        if non_undef.len() == 1 && is_lazy_outer_member(non_undef[0]) {
+            .filter(|&m| m != TypeId::UNDEFINED);
+        let Some(member) = non_undef.next() else {
+            return nested_target;
+        };
+        if non_undef.next().is_none() && is_lazy_outer_member(member) {
             return db.union(vec![outer_intersection, TypeId::UNDEFINED]);
         }
     }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
Recursive-intersection widening still replaces `T | undefined` with `outer_intersection | undefined` only when the union has exactly one non-undefined member and that member is a lazy member of the outer intersection. All zero-member, multi-member, and non-lazy cases still return the original nested target.

## Scope
- Replace the temporary Vec<TypeId> used to count non-undefined union members in widen_if_recursive_intersection_member with iterator probing.
- No recursive-intersection, lazy-type, or union-construction behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver recursive-intersection utility micro-allocation
- Evidence: behavior-preserving storage change only; local solver check, clippy, utils nextest, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-solver/src/utils/mod.rs -> 476
- cargo check -p tsz-solver
- cargo clippy -p tsz-solver --lib -- -D warnings
- cargo nextest run -p tsz-solver utils
- python3 scripts/arch/arch_guard.py
- attempted cargo nextest run -p tsz-checker canonical_repro_interface_recursive_intersection_no_false_ts2353; interrupted after compile when it produced no test output for an extended period.

## Coordination Notes
- Open PR overlap check found no non-M1-A PR touching crates/tsz-solver/src/utils/mod.rs.
- This is independent of M1-A PRs #10246, #10248, and #10249.
