### PR TITLE
fix(checker): resolve ambient module star exports

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/import_member_export_aliases.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_member_export_aliases.rs
@@ -443,6 +443,10 @@ impl<'a> CheckerState<'a> {
             if let Some(exports) = self
                 .ctx
                 .module_exports_for_module(source_binder, source_file_name)
+                .or_else(|| {
+                    self.ctx
+                        .module_exports_for_module(source_binder, source_module)
+                })
                 && exports.has(export_name)
             {
                 return true;

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -4,6 +4,7 @@
 //! `type_resolution/constructors.rs`.
 
 mod interop;
+mod reexports;
 
 use crate::module_resolution::module_specifier_candidates;
 use crate::state::CheckerState;
@@ -831,149 +832,6 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    /// Follow re-export chains across binder boundaries to find an exported symbol.
-    /// Returns the `SymbolId` if the export is found via named or wildcard re-exports.
-    /// Follow re-export chains across binder boundaries to find an exported symbol.
-    /// Returns `(SymbolId, file_idx)` where `file_idx` is the actual file that owns
-    /// the symbol, so callers can record the correct cross-file origin.
-    pub(crate) fn resolve_export_in_file(
-        &self,
-        file_idx: usize,
-        export_name: &str,
-        visited: &mut rustc_hash::FxHashSet<usize>,
-    ) -> Option<(tsz_binder::SymbolId, usize)> {
-        if !visited.insert(file_idx) {
-            return None; // Cycle detection
-        }
-
-        let target_binder = self.ctx.get_binder_for_file(file_idx)?;
-
-        let target_arena = self.ctx.get_arena_for_file(file_idx as u32);
-        let target_file_name = target_arena.source_files.first()?.file_name.clone();
-
-        // Files with an unambiguous ESM extension (.mjs/.mts/.d.mts) generally
-        // do not synthesize a `default` export from `export =`, because
-        // `export =` is a syntax error in ESM (TS1203). `module: preserve` is
-        // the exception: it permits CJS and ESM syntax side-by-side and tsc
-        // treats `export =` as the default-import target there.
-        let target_is_explicit_esm = {
-            let n = target_file_name.as_str();
-            n.ends_with(".mjs") || n.ends_with(".mts")
-        };
-        let default_skips_export_equals = export_name == "default"
-            && (target_is_explicit_esm || self.source_file_idx_is_js_with_esm_syntax(file_idx))
-            && self.ctx.compiler_options.module != tsz_common::common::ModuleKind::Preserve;
-
-        // Check direct exports (module_exports)
-        if let Some(exports) = self
-            .ctx
-            .module_exports_for_module(target_binder, &target_file_name)
-        {
-            let sym_id = if default_skips_export_equals {
-                exports
-                    .get("default")
-                    .filter(|id| target_binder.get_symbol(*id).is_some())
-            } else {
-                self.resolve_export_from_table(target_binder, exports, export_name)
-            };
-            if let Some(sym_id) = sym_id {
-                return Some((sym_id, file_idx));
-            }
-        }
-
-        // Check named re-exports before file_locals so that
-        // `export { X } from './other'` is resolved through the chain.
-        if let Some(reexports) = self
-            .ctx
-            .reexports_for_file(target_binder, &target_file_name)
-            && let Some((source_module, original_name)) = reexports.get(export_name)
-        {
-            let name = original_name.as_deref().unwrap_or(export_name);
-            if let Some(source_idx) = self
-                .ctx
-                .resolve_import_target_from_file(file_idx, source_module)
-                && let Some(result) = self.resolve_export_in_file(source_idx, name, visited)
-            {
-                return Some(result);
-            }
-        }
-
-        // Check wildcard re-exports before file_locals so that
-        // `export * from './other'` is followed to the actual declaring file.
-        // file_locals may contain merged globals that shadow re-exported symbols.
-        if let Some(source_modules) = self
-            .ctx
-            .wildcard_reexports_for_file(target_binder, &target_file_name)
-        {
-            let source_modules = source_modules.clone();
-            for source_module in &source_modules {
-                if let Some(source_idx) = self
-                    .ctx
-                    .resolve_import_target_from_file(file_idx, source_module)
-                    && let Some(result) =
-                        self.resolve_export_in_file(source_idx, export_name, visited)
-                {
-                    return Some(result);
-                }
-            }
-        }
-
-        // Module augmentations should apply after direct exports and re-export chains,
-        // so an augmentation does not mask a concrete exported declaration.
-        if let Some((sym_id, augmenting_file_idx)) =
-            self.resolve_module_augmentation_export_for_file(file_idx, export_name)
-        {
-            return Some((sym_id, augmenting_file_idx));
-        }
-
-        // Last resort: check file_locals (for script files or binding edge cases
-        // where module_exports wasn't populated).
-        //
-        // IMPORTANT: Only use file_locals as a fallback when module_exports is
-        // empty or unavailable AND the target file is a script (not an external
-        // module). For real ES modules — files with `import`/`export` syntax or
-        // module file extensions like `.mts`/`.cts` — `file_locals` may hold
-        // imported aliases (`import x from "./other"`) that are NOT part of the
-        // module's public surface. Returning those here would let
-        // `import * as ns from "./self"` see the file's local imports through
-        // `ns.x`, which `tsc` rejects with TS2339 (issue #3585).
-        let has_module_exports = self
-            .ctx
-            .module_exports_for_module(target_binder, &target_file_name)
-            .is_some_and(|e| !e.is_empty());
-        if has_module_exports {
-            return None;
-        }
-        if target_binder.is_external_module {
-            return None;
-        }
-        // When looking for "default" and the module has `export =`, prefer the
-        // `export =` target over a static member named "default". ESM-extension
-        // files never synthesize this fallback (see note above).
-        if export_name == "default"
-            && !default_skips_export_equals
-            && let Some(sym_id) = target_binder.file_locals.get("export=")
-        {
-            return Some((sym_id, file_idx));
-        }
-        if let Some(sym_id) = target_binder.file_locals.get(export_name) {
-            // Symbol found in file_locals — verify it has a runtime value.
-            // Type-only imports (e.g., `import type * as X from 'mod'`) may
-            // populate file_locals with individual namespace members, but those
-            // members should not be returned as value exports.
-            let has_value = target_binder
-                .get_symbol(sym_id)
-                .is_some_and(|s| !s.is_type_only);
-            if !has_value {
-                // Don't return type-only members as value exports
-            } else {
-                return Some((sym_id, file_idx));
-            }
-        }
-
-        None
-    }
-
     /// Resolve a namespace import (import * as ns) from another file using cross-file resolution.
     ///
     /// Returns a `SymbolTable` containing all exports from the target module.
@@ -1058,7 +916,12 @@ impl<'a> CheckerState<'a> {
                 );
             }
             let mut visited = rustc_hash::FxHashSet::default();
-            self.collect_reexported_symbols(target_file_idx, &mut combined, &mut visited);
+            self.collect_reexported_symbols(
+                target_file_idx,
+                Some(module_specifier),
+                &mut combined,
+                &mut visited,
+            );
             self.merge_module_augmentation_namespace_exports(
                 &mut combined,
                 target_file_idx,
@@ -1086,7 +949,12 @@ impl<'a> CheckerState<'a> {
         if has_reexports {
             let mut combined = tsz_binder::SymbolTable::new();
             let mut visited = rustc_hash::FxHashSet::default();
-            self.collect_reexported_symbols(target_file_idx, &mut combined, &mut visited);
+            self.collect_reexported_symbols(
+                target_file_idx,
+                Some(module_specifier),
+                &mut combined,
+                &mut visited,
+            );
             self.merge_module_augmentation_namespace_exports(
                 &mut combined,
                 target_file_idx,
@@ -1144,7 +1012,12 @@ impl<'a> CheckerState<'a> {
             let mut combined = exports.clone();
             self.merge_export_equals_members(target_binder, exports, &mut combined);
             let mut visited = rustc_hash::FxHashSet::default();
-            self.collect_reexported_symbols(target_file_idx, &mut combined, &mut visited);
+            self.collect_reexported_symbols(
+                target_file_idx,
+                module_specifier,
+                &mut combined,
+                &mut visited,
+            );
             self.merge_module_augmentation_namespace_exports(
                 &mut combined,
                 target_file_idx,
@@ -1165,7 +1038,12 @@ impl<'a> CheckerState<'a> {
         if has_reexports {
             let mut combined = tsz_binder::SymbolTable::new();
             let mut visited = rustc_hash::FxHashSet::default();
-            self.collect_reexported_symbols(target_file_idx, &mut combined, &mut visited);
+            self.collect_reexported_symbols(
+                target_file_idx,
+                module_specifier,
+                &mut combined,
+                &mut visited,
+            );
             self.merge_module_augmentation_namespace_exports(
                 &mut combined,
                 target_file_idx,
@@ -1590,106 +1468,6 @@ impl<'a> CheckerState<'a> {
             return (expr_node.kind == SyntaxKind::ImportKeyword as u16).then_some(idx);
         }
         None
-    }
-
-    /// Collect all symbols reachable through re-export chains into the given `SymbolTable`.
-    fn collect_reexported_symbols(
-        &self,
-        file_idx: usize,
-        result: &mut tsz_binder::SymbolTable,
-        visited: &mut rustc_hash::FxHashSet<usize>,
-    ) {
-        if !visited.insert(file_idx) {
-            return; // Cycle detection
-        }
-
-        let Some(target_binder) = self.ctx.get_binder_for_file(file_idx) else {
-            return;
-        };
-        let Some(target_file_name) = self
-            .ctx
-            .get_arena_for_file(file_idx as u32)
-            .source_files
-            .first()
-            .map(|sf| sf.file_name.clone())
-        else {
-            return;
-        };
-
-        // Collect from wildcard re-exports (export * from './module')
-        if let Some(source_modules) = self
-            .ctx
-            .wildcard_reexports_for_file(target_binder, &target_file_name)
-        {
-            let source_modules = source_modules.clone();
-            // Get type-only flags for wildcard re-exports to skip `export type *` members
-            let type_only_flags = self
-                .ctx
-                .wildcard_reexports_type_only_for_file(target_binder, &target_file_name)
-                .cloned();
-            for (i, source_module) in source_modules.iter().enumerate() {
-                // Skip `export type * from '...'` — these exports should not appear as
-                // value properties on the namespace object. They are only accessible in
-                // type position via symbol-based resolution.
-                let is_type_only = type_only_flags
-                    .as_ref()
-                    .and_then(|flags| flags.get(i).map(|(_, is_to)| *is_to))
-                    .unwrap_or(false);
-                if is_type_only {
-                    continue;
-                }
-                if let Some(source_idx) = self
-                    .ctx
-                    .resolve_import_target_from_file(file_idx, source_module)
-                    && let Some(source_binder) = self.ctx.get_binder_for_file(source_idx)
-                {
-                    // Add all exports from the source module
-                    let source_file_name = self
-                        .ctx
-                        .get_arena_for_file(source_idx as u32)
-                        .source_files
-                        .first()
-                        .map(|sf| sf.file_name.clone());
-                    if let Some(source_file_name) = source_file_name
-                        && let Some(exports) = self
-                            .ctx
-                            .module_exports_for_module(source_binder, &source_file_name)
-                    {
-                        for (name, sym_id) in exports.iter() {
-                            if !result.has(name) {
-                                result.set(name.to_string(), *sym_id);
-                            }
-                        }
-                    }
-                    // Recursively collect from the source's re-exports
-                    self.collect_reexported_symbols(source_idx, result, visited);
-                }
-            }
-        }
-
-        // Collect from named re-exports (export { X } from './module')
-        if let Some(reexports) = self
-            .ctx
-            .reexports_for_file(target_binder, &target_file_name)
-        {
-            let reexports = reexports.clone();
-            for (exported_name, (source_module, original_name)) in &reexports {
-                if !result.has(exported_name) {
-                    let name = original_name.as_deref().unwrap_or(exported_name);
-                    if let Some(source_idx) = self
-                        .ctx
-                        .resolve_import_target_from_file(file_idx, source_module)
-                    {
-                        let mut inner_visited = visited.clone();
-                        if let Some((sym_id, _actual_file_idx)) =
-                            self.resolve_export_in_file(source_idx, name, &mut inner_visited)
-                        {
-                            result.set(exported_name.to_string(), sym_id);
-                        }
-                    }
-                }
-            }
-        }
     }
 
     /// Emit TS2307 error for a module that cannot be found.

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -1,0 +1,266 @@
+use crate::state::CheckerState;
+
+impl<'a> CheckerState<'a> {
+    /// Follow re-export chains across binder boundaries to find an exported symbol.
+    /// Returns `(SymbolId, file_idx)` where `file_idx` is the actual file that owns
+    /// the symbol, so callers can record the correct cross-file origin.
+    pub(crate) fn resolve_export_in_file(
+        &self,
+        file_idx: usize,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<usize>,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        self.resolve_export_in_file_with_module_key(file_idx, None, export_name, visited)
+    }
+
+    fn resolve_export_in_file_with_module_key(
+        &self,
+        file_idx: usize,
+        module_key: Option<&str>,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<usize>,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        if !visited.insert(file_idx) {
+            return None;
+        }
+
+        let target_binder = self.ctx.get_binder_for_file(file_idx)?;
+
+        let target_arena = self.ctx.get_arena_for_file(file_idx as u32);
+        let target_file_name = target_arena.source_files.first()?.file_name.clone();
+
+        // Files with an unambiguous ESM extension (.mjs/.mts/.d.mts) generally
+        // do not synthesize a `default` export from `export =`, because
+        // `export =` is a syntax error in ESM (TS1203). `module: preserve` is
+        // the exception: it permits CJS and ESM syntax side-by-side and tsc
+        // treats `export =` as the default-import target there.
+        let target_is_explicit_esm = {
+            let n = target_file_name.as_str();
+            n.ends_with(".mjs") || n.ends_with(".mts")
+        };
+        let default_skips_export_equals = export_name == "default"
+            && (target_is_explicit_esm || self.source_file_idx_is_js_with_esm_syntax(file_idx))
+            && self.ctx.compiler_options.module != tsz_common::common::ModuleKind::Preserve;
+
+        if let Some(exports) = self
+            .ctx
+            .module_exports_for_module(target_binder, &target_file_name)
+            .or_else(|| {
+                module_key.and_then(|key| self.ctx.module_exports_for_module(target_binder, key))
+            })
+        {
+            let sym_id = if default_skips_export_equals {
+                exports
+                    .get("default")
+                    .filter(|id| target_binder.get_symbol(*id).is_some())
+            } else {
+                self.resolve_export_from_table(target_binder, exports, export_name)
+            };
+            if let Some(sym_id) = sym_id {
+                return Some((sym_id, file_idx));
+            }
+        }
+
+        if let Some(reexports) = self
+            .ctx
+            .reexports_for_file(target_binder, &target_file_name)
+            .or_else(|| module_key.and_then(|key| self.ctx.reexports_for_file(target_binder, key)))
+            && let Some((source_module, original_name)) = reexports.get(export_name)
+        {
+            let name = original_name.as_deref().unwrap_or(export_name);
+            if let Some(source_idx) = self
+                .ctx
+                .resolve_import_target_from_file(file_idx, source_module)
+                && let Some(result) = self.resolve_export_in_file_with_module_key(
+                    source_idx,
+                    Some(source_module),
+                    name,
+                    visited,
+                )
+            {
+                return Some(result);
+            }
+        }
+
+        // Check wildcard re-exports before file_locals so that
+        // `export * from './other'` is followed to the actual declaring file.
+        // file_locals may contain merged globals that shadow re-exported symbols.
+        if let Some(source_modules) = self
+            .ctx
+            .wildcard_reexports_for_file(target_binder, &target_file_name)
+            .or_else(|| {
+                module_key.and_then(|key| self.ctx.wildcard_reexports_for_file(target_binder, key))
+            })
+        {
+            let source_modules = source_modules.clone();
+            for source_module in &source_modules {
+                if let Some(source_idx) = self
+                    .ctx
+                    .resolve_import_target_from_file(file_idx, source_module)
+                    && let Some(result) = self.resolve_export_in_file_with_module_key(
+                        source_idx,
+                        Some(source_module),
+                        export_name,
+                        visited,
+                    )
+                {
+                    return Some(result);
+                }
+            }
+        }
+
+        // Module augmentations should apply after direct exports and re-export chains,
+        // so an augmentation does not mask a concrete exported declaration.
+        if let Some((sym_id, augmenting_file_idx)) =
+            self.resolve_module_augmentation_export_for_file(file_idx, export_name)
+        {
+            return Some((sym_id, augmenting_file_idx));
+        }
+
+        // Last resort: check file_locals only for script files or binding edge
+        // cases where module_exports was not populated. Real external modules
+        // must not leak local imports through their public surface.
+        let has_module_exports = self
+            .ctx
+            .module_exports_for_module(target_binder, &target_file_name)
+            .is_some_and(|e| !e.is_empty());
+        if has_module_exports || target_binder.is_external_module {
+            return None;
+        }
+        if export_name == "default"
+            && !default_skips_export_equals
+            && let Some(sym_id) = target_binder.file_locals.get("export=")
+        {
+            return Some((sym_id, file_idx));
+        }
+        if let Some(sym_id) = target_binder.file_locals.get(export_name) {
+            let has_value = target_binder
+                .get_symbol(sym_id)
+                .is_some_and(|s| !s.is_type_only);
+            if has_value {
+                return Some((sym_id, file_idx));
+            }
+        }
+
+        None
+    }
+
+    /// Collect all symbols reachable through re-export chains into the given `SymbolTable`.
+    pub(super) fn collect_reexported_symbols(
+        &self,
+        file_idx: usize,
+        module_key: Option<&str>,
+        result: &mut tsz_binder::SymbolTable,
+        visited: &mut rustc_hash::FxHashSet<usize>,
+    ) {
+        if !visited.insert(file_idx) {
+            return;
+        }
+
+        let Some(target_binder) = self.ctx.get_binder_for_file(file_idx) else {
+            return;
+        };
+        let Some(target_file_name) = self
+            .ctx
+            .get_arena_for_file(file_idx as u32)
+            .source_files
+            .first()
+            .map(|sf| sf.file_name.clone())
+        else {
+            return;
+        };
+
+        if let Some(source_modules) = self
+            .ctx
+            .wildcard_reexports_for_file(target_binder, &target_file_name)
+            .or_else(|| {
+                module_key.and_then(|key| self.ctx.wildcard_reexports_for_file(target_binder, key))
+            })
+        {
+            let source_modules = source_modules.clone();
+            let type_only_flags = self
+                .ctx
+                .wildcard_reexports_type_only_for_file(target_binder, &target_file_name)
+                .or_else(|| {
+                    module_key.and_then(|key| {
+                        self.ctx
+                            .wildcard_reexports_type_only_for_file(target_binder, key)
+                    })
+                })
+                .cloned();
+            for (i, source_module) in source_modules.iter().enumerate() {
+                let is_type_only = type_only_flags
+                    .as_ref()
+                    .and_then(|flags| flags.get(i).map(|(_, is_to)| *is_to))
+                    .unwrap_or(false);
+                if is_type_only {
+                    continue;
+                }
+                if let Some(source_idx) = self
+                    .ctx
+                    .resolve_import_target_from_file(file_idx, source_module)
+                    && let Some(source_binder) = self.ctx.get_binder_for_file(source_idx)
+                {
+                    let source_file_name = self
+                        .ctx
+                        .get_arena_for_file(source_idx as u32)
+                        .source_files
+                        .first()
+                        .map(|sf| sf.file_name.clone());
+                    if let Some(exports) = source_file_name
+                        .as_ref()
+                        .and_then(|file_name| {
+                            self.ctx.module_exports_for_module(source_binder, file_name)
+                        })
+                        .or_else(|| {
+                            self.ctx
+                                .module_exports_for_module(source_binder, source_module)
+                        })
+                    {
+                        for (name, sym_id) in exports.iter() {
+                            if !result.has(name) {
+                                result.set(name.to_string(), *sym_id);
+                            }
+                        }
+                    }
+                    self.collect_reexported_symbols(
+                        source_idx,
+                        Some(source_module),
+                        result,
+                        visited,
+                    );
+                }
+            }
+        }
+
+        if let Some(reexports) = self
+            .ctx
+            .reexports_for_file(target_binder, &target_file_name)
+            .or_else(|| module_key.and_then(|key| self.ctx.reexports_for_file(target_binder, key)))
+        {
+            let reexports = reexports.clone();
+            for (exported_name, (source_module, original_name)) in &reexports {
+                if !result.has(exported_name) {
+                    let name = original_name.as_deref().unwrap_or(exported_name);
+                    if let Some(source_idx) = self
+                        .ctx
+                        .resolve_import_target_from_file(file_idx, source_module)
+                    {
+                        let mut inner_visited = rustc_hash::FxHashSet::default();
+                        inner_visited.extend(visited.iter().copied());
+                        if let Some((sym_id, _actual_file_idx)) = self
+                            .resolve_export_in_file_with_module_key(
+                                source_idx,
+                                Some(source_module),
+                                name,
+                                &mut inner_visited,
+                            )
+                        {
+                            result.set(exported_name.to_string(), sym_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/tests/ambient_module_renamed_export_ts2460_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_renamed_export_ts2460_tests.rs
@@ -35,6 +35,8 @@ use tsz_checker::test_utils::check_multi_file;
 
 const TS2460: u32 = 2460;
 const TS2305: u32 = 2305;
+const TS2322: u32 = 2322;
+const TS2339: u32 = 2339;
 
 fn ambient_options() -> CheckerOptions {
     CheckerOptions {
@@ -506,5 +508,55 @@ const r: Orig = { v: 1 };
     assert!(
         !diags.iter().any(|(c, _)| *c == TS2460),
         "direct + renamed exports must keep TS2460 silenced; got {diags:#?}"
+    );
+}
+
+// ───────────────────── 9. ambient star re-export ───────────────────────────
+
+/// `export * from "inner"` inside an ambient external module should expose
+/// `inner`'s exported members through the re-exporting module.
+#[test]
+fn ambient_module_export_star_reexports_interface_members() {
+    let diags = diagnostics(
+        &[
+            (
+                "inner.d.ts",
+                r#"
+declare module "inner" {
+  export interface Data { id: number; }
+}
+"#,
+            ),
+            (
+                "outer.d.ts",
+                r#"
+declare module "outer" {
+  export * from "inner";
+}
+"#,
+            ),
+            (
+                "usestar.ts",
+                r#"
+import { Data } from "outer";
+const bad: Data = { id: "x" };
+const d: Data = { id: 1 };
+d.nope;
+"#,
+            ),
+        ],
+        "usestar.ts",
+    );
+    assert!(
+        !diags.iter().any(|(c, _)| *c == TS2305),
+        "ambient star re-export must make Data visible from outer; got {diags:#?}"
+    );
+    assert!(
+        diags.iter().any(|(c, _)| *c == TS2322),
+        "imported Data should preserve id: number and report TS2322; got {diags:#?}"
+    );
+    assert!(
+        diags.iter().any(|(c, _)| *c == TS2339),
+        "imported Data should preserve members and report TS2339; got {diags:#?}"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
M4-D: symbol/lib/module/DefId and cross-file stable identity.

## Invariant
When an ambient external module re-exports another ambient external module with `export * from "inner"`, `tsc` exposes the source module's exported members through the re-exporting module; this PR makes tsz do that through checker module export/re-export resolution while preserving the resolved source symbol identity for downstream diagnostics.

## Scope
- Carry the wildcard source module specifier through checker re-export traversal so ambient module export tables keyed by declared module name are visible.
- Apply the same file-key/module-specifier fallback to the TS2305 suppression path for named imports found through wildcard re-exports.
- Split recursive checker re-export traversal helpers into `crates/tsz-checker/src/state/type_resolution/module/reexports.rs` so the PR no longer grows oversized `module.rs`.
- Add a checker regression test for `declare module "outer" { export * from "inner"; }` importing an interface through `outer`.

## Project Corpus Impact
- Row: unknown / no project-corpus row identified for this focused ambient module repro
- Bug family: ambient external module wildcard re-export symbol resolution
- Evidence: issue #9771 minimal repro now has no false TS2305 and preserves `Data` enough to report TS2322/TS2339 in the focused checker test

## Verification
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-checker --test ambient_module_renamed_export_ts2460_tests ambient_module_export_star_reexports_interface_members`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-checker --test ambient_module_renamed_export_ts2460_tests`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- File-size evidence after the split: `module.rs` is 2596 lines on this head versus 2818 lines on `origin/main`; new `module/reexports.rs` is 266 lines

## Coordination Notes
- Fixes #9771.
- Addressed Reviewer ready-state blocker by converting back to draft, splitting the re-export traversal helpers out of oversized `module.rs`, and republishing head `37dc5b7ff783d0ca52c5ab47da94af0e2dda012a`.
- Full conformance/fourslash/emit suites intentionally not run locally per TSZ policy; ready-for-review CI owns those gates.
- Auto-merge intentionally left disabled.
