### PR TITLE
fix(dts): preserve parameter return annotations

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/returned_function_initializer.rs
@@ -580,6 +580,7 @@ impl<'a> DeclarationEmitter<'a> {
             .flatten();
         let has_direct_function_return = direct_function_return.is_some();
         let return_text = direct_function_return
+            .or_else(|| self.function_body_parameter_return_type_text(func, func_body))
             .or_else(|| self.function_body_preferred_return_type_text(func_body))
             .map(|type_text| {
                 self.expand_rest_tuple_parameters_in_function_type_text(func_body, &type_text)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -41,33 +41,93 @@ impl<'a> DeclarationEmitter<'a> {
         body_idx: NodeIndex,
     ) -> Option<String> {
         let returned_identifier = self.function_body_unique_return_identifier(body_idx)?;
-        let type_text = self.function_parameter_type_text(func, returned_identifier)?;
-        let type_text =
-            Self::compact_single_member_mapped_type_literal_text(&type_text).unwrap_or(type_text);
+        let type_annotation = self.function_parameter_type_annotation(func, returned_identifier)?;
+        let type_text = self
+            .single_line_mapped_type_annotation_text(type_annotation)
+            .or_else(|| self.function_parameter_type_text(func, returned_identifier))?;
         (!type_text.trim().is_empty()).then_some(type_text)
     }
 
-    fn compact_single_member_mapped_type_literal_text(type_text: &str) -> Option<String> {
-        let trimmed = type_text.trim();
-        if !Self::type_text_contains_mapped_type_literal(trimmed) {
-            return None;
-        }
-        let inner = trimmed.strip_prefix('{')?.strip_suffix('}')?.trim();
-        let member = if inner.contains('\n') {
-            let mut lines = inner.lines().map(str::trim).filter(|line| !line.is_empty());
-            let member = lines.next()?;
-            if lines.next().is_some() {
-                return None;
+    fn function_parameter_type_annotation(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        identifier_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let identifier_name = self.get_identifier_text(identifier_idx)?;
+        for param_idx in func.parameters.nodes.iter().copied() {
+            let param_node = self.arena.get(param_idx)?;
+            let param = self.arena.get_parameter(param_node)?;
+            let param_name = self.get_identifier_text(param.name)?;
+            if param_name == identifier_name && param.type_annotation.is_some() {
+                return Some(param.type_annotation);
             }
-            member
-        } else {
-            inner
-        };
-        let member = member.trim_end_matches(';').trim();
-        if !member.contains(" in ") || !member.contains("]:") {
+        }
+        None
+    }
+
+    fn single_line_mapped_type_annotation_text(
+        &self,
+        type_annotation: NodeIndex,
+    ) -> Option<String> {
+        let type_node = self.arena.get(type_annotation)?;
+        if type_node.kind != syntax_kind_ext::MAPPED_TYPE {
             return None;
         }
-        Some(format!("{{ {member}; }}"))
+        let mapped = self.arena.get_mapped_type(type_node)?;
+        if mapped
+            .members
+            .as_ref()
+            .is_some_and(|members| !members.nodes.is_empty())
+        {
+            return None;
+        }
+        let type_param_node = self.arena.get(mapped.type_parameter)?;
+        let type_param = self.arena.get_type_parameter(type_param_node)?;
+        let type_param_name = self.get_identifier_text(type_param.name)?;
+        let constraint_text = self.single_line_type_node_text(type_param.constraint)?;
+        let value_text = self.single_line_type_node_text(mapped.type_node)?;
+
+        let readonly_text = if let Some(readonly_node) = self.arena.get(mapped.readonly_token) {
+            match readonly_node.kind {
+                k if k == SyntaxKind::PlusToken as u16 => "+readonly ",
+                k if k == SyntaxKind::MinusToken as u16 => "-readonly ",
+                _ => "readonly ",
+            }
+        } else {
+            ""
+        };
+        let name_type_text = if mapped.name_type.is_some() {
+            format!(" as {}", self.single_line_type_node_text(mapped.name_type)?)
+        } else {
+            String::new()
+        };
+        let question_text = if let Some(question_node) = self.arena.get(mapped.question_token) {
+            match question_node.kind {
+                k if k == SyntaxKind::PlusToken as u16 => "+?",
+                k if k == SyntaxKind::MinusToken as u16 => "-?",
+                _ => "?",
+            }
+        } else {
+            ""
+        };
+
+        Some(format!(
+            "{{ {readonly_text}[{type_param_name} in {constraint_text}{name_type_text}]{question_text}: {value_text}; }}"
+        ))
+    }
+
+    fn single_line_type_node_text(&self, type_idx: NodeIndex) -> Option<String> {
+        let type_text = self.emit_type_node_text(type_idx)?;
+        if type_text.chars().any(|ch| ch == '\n' || ch == '\r') {
+            return None;
+        }
+        Some(
+            type_text
+                .trim()
+                .trim_end_matches(';')
+                .trim_end()
+                .to_string(),
+        )
     }
 
     pub(in crate::declaration_emitter) fn function_body_single_spread_object_literal_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -35,6 +35,41 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    pub(in crate::declaration_emitter) fn function_body_parameter_return_type_text(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        let returned_identifier = self.function_body_unique_return_identifier(body_idx)?;
+        let type_text = self.function_parameter_type_text(func, returned_identifier)?;
+        let type_text =
+            Self::compact_single_member_mapped_type_literal_text(&type_text).unwrap_or(type_text);
+        (!type_text.trim().is_empty()).then_some(type_text)
+    }
+
+    fn compact_single_member_mapped_type_literal_text(type_text: &str) -> Option<String> {
+        let trimmed = type_text.trim();
+        if !Self::type_text_contains_mapped_type_literal(trimmed) {
+            return None;
+        }
+        let inner = trimmed.strip_prefix('{')?.strip_suffix('}')?.trim();
+        let member = if inner.contains('\n') {
+            let mut lines = inner.lines().map(str::trim).filter(|line| !line.is_empty());
+            let member = lines.next()?;
+            if lines.next().is_some() {
+                return None;
+            }
+            member
+        } else {
+            inner
+        };
+        let member = member.trim_end_matches(';').trim();
+        if !member.contains(" in ") || !member.contains("]:") {
+            return None;
+        }
+        Some(format!("{{ {member}; }}"))
+    }
+
     pub(in crate::declaration_emitter) fn function_body_single_spread_object_literal_type_text(
         &self,
         body_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -67,6 +67,30 @@ fn test_multiple_type_parameters() {
     );
 }
 
+#[test]
+fn test_inferred_return_preserves_mapped_parameter_annotation() {
+    let output = emit_dts(
+        r#"
+    export function makeRecord<T, K extends string>(obj: { [P in K]: T }) {
+        return obj;
+    }
+
+    export function makeDictionary<T>(obj: { [x: string]: T }) {
+        return obj;
+    }
+    "#,
+    );
+
+    assert!(
+        output.contains("): { [P in K]: T; };"),
+        "Expected mapped parameter annotation to drive inferred return type: {output}"
+    );
+    assert!(
+        output.contains("): {\n    [x: string]: T;\n};"),
+        "Expected index signature parameter annotation to keep object return layout: {output}"
+    );
+}
+
 // =============================================================================
 // 7. Ambient / Declare Declarations
 // =============================================================================

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -78,6 +78,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     export function makeDictionary<T>(obj: { [x: string]: T }) {
         return obj;
     }
+
+    export function makeRecordRenamed<Value, Key extends string>(obj: { [X in Key]: Value }) {
+        return obj;
+    }
     "#,
     );
 
@@ -88,6 +92,10 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     assert!(
         output.contains("): {\n    [x: string]: T;\n};"),
         "Expected index signature parameter annotation to keep object return layout: {output}"
+    );
+    assert!(
+        output.contains("): { [X in Key]: Value; };"),
+        "Expected renamed mapped variables to use the same return annotation rule: {output}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit 100% through declaration/public API summary boundaries.

## Invariant
When an unannotated function body uniquely returns a parameter with a declared type annotation, declaration emit should preserve that parameter's public annotation surface as the inferred return type. This PR changes the declaration-summary return hint path only; it does not add checker or solver semantic inference.

## Owner Layer
Declaration summary / DTS return-type normalization.

## Failure Family
DTS nameability and public-surface preservation for inferred function returns.

## Scope
- Preserve parameter annotation text in `function_body_return_hint` before generic fallback body inference.
- Use the returned parameter's `MAPPED_TYPE` AST annotation to render simple single-member mapped returns inline; this avoids deciding from printer/display fragments.
- Keep index-signature object returns in block layout.
- Add focused declaration-emitter coverage for mapped, renamed mapped-variable, and index-signature parameter-return annotations.

## Project Corpus Impact
- Row: emit/dts conformance row `isomorphicMappedTypeInference`
- Bug family: inferred declaration return summaries for returned parameters
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=isomorphicMappedTypeInference --dts-only --verbose --concurrency=1 --timeout=30000 --json-out=/tmp/studio-d-isomorphic-after-main-merge.json` still has the expected remaining row failure, and JSON inspection shows the owned `makeRecord` mapped-parameter annotation diff remains removed after merging `origin/main` at `bf82d905d1`.

## Adjacent-Case Matrix
- Direct returned mapped parameter: covered by `makeRecord<T, K extends string>(obj: { [P in K]: T })` unit test and focused emit filter.
- Renamed mapped binder/type parameters: covered by `makeRecordRenamed<Value, Key extends string>(obj: { [X in Key]: Value })` unit assertion.
- Direct returned index-signature parameter: covered by `makeDictionary<T>(obj: { [x: string]: T })` unit assertion; layout remains object-block style.
- Non-parameter or multi-return bodies: unchanged; they continue through existing body-preferred and solver-backed inference paths.
- Multiline or member-tailed mapped annotations: fall back to existing type annotation/body inference formatting.
- Solver/checker inference gaps in `isomorphicMappedTypeInference`: intentionally out of scope.

## Verification
- `cargo fmt`
- `cargo nextest run -p tsz-emitter test_inferred_return_preserves_mapped_parameter_annotation` (1 passed after main merge)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=isomorphicMappedTypeInference --dts-only --verbose --concurrency=1 --timeout=30000 --json-out=/tmp/studio-d-isomorphic-after-main-merge.json` (expected remaining row failure; owned `makeRecord` diff removed)
- `rg -n "makeRecord|\\{ \\[P in K\\]|\\{ \\[X in Key\\]|isomorphicMappedTypeInference|sum:|x0:|keyof T" /tmp/studio-d-isomorphic-after-main-merge.json` (confirmed remaining diff is the non-owned `applySpec` literal-widening and `Pick`/key inference tail)
- `git diff --check` (passed after main merge)
- `python3 scripts/arch/arch_guard.py` (passed after main merge)

## Coordination Notes
- Current head: bf82d905d1
- Branch is synced with `origin/main` as of the current cycle: `git rev-list --left-right --count origin/main...HEAD` reports `0 3`.
- Branch was started from `origin/main` in the reused `/Users/mohsen/code/tsz-studui-crossfile` worktree.
- Follow-up `05a0a12c51` replaces the original rendered-text mapped-literal recognizer with an AST-shaped `MappedTypeData` path and adds renamed binder coverage.
- Merged `origin/main` (`a6d9252c8c`, #10261) into this branch at `bf82d905d1` and re-ran the focused local checks above.
- Overlap scan found active M4-A/M1-A inference PRs nearby, so this PR is deliberately scoped to declaration-summary output and does not change solver/checker inference.
- Existing Studio-D PR #10275 and stacked #10312 are separate constrained mapped inferred declarations slices.
- Ready for review/heavy CI at `bf82d905d1`; auto-merge remains off for manager/queue ownership after exact-head checks complete.