### PR TITLE
test(solver): cover erase-generics relation cache agreement

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -34,8 +34,8 @@ use crate::relations::relation_queries::{
 };
 use crate::relations::subtype::AnyPropagationMode;
 use crate::types::{
-    CachedAnyMode, PropertyInfo, RelationCacheConfig, RelationCacheKey, RelationCacheKind,
-    RelationFlags,
+    CachedAnyMode, FunctionShape, PropertyInfo, RelationCacheConfig, RelationCacheKey,
+    RelationCacheKind, RelationFlags, TypeParamInfo,
 };
 
 /// Assert that two `RelationPolicy` configurations produce distinct
@@ -836,5 +836,105 @@ fn assignability_policy_flip_matches_uncached_relation_query() {
         )),
         Some(loose_uncached),
         "non-strict policy result must be stored under the non-strict policy-derived key",
+    );
+}
+
+#[test]
+fn assignability_cache_erase_generics_policy_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let target_t = TypeParamInfo {
+        name: interner.intern_string("Target"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let target_t_type = interner.type_param(target_t);
+    let source = interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![],
+        this_type: None,
+        return_type: target_t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let target = interner.function(FunctionShape {
+        type_params: vec![target_t],
+        params: vec![],
+        this_type: None,
+        return_type: target_t_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let erased = RelationPolicy::default().with_erase_generics(true);
+    let strict = RelationPolicy::default().with_erase_generics(false);
+    let erased_key = RelationCacheKey::for_assignability(source, target, erased.cache_config());
+    let strict_key = RelationCacheKey::for_assignability(source, target, strict.cache_config());
+
+    assert_ne!(
+        erased_key, strict_key,
+        "erased and strict generic-signature policies must occupy distinct cache slots",
+    );
+
+    let uncached_erased = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        erased,
+        RelationContext::default(),
+    );
+    let uncached_strict = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict,
+        RelationContext::default(),
+    );
+
+    assert!(
+        uncached_erased.is_related(),
+        "erased generic-signature compatibility should allow the relation",
+    );
+    assert!(
+        !uncached_strict.is_related(),
+        "strict member compatibility must not promote an outer type parameter into a generic signature",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict),
+        uncached_strict.is_related(),
+        "cached strict generic policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(uncached_strict.is_related()),
+        "strict generic result must be stored in the strict slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(erased_key),
+        None,
+        "erased-generic lookup must not hit the strict slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, erased),
+        uncached_erased.is_related(),
+        "cached erased generic policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(erased_key),
+        Some(uncached_erased.is_related()),
+        "erased generic result must be stored in the erased slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(uncached_strict.is_related()),
+        "strict generic slot must remain intact after the erased lookup",
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key cleanup for #8207.

## Invariant
When generic-signature erasure changes an assignability answer, the typed `QueryCache` policy path must match the uncached `query_relation` answer for that same `RelationPolicy` and must not reuse the opposite policy's cache slot.

## Scope
- Adds focused solver coverage in `crates/tsz-solver/tests/relation_cache_config_tests.rs`.
- No production relation semantics changed.
- No checker, emitter, LSP, WASM, or roadmap changes.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache-key contract
- Evidence: test-only solver cache invariant; no project corpus behavior change expected.

## Adjacent Case Matrix
- Erased generic policy: non-generic source referencing the target type parameter is accepted by direct `query_relation` and cached `QueryCache` assignability.
- Strict generic policy: the same source/target pair is rejected when `erase_generics=false`.
- Cache isolation: computing the strict result first leaves the erased cache slot empty, then computing the erased result preserves the strict slot.
- Rebase conflict resolution: preserved main's strict-null policy/cache agreement test and this PR's erase-generics policy/cache agreement test side by side.

## Verification
- Rebased conflict resolution onto `origin/main` `f6afbfa644137ba35e60df41b20e4511acd0bf5e`; force-with-lease pushed current head `f5d2dafe2b06e26f5747005648fc9de88e0ee163`.
- `cargo fmt --check` passed.
- `git diff --check origin/main..HEAD` passed.
- `cargo nextest run -p tsz-solver -E 'test(/^relation_cache_config_tests::/)'` passed, 32 tests.
- Exact-head ready-review CI for `f5d2dafe2b06e26f5747005648fc9de88e0ee163` passed: `CI Summary`, `GitGuardian Security Checks`, lint, unit, dist-binaries, conformance, emit, fourslash, WASM, project compile guard/canary, project-corpus-pr-body, and project-row-drift.

## Coordination Notes
- Part of #8207; does not close the broader relation-policy/cache-key cleanup track.
- Non-overlap: existing M4-B PRs cover strict-null/strict-any/readonly/optional-param relation cases; this PR covers the separate `erase_generics` policy knob.
- Ready for the repo-local merge queue; `merge-queue` added after exact-head PR-head checks passed for `f5d2dafe2b06e26f5747005648fc9de88e0ee163`.
- `Queue Tested` is queue-owned and may be pending until the synthetic latest-`main` merge run completes.
