### PR TITLE
perf(checker): stack-allocate call predicate exclusions

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
@@ -1,6 +1,7 @@
 use super::FlowAnalyzer;
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::flow_analysis as flow_query;
+use smallvec::SmallVec;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{AccessExprData, Node};
 use tsz_solver::TypeId;
@@ -176,7 +177,7 @@ impl<'a> FlowAnalyzer<'a> {
 
             let members = flow_query::union_members_for_type(self.interner, type_id)
                 .unwrap_or_else(|| vec![type_id]);
-            let excluded_members: Vec<TypeId> = members
+            let excluded_members: SmallVec<[TypeId; 4]> = members
                 .iter()
                 .copied()
                 .filter(|member| self.is_assignable_to(*member, predicate_type))


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
False-branch call-predicate narrowing still collects the same union members assignable to the predicate target, in the same order, and passes that set to `narrow_excluding_types`. The temporary exclusion buffer is now stack-backed for common small unions instead of always heap-allocating a Vec.

## Scope
- Use `SmallVec<[TypeId; 4]>` for call-predicate excluded members.
- No type-guard, assignability, or narrowing behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: checker call-predicate narrowing micro-allocation
- Evidence: behavior-preserving buffer change only; local checker compile, clippy, formatting, diff hygiene, and architecture guard passed.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs -> 206
- cargo check -p tsz-checker
- cargo clippy -p tsz-checker --lib -- -D warnings
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no open PR touching `crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs`.
- All earlier M1-A PRs through #10253 have merged; this PR is independent of the remaining M4-A conditional draft.
