### PR TITLE
perf(solver): skip no-op literal union widening

### DIFF
--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -869,7 +869,23 @@ pub fn widen_literal_type(db: &dyn crate::construction::TypeDatabase, type_id: T
             let members = origin_members
                 .as_deref()
                 .map_or(canonical_members.as_ref(), Vec::as_slice);
-            let mapped: Vec<TypeId> = members.iter().map(|&m| widen_literal_type(db, m)).collect();
+            let mut mapped = None;
+            for (index, &member) in members.iter().enumerate() {
+                let widened = widen_literal_type(db, member);
+                if widened != member && mapped.is_none() {
+                    let mut out = Vec::with_capacity(members.len());
+                    out.extend_from_slice(&members[..index]);
+                    mapped = Some(out);
+                }
+                if let Some(mapped) = mapped.as_mut() {
+                    mapped.push(widened);
+                }
+            }
+
+            let Some(mapped) = mapped else {
+                return type_id;
+            };
+
             let result = db.union(mapped.clone());
             display_provenance::record_union_origin(
                 db,

--- a/crates/tsz-solver/tests/widening_tests.rs
+++ b/crates/tsz-solver/tests/widening_tests.rs
@@ -895,6 +895,14 @@ fn test_widen_literal_type_union_maps_each_member() {
 }
 
 #[test]
+fn test_widen_literal_type_union_without_literals_noop() {
+    let interner = TypeInterner::new();
+    let union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+    assert_eq!(widen_literal_type(&interner, union), union);
+}
+
+#[test]
 fn test_widen_literal_type_object_passthrough() {
     // Unlike get_base_type_for_comparison, widen_literal_type does NOT recurse
     // into objects (returns top-level type unchanged for non-literal/non-union).


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
`widen_literal_type` still maps literal union members to their widened primitive types and records source-order union provenance when any member changes. For unions where every member is already unchanged, this PR returns the original `TypeId` directly instead of allocating a mapped member vector and re-interning the same union.

## Scope
- Lazily allocate mapped union members in `widen_literal_type` only after the first member actually widens.
- Add a focused no-op union identity test for already-widened primitive members.
- No relation, inference, diagnostic, or display semantics changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver literal-widening micro-allocation
- Evidence: behavior-preserving no-op fast path; focused widening tests, compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally. No project-row speed claim.

## Verification
Clean isolated worktree: `/Users/mohsen/code/tsz-m1a-10262-refresh` at refreshed head `ca411dced468fb44cf6c5730baed9c86b65a5535` on base `eb3ae10691736b2f8b82d85a181bee803cff5e6d`.

Fresh post-#10260-merge verification on 2026-05-27:

- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-solver/src/operations/widening.rs crates/tsz-solver/tests/widening_tests.rs` -> 959 / 1082
- `cargo check -p tsz-solver`
- `cargo clippy -p tsz-solver --lib -- -D warnings`
- `cargo nextest run -p tsz-solver -- widen_literal_type` -> 9 passed, 6284 skipped
- `python3 scripts/arch/arch_guard.py`

Exact-head PR CI for `ca411dced468fb44cf6c5730baed9c86b65a5535` is running after promotion to ready. `merge-queue` should stay absent until the required PR-head checks are green for this exact head.

## Coordination Notes
- Open PR overlap check found no other PR touching `crates/tsz-solver/src/operations/widening.rs` or `crates/tsz-solver/tests/widening_tests.rs` when this PR was opened.
- #10260 merged on 2026-05-27, so this PR is now the front M1-A solver micro-allocation PR.
- Rebased branch onto current `origin/main` after #10260 and confirmed the remote head is `ca411dced468fb44cf6c5730baed9c86b65a5535`.
- Auto-merge remains off and `merge-queue` is absent. Next owner/action: after exact-head PR-head checks finish green, add `merge-queue`; if any required check fails, inspect logs and fix or return the PR to a clearly signed blocker state.
