### PR TITLE
perf(solver): avoid no-op function narrowing vecs

### DIFF
--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -233,15 +233,35 @@ impl<'a> NarrowingContext<'a> {
     pub(super) fn narrow_to_function(&self, source_type: TypeId) -> TypeId {
         if let Some(members) = union_list_id(self.db, source_type) {
             let members = self.db.type_list(members);
-            let functions: Vec<TypeId> = members
-                .iter()
-                .filter_map(|&member| {
-                    if let Some(narrowed) = self.narrow_type_param_to_function(member) {
-                        return narrowed.non_never();
-                    }
+            let mut functions: Option<Vec<TypeId>> = None;
+            for (index, &member) in members.iter().enumerate() {
+                let narrowed = if let Some(narrowed) = self.narrow_type_param_to_function(member) {
+                    narrowed.non_never()
+                } else {
                     self.is_function_type(member).then_some(member)
-                })
-                .collect();
+                };
+
+                match (narrowed, &mut functions) {
+                    (Some(result), Some(functions)) => functions.push(result),
+                    (Some(result), None) if result == member => {}
+                    (Some(result), None) => {
+                        let mut collected = Vec::with_capacity(members.len());
+                        collected.extend_from_slice(&members[..index]);
+                        collected.push(result);
+                        functions = Some(collected);
+                    }
+                    (None, Some(_)) => {}
+                    (None, None) => {
+                        let mut collected = Vec::with_capacity(members.len());
+                        collected.extend_from_slice(&members[..index]);
+                        functions = Some(collected);
+                    }
+                }
+            }
+
+            let Some(functions) = functions else {
+                return source_type;
+            };
 
             return union_or_single(self.db, functions);
         }
@@ -291,19 +311,38 @@ impl<'a> NarrowingContext<'a> {
     pub fn narrow_excluding_function(&self, source_type: TypeId) -> TypeId {
         if let Some(members) = union_list_id(self.db, source_type) {
             let members = self.db.type_list(members);
-            let remaining: Vec<TypeId> = members
-                .iter()
-                .filter_map(|&member| {
+            let mut remaining: Option<Vec<TypeId>> = None;
+            for (index, &member) in members.iter().enumerate() {
+                let narrowed =
                     if let Some(narrowed) = self.narrow_type_param_excluding_function(member) {
-                        return narrowed.non_never();
-                    }
-                    if self.is_function_type(member) {
+                        narrowed.non_never()
+                    } else if self.is_function_type(member) {
                         None
                     } else {
                         Some(member)
+                    };
+
+                match (narrowed, &mut remaining) {
+                    (Some(result), Some(remaining)) => remaining.push(result),
+                    (Some(result), None) if result == member => {}
+                    (Some(result), None) => {
+                        let mut collected = Vec::with_capacity(members.len());
+                        collected.extend_from_slice(&members[..index]);
+                        collected.push(result);
+                        remaining = Some(collected);
                     }
-                })
-                .collect();
+                    (None, Some(_)) => {}
+                    (None, None) => {
+                        let mut collected = Vec::with_capacity(members.len());
+                        collected.extend_from_slice(&members[..index]);
+                        remaining = Some(collected);
+                    }
+                }
+            }
+
+            let Some(remaining) = remaining else {
+                return source_type;
+            };
 
             return union_or_single(self.db, remaining);
         }


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Performance / solver micro-allocation cleanup

## Invariant
`typeof x === "function"` and `typeof x !== "function"` union narrowing keep the same member inclusion and type-parameter substitution decisions. When every union member is kept unchanged, the helpers now return the original union instead of allocating a temporary result vector. Once a member changes or is removed, the result vector is populated with the same ordered survivors as before.

## Scope
- `crates/tsz-solver/src/narrowing/core/helpers.rs` only.
- No relation, diagnostic, type-parameter substitution, or narrowing semantics changes.

## Project Corpus Impact
- Row: n/a
- Bug family: solver narrowing micro-allocation
- Evidence: behavior-preserving allocation change only; focused solver narrowing tests, compile, clippy, formatting, diff hygiene, line-count, and architecture guard passed locally. No project-row speed claim.

## Verification
Clean isolated worktree: `/Users/mohsen/code/tsz-m1a-10267-refresh` at exact head `9e2267013f42b9b410b7169f21cee259b17219e0` on base `d5926003ecfa7483b38949af75f794250fa8ff24`.

Exact-head local verification on 2026-05-27:

- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-solver/src/narrowing/core/helpers.rs` -> 966
- `cargo fmt --check`
- `cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-solver --lib -- -D warnings`
- `cargo nextest run -p tsz-solver -- narrowing` -> 302 passed, 5991 skipped

Draft light CI was green on the previous head; ready-for-review CI is now running for this exact head and will provide the heavy conformance, emit, fourslash, WASM, and snapshot gates.

## Coordination Notes
- #10264 landed through the merge queue at 2026-05-27T04:39:25Z; this PR is now the front M1-A implementation PR.
- Rebased branch onto current `origin/main` on 2026-05-27 and force-pushed with lease from `679b57929dc2789a61d7253d9844c2f8acf48bc9` to `9e2267013f42b9b410b7169f21cee259b17219e0`.
- This PR is ready for review. Auto-merge remains off and `merge-queue` is absent. Next owner/action: after ready-review PR-head checks complete green on exact head `9e2267013f42b9b410b7169f21cee259b17219e0` (`CI Summary` and `GitGuardian Security Checks`), the queue owner may add `merge-queue`; `Queue Tested` is expected only after enqueue.
- No known overlap with currently open M1-A work. Newly triaged issue #10446 was routed to M4-A because it is solver conditional/application evaluation, not this narrowing perf cleanup.
