### PR TITLE
test(checker): cover ambient module value exports

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -370,6 +370,10 @@ name = "ambient_module_renamed_export_ts2460_tests"
 path = "tests/ambient_module_renamed_export_ts2460_tests.rs"
 
 [[test]]
+name = "ambient_module_value_export_tests"
+path = "tests/ambient_module_value_export_tests.rs"
+
+[[test]]
 name = "cjs_object_export_module_augmentation_merge_tests"
 path = "tests/cjs_object_export_module_augmentation_merge_tests.rs"
 

--- a/crates/tsz-checker/tests/ambient_module_value_export_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_value_export_tests.rs
@@ -1,0 +1,144 @@
+//! Regression coverage for #9742: value exports from `declare module` blocks
+//! must keep their declared type when imported.
+//!
+//! Structural rule: when an ambient module exports a declared value, imports
+//! of that value must resolve to the declared value type at every use site,
+//! including property access and assignment.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn has_code(diags: &[(u32, String)], expected: u32) -> bool {
+    diags.iter().any(|(code, _)| *code == expected)
+}
+
+#[test]
+fn ambient_module_named_const_import_property_access_uses_declared_type() {
+    let diags = diagnostics(
+        &[
+            (
+                "pkg.d.ts",
+                r#"
+declare module "pkg" {
+  export const obj: { foo: number };
+}
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+import { obj } from "pkg";
+obj.bar;
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339 for missing property on imported ambient value; got {diags:#?}"
+    );
+}
+
+#[test]
+fn ambient_module_namespace_const_import_property_access_uses_declared_type() {
+    let diags = diagnostics(
+        &[
+            (
+                "pkg.d.ts",
+                r#"
+declare module "pkg" {
+  export const settings: { port: number };
+}
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+import * as ns from "pkg";
+ns.settings.missing;
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339 for missing property through namespace import; got {diags:#?}"
+    );
+}
+
+#[test]
+fn ambient_module_named_const_import_assignment_uses_declared_type() {
+    let diags = diagnostics(
+        &[
+            (
+                "pkg.d.ts",
+                r#"
+declare module "pkg" {
+  export const value: { expected: number };
+}
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+import { value } from "pkg";
+const assigned: { nope: number } = value;
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    assert!(
+        has_code(&diags, 2741) || has_code(&diags, 2322),
+        "expected assignment diagnostic for imported ambient value; got {diags:#?}"
+    );
+}
+
+#[test]
+fn ambient_module_default_const_export_import_uses_declared_type() {
+    let diags = diagnostics(
+        &[
+            (
+                "pkg.d.ts",
+                r#"
+declare module "pkg" {
+  const exported: { ready: boolean };
+  export default exported;
+}
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+import exported from "pkg";
+exported.absent;
+"#,
+            ),
+        ],
+        "use.ts",
+    );
+
+    assert!(
+        has_code(&diags, 2339),
+        "expected TS2339 for missing property through default import; got {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/ambient_module_value_export_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_value_export_tests.rs
@@ -108,8 +108,8 @@ const assigned: { nope: number } = value;
     );
 
     assert!(
-        has_code(&diags, 2741) || has_code(&diags, 2322),
-        "expected assignment diagnostic for imported ambient value; got {diags:#?}"
+        has_code(&diags, 2741),
+        "expected TS2741 for missing target property on imported ambient value; got {diags:#?}"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Track 4 semantic identity regression coverage.

## Invariant
When an ambient `declare module` exports a declared value, tsz must preserve that value's declared type through named imports, namespace imports, default imports, and assignment/property-access use sites. This PR records the checker behavior with focused regression tests; current `origin/main` already matches the expected diagnostics for #9742.

## Scope
- Register a focused checker integration test target for ambient module value exports.
- Cover named const import property access, namespace import property access, named import assignment, and default const export import.

## Project Corpus Impact
- Row: n/a
- Bug family: ambient module value export identity regression coverage
- Evidence: test-only checker coverage; no compiler implementation, benchmark fixture, module-resolution config, or project-corpus row changes.

## Verification
- `cargo nextest run -p tsz-checker --test ambient_module_value_export_tests` (4/4 passed) on head `a0a9059ba2`
- `cargo fmt --check` on head `a0a9059ba2`
- `git diff --check` on head `a0a9059ba2`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Related issue: #9742.
- Fresh worktree: `/Users/mohsen/code/tsz-m4d-9742-ambient-value-export-20260526`.
- Addressed reviewer feedback by pinning the ambient value assignment diagnostic to `TS2741` instead of accepting either `TS2741` or `TS2322`.
- Investigation found the old #9742 repro matrix already green on current `origin/main`; this PR preserves that behavior so the issue can be closed after the regression coverage lands.
- Existing M4-D PRs remain separate: #10297, #10287, and #10279.

