### PR TITLE
fix(dts): avoid duplicate JSDoc named export functions

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/emit_node.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/emit_node.rs
@@ -572,6 +572,11 @@ impl<'a> DeclarationEmitter<'a> {
                     deferred_statements.insert(target_stmt_idx);
                     continue;
                 }
+                if target_stmt_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+                    && self.statement_has_attached_jsdoc(source_file, target_stmt_node)
+                {
+                    continue;
+                }
                 if target_stmt_node.kind != syntax_kind_ext::FUNCTION_DECLARATION
                     && self.statement_has_attached_jsdoc(source_file, target_stmt_node)
                 {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations.rs
@@ -3478,6 +3478,11 @@ export { g };
         output.contains("export function g(a: {\n    x: string;\n}, b: {\n    y: typeof import(\".\").b;\n}): void | \"\";"),
         "Expected folded JS export function to preserve JSDoc param and return types: {output}"
     );
+    assert_eq!(
+        output.matches("export function g(").count(),
+        1,
+        "Expected folded JS export function to be emitted once: {output}"
+    );
     assert!(
         output.contains(
             "/**\n * @param {{x: string}} a\n * @param {{y: typeof b}} b\n */\nexport function g"


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Emit/DTS parity: JSDoc JavaScript declaration emit

## Invariant
When a JavaScript function declaration with attached JSDoc is exported through a local named export specifier, `tsc` emits one declaration through the JSDoc-preserving deferred path; this PR keeps tsz from also folding that function into the eager named-export emission list.

## Scope
- Adjust JS folded named-export collection for JSDoc-bearing function declarations.
- Strengthen the focused emitter unit test to assert the function is emitted once.

## Project Corpus Impact
- Row: n/a
- Bug family: JSDoc/JavaScript declaration emit ordering and duplicate DTS output
- Evidence: emit-only declaration parity fix; no project row metadata or compile behavior changed.

## Verification
- `scripts/safe-run.sh scripts/emit/run.sh --filter=jsDeclarationsFunctions --dts-only --verbose --concurrency=1 --timeout=15000 --json-out=/tmp/studio-e-jsDeclarationsFunctions-dts-final.json`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=jsDeclarations --dts-only --verbose --json-out=/tmp/studio-e-jsDeclarations-dts-final.json`
- `cargo nextest run -p tsz-emitter test_js_named_export_function_preserves_jsdoc_signature_at_export_position`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- Open PR overlap check found Studio-C class emit work and Studio-F output-surgery cleanup, but no active Studio-E PR and no overlapping JSDoc named-export DTS PR.
- This is a narrow follow-up under #9333/#8275's declaration-summary direction; it does not add checker/solver semantic discovery or output surgery.
