### PR TITLE
chore(arch): ratchet stale guard config

### DIFF
--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -3,119 +3,12 @@ import re
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-LINE_LIMIT_CHECKS = [
-    (
-        "Checker boundary: src files must stay under 2000 LOC",
-        ROOT / "crates" / "tsz-checker" / "src",
-        2000,
-        # Exclusion list pruned 2026-05-01: removed 15 entries for files
-        # that no longer exist (split or renamed) and 16 entries for files
-        # that have since dropped below 2000 lines.
-        #
-        # Refreshed 2026-05-12: removed entries that had since dropped below
-        # 2000 raw lines. The set below is the audited current set of files
-        # above 2000 raw lines.
-        {
-            # ≥2000 LOC, real files. When a file drops below the limit,
-            # delete it from this set in the same diff and the
-            # `test_excluded_files_actually_exceed_limit` test will catch
-            # any regression.
-            "crates/tsz-checker/src/assignability/assignability_checker.rs",
-            "crates/tsz-checker/src/assignability/assignability_diagnostics.rs",
-            "crates/tsz-checker/src/checkers/jsx/tests.rs",
-            "crates/tsz-checker/src/checkers/jsx/props/resolution.rs",
-            "crates/tsz-checker/src/classes/class_checker.rs",
-            "crates/tsz-checker/src/declarations/import/declaration.rs",
-            "crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs",
-            "crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs",
-            "crates/tsz-checker/src/error_reporter/properties.rs",
-            "crates/tsz-checker/src/flow/control_flow/core.rs",
-            "crates/tsz-checker/src/jsdoc/diagnostics.rs",
-            "crates/tsz-checker/src/jsdoc/params.rs",
-            "crates/tsz-checker/src/state/state_checking/class.rs",
-            "crates/tsz-checker/src/state/state_checking/property.rs",
-            "crates/tsz-checker/src/state/state_checking_members/interface_checks.rs",
-            "crates/tsz-checker/src/state/type_analysis/computed_helpers.rs",
-            "crates/tsz-checker/src/state/type_analysis/core.rs",
-            "crates/tsz-checker/src/state/type_environment/core.rs",
-            "crates/tsz-checker/src/state/type_resolution/module.rs",
-            "crates/tsz-checker/src/state/variable_checking/core.rs",
-            "crates/tsz-checker/src/state/variable_checking/destructuring.rs",
-            "crates/tsz-checker/src/tests/architecture_contract_tests.rs",
-            "crates/tsz-checker/src/tests/dispatch_tests.rs",
-            "crates/tsz-checker/src/types/class_type/constructor.rs",
-            "crates/tsz-checker/src/types/class_type/core.rs",
-            "crates/tsz-checker/src/types/computation/binary.rs",
-            "crates/tsz-checker/src/types/computation/call/inner.rs",
-            "crates/tsz-checker/src/types/computation/object_literal/computation.rs",
-            "crates/tsz-checker/src/types/function_type.rs",
-            "crates/tsz-checker/src/types/property_access_type/resolve.rs",
-            "crates/tsz-checker/src/types/queries/core.rs",
-            "crates/tsz-checker/src/types/queries/lib.rs",
-            "crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs",
-            "crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs",
-            "crates/tsz-checker/src/types/utilities/core.rs",
-            "crates/tsz-checker/src/types/utilities/enum_utils.rs",
-        },
-    ),
-    (
-        "Checker computation boundary: type-computation monoliths must stay below 3100 LOC (#8226)",
-        ROOT / "crates" / "tsz-checker" / "src" / "types" / "computation",
-        3100,
-    ),
-]
-
-FILE_LINE_LIMIT_CHECKS = [
-    (
-        "Core boundary: tsz-core lib facade must stay at current 365 LOC baseline",
-        ROOT / "crates" / "tsz-core" / "src" / "lib.rs",
-        365,
-    ),
-    (
-        "Checker query boundary: common quarantine must not grow (#8225)",
-        ROOT
-        / "crates"
-        / "tsz-checker"
-        / "src"
-        / "query_boundaries"
-        / "common.rs",
-        1920,
-    ),
-    (
-        "Solver engine boundary: generic call resolver must stay at current 3381 LOC baseline (#8209)",
-        ROOT
-        / "crates"
-        / "tsz-solver"
-        / "src"
-        / "operations"
-        / "generic_call"
-        / "resolve.rs",
-        3381,
-    ),
-    # Pin the async ES5 IR transformer file size while #8277 splits the
-    # monolith into staged lowering modules. The cap should ratchet down
-    # as more phases (helper scheduling, temp/hoist planning, suspended
-    # target lowering, ...) are extracted into sibling submodules.
-    (
-        "Emitter boundary: async ES5 IR engine size ratchet (#8277)",
-        ROOT
-        / "crates"
-        / "tsz-emitter"
-        / "src"
-        / "transforms"
-        / "async_es5_ir.rs",
-        5150,
-    ),
-]
-
 # Pin field counts on giant coordination structs so workstream-4 (Checker
 # State / Speculation) extraction work shows up as visible metric drift in
 # the diff.  Each entry: (description, file_path, struct_name, max_fields).
 #
-# When a field is added intentionally, bump the cap in the same PR.  This is
-# the same convention as `FILE_LINE_LIMIT_CHECKS` — it makes architecture
-# health metric drift visible at review time (Operating Principle 8 in
-# `docs/plan/ROADMAP.md`).
+# When a field is added intentionally, bump the cap in the same PR. This makes
+# architecture health metric drift visible at review time.
 STRUCT_FIELD_COUNT_CHECKS = [
     (
         "Checker boundary: CheckerContext field count (architecture health metric 1)",

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -241,19 +241,14 @@ LINE_LIMIT_CHECKS = [
             "crates/tsz-checker/src/assignability/assignability_checker.rs",
             "crates/tsz-checker/src/assignability/assignability_diagnostics.rs",
             "crates/tsz-checker/src/checkers/jsx/tests.rs",
-            "crates/tsz-checker/src/classes/class_checker.rs",
             "crates/tsz-checker/src/declarations/import/declaration.rs",
             "crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs",
-            "crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs",
             "crates/tsz-checker/src/error_reporter/properties.rs",
-            "crates/tsz-checker/src/error_reporter/render_failure.rs",
             "crates/tsz-checker/src/flow/control_flow/core.rs",
             "crates/tsz-checker/src/jsdoc/diagnostics.rs",
             "crates/tsz-checker/src/jsdoc/params.rs",
-            "crates/tsz-checker/src/state/state_checking/class.rs",
             "crates/tsz-checker/src/state/state_checking/property.rs",
             "crates/tsz-checker/src/state/state_checking_members/interface_checks.rs",
-            "crates/tsz-checker/src/state/type_analysis/computed_helpers.rs",
             "crates/tsz-checker/src/state/type_analysis/core.rs",
             "crates/tsz-checker/src/state/type_environment/core.rs",
             "crates/tsz-checker/src/state/type_resolution/module.rs",
@@ -263,16 +258,12 @@ LINE_LIMIT_CHECKS = [
             "crates/tsz-checker/src/tests/dispatch_tests.rs",
             "crates/tsz-checker/src/types/class_type/constructor.rs",
             "crates/tsz-checker/src/types/class_type/core.rs",
-            "crates/tsz-checker/src/types/computation/call/inner.rs",
-            "crates/tsz-checker/src/types/computation/call_inference.rs",
-            "crates/tsz-checker/src/types/computation/object_literal/computation.rs",
             "crates/tsz-checker/src/types/property_access_type/resolve.rs",
             "crates/tsz-checker/src/types/queries/core.rs",
             "crates/tsz-checker/src/types/queries/lib.rs",
             "crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs",
             "crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs",
             "crates/tsz-checker/src/types/utilities/core.rs",
-            "crates/tsz-checker/src/types/utilities/enum_utils.rs",
         },
     ),
     (
@@ -527,7 +518,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Refreshed #9852 on current main for contextual-wrapper excess-property
         # diagnostics; this records the merged live count.
-        3440,
+        #
+        # Ratcheted down after current-main guard tests caught slack in the
+        # live direct-reference count.
+        3337,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Architecture guardrail ratchet | launch evidence plumbing

## Invariant
When a guardrail cap or exclusion is no longer needed on current `main`, the architecture guard metadata should ratchet down to the live inventory instead of preserving stale slack or duplicate config.

## Scope
- `scripts/arch/arch_guard_config.py`
- `scripts/arch/arch_guard_shared.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture guard metadata only; no compiler, benchmark, emit, checker, solver, parser, binder, LSP, WASM, or project-corpus behavior changes.

## Verification
- `python3 scripts/arch/test_arch_guard.py`
- `python3 scripts/arch/test_arch_guard_project.py`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-config-ratchet.json`
- `python3 - <<'PY' ...` stale exclusion audit reported `stale_count 0` for the 2000 and 3100 LOC checks
- `git diff --check origin/main...HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Removes stale duplicate line-limit config from `arch_guard_config.py`; the live line-limit source remains `arch_guard_shared.py`, which is what `arch_guard.py` imports.
- Ratchets the checker 2000-line exclusion set after current-main files dropped below the cap, including the `binary.rs` family tracked by #10080.
- Ratchets the direct `query_boundaries::common` reference cap from `3440` to the current live count `3337` after focused guard tests caught slack.
- #10080 now has stronger evidence that both originally named files are below 2000 LOC on current `main`; this PR leaves issue closure to the merged evidence path.