### PR TITLE
fix(checker): preserve nested generic indexed access returns

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1462,6 +1462,28 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        if result_type.is_none()
+            && !skip_flow_narrowing
+            && self.is_generic_index_type(index_type)
+            && crate::query_boundaries::common::is_index_access_type(
+                self.ctx.types,
+                raw_object_type,
+            )
+            && self.get_element_access_type(
+                object_type_for_access,
+                index_type_for_access,
+                literal_index,
+            ) != TypeId::ERROR
+        {
+            result_type = Some(
+                self.ctx
+                    .types
+                    .factory()
+                    .index_access(raw_object_type, index_type),
+            );
+            use_index_signature_check = false;
+        }
+
         let mut result_type = result_type.unwrap_or_else(|| {
             if crate::query_boundaries::common::is_type_parameter(
                 self.ctx.types,

--- a/crates/tsz-checker/tests/indexed_access_resolved_union_property_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_resolved_union_property_tests.rs
@@ -70,3 +70,105 @@ function f<T extends A | B>(x: T) {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn flow_narrowed_indexed_access_identifier_returns_to_declared_indexed_access() {
+    let source = r#"
+class NumBox<T extends number> {
+  private value!: T;
+  get(): T { return this.value; }
+  onlyNum(): void {}
+}
+class StrBox<T extends string> {
+  private value!: T;
+  get(): T { return this.value; }
+  onlyStr(): void {}
+}
+const isNumBox = <Item extends NumBox<number> | StrBox<string>>(
+  item: Item
+): item is Extract<Item, NumBox<any>> => item instanceof NumBox;
+
+type Bag = { [index: string]: NumBox<number> | StrBox<string> };
+class Store<Bags extends { [index: string]: Bag }> {
+  private bags = {} as Bags;
+  get<BagId extends keyof Bags, BagKey extends keyof Bags[BagId]>(
+    bagId: BagId,
+    bagKey: BagKey
+  ): Bags[BagId][BagKey] {
+    let item = this.bags[bagId][bagKey];
+    if (isNumBox(item)) {
+      item.onlyNum();
+    }
+    item.get();
+    return item;
+  }
+}
+"#;
+    let diags = check(source);
+    assert!(
+        !diags.iter().any(|d| d.code == 2322),
+        "Flow-narrowed generic indexed-access return should not emit TS2322, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn quickinfo_return_position_conformance_shape_keeps_only_expected_missing_property() {
+    let source = r#"
+class Alpha<T extends number> {
+  private value!: T;
+  get(): T { return this.value; }
+  alpha(): void {}
+}
+class Beta<T extends string> {
+  private value!: T;
+  get(): T { return this.value; }
+  beta(): void {}
+}
+const isAlpha = <Candidate extends Alpha<number> | Beta<string>>(
+  candidate: Candidate
+): candidate is Extract<Candidate, Alpha<any>> => candidate instanceof Alpha;
+
+class Simple<Entries extends { [index: string]: Alpha<number> | Beta<string> }> {
+  private entries = {} as Entries;
+  get<EntryId extends keyof Entries>(entryId: EntryId): Entries[EntryId] {
+    let entry = this.entries[entryId];
+    entry.alpha();
+    if (isAlpha(entry)) {
+      return entry;
+    }
+    return entry;
+  }
+}
+
+type Slice = { [index: string]: Alpha<number> | Beta<string> };
+class Complex<Slices extends { [index: string]: Slice }> {
+  private slices = {} as Slices;
+  get<SliceId extends keyof Slices, SliceKey extends keyof Slices[SliceId]>(
+    sliceId: SliceId,
+    sliceKey: SliceKey
+  ): Slices[SliceId][SliceKey] {
+    let item = this.slices[sliceId][sliceKey];
+    if (isAlpha(item)) {
+      item.alpha();
+    }
+    item.get();
+    return item;
+  }
+}
+"#;
+    let diags = check(source);
+    let codes: Vec<_> = diags.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![2339],
+        "Expected only TS2339 for the pre-guard missing property, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -910,11 +910,22 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // S[I] <: T[J]  <=>  S <: T  AND  I <: J
         // This handles deferred index access types (usually involving type parameters).
         if let Some((t_obj, t_idx)) = index_access_parts(self.checker.interner, self.target) {
+            // Coinductive check: delegate back to check_subtype for both parts
+            if self.checker.check_subtype(object_type, t_obj).is_true()
+                && self.checker.check_subtype(key_type, t_idx).is_true()
+            {
+                return SubtypeResult::True;
+            }
+
             // CRITICAL FIX: Check if both keys are type parameters with different names.
             // Even if they have the same constraint, different type parameters should not
             // be considered subtypes of each other. This fixes cases like:
             //   JSX.IntrinsicElements[T1] <: JSX.IntrinsicElements[T2]
             // where T1 and T2 are both `extends keyof JSX.IntrinsicElements` but different params.
+            //
+            // Run this after the operand relation above so declaration-scoped type
+            // parameters that were re-created as fresh TypeIds can still prove they
+            // are related through the normal type-parameter relation.
             if self
                 .checker
                 .index_accesses_have_distinct_type_param_keys(key_type, t_idx)
@@ -936,13 +947,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                     return SubtypeResult::False;
                 }
                 return SubtypeResult::False;
-            }
-
-            // Coinductive check: delegate back to check_subtype for both parts
-            if self.checker.check_subtype(object_type, t_obj).is_true()
-                && self.checker.check_subtype(key_type, t_idx).is_true()
-            {
-                return SubtypeResult::True;
             }
 
             // Special case: if both source and target have the same object type,

--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -1304,6 +1304,42 @@ fn test_no_unchecked_indexed_access_tuple_subtyping() {
 }
 
 #[test]
+fn test_index_access_fresh_equivalent_type_parameter_keys_are_related() {
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let key_atom = interner.intern_string("Key");
+    let key_info = TypeParamInfo {
+        name: key_atom,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+    };
+    let source_key = interner.fresh_type_param(key_info);
+    let target_key = interner.fresh_type_param(key_info);
+    let object = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: Vec::new(),
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let source = interner.index_access(object, source_key);
+    let target = interner.index_access(object, target_key);
+
+    assert!(
+        checker.is_subtype_of(source, target),
+        "fresh ids for the same declaration-scoped key should compare through the operand relation"
+    );
+}
+
+#[test]
 fn test_no_unchecked_object_index_signature_subtyping() {
     let interner = TypeInterner::new();
     let mut checker = SubtypeChecker::new(&interner);


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Semantic campaign / conformance strictness: nested indexed-access relation parity.

## Invariant
When a value is read through a nested generic indexed access whose raw receiver is itself a deferred indexed-access type and whose key is generic, `tsc` preserves the dependent indexed-access identity for later return/assignment checks; this PR makes tsz preserve that read surface in checker orchestration and prove the deferred relation through solver indexed-access operands.

## Owner Layer
- Checker owns the property/element access orchestration and source span: it preserves the unevaluated nested `IndexAccess` surface only after the normal element-access path proves the access is valid.
- Solver owns the assignability fact: indexed-access subtyping now tries coinductive object/key operand relations before applying the distinct-generic-key rejection guard.

## Adjacent-Case Matrix
- Reported witness: nested `Slices[SliceId][SliceKey]` return position now keeps only the intentional missing-property TS2339.
- Equivalent renamed shape: `Bags[BagId][BagKey]` with different class/type parameter names has no TS2322 after a type-guard flow branch.
- Solver identity shape: fresh `TypeId`s for the same declaration-scoped generic key compare through operand relations instead of failing on allocation identity.
- Negative guard: existing TS2322 distinct-key coverage (`test_ts2322_distinct_type_parameters_are_not_suppressed`) still passes, so unrelated type parameters with the same constraint keep the TS5075-style rejection path.

## Scope
- Preserve nested generic index-access read surfaces when the raw receiver is already an indexed access and the key is generic.
- Let solver indexed-access subtyping try operand relations before applying the distinct-generic-key rejection guard.
- Add focused checker and solver regression coverage for the return-position conformance witness and fresh equivalent indexed-access keys.

## Fallback Behavior
- Unsupported or invalid element accesses continue through the existing access path and return `TypeId::ERROR` as before.
- Non-index-access receivers and non-generic keys keep existing evaluation/result behavior.
- Distinct generic-key rejections still run when the operand relation cannot prove the keys related.

## Project Corpus Impact
- Row: n/a
- Bug family: nested generic indexed-access assignability / accepted diagnostic conformance regression
- Evidence: focused conformance filter `quickinfoTypeAtReturnPositionsInaccurate` now passes locally; no project corpus row was run or changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --test indexed_access_resolved_union_property_tests`
- `cargo nextest run -p tsz-solver test_index_access_fresh_equivalent_type_parameter_keys_are_related`
- `cargo nextest run -p tsz-checker --test ts2322_tests distinct_type_parameters`
- `./scripts/conformance/conformance.sh run --filter quickinfoTypeAtReturnPositionsInaccurate --verbose`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- Draft light CI passed on head `c6d59a5483c0448334285b814d483e4daeaa78c0`; ready-review heavy CI started after marking ready.

## Coordination Notes
AgentName: M1-C

Fixes #10164.

Open PR overlap checked before coding and again before publishing. Nearby #10273 covers callback literal inference; it does not claim this accepted regression. #10265 owns accepted-regression list cleanup separately, so this PR leaves the accepted-regression file untouched.

Current exact head: `c6d59a5483c0448334285b814d483e4daeaa78c0`. Marked ready after draft light CI passed. Auto-merge remains off; manager/queue owner should decide landing only after exact-head ready-review checks finish cleanly.
