### PR TITLE
perf(checker): keep definite assignment scratch inline

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -8,6 +8,7 @@
 
 use crate::query_boundaries::flow_analysis as query;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use tsz_binder::{FlowNodeId, SymbolId, flow_flags, symbol_flags};
 use tsz_common::comments::{get_jsdoc_content, get_leading_comments_from_cache, is_jsdoc_comment};
 use tsz_parser::parser::NodeIndex;
@@ -172,7 +173,7 @@ impl<'a> FlowAnalyzer<'a> {
                 // Flow node doesn't exist - mark as assigned
                 local_cache.insert(current_flow, true);
                 // Notify any nodes waiting for this one
-                let ready: Vec<_> = waiting_for
+                let ready: SmallVec<[FlowNodeId; 4]> = waiting_for
                     .iter()
                     .filter(|(_, ants)| ants.contains(&current_flow))
                     .map(|(&node, _)| node)
@@ -214,7 +215,7 @@ impl<'a> FlowAnalyzer<'a> {
                 } else {
                     // Check if all antecedents have results
                     let mut all_ready = true;
-                    let mut results = Vec::new();
+                    let mut results: SmallVec<[bool; 4]> = SmallVec::new();
 
                     for &ant in &flow.antecedent {
                         if let Some(ant_node) = self.binder.flow_nodes.get(ant)
@@ -278,7 +279,7 @@ impl<'a> FlowAnalyzer<'a> {
                 } else {
                     // Similar to BRANCH_LABEL - check all antecedents
                     let mut all_ready = true;
-                    let mut results = Vec::new();
+                    let mut results: SmallVec<[bool; 4]> = SmallVec::new();
 
                     for &ant in &flow.antecedent {
                         if let Some(ant_node) = self.binder.flow_nodes.get(ant)
@@ -321,7 +322,7 @@ impl<'a> FlowAnalyzer<'a> {
             local_cache.insert(current_flow, result);
 
             // Notify any nodes waiting for this one
-            let ready: Vec<_> = waiting_for
+            let ready: SmallVec<[FlowNodeId; 4]> = waiting_for
                 .iter()
                 .filter(|(_, ants)| ants.contains(&current_flow))
                 .map(|(&node, _)| node)


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / checker micro-allocation cleanup

## Invariant
Definite-assignment flow traversal visits the same waiting nodes and computes the same antecedent truth values. This PR only changes short-lived scratch buffers from heap-backed `Vec` to stack-backed `SmallVec` for common small flow fan-in cases.

## Scope
- Use `SmallVec<[FlowNodeId; 4]>` for ready waiting-node snapshots.
- Use `SmallVec<[bool; 4]>` for branch/switch antecedent result scratch buffers.
- No flow graph, narrowing, TS2454, or diagnostic behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: checker definite-assignment micro-allocation
- Evidence: behavior-preserving scratch-buffer change only; checker compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally. No project-row speed claim.

## Verification
Clean isolated worktree: `/Users/mohsen/code/tsz-m1a-10257-refresh` at refreshed head `44c0ac5ccb95ea177dfa6a5c5ee6ce31c1a0f362`.

Fresh post-rebase verification on 2026-05-26:

- `cargo fmt --check`
- `git diff --check`
- `wc -l crates/tsz-checker/src/flow/control_flow/var_utils.rs` -> 1097
- `cargo check -p tsz-checker`
- `cargo clippy -p tsz-checker --lib -- -D warnings`
- `python3 scripts/arch/arch_guard.py`

Prior focused test evidence for the same one-file diff before the rebase:

- `cargo nextest run -p tsz-checker -- test_definite_assignment_result` -> 1 passed, 11341 skipped at head `9a7a71c52bbd7e4b8cdf70e90535667006ced44a`

I attempted to rerun that focused nextest filter after the rebase; it completed the test build and then stayed idle with only `cargo-nextest` running, so I killed the local process rather than waiting. Ready-review CI should provide the current-head suite evidence.

## Coordination Notes
- Rebased branch onto current `origin/main` on 2026-05-26 and force-pushed with lease from `9a7a71c52bbd7e4b8cdf70e90535667006ced44a` to `44c0ac5ccb95ea177dfa6a5c5ee6ce31c1a0f362`.
- Open PR overlap check found no other PR touching `crates/tsz-checker/src/flow/control_flow/var_utils.rs` when this PR was opened.
- #10262 has left the ready queue after its `Queue Tested` policy loop, so this PR is the next M1-A perf slice prepared for ready-review CI when the lane promotes it.
- Ready-state body hygiene was repaired on 2026-05-26 after the gate reported queue-hold wording in this section; this body keeps the required Track 1 metadata without queue-hold declarations.
- Auto-merge remains off. Next owner/action: inspect exact-head required CI after promotion and merge only after all required checks for `44c0ac5ccb95ea177dfa6a5c5ee6ce31c1a0f362` are complete and green.
