### PR TITLE
fix(checker): report recursive default accumulator depth

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -365,12 +365,12 @@ impl<'a> CheckerState<'a> {
                         // During symbol resolution, ensure_relation_input_ready is skipped,
                         // leaving the alias body unregistered in the TypeEnvironment. Without
                         // it the evaluator returns the Application unchanged and TS2589 is missed.
-                        if let Some(base_def_id) =
+                        let base_def_id =
                             crate::query_boundaries::common::get_application_lazy_def_id(
                                 self.ctx.types,
                                 type_id,
-                            )
-                        {
+                            );
+                        if let Some(base_def_id) = base_def_id {
                             let _ = self.resolve_and_insert_def_type(base_def_id);
                         }
 
@@ -382,13 +382,21 @@ impl<'a> CheckerState<'a> {
                         // probes. The TS2589-specific evaluator treats any repeated
                         // Application cycle as overflow, which is too aggressive for
                         // bounded recursive conditional aliases.
-                        let (exceeded, tuple_too_large) = {
-                            self.evaluate_type_with_env_uncached(type_id);
-                            (
-                                self.ctx.depth_exceeded.get(),
-                                self.ctx.types.take_tuple_too_large(),
-                            )
-                        };
+                        let computed_recursive_alias = is_type_alias
+                            && self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                        let (exceeded, tuple_too_large) =
+                            if computed_recursive_alias && let Some(base_def_id) = base_def_id {
+                                (
+                                    self.evaluate_type_for_ts2589_check(type_id, base_def_id),
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            } else {
+                                self.evaluate_type_with_env_uncached(type_id);
+                                (
+                                    self.ctx.depth_exceeded.get(),
+                                    self.ctx.types.take_tuple_too_large(),
+                                )
+                            };
 
                         // Also detect circular mapped-type aliases that the evaluator
                         // can't expand: if the alias body is a mapped type that
@@ -1218,13 +1226,23 @@ impl<'a> CheckerState<'a> {
                             // probes. The TS2589-specific evaluator treats any repeated
                             // Application cycle as overflow, which is too aggressive for
                             // bounded recursive conditional aliases.
-                            let (exceeded, tuple_too_large) = {
-                                self.evaluate_type_with_env_uncached(result);
-                                (
-                                    self.ctx.depth_exceeded.get(),
-                                    self.ctx.types.take_tuple_too_large(),
-                                )
-                            };
+                            let app_def_id = query::get_application_info(self.ctx.types, result)
+                                .and_then(|(base, _)| query::get_lazy_def_id(self.ctx.types, base));
+                            let computed_recursive_alias =
+                                self.type_alias_has_computed_recursive_conditional_body(sym_id);
+                            let (exceeded, tuple_too_large) =
+                                if computed_recursive_alias && let Some(app_def_id) = app_def_id {
+                                    (
+                                        self.evaluate_type_for_ts2589_check(result, app_def_id),
+                                        self.ctx.types.take_tuple_too_large(),
+                                    )
+                                } else {
+                                    self.evaluate_type_with_env_uncached(result);
+                                    (
+                                        self.ctx.depth_exceeded.get(),
+                                        self.ctx.types.take_tuple_too_large(),
+                                    )
+                                };
 
                             // Also detect circular mapped-type aliases that the evaluator
                             // can't expand: if the alias body is a mapped type that

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -27,4 +27,5 @@ mod global;
 mod indexed_access;
 mod property_init;
 mod type_alias_checking;
+mod type_alias_depth_helpers;
 mod unused;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -360,29 +360,8 @@ impl<'a> CheckerState<'a> {
                 || has_unresolved_computed_recursive_ref
                 || has_recursive_wrapper_arg
             {
-                // Collect type params that were pushed into scope above
-                let type_params: Vec<tsz_solver::TypeParamInfo> = alias
-                    .type_parameters
-                    .as_ref()
-                    .map(|tps| {
-                        tps.nodes
-                            .iter()
-                            .filter_map(|&param_idx| {
-                                let param_node = self.ctx.arena.get(param_idx)?;
-                                let param = self.ctx.arena.get_type_parameter(param_node)?;
-                                let name_node = self.ctx.arena.get(param.name)?;
-                                let ident = self.ctx.arena.get_identifier(name_node)?;
-                                let atom = self.ctx.types.intern_string(&ident.escaped_text);
-                                Some(tsz_solver::TypeParamInfo {
-                                    name: atom,
-                                    constraint: None,
-                                    default: None,
-                                    is_const: false,
-                                })
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                // Reuse scoped alias params so TS2589 sees constraints/defaults.
+                let type_params = self.current_alias_type_params(alias.type_parameters.as_ref());
 
                 // Register body temporarily for evaluation
                 self.ctx
@@ -823,6 +802,70 @@ impl<'a> CheckerState<'a> {
             .any(|child_idx| {
                 self.conditional_body_has_definite_recursive_alias_ref(child_idx, alias_sid)
             })
+    }
+
+    fn conditional_body_has_computed_recursive_alias_ref(
+        &mut self,
+        node_idx: NodeIndex,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+        {
+            let resolved = self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .map(tsz_binder::SymbolId);
+            return resolved == Some(alias_sid)
+                && type_ref.type_arguments.as_ref().is_some_and(|type_args| {
+                    !self.type_args_match_alias_params(alias_sid, type_args)
+                        && !self
+                            .type_arg_nodes_all_are_deferred_passthrough_for_depth_check(type_args)
+                        && type_args.nodes.iter().copied().any(|arg_idx| {
+                            !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
+                        })
+                });
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.conditional_body_has_computed_recursive_alias_ref(child_idx, alias_sid)
+            })
+    }
+
+    pub(crate) fn type_alias_has_computed_recursive_conditional_body(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+    ) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let declarations = symbol.declarations.clone();
+        declarations.into_iter().any(|decl_idx| {
+            self.ctx.arena.get(decl_idx).is_some_and(|decl_node| {
+                decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                    && self
+                        .ctx
+                        .arena
+                        .get_type_alias(decl_node)
+                        .is_some_and(|alias| {
+                            self.ctx
+                                .arena
+                                .kind_at(alias.type_node)
+                                .is_some_and(|kind| kind == syntax_kind_ext::CONDITIONAL_TYPE)
+                                && self.conditional_body_has_computed_recursive_alias_ref(
+                                    alias.type_node,
+                                    alias_sid,
+                                )
+                        })
+            })
+        })
     }
 
     /// True when the alias body contains a conditional whose `extends` clause is

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -790,6 +790,14 @@ impl<'a> CheckerState<'a> {
                 if self.type_arg_nodes_all_are_deferred_passthrough_for_depth_check(type_args) {
                     return false;
                 }
+                if type_args.nodes.iter().copied().all(|arg_idx| {
+                    self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
+                        || self.type_node_is_bounded_indexed_descent_for_depth_check(
+                            alias_sid, arg_idx,
+                        )
+                }) {
+                    return false;
+                }
                 return !self
                     .type_arg_nodes_contain_scoped_type_parameter_for_depth_check(type_args);
             }
@@ -826,6 +834,9 @@ impl<'a> CheckerState<'a> {
                             .type_arg_nodes_all_are_deferred_passthrough_for_depth_check(type_args)
                         && type_args.nodes.iter().copied().any(|arg_idx| {
                             !self.type_node_is_deferred_passthrough_for_depth_check(arg_idx)
+                                && !self.type_node_is_bounded_indexed_descent_for_depth_check(
+                                    alias_sid, arg_idx,
+                                )
                         })
                 });
         }
@@ -908,55 +919,6 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    fn type_arg_nodes_all_are_deferred_passthrough_for_depth_check(
-        &mut self,
-        type_args: &tsz_parser::parser::NodeList,
-    ) -> bool {
-        !type_args.nodes.is_empty()
-            && type_args
-                .nodes
-                .iter()
-                .copied()
-                .all(|node_idx| self.type_node_is_deferred_passthrough_for_depth_check(node_idx))
-    }
-
-    fn type_node_is_deferred_passthrough_for_depth_check(&mut self, node_idx: NodeIndex) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return false;
-        };
-
-        if let Some(identifier) = self.ctx.arena.get_identifier(node)
-            && self
-                .ctx
-                .type_parameter_scope
-                .contains_key(&identifier.escaped_text)
-        {
-            return true;
-        }
-        if let Some(identifier) = self.ctx.arena.get_identifier(node)
-            && self
-                .identifier_references_enclosing_infer_binding(node_idx, &identifier.escaped_text)
-        {
-            return true;
-        }
-
-        if node.kind == syntax_kind_ext::TYPE_REFERENCE
-            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-        {
-            if type_ref
-                .type_arguments
-                .as_ref()
-                .is_some_and(|type_args| !type_args.nodes.is_empty())
-            {
-                return false;
-            }
-
-            return self.type_name_is_deferred_passthrough_for_depth_check(type_ref.type_name);
-        }
-
-        false
-    }
-
     fn conditional_body_has_unresolved_computed_recursive_alias_ref(
         &mut self,
         node_idx: NodeIndex,
@@ -994,120 +956,6 @@ impl<'a> CheckerState<'a> {
                     child_idx, alias_sid,
                 )
             })
-    }
-
-    fn type_node_contains_unresolved_type_reference_for_depth_check(
-        &mut self,
-        node_idx: NodeIndex,
-    ) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return false;
-        };
-
-        if node.kind == syntax_kind_ext::TYPE_REFERENCE
-            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-            && self
-                .resolve_type_symbol_for_lowering(type_ref.type_name)
-                .is_none()
-            && self
-                .ctx
-                .arena
-                .kind_at(type_ref.type_name)
-                .is_some_and(|kind| kind == syntax_kind_ext::QUALIFIED_NAME)
-            && !self.type_name_is_deferred_passthrough_for_depth_check(type_ref.type_name)
-        {
-            return true;
-        }
-
-        self.ctx
-            .arena
-            .get_children(node_idx)
-            .into_iter()
-            .any(|child_idx| {
-                self.type_node_contains_unresolved_type_reference_for_depth_check(child_idx)
-            })
-    }
-
-    fn type_name_is_deferred_passthrough_for_depth_check(&mut self, name_idx: NodeIndex) -> bool {
-        let Some(name_node) = self.ctx.arena.get(name_idx) else {
-            return false;
-        };
-        let Some(identifier) = self.ctx.arena.get_identifier(name_node) else {
-            return false;
-        };
-
-        self.ctx
-            .type_parameter_scope
-            .contains_key(&identifier.escaped_text)
-            || self
-                .identifier_references_enclosing_infer_binding(name_idx, &identifier.escaped_text)
-    }
-
-    fn identifier_references_enclosing_infer_binding(
-        &self,
-        node_idx: NodeIndex,
-        name: &str,
-    ) -> bool {
-        let mut current = node_idx;
-        for _ in 0..50 {
-            let parent = self
-                .ctx
-                .arena
-                .get_extended(current)
-                .map_or(NodeIndex::NONE, |ext| ext.parent);
-            if parent.is_none() {
-                return false;
-            }
-            let Some(parent_node) = self.ctx.arena.get(parent) else {
-                return false;
-            };
-            if let Some(conditional) = self.ctx.arena.get_conditional_type(parent_node)
-                && self.type_node_contains_infer_binding_named(conditional.extends_type, name)
-            {
-                return true;
-            }
-            current = parent;
-        }
-        false
-    }
-
-    fn type_node_contains_infer_binding_named(&self, node_idx: NodeIndex, name: &str) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return false;
-        };
-        if node.kind == syntax_kind_ext::TEMPLATE_LITERAL_TYPE_SPAN {
-            return self.ctx.arena.get_template_span(node).is_some_and(|span| {
-                self.type_node_contains_infer_binding_named(span.expression, name)
-            });
-        }
-        if node.kind == syntax_kind_ext::INFER_TYPE {
-            let Some(infer_data) = self.ctx.arena.get_infer_type(node) else {
-                return false;
-            };
-            if let Some(type_param_node) = self.ctx.arena.get(infer_data.type_parameter)
-                && let Some(type_param) = self.ctx.arena.get_type_parameter(type_param_node)
-                && let Some(name_node) = self.ctx.arena.get(type_param.name)
-                && let Some(identifier) = self.ctx.arena.get_identifier(name_node)
-                && identifier.escaped_text == name
-            {
-                return true;
-            }
-            return self.type_node_contains_infer_binding_named(infer_data.type_parameter, name);
-        }
-        if node.kind == syntax_kind_ext::TYPE_PARAMETER
-            && let Some(type_param) = self.ctx.arena.get_type_parameter(node)
-        {
-            return (type_param.constraint != NodeIndex::NONE
-                && self.type_node_contains_infer_binding_named(type_param.constraint, name))
-                || (type_param.default != NodeIndex::NONE
-                    && self.type_node_contains_infer_binding_named(type_param.default, name));
-        }
-
-        self.ctx
-            .arena
-            .get_children(node_idx)
-            .into_iter()
-            .any(|child_idx| self.type_node_contains_infer_binding_named(child_idx, name))
     }
 
     /// Walk `extends_type` collecting every `infer X` binding and push each as a

--- a/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_depth_helpers.rs
@@ -1,0 +1,243 @@
+//! Helpers for type-alias recursion depth probes.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, NodeList};
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn type_arg_nodes_all_are_deferred_passthrough_for_depth_check(
+        &mut self,
+        type_args: &NodeList,
+    ) -> bool {
+        !type_args.nodes.is_empty()
+            && type_args
+                .nodes
+                .iter()
+                .copied()
+                .all(|node_idx| self.type_node_is_deferred_passthrough_for_depth_check(node_idx))
+    }
+
+    pub(crate) fn type_node_is_deferred_passthrough_for_depth_check(
+        &mut self,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if let Some(identifier) = self.ctx.arena.get_identifier(node)
+            && self
+                .ctx
+                .type_parameter_scope
+                .contains_key(&identifier.escaped_text)
+        {
+            return true;
+        }
+        if let Some(identifier) = self.ctx.arena.get_identifier(node)
+            && self
+                .identifier_references_enclosing_infer_binding(node_idx, &identifier.escaped_text)
+        {
+            return true;
+        }
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+        {
+            if type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|type_args| !type_args.nodes.is_empty())
+            {
+                return false;
+            }
+
+            return self.type_name_is_deferred_passthrough_for_depth_check(type_ref.type_name);
+        }
+
+        false
+    }
+
+    pub(crate) fn type_node_is_bounded_indexed_descent_for_depth_check(
+        &mut self,
+        alias_sid: tsz_binder::SymbolId,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        let Some(indexed) = self.ctx.arena.get_indexed_access_type(node) else {
+            return false;
+        };
+        self.type_node_is_deferred_passthrough_for_depth_check(indexed.object_type)
+            || self.type_node_is_alias_type_parameter_ref(alias_sid, indexed.object_type)
+    }
+
+    pub(crate) fn type_node_contains_unresolved_type_reference_for_depth_check(
+        &mut self,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+            && self
+                .resolve_type_symbol_for_lowering(type_ref.type_name)
+                .is_none()
+            && self
+                .ctx
+                .arena
+                .kind_at(type_ref.type_name)
+                .is_some_and(|kind| kind == syntax_kind_ext::QUALIFIED_NAME)
+            && !self.type_name_is_deferred_passthrough_for_depth_check(type_ref.type_name)
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.type_node_contains_unresolved_type_reference_for_depth_check(child_idx)
+            })
+    }
+
+    fn type_name_is_deferred_passthrough_for_depth_check(&mut self, name_idx: NodeIndex) -> bool {
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        let Some(identifier) = self.ctx.arena.get_identifier(name_node) else {
+            return false;
+        };
+
+        self.ctx
+            .type_parameter_scope
+            .contains_key(&identifier.escaped_text)
+            || self
+                .identifier_references_enclosing_infer_binding(name_idx, &identifier.escaped_text)
+    }
+
+    fn identifier_references_enclosing_infer_binding(
+        &self,
+        node_idx: NodeIndex,
+        name: &str,
+    ) -> bool {
+        let mut current = node_idx;
+        for _ in 0..50 {
+            let parent = self
+                .ctx
+                .arena
+                .get_extended(current)
+                .map_or(NodeIndex::NONE, |ext| ext.parent);
+            if parent.is_none() {
+                return false;
+            }
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                return false;
+            };
+            if let Some(conditional) = self.ctx.arena.get_conditional_type(parent_node)
+                && self.type_node_contains_infer_binding_named(conditional.extends_type, name)
+            {
+                return true;
+            }
+            current = parent;
+        }
+        false
+    }
+
+    fn type_node_contains_infer_binding_named(&self, node_idx: NodeIndex, name: &str) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::TEMPLATE_LITERAL_TYPE_SPAN {
+            return self.ctx.arena.get_template_span(node).is_some_and(|span| {
+                self.type_node_contains_infer_binding_named(span.expression, name)
+            });
+        }
+        if node.kind == syntax_kind_ext::INFER_TYPE {
+            let Some(infer_data) = self.ctx.arena.get_infer_type(node) else {
+                return false;
+            };
+            if let Some(type_param_node) = self.ctx.arena.get(infer_data.type_parameter)
+                && let Some(type_param) = self.ctx.arena.get_type_parameter(type_param_node)
+                && let Some(name_node) = self.ctx.arena.get(type_param.name)
+                && let Some(identifier) = self.ctx.arena.get_identifier(name_node)
+                && identifier.escaped_text == name
+            {
+                return true;
+            }
+            return self.type_node_contains_infer_binding_named(infer_data.type_parameter, name);
+        }
+        if node.kind == syntax_kind_ext::TYPE_PARAMETER
+            && let Some(type_param) = self.ctx.arena.get_type_parameter(node)
+        {
+            return (type_param.constraint != NodeIndex::NONE
+                && self.type_node_contains_infer_binding_named(type_param.constraint, name))
+                || (type_param.default != NodeIndex::NONE
+                    && self.type_node_contains_infer_binding_named(type_param.default, name));
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.type_node_contains_infer_binding_named(child_idx, name))
+    }
+
+    fn type_node_is_alias_type_parameter_ref(
+        &self,
+        alias_sid: tsz_binder::SymbolId,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let Some(name) = self.type_node_bare_reference_name(node_idx) else {
+            return false;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sid) else {
+            return false;
+        };
+        let Some(decl_idx) = symbol.primary_declaration() else {
+            return false;
+        };
+        let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+            return false;
+        };
+        let Some(alias) = self.ctx.arena.get_type_alias(decl_node) else {
+            return false;
+        };
+        alias.type_parameters.as_ref().is_some_and(|params| {
+            params.nodes.iter().copied().any(|param_idx| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|param_node| self.ctx.arena.get_type_parameter(param_node))
+                    .and_then(|param| self.ctx.arena.get(param.name))
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .is_some_and(|ident| ident.escaped_text == name)
+            })
+        })
+    }
+
+    fn type_node_bare_reference_name(&self, node_idx: NodeIndex) -> Option<&str> {
+        let node = self.ctx.arena.get(node_idx)?;
+        if let Some(identifier) = self.ctx.arena.get_identifier(node) {
+            return Some(identifier.escaped_text.as_str());
+        }
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let type_ref = self.ctx.arena.get_type_ref(node)?;
+            if type_ref
+                .type_arguments
+                .as_ref()
+                .is_some_and(|args| !args.nodes.is_empty())
+            {
+                return None;
+            }
+            let name_node = self.ctx.arena.get(type_ref.type_name)?;
+            let identifier = self.ctx.arena.get_identifier(name_node)?;
+            return Some(identifier.escaped_text.as_str());
+        }
+        None
+    }
+}

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -73,6 +73,10 @@ serde_json = { workspace = true }
 name = "tsc_compat_tests"
 path = "tests/tsc_compat_tests.rs"
 
+[[test]]
+name = "recursive_defaulted_template_accumulator_tests"
+path = "tests/recursive_defaulted_template_accumulator_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/recursive_defaulted_template_accumulator_tests.rs
+++ b/crates/tsz-cli/tests/recursive_defaulted_template_accumulator_tests.rs
@@ -1,0 +1,93 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_recursive_accumulator_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn write_file(path: &Path, contents: &str) {
+    std::fs::write(path, contents).expect("write repro file");
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+#[test]
+fn recursive_defaulted_template_accumulator_reports_ts2589_at_use_site() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    let temp = TempDir::new("use_site").expect("temp dir");
+    write_file(
+        &temp.path.join("repro.ts"),
+        "type Grow<S extends string, A extends string = \"\"> = A extends infer X ? (X extends string ? Grow<S, `${A}${S}`> : never) : never;\ntype R = Grow<\"ab\">;\n",
+    );
+
+    let mut child = Command::new(tsz_bin)
+        .args(["repro.ts", "--noEmit", "--pretty", "false"])
+        .current_dir(&temp.path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn tsz repro");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().expect("poll tsz repro").is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child.wait_with_output().expect("collect killed tsz repro");
+            panic!(
+                "tsz should report TS2589 instead of hanging.\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let output = child.wait_with_output().expect("collect tsz repro output");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "tsz should reject the recursive accumulator repro.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        format!("{stdout}{stderr}").contains("repro.ts(2,10): error TS2589"),
+        "expected TS2589 at the concrete alias use site.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: recursive conditional/template/`infer` evaluation fuel (#9777)

## Invariant
When a recursive conditional alias is instantiated with concrete arguments and a defaulted accumulator grows through a computed template-literal argument, `tsc` reports TS2589 at the concrete alias use site; this PR makes tsz route that concrete use through the solver TS2589 probe while keeping bounded indexed-access descent such as `T[0]` finite.

## Scope
- Preserve alias type-parameter constraints/defaults when registering temporary TS2589 evaluation metadata.
- Detect recursive conditional aliases whose self-application contains computed, non-passthrough arguments.
- Exclude bounded indexed descent into alias type parameters from the aggressive recursive TS2589 probe.
- Split type-alias depth helper logic out of `type_alias_checking.rs` to keep source shards below the 2000-line limit.
- Add a focused CLI regression test with a timeout guard for the exact defaulted template accumulator repro.

## Owner Layer
Checker owns diagnostic location and concrete type-reference orchestration. Solver evaluation remains the owner of the TS2589 depth/growth decision.

## Adjacent Case Matrix
- Unused `Grow<S, A = "">` alias: accepted with no TS2589, matching `tsc`.
- Concrete `type R = Grow<"ab">`: reports TS2589 at `repro.ts(2,10)`, matching `tsc` location for this repro.
- Bounded indexed recursive conditionals such as `Test<T> = [T] extends [any[]] ? { array: Test<T[0]> } : { notArray: T }` do not emit TS2589.
- Pure passthrough recursive aliases such as bounded `infer R` patterns are not opted into the stronger concrete-use probe by this change.
- Existing circular mapped/tuple-too-large use-site handling remains on the prior path.

## Project Corpus Impact
- Row: n/a
- Bug family: recursive conditional/`infer` defaulted accumulator hang / missed TS2589 (#9777)
- Evidence: focused CLI regression test, focused checker bounded-recursion regression test, and focused conformance filter for `recursiveConditionalEvaluationNonInfinite`; no project corpus row is directly changed.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --test conditional_infer_tests bounded_recursive_conditional_alias_array_branch_no_ts2589`
- `cargo nextest run -p tsz-cli --test recursive_defaulted_template_accumulator_tests recursive_defaulted_template_accumulator_reports_ts2589_at_use_site`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter recursiveConditionalEvaluationNonInfinite --verbose`
- Earlier manual unused-alias CLI repro: exit 0 with no diagnostics.
- Earlier manual concrete-use CLI repro: exit 2 with `repro.ts(2,10): error TS2589`.

## Coordination Notes
- AgentName: M4-A
- Fixes #9777.
- Fresh worktree: `/Users/mohsen/code/tsz-m4a-9777-recursive-infer-fuel-20260526`.
- Branch: `codex/m4a-9777-recursive-infer-fuel-20260526`.
- Rebased onto `origin/main` at `5787824581` and pushed head `c2bc226ca6b99b0ea67eb973d3769f2125f210d6`.
- Follow-up fixed ready-CI conformance aggregate regression on `recursiveConditionalEvaluationNonInfinite.ts`; auto-merge remains off for manager/queue-owner handling.
