### PR TITLE
fix(website): gate bench deploys on merged artifact

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -68,17 +68,33 @@ jobs:
         env:
           WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ steps.in_flight.outputs.in_flight }}" = "true" ]; then
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            if [ "$WORKFLOW_RUN_CONCLUSION" = "success" ] && \
-              [ "$WORKFLOW_RUN_HEAD_BRANCH" = "main" ] && \
-              { [ "$WORKFLOW_RUN_NAME" = "CI" ] || [ "$WORKFLOW_RUN_NAME" = "Bench" ]; }; then
+            if [ "$WORKFLOW_RUN_CONCLUSION" != "success" ] || \
+              [ "$WORKFLOW_RUN_HEAD_BRANCH" != "main" ]; then
+              echo "workflow_run was not successful main CI/Bench, skipping"
+              echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            elif [ "$WORKFLOW_RUN_NAME" = "CI" ]; then
               echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            elif [ "$WORKFLOW_RUN_NAME" = "Bench" ]; then
+              artifact_id="$(gh api \
+                "repos/${{ github.repository }}/actions/runs/${WORKFLOW_RUN_ID}/artifacts" \
+                --jq '.artifacts[]? | select(.name == "bench-results-merged" and .expired == false) | .id' 2>/dev/null |
+                head -n 1)"
+              if [ -n "$artifact_id" ]; then
+                echo "Bench run ${WORKFLOW_RUN_ID} published bench-results-merged; deploying fresh benchmark data."
+                echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Bench run ${WORKFLOW_RUN_ID} did not publish bench-results-merged; skipping stale benchmark redeploy."
+                echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+              fi
             else
               echo "workflow_run was not successful main CI/Bench, skipping"
               echo "should_deploy=false" >> "$GITHUB_OUTPUT"

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/gh-pages.yml", "utf8");
+
+assert.match(
+  workflow,
+  /WORKFLOW_RUN_ID:\s*\$\{\{ github\.event\.workflow_run\.id \}\}/,
+  "Pages deploy check should know the exact triggering workflow_run id",
+);
+
+assert.match(
+  workflow,
+  /WORKFLOW_RUN_NAME" = "Bench"[\s\S]+actions\/runs\/\$\{WORKFLOW_RUN_ID\}\/artifacts[\s\S]+bench-results-merged/,
+  "Bench-triggered Pages deploys must inspect the exact Bench run artifact list",
+);
+
+assert.match(
+  workflow,
+  /select\(\.name == "bench-results-merged" and \.expired == false\)/,
+  "Pages deploy should require a non-expired merged benchmark artifact",
+);
+
+assert.match(
+  workflow,
+  /did not publish bench-results-merged; skipping stale benchmark redeploy\.[\s\S]+should_deploy=false/,
+  "Bench-triggered Pages deploys without benchmark data must not redeploy stale fallback charts",
+);
+
+assert.match(
+  workflow,
+  /WORKFLOW_RUN_NAME" = "CI"[\s\S]+should_deploy=true/,
+  "Successful main CI workflow_run events should still deploy normal website changes",
+);
+
+console.log("gh-pages benchmark artifact gate tests passed");

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const workflow = fs.readFileSync(".github/workflows/gh-pages.yml", "utf8");
+const gcpFullCi = fs.readFileSync("scripts/ci/gcp-full-ci.sh", "utf8");
 
 assert.match(
   workflow,
@@ -32,6 +33,12 @@ assert.match(
   workflow,
   /WORKFLOW_RUN_NAME" = "CI"[\s\S]+should_deploy=true/,
   "Successful main CI workflow_run events should still deploy normal website changes",
+);
+
+assert.match(
+  gcpFullCi,
+  /node scripts\/bench\/test-gh-pages-benchmark-artifact-gate\.mjs/,
+  "gcp-full-ci lint should run the benchmark artifact gate test",
 );
 
 console.log("gh-pages benchmark artifact gate tests passed");

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -378,6 +378,7 @@ run_lint() {
   node scripts/bench/test-reduction-backlog.mjs || return $?
   node scripts/bench/test-timeout-runner.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
+  node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?
   for script in scripts/ci/*type-challenges*.mjs; do
     node --check "$script" || return $?
   done


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 / benchmark website publication guard

## Invariant
When a `Bench` workflow completion triggers `Deploy Website`, the website should publish benchmark chart data only if that exact Bench run produced a non-expired `bench-results-merged` artifact. Skipped/stale Bench runs must not redeploy old fallback charts as if fresh data landed, and the cheap lint prelude should keep that workflow-text guard wired in.

## Scope
- Gate `gh-pages.yml` Bench workflow_run deploys on the triggering run's `bench-results-merged` artifact.
- Preserve successful main `CI` workflow_run deploy behavior for ordinary website/docs updates.
- Add a lightweight Node workflow-text test and wire it into lint.
- Assert the lint wiring so the artifact gate test cannot silently fall out of `scripts/ci/gcp-full-ci.sh`.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark website artifact publication
- Evidence: workflow-only guard; no compiler/project corpus behavior changes.

## Verification
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node --check scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `bash -n scripts/ci/gcp-full-ci.sh`
- `git diff --check origin/main...HEAD`

## Coordination Notes
- AgentName: Studio-F
- This PR was originally opened by generated contributor identity `m5-pro-48g-gpt5`; Studio-F claimed the canonical ownership lane for the next coordination step so label audits stay actionable.
- Investigation found `tsz.dev/benchmark-data/latest.json` still serving the repository fallback snapshot generated `2026-05-17T01:23:02Z` while recent `Bench` workflow_run entries were marked successful with all artifact-producing jobs skipped.
- Recent successful Bench runs had no `bench-results-merged` artifact, so `gh-pages.yml` could not fetch fresh data and kept deploying fallback charts.
- This PR stops stale Benchmark-triggered redeploys; a fresh chart still requires a Bench run that actually publishes `bench-results-merged`.
- Local verification is complete at head `0abe4906b49b1e21ac3a3a17307a8a2c9b8e838a`; auto-merge remains off until exact-head ready checks complete.
