### PR TITLE
fix(checker): evaluate inline conditional infer returns

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -654,6 +654,10 @@ name = "conditional_infer_tests"
 path = "tests/conditional_infer_tests.rs"
 
 [[test]]
+name = "inline_conditional_infer_return_tests"
+path = "tests/inline_conditional_infer_return_tests.rs"
+
+[[test]]
 name = "recursive_conditional_mapped_infer_tests"
 path = "tests/recursive_conditional_mapped_infer_tests.rs"
 

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -94,12 +94,14 @@ impl<'a> CheckerState<'a> {
         } else {
             return_type
         };
-        // Eagerly evaluate monomorphic TypeApplications to avoid nested return
-        // chains, but keep Promise-like applications wrapped for await handling.
-        let return_type = if common::is_generic_application(self.ctx.types, return_type)
-            && !self.contains_type_parameters_cached(return_type)
-            && !self.is_promise_type(return_type)
-        {
+        // Eagerly evaluate monomorphic `TypeApplications` and conditionals to avoid
+        // nested return chains, but keep Promise-like applications wrapped for await handling.
+        let is_monomorphic_application =
+            common::is_generic_application(self.ctx.types, return_type)
+                && !self.contains_type_parameters_cached(return_type);
+        let is_conditional_return = common::is_conditional_type(self.ctx.types, return_type);
+        let is_monomorphic_meta_return = is_monomorphic_application || is_conditional_return;
+        let return_type = if is_monomorphic_meta_return && !self.is_promise_type(return_type) {
             self.evaluate_type_with_env(return_type)
         } else {
             return_type

--- a/crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs
+++ b/crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs
@@ -64,3 +64,19 @@ const bad: number = result;
 
     assert_ts2322_mentions(&diagnostics, "string", "number");
 }
+
+#[test]
+fn inline_generic_ref_infer_true_branch_substitutes_inferred_source() {
+    let diagnostics = check_strict(
+        r#"
+interface Box<Value> { val: Value; }
+
+declare function unwrap<Input>(value: Input): Input extends Box<infer Inner> ? Inner : Input;
+
+const result = unwrap({ val: 1 });
+const bad: string = result;
+"#,
+    );
+
+    assert_ts2322_mentions(&diagnostics, "number", "string");
+}

--- a/crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs
+++ b/crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs
@@ -1,0 +1,66 @@
+//! Regression tests for inline conditional return types with `infer` patterns.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_implicit_any: true,
+            strict_null_checks: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .filter(|diagnostic| diagnostic.code != 2318)
+    .collect()
+}
+
+fn assert_ts2322_mentions(
+    diagnostics: &[Diagnostic],
+    expected_source: &str,
+    expected_target: &str,
+) {
+    assert!(
+        diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == 2322
+                && diagnostic.message_text.contains(expected_source)
+                && diagnostic.message_text.contains(expected_target)
+        }),
+        "expected TS2322 mentioning {expected_source:?} and {expected_target:?}, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn generic_identity_return_preserves_inferred_source_control() {
+    let diagnostics = check_strict(
+        r#"
+declare function identity<Input>(value: Input): Input;
+
+const result = identity("hello");
+const bad: number = result;
+"#,
+    );
+
+    assert_ts2322_mentions(&diagnostics, "\"hello\"", "number");
+}
+
+#[test]
+fn inline_generic_ref_infer_false_branch_preserves_inferred_source() {
+    let diagnostics = check_strict(
+        r#"
+interface Box<Value> { val: Value; }
+
+declare function unwrap<Input>(value: Input): Input extends Box<infer Inner> ? Inner : Input;
+
+const result = unwrap("hello");
+const bad: number = result;
+"#,
+    );
+
+    assert_ts2322_mentions(&diagnostics, "string", "number");
+}

--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -41,3 +41,7 @@ doctest = false
 [[test]]
 name = "public_api_tests"
 path = "tests/public_api_tests.rs"
+
+[[test]]
+name = "conditional_deferred_return_tests"
+path = "tests/conditional_deferred_return_tests.rs"

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -766,8 +766,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
 
                 if self.infer_pattern_has_unresolved_application(cond.extends_type)
-                    || (extends_type != cond.extends_type
-                        && self.infer_pattern_has_unresolved_application(extends_type))
+                    && (extends_type == cond.extends_type
+                        || self.infer_pattern_has_unresolved_application(extends_type))
                 {
                     // Lib-backed patterns can be seen before their base is
                     // resolved. Keep the conditional deferred rather than

--- a/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
+++ b/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
@@ -1,0 +1,88 @@
+//! Regression tests for deferred conditional evaluation through the public solver API.
+
+use tsz_solver::computation::evaluate_conditional;
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::query::conditional_type_id;
+use tsz_solver::type_handles::{ConditionalType, PropertyInfo, TypeId, TypeParamInfo};
+
+fn type_param(interner: &TypeInterner, name: &str) -> TypeId {
+    interner.type_param(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default: None,
+        is_const: false,
+    })
+}
+
+fn infer_param(interner: &TypeInterner, name: &str) -> TypeId {
+    interner.infer(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default: None,
+        is_const: false,
+    })
+}
+
+#[test]
+fn infer_conditional_over_unresolved_type_parameter_stays_deferred() {
+    for (check_name, infer_name) in [("Input", "Inner"), ("Subject", "Value")] {
+        let interner = TypeInterner::new();
+        let check_type = type_param(&interner, check_name);
+        let inferred = infer_param(&interner, infer_name);
+        let value_name = interner.intern_string("val");
+        let extends_type = interner.object(vec![PropertyInfo::new(value_name, inferred)]);
+
+        let result = evaluate_conditional(
+            &interner,
+            &ConditionalType {
+                check_type,
+                extends_type,
+                true_type: inferred,
+                false_type: TypeId::STRING,
+                is_distributive: false,
+            },
+        );
+
+        assert_ne!(
+            result,
+            TypeId::STRING,
+            "unresolved {check_name} must not collapse to the false branch"
+        );
+        assert!(
+            conditional_type_id(&interner, result).is_some(),
+            "unresolved {check_name} should stay as a deferred conditional, got {:?}",
+            interner.lookup(result)
+        );
+    }
+}
+
+#[test]
+fn infer_conditional_over_unresolved_application_pattern_stays_deferred() {
+    let interner = TypeInterner::new();
+    let check_type = type_param(&interner, "Input");
+    let inferred = infer_param(&interner, "Element");
+    let unresolved_array = interner.unresolved_type_name(interner.intern_string("Array"));
+    let extends_type = interner.application(unresolved_array, vec![inferred]);
+
+    let result = evaluate_conditional(
+        &interner,
+        &ConditionalType {
+            check_type,
+            extends_type,
+            true_type: inferred,
+            false_type: TypeId::STRING,
+            is_distributive: false,
+        },
+    );
+
+    assert_ne!(
+        result,
+        TypeId::STRING,
+        "unresolved application patterns must not collapse to the false branch"
+    );
+    assert!(
+        conditional_type_id(&interner, result).is_some(),
+        "unresolved application pattern should stay deferred, got {:?}",
+        interner.lookup(result)
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: recursive conditional / `infer` evaluation

## Invariant
When a generic call instantiates an inline conditional return whose `extends` pattern contains `infer`, concrete matching sources reduce through the true branch, concrete non-matching sources reduce through the false branch, and unresolved generic or lib-backed infer patterns stay deferred instead of prematurely choosing the false branch. This PR makes tsz preserve those branch decisions through solver conditional evaluation and checker call-result finalization.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs`: defer raw application-with-`infer` patterns only while the evaluated pattern is still unresolved.
- `crates/tsz-checker/src/types/computation/call_result.rs`: eagerly evaluate conditional call-return shells alongside existing monomorphic application return evaluation.
- `crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs`: focused call-return coverage for identity control, false-branch reduction, and true-branch `infer` substitution.
- `crates/tsz-solver/tests/conditional_deferred_return_tests.rs`: public solver coverage proving unresolved type-parameter and unresolved application infer patterns remain deferred.
- `crates/tsz-checker/Cargo.toml` and `crates/tsz-solver/Cargo.toml`: register the focused test targets.

## Owner Layer
- Solver owns the semantic branch decision for conditional/infer evaluation and unresolved-pattern deferral.
- Checker owns call-result orchestration and asks the solver to reduce a concrete return shell after generic inference has produced the call result.
- No diagnostic decision is based on test names, rendered type strings, or user-chosen identifiers.

## Adjacent Case Matrix
- Reported shape: inline generic return `Input extends Box<infer Inner> ? Inner : Input` with a non-matching primitive source now reports TS2322 from the false branch.
- True-branch shape: the same inline return with a matching `{ val: number }` source now substitutes `Inner` to `number` at the call boundary.
- Deferral shape: unresolved type-parameter checks with renamed check/infer binders remain `ConditionalType` values instead of collapsing to the false branch.
- Lib-backed fallback shape: unresolved application patterns such as `Array<infer Element>` remain deferred until a resolver can expand the application.
- Control shape: ordinary generic identity return still preserves the inferred literal source, proving the fix is not masking call inference itself.
- Existing nearby coverage: `infer_binding_not_visible_in_false_branch` still passes, guarding `infer` scope visibility in the false branch.
- Existing nearby coverage: TS2322 conditional false-branch tests still pass for non-promise and no-false-positive conditional paths.

## Known Fallback Behavior
- Lib-backed application patterns still defer while the evaluated extends pattern remains unresolved, preserving the existing protection against prematurely caching a false branch for unresolved `Array<infer U>`-style patterns.
- A broad local solver `conditional` filter still exposes pre-existing `Equal<any, X>` failures; this PR does not claim to fix that separate conditional identity family.

## Project Corpus Impact
- Row: n/a
- Bug family: inline generic conditional return branch evaluation with `infer` patterns
- Evidence: focused checker regression reproduces missing TS2322 from issue #9696, plus solver coverage for unresolved deferral; no project-row-specific reduction is identified for this narrow call-return bug.

## Verification
- `cargo nextest run -p tsz-checker --test inline_conditional_infer_return_tests` (3 tests passed)
- `cargo nextest run -p tsz-solver --test conditional_deferred_return_tests` (2 tests passed)
- `cargo nextest run -p tsz-checker --test conditional_infer_tests --test ts2322_tests test_ts2322_generic_alias_chain_negative_non_promise_takes_false_branch test_ts2322_no_false_positive_conditional_type_false_branch infer_binding_not_visible_in_false_branch` (3 tests passed)
- `cargo fmt --check`
- `git diff --check`
- `wc -l crates/tsz-checker/src/types/computation/call_result.rs crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs crates/tsz-checker/tests/inline_conditional_infer_return_tests.rs crates/tsz-solver/tests/conditional_deferred_return_tests.rs crates/tsz-checker/Cargo.toml crates/tsz-solver/Cargo.toml`

## Coordination Notes
- Addresses #9696.
- Review follow-up from https://github.com/mohsen1/tsz/pull/10292#issuecomment-4544276434 added true-branch checker coverage and deferred solver coverage in `ca9fc4ca98`.
- Branch is synced with `origin/main` after commit (`git rev-list --left-right --count HEAD...origin/main` reported `2 0`).
- Draft PR intentionally leaves heavy conformance/emit/fourslash/WASM to ready-for-review CI.
- Latest head is `ca9fc4ca98b99d57e883aaa59392b99c26b9975f`; auto-merge remains off.
