### PR TITLE
test(solver): cover readonly conditional array relation

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -394,6 +394,9 @@ mod conditional_infer_callable_arity_tests;
 #[path = "../tests/conditional_keyof_variance_tests.rs"]
 mod conditional_keyof_variance_tests;
 #[cfg(test)]
+#[path = "../tests/conditional_readonly_array_relation_tests.rs"]
+mod conditional_readonly_array_relation_tests;
+#[cfg(test)]
 #[path = "../tests/constraint_tests.rs"]
 mod constraint_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/tests/conditional_readonly_array_relation_tests.rs
+++ b/crates/tsz-solver/tests/conditional_readonly_array_relation_tests.rs
@@ -1,0 +1,125 @@
+//! Conditional `extends` relation coverage for readonly array surfaces.
+
+use super::*;
+use crate::evaluation::evaluate::evaluate_type;
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::intern::TypeInterner;
+use crate::types::{ConditionalType, TupleElement, TypeParamInfo};
+
+fn conditional_result(interner: &TypeInterner, check_type: TypeId, extends_type: TypeId) -> TypeId {
+    let yes = interner.literal_string("Y");
+    let no = interner.literal_string("N");
+    let cond_id = interner.conditional(ConditionalType {
+        check_type,
+        extends_type,
+        true_type: yes,
+        false_type: no,
+        is_distributive: false,
+    });
+    evaluate_type(interner, cond_id)
+}
+
+#[test]
+fn generic_readonly_array_extends_mutable_array_takes_false_branch() {
+    let interner = TypeInterner::new();
+    let s_name = interner.intern_string("S");
+    let t_name = interner.intern_string("T");
+    let s_param = interner.type_param(TypeParamInfo::simple(s_name));
+    let t_param = interner.type_param(TypeParamInfo::simple(t_name));
+    let readonly_numbers = interner.readonly_array(TypeId::NUMBER);
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let no = interner.literal_string("N");
+    let cond_id = interner.conditional(ConditionalType {
+        check_type: s_param,
+        extends_type: t_param,
+        true_type: interner.literal_string("Y"),
+        false_type: no,
+        is_distributive: false,
+    });
+    let mut subst = TypeSubstitution::new();
+    subst.insert(s_name, readonly_numbers);
+    subst.insert(t_name, mutable_numbers);
+    let instantiated = instantiate_type(&interner, cond_id, &subst);
+
+    assert_eq!(
+        evaluate_type(&interner, instantiated),
+        no,
+        "R<readonly number[], number[]> should take the false branch"
+    );
+}
+
+#[test]
+fn generic_readonly_tuple_extends_mutable_array_takes_false_branch() {
+    let interner = TypeInterner::new();
+    let s_name = interner.intern_string("S");
+    let t_name = interner.intern_string("T");
+    let s_param = interner.type_param(TypeParamInfo::simple(s_name));
+    let t_param = interner.type_param(TypeParamInfo::simple(t_name));
+    let tuple = interner.tuple(vec![
+        TupleElement {
+            type_id: interner.literal_number(1.0),
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: interner.literal_number(2.0),
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let readonly_tuple = interner.readonly_type(tuple);
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let no = interner.literal_string("N");
+    let cond_id = interner.conditional(ConditionalType {
+        check_type: s_param,
+        extends_type: t_param,
+        true_type: interner.literal_string("Y"),
+        false_type: no,
+        is_distributive: false,
+    });
+    let mut subst = TypeSubstitution::new();
+    subst.insert(s_name, readonly_tuple);
+    subst.insert(t_name, mutable_numbers);
+    let instantiated = instantiate_type(&interner, cond_id, &subst);
+
+    assert_eq!(
+        evaluate_type(&interner, instantiated),
+        no,
+        "R<readonly [1, 2], number[]> should take the false branch"
+    );
+}
+
+#[test]
+fn readonly_target_controls_take_true_branch() {
+    let interner = TypeInterner::new();
+    let readonly_numbers = interner.readonly_array(TypeId::NUMBER);
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let yes = interner.literal_string("Y");
+
+    assert_eq!(
+        conditional_result(&interner, readonly_numbers, readonly_numbers),
+        yes,
+        "readonly number[] extends readonly number[] should take the true branch"
+    );
+    assert_eq!(
+        conditional_result(&interner, mutable_numbers, readonly_numbers),
+        yes,
+        "number[] extends readonly number[] should take the true branch"
+    );
+}
+
+#[test]
+fn direct_readonly_array_extends_mutable_array_takes_false_branch() {
+    let interner = TypeInterner::new();
+    let readonly_numbers = interner.readonly_array(TypeId::NUMBER);
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let no = interner.literal_string("N");
+
+    assert_eq!(
+        conditional_result(&interner, readonly_numbers, mutable_numbers),
+        no,
+        "direct readonly number[] extends number[] should stay false"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic substrate / test-only relation variance coverage for #9743.

## Invariant
When a conditional type compares a readonly array or readonly tuple source against a mutable array target, `tsc` takes the false branch; this PR preserves that solver relation behavior with focused generic and direct conditional coverage.

## Scope
- `crates/tsz-solver/tests/conditional_readonly_array_relation_tests.rs`
- `crates/tsz-solver/src/lib.rs`
- Adds solver regression coverage only; no production relation semantics changed.

## Project Corpus Impact
- Row: n/a
- Bug family: readonly/mutable array relation in conditional `extends`
- Evidence: test-only solver coverage for #9743 plus local CLI smoke of the exact repro; no benchmark project row changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(/^conditional_readonly_array_relation_tests::/)'`
- `cargo run -q -p tsz-cli --bin tsz -- --noEmit --strict /tmp/tsz-9743-verify-<pid>.ts`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- Refs #9743. Current `origin/main` already accepts the exact issue repro; this PR adds regression coverage so future relation-policy work does not reintroduce the readonly-to-mutable conditional branch bug.
- #10269 remains the other M4-B PR and is waiting on exact-head CI visibility; this PR does not modify the relation cache-policy contract from #10269.
- No open PR overlap found for #9743 during intake.
