### PR TITLE
perf(checker): borrow jsdoc import scan inputs

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics_imports.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_imports.rs
@@ -14,45 +14,45 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn check_jsdoc_duplicate_imports(&mut self) {
         use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
 
-        let Some(sf) = self.ctx.arena.source_files.first() else {
-            return;
-        };
-        let source_text: String = sf.text.to_string();
-        let comments = sf.comments.clone();
-        let statements: Vec<NodeIndex> = sf.statements.nodes.clone();
-
         // (name, abs_pos, len, is_jsdoc)
         let mut import_positions: Vec<(String, u32, u32, bool)> = Vec::new();
 
-        // Collect JSDoc `@import` names and positions.
-        for comment in &comments {
-            if !is_jsdoc_comment(comment, &source_text) {
-                continue;
-            }
-            let comment_text =
-                &source_text[comment.pos as usize..(comment.end as usize).min(source_text.len())];
-            let content = get_jsdoc_content(comment, &source_text);
+        {
+            let Some(sf) = self.ctx.arena.source_files.first() else {
+                return;
+            };
+            let source_text = sf.text.as_ref();
 
-            for line in content.lines() {
-                let trimmed = line.trim_start_matches('*').trim();
-                if let Some(rest) = Self::strip_jsdoc_tag_prefix(trimmed, "import") {
-                    let imports = Self::parse_jsdoc_import_tag(rest);
-                    for (local_name, _specifier, _import_name) in imports {
-                        if let Some(name_offset) =
-                            Self::find_import_name_in_comment(comment_text, &local_name)
-                        {
-                            let abs_pos = comment.pos + name_offset as u32;
-                            let len = local_name.len() as u32;
-                            import_positions.push((local_name, abs_pos, len, true));
+            // Collect JSDoc `@import` names and positions.
+            for comment in &sf.comments {
+                if !is_jsdoc_comment(comment, source_text) {
+                    continue;
+                }
+                let comment_text = &source_text
+                    [comment.pos as usize..(comment.end as usize).min(source_text.len())];
+                let content = get_jsdoc_content(comment, source_text);
+
+                for line in content.lines() {
+                    let trimmed = line.trim_start_matches('*').trim();
+                    if let Some(rest) = Self::strip_jsdoc_tag_prefix(trimmed, "import") {
+                        let imports = Self::parse_jsdoc_import_tag(rest);
+                        for (local_name, _specifier, _import_name) in imports {
+                            if let Some(name_offset) =
+                                Self::find_import_name_in_comment(comment_text, &local_name)
+                            {
+                                let abs_pos = comment.pos + name_offset as u32;
+                                let len = local_name.len() as u32;
+                                import_positions.push((local_name, abs_pos, len, true));
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // Collect runtime ES import names and positions from top-level statements.
-        for stmt_idx in &statements {
-            self.collect_runtime_import_positions(*stmt_idx, &mut import_positions);
+            // Collect runtime ES import names and positions from top-level statements.
+            for &stmt_idx in &sf.statements.nodes {
+                self.collect_runtime_import_positions(stmt_idx, &mut import_positions);
+            }
         }
 
         let mut seen: std::collections::HashMap<String, Vec<(u32, u32, bool)>> =


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
JSDoc `@import` duplicate detection still scans the same comments and top-level import declarations, records the same name/spans, and emits TS2300 only after at least one duplicate occurrence is JSDoc. The scan phase now borrows parser-owned source text, comments, and statements instead of cloning them before diagnostics are emitted.

## Scope
- Remove full source-text clone in `check_jsdoc_duplicate_imports`.
- Remove comment-range and statement-list clones by scoping parser borrows to the scan phase.
- No import parsing, duplicate grouping, or diagnostic behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: checker JSDoc import diagnostic micro-allocation
- Evidence: behavior-preserving storage change only; local checker compile, clippy, formatting, diff hygiene, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-checker/src/jsdoc/diagnostics_imports.rs -> 179
- cargo check -p tsz-checker
- cargo clippy -p tsz-checker --lib -- -D warnings
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no open PR touching `crates/tsz-checker/src/jsdoc/diagnostics_imports.rs`.
- Existing M1-A PRs #10250, #10251, and #10252 remain unmerged because required checks are pending; this PR is independent of them.
