### PR TITLE
perf(solver): collect property narrowing matches once

### DIFF
--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -166,7 +166,7 @@ impl<'a> NarrowingContext<'a> {
 
             let matching: Vec<TypeId> = members
                 .iter()
-                .map(|&member| {
+                .filter_map(|&member| {
                     // CRITICAL: Resolve Lazy types for each member
                     let resolved_member = self.resolve_type(member);
 
@@ -177,34 +177,26 @@ impl<'a> NarrowingContext<'a> {
                             // Property exists: Keep the member as-is
                             // CRITICAL: For union narrowing, we don't modify the member type
                             // We just filter to keep only members that have the property
-                            member
+                            Some(member)
                         } else {
-                            // Property not found: Exclude member (return NEVER)
+                            // Property not found: Exclude member
                             // Per TypeScript: "prop in x" being true means x MUST have the property
                             // If x doesn't have it (and no index signature), narrow to never
-                            TypeId::NEVER
+                            None
                         }
                     } else {
                         // Negative: !("prop" in member)
                         // Exclude member ONLY if property is required
                         if self.is_property_required(resolved_member, property_name) {
-                            return TypeId::NEVER;
+                            return None;
                         }
                         // Keep member (no required property found, or property is optional)
-                        member
+                        Some(member)
                     }
                 })
                 .collect();
 
-            // CRITICAL FIX: Filter out NEVER types before creating the union
-            // When a union member doesn't have the required property, it becomes NEVER
-            // and should be EXCLUDED from the result, not included in the union
-            let matching_non_never: Vec<TypeId> = matching
-                .into_iter()
-                .filter(|&t| t != TypeId::NEVER)
-                .collect();
-
-            if matching_non_never.is_empty() {
+            if matching.is_empty() {
                 // When NO union member has the property, TypeScript narrows to
                 // `Union & Record<prop, unknown>` instead of `never`.
                 // This matches TSC behavior: if the type could structurally have the
@@ -215,15 +207,15 @@ impl<'a> NarrowingContext<'a> {
                 );
                 let record_type = self.make_record_type(property_name);
                 return self.db.intersect_types_raw2(source_type, record_type);
-            } else if matching_non_never.len() == 1 {
+            } else if matching.len() == 1 {
                 trace!(
                     "Found single member after filtering, returning {}",
-                    matching_non_never[0].0
+                    matching[0].0
                 );
-                return matching_non_never[0];
+                return matching[0];
             }
-            trace!("Created union with {} members", matching_non_never.len());
-            return self.db.union(matching_non_never);
+            trace!("Created union with {} members", matching.len());
+            return self.db.union(matching);
         }
 
         // For non-union types, check if the property exists


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
`in`-operator union narrowing keeps the same member inclusion decisions, but now collects surviving members directly instead of materializing `NEVER` sentinels and filtering them in a second vector. Empty, single-member, and multi-member result handling is unchanged.

## Scope
- `crates/tsz-solver/src/narrowing/property.rs` only.
- No relation, diagnostic, property lookup, or narrowing semantics changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver narrowing micro-allocation
- Evidence: behavior-preserving allocation change only; focused solver narrowing tests, compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally. No project-row speed claim.

## Verification
Clean isolated worktree: `/Users/mohsen/code/tsz-m1a-10264-refresh` at refreshed head `5dcaf1d09993d52dd800434379afe879617c7eca` on base `902cc1c892533049c8c25a538552b11d7089aa59`.

Fresh post-#10377-merge verification on 2026-05-27:

- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-solver/src/narrowing/property.rs` -> 573
- `cargo fmt --check`
- `cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py`

Earlier verification on `c2b239b41e82d48267378f48bdc7ff1a4ee0166b` included:

- `cargo clippy -p tsz-solver --lib -- -D warnings`
- `cargo nextest run -p tsz-solver -- narrowing` -> 302 passed, 5990 skipped

Ready-review CI on the exact head is expected to run the heavier gates before this PR can be queued.

## Coordination Notes
- #10260 and #10262 have merged; this is now the front M1-A follow-up, with #10267 intentionally still draft behind it.
- Rebased branch onto current `origin/main` after #10377 merged on 2026-05-27 and force-pushed with lease from `78b02692ea6987c74a3c04bc56216f7482bd461f` to `5dcaf1d09993d52dd800434379afe879617c7eca`.
- Auto-merge remains off and `merge-queue` is absent. Next owner/action: add `merge-queue` only after exact-head ready-review PR checks complete green.
