### PR TITLE
chore(conformance): retire stale accepted regressions

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -52,7 +52,7 @@ uses exact artifact numerators and denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `0` listed tests |
+| Accepted-regression strictness | `15` listed tests |
 | JavaScript emit | `13,094 / 13,530` in checked-in emit snapshot (`94.8%` / `12,820 / 13,530` still shown in README) |
 | Declaration emit | `1,606 / 1,669` in checked-in emit snapshot (`91.7%` / `1,531 / 1,669` still shown in README) |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -52,7 +52,7 @@ uses exact artifact numerators and denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `25` listed tests |
+| Accepted-regression strictness | `24` listed tests |
 | JavaScript emit | `13,094 / 13,530` in checked-in emit snapshot (`94.8%` / `12,820 / 13,530` still shown in README) |
 | Declaration emit | `1,606 / 1,669` in checked-in emit snapshot (`91.7%` / `1,531 / 1,669` still shown in README) |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -52,7 +52,7 @@ uses exact artifact numerators and denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `15` listed tests |
+| Accepted-regression strictness | `25` listed tests |
 | JavaScript emit | `13,094 / 13,530` in checked-in emit snapshot (`94.8%` / `12,820 / 13,530` still shown in README) |
 | Declaration emit | `1,606 / 1,669` in checked-in emit snapshot (`91.7%` / `1,531 / 1,669` still shown in README) |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -52,7 +52,7 @@ uses exact artifact numerators and denominators.
 | Surface | Current |
 | --- | ---: |
 | Diagnostic conformance | `100.0%` exact (`12,582 / 12,582`) |
-| Accepted-regression strictness | `30` listed tests |
+| Accepted-regression strictness | `0` listed tests |
 | JavaScript emit | `13,094 / 13,530` in checked-in emit snapshot (`94.8%` / `12,820 / 13,530` still shown in README) |
 | Declaration emit | `1,606 / 1,669` in checked-in emit snapshot (`91.7%` / `1,531 / 1,669` still shown in README) |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,6 +2,8 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
+TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
+TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
@@ -10,20 +12,17 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
-TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
+TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
+TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
-TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,18 +2,28 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
+TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
+TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
+TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
+TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
+TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
+TypeScript/tests/cases/compiler/temporal.ts
+TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
+TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
+TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
+TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,3 +2,18 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
+TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
+TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
+TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
+TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
+TypeScript/tests/cases/compiler/reorderProperties.ts
+TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
+TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
+TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
+TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
+TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
+TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
+TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -2,33 +2,3 @@
 # Add a test path here (one per line) to allow it to fail in CI without
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
-TypeScript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
-TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
-TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
-TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
-TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
-TypeScript/tests/cases/compiler/relationComplexityError.ts
-TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
-TypeScript/tests/cases/compiler/temporal.ts
-TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
-TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
-TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
-TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
-TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
-TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
-TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
-TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts
-TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 8/10 conformance strictness and diagnostic debt: accepted-regression runway cleanup.

## Invariant
When ready-review CI aggregate evidence proves only a subset of accepted-regression entries currently fails, the accepted-regression gate should retain exactly that active subset and retire stale entries. This PR ratchets the list from 30 paths to the 24 paths named by current CI evidence, instead of keeping stale suppressions or claiming zero too early.

## Scope
- Remove stale accepted-regression paths from `scripts/conformance/conformance-accepted-regressions.txt`.
- Retain the 24 paths required by current ready-review CI evidence.
- Update the living roadmap public metric from `30` listed tests to `24` listed tests.
- Keep tracker issue #10306 current for the retained accepted-regression set and its CI evidence.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: conformance artifact/metadata-only change; no checker, solver, parser, binder, emitter, LSP, WASM, or benchmark behavior changed.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard` reports `12582/12582` and `Accepted-regression gate: 24 listed tests`.
- `python3 scripts/conformance/link-regression-issues.py --from-file scripts/conformance/conformance-accepted-regressions.txt` reports the retained entries as stale against the checked-in snapshot, which is expected because the checked-in artifact is older than the ready-review aggregate failure.
- `python3 -m unittest scripts/conformance/test_link_regression_issues.py`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- CI evidence requiring the current retained set: ready-review run 26457779727 on merge SHA `6be71f83af5a63d764aa137b81b3c21da6c17099` failed `conformance-aggregate` with four unlisted regressions and five retained paths resolved.

## Coordination Notes
- Issue #10306 tracks the retained current accepted-regression set.
- Earlier head `922fe81d6b8f39cdd4182a911094067d30d5ee8b` failed `conformance-aggregate` because the 15-entry list was too narrow for current CI.
- Previous head `8cbfd1f71266f02c8e4fbf98b97c92c7c5a38f0e` failed `conformance-aggregate` because the 25-entry list was one path too broad/narrow for run 26457779727.
- Current head `4fb9b721992e27a92d4cd87cf756d189de04f595` updates the accepted-regression artifact and roadmap metric to the 24-entry set required by that run. Auto-merge remains off and merge/queue decisions are left to the manager.
- Non-overlap: #10278 handles source-text/rendered-message diagnostic-debt ratchets; #10304 handles TS2488 spread literal display; #10318 handles NoInfer TS2345 target display; #10325 handles nested generic indexed-access return positions. This PR is accepted-regression artifact strictness only.
