### PR TITLE
test(checker): cover imported JSDoc typedef assignment

### DIFF
--- a/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
@@ -217,6 +217,36 @@ const u = { id: 1, extra: true };
 }
 
 #[test]
+fn jsdoc_import_type_object_typedef_checks_non_literal_initializer_source() {
+    let diagnostics = check_js_file_with_types_diagnostics(
+        "types.js",
+        r#"
+/** @typedef {{ id: number }} User */
+module.exports = {};
+"#,
+        "consumer.js",
+        r#"
+const candidate = /** @type {{ id: string }} */ ({ id: "wrong" });
+
+/** @type {import('./types.js').User} */
+const u = candidate;
+"#,
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts2322: Vec<&Diagnostic> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected imported object typedef @type to check non-literal initializer source, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn non_import_jsdoc_object_union_preserves_contextual_literal_initializer() {
     let diagnostics = check_js_file_with_types_diagnostics(
         "types.js",


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Track 4 / checker regression coverage for checked-JS JSDoc typedef assignment.

## Invariant
When a checked-JS variable has a JSDoc `@type {import(...).ObjectTypedef}` annotation, `tsc` checks the initializer through the normal assignment and excess-property path; this PR adds the missing non-literal-source regression guard for that checker surface.

## Scope
- Add a focused cross-file JSDoc typedef test for assignment from a typed intermediate value.
- No checker, solver, binder, emitter, LSP, WASM, or roadmap code changes.

## Project Corpus Impact
- Row: n/a
- Bug family: checked-JS JSDoc imported object typedef initializer assignability
- Evidence: test-only regression coverage; no project-corpus fixture behavior changed.

## Verification
- `cargo nextest run -p tsz-checker --test jsdoc_cross_file_typedef_tests -E 'test(jsdoc_import_type_object_typedef_checks_non_literal_initializer_source)'`
- `cargo nextest run -p tsz-checker --test jsdoc_cross_file_typedef_tests -E 'test(jsdoc_import_type_object_typedef_checks)'`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-E
- Issue #9760's direct wrong-member, missing-property, and excess-property imported-object typedef cases already pass on current `origin/main`; this PR covers the remaining non-literal-source matrix item from that issue.
- Overlap checked against open PRs and agent-label audit on 2026-05-26; no active PR claims #9760.
- Closes #9760 once merged.
