### PR TITLE
refactor(checker): route inferred predicates through flow boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -5,7 +5,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::node::{CallExprData, NodeArena};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::narrowing::{GuardSense, TypeGuard, TypeofKind};
+use tsz_solver::narrowing::{TypeGuard, TypeofKind};
 use tsz_solver::{ParamInfo, SymbolRef, TypeId, TypePredicate, TypePredicateTarget};
 
 use crate::state::MAX_TREE_WALK_ITERATIONS;
@@ -1740,14 +1740,13 @@ impl<'a> FlowAnalyzer<'a> {
         param_type: TypeId,
         guard: &TypeGuard,
     ) -> TypeId {
-        if let Some(env) = &self.type_environment {
-            let env_borrow = env.borrow();
-            let narrowing = self.make_narrowing_context().with_resolver(&*env_borrow);
-            narrowing.narrow_type(param_type, guard, GuardSense::Positive)
-        } else {
-            self.make_narrowing_context()
-                .narrow_type(param_type, guard, GuardSense::Positive)
-        }
+        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
+        flow_query::narrow_inferred_predicate_guard(
+            self.interner,
+            env_borrow.as_deref(),
+            param_type,
+            guard,
+        )
     }
 
     /// Check if a node is a simple reference (identifier or property access).

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -1388,7 +1388,7 @@ impl<'a> FlowAnalyzer<'a> {
             false,
             tsz_binder::FlowNodeId::NONE,
         );
-        if !self.is_nullish_only_type(falsy) {
+        if !flow_query::is_nullish_only_type(self.interner, falsy) {
             return None;
         }
 
@@ -1425,19 +1425,6 @@ impl<'a> FlowAnalyzer<'a> {
         } else {
             None
         }
-    }
-
-    fn is_nullish_only_type(&self, type_id: TypeId) -> bool {
-        if matches!(type_id, TypeId::NEVER | TypeId::NULL | TypeId::UNDEFINED) {
-            return true;
-        }
-        if let Some(members) = flow_query::union_members_for_type(self.interner, type_id) {
-            return !members.is_empty()
-                && members
-                    .iter()
-                    .all(|member| matches!(*member, TypeId::NULL | TypeId::UNDEFINED));
-        }
-        false
     }
 
     fn try_infer_logical_or_type_predicate(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -139,6 +139,9 @@ mod enum_recursion_tests;
 #[path = "../tests/environment_capabilities_tests.rs"]
 mod environment_capabilities_tests;
 #[cfg(test)]
+#[path = "tests/flow_inferred_predicate_boundary_tests.rs"]
+mod flow_inferred_predicate_boundary_tests;
+#[cfg(test)]
 #[path = "tests/function_type_return_node_tests.rs"]
 mod function_type_return_node_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -216,6 +216,25 @@ pub(crate) fn narrow_inferred_predicate_guard(
     narrowing.narrow_type(param_type, guard, GuardSense::Positive)
 }
 
+/// Return true when a falsy branch type contains only nullish constituents.
+///
+/// The checker owns recognizing double-negation truthiness in an inferable
+/// predicate body. This boundary owns the reusable type-shape classification
+/// that decides whether the false branch is narrow enough for tsc-style
+/// inferred predicate synthesis.
+pub(crate) fn is_nullish_only_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if matches!(type_id, TypeId::NEVER | TypeId::NULL | TypeId::UNDEFINED) {
+        return true;
+    }
+    if let Some(members) = union_members_for_type(db, type_id) {
+        return !members.is_empty()
+            && members
+                .iter()
+                .all(|member| matches!(*member, TypeId::NULL | TypeId::UNDEFINED));
+    }
+    false
+}
+
 fn resolve_assignment_reduction_type(
     db: &dyn TypeDatabase,
     env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1,5 +1,6 @@
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+use tsz_solver::narrowing::{GuardSense, TypeGuard};
 
 pub(crate) use super::common::{
     LiteralValueKind, PredicateSignatureKind, TypeResolver,
@@ -194,6 +195,25 @@ pub(crate) fn cases_exhaust_type(
         narrowing = narrowing.with_resolver(environment);
     }
     narrowing.narrow_excluding_types(switch_type, case_types) == TypeId::NEVER
+}
+
+/// Apply an inferred predicate guard to a parameter type.
+///
+/// The checker owns recognizing an inferable predicate body and matching the
+/// guard target to a parameter. This boundary owns the reusable semantic guard
+/// application and wires the optional `TypeEnvironment` so `Lazy(DefId)` inputs
+/// resolve consistently during solver narrowing.
+pub(crate) fn narrow_inferred_predicate_guard(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    param_type: TypeId,
+    guard: &TypeGuard,
+) -> TypeId {
+    let mut narrowing = tsz_solver::narrowing::NarrowingContext::new(db);
+    if let Some(environment) = env {
+        narrowing = narrowing.with_resolver(environment);
+    }
+    narrowing.narrow_type(param_type, guard, GuardSense::Positive)
 }
 
 fn resolve_assignment_reduction_type(

--- a/crates/tsz-checker/src/tests/flow_inferred_predicate_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_inferred_predicate_boundary_tests.rs
@@ -1,7 +1,10 @@
 //! Focused coverage for inferred predicate guard narrowing through flow
 //! query-boundary helpers.
 
-use crate::test_utils::check_source_strict_codes as check_strict;
+use crate::context::CheckerOptions;
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::{check_multi_file, check_source_strict_codes as check_strict};
+use tsz_common::common::ModuleKind;
 
 #[test]
 fn inferred_predicate_narrows_both_call_branches() {
@@ -44,5 +47,52 @@ function use(value: string | number) {
     assert!(
         codes.contains(&2322),
         "expected explicit boolean annotation to keep value wide, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn imported_alias_inferred_predicate_narrows_true_branch() {
+    let diagnostics = check_multi_file(
+        &[
+            (
+                "./types.ts",
+                r#"
+export type TextOrCount = string | number;
+"#,
+            ),
+            (
+                "./main.ts",
+                r#"
+import type { TextOrCount } from "./types";
+
+const isText = (candidate: TextOrCount) => typeof candidate === "string";
+
+function use(value: TextOrCount) {
+    if (isText(value)) {
+        const text: string = value;
+        text.toUpperCase();
+    } else {
+        value;
+    }
+}
+"#,
+            ),
+        ],
+        "./main.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let codes = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect::<Vec<_>>();
+
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+            && !codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "expected imported alias predicate to narrow the true branch, got diagnostics: {diagnostics:?}"
     );
 }

--- a/crates/tsz-checker/src/tests/flow_inferred_predicate_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_inferred_predicate_boundary_tests.rs
@@ -1,0 +1,48 @@
+//! Focused coverage for inferred predicate guard narrowing through flow
+//! query-boundary helpers.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+#[test]
+fn inferred_predicate_narrows_both_call_branches() {
+    let codes = check_strict(
+        r#"
+const isText = (candidate: string | number) => typeof candidate === "string";
+
+function use(value: string | number) {
+    if (isText(value)) {
+        const text: string = value;
+        text.toUpperCase();
+    } else {
+        const count: number = value;
+        count.toFixed();
+    }
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2339),
+        "expected inferred predicate to narrow both branches, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn explicit_boolean_annotation_does_not_infer_predicate() {
+    let codes = check_strict(
+        r#"
+const isText = (candidate: string | number): boolean => typeof candidate === "string";
+
+function use(value: string | number) {
+    if (isText(value)) {
+        const text: string = value;
+    }
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&2322),
+        "expected explicit boolean annotation to keep value wide, got codes: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Track 1 semantic-flow architecture cleanup / refactor with focused coverage.

## Invariant
When checker flow has recognized an inferred type-predicate body and matched its guard target to a parameter, checker supplies the syntactic guard and optional `TypeEnvironment`; this PR routes semantic guard application and inferred-truthiness false-branch classification through `query_boundaries::flow_analysis` so solver-owned narrowing and boundary helpers compute the resulting parameter `TypeId` and classifier facts.

## Scope
- `crates/tsz-checker/src/flow/control_flow/type_guards.rs`
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`
- `crates/tsz-checker/src/tests/flow_inferred_predicate_boundary_tests.rs`
- `crates/tsz-checker/src/lib.rs`
- No solver behavior changes.
- No roadmap update: this is a routine boundary ratchet.

## Project Corpus Impact
- Row: n/a
- Bug family: flow graph / inferred predicate narrowing boundary cleanup
- Evidence: refactor-only; focused checker tests cover same-file inferred predicate branch narrowing, imported-alias true-branch narrowing through project environment wiring, explicit-boolean negative behavior, and double-negation truthiness positive/negative cases.

ReviewHelper note: normalized Project Corpus Impact fields to the dashed shape expected by the ready-PR body gate.

## Verification
Latest head `a1e71ad20d69d983f56fff2aeaf7ab6fd956861e`:
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --lib flow_inferred_predicate_boundary_tests`
- `cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings`

Earlier head `816a19057886293938064cc52afde2970f3ba0e5` before the test-only follow-up:
- `cargo nextest run -p tsz-checker --lib inferred_type_predicate_handles_safe_double_negation_truthiness inferred_type_predicate_rejects_number_double_negation_truthiness`
- `scripts/arch/check-checker-boundaries.sh`

No full conformance, emit, or fourslash suites were run locally.

## Coordination Notes
- Start-cycle commands completed for M1-D, including owned work and issue search.
- Existing M1-D PR #10272 is ready but blocked by external GitHub checkout/account access.
- Existing M1-D PR #10281 covers call predicate/`instanceof` guard application; this PR covers the separate inferred-predicate synthesis path from a fresh `origin/main` branch.
- Open PR/issue overlap checked before publishing; no other active inferred-predicate flow-boundary PR found.
- Reviewer-requested imported/lazy/project-environment coverage added in `imported_alias_inferred_predicate_narrows_true_branch`.
- While probing broader branch behavior, I found imported inferred predicates still do not narrow the false branch; filed follow-up #10295 instead of expanding this refactor PR.
- A first local clippy attempt hit `No space left on device` while writing `.target` incremental artifacts. I ran the cache-preserving cleanup ladder (`scripts/setup/disk-worktree-guard.sh --auto-prune`, then `scripts/setup/clean.sh --quiet`); after macOS reclaimed space, clippy passed.
