### PR TITLE
perf(solver): lazily allocate undefined filtering

### DIFF
--- a/crates/tsz-solver/src/narrowing/utils.rs
+++ b/crates/tsz-solver/src/narrowing/utils.rs
@@ -630,14 +630,18 @@ pub fn remove_undefined(types: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
         return TypeId::NEVER;
     }
     if let Some(members) = top_level_union_members(types, type_id) {
-        let filtered: Vec<TypeId> = members
-            .iter()
-            .copied()
-            .filter(|&m| m != TypeId::UNDEFINED)
-            .collect();
-        if filtered.len() == members.len() {
-            return type_id; // no undefined to remove
-        }
+        let Some(undefined_index) = members.iter().position(|&m| m == TypeId::UNDEFINED) else {
+            return type_id;
+        };
+
+        let mut filtered = Vec::with_capacity(members.len() - 1);
+        filtered.extend_from_slice(&members[..undefined_index]);
+        filtered.extend(
+            members[undefined_index + 1..]
+                .iter()
+                .copied()
+                .filter(|&m| m != TypeId::UNDEFINED),
+        );
         match filtered.len() {
             0 => TypeId::NEVER,
             1 => filtered[0],


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
`remove_undefined` returns the original union `TypeId` when no top-level `undefined` member exists, and returns the same filtered member set when `undefined` is present. This PR only delays allocation of the filtered member buffer until the first `undefined` member is found.

## Scope
- Avoid allocating a temporary `Vec<TypeId>` for `remove_undefined` union inputs that do not contain `undefined`.
- Preserve member order and existing reconstruction behavior for unions that do contain `undefined`.
- No relation, narrowing, or diagnostic behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver `remove_undefined` micro-allocation
- Evidence: behavior-preserving allocation change only; focused solver tests, compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/tsz-solver/src/narrowing/utils.rs -> 653
- cargo nextest run -p tsz-solver -- remove_undefined
- cargo check -p tsz-solver
- cargo clippy -p tsz-solver --lib -- -D warnings
- python3 scripts/arch/arch_guard.py

## Coordination Notes
- Open PR overlap check found no other PR touching `crates/tsz-solver/src/narrowing/utils.rs`.
- The only non-M1-A open implementation PR is M4-A #9948, which touches conditional readonly variance paths and is intentionally avoided.
- Existing M1-A PR #10254 remains open and blocked on missing required CI; this PR is independent.
