### PR TITLE
test(solver): cover strict-any relation cache agreement

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -29,10 +29,13 @@ use super::*;
 use crate::caches::db::QueryDatabase;
 use crate::caches::query_cache::QueryCache;
 use crate::intern::TypeInterner;
-use crate::relations::relation_queries::RelationPolicy;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
 use crate::relations::subtype::AnyPropagationMode;
 use crate::types::{
-    CachedAnyMode, RelationCacheConfig, RelationCacheKey, RelationCacheKind, RelationFlags,
+    CachedAnyMode, PropertyInfo, RelationCacheConfig, RelationCacheKey, RelationCacheKind,
+    RelationFlags,
 };
 
 /// Assert that two `RelationPolicy` configurations produce distinct
@@ -721,5 +724,49 @@ fn query_cache_typed_policy_entrypoints_insert_policy_shaped_keys() {
         )),
         Some(true),
         "typed assignability policy path must insert under the policy-derived cache key",
+    );
+}
+
+#[test]
+fn assignability_cache_strict_any_policy_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::NUMBER)]);
+    let policy = RelationPolicy::default().with_strict_any_propagation(true);
+
+    let uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        policy,
+        RelationContext::default(),
+    );
+    let cached = db.is_assignable_to_with_policy(source, target, policy);
+    let cached_again = db.is_assignable_to_with_policy(source, target, policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        cached,
+        uncached.is_related(),
+        "cached strict-any assignability must match the uncached relation facade",
+    );
+    assert_eq!(
+        cached_again, cached,
+        "second strict-any lookup should reuse the same policy-shaped answer",
+    );
+    assert!(
+        stats.assignability_hits >= 1,
+        "second strict-any lookup should hit the assignability cache",
+    );
+    assert!(
+        stats.assignability_misses >= 1,
+        "first strict-any lookup should miss before inserting",
+    );
+    assert!(
+        !cached,
+        "strict-any policy must not let nested `any` silence the property mismatch",
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic substrate / test-only relation cache contract for #8207.

## Invariant
When assignability is evaluated for the same structural object pair under strict-any propagation, the cached `QueryCache` typed-policy entrypoint and the uncached `query_relation` facade must agree, and the second cached lookup must reuse the policy-shaped assignability cache slot.

## Scope
- `crates/tsz-solver/tests/relation_cache_config_tests.rs`
- Adds focused solver coverage only; no production relation semantics change.

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache correctness / strict-any policy contract
- Evidence: test-only solver contract for #8207; no project corpus row or runtime behavior changed.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(=relation_cache_config_tests::assignability_cache_strict_any_policy_matches_uncached_relation_query)'`
- `cargo nextest run -p tsz-solver -E 'test(/^relation_cache_config_tests::/)'`
- `cargo fmt --check`
- `git diff --check`
- Draft-light CI for head `ad3df757fd1b69cd0e7cd9b4bb9d3a43f49ea1ae`: `CI Light Summary`, `unit`, `lint`, `dist-binaries`, `cargo-deny`, `unit-cloudbuild`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian pass.

## Coordination Notes
- AgentName: M4-B
- Open overlap checked on 2026-05-26 before this branch. Existing M4-B PR #10269 covers strict-null/non-strict-null relation-cache agreement; this PR is a separate strict-any nested structural-object agreement slice for #8207.
- Draft-light CI is green for head `ad3df757fd1b69cd0e7cd9b4bb9d3a43f49ea1ae`; marking ready so heavy CI can validate the exact head. Auto-merge remains off for the manager/queue owner.
