### PR TITLE
perf(checker): lazily normalize enum switch unions

### DIFF
--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -328,15 +328,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn normalize_enum_union_members(&self, type_id: TypeId) -> TypeId {
-        if let Some(members) = query::union_members_for_type(self.ctx.types, type_id) {
-            let normalized: Vec<TypeId> = members
-                .into_iter()
-                .map(|member| query::enum_member_domain(self.ctx.types, member))
-                .collect();
-            query::union_types(self.ctx.types, normalized)
-        } else {
-            query::enum_member_domain(self.ctx.types, type_id)
-        }
+        query::enum_member_union_domain(self.ctx.types, type_id)
     }
 
     fn typeof_switch_operand(&self, switch_expr: NodeIndex) -> Option<NodeIndex> {

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -73,6 +73,27 @@ pub(crate) fn enum_member_domain(db: &dyn TypeDatabase, type_id: TypeId) -> Type
         .unwrap_or(type_id)
 }
 
+pub(crate) fn enum_member_union_domain(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    let Some(members) = union_members_for_type(db, type_id) else {
+        return enum_member_domain(db, type_id);
+    };
+
+    let mut normalized: Option<Vec<TypeId>> = None;
+    for (index, member) in members.iter().copied().enumerate() {
+        let domain = enum_member_domain(db, member);
+        if let Some(normalized) = normalized.as_mut() {
+            normalized.push(domain);
+        } else if domain != member {
+            let mut changed = Vec::with_capacity(members.len());
+            changed.extend_from_slice(&members[..index]);
+            changed.push(domain);
+            normalized = Some(changed);
+        }
+    }
+
+    normalized.map_or(type_id, |members| union_types(db, members))
+}
+
 pub(crate) fn type_has_typeof_result(
     db: &dyn QueryDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
@@ -764,6 +785,30 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&db.literal_string("string")));
         assert!(members.contains(&db.literal_string("number")));
+    }
+
+    #[test]
+    fn enum_member_union_domain_keeps_plain_union_identity() {
+        let db = TypeInterner::new();
+        let union = db.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+        assert_eq!(enum_member_union_domain(&db, union), union);
+    }
+
+    #[test]
+    fn enum_member_union_domain_rewrites_only_enum_members() {
+        let db = TypeInterner::new();
+        let literal = db.literal_string("ready");
+        let enum_member = db.enum_type(tsz_solver::def::DefId(701), literal);
+        let union = db.union(vec![enum_member, TypeId::NUMBER]);
+
+        let domain = enum_member_union_domain(&db, union);
+        let members = union_members_for_type(&db, domain).unwrap_or_else(|| vec![domain]);
+
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&literal));
+        assert!(members.contains(&TypeId::NUMBER));
+        assert!(!members.contains(&enum_member));
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
Switch exhaustiveness enum-domain normalization still unwraps enum-member types to their structural member domain before assignability comparison. Plain unions with no enum-member domain changes now keep their original TypeId instead of allocating and re-interning an equivalent union.

## Scope
- Add `enum_member_union_domain` to the flow query boundary.
- Make reachability switch exhaustiveness delegate enum-union normalization to that boundary.
- Add focused boundary tests for the no-change union fast path and enum-member rewrite path.

## Project Corpus Impact
- Row: n/a
- Bug family: checker switch-exhaustiveness enum-domain micro-allocation
- Evidence: behavior-preserving storage change only; local checker compile, clippy, formatting, diff hygiene, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-checker/src/query_boundaries/flow_analysis.rs crates/tsz-checker/src/flow/reachability_checker.rs -> 896 / 877
- cargo check -p tsz-checker
- cargo clippy -p tsz-checker --lib -- -D warnings
- python3 scripts/arch/arch_guard.py
- attempted cargo nextest run -p tsz-checker enum_member_union_domain; interrupted after compile when the nextest runner produced no test result output
- attempted cargo nextest run -p tsz-checker -E 'test(enum_member_union_domain)'; interrupted after compile when the nextest runner produced no test result output

## Coordination Notes
- Open PR overlap check found no non-M1-A PR touching `crates/tsz-checker/src/flow/reachability_checker.rs` or `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`.
- Existing M1-A PRs #10249 and #10250 remain unmerged because required `Queue Tested` is pending; this PR is independent of both.
