### PR TITLE
refactor(checker): route static side relation outcome

### DIFF
--- a/crates/tsz-checker/src/classes/class_static_side_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_static_side_helpers.rs
@@ -41,7 +41,9 @@ impl<'a> CheckerState<'a> {
             && derived_ctor_type != TypeId::ERROR
             && base_ctor_type != TypeId::UNKNOWN
             && base_ctor_type != TypeId::ERROR
-            && !self.diagnostic_relation_boolean_guard(derived_ctor_type, base_ctor_type)
+            && !self
+                .assign_relation_outcome(derived_ctor_type, base_ctor_type)
+                .related
         {
             self.error_at_node(
                 class_name,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -442,6 +442,9 @@ mod class_index_signature_compat_tests;
 #[path = "tests/class_static_init_self_new_tests.rs"]
 mod class_static_init_self_new_tests;
 #[cfg(test)]
+#[path = "tests/class_static_side_relation_routing_arch_tests.rs"]
+mod class_static_side_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/closure_destructuring_top_level_diagnostics_tests.rs"]
 mod closure_destructuring_top_level_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_static_side_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_static_side_relation_routing_arch_tests.rs
@@ -1,0 +1,19 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn namespace_merged_static_side_mismatch_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/classes/class_static_side_helpers.rs"),
+    )
+    .expect("failed to read class_static_side_helpers.rs");
+
+    assert!(
+        source.contains("assign_relation_outcome(derived_ctor_type, base_ctor_type)"),
+        "namespace-merged static-side diagnostics should route the relation through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard(derived_ctor_type, base_ctor_type)"),
+        "namespace-merged static-side diagnostics should not pre-gate with a raw boolean relation"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a namespace-merged derived class has overlapping static namespace exports with its base class, `tsc` reports the static-side mismatch at the derived class name when the derived constructor side is not assignable to the base constructor side; this PR keeps the checker-owned custom diagnostic while routing the relation decision through the shared assignability outcome boundary.

## Scope
- Route `report_namespace_merged_static_side_mismatch` through `assign_relation_outcome(...).related` instead of a raw `diagnostic_relation_boolean_guard`.
- Add a focused architecture test guarding this static-side diagnostic path against regressing to a raw boolean relation pre-gate.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / class static-side routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib namespace_merged_static_side_mismatch_uses_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing assignability pre-gate onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, and #10320 destructuring element diagnostics.
- Based on `origin/main` at `06a7d7d214e7450de9d8f8756e0fd3a811e967f6`; head is `3ae8bc4b5a95b83157434dda6475648ec7e40831`.
- No solver policy, variance, any-propagation, relation cache-key behavior, or diagnostic display-string decision changed.
