### PR TITLE
fix(solver): union mapped key-remap collisions

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -753,6 +753,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
         }
 
+        crate::type_queries::merge_colliding_mapped_properties(self.interner(), &mut properties);
+
         // For homomorphic mapped types, restore source declaration order.
         // The key extraction and dedup may have reordered properties.
         if !source_decl_order.is_empty() {
@@ -973,6 +975,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 });
             }
         }
+
+        crate::type_queries::merge_colliding_mapped_properties(self.interner(), &mut properties);
 
         Some(self.interner().object(properties))
     }

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -1308,6 +1308,42 @@ pub const fn compute_mapped_modifiers(
     (optional, readonly)
 }
 
+/// Merge mapped properties whose `as` clause remaps multiple source keys to
+/// the same output key. TypeScript unions all value contributions for a
+/// colliding key instead of letting a later source key overwrite an earlier one.
+pub fn merge_colliding_mapped_properties(
+    db: &dyn TypeDatabase,
+    properties: &mut Vec<PropertyInfo>,
+) {
+    if properties.len() < 2 {
+        return;
+    }
+
+    let mut merged = Vec::with_capacity(properties.len());
+    let mut by_name: FxHashMap<Atom, usize> = FxHashMap::default();
+
+    for property in properties.drain(..) {
+        if let Some(&existing_index) = by_name.get(&property.name) {
+            let existing: &mut PropertyInfo = &mut merged[existing_index];
+            existing.type_id = db.union_preserve_members(vec![existing.type_id, property.type_id]);
+            existing.write_type =
+                db.union_preserve_members(vec![existing.write_type, property.write_type]);
+            existing.optional &= property.optional;
+            existing.readonly &= property.readonly;
+            existing.is_method &= property.is_method;
+            existing.is_string_named &= property.is_string_named;
+            existing.is_symbol_named &= property.is_symbol_named;
+            existing.single_quoted_name &= property.single_quoted_name;
+            existing.declaration_order = existing.declaration_order.min(property.declaration_order);
+        } else {
+            by_name.insert(property.name, merged.len());
+            merged.push(property);
+        }
+    }
+
+    *properties = merged;
+}
+
 /// Collect source property info from a homomorphic mapped type's source object.
 ///
 /// For a mapped type `{ [K in keyof T]: ... }`, this resolves `T` and collects
@@ -1543,6 +1579,7 @@ pub fn expand_mapped_type_to_properties(
         }
     }
 
+    merge_colliding_mapped_properties(db, &mut properties);
     properties
 }
 

--- a/crates/tsz-solver/tests/mapped_key_remap_tests.rs
+++ b/crates/tsz-solver/tests/mapped_key_remap_tests.rs
@@ -1203,3 +1203,128 @@ fn test_keyof_generic_remapped_mapped_type_keeps_concrete_lower_bound_keys() {
         interner.lookup(keyof_mapped)
     );
 }
+
+fn assert_union_members(
+    interner: &TypeInterner,
+    actual: TypeId,
+    expected: &[TypeId],
+    context: &str,
+) {
+    let members =
+        crate::type_queries::get_union_members(interner, actual).unwrap_or_else(|| vec![actual]);
+    assert_eq!(
+        members.len(),
+        expected.len(),
+        "{context}: expected {} union members, got {:?}",
+        expected.len(),
+        members
+            .iter()
+            .map(|member| interner.lookup(*member))
+            .collect::<Vec<_>>()
+    );
+    for expected_member in expected {
+        assert!(
+            members.contains(expected_member),
+            "{context}: expected member {:?}, got {:?}",
+            interner.lookup(*expected_member),
+            members
+                .iter()
+                .map(|member| interner.lookup(*member))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+fn evaluated_remapped_property_type(
+    interner: &TypeInterner,
+    iter_name: &str,
+    source: TypeId,
+    name_type: TypeId,
+    property_name: &str,
+) -> TypeId {
+    let iter_info = TypeParamInfo {
+        name: interner.intern_string(iter_name),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let iter_type = interner.intern(TypeData::TypeParameter(iter_info));
+    let mapped = interner.mapped(MappedType {
+        type_param: iter_info,
+        constraint: interner.keyof(source),
+        name_type: Some(name_type),
+        template: interner.index_access(source, iter_type),
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    let evaluated = evaluate_type(interner, mapped);
+    crate::type_queries::get_raw_property_type(
+        interner,
+        evaluated,
+        interner.intern_string(property_name),
+    )
+    .unwrap_or_else(|| {
+        panic!(
+            "expected evaluated mapped property `{property_name}`, got {:?}",
+            interner.lookup(evaluated)
+        )
+    })
+}
+
+#[test]
+fn remapped_key_collisions_union_value_types_for_each_iteration_key_name() {
+    for iter_name in ["K", "P"] {
+        let interner = TypeInterner::new();
+        let collapsed_name = interner.literal_string("all");
+        let source = interner.object(vec![
+            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+            PropertyInfo::new(interner.intern_string("b"), TypeId::STRING),
+            PropertyInfo::new(interner.intern_string("c"), TypeId::BOOLEAN),
+        ]);
+
+        let prop_type =
+            evaluated_remapped_property_type(&interner, iter_name, source, collapsed_name, "all");
+
+        assert_union_members(
+            &interner,
+            prop_type,
+            &[TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN],
+            iter_name,
+        );
+    }
+}
+
+#[test]
+fn conditional_remap_collisions_union_value_types_from_both_branches() {
+    let interner = TypeInterner::new();
+    let iter_info = TypeParamInfo {
+        name: interner.intern_string("Q"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let iter_type = interner.intern(TypeData::TypeParameter(iter_info));
+    let source = interner.object(vec![
+        PropertyInfo::new(interner.intern_string("x"), TypeId::NUMBER),
+        PropertyInfo::new(interner.intern_string("y"), TypeId::STRING),
+    ]);
+    let source_value = interner.index_access(source, iter_type);
+    let collapsed_name = interner.literal_string("bucket");
+    let name_type = interner.conditional(ConditionalType {
+        check_type: source_value,
+        extends_type: TypeId::NUMBER,
+        true_type: collapsed_name,
+        false_type: collapsed_name,
+        is_distributive: false,
+    });
+
+    let prop_type = evaluated_remapped_property_type(&interner, "Q", source, name_type, "bucket");
+
+    assert_union_members(
+        &interner,
+        prop_type,
+        &[TypeId::STRING, TypeId::NUMBER],
+        "conditional collision",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: mapped/key-remapped type evaluation (#9655)

## Invariant
When a mapped type `as` clause remaps multiple finite source keys to the same output property key, `tsc` unions every contributing source value type into that property. This PR makes tsz do the same through solver-owned mapped property construction.

## Scope
- Add focused solver coverage for remapped-key collisions with renamed iteration variables and conditional remap branches.
- Merge duplicate mapped properties in the shared solver mapped expansion helper.
- Reuse that merge from eager mapped evaluation, including the non-literal `as` constraint path.

## Owner Layer
Solver mapped property construction owns the collision merge. Checker code is not changed for this decision, and no diagnostic path depends on rendered type strings or user-chosen names.

## Adjacent Case Matrix
- Reported constant remap shape: `{ [K in keyof T as "all"]: T[K] }`.
- Renamed iteration variable: the same shape with `P`.
- Three source keys collapse into one property, proving all value contributions are preserved.
- Conditional remap branches both produce the same key and still merge branch contributions.
- Existing non-colliding/key-filtering/keyof remap tests stay green.

## Known Fallback Behavior
Non-colliding remapped keys continue through the existing mapped expansion path. Unsupported remap shapes fall back to the normal solver mapped evaluation path rather than adding checker-side acceptance or a display-string decision.

## Project Corpus Impact
- Row: n/a
- Bug family: mapped key-remapped type evaluation false negative (#9655)
- Evidence: focused solver tests cover the invariant; no project row was run because this is a narrow solver semantic unit fix.

## Verification
- RED before fix: `cargo nextest run -p tsz-solver remapped_key_collisions_union_value_types_for_each_iteration_key_name conditional_remap_collisions_union_value_types_from_both_branches` failed with single-member `number` property types.
- GREEN after rebase to `origin/main` at `156b7e754f`, current head `b0ce3a1c373385467b3b3329c22541770ef8ebe7`:
  - `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-solver remapped_key_collisions_union_value_types_for_each_iteration_key_name conditional_remap_collisions_union_value_types_from_both_branches` (2/2 passed)
  - `cargo fmt --check`
  - `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-solver mapped_key_remap_tests` (21/21 passed)
  - `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-solver mapped_architecture_tests` (30/30 passed)
  - `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-solver mapped_comprehensive_tests` (37/37 passed)
  - `git diff --check origin/main...HEAD`
  - `scripts/arch/check-checker-boundaries.sh`
- File-size check after rebase: `evaluation/evaluate_rules/mapped.rs` 1968 lines, `type_queries/mapped.rs` 1846 lines, `mapped_key_remap_tests.rs` 1330 lines.

## Coordination Notes
- Fixes #9655.
- Branch is synced with `origin/main` (`git rev-list --left-right --count HEAD...origin/main` reported `1 0`).
- Current head is `b0ce3a1c373385467b3b3329c22541770ef8ebe7`.
- Ready-for-review state is intentional, but auto-merge remains off until exact-head required checks are visible and green.
- ReviewHelper rebased and force-with-lease pushed onto current `origin/main` after #10386 and later main merges; exact-head PR CI is pending for the refreshed branch.

