### PR TITLE
refactor(checker): route switch exhaustion through flow boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -103,25 +103,14 @@ impl<'a> FlowAnalyzer<'a> {
         else {
             return false;
         };
-        let switch_type = query::enum_member_domain(self.interner, switch_type);
         let case_types = self.case_types_for_exhaustiveness(switch_data.case_block);
-        if case_types.is_empty()
-            || matches!(switch_type, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN)
-            || case_types
-                .iter()
-                .any(|&ty| matches!(ty, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN))
-        {
-            return false;
-        }
-
-        let env_borrow;
-        let mut narrowing = self.make_narrowing_context();
-        if let Some(env) = &self.type_environment {
-            env_borrow = env.borrow();
-            narrowing = narrowing.with_resolver(&*env_borrow);
-        }
-
-        narrowing.narrow_excluding_types(switch_type, &case_types) == TypeId::NEVER
+        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
+        query::cases_exhaust_type(
+            self.interner,
+            env_borrow.as_deref(),
+            switch_type,
+            &case_types,
+        )
     }
 
     /// Iterative flow graph traversal for definite assignment checks.


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Track 1 semantic-flow architecture cleanup / refactor only.

## Invariant
When switch case values exhaust the switch operand domain, `tsc` treats the implicit default edge as unreachable; this PR keeps checker responsible for collecting the switch/case facts and routes the semantic exhaustion decision through `query_boundaries::flow_analysis::cases_exhaust_type`.

## Scope
- `crates/tsz-checker/src/flow/control_flow/var_utils.rs`
- No solver behavior changes.
- No roadmap update: this is a routine boundary ratchet.

## Project Corpus Impact
- Row: n/a
- Bug family: flow graph / switch exhaustiveness boundary cleanup
- Evidence: refactor-only; no project-corpus behavior claim.

ReviewHelper note: formatted these fields with the dashed Project Corpus Impact shape required by the ready-PR body gate.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-checker`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib enum_residual_narrowing_tests::switch_default_excluding_numeric_enum_members_leaves_single_member`
- `cargo nextest run -p tsz-checker --lib definite_assignment_tests::test_ts2454_not_emitted_for_exhaustive_switch_implicit_default_path`

Note: I accidentally tried `cargo nextest run -p tsz-checker --test definite_assignment_tests ...`; that target does not exist because the test is included through the lib test binary. No full conformance, emit, or fourslash suites were run locally.

## Coordination Notes
- Open M1-D owned PRs: none at intake.
- Open PR overlap checked; current open PRs were M1-A perf and Studio docs/emit work, no M1-D flow/switch overlap.
- Related stale issue #9659 was closed with signed evidence after confirming merged PR #9937 satisfied its hold-open condition.
