### PR TITLE
docs(solver): correct infer pattern split module names

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -6,9 +6,10 @@
 //! - Callable type patterns
 //! - Signature parameter / rest matching and template-capture binding helpers
 //!
-//! Object, object-with-index, union, and template-literal pattern matchers live
-//! in `infer_pattern_object_helpers.rs` (split to stay under the file-size
-//! ceiling); both are `impl TypeEvaluator` blocks in the same module tree.
+//! Object, object-with-index, and union matchers live in
+//! `infer_pattern_object_match.rs`; template-literal matchers live in
+//! `infer_pattern_template_match.rs`. These split modules stay under the
+//! file-size ceiling while sharing the same `impl TypeEvaluator` module tree.
 
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Refactor-only / solver inference documentation hygiene following #10079.

## Invariant
When future solver work navigates infer-pattern helpers, the module docs should name the actual split modules; this PR changes comments only and does not alter solver behavior.

## Scope
- Correct the module names listed in `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only Rust module comment update; no checker, solver runtime, emit, benchmark fixture, or project corpus behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- Line count check: infer-pattern split shards remain below 2000 lines (`infer_pattern_helpers.rs` 1445, `infer_pattern_object_match.rs` 780, `infer_pattern_template_match.rs` 866).
- Draft light CI at head `95392a7a937b6f23c2d09acf1133d9519ed82ffc`: CI Light Summary, unit, project-row-drift, cargo-deny, cargo-shear, unit-cloudbuild, lint, dist-binaries, gate, and GitGuardian succeeded.

## Coordination Notes
- Follow-up from verifying and closing #10079 after merged #9798.
- Marked ready after light CI completed; ready-review CI is the remaining signal.
- No auto-merge requested from this lane.
