### PR TITLE
fix(ci): keep merge queue off GraphQL PR reads

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -156,6 +156,27 @@ function runGhJson(args) {
   return JSON.parse(runGh(args));
 }
 
+function encodedQuery(params) {
+  return Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join("&");
+}
+
+function readPaginatedArray(path, { limit = Number.POSITIVE_INFINITY, perPage = 100 } = {}) {
+  const items = [];
+  for (let page = 1; items.length < limit; page += 1) {
+    const pageSize = Math.min(perPage, limit - items.length);
+    const separator = path.includes("?") ? "&" : "?";
+    const chunk = runGhJson(["api", `${path}${separator}per_page=${pageSize}&page=${page}`]);
+    if (!Array.isArray(chunk)) {
+      throw new Error(`expected GitHub API array from ${path}`);
+    }
+    items.push(...chunk);
+    if (chunk.length < pageSize) break;
+  }
+  return items.slice(0, limit);
+}
+
 function git(args, options = {}) {
   return run("git", args, options);
 }
@@ -325,68 +346,67 @@ export function queueSkipReason(pr, requiredState, base) {
   return null;
 }
 
+export function normalizeRestPullRequest(pr, repository, statusCheckRollup = undefined) {
+  const baseRepository = pr.base?.repo?.full_name || repository;
+  const headRepository = pr.head?.repo?.full_name || "";
+  const normalized = {
+    autoMergeRequest: pr.auto_merge || null,
+    baseRefName: pr.base?.ref || "",
+    body: pr.body || "",
+    headRefName: pr.head?.ref || "",
+    headRefOid: pr.head?.sha || "",
+    isCrossRepository: Boolean(headRepository && baseRepository && headRepository !== baseRepository),
+    isDraft: Boolean(pr.draft),
+    labels: Array.isArray(pr.labels) ? pr.labels : [],
+    number: pr.number,
+    title: pr.title || "",
+    updatedAt: pr.updated_at || "",
+    url: pr.html_url || "",
+  };
+  if (statusCheckRollup !== undefined) {
+    normalized.statusCheckRollup = statusCheckRollup;
+  }
+  return normalized;
+}
+
 function readPullRequests(repository, base, maxPrs) {
-  return runGhJson([
-    "pr", "list",
-    "--repo", repository,
-    "--state", "open",
-    "--base", base,
-    "--limit", String(maxPrs),
-    "--json", [
-      "autoMergeRequest",
-      "baseRefName",
-      "body",
-      "headRefName",
-      "headRefOid",
-      "isCrossRepository",
-      "isDraft",
-      "labels",
-      "number",
-      "title",
-      "updatedAt",
-      "url",
-    ].join(","),
-  ]);
+  const query = encodedQuery({ state: "open", base });
+  return readPaginatedArray(`repos/${repository}/pulls?${query}`, { limit: maxPrs })
+    .map((pr) => normalizeRestPullRequest(pr, repository));
 }
 
 function readPullRequest(repository, number) {
-  return runGhJson([
-    "pr", "view", String(number),
-    "--repo", repository,
-    "--json", [
-      "autoMergeRequest",
-      "baseRefName",
-      "body",
-      "headRefName",
-      "headRefOid",
-      "isCrossRepository",
-      "isDraft",
-      "labels",
-      "number",
-      "statusCheckRollup",
-      "title",
-      "updatedAt",
-      "url",
-    ].join(","),
-  ]);
+  const pr = runGhJson(["api", `repos/${repository}/pulls/${number}`]);
+  const normalized = normalizeRestPullRequest(pr, repository);
+  return normalizeRestPullRequest(
+    pr,
+    repository,
+    normalized.headRefOid ? commitStatusRollup(repository, normalized.headRefOid) : [],
+  );
+}
+
+export function normalizeRestWorkflowRun(run) {
+  return {
+    databaseId: run.id,
+    status: run.status || "",
+    conclusion: run.conclusion || "",
+    headSha: run.head_sha || "",
+    url: run.html_url || "",
+    createdAt: run.created_at || "",
+    startedAt: run.run_started_at || run.created_at || "",
+    updatedAt: run.updated_at || "",
+  };
 }
 
 function readWorkflowRun(repository, runId) {
-  return runGhJson([
-    "run", "view", runId,
-    "--repo", repository,
-    "--json", "databaseId,status,conclusion,url,createdAt,startedAt,updatedAt",
-  ]);
+  return normalizeRestWorkflowRun(runGhJson(["api", `repos/${repository}/actions/runs/${runId}`]));
 }
 
 function readBranchWorkflowRuns(repository, branch) {
-  return runGhJson([
-    "run", "list",
-    "--repo", repository,
-    "--branch", branch,
-    "--limit", "20",
-    "--json", "databaseId,status,conclusion,headSha,url,createdAt,startedAt,updatedAt",
-  ]);
+  const query = encodedQuery({ branch });
+  const response = runGhJson(["api", `repos/${repository}/actions/runs?${query}&per_page=20`]);
+  const runs = Array.isArray(response.workflow_runs) ? response.workflow_runs : [];
+  return runs.map(normalizeRestWorkflowRun);
 }
 
 function readRemoteQueueBranches(options) {
@@ -433,11 +453,7 @@ function readPullRequestState(repository, number) {
 }
 
 function readPullRequestOwner(repository, number) {
-  const pr = runGhJson([
-    "pr", "view", String(number),
-    "--repo", repository,
-    "--json", "labels",
-  ]);
+  const pr = runGhJson(["api", `repos/${repository}/pulls/${number}`]);
   return agentLabel(pr.labels);
 }
 
@@ -862,13 +878,17 @@ function commitStatusRollup(repository, sha) {
   ]);
   return [
     ...(status.statuses || []).map((item) => ({
+      __typename: "StatusContext",
       context: item.context,
       state: item.state,
+      targetUrl: item.target_url || "",
     })),
     ...(checks.check_runs || []).map((item) => ({
+      __typename: "CheckRun",
       name: item.name,
       status: item.status,
       conclusion: item.conclusion,
+      detailsUrl: item.html_url || item.details_url || "",
     })),
   ];
 }
@@ -899,10 +919,10 @@ function waitForSyntheticChecks(repository, synthetic, options) {
 
 function mergePullRequest(repository, pr) {
   runGh([
-    "pr", "merge", String(pr.number),
-    "--repo", repository,
-    "--squash",
-    "--match-head-commit", pr.headRefOid,
+    "api", "-X", "PUT",
+    `repos/${repository}/pulls/${pr.number}/merge`,
+    "-f", `merge_method=squash`,
+    "-f", `sha=${pr.headRefOid}`,
   ]);
 }
 

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -7,6 +7,8 @@ import {
   failureCommentBody,
   formatResult,
   hasPendingPlaceholderQueueStatus,
+  normalizeRestPullRequest,
+  normalizeRestWorkflowRun,
   pendingQueueRun,
   parseArgs,
   queueBranchMetadata,
@@ -190,6 +192,64 @@ assert.equal(queueSkipReason(pr({ labels: ["WIP"] }), { kind: "passed" }, "main"
 assert.equal(queueSkipReason(pr(), { kind: "pending", reason: "pending checks" }, "main"), "pending checks");
 assert.equal(queueSkipReason(pr(), { kind: "passed" }, "main"), null);
 assert.equal(queueSkipReason({ ...pr(), statusCheckRollup: undefined }, { kind: "passed" }, "main"), null);
+assert.deepEqual(
+  normalizeRestPullRequest({
+    auto_merge: { merge_method: "squash" },
+    base: { ref: "main", repo: { full_name: "owner/repo" } },
+    body: "AgentName: TestAgent",
+    draft: false,
+    head: { ref: "feature", repo: { full_name: "owner/repo" }, sha: "b".repeat(40) },
+    html_url: "https://github.example/owner/repo/pull/42",
+    labels: [{ name: "agent:M4-A" }],
+    number: 42,
+    title: "fix(ci): sample",
+    updated_at: "2026-05-26T10:00:00Z",
+  }, "owner/repo", [{ context: "CI Summary", state: "success" }]),
+  {
+    autoMergeRequest: { merge_method: "squash" },
+    baseRefName: "main",
+    body: "AgentName: TestAgent",
+    headRefName: "feature",
+    headRefOid: "b".repeat(40),
+    isCrossRepository: false,
+    isDraft: false,
+    labels: [{ name: "agent:M4-A" }],
+    number: 42,
+    statusCheckRollup: [{ context: "CI Summary", state: "success" }],
+    title: "fix(ci): sample",
+    updatedAt: "2026-05-26T10:00:00Z",
+    url: "https://github.example/owner/repo/pull/42",
+  },
+);
+assert.equal(
+  normalizeRestPullRequest({
+    base: { ref: "main", repo: { full_name: "owner/repo" } },
+    head: { ref: "feature", repo: { full_name: "fork/repo" }, sha: "b".repeat(40) },
+  }, "owner/repo").isCrossRepository,
+  true,
+);
+assert.deepEqual(
+  normalizeRestWorkflowRun({
+    id: 123,
+    status: "in_progress",
+    conclusion: null,
+    head_sha: "c".repeat(40),
+    html_url: "https://github.example/runs/123",
+    created_at: "2026-05-26T10:00:00Z",
+    run_started_at: "2026-05-26T10:01:00Z",
+    updated_at: "2026-05-26T10:02:00Z",
+  }),
+  {
+    databaseId: 123,
+    status: "in_progress",
+    conclusion: "",
+    headSha: "c".repeat(40),
+    url: "https://github.example/runs/123",
+    createdAt: "2026-05-26T10:00:00Z",
+    startedAt: "2026-05-26T10:01:00Z",
+    updatedAt: "2026-05-26T10:02:00Z",
+  },
+);
 assert.deepEqual(
   skipReasonCounts([
     { number: 1, reason: "draft PR" },


### PR DESCRIPTION
## Agent
AgentName: Reviewer

## Track
CI / merge queue emergency reliability.

## Invariant
When the shared GitHub GraphQL quota is exhausted, the poor-man merge queue should still inspect PRs, workflow runs, and commit status through REST so candidate selection does not fail before queue policy is evaluated.

## Scope
- `scripts/ci/poor-mans-merge-queue.mjs`
- `scripts/ci/test-poor-mans-merge-queue.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/queue tooling only; no compiler or project corpus behavior changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --dry-run --verbose --wait-attempts 1`
- Local patched apply pass for #10274 preserved active synthetic run `26457120909` after fixing the REST Actions response shape.

## Coordination Notes
- Canonical owner label: `agent:Reviewer`.
- Runner identity before canonicalization: ReviewHelper.
- Emergency fix for queue failures like run `26456252879`, where `gh pr list` failed on exhausted GraphQL quota while REST quota remained healthy.
- Replaces queue PR list/view, workflow run reads, owner lookup, and final squash merge with REST-backed `gh api` calls.
- Also handles the Actions list-runs REST response shape (`workflow_runs`) after a local patched queue pass exposed it.
- Live dry-run completed under exhausted GraphQL and reported no queue-ready PR because auto-merge was disarmed across the open ready set; this PR fixes the infra crash, not queue policy.