### PR TITLE
refactor(checker): route flow relation flags through boundary

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -688,6 +688,9 @@ mod recursive_generic_arrow_tests;
 #[path = "tests/recursive_path_default_type_param_tests.rs"]
 mod recursive_path_default_type_param_tests;
 #[cfg(test)]
+#[path = "tests/relation_flags_boundary_contract_tests.rs"]
+mod relation_flags_boundary_contract_tests;
+#[cfg(test)]
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -810,7 +810,7 @@ pub(crate) fn are_types_overlapping_with_env(
 ) -> bool {
     let mut flags: u16 = 0;
     if strict_null_checks {
-        flags |= tsz_solver::RelationCacheKey::FLAG_STRICT_NULL_CHECKS;
+        flags |= RelationFlags::STRICT_NULL_CHECKS;
     }
 
     let policy = tsz_solver::relations::relation_queries::RelationPolicy::from_flags(flags);

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1,6 +1,8 @@
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 
+use super::assignability::RelationFlags;
+
 pub(crate) use super::common::{
     LiteralValueKind, PredicateSignatureKind, TypeResolver,
     array_element_type as get_array_element_type, call_signatures_for_type,
@@ -435,7 +437,7 @@ pub(crate) fn is_assignable_strict_null(
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
         tsz_solver::relations::relation_queries::RelationPolicy::from_flags(
-            tsz_solver::RelationCacheKey::FLAG_STRICT_NULL_CHECKS,
+            RelationFlags::STRICT_NULL_CHECKS,
         ),
         tsz_solver::relations::relation_queries::RelationContext::default(),
     )
@@ -505,7 +507,7 @@ pub(crate) fn is_assignable_with_env(
 ) -> bool {
     let mut flags = 0u16;
     if strict_null_checks {
-        flags |= tsz_solver::RelationCacheKey::FLAG_STRICT_NULL_CHECKS;
+        flags |= RelationFlags::STRICT_NULL_CHECKS;
     }
 
     tsz_solver::relations::relation_queries::query_relation_with_resolver(
@@ -616,7 +618,7 @@ fn types_are_subtype_with_env(
 ) -> bool {
     let mut flags = 0u16;
     if strict_null_checks {
-        flags |= tsz_solver::RelationCacheKey::FLAG_STRICT_NULL_CHECKS;
+        flags |= RelationFlags::STRICT_NULL_CHECKS;
     }
 
     tsz_solver::relations::relation_queries::query_relation_with_resolver(

--- a/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+
+/// Flow analysis relation helpers must stay on the boundary-owned
+/// `RelationFlags` wrapper rather than reaching into solver internals.
+#[test]
+fn flow_analysis_uses_boundary_relation_flags_surface() {
+    let source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read query_boundaries/flow_analysis.rs");
+
+    assert!(
+        source.contains("use super::assignability::RelationFlags;"),
+        "flow_analysis relation helpers must import boundary-owned RelationFlags"
+    );
+
+    assert!(
+        source.contains("RelationFlags::STRICT_NULL_CHECKS"),
+        "flow_analysis relation helpers must use RelationFlags when encoding strict-null policy"
+    );
+
+    assert!(
+        !source.contains("RelationCacheKey::FLAG_STRICT_NULL_CHECKS"),
+        "flow_analysis relation helpers must not reach directly into RelationCacheKey bits"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic substrate / relation policy boundary cleanup for #8207 under #8203.

## Invariant
Checker query-boundary helpers that encode relation strict-null policy should use the checker-owned `RelationFlags` wrapper rather than reaching directly into the solver's `RelationCacheKey::FLAG_*` constants.

## Owner Layer
Checker query boundary. This is a boundary-surface cleanup only: relation semantics and solver cache-key construction remain owned by the solver relation policy path.

## Adjacent-Case Matrix
- Flow assignability strict-null helper now uses `RelationFlags::STRICT_NULL_CHECKS`.
- Flow assignability-with-env and subtype-with-env helpers now use the same wrapper.
- Assignability overlap-with-env helper now uses the same wrapper.
- The sole checker wrapper definition still maps to the solver constant in one place.

## Scope
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`
- `crates/tsz-checker/src/query_boundaries/assignability.rs`
- `crates/tsz-checker/src/tests/relation_flags_boundary_contract_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy boundary hygiene / #8207 legacy flag surface cleanup
- Evidence: refactor-only checker boundary change plus architecture guard; no runtime relation behavior or project corpus row changed.

## Unsupported Shapes / Fallback
No type relation behavior changed. The PR only changes where packed strict-null flag constants are read from; all relation queries still funnel through the existing solver `RelationPolicy::from_flags` path.

## Verification
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib -E 'test(=relation_flags_boundary_contract_tests::flow_analysis_uses_boundary_relation_flags_surface)'`
- `git diff --check`
- File-size check for touched files: `flow_analysis.rs` 898 lines, `assignability.rs` 1871 lines, `lib.rs` 851 lines, `relation_flags_boundary_contract_tests.rs` 24 lines.
- Draft CI on head `6cd6f35efc3c4bea3c968a56cc0ece0a6cd8b7e8`: `CI Light Summary`, `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `project-row-drift`, `gate`, and GitGuardian all passed.

## Coordination Notes
- AgentName: M4-B
- Open overlap rechecked on 2026-05-26. #10269 remains the relation cache agreement test slice, #10277 covers readonly conditional array relation coverage, and #10282 covers the optional source parameter relation fix; this PR is a separate checker-boundary cleanup for #8207.
- The original draft blocker was the temporary external GitHub Actions checkout/action-download outage. Draft CI is now clean for the current head, so this PR is ready for review/heavy CI. Auto-merge remains off for the manager/queue owner.