### PR TITLE
fix(checker): resolve JSDoc class self parameter types

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -1054,6 +1054,12 @@ impl<'a> CheckerState<'a> {
                 || canonical_sym
                     .is_some_and(|sym| self.ctx.class_instance_resolution_set.contains(&sym))
             {
+                if let Some(&partial_instance) = self.ctx.class_instance_type_cache.get(&decl_idx)
+                    && partial_instance != TypeId::ERROR
+                    && partial_instance != TypeId::ANY
+                {
+                    return Some((partial_instance, Vec::new()));
+                }
                 let fallback = self.ctx.create_lazy_type_ref(active_class_sym);
                 return Some((fallback, Vec::new()));
             }

--- a/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tsz_binder::BinderState;
 use tsz_checker::context::{CheckerOptions, ScriptTarget};
 use tsz_checker::state::CheckerState;
+use tsz_checker::test_utils::{check_multi_file_with_libs, load_lib_files};
 use tsz_common::diagnostics::Diagnostic;
 use tsz_parser::parser::ParserState;
 use tsz_solver::construction::TypeInterner;
@@ -185,6 +186,61 @@ const u = {};
         ts2741.len(),
         1,
         "Expected imported object typedef @type to check missing initializer property, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn jsdoc_class_self_param_uses_instance_type_across_commonjs_file() {
+    let lib_files = load_lib_files(&["es5.d.ts", "es2015.symbol.d.ts", "es2015.iterable.d.ts"]);
+    let diagnostics = check_multi_file_with_libs(
+        &[
+            (
+                "index.js",
+                r#"
+const LazySet = require("./LazySet");
+
+/** @type {LazySet} */
+const stringSet = undefined;
+stringSet.addAll(stringSet);
+"#,
+            ),
+            (
+                "LazySet.js",
+                r#"
+/**
+ * @typedef {Object} SomeObject
+ */
+class LazySet {
+    /**
+     * @param {LazySet} iterable
+     */
+    addAll(iterable) {}
+    [Symbol.iterator]() {}
+}
+
+module.exports = LazySet;
+"#,
+            ),
+        ],
+        "index.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    );
+
+    let codes: Vec<u32> = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect();
+    assert_eq!(
+        codes,
+        vec![2322],
+        "JSDoc class self references should resolve to the instance type, got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-E

## Track
Studio-E JSDoc/JS declaration emit and LSP/WASM compiler-service consumer boundaries; checker parity fix for issue #8720.

## Invariant
When checked JavaScript resolves a bare class name in JSDoc type position while that class instance is already being built, the reference should use the in-progress instance type, not the value-side constructor type. This PR changes the checker class type-resolution fallback so re-entrant class instance lookups consult the partial instance cache before falling back to `Lazy(DefId)`.

## Scope
- `crates/tsz-checker/src/state/type_resolution/reference_helpers.rs`: prefer the partial class instance during re-entrant class self-reference resolution.
- `crates/tsz-checker/tests/jsdoc_cross_file_typedef_tests.rs`: add a CommonJS checked-JS regression for `jsDeclarationsTypedefAndLatebound`.

## Project Corpus Impact
- Row: conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound
- Bug family: JSDoc class self-reference constructor-vs-instance split in checked JS
- Evidence: targeted conformance filter now reports 1/1 passed with no fingerprint-only failures.

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(jsdoc_class_self_param_uses_instance_type_across_commonjs_file)'`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter jsDeclarationsTypedefAndLatebound --verbose`
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Fixes #8720.
- Avoids broad declaration-summary/DTS work that overlaps Studio-D PR #10275 and the wider #8275 lane.
- Ready for manager review/queue after CI; Studio-E did not enable auto-merge.