### PR TITLE
refactor(checker): route destructuring element diagnostics

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1109,6 +1109,43 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Check pre-resolved source/target types and keep those exact types in the
+    /// generic TS2322 display.
+    pub(crate) fn check_pre_resolved_assignable_or_report_at_exact_anchor(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        source_idx: NodeIndex,
+        diag_idx: NodeIndex,
+    ) -> bool {
+        if self.should_suppress_assignability_diagnostic(source, target) {
+            return true;
+        }
+        if self.should_suppress_assignability_for_parse_recovery(source_idx, diag_idx) {
+            return true;
+        }
+
+        let outcome = self.assign_relation_outcome(source, target);
+        if outcome.related {
+            return true;
+        }
+        if self.should_skip_weak_union_error_with_outcome(
+            source,
+            target,
+            source_idx,
+            Some(&outcome),
+        ) {
+            return true;
+        }
+        if outcome.weak_union_violation {
+            self.error_no_common_properties(source, target, diag_idx);
+            return false;
+        }
+
+        self.error_type_not_assignable_at_with_raw_display_types(source, target, diag_idx);
+        false
+    }
+
     /// Check assignability and emit a generic TS2322 diagnostic at `diag_idx`.
     ///
     /// This is used for call sites that intentionally avoid detailed reason rendering

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -739,24 +739,12 @@ impl<'a> CheckerState<'a> {
                         {
                             self.ensure_relation_input_ready(check_type);
                             self.ensure_relation_input_ready(target_type);
-                            if !self.diagnostic_relation_boolean_guard(check_type, target_type) {
-                                // Emit TS2322 directly with pre-resolved types.
-                                // The standard error pipeline would re-derive
-                                // the source type from the anchor node's parent
-                                // assignment, incorrectly showing the RHS array
-                                // type instead of the element type.
-                                let source_str = self.format_type_diagnostic(check_type);
-                                let target_str = self.format_type_diagnostic(target_type);
-                                let message = crate::diagnostics::format_message(
-                                    diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                                    &[&source_str, &target_str],
-                                );
-                                self.error_at_node(
-                                    target_idx,
-                                    &message,
-                                    diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                                );
-                            }
+                            self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(
+                                check_type,
+                                target_type,
+                                target_idx,
+                                target_idx,
+                            );
                         }
                     }
                 }

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -739,7 +739,7 @@ impl<'a> CheckerState<'a> {
                         {
                             self.ensure_relation_input_ready(check_type);
                             self.ensure_relation_input_ready(target_type);
-                            self.check_assignable_or_report_at_exact_anchor_without_source_elaboration(
+                            self.check_pre_resolved_assignable_or_report_at_exact_anchor(
                                 check_type,
                                 target_type,
                                 target_idx,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -475,6 +475,9 @@ mod cross_file_type_params_cache_tests;
 #[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
 mod destructured_discriminant_source_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/destructuring_relation_routing_arch_tests.rs"]
+mod destructuring_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/direct_generic_return_tests.rs"]
 mod direct_generic_return_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
@@ -1,17 +1,18 @@
 use std::fs;
 
 /// Array-destructuring element diagnostics introduced by
-/// `noUncheckedIndexedAccess` should use the exact-anchor relation diagnostic
-/// helper instead of a raw relation guard plus a manual TS2322 reporter.
+/// `noUncheckedIndexedAccess` should use the pre-resolved exact-anchor relation
+/// diagnostic helper instead of a raw relation guard plus a manual TS2322
+/// reporter.
 #[test]
 fn array_destructuring_unchecked_element_uses_relation_diagnostic_helper() {
     let source = fs::read_to_string("src/assignability/assignment_checker/destructuring.rs")
         .expect("failed to read assignment_checker/destructuring.rs");
 
     assert!(
-        source.contains("check_assignable_or_report_at_exact_anchor_without_source_elaboration"),
+        source.contains("check_pre_resolved_assignable_or_report_at_exact_anchor"),
         "array destructuring element validation must route through the \
-         exact-anchor relation diagnostic helper"
+         pre-resolved exact-anchor relation diagnostic helper"
     );
     assert!(
         !source.contains("diagnostic_relation_boolean_guard(check_type, target_type)"),

--- a/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/destructuring_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+/// Array-destructuring element diagnostics introduced by
+/// `noUncheckedIndexedAccess` should use the exact-anchor relation diagnostic
+/// helper instead of a raw relation guard plus a manual TS2322 reporter.
+#[test]
+fn array_destructuring_unchecked_element_uses_relation_diagnostic_helper() {
+    let source = fs::read_to_string("src/assignability/assignment_checker/destructuring.rs")
+        .expect("failed to read assignment_checker/destructuring.rs");
+
+    assert!(
+        source.contains("check_assignable_or_report_at_exact_anchor_without_source_elaboration"),
+        "array destructuring element validation must route through the \
+         exact-anchor relation diagnostic helper"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard(check_type, target_type)"),
+        "array destructuring element validation must not pre-gate TS2322 with \
+         a raw diagnostic relation boolean"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When `noUncheckedIndexedAccess` augments an array-destructuring element type and that element is not assignable to the target binding type, `tsc` reports TS2322 at the target binding with the pre-resolved element type in the source display; this PR keeps that checker-owned target anchor while routing the relation decision through a canonical relation outcome helper.

## Scope
- Route the `noUncheckedIndexedAccess` array-destructuring element mismatch path in `assignability/assignment_checker/destructuring.rs` through `check_pre_resolved_assignable_or_report_at_exact_anchor`.
- Preserve existing relation-input readiness for the pre-resolved element and target types.
- Remove the local `diagnostic_relation_boolean_guard(check_type, target_type)` pre-gate plus manual TS2322 string construction from that path.
- Add a focused architecture test module that keeps this path on the pre-resolved relation helper.
- Add the helper in `assignability_diagnostics.rs` so the relation outcome and weak-union skip policy stay centralized while the TS2322 display uses the exact pre-resolved source/target types.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / TS2322 routing
- Evidence: architecture-only routing slice; focused conformance witness `noUncheckedIndexedAccessDestructuring` passes after preserving the pre-resolved source display.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib array_destructuring_unchecked_element_uses_relation_diagnostic_helper`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter noUncheckedIndexedAccessDestructuring --verbose`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing TS2322 path onto a canonical relation outcome helper.
- Disjoint from #10270 object-literal/property diagnostics and #10319 enum object-member diagnostics.
- Initial ready-review CI exposed a fingerprint-only conformance regression for `noUncheckedIndexedAccessDestructuring`; fixed at head `d387a6a3c9089dca4b928952deb88c2d21ef53ef` by preserving the pre-resolved `string | undefined` source display.
- No solver policy, variance, any-propagation, relation cache-key behavior, or diagnostic display-string decision changed.