### PR TITLE
fix(solver): preserve template keyof index keys

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1494,6 +1494,10 @@ name = "template_literal_record_key_tests"
 path = "tests/template_literal_record_key_tests.rs"
 
 [[test]]
+name = "keyof_template_index_signature_tests"
+path = "tests/keyof_template_index_signature_tests.rs"
+
+[[test]]
 name = "template_literal_generic_call_indexed_keyof_constraint_tests"
 path = "tests/template_literal_generic_call_indexed_keyof_constraint_tests.rs"
 

--- a/crates/tsz-checker/tests/keyof_template_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/keyof_template_index_signature_tests.rs
@@ -58,3 +58,21 @@ let goodNumber: K = 42;
         "plain string index signatures still produce string | number keys"
     );
 }
+
+#[test]
+fn keyof_template_and_number_index_signature_accepts_number_key() {
+    let source = r#"
+type Mixed = { [key: `prefix_${string}`]: boolean; [idx: number]: boolean };
+type K = keyof Mixed;
+
+let okTemplate: K = "prefix_hello";
+let okNumber: K = 42;
+let bad: K = "nope";
+"#;
+
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "`keyof` must keep number when a numeric index is paired with a template index"
+    );
+}

--- a/crates/tsz-checker/tests/keyof_template_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/keyof_template_index_signature_tests.rs
@@ -1,0 +1,60 @@
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn ts2322_count(source: &str) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|code| *code == 2322)
+        .count()
+}
+
+#[test]
+fn keyof_template_index_signature_rejects_non_matching_string_and_number() {
+    let source = r#"
+type Tmpl = { [key: `prefix_${string}`]: boolean };
+type K = keyof Tmpl;
+
+let good: K = "prefix_hello";
+let bad: K = "nope";
+let num: K = 42;
+"#;
+
+    assert_eq!(
+        ts2322_count(source),
+        2,
+        "`keyof` of a template index signature must reject non-matching strings and numbers"
+    );
+}
+
+#[test]
+fn keyof_template_index_signature_pattern_is_not_name_dependent() {
+    let source = r#"
+type Env = { [prop: `env:${string}`]: string };
+type EnvKey = keyof Env;
+
+let good: EnvKey = "env:PATH";
+let bad: EnvKey = "prefix_PATH";
+"#;
+
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "`keyof` must preserve the template pattern regardless of the index parameter name"
+    );
+}
+
+#[test]
+fn keyof_plain_string_index_signature_still_accepts_number_keys() {
+    let source = r#"
+type Dict = { [key: string]: boolean };
+type K = keyof Dict;
+
+let goodString: K = "anything";
+let goodNumber: K = 42;
+"#;
+
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "plain string index signatures still produce string | number keys"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -32,9 +32,10 @@ use super::super::evaluate::{
 /// - Symbol-keyed signature: contributes `symbol`.
 /// - String-keyed signature: contributes `string | number` (string indexes
 ///   are implicitly numeric-key-compatible in TS).
-/// - Number-keyed signature (only when no string-slot signature is present):
-///   contributes `number`, except for enum namespace types where tsc excludes
-///   the implicit `[index: number]: string` from `keyof typeof E`.
+/// - Number-keyed signature contributes `number` when no string-slot signature
+///   already contributed numeric keyspace, except for enum namespace types
+///   where tsc excludes the implicit `[index: number]: string` from
+///   `keyof typeof E`.
 fn index_signature_key_includes_symbol(interner: &dyn TypeDatabase, key_type: TypeId) -> bool {
     if key_type == TypeId::SYMBOL {
         return true;
@@ -52,27 +53,34 @@ fn extend_keyof_with_index_signature_key_type(
     interner: &dyn TypeDatabase,
     key_types: &mut Vec<TypeId>,
     key_type: TypeId,
-) {
+) -> bool {
     match interner.lookup(key_type) {
         Some(TypeData::Union(members)) => {
+            let mut contributed_number = false;
             for &member in interner.type_list(members).iter() {
-                extend_keyof_with_index_signature_key_type(interner, key_types, member);
+                contributed_number |=
+                    extend_keyof_with_index_signature_key_type(interner, key_types, member);
             }
+            contributed_number
         }
         Some(TypeData::Intrinsic(IntrinsicKind::String)) => {
             key_types.push(TypeId::STRING);
             key_types.push(TypeId::NUMBER);
+            true
         }
         Some(TypeData::Intrinsic(IntrinsicKind::Number)) => {
             key_types.push(TypeId::NUMBER);
+            true
         }
         Some(TypeData::Intrinsic(IntrinsicKind::Symbol)) => {
             key_types.push(TypeId::SYMBOL);
+            false
         }
         Some(TypeData::TemplateLiteral(_))
         | Some(TypeData::StringIntrinsic { .. })
         | Some(TypeData::Literal(LiteralValue::String(_))) => {
             key_types.push(key_type);
+            false
         }
         _ => {
             key_types.push(TypeId::STRING);
@@ -80,6 +88,7 @@ fn extend_keyof_with_index_signature_key_type(
             if index_signature_key_includes_symbol(interner, key_type) {
                 key_types.push(TypeId::SYMBOL);
             }
+            true
         }
     }
 }
@@ -91,9 +100,13 @@ fn extend_keyof_with_index_signature_keys(
     number_index: Option<&IndexSignature>,
     is_enum_namespace: bool,
 ) {
-    if let Some(idx) = string_or_symbol_index {
-        extend_keyof_with_index_signature_key_type(interner, key_types, idx.key_type);
-    } else if number_index.is_some() && !is_enum_namespace {
+    let string_slot_contributed_number = if let Some(idx) = string_or_symbol_index {
+        extend_keyof_with_index_signature_key_type(interner, key_types, idx.key_type)
+    } else {
+        false
+    };
+
+    if number_index.is_some() && !is_enum_namespace && !string_slot_contributed_number {
         key_types.push(TypeId::NUMBER);
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -48,6 +48,42 @@ fn index_signature_key_includes_symbol(interner: &dyn TypeDatabase, key_type: Ty
     }
 }
 
+fn extend_keyof_with_index_signature_key_type(
+    interner: &dyn TypeDatabase,
+    key_types: &mut Vec<TypeId>,
+    key_type: TypeId,
+) {
+    match interner.lookup(key_type) {
+        Some(TypeData::Union(members)) => {
+            for &member in interner.type_list(members).iter() {
+                extend_keyof_with_index_signature_key_type(interner, key_types, member);
+            }
+        }
+        Some(TypeData::Intrinsic(IntrinsicKind::String)) => {
+            key_types.push(TypeId::STRING);
+            key_types.push(TypeId::NUMBER);
+        }
+        Some(TypeData::Intrinsic(IntrinsicKind::Number)) => {
+            key_types.push(TypeId::NUMBER);
+        }
+        Some(TypeData::Intrinsic(IntrinsicKind::Symbol)) => {
+            key_types.push(TypeId::SYMBOL);
+        }
+        Some(TypeData::TemplateLiteral(_))
+        | Some(TypeData::StringIntrinsic { .. })
+        | Some(TypeData::Literal(LiteralValue::String(_))) => {
+            key_types.push(key_type);
+        }
+        _ => {
+            key_types.push(TypeId::STRING);
+            key_types.push(TypeId::NUMBER);
+            if index_signature_key_includes_symbol(interner, key_type) {
+                key_types.push(TypeId::SYMBOL);
+            }
+        }
+    }
+}
+
 fn extend_keyof_with_index_signature_keys(
     interner: &dyn TypeDatabase,
     key_types: &mut Vec<TypeId>,
@@ -56,15 +92,7 @@ fn extend_keyof_with_index_signature_keys(
     is_enum_namespace: bool,
 ) {
     if let Some(idx) = string_or_symbol_index {
-        if idx.key_type == TypeId::SYMBOL {
-            key_types.push(TypeId::SYMBOL);
-        } else {
-            key_types.push(TypeId::STRING);
-            key_types.push(TypeId::NUMBER);
-            if index_signature_key_includes_symbol(interner, idx.key_type) {
-                key_types.push(TypeId::SYMBOL);
-            }
-        }
+        extend_keyof_with_index_signature_key_type(interner, key_types, idx.key_type);
     } else if number_index.is_some() && !is_enum_namespace {
         key_types.push(TypeId::NUMBER);
     }

--- a/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
@@ -528,6 +528,45 @@ fn test_keyof_template_index_signature_with_fixed_property_excludes_plain_string
 }
 
 #[test]
+fn test_keyof_template_and_number_index_signature_includes_number() {
+    let interner = TypeInterner::new();
+    let template_key = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("prefix_")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: template_key,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(obj));
+    let Some(TypeData::Union(members)) = interner.lookup(result) else {
+        panic!(
+            "Expected union for template plus number index signature, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    let member_list = interner.type_list(members);
+
+    assert!(member_list.contains(&template_key));
+    assert!(member_list.contains(&TypeId::NUMBER));
+    assert!(!member_list.contains(&TypeId::STRING));
+}
+
+#[test]
 fn test_keyof_object_with_number_index_includes_number() {
     let interner = TypeInterner::new();
     let obj_with_index = interner.object_with_index(ObjectShape {

--- a/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
@@ -10,7 +10,7 @@ use crate::evaluation::evaluate::evaluate_type;
 use crate::intern::TypeInterner;
 use crate::types::{
     CallSignature, CallableShape, FunctionShape, IndexSignature, ObjectFlags, ObjectShape,
-    ParamInfo, TypeData,
+    ParamInfo, TemplateSpan, TypeData,
 };
 
 /// Helper to check if a type is a union containing specific literals
@@ -458,6 +458,73 @@ fn test_keyof_object_with_collapsed_string_symbol_index_includes_symbol() {
     assert!(member_list.contains(&TypeId::STRING));
     assert!(member_list.contains(&TypeId::NUMBER));
     assert!(member_list.contains(&TypeId::SYMBOL));
+}
+
+#[test]
+fn test_keyof_template_index_signature_preserves_template_key() {
+    let interner = TypeInterner::new();
+    let template_key = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("prefix_")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: template_key,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(obj));
+
+    assert_eq!(
+        result, template_key,
+        "keyof a template-literal index signature must preserve the template key type"
+    );
+}
+
+#[test]
+fn test_keyof_template_index_signature_with_fixed_property_excludes_plain_string_number() {
+    let interner = TypeInterner::new();
+    let template_key = interner.template_literal(vec![
+        TemplateSpan::Text(interner.intern_string("env:")),
+        TemplateSpan::Type(TypeId::STRING),
+    ]);
+    let fixed_key = interner.literal_string("fixed");
+    let obj = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![PropertyInfo::new(
+            interner.intern_string("fixed"),
+            TypeId::STRING,
+        )],
+        string_index: Some(IndexSignature {
+            key_type: template_key,
+            value_type: TypeId::BOOLEAN,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let result = evaluate_type(&interner, interner.keyof(obj));
+    let Some(TypeData::Union(members)) = interner.lookup(result) else {
+        panic!(
+            "Expected union for fixed property plus template index, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    let member_list = interner.type_list(members);
+
+    assert!(member_list.contains(&fixed_key));
+    assert!(member_list.contains(&template_key));
+    assert!(!member_list.contains(&TypeId::STRING));
+    assert!(!member_list.contains(&TypeId::NUMBER));
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: template-literal/indexed-access key-space evaluation (#9686)

## Invariant
When an object index signature key type is a template-literal pattern, `keyof` preserves that pattern key type. When that patterned index coexists with a numeric index signature, `keyof` also preserves `number` unless a plain string index already contributed `string | number`. This PR keeps that key-space computation solver-owned while plain string index signatures continue to widen to `string | number`.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs`: classify index-signature key contribution from the stored key type, and add an independent numeric index when the string/symbol slot did not already contribute numeric keyspace.
- `crates/tsz-solver/tests/keyof_comprehensive_tests.rs`: solver coverage for template index keys, template index plus fixed properties, and mixed template-plus-number index signatures.
- `crates/tsz-checker/tests/keyof_template_index_signature_tests.rs`: TS2322 surface coverage for matching and non-matching assignments, renamed index parameter, mixed template-plus-number index signatures, and the plain string-index control.
- `crates/tsz-checker/Cargo.toml`: register the focused checker test target.

## Owner Layer
Solver evaluation owns the `keyof` key-space computation. Checker coverage verifies diagnostics only and does not special-case template-literal index signatures.

## Adjacent Case Matrix
- Template index signature: `keyof` of a prefix template index preserves the template key.
- Template index plus fixed property: the result includes the fixed literal and template key, not plain `string | number`.
- Template index plus number index: the result includes the template key and `number`, not plain `string`.
- Renamed index parameter: the behavior is independent of the source parameter name.
- Plain string index signature: still accepts string and number keys.
- Collapsed string/symbol signature and number index signature: existing adjacent solver tests stay green.

## Known Fallback Behavior
Unknown or non-standard index signature key types keep the previous conservative `string | number` fallback, with `symbol` included when the key type contains symbol.

## Project Corpus Impact
- Row: n/a
- Bug family: template-literal index signature `keyof` widening
- Evidence: focused local solver/checker regressions cover issue #9686; no project-corpus row identified for this narrow semantic unit bug.

## Verification
- `cargo nextest run -p tsz-solver test_keyof_template_and_number_index_signature_includes_number` (red before fix, then 1 test passed)
- `cargo nextest run -p tsz-checker --test keyof_template_index_signature_tests keyof_template_and_number_index_signature_accepts_number_key` (red before fix, then 1 test passed)
- `cargo nextest run -p tsz-solver keyof_template_index_signature` (2 tests passed)
- `cargo nextest run -p tsz-checker --test keyof_template_index_signature_tests` (4 tests passed)
- `cargo nextest run -p tsz-solver test_keyof_object_with` (7 tests passed)
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- Fixes #9686.
- Review follow-up addressed in `326b755643`: mixed template-plus-number index signatures now preserve both key contributions.
- Fresh worktree: `/Users/mohsen/code/tsz-m4a-template-keyof-index-20260526`.
- Branch: `codex/m4a-template-keyof-index-20260526`.
- Overlap check: M4-A owned work listed no active draft PR for #9686 before this PR; existing owned PRs are separate issues (#9696, #9715, #9767, #9655).
- Draft PR intentionally leaves heavy conformance/emit/fourslash/WASM to ready-for-review CI. Auto-merge remains off.