### PR TITLE
fix(checker): strip NoInfer from TS2345 parameter display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -110,6 +110,10 @@ name = "new_expression_regression_tests"
 path = "tests/new_expression_regression_tests.rs"
 
 [[test]]
+name = "noinfer_diagnostic_display_tests"
+path = "tests/noinfer_diagnostic_display_tests.rs"
+
+[[test]]
 name = "array_generic_shorthand_canonical_tests"
 path = "tests/array_generic_shorthand_canonical_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -2345,6 +2345,7 @@ impl<'a> CheckerState<'a> {
         param_type: TypeId,
         arg_type: TypeId,
         arg_idx: NodeIndex,
+        strip_noinfer_for_mismatch: bool,
     ) -> String {
         let direct_param_display = self.format_type_diagnostic(param_type);
 
@@ -2366,6 +2367,13 @@ impl<'a> CheckerState<'a> {
 
         if let Some(display) =
             self.expanded_rest_tuple_parameter_display_for_call(param_type, arg_idx)
+        {
+            return display;
+        }
+
+        if strip_noinfer_for_mismatch
+            && let Some(display) =
+                self.noinfer_call_parameter_mismatch_display(param_type, arg_type)
         {
             return display;
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -159,7 +159,7 @@ impl<'a> CheckerState<'a> {
             );
             let param_str = self.format_type_for_diagnostic_role(
                 param_type,
-                DiagnosticTypeDisplayRole::CallParameter {
+                DiagnosticTypeDisplayRole::WeakCallParameter {
                     argument: arg_type,
                     argument_idx: idx,
                 },

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -936,6 +936,31 @@ impl<'a> CheckerState<'a> {
         self.format_assignability_type_for_message_internal(ty, other, true)
     }
 
+    pub(crate) fn format_type_for_assignability_message_skip_application_alias(
+        &mut self,
+        ty: TypeId,
+    ) -> String {
+        self.ensure_relation_input_ready(ty);
+        let mut formatter =
+            tsz_solver::TypeFormatter::with_symbols(self.ctx.types, &self.ctx.binder.symbols)
+                .with_def_store(&self.ctx.definition_store)
+                .with_diagnostic_mode()
+                .with_skip_application_display_alias_chase()
+                .with_preserve_optional_parameter_surface_syntax(true)
+                .with_strict_null_checks(self.ctx.compiler_options.strict_null_checks)
+                .with_builtin_iterator_return_type(
+                    if self.ctx.compiler_options.strict_builtin_iterator_return {
+                        TypeId::UNDEFINED
+                    } else {
+                        TypeId::ANY
+                    },
+                )
+                .with_exact_optional_property_types(
+                    self.ctx.compiler_options.exact_optional_property_types,
+                );
+        formatter.format(ty).into_owned()
+    }
+
     pub(crate) fn format_assignability_type_for_message_preserving_nullish(
         &mut self,
         ty: TypeId,

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -33,6 +33,7 @@ mod generics;
 mod literal_alias_display;
 mod literal_alias_rewrites;
 mod name_resolution;
+mod noinfer_diagnostic_display;
 mod operator_errors;
 mod primitive_intersection_display;
 mod properties;

--- a/crates/tsz-checker/src/error_reporter/noinfer_diagnostic_display.rs
+++ b/crates/tsz-checker/src/error_reporter/noinfer_diagnostic_display.rs
@@ -1,0 +1,47 @@
+//! Display helpers for diagnostics involving `NoInfer<T>`.
+
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn noinfer_call_parameter_mismatch_display(
+        &mut self,
+        param_type: TypeId,
+        arg_type: TypeId,
+    ) -> Option<String> {
+        let stripped = crate::query_boundaries::type_rewrite::strip_noinfer_wrappers(
+            self.ctx.types,
+            param_type,
+        );
+        let alias_stripped = self
+            .ctx
+            .types
+            .get_display_alias(param_type)
+            .and_then(|alias| {
+                let stripped_alias = crate::query_boundaries::type_rewrite::strip_noinfer_wrappers(
+                    self.ctx.types,
+                    alias,
+                );
+                (stripped_alias != alias).then_some(stripped_alias)
+            });
+        if stripped == param_type && alias_stripped.is_none() {
+            return None;
+        }
+
+        let display_type = if stripped != param_type {
+            stripped
+        } else {
+            param_type
+        };
+        let evaluated = self.evaluate_type_with_env(display_type);
+        let display_type = if evaluated != TypeId::ERROR {
+            evaluated
+        } else {
+            display_type
+        };
+        let display_type = self
+            .strip_nullish_for_assignability_display(display_type, arg_type)
+            .unwrap_or(display_type);
+        Some(self.format_type_for_assignability_message_skip_application_alias(display_type))
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -31,6 +31,10 @@ pub(in crate::error_reporter) enum DiagnosticTypeDisplayRole {
         argument: TypeId,
         argument_idx: NodeIndex,
     },
+    WeakCallParameter {
+        argument: TypeId,
+        argument_idx: NodeIndex,
+    },
     PropertyReceiver,
 }
 
@@ -85,6 +89,7 @@ impl<'a> CheckerState<'a> {
         let ty = match role {
             DiagnosticTypeDisplayRole::CallArgument { .. }
             | DiagnosticTypeDisplayRole::CallParameter { .. }
+            | DiagnosticTypeDisplayRole::WeakCallParameter { .. }
             | DiagnosticTypeDisplayRole::Assignability => {
                 self.resolve_indexed_access_alias_for_display(ty)
             }
@@ -113,8 +118,29 @@ impl<'a> CheckerState<'a> {
                 argument,
                 argument_idx,
             } => {
-                let display =
-                    self.format_call_parameter_type_for_diagnostic(ty, argument, argument_idx);
+                let display = self.format_call_parameter_type_for_diagnostic(
+                    ty,
+                    argument,
+                    argument_idx,
+                    true,
+                );
+                if crate::query_boundaries::common::array_element_type(self.ctx.types, ty).is_some()
+                {
+                    Self::normalize_array_generic_to_shorthand(&display)
+                } else {
+                    display
+                }
+            }
+            DiagnosticTypeDisplayRole::WeakCallParameter {
+                argument,
+                argument_idx,
+            } => {
+                let display = self.format_call_parameter_type_for_diagnostic(
+                    ty,
+                    argument,
+                    argument_idx,
+                    false,
+                );
                 if crate::query_boundaries::common::array_element_type(self.ctx.types, ty).is_some()
                 {
                     Self::normalize_array_generic_to_shorthand(&display)

--- a/crates/tsz-checker/src/query_boundaries/type_rewrite.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_rewrite.rs
@@ -234,3 +234,134 @@ pub(crate) fn replace_type_queries_and_lazies_with(
         &mut rustc_hash::FxHashSet::default(),
     )
 }
+
+pub(crate) fn strip_noinfer_wrappers(db: &dyn QueryDatabase, type_id: TypeId) -> TypeId {
+    fn rewrite(
+        db: &dyn QueryDatabase,
+        type_id: TypeId,
+        active: &mut rustc_hash::FxHashSet<TypeId>,
+    ) -> TypeId {
+        if !active.insert(type_id) {
+            return type_id;
+        }
+        let Some(key) = db.lookup(type_id) else {
+            active.remove(&type_id);
+            return type_id;
+        };
+        let rewritten = match key {
+            TypeData::NoInfer(inner) => rewrite(db, inner, active),
+            TypeData::Union(list_id) => {
+                let members = db.type_list(list_id);
+                let rewritten: Vec<_> = members
+                    .iter()
+                    .map(|&member| rewrite(db, member, active))
+                    .collect();
+                if members
+                    .iter()
+                    .zip(rewritten.iter())
+                    .all(|(&before, &after)| before == after)
+                {
+                    type_id
+                } else {
+                    db.factory().union_preserve_members(rewritten)
+                }
+            }
+            TypeData::Intersection(list_id) => {
+                let members = db.type_list(list_id);
+                let rewritten: Vec<_> = members
+                    .iter()
+                    .map(|&member| rewrite(db, member, active))
+                    .collect();
+                if members
+                    .iter()
+                    .zip(rewritten.iter())
+                    .all(|(&before, &after)| before == after)
+                {
+                    type_id
+                } else {
+                    db.factory().intersection(rewritten)
+                }
+            }
+            TypeData::ReadonlyType(inner) => {
+                let inner = rewrite(db, inner, active);
+                if let Some(TypeData::ReadonlyType(before)) = db.lookup(type_id)
+                    && inner == before
+                {
+                    type_id
+                } else {
+                    db.factory().readonly_type(inner)
+                }
+            }
+            TypeData::Array(element) => {
+                let element = rewrite(db, element, active);
+                if let Some(TypeData::Array(before)) = db.lookup(type_id)
+                    && element == before
+                {
+                    type_id
+                } else {
+                    db.factory().array(element)
+                }
+            }
+            TypeData::Tuple(tuple_list_id) => {
+                let elements = db.tuple_list(tuple_list_id);
+                let rewritten: Vec<_> = elements
+                    .iter()
+                    .map(|element| {
+                        let mut element = *element;
+                        element.type_id = rewrite(db, element.type_id, active);
+                        element
+                    })
+                    .collect();
+                if elements
+                    .iter()
+                    .zip(rewritten.iter())
+                    .all(|(&before, &after)| before == after)
+                {
+                    type_id
+                } else {
+                    db.factory().tuple(rewritten)
+                }
+            }
+            TypeData::Application(app_id) => {
+                let app = db.type_application(app_id);
+                let base = rewrite(db, app.base, active);
+                let args: Vec<_> = app
+                    .args
+                    .iter()
+                    .map(|&arg| rewrite(db, arg, active))
+                    .collect();
+                if base == app.base && args.iter().zip(app.args.iter()).all(|(&a, &b)| a == b) {
+                    type_id
+                } else {
+                    db.factory().application(base, args)
+                }
+            }
+            TypeData::Function(shape_id) => {
+                let mut shape = db.function_shape(shape_id).as_ref().clone();
+                let mut changed = false;
+                for param in &mut shape.params {
+                    let rewritten = rewrite(db, param.type_id, active);
+                    if rewritten != param.type_id {
+                        param.type_id = rewritten;
+                        changed = true;
+                    }
+                }
+                let return_type = rewrite(db, shape.return_type, active);
+                if return_type != shape.return_type {
+                    shape.return_type = return_type;
+                    changed = true;
+                }
+                if changed {
+                    db.factory().function(shape)
+                } else {
+                    type_id
+                }
+            }
+            _ => type_id,
+        };
+        active.remove(&type_id);
+        rewritten
+    }
+
+    rewrite(db, type_id, &mut rustc_hash::FxHashSet::default())
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -254,6 +254,7 @@ impl<'a> CheckerState<'a> {
                 self.finite_mapped_parameter_display_type(param_type)
                     .map(|display_type| self.format_type_for_assignability_message(display_type))
             })
+            .or_else(|| self.noinfer_call_parameter_mismatch_display(param_type, arg_type))
             .unwrap_or_else(|| self.format_type_diagnostic(param_type));
         if target_display.contains("Array<") {
             target_display = Self::normalize_array_generic_to_shorthand(&target_display);

--- a/crates/tsz-checker/tests/noinfer_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/tests/noinfer_diagnostic_display_tests.rs
@@ -1,0 +1,137 @@
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::diagnostic_codes;
+
+fn strict_messages(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
+    .collect()
+}
+
+#[test]
+fn ts2345_union_noinfer_parameter_displays_failed_inner_target() {
+    let diagnostics = strict_messages(
+        r#"
+declare function f<T>(a: T, b: NoInfer<T> | null): T;
+f("a", "b");
+"#,
+    );
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| {
+            *code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .collect();
+
+    assert_eq!(ts2345.len(), 1, "expected one TS2345, got {diagnostics:?}");
+    let message = &ts2345[0].1;
+    assert!(
+        message.contains("parameter of type '\"a\"'"),
+        "expected failed inner target display, got: {message}"
+    );
+    assert!(
+        !message.contains("NoInfer") && !message.contains("null"),
+        "expected NoInfer/null elided from TS2345 target, got: {message}"
+    );
+}
+
+#[test]
+fn ts2345_intersection_noinfer_parameter_uses_renamed_inner_target() {
+    let diagnostics = strict_messages(
+        r#"
+declare function f<U>(a: U, b: NoInfer<U> & {}): U;
+f("a", "b");
+"#,
+    );
+    let ts2345: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| {
+            *code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .collect();
+
+    assert_eq!(ts2345.len(), 1, "expected one TS2345, got {diagnostics:?}");
+    let message = &ts2345[0].1;
+    assert!(
+        message.contains("parameter of type '\"a\"'"),
+        "expected renamed inner target display, got: {message}"
+    );
+    assert!(
+        !message.contains("NoInfer"),
+        "expected NoInfer elided from TS2345 target, got: {message}"
+    );
+}
+
+#[test]
+fn ts2353_noinfer_union_excess_property_preserves_union_surface() {
+    let diagnostics = strict_messages(
+        r#"
+declare function f<T extends { x: string }>(
+  a: T,
+  b: NoInfer<T> | (() => NoInfer<T>),
+): void;
+f({ x: "foo" }, { x: "bar", y: 42 });
+"#,
+    );
+    let ts2353: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| {
+            *code
+                == diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE
+        })
+        .collect();
+
+    assert_eq!(ts2353.len(), 1, "expected one TS2353, got {diagnostics:?}");
+    let message = &ts2353[0].1;
+    assert!(
+        message.contains("NoInfer<{ x: string; }> | (() => NoInfer<{ x: string; }>)"),
+        "expected TS2353 to preserve NoInfer union surface, got: {message}"
+    );
+}
+
+#[test]
+fn ts2559_noinfer_weak_type_parameter_preserves_wrapper_surface() {
+    let diagnostics = strict_messages(
+        r#"
+type Partial<T> = { [P in keyof T]?: T[P] };
+declare const partialObj1: Partial<{ a: unknown; b: unknown }>;
+declare const partialObj2: Partial<{ c: unknown; d: unknown }>;
+declare const someObj1: { x: string };
+
+declare function test1<T>(a: T, b: NoInfer<T> & { prop?: unknown }): void;
+test1(partialObj1, someObj1);
+
+declare function test2<T1, T2>(
+  a: T1,
+  b: T2,
+  c: NoInfer<T1> & NoInfer<T2>,
+): void;
+test2(partialObj1, partialObj2, someObj1);
+"#,
+    );
+    let ts2559: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == diagnostic_codes::TYPE_HAS_NO_PROPERTIES_IN_COMMON_WITH_TYPE)
+        .collect();
+
+    assert_eq!(ts2559.len(), 2, "expected two TS2559, got {diagnostics:?}");
+    assert!(
+        ts2559.iter().any(|(_, message)| message
+            .contains("NoInfer<Partial<{ a: unknown; b: unknown; }>> & { prop?: unknown; }")),
+        "expected weak-type display to preserve NoInfer intersection wrapper, got: {ts2559:?}"
+    );
+    assert!(
+        ts2559.iter().any(|(_, message)| message.contains(
+            "NoInfer<Partial<{ a: unknown; b: unknown; }>> & NoInfer<Partial<{ c: unknown; d: unknown; }>>"
+        )),
+        "expected weak-type display to preserve both NoInfer wrappers, got: {ts2559:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
conformance strictness / diagnostic display parity; semantic diagnostic-display fix

## Invariant
When a TS2345 call argument mismatch compares against a parameter target whose structural display provenance contains `NoInfer`, `tsc` reports the failed inner target rather than the wrapper surface; this PR makes tsz select that target through a checker diagnostic helper backed by a query-boundary type rewrite, while preserving wrapper surfaces for diagnostics whose contract is to print the original weak-type target.

## Owner Layer
- Owner: checker diagnostic display policy plus a query-boundary structural rewrite helper.
- Reason: assignability semantics already compare the normalized type; the gap is which target surface is rendered for TS2345. The rewrite exposes the structural display fact without moving diagnostic presentation into solver internals.

## Scope
- Add a query-boundary rewrite that strips `NoInfer` wrappers from diagnostic target shapes.
- Route TS2345 call parameter display paths through one shared NoInfer diagnostic helper.
- Keep TS2559 weak-type call-parameter display on the wrapper-preserving diagnostic role.
- Add focused checker diagnostics coverage for NoInfer union/intersection TS2345 display, TS2559 weak-type wrapper preservation, and the TS2353 union control case.

## Adjacent-Case Matrix
- Reported shape: `NoInfer<T> | null` in a call parameter reports the failed inferred literal target and elides the wrapper/nullish display.
- Renamed binder/intersection shape: `NoInfer<U> & {}` proves the rule is not keyed to the type parameter name or a single union spelling.
- Weak-type control: `NoInfer<T> & { prop?: unknown }` and `NoInfer<T1> & NoInfer<T2>` preserve the wrapper surface for TS2559.
- Negative/control shape: TS2353 excess-property display for `NoInfer<T> | (() => NoInfer<T>)` preserves the original wrapper union surface instead of using the TS2345 target rewrite.

## Fallback Behavior
Unsupported or unchanged shapes fall back to the existing call-parameter display pipeline. The helper only changes display when stripping `NoInfer` from the parameter type or its display alias changes the structural target; otherwise it returns `None` and existing rendering remains authoritative. Weak-type TS2559 call-parameter display uses a wrapper-preserving role and does not invoke the TS2345 NoInfer strip.

## Project Corpus Impact
- Row: n/a
- Bug family: type-display / TS2345 diagnostic parity
- Evidence: checker diagnostic display only; no project corpus row targeted.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `cargo nextest run -p tsz-checker --test noinfer_diagnostic_display_tests`
- `./scripts/conformance/conformance.sh run --filter noInferCommonPropertyCheck1 --verbose`
- After rebasing onto current `origin/main` (`df894573cc`): `git diff --check HEAD~1..HEAD`
- After rebasing onto current `origin/main` (`df894573cc`): `cargo nextest run -p tsz-checker --test noinfer_diagnostic_display_tests`
- Earlier on the original head: `cargo nextest run -p tsz-checker --lib ts2345_call_parameter_display`
- Earlier on the original head: `cargo nextest run -p tsz-checker --test ts2353_tests noinfer_union_excess_property_display_orders_object_before_function`
- Earlier on the original head: `scripts/arch/check-checker-boundaries.sh`
- Earlier on the original head: `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
AgentName: M1-C

Fixes #9722.

Opened from a fresh worktree off `origin/main` per user request: `/Users/mohsen/code/tsz-m1c-fresh-origin-main-20260526-165511`. Updated from fresh `origin/main` worktree `/Users/mohsen/code/tsz-m1c-fresh-origin-main-20260526-1900` after ready-review CI exposed `noInferCommonPropertyCheck1.ts` as a TS2559 fingerprint-only regression.

Current repaired head: `1daacfbb9e`, rebased onto `origin/main` after #10299. Previous repaired head `9feafaad97` fixed the TS2559 regression; old failing head was `be3fdaf6d5`.

This does not edit the accepted-regression list and avoids overlap with #10265. Auto-merge remains off; ready-review CI should validate the new exact head.
