### PR TITLE
perf(checker): avoid statement copies in parse-only passes

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -803,13 +803,13 @@ pub fn run_js_grammar_pass(
     let Some(source) = arena.get_source_file_at(source_file) else {
         return Vec::new();
     };
-    let statements: Vec<tsz_parser::NodeIndex> = source.statements.nodes.to_vec();
+    let statements = source.statements.nodes.as_slice();
     if statements.is_empty() {
         return Vec::new();
     }
     let interner = tsz_solver::construction::TypeInterner::new();
     let mut checker = CheckerState::new(arena, binder, &interner, file_name, options);
-    checker.check_js_grammar_statements(&statements);
+    checker.check_js_grammar_statements(statements);
     checker.ctx.diagnostics
 }
 
@@ -835,14 +835,14 @@ pub fn run_isolated_declarations_pass(
     let Some(source) = arena.get_source_file_at(source_file) else {
         return Vec::new();
     };
-    let statements: Vec<tsz_parser::NodeIndex> = source.statements.nodes.to_vec();
+    let statements = source.statements.nodes.as_slice();
     if statements.is_empty() {
         return Vec::new();
     }
     let interner = tsz_solver::construction::TypeInterner::new();
     let mut checker = CheckerState::new(arena, binder, &interner, file_name, options);
-    checker.check_isolated_declarations(&statements);
-    checker.check_isolated_decl_class_expressions(&statements);
-    checker.check_isolated_decl_augmentations(&statements);
+    checker.check_isolated_declarations(statements);
+    checker.check_isolated_decl_class_expressions(statements);
+    checker.check_isolated_decl_augmentations(statements);
     checker.ctx.diagnostics
 }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
The JS grammar and isolated-declarations parse-only entrypoints still process the same source-file statement list in the same order and still return early for empty statement lists. They now pass the parser-owned statement slice directly instead of cloning `NodeIndex` values into a temporary Vec.

## Scope
- Remove temporary statement Vec allocation in `run_js_grammar_pass`.
- Remove temporary statement Vec allocation in `run_isolated_declarations_pass`.
- No grammar, diagnostic, or checker traversal behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: checker parse-only entrypoint micro-allocation
- Evidence: behavior-preserving storage change only; local checker compile, clippy, formatting, diff hygiene, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-checker/src/lib.rs -> 848
- cargo check -p tsz-checker
- cargo clippy -p tsz-checker --lib -- -D warnings
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no open PR touching `crates/tsz-checker/src/lib.rs`.
- Existing M1-A PRs #10249, #10250, and #10251 remain unmerged because required checks are pending; this PR is independent of them.
