### PR TITLE
fix(checker): preserve spread literal TS2488 display

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -974,7 +974,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Not iterable - emit TS2488
-        self.emit_ts2488_not_iterable(expr_type, expr_idx, false);
+        self.emit_ts2488_not_iterable(expr_type, expr_idx, false, None);
         false
     }
 
@@ -1064,7 +1064,8 @@ impl<'a> CheckerState<'a> {
         }
 
         // Not iterable - emit TS2488
-        self.emit_ts2488_not_iterable(spread_type, expr_idx, false);
+        let literal_display_type = self.literal_type_from_initializer(expr_idx);
+        self.emit_ts2488_not_iterable(spread_type, expr_idx, false, literal_display_type);
         false
     }
 
@@ -1152,7 +1153,12 @@ impl<'a> CheckerState<'a> {
             };
 
             // tsc reports TS2488 before TS2571 for this path.
-            self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target);
+            self.emit_ts2488_not_iterable(
+                pattern_type,
+                pattern_idx,
+                is_assignment_array_target,
+                None,
+            );
             if let Some((start, end)) = ts2571_span {
                 self.error(
                     start,
@@ -1166,7 +1172,12 @@ impl<'a> CheckerState<'a> {
 
         // In array destructuring, TypeScript still reports TS2488 for `never`.
         if resolved_type == TypeId::NEVER {
-            self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target);
+            self.emit_ts2488_not_iterable(
+                pattern_type,
+                pattern_idx,
+                is_assignment_array_target,
+                None,
+            );
             return false;
         }
 
@@ -1237,7 +1248,7 @@ impl<'a> CheckerState<'a> {
         // path, and that case is already handled above when `target.is_es5()`.
 
         // Not iterable - emit TS2488
-        self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target);
+        self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target, None);
         false
     }
 
@@ -1509,6 +1520,7 @@ impl<'a> CheckerState<'a> {
         type_id: TypeId,
         error_node: NodeIndex,
         is_assignment_target: bool,
+        literal_display_type: Option<TypeId>,
     ) {
         if let Some((start, end)) = self.get_node_span(error_node) {
             let evaluated_type = self.evaluate_type_for_assignability(type_id);
@@ -1522,7 +1534,11 @@ impl<'a> CheckerState<'a> {
             } else {
                 evaluated_type
             };
-            let type_str = self.format_type_diagnostic_widened(display_type);
+            let type_str = if let Some(literal_display_type) = literal_display_type {
+                self.format_type(literal_display_type)
+            } else {
+                self.format_type_diagnostic_widened(display_type)
+            };
             let message = format_message(
                 diagnostic_messages::TYPE_MUST_HAVE_A_SYMBOL_ITERATOR_METHOD_THAT_RETURNS_AN_ITERATOR,
                 &[&type_str],

--- a/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_diagnostics_tests.rs
@@ -570,6 +570,44 @@ var c: MyNumberArray = [...strs];
 }
 
 #[test]
+fn test_array_spread_ts2488_preserves_literal_operand_display() {
+    let source = r#"
+const a = [...5];
+const b = [...true];
+const c = [...{ value: 1 }];
+declare let n: number;
+const d = [...n];
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let messages = diagnostic_messages_with_code(&diagnostics, 2488);
+
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.contains("Type '5' must have")),
+        "numeric spread literal should stay literal in TS2488; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.contains("Type 'true' must have")),
+        "boolean spread literal should stay literal in TS2488; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.contains("Type '{ value: number; }' must have")),
+        "object spread operand should keep widened property display; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|msg| msg.contains("Type 'number' must have")),
+        "non-literal number spread operand should still display number; got {messages:?}"
+    );
+}
+
+#[test]
 fn test_destructuring_index_signature_only_emits_ts2488_in_es2015() {
     // Pinned by `destructuringArrayBindingPatternAndAssignment2.ts`. tsc emits
     // TS2488 for `var [c4, c5, c6] = foo(1)` when `foo` returns an interface


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 10 diagnostic type-display debt: TS2488 spread operand display parity.

## Invariant
When a non-iterable array/call spread operand is a primitive literal expression, `tsc` renders that operand's literal type in TS2488 while still widening object-literal properties and non-literal operands. This PR makes the checker use syntax-derived literal display provenance only for the spread-origin TS2488 diagnostic; the semantic iterability check still uses the normal spread operand `TypeId`.

## Scope
- Thread display-only literal provenance into the spread TS2488 emission path in `iterable_checker`.
- Keep for-of and destructuring TS2488 on their existing widened diagnostic policy.
- Add a focused spread/rest diagnostic regression test covering literal and non-literal controls.

## Project Corpus Impact
- Row: n/a
- Bug family: type-display parity
- Evidence: checker diagnostic-rendering-only change for TS2488 spread operands; no parser, binder, solver relation, emitter, LSP, WASM, or benchmark behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(test_array_spread_ts2488_preserves_literal_operand_display)'`
- `cargo nextest run -p tsz-checker --lib -E 'test(spread_rest_diagnostics_tests)'`

## Coordination Notes
- Fixes #9748.
- Non-overlap: #10265 handles accepted-regression artifact cleanup and #10278 handles post-check conformance fingerprint/source-text rewrite debt. This PR is a separate checker diagnostic display fix.
- Adjacent-case matrix: `[...5]` and `[...true]` preserve primitive literal display; `[...{ value: 1 }]` keeps widened object-property display; spreading a `number` variable still displays `number`.
- The first unqualified `cargo nextest` attempt spent excessive time enumerating the full checker package; rerunning with `--lib` resolved the intended single/module filters.
- Ready-review CI run 26452659483 passed on head `020778c60a27f3e00baf65e9aa405f222a95b948`; auto-merge remains off and merge/queue decisions are left to the manager.

