### PR TITLE
fix(ci): lease existing merge queue branches explicitly

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -421,6 +421,24 @@ function readRemoteQueueBranches(options) {
   });
 }
 
+function readRemoteBranchOid(branch) {
+  const output = git(["ls-remote", "--heads", "origin", branch]);
+  const trimmed = output.trim();
+  if (!trimmed) return "";
+  const [oid] = trimmed.split(/\s+/);
+  return oid || "";
+}
+
+export function forceWithLeaseArgForOid(branch, remoteOid) {
+  return remoteOid
+    ? `--force-with-lease=refs/heads/${branch}:${remoteOid}`
+    : `--force-with-lease=refs/heads/${branch}:`;
+}
+
+function forceWithLeaseArg(branch) {
+  return forceWithLeaseArgForOid(branch, readRemoteBranchOid(branch));
+}
+
 export function queueBranchPrNumber(branch, queueBranchPrefix = DEFAULT_QUEUE_BRANCH_PREFIX) {
   return queueBranchMetadata(branch, queueBranchPrefix)?.number ?? null;
 }
@@ -857,7 +875,7 @@ function prepareSyntheticMerge(repository, pr, baseOid, options) {
   ], { stdio: "inherit" });
   const mergeOid = git(["rev-parse", "HEAD"]).trim();
   if (!options.dryRun) {
-    git(["push", "--force-with-lease", "origin", `${mergeOid}:refs/heads/${branch}`], { stdio: "inherit" });
+    git(["push", forceWithLeaseArg(branch), "origin", `${mergeOid}:refs/heads/${branch}`], { stdio: "inherit" });
     runGh(["workflow", "run", "ci.yml", "--repo", repository, "--ref", branch]);
   }
   return { branch, mergeOid };

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -5,6 +5,7 @@ import {
   activeRunOwnerStatusCounts,
   activeSyntheticQueueRun,
   failureCommentBody,
+  forceWithLeaseArgForOid,
   formatResult,
   hasPendingPlaceholderQueueStatus,
   normalizeRestPullRequest,
@@ -79,6 +80,14 @@ assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-a56115a-m4c"), 1
 assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123/extra"), null);
 assert.equal(queueBranchPrNumber("automation/merge-queue/not-pr-123"), null);
 assert.equal(queueBranchPrNumber("custom/queue/pr-456", "custom/queue"), 456);
+assert.equal(
+  forceWithLeaseArgForOid("automation/merge-queue/pr-123", "a".repeat(40)),
+  `--force-with-lease=refs/heads/automation/merge-queue/pr-123:${"a".repeat(40)}`,
+);
+assert.equal(
+  forceWithLeaseArgForOid("automation/merge-queue/pr-123", ""),
+  "--force-with-lease=refs/heads/automation/merge-queue/pr-123:",
+);
 assert.deepEqual(
   queueBranchMetadata("automation/merge-queue/pr-123-a56115a-m4c"),
   { number: 123, suffix: "a56115a-m4c" },


### PR DESCRIPTION
## Agent
AgentName: Reviewer

## Track
CI / merge queue reliability.

## Invariant
When a synthetic queue branch already exists, a fresh runner should still update it with force-with-lease protection based on the live remote branch SHA, not fail because it lacks a local remote-tracking ref.

## Scope
- `scripts/ci/poor-mans-merge-queue.mjs`
- `scripts/ci/test-poor-mans-merge-queue.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/queue tooling only; no compiler or project corpus behavior changed.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`

## Coordination Notes
- Runner identity before canonicalization: ReviewHelper.
- Follow-up to #10317 after local queue pass for #10298 exposed a stale `--force-with-lease` rejection against existing branch `automation/merge-queue/pr-10298`.
- Keeps lease protection by reading the current remote branch OID with `git ls-remote` and using an explicit `--force-with-lease=refs/heads/<branch>:<oid>`.
- If the branch does not exist, the lease explicitly expects absence with `--force-with-lease=refs/heads/<branch>:`.