### PR TITLE
chore(setup): skip dirty worktree reuse candidates

### DIFF
--- a/scripts/setup/disk-worktree-guard.sh
+++ b/scripts/setup/disk-worktree-guard.sh
@@ -15,8 +15,8 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
 REPO_PARENT="$(dirname "$REPO_ROOT")"
 WORKTREE_PARENT="$REPO_PARENT"
 

--- a/scripts/setup/disk-worktree-guard.sh
+++ b/scripts/setup/disk-worktree-guard.sh
@@ -120,6 +120,12 @@ reuse_candidates="$(
         [[ "$wt" != "$REPO_ROOT" ]] || continue
         [[ -d "$wt" ]] || continue
 
+        dirty="$(
+          git -C "$wt" status --porcelain --untracked-files=normal 2>/dev/null \
+            || printf '__status_failed__\n'
+        )"
+        [[ -z "$dirty" ]] || continue
+
         recent="$(
           find "$wt" \
             \( -path "$wt/.git" -o -path "$wt/target" -o -path "$wt/.target" \

--- a/scripts/setup/test_disk_worktree_guard.py
+++ b/scripts/setup/test_disk_worktree_guard.py
@@ -1,0 +1,75 @@
+import os
+import pathlib
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "setup" / "disk-worktree-guard.sh"
+
+
+class DiskWorktreeGuardTests(unittest.TestCase):
+    def run_git(self, args, cwd):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def age_worktree_files(self, worktree, old_timestamp):
+        for path in worktree.rglob("*"):
+            if path.is_file():
+                os.utime(path, (old_timestamp, old_timestamp))
+
+    def test_dirty_worktrees_are_not_reuse_candidates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo = temp_root / "tsz"
+            fake_repo.mkdir()
+
+            script_dir = fake_repo / "scripts" / "setup"
+            script_dir.mkdir(parents=True)
+            fake_script = script_dir / "disk-worktree-guard.sh"
+            fake_script.symlink_to(SCRIPT)
+
+            self.run_git(["init"], fake_repo)
+            self.run_git(["config", "user.email", "studio-f@example.invalid"], fake_repo)
+            self.run_git(["config", "user.name", "Studio F"], fake_repo)
+            (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
+            self.run_git(["add", "README.md"], fake_repo)
+            self.run_git(["commit", "-m", "initial"], fake_repo)
+
+            clean_worktree = temp_root / "tsz-clean"
+            dirty_worktree = temp_root / "tsz-dirty"
+            self.run_git(["worktree", "add", "--detach", str(clean_worktree), "HEAD"], fake_repo)
+            self.run_git(["worktree", "add", "--detach", str(dirty_worktree), "HEAD"], fake_repo)
+            old_timestamp = time.time() - 7200
+            self.age_worktree_files(clean_worktree, old_timestamp)
+            self.age_worktree_files(dirty_worktree, old_timestamp)
+            (dirty_worktree / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+
+            env = {
+                **os.environ,
+                "TSZ_WORKTREE_INACTIVE_HOURS": "1",
+            }
+            result = subprocess.run(
+                ["bash", str(fake_script)],
+                cwd=fake_repo,
+                env=env,
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertIn(f"  {clean_worktree} branch=detached:", result.stdout)
+            self.assertNotIn(str(dirty_worktree), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/setup/test_disk_worktree_guard.py
+++ b/scripts/setup/test_disk_worktree_guard.py
@@ -26,49 +26,79 @@ class DiskWorktreeGuardTests(unittest.TestCase):
             if path.is_file():
                 os.utime(path, (old_timestamp, old_timestamp))
 
+    def make_fake_repo(self, temp_root):
+        fake_repo = temp_root / "tsz"
+        fake_repo.mkdir()
+
+        script_dir = fake_repo / "scripts" / "setup"
+        script_dir.mkdir(parents=True)
+        fake_script = script_dir / "disk-worktree-guard.sh"
+        fake_script.symlink_to(SCRIPT)
+
+        self.run_git(["init"], fake_repo)
+        self.run_git(["config", "user.email", "studio-f@example.invalid"], fake_repo)
+        self.run_git(["config", "user.name", "Studio F"], fake_repo)
+        (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
+        self.run_git(["add", "README.md"], fake_repo)
+        self.run_git(["commit", "-m", "initial"], fake_repo)
+        return fake_repo, fake_script
+
+    def run_guard(self, fake_repo, fake_script):
+        env = {
+            **os.environ,
+            "TSZ_WORKTREE_INACTIVE_HOURS": "1",
+        }
+        return subprocess.run(
+            ["bash", str(fake_script)],
+            cwd=fake_repo,
+            env=env,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def add_clean_and_dirty_worktrees(self, fake_repo, temp_root):
+        clean_worktree = temp_root / "tsz-clean"
+        dirty_worktree = temp_root / "tsz-dirty"
+        self.run_git(["worktree", "add", "--detach", str(clean_worktree), "HEAD"], fake_repo)
+        self.run_git(["worktree", "add", "--detach", str(dirty_worktree), "HEAD"], fake_repo)
+        old_timestamp = time.time() - 7200
+        self.age_worktree_files(clean_worktree, old_timestamp)
+        self.age_worktree_files(dirty_worktree, old_timestamp)
+        (dirty_worktree / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+        return clean_worktree, dirty_worktree
+
     def test_dirty_worktrees_are_not_reuse_candidates(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_root = pathlib.Path(temp_dir).resolve()
-            fake_repo = temp_root / "tsz"
-            fake_repo.mkdir()
-
-            script_dir = fake_repo / "scripts" / "setup"
-            script_dir.mkdir(parents=True)
-            fake_script = script_dir / "disk-worktree-guard.sh"
-            fake_script.symlink_to(SCRIPT)
-
-            self.run_git(["init"], fake_repo)
-            self.run_git(["config", "user.email", "studio-f@example.invalid"], fake_repo)
-            self.run_git(["config", "user.name", "Studio F"], fake_repo)
-            (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
-            self.run_git(["add", "README.md"], fake_repo)
-            self.run_git(["commit", "-m", "initial"], fake_repo)
-
-            clean_worktree = temp_root / "tsz-clean"
-            dirty_worktree = temp_root / "tsz-dirty"
-            self.run_git(["worktree", "add", "--detach", str(clean_worktree), "HEAD"], fake_repo)
-            self.run_git(["worktree", "add", "--detach", str(dirty_worktree), "HEAD"], fake_repo)
-            old_timestamp = time.time() - 7200
-            self.age_worktree_files(clean_worktree, old_timestamp)
-            self.age_worktree_files(dirty_worktree, old_timestamp)
-            (dirty_worktree / "untracked.txt").write_text("dirty\n", encoding="utf-8")
-
-            env = {
-                **os.environ,
-                "TSZ_WORKTREE_INACTIVE_HOURS": "1",
-            }
-            result = subprocess.run(
-                ["bash", str(fake_script)],
-                cwd=fake_repo,
-                env=env,
-                check=True,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            clean_worktree, dirty_worktree = self.add_clean_and_dirty_worktrees(
+                fake_repo, temp_root
             )
+            result = self.run_guard(fake_repo, fake_script)
 
             self.assertIn(f"  {clean_worktree} branch=detached:", result.stdout)
             self.assertNotIn(str(dirty_worktree), result.stdout)
+
+    def test_symlinked_repo_parent_still_finds_sibling_worktrees(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            real_parent = temp_root / "real-parent"
+            alias_parent = temp_root / "alias-parent"
+            real_parent.mkdir()
+            alias_parent.symlink_to(real_parent)
+
+            fake_repo, fake_script = self.make_fake_repo(alias_parent)
+            clean_worktree, dirty_worktree = self.add_clean_and_dirty_worktrees(
+                fake_repo, alias_parent
+            )
+            result = self.run_guard(fake_repo, fake_script)
+
+            clean_real = clean_worktree.resolve()
+            dirty_real = dirty_worktree.resolve()
+            self.assertIn(f"  {clean_real} branch=detached:", result.stdout)
+            self.assertNotIn(str(dirty_real), result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Studio-F launch infrastructure / disk-worktree hygiene

## Invariant
When a sister worktree is inactive but has local changes or unresolved conflicts, setup guidance should not advertise it as reusable; when the checkout is reached through a symlinked parent, the compact disk guard should still compare against Git's physical worktree paths. This PR makes the guard only list clean inactive worktrees as reuse candidates and canonicalizes its repo/worktree root paths.

## Scope
- `scripts/setup/disk-worktree-guard.sh`
- `scripts/setup/test_disk_worktree_guard.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: setup-script-only; no compiler, emit, checker, solver, or project corpus behavior changes.

## Verification
- `python3 scripts/setup/test_disk_worktree_guard.py`
- `bash -n scripts/setup/disk-worktree-guard.sh scripts/agents/disk-preflight.sh`
- `scripts/setup/disk-worktree-guard.sh --help`
- `scripts/setup/disk-worktree-guard.sh`
- `scripts/agents/disk-preflight.sh Studio-F`
- `git diff --check`

## Coordination Notes
- AgentName: Studio-F
- Found during Studio-F start-cycle disk preflight: `/Users/mohsen/code/tsz-studio-c-9645` was shown as a reuse candidate even though it is detached with unresolved conflicts.
- Added focused regression tests that create clean and dirty temporary sibling worktrees, including a symlinked-parent checkout case, and verify only clean inactive worktrees are advertised.
- This PR leaves dirty/conflicted worktrees visible in the broader `disk-preflight` cache-signal list, but excludes them from the narrower reuse-candidate recommendation.
- No overlap found with open Studio-F PRs; auto-merge remains off for manager/queue handling.