### PR TITLE
fix(solver): preserve inline mapped array returns

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -738,6 +738,10 @@ name = "generic_call_inference_tests"
 path = "tests/generic_call_inference_tests.rs"
 
 [[test]]
+name = "inline_mapped_array_return_tests"
+path = "tests/inline_mapped_array_return_tests.rs"
+
+[[test]]
 name = "overload_inference_literal_preservation_tests"
 path = "tests/overload_inference_literal_preservation_tests.rs"
 

--- a/crates/tsz-checker/tests/inline_mapped_array_return_tests.rs
+++ b/crates/tsz-checker/tests/inline_mapped_array_return_tests.rs
@@ -72,3 +72,55 @@ const bad: number = mapped;
         "inline mapped array return must not enumerate array prototype keys, got {diagnostics:#?}"
     );
 }
+
+#[test]
+fn inline_homomorphic_mapped_return_preserves_readonly_tuple_shape() {
+    let diagnostics = relevant_strict_default_lib_diagnostics(
+        r#"
+declare function mapAll<Items extends readonly any[]>(items: Items): { [Pos in keyof Items]: boolean };
+declare const input: readonly [number, string];
+const mapped = mapAll(input);
+const bad: number = mapped;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got {diagnostics:#?}"));
+
+    assert!(
+        ts2322.1.contains("readonly [boolean, boolean]"),
+        "inline mapped readonly tuple return should display as a readonly tuple, got {diagnostics:#?}"
+    );
+    assert!(
+        !ts2322.1.contains("concat") && !ts2322.1.contains("filter"),
+        "inline mapped readonly tuple return must not enumerate array prototype keys, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn inline_homomorphic_mapped_return_preserves_readonly_array_shape() {
+    let diagnostics = relevant_strict_default_lib_diagnostics(
+        r#"
+declare function mapAll<Items extends readonly any[]>(items: Items): { [Pos in keyof Items]: string };
+declare const input: readonly number[];
+const mapped = mapAll(input);
+const bad: number = mapped;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got {diagnostics:#?}"));
+
+    assert!(
+        ts2322.1.contains("readonly string[]"),
+        "inline mapped readonly array return should display as a readonly array, got {diagnostics:#?}"
+    );
+    assert!(
+        !ts2322.1.contains("concat") && !ts2322.1.contains("filter"),
+        "inline mapped readonly array return must not enumerate array prototype keys, got {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/inline_mapped_array_return_tests.rs
+++ b/crates/tsz-checker/tests/inline_mapped_array_return_tests.rs
@@ -1,0 +1,74 @@
+//! Regression tests for inline homomorphic mapped return types over arrays.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+fn relevant_strict_default_lib_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let lib_files = load_default_lib_files();
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_implicit_any: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+    .into_iter()
+    .filter(|(code, _)| *code != 2318)
+    .collect()
+}
+
+#[test]
+fn inline_homomorphic_mapped_return_preserves_tuple_shape() {
+    let diagnostics = relevant_strict_default_lib_diagnostics(
+        r#"
+declare function mapAll<Items extends readonly any[]>(items: Items): { [Pos in keyof Items]: boolean };
+declare const input: [number, string];
+const mapped = mapAll(input);
+const bad: number = mapped;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got {diagnostics:#?}"));
+
+    assert!(
+        ts2322.1.contains("[boolean, boolean]"),
+        "inline mapped tuple return should display as a tuple, got {diagnostics:#?}"
+    );
+    assert!(
+        !ts2322.1.contains("concat") && !ts2322.1.contains("filter"),
+        "inline mapped tuple return must not enumerate array prototype keys, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn inline_homomorphic_mapped_return_preserves_array_shape() {
+    let diagnostics = relevant_strict_default_lib_diagnostics(
+        r#"
+declare function mapAll<Items extends readonly any[]>(items: Items): { [Pos in keyof Items]: string };
+declare const input: number[];
+const mapped = mapAll(input);
+const bad: number = mapped;
+"#,
+    );
+
+    let ts2322 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got {diagnostics:#?}"));
+
+    assert!(
+        ts2322.1.contains("string[]"),
+        "inline mapped array return should display as an array, got {diagnostics:#?}"
+    );
+    assert!(
+        !ts2322.1.contains("concat") && !ts2322.1.contains("filter"),
+        "inline mapped array return must not enumerate array prototype keys, got {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1445,15 +1445,12 @@ impl<'a> TypeInstantiator<'a> {
                         self.interner.lookup(mapped.constraint)
                     && let Some(TypeData::TypeParameter(tp_info)) =
                         self.interner.lookup(keyof_source)
-                    && Self::mapped_template_uses_source_index(
-                        self.interner,
-                        mapped.template,
-                        keyof_source,
-                        mapped.type_param.name,
-                    )
                     && !self.is_shadowed(tp_info.name)
                     && let Some(substituted) = self.substitution.get(tp_info.name)
                 {
+                    let template_uses_source_index = Self::mapped_template_uses_source_index(
+                        self.interner, mapped.template, keyof_source, mapped.type_param.name,
+                    );
                     let resolved =
                         crate::evaluation::evaluate::evaluate_type(self.interner, substituted);
 
@@ -1631,7 +1628,7 @@ impl<'a> TypeInstantiator<'a> {
                     // unions or other compound types (not just at the top level of a type
                     // alias body). Without this, `{ [K in keyof null]: null[K] }` inside
                     // a union evaluates to `{}` instead of `null`.
-                    if Self::is_primitive_or_primitive_union(self.interner, resolved) {
+                    if template_uses_source_index && Self::is_primitive_or_primitive_union(self.interner, resolved) {
                         self.exit_shadowing_scope(shadowed_len, saved_visiting);
                         return resolved;
                     }


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: mapped/homomorphic array and tuple evaluation (#9715)

## Invariant
When an inline homomorphic mapped return type `{ [K in keyof T]: U }` is instantiated with an array or tuple `T`, tsz must preserve the array or tuple shape instead of expanding array prototype keys into an object. Readonly array and tuple sources must preserve their readonly array/tuple surface as well.

## Scope
- `crates/tsz-solver/src/instantiation/instantiate.rs`: allow the homomorphic array/tuple instantiation path for constant mapped templates as well as `T[K]` templates.
- `crates/tsz-checker/tests/inline_mapped_array_return_tests.rs`: regression coverage for tuple, array, readonly tuple, and readonly array call returns.
- `crates/tsz-checker/Cargo.toml`: register the focused checker test target.

## Owner Layer
Solver instantiation owns the homomorphic mapped array/tuple preservation rule. Checker coverage only exercises call-return behavior at the user-facing diagnostic/display surface.

## Adjacent Case Matrix
- Tuple source: inline mapped return preserves fixed tuple shape.
- Plain array source: inline mapped return preserves array surface instead of expanding prototype keys.
- Readonly tuple source: readonly tuple shape is preserved.
- Readonly array source: readonly array surface is preserved.
- Control shape: generic identity return and existing mapped instantiation coverage continue to pass.

## Known Fallback Behavior
The existing non-homomorphic mapped expansion remains the fallback for mapped types that are not over `keyof T` array/tuple sources. This PR does not widen checker acceptance or special-case a specific alias name.

## Project Corpus Impact
- Row: n/a
- Bug family: homomorphic mapped return instantiation over array/tuple sources
- Evidence: issue #9715 minimized repro; local checker regressions verify tuple, array, readonly tuple, and readonly array displays no longer enumerate array prototype members.

## Verification
- `cargo nextest run -p tsz-checker --test inline_mapped_array_return_tests inline_homomorphic_mapped_return_preserves_tuple_shape` failed before the fix with a giant object including `concat`/`filter`.
- `cargo nextest run -p tsz-checker --test inline_mapped_array_return_tests inline_homomorphic_mapped_return_preserves_readonly` (2 tests passed; coverage-only review follow-up on fixed branch)
- `cargo nextest run -p tsz-checker --test inline_mapped_array_return_tests` (4 tests passed)
- `cargo nextest run -p tsz-solver test_instantiate_mapped_over_tuple_preserves_tuple test_instantiate_homomorphic_mapped_any_array_constraint_constant_template identity_mapped_fixed_tuple_and_plain_array_controls_roundtrip`
- `cargo nextest run -p tsz-solver mapped_comprehensive_tests`
- `cargo nextest run -p tsz-solver instantiation::instantiate::tests`
- `cargo fmt --check`
- `git diff --check`
- File-size check: `instantiate.rs` 1997 lines, checker test 126 lines, checker `Cargo.toml` 1685 lines.

## Coordination Notes
- Fixes #9715.
- Review follow-up from https://github.com/mohsen1/tsz/pull/10283#issuecomment-4544094671 added readonly tuple and readonly array checker coverage in `feffd7027b` without production edits.
- No overlap found with active M4-A PRs #10268, #10274, #10292, or #10299; those cover remapped key collisions, template remap indexing, conditional infer returns, and template index-signature `keyof`.
- Light CI is green on head `feffd7027b43bb723f7edc4d6842f1045af7984d`; auto-merge remains off.
