### PR TITLE
fix(checker): honor JSDoc overload calls

### DIFF
--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -7,6 +7,9 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{CallSignature, TypeId, TypeParamInfo};
 
+type JsdocTemplateParamScopeUpdates = Vec<(String, Option<TypeId>, bool)>;
+type JsdocTemplateParamPushResult = (Vec<TypeParamInfo>, JsdocTemplateParamScopeUpdates);
+
 // =============================================================================
 // Signature Building Methods
 // =============================================================================
@@ -128,10 +131,7 @@ impl<'a> CheckerState<'a> {
             .collect()
     }
 
-    fn push_jsdoc_overload_template_params(
-        &mut self,
-        jsdoc: &str,
-    ) -> (Vec<TypeParamInfo>, Vec<(String, Option<TypeId>, bool)>) {
+    fn push_jsdoc_overload_template_params(&mut self, jsdoc: &str) -> JsdocTemplateParamPushResult {
         let template_names = Self::jsdoc_template_type_params(jsdoc);
         if template_names.is_empty() {
             return (Vec::new(), Vec::new());

--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -5,7 +5,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::TypeId;
+use tsz_solver::{CallSignature, TypeId, TypeParamInfo};
 
 // =============================================================================
 // Signature Building Methods
@@ -24,7 +24,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         func: &tsz_parser::parser::node::FunctionData,
         func_idx: tsz_parser::parser::NodeIndex,
-    ) -> tsz_solver::CallSignature {
+    ) -> CallSignature {
         // Push enclosing type parameters so that overload signatures can reference
         // type parameters from outer function/class/interface scopes.
         let enclosing_updates = self.push_enclosing_type_parameters(func_idx);
@@ -38,7 +38,7 @@ impl<'a> CheckerState<'a> {
         self.pop_type_parameters(type_param_updates);
         self.pop_type_parameters(enclosing_updates);
 
-        tsz_solver::CallSignature {
+        CallSignature {
             type_params,
             params,
             this_type,
@@ -46,6 +46,119 @@ impl<'a> CheckerState<'a> {
             type_predicate,
             is_method: false,
         }
+    }
+
+    pub(crate) fn jsdoc_overload_call_signatures_for_function(
+        &mut self,
+        func: &tsz_parser::parser::node::FunctionData,
+        func_idx: NodeIndex,
+    ) -> Vec<CallSignature> {
+        use tsz_common::comments::get_jsdoc_content;
+
+        if !self.is_js_file() || !self.ctx.compiler_options.check_js {
+            return Vec::new();
+        }
+
+        let Some(sf) = self.ctx.arena.source_files.first() else {
+            return Vec::new();
+        };
+        let source_text = sf.text.to_string();
+        let overload_docs: Vec<(String, u32)> = self
+            .leading_jsdoc_comments_for_node(func_idx)
+            .into_iter()
+            .filter_map(|comment| {
+                let jsdoc = get_jsdoc_content(&comment, &source_text);
+                Self::jsdoc_contains_tag(&jsdoc, "overload").then_some((jsdoc, comment.pos))
+            })
+            .collect();
+        if overload_docs.is_empty() {
+            return Vec::new();
+        }
+
+        let base_signature = self.call_signature_from_function(func, func_idx);
+        overload_docs
+            .into_iter()
+            .map(|(jsdoc, comment_pos)| {
+                let (type_params, updates) = self.push_jsdoc_overload_template_params(&jsdoc);
+                let mut signature = base_signature.clone();
+                signature.type_params = type_params;
+                let jsdoc_params = Self::extract_jsdoc_param_names(&jsdoc);
+                signature.params.truncate(jsdoc_params.len());
+
+                for (i, (param_name, _)) in jsdoc_params.iter().enumerate() {
+                    let Some(param) = signature.params.get_mut(i) else {
+                        break;
+                    };
+
+                    let jsdoc_optional = Self::extract_jsdoc_param_type_string(&jsdoc, param_name)
+                        .is_some_and(|type_expr| type_expr.trim().ends_with('='))
+                        || Self::is_jsdoc_param_optional_by_brackets(&jsdoc, param_name);
+
+                    if let Some(jsdoc_type) = self.resolve_jsdoc_param_type_with_pos(
+                        &jsdoc,
+                        param_name,
+                        Some(comment_pos),
+                    ) {
+                        param.type_id = jsdoc_type;
+                    }
+                    param.optional = jsdoc_optional;
+                    param.rest = Self::jsdoc_param_is_rest(&jsdoc, param_name);
+                }
+
+                let jsdoc_for_predicate = Some(jsdoc.clone());
+                if let Some(predicate) = self
+                    .extract_jsdoc_return_type_predicate(&jsdoc_for_predicate, &signature.params)
+                {
+                    signature.return_type = if predicate.asserts {
+                        TypeId::VOID
+                    } else {
+                        TypeId::BOOLEAN
+                    };
+                    signature.type_predicate = Some(predicate);
+                } else {
+                    signature.return_type = self
+                        .resolve_jsdoc_return_type(&jsdoc)
+                        .unwrap_or(TypeId::ANY);
+                    signature.type_predicate = None;
+                }
+
+                self.pop_type_parameters(updates);
+                signature
+            })
+            .collect()
+    }
+
+    fn push_jsdoc_overload_template_params(
+        &mut self,
+        jsdoc: &str,
+    ) -> (Vec<TypeParamInfo>, Vec<(String, Option<TypeId>, bool)>) {
+        let template_names = Self::jsdoc_template_type_params(jsdoc);
+        if template_names.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+
+        let factory = self.ctx.types.factory();
+        let mut type_params = Vec::with_capacity(template_names.len());
+        let mut updates = Vec::with_capacity(template_names.len());
+
+        for (name, is_const, default_str) in template_names {
+            let atom = self.ctx.types.intern_string(&name);
+            let default = default_str
+                .as_deref()
+                .and_then(|type_expr| self.resolve_jsdoc_reference(type_expr));
+            let info = TypeParamInfo {
+                name: atom,
+                constraint: None,
+                default,
+                is_const,
+            };
+            let type_id = factory.type_param(info);
+            let previous = self.ctx.type_parameter_scope.insert(name.clone(), type_id);
+            updates.push((name, previous, false));
+            type_params.push(info);
+        }
+
+        (type_params, updates)
     }
 
     /// Build a `CallSignature` from a method declaration.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -568,6 +568,9 @@ mod jsdoc_enum_circular_tests;
 #[path = "../tests/jsdoc_function_return_type_anchor_tests.rs"]
 mod jsdoc_function_return_type_anchor_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_overload_call_resolution_tests.rs"]
+mod jsdoc_overload_call_resolution_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
 mod jsdoc_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -77,7 +77,7 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn leading_jsdoc_comments_for_node(
+    pub(crate) fn leading_jsdoc_comments_for_node(
         &self,
         node_idx: NodeIndex,
     ) -> Vec<tsz_common::comments::CommentRange> {

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1441,6 +1441,11 @@ impl<'a> CheckerState<'a> {
                     overloads.push(self.call_signature_from_function(func, decl_idx));
                 } else {
                     implementation_decl = decl_idx;
+                    if overloads.is_empty() {
+                        overloads.extend(
+                            self.jsdoc_overload_call_signatures_for_function(func, decl_idx),
+                        );
+                    }
                 }
             }
 

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -322,6 +322,10 @@ impl<'a> CheckerState<'a> {
                 overloads.push(sig);
             } else if implementation_sig.is_none() {
                 implementation_sig = Some(sig);
+                if overloads.is_empty() {
+                    overloads
+                        .extend(self.jsdoc_overload_call_signatures_for_function(func, decl_idx));
+                }
             }
         }
 

--- a/crates/tsz-checker/src/tests/jsdoc_overload_call_resolution_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_overload_call_resolution_tests.rs
@@ -81,6 +81,38 @@ const b = choose("x");
 }
 
 #[test]
+fn jsdoc_overload_call_rejects_unmatched_implementation_argument() {
+    let messages = check_js_source_code_messages(
+        r#"
+/**
+ * @overload
+ * @param {number} value
+ * @returns {string}
+ */
+/**
+ * @overload
+ * @param {string} value
+ * @returns {number}
+ */
+/**
+ * @param {number | string | boolean} value
+ * @returns {string | number | boolean}
+ */
+function choose(value) { return value; }
+
+choose(true);
+"#,
+    );
+
+    let ts2769 = messages_for_code(&messages, 2769);
+    assert_eq!(ts2769.len(), 1, "expected one TS2769, got {messages:?}");
+    assert!(
+        ts2769[0].contains("No overload matches this call."),
+        "expected no-overload diagnostic, got {ts2769:?}"
+    );
+}
+
+#[test]
 fn jsdoc_without_overload_keeps_implementation_signature_callable() {
     let messages = check_js_source_code_messages(
         r#"

--- a/crates/tsz-checker/src/tests/jsdoc_overload_call_resolution_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_overload_call_resolution_tests.rs
@@ -1,0 +1,104 @@
+//! Regression tests for checked-JS `@overload` call resolution.
+
+use crate::test_utils::check_js_source_code_messages;
+
+fn messages_for_code(messages: &[(u32, String)], code: u32) -> Vec<&str> {
+    messages
+        .iter()
+        .filter_map(|(diag_code, message)| (*diag_code == code).then_some(message.as_str()))
+        .collect()
+}
+
+#[test]
+fn jsdoc_overload_call_uses_overload_return_not_implementation_return() {
+    let messages = check_js_source_code_messages(
+        r#"
+/**
+ * @overload
+ * @param {number} x
+ * @returns {string}
+ */
+/**
+ * @param {number} x
+ * @returns {string | number}
+ */
+function f(x) { return x; }
+
+/** @type {boolean} */
+const b = f(1);
+"#,
+    );
+
+    let ts2322 = messages_for_code(&messages, 2322);
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got {messages:?}");
+    assert!(
+        ts2322[0].contains("Type 'string' is not assignable to type 'boolean'"),
+        "expected selected overload return in diagnostic, got {ts2322:?}"
+    );
+    assert!(
+        !ts2322[0].contains("string | number"),
+        "implementation return should not be used for calls with JSDoc overloads: {ts2322:?}"
+    );
+}
+
+#[test]
+fn jsdoc_overload_call_selects_by_argument_type() {
+    let messages = check_js_source_code_messages(
+        r#"
+/**
+ * @overload
+ * @param {number} value
+ * @returns {string}
+ */
+/**
+ * @overload
+ * @param {string} value
+ * @returns {number}
+ */
+/**
+ * @param {number | string} value
+ * @returns {string | number}
+ */
+function choose(value) { return value; }
+
+/** @type {string} */
+const s = choose(1);
+
+/** @type {number} */
+const n = choose("x");
+
+/** @type {boolean} */
+const b = choose("x");
+"#,
+    );
+
+    let ts2322 = messages_for_code(&messages, 2322);
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got {messages:?}");
+    assert!(
+        ts2322[0].contains("Type 'number' is not assignable to type 'boolean'"),
+        "expected string-argument overload return in diagnostic, got {ts2322:?}"
+    );
+}
+
+#[test]
+fn jsdoc_without_overload_keeps_implementation_signature_callable() {
+    let messages = check_js_source_code_messages(
+        r#"
+/**
+ * @param {number} x
+ * @returns {string | number}
+ */
+function plain(x) { return x; }
+
+/** @type {boolean} */
+const b = plain(1);
+"#,
+    );
+
+    let ts2322 = messages_for_code(&messages, 2322);
+    assert_eq!(ts2322.len(), 1, "expected one TS2322, got {messages:?}");
+    assert!(
+        ts2322[0].contains("string | number"),
+        "non-overload JSDoc should keep implementation return visible: {ts2322:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track: JSDoc checked-JS semantic parity / checker call-resolution bug fix.

## Invariant
When a checked JavaScript function has leading JSDoc `@overload` blocks, `tsc` resolves calls against those overload signatures and does not expose the implementation signature as the callable return surface. This PR makes tsz lower those JSDoc overload comments into the existing checker `CallableShape` overload path.

## Scope
- Adds JSDoc overload call-signature lowering in `signature_builder`.
- Reuses the existing leading-JSDoc comment walk used by overload compatibility.
- Feeds JSDoc overload signatures into current function-symbol callable construction.
- Adds focused checked-JS regression tests for selected overload returns, argument-based overload selection, and non-overload JSDoc behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: checked-JS JSDoc overload call resolution.
- Evidence: focused checker regression for issue #9744; no specific project-corpus row identified.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(jsdoc_overload_call)'`
- `cargo fmt --check`
- `cargo clippy -p tsz-checker --lib -- -D warnings`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- AgentName: Studio-E.
- Fixes #9744.
- Follow-up `3f78c742a5` names the JSDoc overload template helper return type after current-head lint found `clippy::type_complexity`; no behavior changed.
- No open PR overlap found for JSDoc overload call resolution during intake; existing Studio-E PR #10271 is a separate DTS duplicate-emission fix.
- Ready for manager review/queue after remote body and label verification.
- Follow-up `91286d6938` adds the Reviewer-requested unmatched-call regression proving wider implementation parameters do not rescue failed JSDoc overload calls.