### PR TITLE
fix(checker): preserve imported symbol computed keys

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -121,13 +121,14 @@ impl<'a> CheckerState<'a> {
             .map(|name| self.ctx.types.literal_string(name))
             .unwrap_or(index_type);
 
-        // When the index is a `symbol`-typed identifier, convert to a
-        // `UniqueSymbol(SymbolRef)` so the solver can match binding-identity
-        // properties stored as `__unique_<sym_id>`.  This mirrors how TypeScript
-        // resolves `ws[sym]` when `sym: symbol` was used as a computed property
-        // name in the object's type declaration.
+        // When the index is a `symbol`-typed identifier, convert it to the same
+        // binding-identity key used by computed property lowering. Cross-file
+        // const-symbol bindings use the stable `__symbol_<file>_<sym>` atom;
+        // local non-unique symbol declarations fall back to `__unique_<sym>`.
         let index_type_for_access = if index_type == TypeId::SYMBOL {
-            self.nonunique_symbol_index_type(access.name_or_argument)
+            self.symbol_valued_binding_property_name(access.name_or_argument, index_type)
+                .map(|name| self.ctx.types.literal_string(&name))
+                .or_else(|| self.nonunique_symbol_index_type(access.name_or_argument))
                 .unwrap_or(index_type_for_access)
         } else {
             index_type_for_access

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -316,10 +316,7 @@ impl<'a> CheckerState<'a> {
             } else if member_node.kind == PROPERTY_SIGNATURE {
                 // Extract property signature
                 if let Some(sig) = self.ctx.arena.get_signature(member_node) {
-                    let name_atom = self.get_member_name_atom(sig.name).or_else(|| {
-                        self.get_property_name_resolved(sig.name)
-                            .map(|name| self.ctx.types.intern_string(&name))
-                    });
+                    let name_atom = self.get_member_name_atom(sig.name);
                     if let Some(name_atom) = name_atom {
                         let is_symbol_named = self.is_symbol_property_name(sig.name);
                         let (is_string_named, single_quoted_name) =
@@ -368,10 +365,7 @@ impl<'a> CheckerState<'a> {
                 // collected and later combined into a single Callable type so
                 // that overload resolution works correctly (e.g., Object.freeze).
                 if let Some(sig) = self.ctx.arena.get_signature(member_node) {
-                    let name_atom = self.get_member_name_atom(sig.name).or_else(|| {
-                        self.get_property_name_resolved(sig.name)
-                            .map(|name| self.ctx.types.intern_string(&name))
-                    });
+                    let name_atom = self.get_member_name_atom(sig.name);
                     if let Some(name_atom) = name_atom {
                         let is_symbol_named = self.is_symbol_property_name(sig.name);
                         let (is_string_named, single_quoted_name) =
@@ -444,10 +438,7 @@ impl<'a> CheckerState<'a> {
                 || member_node.kind == syntax_kind_ext::SET_ACCESSOR
             {
                 if let Some(accessor) = self.ctx.arena.get_accessor(member_node) {
-                    let name_atom = self.get_member_name_atom(accessor.name).or_else(|| {
-                        self.get_property_name_resolved(accessor.name)
-                            .map(|name| self.ctx.types.intern_string(&name))
-                    });
+                    let name_atom = self.get_member_name_atom(accessor.name);
                     if let Some(name_atom) = name_atom {
                         let is_symbol_named = self.is_symbol_property_name(accessor.name);
                         let (is_string_named, single_quoted_name) =
@@ -1520,13 +1511,10 @@ impl<'a> CheckerState<'a> {
         merged
     }
 
-    /// Get the interned Atom for a member name node, handling identifiers,
-    /// string literals, and numeric literals (with canonical normalization).
-    fn get_member_name_atom(&self, name_idx: NodeIndex) -> Option<Atom> {
-        let name = crate::types_domain::queries::core::get_literal_property_name(
-            self.ctx.arena,
-            name_idx,
-        )?;
+    /// Get the interned Atom for a member name node, resolving computed symbol
+    /// names before falling back to syntactic literal names.
+    fn get_member_name_atom(&mut self, name_idx: NodeIndex) -> Option<Atom> {
+        let name = self.get_property_name_resolved(name_idx)?;
         Some(self.ctx.types.intern_string(&name))
     }
 }

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -139,11 +139,15 @@ impl<'a> CheckerState<'a> {
             .ctx
             .resolve_import_alias_and_register(local_sym_id)
             .unwrap_or(local_sym_id);
-        let symbol = self.get_cross_file_symbol(sym_id)?;
-        let file_idx = self
+        let file_idx = self.ctx.resolve_symbol_file_index(sym_id).or_else(|| {
+            self.get_cross_file_symbol(sym_id)
+                .map(|symbol| symbol.decl_file_idx as usize)
+        })?;
+        let symbol = self
             .ctx
-            .resolve_symbol_file_index(sym_id)
-            .unwrap_or(symbol.decl_file_idx as usize);
+            .get_binder_for_file(file_idx)
+            .and_then(|binder| binder.get_symbol(sym_id))
+            .or_else(|| self.get_cross_file_symbol(sym_id))?;
         let value_decl = symbol.value_declaration;
         let decl_arena = self.ctx.get_arena_for_file(file_idx as u32);
         if value_decl.is_none() || !decl_arena.is_const_variable_declaration(value_decl) {

--- a/crates/tsz-checker/src/types/type_node_property_names.rs
+++ b/crates/tsz-checker/src/types/type_node_property_names.rs
@@ -95,7 +95,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
 
         self.resolve_computed_property_symbol(computed.expression)
-            .is_some_and(|sym_id| self.symbol_refers_to_unique_symbol(sym_id))
+            .is_some_and(|sym_id| {
+                self.symbol_refers_to_unique_symbol(sym_id)
+                    || self.symbol_has_nonunique_symbol_annotation(sym_id)
+            })
     }
 
     pub(super) fn computed_property_expression_name_atom(
@@ -107,7 +110,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
 
         let sym_id = self.resolve_computed_property_symbol(expr_idx)?;
-        self.symbol_refers_to_unique_symbol(sym_id).then(|| {
+        (self.symbol_refers_to_unique_symbol(sym_id)
+            || self.symbol_has_nonunique_symbol_annotation(sym_id))
+        .then(|| {
             self.ctx
                 .types
                 .intern_string(&format!("__unique_{}", sym_id.0))
@@ -118,7 +123,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         self.get_well_known_symbol_property_name(expr_idx).is_some()
             || self
                 .resolve_computed_property_symbol(expr_idx)
-                .is_some_and(|sym_id| self.symbol_refers_to_unique_symbol(sym_id))
+                .is_some_and(|sym_id| {
+                    self.symbol_refers_to_unique_symbol(sym_id)
+                        || self.symbol_has_nonunique_symbol_annotation(sym_id)
+                })
     }
 
     fn get_well_known_symbol_property_name(&self, expr_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -234,10 +234,15 @@ const value: number = ws[importedSym];
         "./b.ts",
     );
 
-    assert!(
-        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
-        "imported same-binding symbol access should preserve declared member type, got {codes:?}",
-    );
+    for code in [
+        diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+        diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+    ] {
+        assert!(
+            !codes.contains(&code),
+            "imported same-binding symbol access should preserve declared member type, got {codes:?}",
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -246,6 +246,42 @@ const value: number = ws[importedSym];
 }
 
 #[test]
+fn imported_distinct_symbol_binding_does_not_match_computed_member() {
+    let codes = diagnostic_codes_for_project(
+        &[
+            (
+                "./a.ts",
+                r#"
+export declare const memberKey: symbol;
+export declare const otherKey: symbol;
+
+export interface WithSymbol {
+    [memberKey]: number;
+}
+"#,
+            ),
+            (
+                "./b.ts",
+                r#"
+import { otherKey, type WithSymbol } from "./a";
+
+declare const ws: WithSymbol;
+const value = ws[otherKey];
+"#,
+            ),
+        ],
+        "./b.ts",
+    );
+
+    assert!(
+        codes.contains(
+            &diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN
+        ),
+        "different exported symbol bindings must not resolve to the declared member type, got {codes:?}",
+    );
+}
+
+#[test]
 fn jsdoc_symbol_index_signature_reports_computed_property_value_mismatch() {
     let codes = diagnostic_codes_for_js(
         r#"


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
M4-D symbol/lib/module/DefId/cross-file stable identity; checker behavior fix for imported symbol-keyed member access.

## Invariant
When an imported alias points at the same exported `symbol` binding used as a computed member key, `tsc` resolves `obj[alias]` through that binding identity; when the imported `symbol` binding is distinct, tsz must not collapse it into the declared member key. This PR makes tsz use stable computed-key identity in checker element access and computed-name helpers.

## Owner Layer
Checker orchestration owns this slice because it converts syntax/binder facts into solver-visible element-access keys. The solver still performs property lookup over `TypeId`/object shapes; this PR aligns the checker-produced key with the existing lowered property key instead of adding a solver special case.

## Scope
- Preserve cross-file `__symbol_<file>_<sym>` computed-key identity when indexing with an imported `symbol` binding.
- Resolve symbol-valued binding property names through the registered owning file binder to avoid local import-alias raw-id collisions.
- Align interface/type-node computed symbol naming helpers so explicit `: symbol` computed members are treated consistently as symbol-named members.
- Tighten multi-file symbol regressions to reject both TS7053/TS2322 on same-binding false positives and to reject distinct exported symbol bindings that should not match.

## Adjacent Case Matrix
- Imported same binding: `import { sym as importedSym } from "./a"; ws[importedSym]` must find the declared `[sym]` member.
- Imported distinct binding: `otherKey` exported from the same module must not resolve to the `[memberKey]` member; tsz reports TS7053 instead of treating both exported symbols as one key.
- Local non-unique `symbol`: existing `non_unique_symbol_late_bound_member_tests` cover local interface/type-literal symbol bindings and renamed keys.
- Symbol-index fallback: `symbol_index_signature_tests` still cover wide symbol index signatures, plain-object TS7053, array/tuple TS7015, unique symbol keys, and well-known symbols.

## Fallback Behavior
If a `symbol` index expression cannot be proven to be a stable cross-file const-symbol binding, the existing local non-unique-symbol conversion remains the fallback. If neither identity path applies, tsz keeps the wide `symbol` access behavior and reports the usual missing-index diagnostics where appropriate.

## Project Corpus Impact
- Row: n/a
- Bug family: cross-file symbol-key identity / computed member access
- Evidence: targeted checker regression in `symbol_index_signature_tests` now covers imported same-binding symbol access without TS7053/TS2322 and distinct exported symbol bindings with TS7053.

## Verification
- `cargo nextest run -p tsz-checker --test symbol_index_signature_tests imported_distinct_symbol_binding_does_not_match_computed_member` (1 passed)
- `cargo nextest run -p tsz-checker --test symbol_index_signature_tests` (44/44 passed)
- `cargo nextest run -p tsz-checker --test non_unique_symbol_late_bound_member_tests` (10/10 passed)
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Branch: `codex/m4-d-symbol-index-lazy-target-20260526`
- Latest commit: `9408dbd20b test(checker): cover distinct imported symbol keys`
- Review response: added the adjacent negative coverage requested by Reviewer for distinct exported `symbol` bindings.
- A package-level lib-test filter for `no_false_positive_ts2416_const_symbol_computed_property_name` was attempted after disk cleanup, but stopped because Cargo expanded it into compiling the full checker test target set while sibling worktrees were already compiling large suites. The focused integration suites above cover this PRs changed access path directly.
- Auto-merge remains off for manager/queue-owner handling.