### PR TITLE
perf(solver): avoid double scan stripping tuple undefined

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1185,18 +1185,23 @@ impl TypeInterner {
         }
         if let Some(TypeData::Union(list_id)) = self.lookup(type_id) {
             let members = self.type_list(list_id);
-            if members.contains(&TypeId::UNDEFINED) {
-                let filtered: Vec<TypeId> = members
+            let Some(undefined_index) = members.iter().position(|&m| m == TypeId::UNDEFINED) else {
+                return type_id;
+            };
+
+            let mut filtered = Vec::with_capacity(members.len() - 1);
+            filtered.extend_from_slice(&members[..undefined_index]);
+            filtered.extend(
+                members[undefined_index + 1..]
                     .iter()
                     .copied()
-                    .filter(|&m| m != TypeId::UNDEFINED)
-                    .collect();
-                return match filtered.len() {
-                    0 => TypeId::NEVER,
-                    1 => filtered[0],
-                    _ => self.union_from_sorted_vec(filtered),
-                };
-            }
+                    .filter(|&m| m != TypeId::UNDEFINED),
+            );
+            return match filtered.len() {
+                0 => TypeId::NEVER,
+                1 => filtered[0],
+                _ => self.union_from_sorted_vec(filtered),
+            };
         }
         type_id
     }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
Optional tuple normalization still strips top-level `undefined` from optional element union types under inexact optional-property mode, preserves non-union and no-undefined inputs, and reconstructs the same resulting `TypeId`. This PR only avoids a separate `contains` scan before constructing the filtered union member buffer.

## Scope
- Convert `strip_undefined_from_type` in tuple construction to find the first `undefined` member and allocate only after it is present.
- Preserve member order and existing `union_from_sorted_vec` reconstruction for filtered unions.
- No tuple, relation, diagnostic, or exact optional-property semantics changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver tuple optional-element normalization micro-allocation
- Evidence: behavior-preserving allocation/scan change only; focused tuple tests, compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally. No project-row speed claim.

## Verification
Clean isolated worktree: `/Users/mohsen/code/tsz-m1a-10260-refresh` at refreshed head `1cde4c0bf64ee9a4d17af43ab944893c63e7cd29` on base `929041f62c89b7beb17429fe232fb8d5f338d45c`.

Fresh post-#10258-merge verification on 2026-05-27:

- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-solver/src/intern/core/constructors.rs` -> 1594
- `cargo check -p tsz-solver`
- `cargo clippy -p tsz-solver --lib -- -D warnings`
- `cargo nextest run -p tsz-solver -- tuple_optional_normalizes_undefined` -> 1 passed, 6291 skipped
- `cargo nextest run -p tsz-solver -- test_tuple_optional_basic` -> 1 passed, 6291 skipped
- `python3 scripts/arch/arch_guard.py`

Prior ready CI run `26448954394` failed for infrastructure reasons before relevant project commands: `unit` failed downloading `actions/checkout@v4`; `conformance-snapshot-gate` failed on `git fetch` with HTTP 403 / `remote: Your account is suspended`. Heavy aggregate jobs were then cancelled. No PR-owned code failure was identified from those failed logs.

## Coordination Notes
- Open PR overlap check found no other PR touching `crates/tsz-solver/src/intern/core/constructors.rs` when this PR was opened.
- #10258 has merged into `origin/main`; this branch is refreshed on top of that main head.
- #10260 is now the front M1-A PR and is ready for ready-review CI at exact head `1cde4c0bf64ee9a4d17af43ab944893c63e7cd29`.
- Auto-merge remains off. Next owner/action: let ready-for-review CI run the heavy gates, and add `merge-queue` only after exact-head PR-head checks are complete and green.
