### PR TITLE
fix(checker): preserve enum typeof indexed access keys

### DIFF
--- a/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
@@ -2,8 +2,17 @@ use super::super::type_node::TypeNodeChecker;
 use tsz_solver::TypeId;
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
-    pub(super) fn enum_namespace_property_object(&self, type_id: TypeId) -> Option<TypeId> {
-        let sym_id = self.ctx.resolve_type_to_symbol_id(type_id)?;
+    pub(super) fn enum_namespace_property_object(
+        &self,
+        surface_type: TypeId,
+        resolved_type: TypeId,
+        surface_is_type_query_node: bool,
+    ) -> Option<TypeId> {
+        if !surface_is_type_query_node && !self.type_surface_is_type_query_alias(surface_type) {
+            return None;
+        }
+
+        let sym_id = self.ctx.resolve_type_to_symbol_id(resolved_type)?;
         let symbol = self.ctx.binder.symbols.get(sym_id)?;
         if !symbol.has_any_flags(tsz_binder::symbol_flags::ENUM)
             || symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
@@ -12,6 +21,40 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         }
 
         self.ctx.enum_namespace_types.get(&sym_id).copied()
+    }
+
+    fn type_surface_is_type_query_alias(&self, type_id: TypeId) -> bool {
+        if crate::query_boundaries::common::is_type_query_type(self.ctx.types, type_id) {
+            return true;
+        }
+
+        let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, type_id)
+        else {
+            return false;
+        };
+        let Some(def) = self.ctx.definition_store.get(def_id) else {
+            return false;
+        };
+        if def.kind != tsz_solver::def::DefKind::TypeAlias {
+            return false;
+        }
+
+        def.symbol_id
+            .map(tsz_binder::SymbolId)
+            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+            .is_some_and(|symbol| {
+                symbol.declarations.iter().any(|&decl_idx| {
+                    let Some(node) = self.ctx.arena.get(decl_idx) else {
+                        return false;
+                    };
+                    let Some(alias) = self.ctx.arena.get_type_alias(node) else {
+                        return false;
+                    };
+                    self.ctx.arena.get(alias.type_node).is_some_and(|body| {
+                        body.kind == tsz_parser::parser::syntax_kind_ext::TYPE_QUERY
+                    })
+                })
+            })
     }
 
     pub(super) fn full_enum_member_union_parent_type(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
@@ -2,6 +2,18 @@ use super::super::type_node::TypeNodeChecker;
 use tsz_solver::TypeId;
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
+    pub(super) fn enum_namespace_property_object(&self, type_id: TypeId) -> Option<TypeId> {
+        let sym_id = self.ctx.resolve_type_to_symbol_id(type_id)?;
+        let symbol = self.ctx.binder.symbols.get(sym_id)?;
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::ENUM)
+            || symbol.has_any_flags(tsz_binder::symbol_flags::ENUM_MEMBER)
+        {
+            return None;
+        }
+
+        self.ctx.enum_namespace_types.get(&sym_id).copied()
+    }
+
     pub(super) fn full_enum_member_union_parent_type(&self, type_id: TypeId) -> Option<TypeId> {
         let list_id = crate::query_boundaries::common::union_list_id(self.ctx.types, type_id)?;
         let members = self.ctx.types.type_list(list_id);

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -404,7 +404,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     // Check property existence against the materialized object so
                     // unevaluated mapped-alias intersection members contribute their
                     // keys (see `evaluate_type_for_property_check`).
-                    let property_object = self.evaluate_type_for_property_check(resolved_object);
+                    let property_object = self
+                        .enum_namespace_property_object(resolved_object)
+                        .unwrap_or_else(|| self.evaluate_type_for_property_check(resolved_object));
                     let prop_result =
                         crate::query_boundaries::property_access::resolve_property_access(
                             self.ctx.types,

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -405,7 +405,11 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     // unevaluated mapped-alias intersection members contribute their
                     // keys (see `evaluate_type_for_property_check`).
                     let property_object = self
-                        .enum_namespace_property_object(resolved_object)
+                        .enum_namespace_property_object(
+                            object_type,
+                            resolved_object,
+                            object_is_type_query_node,
+                        )
                         .unwrap_or_else(|| self.evaluate_type_for_property_check(resolved_object));
                     let prop_result =
                         crate::query_boundaries::property_access::resolve_property_access(

--- a/crates/tsz-checker/tests/enum_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/enum_indexed_access_tests.rs
@@ -34,6 +34,14 @@ fn expect_no_type_or_property_error(source: &str) {
     );
 }
 
+fn expect_property_error(source: &str) {
+    let errors = diagnostics_for(source)
+        .into_iter()
+        .filter(|&c| c == 2339)
+        .count();
+    assert!(errors > 0, "Expected at least one TS2339 error:\n{source}");
+}
+
 fn expect_error(source: &str) {
     let errors = diagnostics_for(source)
         .into_iter()
@@ -98,6 +106,28 @@ declare const write: WriteType;
 const check: Mode.Write = write;
 "#;
     expect_no_type_or_property_error(source);
+}
+
+#[test]
+fn test_numeric_enum_typeof_alias_indexed_access_literal_member() {
+    let source = r#"
+enum Direction { Up, Down, Left, Right }
+type DirectionObject = typeof Direction;
+type UpType = DirectionObject["Up"];
+declare const up: UpType;
+const check: Direction.Up = up;
+"#;
+    expect_no_type_or_property_error(source);
+}
+
+#[test]
+fn test_numeric_enum_type_alias_indexed_access_rejects_namespace_member() {
+    let source = r#"
+enum Direction { Up, Down, Left, Right }
+type DirectionValue = Direction;
+type UpType = DirectionValue["Up"];
+"#;
+    expect_property_error(source);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tsz-checker/tests/enum_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/enum_indexed_access_tests.rs
@@ -9,16 +9,33 @@
 
 use tsz_checker::test_utils::check_source_codes;
 
+fn diagnostics_for(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+}
+
 fn expect_no_error(source: &str) {
-    let errors = check_source_codes(source)
+    let errors = diagnostics_for(source)
         .into_iter()
         .filter(|&c| c == 2322)
         .count();
     assert_eq!(errors, 0, "Expected no TS2322 errors:\n{source}");
 }
 
+fn expect_no_type_or_property_error(source: &str) {
+    let diagnostics = diagnostics_for(source);
+    let unexpected = diagnostics
+        .iter()
+        .copied()
+        .filter(|&c| matches!(c, 2322 | 2339))
+        .collect::<Vec<_>>();
+    assert!(
+        unexpected.is_empty(),
+        "Expected no TS2322/TS2339 errors, got {unexpected:?} from {diagnostics:?}:\n{source}"
+    );
+}
+
 fn expect_error(source: &str) {
-    let errors = check_source_codes(source)
+    let errors = diagnostics_for(source)
         .into_iter()
         .filter(|&c| c == 2322)
         .count();
@@ -59,6 +76,28 @@ const g: number = obj["Green"];
 const b: number = obj["Blue"];
 "#;
     expect_no_error(source);
+}
+
+#[test]
+fn test_numeric_enum_typeof_indexed_access_literal_member() {
+    let source = r#"
+enum Direction { Up, Down, Left, Right }
+type UpType = (typeof Direction)["Up"];
+declare const up: UpType;
+const check: Direction.Up = up;
+"#;
+    expect_no_type_or_property_error(source);
+}
+
+#[test]
+fn test_numeric_enum_typeof_indexed_access_literal_renamed_member() {
+    let source = r#"
+enum Mode { Read = 1, Write = 2 }
+type WriteType = (typeof Mode)["Write"];
+declare const write: WriteType;
+const check: Mode.Write = write;
+"#;
+    expect_no_type_or_property_error(source);
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +153,17 @@ declare const obj: typeof Status;
 const v: string = obj.Active;
 "#;
     expect_no_error(source);
+}
+
+#[test]
+fn test_string_enum_typeof_indexed_access_literal_member() {
+    let source = r#"
+enum Status { Active = "active", Inactive = "inactive" }
+type ActiveType = (typeof Status)["Active"];
+declare const active: ActiveType;
+const check: Status.Active = active;
+"#;
+    expect_no_type_or_property_error(source);
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
M4-D symbol/lib/module/DefId/cross-file stable identity; checker diagnostic and type-node behavior fix for enum object identity in indexed-access types.

## Invariant
When an indexed-access type uses a `typeof Enum` object receiver and a literal enum-member key, `tsc` resolves the key against the enum namespace object and does not emit TS2339. When the receiver is an enum value/type surface such as `type Alias = Enum`, `tsc` does not treat it as the enum namespace object. This PR makes tsz use the existing enum namespace object only for `typeof Enum` surfaces while leaving indexed-access evaluation in the solver.

## Owner Layer
Checker orchestration owns this slice because the false diagnostic is emitted by the checker pre-diagnostic property-existence probe before solver evaluation. The solver already evaluates enum indexed access through enum namespace identity; this PR aligns the checker probe with that identity without adding a solver special case.

## Scope
- Use the cached enum namespace object for string-literal indexed-access property validation on `typeof Enum` receivers.
- Preserve the distinction between `typeof Enum` object surfaces and enum value/type alias surfaces.
- Add focused regression coverage for numeric, renamed, string, aliased-`typeof`, and non-`typeof` enum indexed-access cases.
- Preserve existing value-level and mapped enum indexed-access coverage.

## Adjacent Case Matrix
- Numeric enum: `(typeof Direction)["Up"]` resolves without TS2339 and is assignable to `Direction.Up`.
- Renamed numeric enum/member: `(typeof Mode)["Write"]` proves the fix is not spelling-specific.
- String enum: `(typeof Status)["Active"]` resolves without TS2339 and is assignable to `Status.Active`.
- Alias wrapper: `type DirectionObject = typeof Direction; DirectionObject["Up"]` preserves the `typeof` surface through an alias.
- Negative/fallback: `type DirectionValue = Direction; DirectionValue["Up"]` reports TS2339 instead of silently accepting enum namespace members.
- Control: existing `typeof Direction[keyof typeof Direction]` enum control still passes.

## Project Corpus Impact
- Row: n/a
- Bug family: enum object identity / indexed-access type false TS2339
- Evidence: focused checker regression tests for issue #9680; no project-corpus row targeted by this diagnostic identity repair.

## Verification
- RED before initial fix: `cargo nextest run -p tsz-checker --test enum_indexed_access_tests` failed the new `(typeof Enum)["Member"]` cases with TS2339.
- Initial local verification on earlier head: `cargo nextest run -p tsz-checker --test enum_indexed_access_tests` (15 passed), `cargo nextest run -p tsz-checker --test enum_nominality_tests test_typeof_enum_keyof_indexed_access_assigns_to_enum` (1 passed), `cargo fmt --check`, `git diff --check`, `python3 scripts/arch/arch_guard.py`, and `scripts/arch/check-checker-boundaries.sh`.
- CI found an aggregate regression on head `44373dceea8a91c1bcf5a2300a8753868ed69803`: all six shards passed individually, but `conformance-aggregate` reported unlisted `TypeScript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts`.
- Follow-up local verification on head `d700cef8264c71c0a92a90c05297adfa2155ad46`: `cargo fmt -p tsz-checker` and `git diff --check` passed.
- Ready-review CI passed on exact head `d700cef8264c71c0a92a90c05297adfa2155ad46`: CI Summary, conformance aggregate, fourslash aggregate, emit, LSP e2e, project compile guard/canary, wasm/wasm-web, node-harness-prep, unit, unit-cloudbuild, lint, dist-binaries, cargo-deny, cargo-shear, conformance-snapshot-gate, project-row-drift, project-corpus-pr-body, gate, and GitGuardian are all green. `Queue Tested` remains pending for manager/queue handling.

## Coordination Notes
- Fixes #9680.
- No open PR claimed the `(typeof Enum)["Member"]` indexed-access type path during overlap scan.
- Branch: `codex/m4-d-9680-enum-typeof-indexed-access-20260526`
- Latest commit: `d700cef826 fix(checker): limit enum namespace indexed access to typeof`
- Follow-up root cause: the initial checker probe materialized enum namespace members for any surface that resolved to an enum symbol, which erased the `Enum` vs `typeof Enum` distinction. The current head requires a direct `TYPE_QUERY` surface or an alias whose declared body is `typeof Enum`.
- Auto-merge remains off for manager/queue-owner handling; exact-head CI is green except queue state.
- AgentName: M4-D.
