### PR TITLE
test(checker): cover reduce accumulator context

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -50,6 +50,10 @@ name = "generic_multi_prop_object_literal_tests"
 path = "tests/generic_multi_prop_object_literal_tests.rs"
 
 [[test]]
+name = "issue_9757_reduce_accumulator_context_tests"
+path = "tests/issue_9757_reduce_accumulator_context_tests.rs"
+
+[[test]]
 name = "abstract_constructor_argument_tests"
 path = "tests/abstract_constructor_argument_tests.rs"
 

--- a/crates/tsz-checker/tests/issue_9757_reduce_accumulator_context_tests.rs
+++ b/crates/tsz-checker/tests/issue_9757_reduce_accumulator_context_tests.rs
@@ -1,0 +1,85 @@
+//! Regression coverage for issue #9757.
+//!
+//! Structural rule: when `Array.prototype.reduce` resolves the overload with
+//! an explicit initial accumulator value, the callback accumulator parameter is
+//! contextually typed as the widened accumulator type, not as the initializer's
+//! literal type.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_compiled_lib_files};
+
+fn check_with_es5(source: &str) -> Vec<(u32, String)> {
+    let libs = load_compiled_lib_files(&["lib.es5.d.ts"]);
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .filter(|(code, _)| *code != 2318)
+    .collect()
+}
+
+#[test]
+fn reduce_accumulator_parameter_uses_widened_initial_value() {
+    let diagnostics = check_with_es5(
+        r#"
+declare const values: number[];
+values.reduce((acc, cur) => {
+  const probe: string = acc;
+  return acc + cur;
+}, 0);
+"#,
+    );
+
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .collect();
+
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected one TS2322 probing the accumulator type, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322[0]
+            .1
+            .contains("Type 'number' is not assignable to type 'string'"),
+        "accumulator should be contextually typed as widened number, got: {ts2322:?}"
+    );
+}
+
+#[test]
+fn reduce_right_accumulator_parameter_uses_widened_initial_value() {
+    let diagnostics = check_with_es5(
+        r#"
+declare const values: number[];
+values.reduceRight((acc, cur) => {
+  const probe: string = acc;
+  return acc + cur;
+}, 0);
+"#,
+    );
+
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .collect();
+
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected one TS2322 probing the reduceRight accumulator type, got: {diagnostics:?}"
+    );
+    assert!(
+        ts2322[0]
+            .1
+            .contains("Type 'number' is not assignable to type 'string'"),
+        "reduceRight accumulator should be widened to number, got: {ts2322:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Track 3 regression coverage: contextual generic inference for `Array.prototype.reduce` / `reduceRight` accumulator parameters.

## Invariant
When `Array.prototype.reduce` or `reduceRight` resolves the overload with an explicit initial accumulator value, the callback accumulator parameter is contextually typed as the widened accumulator type, not as the initializer literal; this PR locks current tsz checker behavior with focused lib-backed regression tests.

## Scope
- Add checker integration coverage for issue #9757 on `reduce` and `reduceRight` accumulator contextual typing.
- Register the new test target in `crates/tsz-checker/Cargo.toml`.

## Project Corpus Impact
- Row: n/a
- Bug family: Array reduce callback contextual typing / literal initializer widening (#9757)
- Evidence: checker-only regression tests over compiled `lib.es5.d.ts`; no project fixture or corpus metadata touched.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test issue_9757_reduce_accumulator_context_tests`
- Draft CI Light Summary passed on head `b7350bf859bf84497f2925a90a3f8d7113ca1bae` (rerun `26447602640`).

## Coordination Notes
- AgentName: M4-C
- #9757 is currently labeled WIP with M4-C ownership but had no active PR; current main already satisfies the reported `reduce` and `reduceRight` accumulator probes.
- This PR preserves the invariant so the stale issue can be closed after merge if CI agrees.
- GitHub checkout/action-download blocker cleared on rerun; marked ready for review so heavy CI can run.