### PR TITLE
fix(solver): treat optional source params as undefined unions

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -400,6 +400,9 @@ mod constraint_tests;
 #[path = "../tests/function_comprehensive_tests.rs"]
 mod function_comprehensive_tests;
 #[cfg(test)]
+#[path = "../tests/function_optional_param_relation_tests.rs"]
+mod function_optional_param_relation_tests;
+#[cfg(test)]
 #[path = "../tests/index_access_comprehensive_tests.rs"]
 mod index_access_comprehensive_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -644,10 +644,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Compute effective parameter types for a pair of parameters being compared
     /// in signature compatibility.
     ///
-    /// TypeScript compares declared optional parameter types during signature
-    /// compatibility rather than eagerly widening them to `T | undefined`.
-    /// That keeps `(x: string) => void` assignable to `(x?: string) => void`
-    /// and vice versa, matching the solver unit tests and tsc's behavior for
+    /// TypeScript treats a source optional parameter as accepting explicit
+    /// `undefined` when it is compared against a required target parameter.
+    /// This keeps `(x?: T) => void` assignable to `(x: T | undefined) => void`
+    /// under strict function contravariance.
+    ///
+    /// A target optional parameter still compares by its declared type rather
+    /// than eagerly widening to `T | undefined`. That keeps `(x: string) =>
+    /// void` assignable to `(x?: string) => void`, matching tsc's behavior for
     /// regular function signature relation checks.
     ///
     /// When both parameters are optional, strip `undefined` from their types
@@ -655,22 +659,35 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// matches tsc's behavior where both forms are interchangeable in
     /// signature comparison.
     ///
-    /// When only one parameter is optional (or neither), returns the raw types
-    /// without stripping, preserving the stricter comparison needed to catch
-    /// legitimate undefined-related mismatches.
+    /// When only the source parameter is optional, add `undefined` to the source
+    /// type. Other one-sided optional comparisons keep their declared types,
+    /// preserving the stricter comparison needed to catch legitimate
+    /// undefined-related mismatches.
     pub(crate) fn effective_param_type_pair(
         &self,
         s_param: &ParamInfo,
         t_param: &ParamInfo,
     ) -> (TypeId, TypeId) {
-        if s_param.optional && t_param.optional {
-            (
+        match (s_param.optional, t_param.optional) {
+            (true, true) => (
                 self.strip_undefined_from_param_type(s_param.type_id),
                 self.strip_undefined_from_param_type(t_param.type_id),
-            )
-        } else {
-            (s_param.type_id, t_param.type_id)
+            ),
+            (true, false) => (
+                self.add_undefined_to_param_type(s_param.type_id),
+                t_param.type_id,
+            ),
+            _ => (s_param.type_id, t_param.type_id),
         }
+    }
+
+    /// Add `undefined` to an optional source parameter type for signature
+    /// compatibility. `union2` canonicalizes duplicate `undefined` members.
+    fn add_undefined_to_param_type(&self, type_id: TypeId) -> TypeId {
+        if type_id == TypeId::UNDEFINED {
+            return type_id;
+        }
+        self.interner.union2(type_id, TypeId::UNDEFINED)
     }
 
     /// Strip `undefined` from a type for optional parameter normalization.

--- a/crates/tsz-solver/tests/function_optional_param_relation_tests.rs
+++ b/crates/tsz-solver/tests/function_optional_param_relation_tests.rs
@@ -1,0 +1,113 @@
+//! Regression tests for optional parameter relation compatibility.
+
+use super::*;
+use crate::intern::TypeInterner;
+use crate::relations::compat::CompatChecker;
+
+fn function_with_param(
+    interner: &TypeInterner,
+    name: &str,
+    type_id: TypeId,
+    optional: bool,
+) -> TypeId {
+    interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string(name)),
+            type_id,
+            optional,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
+fn object_with_function_property(
+    interner: &TypeInterner,
+    prop_name: &str,
+    param_type: TypeId,
+    param_optional: bool,
+) -> TypeId {
+    let function = function_with_param(interner, "value", param_type, param_optional);
+    interner.object(vec![PropertyInfo::new(
+        interner.intern_string(prop_name),
+        function,
+    )])
+}
+
+fn strict_checker(interner: &TypeInterner) -> CompatChecker<'_> {
+    let mut checker = CompatChecker::new(interner);
+    checker.set_strict_function_types(true);
+    checker.set_strict_null_checks(true);
+    checker
+}
+
+#[test]
+fn optional_source_param_matches_target_param_unioned_with_undefined() {
+    let interner = TypeInterner::new();
+    let mut checker = strict_checker(&interner);
+    let number_or_undefined = interner.union2(TypeId::NUMBER, TypeId::UNDEFINED);
+
+    let source = function_with_param(&interner, "x", TypeId::NUMBER, true);
+    let target = function_with_param(&interner, "x", number_or_undefined, false);
+
+    assert!(
+        checker.is_assignable(source, target),
+        "tsc accepts assigning `(x?: number) => void` to `(x: number | undefined) => void`",
+    );
+}
+
+#[test]
+fn renamed_optional_source_param_matches_target_param_unioned_with_undefined() {
+    let interner = TypeInterner::new();
+    let mut checker = strict_checker(&interner);
+    let string_or_undefined = interner.union2(TypeId::STRING, TypeId::UNDEFINED);
+
+    let source = function_with_param(&interner, "source", TypeId::STRING, true);
+    let target = function_with_param(&interner, "target", string_or_undefined, false);
+
+    assert!(checker.is_assignable(source, target));
+}
+
+#[test]
+fn target_optional_param_still_accepts_explicit_undefined_union_source() {
+    let interner = TypeInterner::new();
+    let mut checker = strict_checker(&interner);
+    let number_or_undefined = interner.union2(TypeId::NUMBER, TypeId::UNDEFINED);
+
+    let source = function_with_param(&interner, "x", number_or_undefined, false);
+    let target = function_with_param(&interner, "x", TypeId::NUMBER, true);
+
+    assert!(checker.is_assignable(source, target));
+}
+
+#[test]
+fn required_source_param_does_not_match_target_param_unioned_with_undefined() {
+    let interner = TypeInterner::new();
+    let mut checker = strict_checker(&interner);
+    let number_or_undefined = interner.union2(TypeId::NUMBER, TypeId::UNDEFINED);
+
+    let source = function_with_param(&interner, "x", TypeId::NUMBER, false);
+    let target = function_with_param(&interner, "x", number_or_undefined, false);
+
+    assert!(
+        !checker.is_assignable(source, target),
+        "strict contravariance still rejects `(x: number) => void` for `(x: number | undefined) => void`",
+    );
+}
+
+#[test]
+fn object_member_optional_source_param_matches_required_undefined_union_target() {
+    let interner = TypeInterner::new();
+    let mut checker = strict_checker(&interner);
+    let number_or_undefined = interner.union2(TypeId::NUMBER, TypeId::UNDEFINED);
+
+    let source = object_with_function_property(&interner, "f", TypeId::NUMBER, true);
+    let target = object_with_function_property(&interner, "f", number_or_undefined, false);
+
+    assert!(checker.is_assignable(source, target));
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic substrate / solver relation variance fix for #9657.

## Invariant
When a source function parameter is optional (`x?: T`) and the target parameter is required but explicitly accepts `undefined` (`x: T | undefined`), `tsc` accepts the assignment; this PR makes tsz model that through the solver function-signature relation path.

## Owner Layer
Solver relation policy. The behavior is a function-signature assignability rule in `SubtypeChecker::effective_param_type_pair`; checker diagnostics should continue to consume the shared relation answer rather than adding a TS2322-site exception.

## Adjacent-Case Matrix
- Reported repro: `(x?: number) => void` assigned to `(x: number | undefined) => void` is accepted.
- Renamed/different primitive: `(source?: string) => void` assigned to `(target: string | undefined) => void` is accepted.
- Reverse compatible case: `(x: number | undefined) => void` assigned to `(x?: number) => void` remains accepted.
- Object-member form: `{ f: (value?: number) => void }` assigned to `{ f: (value: number | undefined) => void }` is accepted through the same relation path.
- Negative control: `(x: number) => void` assigned to `(x: number | undefined) => void` still emits `TS2322` under strict function types.

## Scope
- `crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`
- `crates/tsz-solver/tests/function_optional_param_relation_tests.rs`
- `crates/tsz-solver/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: function parameter variance / optional parameter relation false positive
- Evidence: focused solver tests and CLI smoke for #9657; no benchmark project row was targeted.

## Unsupported Shapes / Fallback
No special spelling, identifier, or file-path fast path was added. The change only affects the structural source-optional/target-required parameter pair; target-optional and both-optional parameter comparisons keep their existing solver normalization, and all other relation shapes fall back to the existing parameter compatibility path.

## Verification
- Red first: `cargo nextest run -p tsz-solver -E 'test(/^function_optional_param_relation_tests::/)'` failed on the optional-source repros before the solver change.
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver -E 'test(/^function_optional_param_relation_tests::/)'`
- `cargo nextest run -p tsz-solver -E 'test(/^integration_tests::function_variance_tests::/)'`
- `cargo run -q -p tsz-cli --bin tsz -- --noEmit --strict --pretty false /tmp/tsz-9657-clean-<pid>.ts`
- Negative control assertion: `cargo run -q -p tsz-cli --bin tsz -- --noEmit --strict --pretty false /tmp/tsz-9657-negative-<pid>.ts` still emits `TS2322` for `(x: number) => void` assigned to `(x: number | undefined) => void`.
- `git diff --check`
- Draft CI rerun on head `e0f080403174ae6496d312fde933394ffa46d79b`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `project-row-drift`, `queue-one-pr`, `gate`, and GitGuardian all passed.

## Coordination Notes
- AgentName: M4-B
- Fixes #9657.
- #10269, #10277, and #10290 remain separate M4-B PRs; this branch does not overlap their relation-cache, readonly-conditional-array, or checker-boundary cleanup coverage.
- The original draft blocker was the temporary external GitHub Actions checkout/action-download outage. Draft CI is now clean for the current head, so this PR is ready for review/heavy CI. Auto-merge remains off for the manager/queue owner.