### PR TITLE
perf(solver): avoid no-op narrowing filter vecs

### DIFF
--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -82,21 +82,27 @@ impl<'a> NarrowingContext<'a> {
             return source_type;
         };
 
-        // Filter union members: keep only non-object types
         let members = self.db.type_list(members);
-        let kept: Vec<TypeId> = members
-            .iter()
-            .filter(|&&member| {
-                let resolved_member = self.resolve_type(member);
-                !self.is_typeof_object(resolved_member)
-            })
-            .copied()
-            .collect();
+        let mut kept = None;
+        for (index, &member) in members.iter().enumerate() {
+            let resolved_member = self.resolve_type(member);
+            if self.is_typeof_object(resolved_member) {
+                if kept.is_none() {
+                    let mut filtered = Vec::with_capacity(members.len().saturating_sub(1));
+                    filtered.extend_from_slice(&members[..index]);
+                    kept = Some(filtered);
+                }
+            } else if let Some(kept) = kept.as_mut() {
+                kept.push(member);
+            }
+        }
+
+        let Some(kept) = kept else {
+            return source_type;
+        };
 
         if kept.is_empty() {
             TypeId::NEVER
-        } else if kept.len() == members.len() {
-            source_type
         } else {
             self.db.union(kept)
         }
@@ -203,16 +209,26 @@ impl<'a> NarrowingContext<'a> {
         // Handle unions: filter out primitive members
         if let Some(members_id) = union_list_id(self.db, resolved) {
             let members = self.db.type_list(members_id);
-            let kept: Vec<TypeId> = members
-                .iter()
-                .filter(|&&member| !self.is_definitely_primitive(member))
-                .copied()
-                .collect();
+            let mut kept = None;
+            for (index, &member) in members.iter().enumerate() {
+                if self.is_definitely_primitive(member) {
+                    if kept.is_none() {
+                        let mut filtered = Vec::with_capacity(members.len().saturating_sub(1));
+                        filtered.extend_from_slice(&members[..index]);
+                        kept = Some(filtered);
+                    }
+                } else if let Some(kept) = kept.as_mut() {
+                    kept.push(member);
+                }
+            }
+
+            let Some(kept) = kept else {
+                return source_type;
+            };
 
             return match kept.len() {
                 0 => TypeId::NEVER,
                 1 => kept[0],
-                n if n == members.len() => source_type, // All members kept
                 _ => self.db.union(kept),
             };
         }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup.

## Invariant
Narrowing filters should avoid allocating replacement vectors when filtering does not change the candidate set. This PR changes only solver narrowing allocation behavior and preserves the existing relation/type semantics.

## Scope
- `crates/tsz-solver/src/narrowing/compound.rs`
- No checker, binder, emitter, parser, LSP, WASM, or conformance snapshot changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: micro-allocation cleanup only; no project-corpus row speed claim. Ready-review CI remains the source of broad parity evidence.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `wc -l crates/tsz-solver/src/narrowing/compound.rs` -> 980
- `cargo check -p tsz-solver`
- `cargo clippy -p tsz-solver --lib -- -D warnings`
- `cargo nextest run -p tsz-solver -- narrowing` -> 225 passed, 6046 skipped
- 2026-05-27 refresh on head `5076e98a546495051cadfb1f849df8db36c8d0cf`: `git diff --check origin/main...HEAD` passed; diff remains only `crates/tsz-solver/src/narrowing/compound.rs`; file remains 980 lines.
- 2026-05-27 refresh on base `7532eda8595aef4652456cd358d6536d32b9cbd6` (`chore(emit, arch): ratchet output-surgery guardrails (#10373)`): `python3 scripts/arch/arch_guard.py` passed.
- Previous ready-review CI run https://github.com/mohsen1/tsz/actions/runs/26482635770 passed `unit`, `unit-cloudbuild`, `dist-binaries`, `wasm`, `wasm-web`, `emit`, `fourslash-*`, `fourslash-aggregate`, `conformance-*`, `conformance-aggregate`, project compile guards, and `GitGuardian Security Checks`; its `lint` failure was the now-landed inherited architecture guard issue.
- Exact-head CI for `5076e98a546495051cadfb1f849df8db36c8d0cf` passed on 2026-05-27: `CI Summary`, `GitGuardian Security Checks`, conformance aggregate, fourslash aggregate, emit, WASM, lint, unit, project compile guards, and project-corpus PR body are green. `Queue Tested` remains queue-owned.
- 2026-05-27 M1-A coordination cycle: latest observed `origin/main` is `55595ab16decd3764a34b2fca69992e305d8a5c2` (`refactor(checker): route namespace mismatch lookups (#10386)`); the PR remains queued and the merge queue owns latest-main synthetic testing.

## Coordination Notes
- AgentName: M1-A
- Current head: `5076e98a546495051cadfb1f849df8db36c8d0cf`
- Last refreshed base used for local arch-guard verification: `7532eda8595aef4652456cd358d6536d32b9cbd6` (`chore(emit, arch): ratchet output-surgery guardrails (#10373)`).
- Latest observed `origin/main`: `55595ab16decd3764a34b2fca69992e305d8a5c2` (`refactor(checker): route namespace mismatch lookups (#10386)`). GitHub still reports the PR baseRefOid as the refreshed base above while the repo-local merge queue is responsible for synthetic latest-main validation before landing.
- Rebased cleanly after #10373 landed; the behavioral diff remains the original solver narrowing micro-allocation slice.
- The previous architecture-guard blocker is gone on this refreshed base; local arch guard passed on the current head.
- `merge-queue` is present after exact-head PR-head checks, including `CI Summary` and `GitGuardian Security Checks`, passed for `5076e98a546495051cadfb1f849df8db36c8d0cf`; auto-merge remains off and `Queue Tested` is queue-owned.
