### PR TITLE
test(solver): cover relation policy cache agreement

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -770,3 +770,71 @@ fn assignability_cache_strict_any_policy_matches_uncached_relation_query() {
         "strict-any policy must not let nested `any` silence the property mismatch",
     );
 }
+
+#[test]
+fn assignability_policy_flip_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let strict = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
+    let loose = RelationPolicy::from_flags(0);
+
+    let strict_uncached = query_relation(
+        &interner,
+        TypeId::NULL,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        strict,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_cached = db.is_assignable_to_with_policy(TypeId::NULL, TypeId::NUMBER, strict);
+
+    assert_eq!(
+        strict_cached, strict_uncached,
+        "cached strict-null assignability must match the uncached typed relation query",
+    );
+
+    let loose_uncached = query_relation(
+        &interner,
+        TypeId::NULL,
+        TypeId::NUMBER,
+        RelationKind::Assignable,
+        loose,
+        RelationContext::default(),
+    )
+    .is_related();
+    let loose_cached = db.is_assignable_to_with_policy(TypeId::NULL, TypeId::NUMBER, loose);
+
+    assert_eq!(
+        loose_cached, loose_uncached,
+        "cached non-strict assignability must match the uncached typed relation query",
+    );
+    assert_ne!(
+        strict_cached, loose_cached,
+        "null assignability should differ across strict-null policy slots",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(TypeId::NULL, TypeId::NUMBER, strict),
+        strict_uncached,
+        "strict slot must remain stable after populating the non-strict slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(RelationCacheKey::for_assignability(
+            TypeId::NULL,
+            TypeId::NUMBER,
+            strict.cache_config(),
+        )),
+        Some(strict_uncached),
+        "strict policy result must be stored under the strict policy-derived key",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(RelationCacheKey::for_assignability(
+            TypeId::NULL,
+            TypeId::NUMBER,
+            loose.cache_config(),
+        )),
+        Some(loose_uncached),
+        "non-strict policy result must be stored under the non-strict policy-derived key",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic substrate / refactor-only relation cache contract for #8207 under #8203.

## Invariant
When assignability is evaluated for the same source and target under a behavior-changing relation policy, the cached `QueryCache` wrapper and uncached typed `query_relation` facade must agree, and strict-null and non-strict-null answers must occupy distinct policy-derived cache slots.

## Scope
- `crates/tsz-solver/tests/relation_cache_config_tests.rs`
- Adds focused solver coverage only; no production relation semantics change.

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache correctness / relation policy contract
- Evidence: test-only solver contract for #8207; no project corpus row or runtime behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(/^relation_cache_config_tests::/)'`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Rebased onto `origin/main` and force-with-lease pushed head `d36450968dc9874346358d04d2e92fdbdd8524b9`; exact-head CI is queued/running.

## Coordination Notes
- AgentName: M4-B
- Rebase conflict resolution preserved main's strict-any policy/cache agreement test and this PR's strict-null policy/cache agreement test side by side.
- Open overlap rechecked on 2026-05-26 after #10277, #10282, and #10315 were opened. Those PRs cover separate M4-B slices for readonly conditional array relation coverage (#9743), optional source parameter assignability (#9657), and erase-generics relation cache agreement; this PR remains the strict-null relation policy cache-key contract slice for #8207.
- This is a small first slice for #8207: executable cache-enabled/cache-disabled agreement before retiring more legacy flag protocol paths.
- Auto-merge remains off; manager/queue owner should handle merge/auto-merge decisions after exact-head CI completes.
