### PR TITLE
fix(solver): resolve remapped template pattern indexes

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -863,8 +863,16 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             .interner()
             .get_mapped(MappedTypeId(mapped_id));
 
-        // Only apply if no name remapping (as clause)
         if mapped.name_type.is_some() {
+            if let Some(result) =
+                super::mapped_template_index::try_evaluate_remapped_mapped_template_for_index(
+                    self.evaluator,
+                    &mapped,
+                    self.index_type,
+                )
+            {
+                return Some(result);
+            }
             return None;
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_template_index.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_template_index.rs
@@ -3,8 +3,8 @@
 use super::mapped::MappedKeys;
 use crate::evaluation::evaluate::TypeEvaluator;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
-use crate::relations::subtype::TypeResolver;
-use crate::types::{MappedType, TypeId};
+use crate::relations::subtype::{SubtypeChecker, TypeResolver};
+use crate::types::{MappedModifier, MappedType, TypeData, TypeId};
 use smallvec::SmallVec;
 
 /// Evaluate `mapped[constraint]` by substituting each concrete key literal into the
@@ -42,4 +42,85 @@ pub(super) fn try_evaluate_mapped_template_per_concrete_key<R: TypeResolver>(
         1 => results[0],
         _ => evaluator.interner().union(results.into_vec()),
     })
+}
+
+/// Evaluate `mapped[index]` for finite mapped types whose `as` clause remaps
+/// source keys to open template-literal patterns.
+///
+/// For ``{ [K in keyof T as `${K}${string}`]: T[K] }["axyz"]``, the mapped type
+/// cannot be materialized as a concrete property named `"axyz"`. Keep the
+/// correlation by checking the requested literal index against each remapped key
+/// pattern, then substitute the original source key into the template.
+pub(super) fn try_evaluate_remapped_mapped_template_for_index<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    mapped: &MappedType,
+    index_type: TypeId,
+) -> Option<TypeId> {
+    mapped.name_type?;
+
+    if crate::type_queries::get_literal_property_name(evaluator.interner(), index_type).is_none()
+        && crate::literal_number(evaluator.interner(), index_type).is_none()
+    {
+        return None;
+    }
+
+    let keys: MappedKeys = evaluator.extract_mapped_keys(mapped.constraint)?;
+    if keys.has_string
+        || keys.has_number
+        || !keys.template_literals.is_empty()
+        || !keys.symbol_keys.is_empty()
+    {
+        return None;
+    }
+
+    let mut results: SmallVec<[TypeId; 4]> = SmallVec::new();
+
+    for mapped_key in keys.keys {
+        let remapped_key = match evaluator.remap_key_type_for_mapped(mapped, mapped_key.key_literal)
+        {
+            Ok(Some(remapped_key)) => remapped_key,
+            Ok(None) => continue,
+            Err(()) => return None,
+        };
+
+        if !remapped_key_matches_index(evaluator, remapped_key, index_type) {
+            continue;
+        }
+
+        let subst = TypeSubstitution::single(mapped.type_param.name, mapped_key.key_literal);
+        let instantiated = instantiate_type(evaluator.interner(), mapped.template, &subst);
+        let mut evaluated = evaluator.evaluate(instantiated);
+        if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
+            evaluated = evaluator.interner().union2(evaluated, TypeId::UNDEFINED);
+        }
+        if evaluated != TypeId::NEVER {
+            results.push(evaluated);
+        }
+    }
+
+    Some(match results.len() {
+        0 => TypeId::UNDEFINED,
+        1 => results[0],
+        _ => evaluator.interner().union(results.into_vec()),
+    })
+}
+
+fn remapped_key_matches_index<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    remapped_key: TypeId,
+    index_type: TypeId,
+) -> bool {
+    if remapped_key == index_type {
+        return true;
+    }
+
+    if let Some(TypeData::Union(list_id)) = evaluator.interner().lookup(remapped_key) {
+        let members = evaluator.interner().type_list(list_id);
+        return members
+            .iter()
+            .any(|&member| remapped_key_matches_index(evaluator, member, index_type));
+    }
+
+    let mut checker = SubtypeChecker::with_resolver(evaluator.interner(), evaluator.resolver());
+    checker.is_subtype_of(index_type, remapped_key)
 }

--- a/crates/tsz-solver/tests/mapped_key_remap_tests.rs
+++ b/crates/tsz-solver/tests/mapped_key_remap_tests.rs
@@ -4,7 +4,7 @@
 
 use crate::types::*;
 use crate::{
-    evaluation::evaluate::evaluate_type,
+    evaluation::evaluate::{evaluate_index_access, evaluate_type},
     intern::TypeInterner,
     relations::subtype::SubtypeChecker,
     type_queries::{
@@ -80,6 +80,130 @@ fn test_mapped_type_as_never_skips_property() {
         matches!(interner.lookup(result), Some(TypeData::Mapped(_))),
         "Expected mapped type (deferred due to unresolved K), got {:?}",
         interner.lookup(result)
+    );
+}
+
+#[test]
+fn remapped_template_pattern_key_indexes_matching_literal() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::NUMBER,
+    )]);
+    let key_space = interner.keyof(source);
+
+    let key_param = TypeParamInfo {
+        name: interner.intern_string("K"),
+        constraint: Some(key_space),
+        default: None,
+        is_const: false,
+    };
+    let key_type = interner.type_param(key_param);
+    let remapped_pattern = interner.template_literal(vec![
+        TemplateSpan::Type(interner.intersection2(TypeId::STRING, key_type)),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+
+    let mapped = interner.mapped(MappedType {
+        type_param: key_param,
+        constraint: key_space,
+        name_type: Some(remapped_pattern),
+        template: interner.index_access(source, key_type),
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    let result = evaluate_index_access(&interner, mapped, interner.literal_string("axyz"));
+    assert_eq!(
+        result,
+        TypeId::NUMBER,
+        "mapped template-pattern keys should resolve matching pattern indexes"
+    );
+}
+
+#[test]
+fn remapped_template_pattern_key_preserves_per_source_value_type() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object(vec![
+        PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+        PropertyInfo::new(interner.intern_string("b"), TypeId::STRING),
+    ]);
+    let key_space = interner.keyof(source);
+
+    let key_param = TypeParamInfo {
+        name: interner.intern_string("K"),
+        constraint: Some(key_space),
+        default: None,
+        is_const: false,
+    };
+    let key_type = interner.type_param(key_param);
+    let remapped_pattern = interner.template_literal(vec![
+        TemplateSpan::Type(interner.intersection2(TypeId::STRING, key_type)),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+
+    let mapped = interner.mapped(MappedType {
+        type_param: key_param,
+        constraint: key_space,
+        name_type: Some(remapped_pattern),
+        template: interner.index_access(source, key_type),
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    assert_eq!(
+        evaluate_index_access(&interner, mapped, interner.literal_string("axyz")),
+        TypeId::NUMBER
+    );
+    assert_eq!(
+        evaluate_index_access(&interner, mapped, interner.literal_string("bxyz")),
+        TypeId::STRING
+    );
+    assert_eq!(
+        evaluate_index_access(&interner, mapped, interner.literal_string("cxyz")),
+        TypeId::UNDEFINED
+    );
+}
+
+#[test]
+fn remapped_template_pattern_key_matches_renamed_iteration_param_with_suffix() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::BOOLEAN,
+    )]);
+    let key_space = interner.keyof(source);
+
+    let key_param = TypeParamInfo {
+        name: interner.intern_string("P"),
+        constraint: Some(key_space),
+        default: None,
+        is_const: false,
+    };
+    let key_type = interner.type_param(key_param);
+    let remapped_pattern = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("pre_")),
+        TemplateSpan::Type(interner.intersection2(TypeId::STRING, key_type)),
+        TemplateSpan::Text(interner.intern_string("_")),
+        TemplateSpan::Type(TypeId::STRING),
+        TemplateSpan::Text(interner.intern_string("_post")),
+    ]);
+
+    let mapped = interner.mapped(MappedType {
+        type_param: key_param,
+        constraint: key_space,
+        name_type: Some(remapped_pattern),
+        template: interner.index_access(source, key_type),
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    assert_eq!(
+        evaluate_index_access(&interner, mapped, interner.literal_string("pre_a_mid_post")),
+        TypeId::BOOLEAN
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: mapped/template-literal indexed-access evaluation (#9767)

## Invariant
Indexed access into a finite mapped type with a template-literal-pattern `as` remap must test the requested literal index against each remapped key pattern while preserving the original source-key-to-template correlation.

## Scope
- Fixes #9767.
- Adds a solver indexed-access helper for remapped mapped types whose finite source keys remap to open template-literal patterns.
- Keeps the existing non-remapped mapped substitution path unchanged.
- Adds unit coverage for matching literals, renamed iteration parameters, prefix/suffix patterns, per-source value precision, and non-matching literals.

## Owner Layer
Solver indexed-access evaluation owns the semantic match between requested literal keys and remapped template-literal key patterns. Checker code is not changed for this decision.

## Adjacent Case Matrix
- Matching literal against a prefix template pattern resolves the mapped template value.
- Matching literal against a suffix template pattern resolves the mapped template value.
- Renamed mapped iteration parameter preserves behavior.
- Per-source value precision is preserved when different source keys remap to different pattern matches.
- Non-matching literal remains unresolved/rejected instead of falling through to an unrelated value.

## Known Fallback Behavior
The existing non-remapped mapped substitution path remains unchanged. Unsupported remapped shapes fall back to normal indexed-access evaluation rather than introducing checker-side acceptance.

## Project Corpus Impact
- Row: n/a
- Bug family: mapped type key remapping plus template-literal-pattern indexed access false positive
- Evidence: solver-only minimized repro from #9767 covered by `mapped_key_remap_tests`; no project-corpus row identified for this isolated type-evaluation bug.

## Verification
- `cargo nextest run -p tsz-solver remapped_template_pattern_key` (red before fix after adding the first repro; green after implementation)
- `cargo nextest run -p tsz-solver mapped_key_remap_tests`
- `cargo nextest run -p tsz-solver index_access_comprehensive_tests`
- `cargo nextest run -p tsz-solver mapped_architecture_tests`
- `cargo fmt --check`
- `git diff --check`
- File-size check: `index_access.rs` 1841 lines, `mapped_template_index.rs` 126 lines, `mapped_key_remap_tests.rs` 1205 lines

## Coordination Notes
- Opened as draft for CI coordination; ready should wait until the draft checks are visible and clean for head `7bcd0dd54fce7f04b7f6d8ad8d48218757cb0f45`.
- No open PR was found for #9767 before starting; the older issue claim had no active PR handoff.
- The failed `queue-one-pr` check on head `7bcd0dd54fce7f04b7f6d8ad8d48218757cb0f45` was an `actions/checkout` 403 during fetch, not a test/build failure; rerun requested by M4-A.
- Auto-merge remains off.
