### PR TITLE
refactor(checker): route enum object member diagnostics

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -493,6 +493,9 @@ mod enum_indexed_access_tests;
 #[path = "../tests/enum_nominality_tests.rs"]
 mod enum_nominality_tests;
 #[cfg(test)]
+#[path = "tests/enum_relation_routing_arch_tests.rs"]
+mod enum_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/enum_residual_narrowing_tests.rs"]
 mod enum_residual_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -227,10 +227,7 @@ impl<'a> CheckerState<'a> {
         for (prop_name_idx, prop_value_idx) in property_pairs {
             let value_type = self.get_type_of_node_with_request(prop_value_idx, &request);
             let value_type = self.resolve_lazy_type(value_type);
-            if value_type == TypeId::ERROR
-                || value_type == TypeId::ANY
-                || self.diagnostic_relation_boolean_guard(value_type, enum_element_type)
-            {
+            if value_type == TypeId::ERROR || value_type == TypeId::ANY {
                 continue;
             }
             // Match tsc's `elaborateElementwise`: anchor TS2322 at the property
@@ -240,9 +237,10 @@ impl<'a> CheckerState<'a> {
             // variable declaration and reformats the source as the whole
             // object-literal type — emitting one merged `{ … }` vs `T` error
             // at the binding name. tsc instead reports per-member.
-            self.error_type_not_assignable_at_with_anchor_elaboration(
+            self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(
                 value_type,
                 enum_element_type,
+                prop_value_idx,
                 prop_name_idx,
             );
         }

--- a/crates/tsz-checker/src/tests/enum_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/enum_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+/// Enum-element object-literal member diagnostics should use the canonical
+/// exact-anchor relation diagnostic helper instead of a raw relation guard plus
+/// a manual TS2322 reporter.
+#[test]
+fn enum_member_object_literal_validation_uses_relation_diagnostic_helper() {
+    let source = fs::read_to_string("src/state/variable_checking/core.rs")
+        .expect("failed to read variable_checking/core.rs");
+
+    assert!(
+        source.contains("check_assignable_or_report_at_exact_anchor_without_source_elaboration"),
+        "per-member enum object-literal validation must route through the \
+         exact-anchor relation diagnostic helper"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard(value_type, enum_element_type)"),
+        "per-member enum object-literal validation must not pre-gate TS2322 \
+         with a raw diagnostic relation boolean"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When an object-literal initializer is validated per member against an enum-element contextual type, `tsc` reports TS2322 at the offending property name using the member value type versus the enum element type; this PR keeps the checker-owned property-name anchor while routing the relation decision and diagnostic emission through the canonical exact-anchor relation helper.

## Scope
- Route per-member enum object-literal validation in `state/variable_checking/core.rs` through `check_assignable_or_report_at_exact_anchor_without_source_elaboration`.
- Remove the local `diagnostic_relation_boolean_guard(value_type, enum_element_type)` pre-gate plus direct reporter call from that path.
- Add a focused architecture test module that keeps this path on the helper.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / TS2322 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib enum_member_object_literal_validation_uses_relation_diagnostic_helper`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing TS2322 path onto a canonical relation helper.
- Disjoint from #10270, which owns object-literal/property-access property diagnostics; this slice touches enum contextual member validation in `state/variable_checking/core.rs`.
- Based on `origin/main` at `a6d9252c8c`.
- No solver policy, variance, any-propagation, relation cache-key behavior, or diagnostic display-string decision changed.
