### PR TITLE
fix(dts): surface mapped union call results

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -290,10 +290,31 @@ impl<'a> DeclarationEmitter<'a> {
                     reused_type_text.as_deref().is_some_and(|type_text| {
                         self.type_text_starts_with_function_local_type_alias(type_text)
                     });
+                let call_type_id = self.get_node_type_or_names(&[expr_idx]).filter(|type_id| {
+                    *type_id != tsz_solver::types::TypeId::ANY
+                        && *type_id != tsz_solver::types::TypeId::ERROR
+                });
+                if let Some(type_id) = call_type_id
+                    && self
+                        .inferred_declaration_mapped_constraint_surface(type_id)
+                        .is_some()
+                {
+                    let printed = self.print_type_id_for_inferred_declaration(type_id);
+                    if let Some(call) = self.arena.get_call_expr(expr_node) {
+                        if let Some((alias_name, module_specifier)) =
+                            self.call_receiver_default_import_alias(call.expression)
+                        {
+                            return Some(Self::rewrite_import_type_export_to_default_alias(
+                                &printed,
+                                &alias_name,
+                                &module_specifier,
+                            ));
+                        }
+                    }
+                    return Some(printed);
+                }
                 if reused_type_text.is_some()
-                    && let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
-                    && type_id != tsz_solver::types::TypeId::ANY
-                    && type_id != tsz_solver::types::TypeId::ERROR
+                    && let Some(type_id) = call_type_id
                     && (reused_type_uses_function_local_alias
                         || self.should_expand_named_application_for_inferred_declaration(type_id)
                         || self.type_contains_conditional_alias_application_for_inferred_emit(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -307,12 +307,22 @@ impl<'a> DeclarationEmitter<'a> {
         source_type_text: &str,
     ) -> (String, bool) {
         let (text, substituted_parameter_type_query) =
-            self.substitute_function_parameter_type_queries(func, source_type_text);
+            self.function_source_return_type_text_for_declaration_scope(func, source_type_text);
         let text = self.rewrite_returned_auto_accessor_parameter_unknowns(func, &text);
         let text = self.rewrite_returned_call_conditional_unknown_subject(func, &text);
         let text = self
             .expand_mapped_alias_index_conditional_text(self.arena, &text)
             .unwrap_or(text);
+        (text, substituted_parameter_type_query)
+    }
+
+    pub(in crate::declaration_emitter) fn function_source_return_type_text_for_declaration_scope(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        source_type_text: &str,
+    ) -> (String, bool) {
+        let (text, substituted_parameter_type_query) =
+            self.substitute_function_parameter_type_queries(func, source_type_text);
         let Some(ref type_params) = func.type_parameters else {
             return (text, substituted_parameter_type_query);
         };
@@ -333,6 +343,12 @@ impl<'a> DeclarationEmitter<'a> {
         func: &tsz_parser::parser::node::FunctionData,
         return_type_id: tsz_solver::types::TypeId,
     ) -> String {
+        if let Some(text) = self.function_body_declared_return_identifier_type_text(func) {
+            return self
+                .rewrite_current_source_named_import_type_text(&text)
+                .unwrap_or(text);
+        }
+
         let text = if let Some(ref type_params) = func.type_parameters
             && !type_params.nodes.is_empty()
         {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -1,8 +1,63 @@
 use super::DeclarationEmitter;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::construction::TypeInterner;
 
 static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
+
+fn first_function_declared_return_identifier_type_text(source: &str) -> Option<String> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+
+    parser.arena.nodes.iter().find_map(|node| {
+        (node.kind == syntax_kind_ext::FUNCTION_DECLARATION)
+            .then(|| parser.arena.get_function(node))
+            .flatten()
+            .and_then(|func| emitter.function_body_declared_return_identifier_type_text(func))
+    })
+}
+
+#[test]
+fn function_return_surface_reuses_returned_identifier_mapped_annotation() {
+    let text = first_function_declared_return_identifier_type_text(
+        r#"
+type PartialProperties<T, K extends keyof T> = Partial<Pick<T, K>>;
+export function sample<T extends { prop: string }>(a: T) {
+    const value: { [K in keyof PartialProperties<T, "prop">]: PartialProperties<T, "prop">[K]; } = null as any;
+    return value;
+}
+"#,
+    )
+    .expect("return identifier type text");
+
+    assert!(text.contains("[K in keyof PartialProperties<T, \"prop\">]"));
+    assert!(text.contains("PartialProperties<T, \"prop\">[K]"));
+}
+
+#[test]
+fn function_return_surface_reuses_renamed_returned_identifier_mapped_annotation() {
+    let text = first_function_declared_return_identifier_type_text(
+        r#"
+type Picked<U, Q extends keyof U> = Pick<U, Q>;
+export function sample<U extends { name: string }>(input: U) {
+    const value: { [Q in keyof Picked<U, "name">]: Picked<U, "name">[Q]; } = null as any;
+    return value;
+}
+"#,
+    )
+    .expect("return identifier type text");
+
+    assert!(text.contains("[Q in keyof Picked<U, \"name\">]"));
+    assert!(text.contains("Picked<U, \"name\">[Q]"));
+}
 
 #[test]
 fn simultaneous_word_replacement_does_not_rewrite_inserted_import_paths() {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -340,6 +340,32 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    pub(in crate::declaration_emitter) fn function_body_declared_return_identifier_type_text(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+    ) -> Option<String> {
+        if !func.body.is_some() || func.is_async || func.asterisk_token {
+            return None;
+        }
+        let returned_identifier = self.function_body_unique_return_identifier(func.body)?;
+        let type_text = self
+            .function_parameter_type_text(func, returned_identifier)
+            .or_else(|| self.returned_function_initializer_type_text(func, returned_identifier))
+            .or_else(|| {
+                let type_text =
+                    self.reference_declared_source_type_annotation_text(returned_identifier)?;
+                if let Some(type_id) = self.reference_declared_type_id(returned_identifier)
+                    && self.printed_type_uses_non_emittable_local_alias_root(&type_text)
+                {
+                    return Some(self.print_type_id_for_inferred_declaration(type_id));
+                }
+                Some(type_text)
+            })?;
+        let (type_text, _) =
+            self.function_source_return_type_text_for_declaration_scope(func, &type_text);
+        Some(type_text)
+    }
+
     pub(in crate::declaration_emitter) fn function_return_identifier_declared_type_id(
         &self,
         func: &tsz_parser::parser::node::FunctionData,

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -1052,7 +1052,17 @@ pub fn inferred_declaration_mapped_constraint_surface_with(
     let mapped_id = crate::mapped_type_id(db, type_id)?;
     let mapped = db.mapped_type(mapped_id);
     let source = crate::keyof_inner_type(db, mapped.constraint)?;
-    let source_param = crate::type_param_info(db, source)?;
+    let Some(source_param) = crate::type_param_info(db, source) else {
+        let source = evaluate(source);
+        if is_primitive_or_primitive_union_for_mapped_surface(db, source) {
+            return Some(source);
+        }
+        let evaluated = mapped_surface_with_optional_undefined(db, evaluate(type_id));
+        return (evaluated != type_id
+            && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_)))
+            && is_concrete_object_like_mapped_surface_source(db, evaluated))
+        .then_some(evaluated);
+    };
     let declared_constraint = source_param.constraint?;
     let constraint = evaluate(declared_constraint);
 
@@ -1083,8 +1093,60 @@ pub fn inferred_declaration_mapped_constraint_surface_with(
     {
         evaluated = sorted;
     }
+    evaluated = mapped_surface_with_optional_undefined(db, evaluated);
     (evaluated != type_id && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_))))
         .then_some(evaluated)
+}
+
+fn mapped_surface_with_optional_undefined(db: &dyn TypeDatabase, surface: TypeId) -> TypeId {
+    let Some(TypeData::Object(shape_id)) = db.lookup(surface) else {
+        return surface;
+    };
+    let shape = db.object_shape(shape_id);
+    let mut changed = false;
+    let mut properties = shape.properties.clone();
+    for prop in &mut properties {
+        if !prop.optional || super::type_includes_undefined(db, prop.type_id) {
+            continue;
+        }
+        let original_type = prop.type_id;
+        prop.type_id = db.union2(prop.type_id, TypeId::UNDEFINED);
+        if prop.write_type == original_type {
+            prop.write_type = prop.type_id;
+        }
+        changed = true;
+    }
+    if changed {
+        db.object_with_flags_and_symbol(properties, shape.flags, shape.symbol)
+    } else {
+        surface
+    }
+}
+
+fn is_concrete_object_like_mapped_surface_source(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(
+            TypeData::Object(_)
+            | TypeData::ObjectWithIndex(_)
+            | TypeData::Array(_)
+            | TypeData::Tuple(_)
+            | TypeData::Mapped(_)
+            | TypeData::Function(_)
+            | TypeData::Callable(_),
+        ) => true,
+        Some(TypeData::ReadonlyType(inner)) => {
+            is_concrete_object_like_mapped_surface_source(db, inner)
+        }
+        Some(TypeData::Intersection(list_id)) => db
+            .type_list(list_id)
+            .iter()
+            .copied()
+            .all(|member| is_concrete_object_like_mapped_surface_source(db, member)),
+        _ => false,
+    }
 }
 
 fn is_primitive_or_primitive_union_for_mapped_surface(

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -9,9 +9,7 @@
 
 use super::data::ExactLiteralPropertyKey;
 use crate::construction::TypeDatabase;
-use crate::types::{
-    IntrinsicKind, MappedModifier, MappedType, ObjectFlags, PropertyInfo, TypeData, TypeId,
-};
+use crate::types::{MappedModifier, PropertyInfo, TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::Atom;
 
@@ -1027,144 +1025,6 @@ pub fn evaluate_identity_mapped_passthrough(
     None
 }
 
-/// Return the public declaration surface for an inferred mapped type whose
-/// source is a constrained type parameter.
-///
-/// Declaration emit needs the type that `tsc` exposes for an inferred public
-/// variable, not the deferred implementation form `{ [K in keyof T]: ... }`
-/// when `T` only survives as a generic constraint. This query keeps that
-/// reduction structural: primitive constraints pass through, while object-like
-/// constraints are substituted into the mapped source and evaluated normally.
-pub fn inferred_declaration_mapped_constraint_surface(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> Option<TypeId> {
-    inferred_declaration_mapped_constraint_surface_with(db, type_id, |ty| {
-        crate::evaluation::evaluate::evaluate_type(db, ty)
-    })
-}
-
-pub fn inferred_declaration_mapped_constraint_surface_with(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-    mut evaluate: impl FnMut(TypeId) -> TypeId,
-) -> Option<TypeId> {
-    let mapped_id = crate::mapped_type_id(db, type_id)?;
-    let mapped = db.mapped_type(mapped_id);
-    let source = crate::keyof_inner_type(db, mapped.constraint)?;
-    let Some(source_param) = crate::type_param_info(db, source) else {
-        let source = evaluate(source);
-        if is_primitive_or_primitive_union_for_mapped_surface(db, source) {
-            return Some(source);
-        }
-        let evaluated = mapped_surface_with_optional_undefined(db, evaluate(type_id));
-        return (evaluated != type_id
-            && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_)))
-            && is_concrete_object_like_mapped_surface_source(db, evaluated))
-        .then_some(evaluated);
-    };
-    let declared_constraint = source_param.constraint?;
-    let constraint = evaluate(declared_constraint);
-
-    if is_primitive_or_primitive_union_for_mapped_surface(db, constraint) {
-        return Some(constraint);
-    }
-    if is_number_wrapper_display_source(db, declared_constraint, constraint) {
-        db.store_display_alias(constraint, declared_constraint);
-    }
-
-    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_preserving};
-
-    let subst = TypeSubstitution::single(source_param.name, constraint);
-    let substituted = MappedType {
-        type_param: mapped.type_param,
-        constraint: instantiate_type_preserving(db, mapped.constraint, &subst),
-        name_type: mapped
-            .name_type
-            .map(|name_type| instantiate_type_preserving(db, name_type, &subst)),
-        template: instantiate_type_preserving(db, mapped.template, &subst),
-        readonly_modifier: mapped.readonly_modifier,
-        optional_modifier: mapped.optional_modifier,
-    };
-    let substituted_type = db.mapped(substituted);
-    let mut evaluated = evaluate(substituted_type);
-    if let Some(sorted) =
-        sort_number_wrapper_surface_object(db, declared_constraint, constraint, evaluated)
-    {
-        evaluated = sorted;
-    }
-    evaluated = mapped_surface_with_optional_undefined(db, evaluated);
-    (evaluated != type_id && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_))))
-        .then_some(evaluated)
-}
-
-fn mapped_surface_with_optional_undefined(db: &dyn TypeDatabase, surface: TypeId) -> TypeId {
-    let Some(TypeData::Object(shape_id)) = db.lookup(surface) else {
-        return surface;
-    };
-    let shape = db.object_shape(shape_id);
-    let mut changed = false;
-    let mut properties = shape.properties.clone();
-    for prop in &mut properties {
-        if !prop.optional || super::type_includes_undefined(db, prop.type_id) {
-            continue;
-        }
-        let original_type = prop.type_id;
-        prop.type_id = db.union2(prop.type_id, TypeId::UNDEFINED);
-        if prop.write_type == original_type {
-            prop.write_type = prop.type_id;
-        }
-        changed = true;
-    }
-    if changed {
-        db.object_with_flags_and_symbol(properties, shape.flags, shape.symbol)
-    } else {
-        surface
-    }
-}
-
-fn is_concrete_object_like_mapped_surface_source(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    if type_id.is_intrinsic() {
-        return false;
-    }
-    match db.lookup(type_id) {
-        Some(
-            TypeData::Object(_)
-            | TypeData::ObjectWithIndex(_)
-            | TypeData::Array(_)
-            | TypeData::Tuple(_)
-            | TypeData::Mapped(_)
-            | TypeData::Function(_)
-            | TypeData::Callable(_),
-        ) => true,
-        Some(TypeData::ReadonlyType(inner)) => {
-            is_concrete_object_like_mapped_surface_source(db, inner)
-        }
-        Some(TypeData::Intersection(list_id)) => db
-            .type_list(list_id)
-            .iter()
-            .copied()
-            .all(|member| is_concrete_object_like_mapped_surface_source(db, member)),
-        _ => false,
-    }
-}
-
-fn is_primitive_or_primitive_union_for_mapped_surface(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> bool {
-    if crate::is_primitive_type(db, type_id) {
-        return true;
-    }
-    let Some(TypeData::Union(list_id)) = db.lookup(type_id) else {
-        return false;
-    };
-    db.type_list(list_id)
-        .iter()
-        .copied()
-        .all(|member| crate::is_primitive_type(db, member))
-}
-
 /// Check if a mapped type's template is callable (has call/construct signatures).
 ///
 /// This is used for TS2344 constraint checking: when an indexed access into a
@@ -1607,7 +1467,7 @@ pub fn sort_homomorphic_source_properties_for_display(
     resolved_source: TypeId,
     props: &mut [PropertyInfo],
 ) {
-    if sort_number_wrapper_properties_for_display(db, source, resolved_source, props) {
+    if super::sort_number_wrapper_properties_for_display(db, source, resolved_source, props) {
         return;
     }
 
@@ -1628,85 +1488,6 @@ pub fn sort_homomorphic_source_properties_for_display(
     } else if props.iter().any(|prop| prop.declaration_order != 0) {
         props.sort_by_key(|prop| prop.declaration_order);
     }
-}
-
-pub fn sort_number_wrapper_properties_for_display(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    resolved_source: TypeId,
-    props: &mut [PropertyInfo],
-) -> bool {
-    if !is_number_wrapper_display_source(db, source, resolved_source) {
-        return false;
-    }
-    if props.len() == 6
-        && props
-            .iter()
-            .all(|prop| number_wrapper_rank(db, prop.name).is_some())
-    {
-        props.sort_by_key(|prop| number_wrapper_rank(db, prop.name));
-        for (index, prop) in props.iter_mut().enumerate() {
-            prop.declaration_order = (index + 1) as u32;
-        }
-        return true;
-    }
-    false
-}
-
-fn sort_number_wrapper_surface_object(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    resolved_source: TypeId,
-    type_id: TypeId,
-) -> Option<TypeId> {
-    let Some(TypeData::Object(shape_id)) = db.lookup(type_id) else {
-        return None;
-    };
-    let mut props = db.object_shape(shape_id).properties.clone();
-    sort_number_wrapper_properties_for_display(db, source, resolved_source, &mut props)
-        .then(|| db.object_with_flags(props, ObjectFlags::PRESERVE_DECLARATION_ORDER))
-}
-
-fn is_number_wrapper_display_source(
-    db: &dyn TypeDatabase,
-    source: TypeId,
-    resolved_source: TypeId,
-) -> bool {
-    is_number_wrapper_type_id(db, source)
-        || is_number_wrapper_type_id(db, resolved_source)
-        || db
-            .get_display_alias(source)
-            .is_some_and(|alias| is_number_wrapper_type_id(db, alias))
-        || db
-            .get_display_alias(resolved_source)
-            .is_some_and(|alias| is_number_wrapper_type_id(db, alias))
-}
-
-fn is_number_wrapper_type_id(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    db.get_boxed_type(IntrinsicKind::Number) == Some(type_id)
-        || matches!(
-            db.lookup(type_id),
-            Some(TypeData::Lazy(def_id)) if db.is_boxed_def_id(def_id, IntrinsicKind::Number)
-        )
-        || match db.lookup(type_id) {
-            Some(TypeData::Application(app_id)) => {
-                is_number_wrapper_type_id(db, db.type_application(app_id).base)
-            }
-            _ => false,
-        }
-}
-
-fn number_wrapper_rank(db: &dyn TypeDatabase, name: Atom) -> Option<usize> {
-    ([
-        "toString",
-        "toFixed",
-        "toExponential",
-        "toPrecision",
-        "valueOf",
-        "toLocaleString",
-    ])
-    .iter()
-    .position(|candidate| db.resolve_atom_ref(name).as_ref() == *candidate)
 }
 
 pub fn collect_homomorphic_source_properties(

--- a/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
+++ b/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
@@ -1,0 +1,222 @@
+//! Public declaration surfaces for mapped types.
+
+use crate::construction::TypeDatabase;
+use crate::types::{IntrinsicKind, MappedType, ObjectFlags, PropertyInfo, TypeData, TypeId};
+use tsz_common::Atom;
+
+/// Return the public declaration surface for an inferred mapped type whose
+/// source is a constrained type parameter.
+///
+/// Declaration emit needs the type that `tsc` exposes for an inferred public
+/// variable, not the deferred implementation form `{ [K in keyof T]: ... }`
+/// when `T` only survives as a generic constraint. This query keeps that
+/// reduction structural: primitive constraints pass through, while object-like
+/// constraints are substituted into the mapped source and evaluated normally.
+pub fn inferred_declaration_mapped_constraint_surface(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    inferred_declaration_mapped_constraint_surface_with(db, type_id, |ty| {
+        crate::evaluation::evaluate::evaluate_type(db, ty)
+    })
+}
+
+pub fn inferred_declaration_mapped_constraint_surface_with(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    mut evaluate: impl FnMut(TypeId) -> TypeId,
+) -> Option<TypeId> {
+    let mapped_id = crate::mapped_type_id(db, type_id)?;
+    let mapped = db.mapped_type(mapped_id);
+    let source = crate::keyof_inner_type(db, mapped.constraint)?;
+    let Some(source_param) = crate::type_param_info(db, source) else {
+        let source = evaluate(source);
+        if is_primitive_or_primitive_union_for_mapped_surface(db, source) {
+            return Some(source);
+        }
+        let evaluated = mapped_surface_with_optional_undefined(db, evaluate(type_id));
+        return (evaluated != type_id
+            && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_)))
+            && is_concrete_object_like_mapped_surface_source(db, evaluated))
+        .then_some(evaluated);
+    };
+    let declared_constraint = source_param.constraint?;
+    let constraint = evaluate(declared_constraint);
+
+    if is_primitive_or_primitive_union_for_mapped_surface(db, constraint) {
+        return Some(constraint);
+    }
+    if is_number_wrapper_display_source(db, declared_constraint, constraint) {
+        db.store_display_alias(constraint, declared_constraint);
+    }
+
+    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_preserving};
+
+    let subst = TypeSubstitution::single(source_param.name, constraint);
+    let substituted = MappedType {
+        type_param: mapped.type_param,
+        constraint: instantiate_type_preserving(db, mapped.constraint, &subst),
+        name_type: mapped
+            .name_type
+            .map(|name_type| instantiate_type_preserving(db, name_type, &subst)),
+        template: instantiate_type_preserving(db, mapped.template, &subst),
+        readonly_modifier: mapped.readonly_modifier,
+        optional_modifier: mapped.optional_modifier,
+    };
+    let substituted_type = db.mapped(substituted);
+    let mut evaluated = evaluate(substituted_type);
+    if let Some(sorted) =
+        sort_number_wrapper_surface_object(db, declared_constraint, constraint, evaluated)
+    {
+        evaluated = sorted;
+    }
+    evaluated = mapped_surface_with_optional_undefined(db, evaluated);
+    (evaluated != type_id && !matches!(db.lookup(evaluated), Some(TypeData::Mapped(_))))
+        .then_some(evaluated)
+}
+
+fn mapped_surface_with_optional_undefined(db: &dyn TypeDatabase, surface: TypeId) -> TypeId {
+    let Some(TypeData::Object(shape_id)) = db.lookup(surface) else {
+        return surface;
+    };
+    let shape = db.object_shape(shape_id);
+    let mut changed = false;
+    let mut properties = shape.properties.clone();
+    for prop in &mut properties {
+        if !prop.optional || super::type_includes_undefined(db, prop.type_id) {
+            continue;
+        }
+        let original_type = prop.type_id;
+        prop.type_id = db.union2(prop.type_id, TypeId::UNDEFINED);
+        if prop.write_type == original_type {
+            prop.write_type = prop.type_id;
+        }
+        changed = true;
+    }
+    if changed {
+        db.object_with_flags_and_symbol(properties, shape.flags, shape.symbol)
+    } else {
+        surface
+    }
+}
+
+fn is_concrete_object_like_mapped_surface_source(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(
+            TypeData::Object(_)
+            | TypeData::ObjectWithIndex(_)
+            | TypeData::Array(_)
+            | TypeData::Tuple(_)
+            | TypeData::Mapped(_)
+            | TypeData::Function(_)
+            | TypeData::Callable(_),
+        ) => true,
+        Some(TypeData::ReadonlyType(inner)) => {
+            is_concrete_object_like_mapped_surface_source(db, inner)
+        }
+        Some(TypeData::Intersection(list_id)) => db
+            .type_list(list_id)
+            .iter()
+            .copied()
+            .all(|member| is_concrete_object_like_mapped_surface_source(db, member)),
+        _ => false,
+    }
+}
+
+fn is_primitive_or_primitive_union_for_mapped_surface(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    if crate::is_primitive_type(db, type_id) {
+        return true;
+    }
+    let Some(TypeData::Union(list_id)) = db.lookup(type_id) else {
+        return false;
+    };
+    db.type_list(list_id)
+        .iter()
+        .copied()
+        .all(|member| crate::is_primitive_type(db, member))
+}
+
+pub fn sort_number_wrapper_properties_for_display(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    resolved_source: TypeId,
+    props: &mut [PropertyInfo],
+) -> bool {
+    if !is_number_wrapper_display_source(db, source, resolved_source) {
+        return false;
+    }
+    if props.len() == 6
+        && props
+            .iter()
+            .all(|prop| number_wrapper_rank(db, prop.name).is_some())
+    {
+        props.sort_by_key(|prop| number_wrapper_rank(db, prop.name));
+        for (index, prop) in props.iter_mut().enumerate() {
+            prop.declaration_order = (index + 1) as u32;
+        }
+        return true;
+    }
+    false
+}
+
+fn sort_number_wrapper_surface_object(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    resolved_source: TypeId,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let Some(TypeData::Object(shape_id)) = db.lookup(type_id) else {
+        return None;
+    };
+    let mut props = db.object_shape(shape_id).properties.clone();
+    sort_number_wrapper_properties_for_display(db, source, resolved_source, &mut props)
+        .then(|| db.object_with_flags(props, ObjectFlags::PRESERVE_DECLARATION_ORDER))
+}
+
+fn is_number_wrapper_display_source(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    resolved_source: TypeId,
+) -> bool {
+    is_number_wrapper_type_id(db, source)
+        || is_number_wrapper_type_id(db, resolved_source)
+        || db
+            .get_display_alias(source)
+            .is_some_and(|alias| is_number_wrapper_type_id(db, alias))
+        || db
+            .get_display_alias(resolved_source)
+            .is_some_and(|alias| is_number_wrapper_type_id(db, alias))
+}
+
+fn is_number_wrapper_type_id(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    db.get_boxed_type(IntrinsicKind::Number) == Some(type_id)
+        || matches!(
+            db.lookup(type_id),
+            Some(TypeData::Lazy(def_id)) if db.is_boxed_def_id(def_id, IntrinsicKind::Number)
+        )
+        || match db.lookup(type_id) {
+            Some(TypeData::Application(app_id)) => {
+                is_number_wrapper_type_id(db, db.type_application(app_id).base)
+            }
+            _ => false,
+        }
+}
+
+fn number_wrapper_rank(db: &dyn TypeDatabase, name: Atom) -> Option<usize> {
+    ([
+        "toString",
+        "toFixed",
+        "toExponential",
+        "toPrecision",
+        "valueOf",
+        "toLocaleString",
+    ])
+    .iter()
+    .position(|candidate| db.resolve_atom_ref(name).as_ref() == *candidate)
+}

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -35,6 +35,7 @@ pub mod extended_constructors;
 pub mod flow;
 pub mod iterable;
 pub mod mapped;
+pub mod mapped_declaration_surface;
 pub mod shape_queries;
 pub mod traversal;
 
@@ -91,6 +92,7 @@ pub use data::*;
 pub use flow::*;
 pub use iterable::*;
 pub use mapped::*;
+pub use mapped_declaration_surface::*;
 pub use shape_queries::*;
 pub use traversal::*;
 

--- a/crates/tsz-solver/tests/inferred_declaration_mapped_surface_tests.rs
+++ b/crates/tsz-solver/tests/inferred_declaration_mapped_surface_tests.rs
@@ -1,7 +1,8 @@
 use crate::construction::TypeInterner;
 use crate::def::DefId;
 use crate::types::{
-    IntrinsicKind, MappedType, ObjectFlags, PropertyInfo, TypeData, TypeId, TypeParamInfo,
+    IntrinsicKind, MappedModifier, MappedType, ObjectFlags, PropertyInfo, TypeData, TypeId,
+    TypeParamInfo,
 };
 
 #[test]
@@ -91,6 +92,56 @@ fn inferred_declaration_mapped_constraint_surface_expands_object_constraint() {
         .expect("expected b property");
     assert_eq!(a_prop.type_id, TypeId::VOID);
     assert_eq!(b_prop.type_id, TypeId::VOID);
+}
+
+#[test]
+fn inferred_declaration_mapped_constraint_surface_expands_concrete_object_source() {
+    let interner = TypeInterner::new();
+    let key_name = interner.intern_string("Property");
+    let prop_name = interner.intern_string("prop");
+    let source = interner.object(vec![PropertyInfo::new(prop_name, TypeId::STRING)]);
+    let key_param = interner.type_param(TypeParamInfo {
+        name: key_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    });
+
+    let mapped = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: key_name,
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        constraint: interner.keyof(source),
+        name_type: None,
+        template: interner.index_access(source, key_param),
+        readonly_modifier: None,
+        optional_modifier: Some(MappedModifier::Add),
+    });
+
+    let surface =
+        crate::type_queries::inferred_declaration_mapped_constraint_surface(&interner, mapped)
+            .expect("concrete object source should produce a public surface");
+    let Some(TypeData::Object(shape_id)) = interner.lookup(surface) else {
+        panic!(
+            "expected object surface, got {:?}",
+            interner.lookup(surface)
+        );
+    };
+    let shape = interner.object_shape(shape_id);
+    assert_eq!(shape.properties.len(), 1);
+    let prop = shape
+        .properties
+        .iter()
+        .find(|prop| prop.name == prop_name)
+        .expect("expected prop property");
+    assert!(prop.optional);
+    assert_eq!(
+        prop.type_id,
+        interner.union2(TypeId::STRING, TypeId::UNDEFINED)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit / emit-DTS parity through solver-owned public mapped surfaces.

## Invariant
When an exported declaration infers a public type from a homomorphic mapped return surface over a concrete/evaluable object source, `tsc` emits the evaluated object surface with inexact optional properties including `undefined`; this PR makes tsz route the returned-local and call-initializer paths through the solver mapped-surface boundary instead of reusing deferred mapped/indexed source text.

## Scope
- Reuse explicit returned-local annotations for source-annotated function return surfaces.
- Extend `inferred_declaration_mapped_constraint_surface` to handle concrete/evaluable mapped sources, including optional-property `undefined` on the public surface.
- Prefer that mapped public surface for call-expression initializer declarations before falling back to reconstructed source return text.
- Add focused solver coverage for concrete object mapped surfaces and keep the existing returned-local emitter coverage.

## Project Corpus Impact
- Row: `mappedTypeUnionConstraintInferences`
- Bug family: mapped/indexed DTS public surfaces for returned locals and exported call-initializer variables
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeUnionConstraintInferences --dts-only --verbose --concurrency=1 --timeout=30000 --json-out=/tmp/studio-d-mapped-union-after-main-rebase-split.json` passes `1/1` on rebased head `4f920a1434` after #10275 and #10326 landed on `main`.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver inferred_declaration_mapped` (7 passed on current-main rebased head)
- `cargo nextest run -p tsz-emitter function_return_surface_reuses` (2 passed on current-main rebased head)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypeUnionConstraintInferences --dts-only --verbose --concurrency=1 --timeout=30000 --json-out=/tmp/studio-d-mapped-union-after-main-rebase-split.json` (1 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypes1 --dts-only --verbose --concurrency=1 --timeout=30000 --json-out=/tmp/studio-d-mapped-types1-after-concrete-source.json`
- `git diff --check`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter mappedTypeWithAsClauseAndLateBoundProperty --verbose` (2/2 passed; 1 JS cache skip)

## Coordination Notes
- AgentName: Studio-D
- Retargeted to `main` by Studio-D on 2026-05-27 after #10275 landed; #10346 remains stacked on this branch.
- Replayed the two #10312-specific commits onto `origin/main` `93568cdd80`, then split mapped declaration-surface queries into `crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs` so `mapped.rs` is 1875 lines on head `4f920a1434`.
- File-size blocker addressed: `crates/tsz-solver/src/type_queries/mapped.rs` is below the 2000-line ceiling; no allowlist or ceiling was added.
- The row passes locally for both the `doSomething_Actual` function return and the exported `a`/`b` call-initializer variables.
- Checker diagnostics are unaffected: this changes declaration emit type selection and a solver declaration-surface query, not checker relation/diagnostic behavior.
- No output-string semantic decision was added; optional `undefined` is represented in the solver `TypeId` surface before declaration printing.
- Marked ready by Studio-D on 2026-05-27 at `4f920a1434` after syncing to `origin/main` `93568cdd80`, addressing the mapped.rs file-size blocker, and rerunning focused solver/emitter tests. Ready-review CI passed on head `4f920a1434`; Studio-D added `merge-queue` on 2026-05-27 per the live intake rule. Auto-merge remains off.



