### PR TITLE
fix(dts): preserve mapped and indexed public surfaces

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1071,6 +1071,16 @@ impl<'a> DeclarationEmitter<'a> {
                     {
                         self.write(": ");
                         self.write(&type_text);
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| {
+                            self.function_body_source_indexed_access_return_type_text(func_body)
+                        })
+                        .flatten()
+                        && self.print_type_id(effective_return_type_id) != type_text
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
                     } else if let Some((type_text, substituted_parameter_type_query)) =
                         scoped_preferred_return.as_ref()
                         && let Some(func_name_text) = self.get_identifier_text(func_name)

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_members.rs
@@ -331,6 +331,14 @@ impl<'a> DeclarationEmitter<'a> {
                                 &self.inferred_method_return_type_text(method, return_type_id),
                             );
                         }
+                    } else if method_body.is_some()
+                        && let Some(type_text) =
+                            self.function_body_source_indexed_access_return_type_text(method_body)
+                        && self.print_type_id(return_type_id) != type_text
+                    {
+                        self.write(": ");
+                        let type_text = self.wrap_async_method_return_type_text(method, type_text);
+                        self.write(&type_text);
                     } else if self
                         .type_mentions_scoped_type_param_nodes(return_type_id, &all_param_nodes)
                     {
@@ -357,6 +365,14 @@ impl<'a> DeclarationEmitter<'a> {
                         self.write(": ");
                         self.write(&self.inferred_method_return_type_text(method, return_type_id));
                     }
+                } else if method_body.is_some()
+                    && let Some(type_text) =
+                        self.function_body_source_indexed_access_return_type_text(method_body)
+                    && self.print_type_id(method_type_id) != type_text
+                {
+                    self.write(": ");
+                    let type_text = self.wrap_async_method_return_type_text(method, type_text);
+                    self.write(&type_text);
                 } else if self
                     .type_mentions_scoped_type_param_nodes(method_type_id, &all_param_nodes)
                     && method_type_id != tsz_solver::types::TypeId::ANY

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -17,11 +17,17 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| {
                 self.super_method_call_return_type_text(expr_idx)
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
+                    .or_else(|| self.generic_call_pick_mapped_type_text(expr_idx))
+                    .or_else(|| self.generic_call_constrained_mapped_return_type_text(expr_idx))
+                    .or_else(|| self.generic_call_returned_function_object_type_text(expr_idx))
                     .or_else(|| self.call_expression_function_variable_return_type_text(expr_idx))
                     .or_else(|| self.generic_call_returned_identity_callback_type_text(expr_idx))
                     .or_else(|| self.call_expression_local_overload_return_type_text(expr_idx))
                     .or_else(|| self.generic_rest_identity_parameters_tuple_type_text(expr_idx))
                     .or_else(|| self.call_expression_parameters_return_tuple_type_text(expr_idx))
+                    .or_else(|| {
+                        self.explicit_type_argument_indexed_member_return_type_text(expr_idx)
+                    })
                     .or_else(|| self.call_expression_source_return_type_text(expr_idx))
                     .or_else(|| self.bind_call_remaining_function_type_text(expr_idx))
                     .or_else(|| self.call_expression_declared_return_type_text(expr_idx))
@@ -59,6 +65,96 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(inner.to_string());
         }
         None
+    }
+
+    fn explicit_type_argument_indexed_member_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+        let call = self.arena.get_call_expr(expr_node)?;
+        let type_args = call.type_arguments.as_ref()?;
+        let binder = self.binder?;
+        let raw_sym_id = self.value_reference_symbol(call.expression)?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+
+        let mut candidate = None;
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+            if !callable.type_annotation.is_some()
+                || !self.function_signature_accepts_call_arguments(
+                    source_arena,
+                    callable.parameters,
+                    call,
+                )
+            {
+                return None;
+            }
+
+            let annotation_node = source_arena.get(callable.type_annotation)?;
+            let indexed = source_arena.get_indexed_access_type(annotation_node)?;
+            let object_type_param =
+                self.simple_type_reference_name_from_arena(source_arena, indexed.object_type)?;
+            let member_name =
+                self.indexed_access_literal_member_name(source_arena, indexed.index_type)?;
+
+            let type_params = callable.type_parameters?;
+            let type_arg_position = type_params.nodes.iter().position(|param_idx| {
+                source_arena
+                    .get(*param_idx)
+                    .and_then(|param_node| source_arena.get_type_parameter(param_node))
+                    .and_then(|param| self.identifier_text_from_arena(source_arena, param.name))
+                    .is_some_and(|name| name == object_type_param)
+            })?;
+            let explicit_arg_idx = *type_args.nodes.get(type_arg_position)?;
+            let type_sym_id =
+                self.declaration_type_symbol_from_type_node(self.arena, explicit_arg_idx)?;
+            let type_text =
+                self.type_member_declared_type_annotation_text(type_sym_id, &member_name)?;
+            Some(type_text)
+        })
+        .and_then(|type_text| {
+            if candidate.replace(type_text.clone()).is_some() {
+                None
+            } else {
+                Some(type_text)
+            }
+        })
+    }
+
+    fn simple_type_reference_name_from_arena(
+        &self,
+        arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<String> {
+        let type_node = arena.get(type_idx)?;
+        if type_node.kind == SyntaxKind::Identifier as u16 {
+            return self.identifier_text_from_arena(arena, type_idx);
+        }
+        if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let type_ref = arena.get_type_ref(type_node)?;
+            return self.identifier_text_from_arena(arena, type_ref.type_name);
+        }
+        None
+    }
+
+    fn indexed_access_literal_member_name(
+        &self,
+        arena: &NodeArena,
+        index_type_idx: NodeIndex,
+    ) -> Option<String> {
+        let index_type_node = arena.get(index_type_idx)?;
+        if index_type_node.kind == syntax_kind_ext::LITERAL_TYPE {
+            let literal_type = arena.get_literal_type(index_type_node)?;
+            return self.property_name_text_from_arena(arena, literal_type.literal);
+        }
+        self.property_name_text_from_arena(arena, index_type_idx)
     }
 
     fn generic_rest_identity_parameters_tuple_type_text(
@@ -1078,6 +1174,157 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    fn generic_call_returned_function_object_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let arguments = call.arguments.as_ref()?;
+        let [arg_idx] = arguments.nodes.as_slice() else {
+            return None;
+        };
+
+        if self.function_expression_has_type_parameters(call.expression) {
+            let callee_idx = self.skip_parenthesized_expression(call.expression)?;
+            let callee_node = self.arena.get(callee_idx)?;
+            let func = self.arena.get_function(callee_node)?;
+            return self.generic_call_returned_function_object_type_text_for_function(
+                self.arena, func, *arg_idx,
+            );
+        }
+
+        let sym_id = self.value_reference_symbol(call.expression)?;
+        let binder = self.binder?;
+        let sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(sym_id, binder));
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let func = callable_function_from_symbol_decl(source_arena, decl_idx)?;
+            self.generic_call_returned_function_object_type_text_for_function(
+                source_arena,
+                func,
+                *arg_idx,
+            )
+        })
+    }
+
+    fn generic_call_returned_function_object_type_text_for_function(
+        &self,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+        arg_idx: NodeIndex,
+    ) -> Option<String> {
+        let return_type_param = function_returned_function_type_parameter_name(source_arena, func)?;
+        if !function_declares_type_parameter(source_arena, func, &return_type_param) {
+            return None;
+        }
+
+        let has_matching_parameter = func.parameters.nodes.iter().copied().any(|param_idx| {
+            source_arena
+                .get(param_idx)
+                .and_then(|node| source_arena.get_parameter(node))
+                .is_some_and(|param| {
+                    type_node_references_type_parameter(
+                        source_arena,
+                        param.type_annotation,
+                        &return_type_param,
+                        0,
+                    ) && type_reference_identifier_name(source_arena, param.type_annotation)
+                        .as_deref()
+                        != Some(return_type_param.as_str())
+                })
+        });
+        if !has_matching_parameter {
+            return None;
+        }
+
+        let object_text = self.object_literal_callback_return_shape_type_text(arg_idx, 0)?;
+        let return_annotation = self
+            .source_slice_from_arena(source_arena, func.type_annotation)
+            .or_else(|| self.emit_type_node_text_from_arena(source_arena, func.type_annotation))?;
+        let prefix = return_annotation.split_once("=>")?.0.trim_end();
+        Some(format!("{prefix} => {object_text}"))
+    }
+
+    fn object_literal_callback_return_shape_type_text(
+        &self,
+        object_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        if object_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(object_node)?;
+        let mut members = Vec::new();
+
+        for &member_idx in &object.elements.nodes {
+            let member_node = self.arena.get(member_idx)?;
+            if member_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                return None;
+            }
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name = self.object_literal_member_name_text(name_idx)?;
+            if name.is_empty() || name == ":" {
+                return None;
+            }
+            let initializer = self.object_literal_member_initializer(member_node)?;
+            let type_text = self.callback_spec_member_result_type_text(initializer, depth + 1)?;
+            members.push(Self::format_object_member_type_text(
+                &name,
+                &type_text,
+                depth + 1,
+            ));
+        }
+
+        if members.is_empty() {
+            return None;
+        }
+        let member_indent = "    ".repeat((depth + 1) as usize);
+        let closing_indent = "    ".repeat(depth as usize);
+        let formatted_members = members
+            .iter()
+            .map(|member| Self::format_object_member_entry(&member_indent, member))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("{{\n{formatted_members}\n{closing_indent}}}"))
+    }
+
+    fn callback_spec_member_result_type_text(
+        &self,
+        initializer: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        let initializer = self.skip_parenthesized_expression(initializer)?;
+        let node = self.arena.get(initializer)?;
+        if node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return self.object_literal_callback_return_shape_type_text(initializer, depth);
+        }
+        if node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return None;
+        }
+        let return_type = self.callback_function_widened_return_type_text(initializer)?;
+        (!return_type.is_empty() && return_type != "any").then_some(return_type)
+    }
+
+    fn callback_function_widened_return_type_text(&self, func_idx: NodeIndex) -> Option<String> {
+        if let Some(literal_text) = self.function_expression_literal_return_type_text(func_idx)
+            && let Some(primitive) = Self::overload_literal_primitive_name(&literal_text)
+        {
+            return Some(primitive.to_string());
+        }
+
+        let interner = self.type_interner?;
+        let func_type = self.get_node_type_or_names(&[func_idx])?;
+        let return_type = tsz_solver::type_queries::get_return_type(interner, func_type)?;
+        let widened = tsz_solver::operations::widening::widen_literal_type(interner, return_type);
+        Some(self.print_type_id_for_inferred_declaration(widened))
+    }
+
     fn call_expression_has_generic_callee(&self, expr_idx: NodeIndex) -> bool {
         let Some(expr_node) = self.arena.get(expr_idx) else {
             return false;
@@ -1148,6 +1395,34 @@ fn function_return_type_parameter_name(
     func: &FunctionData,
 ) -> Option<String> {
     type_reference_identifier_name(source_arena, func.type_annotation)
+}
+
+fn function_returned_function_type_parameter_name(
+    source_arena: &NodeArena,
+    func: &FunctionData,
+) -> Option<String> {
+    let return_node = source_arena.get(func.type_annotation)?;
+    if return_node.kind != syntax_kind_ext::FUNCTION_TYPE {
+        return None;
+    }
+    let function_type = source_arena.get_function_type(return_node)?;
+    type_reference_identifier_name(source_arena, function_type.type_annotation)
+}
+
+fn function_declares_type_parameter(
+    source_arena: &NodeArena,
+    func: &FunctionData,
+    type_param_name: &str,
+) -> bool {
+    func.type_parameters.as_ref().is_some_and(|type_params| {
+        type_params.nodes.iter().copied().any(|param_idx| {
+            source_arena
+                .get(param_idx)
+                .and_then(|node| source_arena.get_type_parameter(node))
+                .and_then(|param| identifier_text(source_arena, param.name))
+                .is_some_and(|name| name == type_param_name)
+        })
+    })
 }
 
 fn function_return_tuple_type_parameter_names(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
@@ -1,0 +1,754 @@
+//! Declaration emit helpers for generic calls through mapped utility surfaces.
+
+use super::super::DeclarationEmitter;
+use tsz_binder::SymbolId;
+use tsz_parser::parser::node::{FunctionData, NodeArena, TypeAliasData};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, NodeList};
+use tsz_scanner::SyntaxKind;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn generic_call_pick_mapped_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let arguments = call.arguments.as_ref()?;
+
+        if self.pick_call_function_expression_has_type_parameters(call.expression) {
+            let callee_idx = self.skip_parenthesized_expression(call.expression)?;
+            let callee_node = self.arena.get(callee_idx)?;
+            let func = self.arena.get_function(callee_node)?;
+            return self
+                .generic_call_pick_mapped_type_text_for_function(self.arena, func, arguments);
+        }
+
+        let sym_id = self.value_reference_symbol(call.expression)?;
+        let binder = self.binder?;
+        let sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(sym_id, binder));
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let func = callable_function_from_symbol_decl(source_arena, decl_idx)?;
+            self.generic_call_pick_mapped_type_text_for_function(source_arena, func, arguments)
+        })
+    }
+
+    pub(in crate::declaration_emitter) fn generic_call_constrained_mapped_return_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        if call
+            .arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        let sym_id = self.value_reference_symbol(call.expression)?;
+        let binder = self.binder?;
+        let sym_id = self
+            .resolve_portability_import_alias(sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(sym_id, binder));
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let func = callable_function_from_symbol_decl(source_arena, decl_idx)?;
+            self.generic_call_constrained_mapped_return_type_text_for_function(
+                expr_idx,
+                source_arena,
+                func,
+            )
+        })
+    }
+
+    fn generic_call_pick_mapped_type_text_for_function(
+        &self,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+        arguments: &NodeList,
+    ) -> Option<String> {
+        if let Some((return_object_idx, return_key_idx)) =
+            self.pick_type_reference_args(source_arena, func.type_annotation)
+        {
+            let object_text = self.type_parameter_argument_type_text(
+                source_arena,
+                func,
+                arguments,
+                return_object_idx,
+            )?;
+            let key_text = self.type_parameter_argument_type_text(
+                source_arena,
+                func,
+                arguments,
+                return_key_idx,
+            )?;
+            if object_text == "any" {
+                return Some(format!("Pick<any, {key_text}>"));
+            }
+        }
+
+        let return_text = self
+            .emit_type_node_text_from_arena(source_arena, func.type_annotation)
+            .or_else(|| self.source_slice_from_arena(source_arena, func.type_annotation))?
+            .trim()
+            .to_string();
+
+        func.parameters
+            .nodes
+            .iter()
+            .copied()
+            .zip(arguments.nodes.iter().copied())
+            .find_map(|(param_idx, arg_idx)| {
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_parameter(param_node)?;
+                let pick = self.pick_type_reference_in_type(source_arena, param.type_annotation)?;
+                let object_text = self
+                    .emit_type_node_text_from_arena(source_arena, pick.object_type)
+                    .or_else(|| self.source_slice_from_arena(source_arena, pick.object_type))?
+                    .trim()
+                    .to_string();
+                let key_text = self
+                    .emit_type_node_text_from_arena(source_arena, pick.key_type)
+                    .or_else(|| self.source_slice_from_arena(source_arena, pick.key_type))?
+                    .trim()
+                    .to_string();
+
+                if return_text == key_text {
+                    return self.object_literal_key_union_type_text(arg_idx);
+                }
+
+                if return_text != object_text {
+                    return None;
+                }
+
+                let shape_text = self.object_literal_pick_argument_shape_type_text(
+                    arg_idx,
+                    pick.requires_single_property_unwrap,
+                    0,
+                )?;
+                if source_arena
+                    .get(pick.object_type)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::INTERSECTION_TYPE)
+                {
+                    let arm_count = source_arena
+                        .get(pick.object_type)
+                        .and_then(|node| source_arena.get_composite_type(node))
+                        .map(|composite| composite.types.nodes.len())
+                        .unwrap_or(1);
+                    return Some(vec![shape_text; arm_count].join(" & "));
+                }
+                Some(shape_text)
+            })
+    }
+
+    fn generic_call_constrained_mapped_return_type_text_for_function(
+        &self,
+        expr_idx: NodeIndex,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+    ) -> Option<String> {
+        let mapped = mapped_type_from_annotation(source_arena, func.type_annotation)?;
+        let type_params = func.type_parameters.as_ref()?;
+        let mapped_param = source_arena
+            .get(mapped.type_parameter)
+            .and_then(|node| source_arena.get_type_parameter(node))?;
+        let type_op = source_arena
+            .get(mapped_param.constraint)
+            .and_then(|node| source_arena.get_type_operator(node))?;
+        if type_op.operator != SyntaxKind::KeyOfKeyword as u16 {
+            return None;
+        }
+        let source_param_name = type_reference_identifier_name(source_arena, type_op.type_node)?;
+        let source_type_idx = type_params.nodes.iter().copied().find_map(|param_idx| {
+            let param = source_arena
+                .get(param_idx)
+                .and_then(|node| source_arena.get_type_parameter(node))?;
+            if identifier_text(source_arena, param.name).as_deref()
+                == Some(source_param_name.as_str())
+            {
+                param
+                    .default
+                    .into_option()
+                    .or_else(|| param.constraint.into_option())
+            } else {
+                None
+            }
+        })?;
+        if let Some(primitive_text) =
+            self.primitive_keyword_type_text(source_arena, source_type_idx)
+        {
+            return Some(primitive_text);
+        }
+
+        let template_text = self
+            .emit_type_node_text_from_arena(source_arena, mapped.type_node)
+            .or_else(|| self.source_slice_from_arena(source_arena, mapped.type_node))?
+            .trim()
+            .to_string();
+        if template_text.is_empty()
+            || identifier_text(source_arena, mapped_param.name)
+                .is_some_and(|name| Self::contains_whole_word_in_text(&template_text, &name))
+            || Self::contains_whole_word_in_text(&template_text, &source_param_name)
+        {
+            return None;
+        }
+        self.mapped_constraint_member_object_type_text(
+            source_arena,
+            source_type_idx,
+            &template_text,
+        )
+        .or_else(|| {
+            let type_id = self.get_node_type_or_names(&[expr_idx])?;
+            let expanded = self.print_type_id_expanded_for_inferred_declaration(type_id);
+            (!expanded.is_empty() && !matches!(expanded.as_str(), "any" | "unknown"))
+                .then_some(Self::strip_synthetic_anonymous_object_members(&expanded))
+        })
+    }
+
+    fn primitive_keyword_type_text(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<String> {
+        let node = source_arena.get(type_idx)?;
+        let type_name_idx = if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            source_arena.get_type_ref(node)?.type_name
+        } else {
+            type_idx
+        };
+        let primitive = match identifier_text(source_arena, type_name_idx)?.as_str() {
+            "string" => "string",
+            "number" => "number",
+            "boolean" => "boolean",
+            "bigint" => "bigint",
+            "symbol" => "symbol",
+            _ => return None,
+        };
+        Some(primitive.to_string())
+    }
+
+    fn mapped_constraint_member_object_type_text(
+        &self,
+        source_arena: &NodeArena,
+        source_type_idx: NodeIndex,
+        template_text: &str,
+    ) -> Option<String> {
+        let sym_id = self
+            .type_reference_symbol_from_arena(source_arena, source_type_idx)
+            .or_else(|| {
+                let name = type_reference_identifier_name(source_arena, source_type_idx)?;
+                self.binder?.get_global_type(&name)
+            })?;
+        let member_texts = self.mapped_constraint_member_type_texts(sym_id, template_text)?;
+        let member_indent = "    ".to_string();
+        let formatted_members = member_texts
+            .iter()
+            .map(|member| Self::format_object_member_entry(&member_indent, member))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("{{\n{formatted_members}\n}}"))
+    }
+
+    fn mapped_constraint_member_type_texts(
+        &self,
+        sym_id: SymbolId,
+        template_text: &str,
+    ) -> Option<Vec<String>> {
+        let binder = self.binder?;
+        let symbol = binder.symbols.get(sym_id)?;
+        let mut member_texts = Vec::new();
+        for decl_idx in symbol.declarations.iter().copied() {
+            if self.arena.get(decl_idx).is_some() {
+                self.collect_mapped_constraint_members_from_decl(
+                    self.arena,
+                    decl_idx,
+                    template_text,
+                    &mut member_texts,
+                );
+            }
+            if let Some(arenas) = binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+                for arena in arenas {
+                    self.collect_mapped_constraint_members_from_decl(
+                        arena.as_ref(),
+                        decl_idx,
+                        template_text,
+                        &mut member_texts,
+                    );
+                }
+            }
+            if let Some(arena) = binder.symbol_arenas.get(&sym_id) {
+                self.collect_mapped_constraint_members_from_decl(
+                    arena.as_ref(),
+                    decl_idx,
+                    template_text,
+                    &mut member_texts,
+                );
+            }
+            if let Some(arena) = self.global_symbol_arenas.get(&sym_id) {
+                self.collect_mapped_constraint_members_from_decl(
+                    arena.as_ref(),
+                    decl_idx,
+                    template_text,
+                    &mut member_texts,
+                );
+            }
+        }
+        (!member_texts.is_empty()).then_some(member_texts)
+    }
+
+    fn collect_mapped_constraint_members_from_decl(
+        &self,
+        decl_arena: &NodeArena,
+        decl_idx: NodeIndex,
+        template_text: &str,
+        member_texts: &mut Vec<String>,
+    ) {
+        let Some(decl_node) = decl_arena.get(decl_idx) else {
+            return;
+        };
+        let Some(members) = decl_arena
+            .get_interface(decl_node)
+            .map(|iface| iface.members.nodes.as_slice())
+            .or_else(|| {
+                decl_arena
+                    .get_class(decl_node)
+                    .map(|class| class.members.nodes.as_slice())
+            })
+        else {
+            return;
+        };
+        for &member_idx in members {
+            let Some(member_node) = decl_arena.get(member_idx) else {
+                continue;
+            };
+            let name_idx = decl_arena
+                .get_signature(member_node)
+                .map(|signature| signature.name)
+                .or_else(|| {
+                    decl_arena
+                        .get_method_decl(member_node)
+                        .map(|method| method.name)
+                })
+                .or_else(|| {
+                    decl_arena
+                        .get_property_decl(member_node)
+                        .map(|prop| prop.name)
+                });
+            let Some(name) =
+                name_idx.and_then(|idx| self.property_name_text_from_arena(decl_arena, idx))
+            else {
+                continue;
+            };
+            let member_text = Self::format_object_member_type_text(&name, template_text, 1);
+            if !member_texts.contains(&member_text) {
+                member_texts.push(member_text);
+            }
+        }
+    }
+
+    fn type_parameter_argument_type_text(
+        &self,
+        source_arena: &NodeArena,
+        func: &FunctionData,
+        arguments: &NodeList,
+        type_param_idx: NodeIndex,
+    ) -> Option<String> {
+        let type_param_name = type_reference_identifier_name(source_arena, type_param_idx)?;
+        func.parameters
+            .nodes
+            .iter()
+            .copied()
+            .zip(arguments.nodes.iter().copied())
+            .find_map(|(param_idx, arg_idx)| {
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_parameter(param_node)?;
+                if type_reference_identifier_name(source_arena, param.type_annotation).as_deref()
+                    == Some(type_param_name.as_str())
+                {
+                    return self
+                        .preferred_expression_type_text(arg_idx)
+                        .or_else(|| self.infer_fallback_type_text_at(arg_idx, 0));
+                }
+                if array_type_element_identifier_name(source_arena, param.type_annotation)
+                    .as_deref()
+                    == Some(type_param_name.as_str())
+                {
+                    return self.array_literal_const_union_type_text(arg_idx);
+                }
+                None
+            })
+    }
+
+    fn object_literal_pick_argument_shape_type_text(
+        &self,
+        object_idx: NodeIndex,
+        unwrap_single_property_object: bool,
+        depth: u32,
+    ) -> Option<String> {
+        if !unwrap_single_property_object {
+            return self.infer_object_literal_type_text_at(object_idx, depth);
+        }
+
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        if object_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(object_node)?;
+        let mut members = Vec::new();
+        for &member_idx in &object.elements.nodes {
+            let member_node = self.arena.get(member_idx)?;
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name = self.object_literal_member_name_text(name_idx)?;
+            if name.is_empty() || name == ":" {
+                return None;
+            }
+            let initializer = self.object_literal_member_initializer(member_node)?;
+            let value_idx = self.single_property_object_literal_value(initializer)?;
+            let type_text = self
+                .infer_fallback_type_text_at(value_idx, depth + 1)
+                .or_else(|| self.preferred_expression_type_text(value_idx))?;
+            members.push(Self::format_object_member_type_text(
+                &name,
+                &type_text,
+                depth + 1,
+            ));
+        }
+
+        if members.is_empty() {
+            return None;
+        }
+        let member_indent = "    ".repeat((depth + 1) as usize);
+        let closing_indent = "    ".repeat(depth as usize);
+        let formatted_members = members
+            .iter()
+            .map(|member| Self::format_object_member_entry(&member_indent, member))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!("{{\n{formatted_members}\n{closing_indent}}}"))
+    }
+
+    fn single_property_object_literal_value(&self, object_idx: NodeIndex) -> Option<NodeIndex> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        if object_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(object_node)?;
+        let [member_idx] = object.elements.nodes.as_slice() else {
+            return None;
+        };
+        let member_node = self.arena.get(*member_idx)?;
+        if member_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+            return None;
+        }
+        self.object_literal_member_initializer(member_node)
+    }
+
+    fn object_literal_key_union_type_text(&self, object_idx: NodeIndex) -> Option<String> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        if object_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(object_node)?;
+        let mut keys = Vec::new();
+        for &member_idx in &object.elements.nodes {
+            let member_node = self.arena.get(member_idx)?;
+            if member_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT {
+                return None;
+            }
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name = self.object_literal_member_name_text(name_idx)?;
+            if name.is_empty() || name == ":" {
+                return None;
+            }
+            keys.push(format!("\"{name}\""));
+        }
+        (!keys.is_empty()).then(|| keys.join(" | "))
+    }
+
+    fn array_literal_const_union_type_text(&self, array_idx: NodeIndex) -> Option<String> {
+        let array_idx = self.skip_parenthesized_expression(array_idx)?;
+        let array_node = self.arena.get(array_idx)?;
+        if array_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            return None;
+        }
+        let array = self.arena.get_literal_expr(array_node)?;
+        let mut elements = Vec::new();
+        for &element_idx in &array.elements.nodes {
+            elements.push(self.const_literal_initializer_text(element_idx)?);
+        }
+        (!elements.is_empty()).then(|| elements.join(" | "))
+    }
+
+    fn pick_call_function_expression_has_type_parameters(&self, expr_idx: NodeIndex) -> bool {
+        let Some(expr_idx) = self.skip_parenthesized_expression(expr_idx) else {
+            return false;
+        };
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && expr_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return false;
+        }
+        self.arena
+            .get_function(expr_node)
+            .and_then(|func| func.type_parameters.as_ref())
+            .is_some_and(|params| !params.nodes.is_empty())
+    }
+
+    fn pick_type_reference_args(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<(NodeIndex, NodeIndex)> {
+        let type_node = source_arena.get(type_idx)?;
+        if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = source_arena.get_type_ref(type_node)?;
+        let type_args = type_ref.type_arguments.as_ref()?;
+        let [object_type, key_type] = type_args.nodes.as_slice() else {
+            return None;
+        };
+        let sym_id = self.type_reference_symbol_from_arena(source_arena, type_ref.type_name)?;
+        self.symbol_declares_pick_like_alias(sym_id)
+            .then_some((*object_type, *key_type))
+    }
+
+    fn pick_type_reference_in_type(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<PickTypeReference> {
+        self.pick_type_reference_in_type_inner(source_arena, type_idx, false)
+    }
+
+    fn pick_type_reference_in_type_inner(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        requires_single_property_unwrap: bool,
+    ) -> Option<PickTypeReference> {
+        let type_node = source_arena.get(type_idx)?;
+        match type_node.kind {
+            k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                if let Some((object_type, key_type)) =
+                    self.pick_type_reference_args(source_arena, type_idx)
+                {
+                    return Some(PickTypeReference {
+                        object_type,
+                        key_type,
+                        requires_single_property_unwrap,
+                    });
+                }
+                let type_ref = source_arena.get_type_ref(type_node)?;
+                type_ref
+                    .type_arguments
+                    .as_ref()?
+                    .nodes
+                    .iter()
+                    .copied()
+                    .find_map(|arg_idx| {
+                        self.pick_type_reference_in_type_inner(source_arena, arg_idx, true)
+                    })
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => source_arena
+                .get_wrapped_type(type_node)
+                .and_then(|wrapped| {
+                    self.pick_type_reference_in_type_inner(
+                        source_arena,
+                        wrapped.type_node,
+                        requires_single_property_unwrap,
+                    )
+                }),
+            _ => None,
+        }
+    }
+
+    fn type_reference_symbol_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        type_or_name_idx: NodeIndex,
+    ) -> Option<SymbolId> {
+        let binder = self.binder?;
+        let type_name_idx = source_arena.get(type_or_name_idx).and_then(|node| {
+            if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+                source_arena
+                    .get_type_ref(node)
+                    .map(|type_ref| type_ref.type_name)
+            } else {
+                Some(type_or_name_idx)
+            }
+        })?;
+        if std::ptr::eq(source_arena, self.arena)
+            && let Some(sym_id) = binder
+                .get_node_symbol(type_name_idx)
+                .or_else(|| binder.get_node_symbol(type_or_name_idx))
+        {
+            return Some(sym_id);
+        }
+        let name = identifier_text(source_arena, type_name_idx)?;
+        if std::ptr::eq(source_arena, self.arena)
+            && let Some(sym_id) = self.resolve_identifier_symbol(type_name_idx, &name)
+        {
+            return Some(sym_id);
+        }
+        binder.get_global_type(&name)
+    }
+
+    fn symbol_declares_pick_like_alias(&self, sym_id: SymbolId) -> bool {
+        self.with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+            let alias_node = source_arena.get(decl_idx)?;
+            let alias = source_arena.get_type_alias(alias_node)?;
+            type_alias_is_pick_like(source_arena, alias).then_some(())
+        })
+        .is_some()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PickTypeReference {
+    object_type: NodeIndex,
+    key_type: NodeIndex,
+    requires_single_property_unwrap: bool,
+}
+
+fn array_type_element_identifier_name(
+    source_arena: &NodeArena,
+    type_idx: NodeIndex,
+) -> Option<String> {
+    let type_node = source_arena.get(type_idx)?;
+    if type_node.kind != syntax_kind_ext::ARRAY_TYPE {
+        return None;
+    }
+    let array = source_arena.get_array_type(type_node)?;
+    type_reference_identifier_name(source_arena, array.element_type)
+}
+
+fn type_alias_is_pick_like(source_arena: &NodeArena, alias: &TypeAliasData) -> bool {
+    let Some(type_params) = alias.type_parameters.as_ref() else {
+        return false;
+    };
+    let [object_param_idx, key_param_idx] = type_params.nodes.as_slice() else {
+        return false;
+    };
+    let Some(object_param_name) = type_parameter_name(source_arena, *object_param_idx) else {
+        return false;
+    };
+    let Some(key_param_name) = type_parameter_name(source_arena, *key_param_idx) else {
+        return false;
+    };
+
+    let Some(type_node) = source_arena.get(alias.type_node) else {
+        return false;
+    };
+    if type_node.kind != syntax_kind_ext::MAPPED_TYPE {
+        return false;
+    }
+    let Some(mapped) = source_arena.get_mapped_type(type_node) else {
+        return false;
+    };
+    let Some(mapped_param) = source_arena
+        .get(mapped.type_parameter)
+        .and_then(|node| source_arena.get_type_parameter(node))
+    else {
+        return false;
+    };
+    let Some(mapped_param_name) = identifier_text(source_arena, mapped_param.name) else {
+        return false;
+    };
+    if type_reference_identifier_name(source_arena, mapped_param.constraint).as_deref()
+        != Some(key_param_name.as_str())
+    {
+        return false;
+    }
+
+    let Some(template_node) = source_arena.get(mapped.type_node) else {
+        return false;
+    };
+    let Some(indexed) = source_arena.get_indexed_access_type(template_node) else {
+        return false;
+    };
+    type_reference_identifier_name(source_arena, indexed.object_type).as_deref()
+        == Some(object_param_name.as_str())
+        && type_reference_identifier_name(source_arena, indexed.index_type).as_deref()
+            == Some(mapped_param_name.as_str())
+}
+
+fn type_parameter_name(source_arena: &NodeArena, type_param_idx: NodeIndex) -> Option<String> {
+    source_arena
+        .get(type_param_idx)
+        .and_then(|node| source_arena.get_type_parameter(node))
+        .and_then(|param| identifier_text(source_arena, param.name))
+}
+
+fn mapped_type_from_annotation(
+    source_arena: &NodeArena,
+    type_idx: NodeIndex,
+) -> Option<&tsz_parser::parser::node::MappedTypeData> {
+    let type_node = source_arena.get(type_idx)?;
+    if type_node.kind == syntax_kind_ext::MAPPED_TYPE {
+        return source_arena.get_mapped_type(type_node);
+    }
+    if type_node.kind == syntax_kind_ext::TYPE_LITERAL {
+        let literal = source_arena.get_type_literal(type_node)?;
+        let [member_idx] = literal.members.nodes.as_slice() else {
+            return None;
+        };
+        let member_node = source_arena.get(*member_idx)?;
+        if member_node.kind == syntax_kind_ext::MAPPED_TYPE {
+            return source_arena.get_mapped_type(member_node);
+        }
+    }
+    None
+}
+
+fn type_reference_identifier_name(source_arena: &NodeArena, type_idx: NodeIndex) -> Option<String> {
+    let type_node = source_arena.get(type_idx)?;
+    if type_node.kind == SyntaxKind::Identifier as u16 {
+        return identifier_text(source_arena, type_idx);
+    }
+    let type_ref = source_arena.get_type_ref(type_node)?;
+    identifier_text(source_arena, type_ref.type_name)
+}
+
+fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    source_arena
+        .get(idx)
+        .and_then(|node| source_arena.get_identifier(node))
+        .map(|ident| ident.escaped_text.clone())
+}
+
+fn callable_function_from_symbol_decl(
+    source_arena: &NodeArena,
+    decl_idx: NodeIndex,
+) -> Option<&FunctionData> {
+    if let Some(func) = source_arena
+        .get(decl_idx)
+        .and_then(|node| source_arena.get_function(node))
+    {
+        return Some(func);
+    }
+
+    let mut current = decl_idx;
+    for _ in 0..8 {
+        let node = source_arena.get(current)?;
+        if let Some(var_decl) = source_arena.get_variable_declaration(node) {
+            let initializer_node = source_arena.get(var_decl.initializer)?;
+            if initializer_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || initializer_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            {
+                return source_arena.get_function(initializer_node);
+            }
+        }
+        current = source_arena.parent_of(current)?;
+    }
+
+    None
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -252,6 +252,7 @@ mod default_import_alias_rewrite;
 mod emit_node;
 mod function_analysis;
 mod generic_call_literal;
+mod generic_call_mapped_inference;
 mod js_exports;
 mod jsdoc;
 mod jsdoc_function_signature;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -5,7 +5,7 @@
 //! returned object/class/function text using declaration-scope parameter types.
 
 use super::super::DeclarationEmitter;
-use tsz_parser::parser::node::{MethodDeclData, NodeAccess, NodeArena};
+use tsz_parser::parser::node::{CallExprData, ClassData, MethodDeclData, NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
@@ -138,6 +138,14 @@ impl<'a> DeclarationEmitter<'a> {
         let object_node = self.arena.get(object_expr_idx)?;
         let object = self.arena.get_literal_expr(object_node)?;
         self.single_spread_object_literal_type_text(object)
+    }
+
+    pub(in crate::declaration_emitter) fn function_body_source_indexed_access_return_type_text(
+        &self,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        let expression = self.function_body_single_return_expression(body_idx)?;
+        self.source_indexed_access_return_type_text(expression)
     }
 
     pub(in crate::declaration_emitter) fn should_prefer_source_return_type_text(
@@ -1178,6 +1186,21 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     text
                 } else if let Some(text) = self
+                    .source_indexed_access_return_type_text(ret.expression)
+                    .filter(|text| !text.is_empty())
+                {
+                    text
+                } else if let Some(text) = self
+                    .source_indexed_access_call_return_type_text(ret.expression)
+                    .filter(|text| !text.is_empty())
+                {
+                    text
+                } else if let Some(text) = self
+                    .local_variable_source_indexed_initializer_type_text(ret.expression, stmt_idx)
+                    .filter(|text| !text.is_empty())
+                {
+                    text
+                } else if let Some(text) = self
                     .widened_inferred_expression_type_text(ret.expression)
                     .filter(|text| !text.is_empty() && text != "any")
                 {
@@ -1282,6 +1305,653 @@ impl<'a> DeclarationEmitter<'a> {
             }
             _ => true,
         }
+    }
+
+    fn source_indexed_access_return_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(expr_node)?;
+        let receiver_text = self.indexed_access_receiver_type_text(access.expression)?;
+        let key_text = self.indexed_access_key_type_text(access.name_or_argument)?;
+        Some(format!("{receiver_text}[{key_text}]"))
+    }
+
+    fn source_indexed_access_call_return_type_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return None;
+        }
+
+        let call = self.arena.get_call_expr(expr_node)?;
+        let binder = self.binder?;
+        let Some(raw_sym_id) = self.value_reference_symbol(call.expression) else {
+            return self
+                .lexical_function_source_indexed_call_return_type_text(call)
+                .or_else(|| self.this_method_source_indexed_call_return_type_text(call));
+        };
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or_else(|| self.resolve_portability_symbol(raw_sym_id, binder));
+        let symbol = binder.symbols.get(sym_id)?;
+        let source_arena = binder
+            .symbol_arenas
+            .get(&sym_id)
+            .or_else(|| self.global_symbol_arenas.get(&sym_id))
+            .map(|arena| arena.as_ref())
+            .unwrap_or(self.arena);
+
+        let mut indexed_return_text = None;
+        for decl_idx in symbol.declarations.iter().copied() {
+            let Some(func) = self.callable_function_from_symbol_decl(source_arena, decl_idx) else {
+                continue;
+            };
+            let Some(type_text) =
+                self.callable_source_indexed_access_return_type_text(source_arena, func)
+            else {
+                continue;
+            };
+            if indexed_return_text.replace((func, type_text)).is_some() {
+                return None;
+            }
+        }
+
+        let Some((func, type_text)) = indexed_return_text else {
+            return self
+                .lexical_function_source_indexed_call_return_type_text(call)
+                .or_else(|| self.this_method_source_indexed_call_return_type_text(call));
+        };
+        self.substitute_indexed_call_type_parameters(source_arena, func, call, type_text)
+            .or_else(|| self.lexical_function_source_indexed_call_return_type_text(call))
+            .or_else(|| self.this_method_source_indexed_call_return_type_text(call))
+    }
+
+    fn local_variable_source_indexed_initializer_type_text(
+        &self,
+        expr_idx: NodeIndex,
+        return_stmt_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let local_name = self.get_identifier_text(expr_idx)?;
+        let return_stmt_idx = self.statement_ancestor_in_block(return_stmt_idx)?;
+        let block_idx = self.arena.parent_of(return_stmt_idx)?;
+        let block = self
+            .arena
+            .get(block_idx)
+            .and_then(|node| self.arena.get_block(node))?;
+        let mut candidate = None;
+        for &stmt_idx in &block.statements.nodes {
+            if stmt_idx == return_stmt_idx {
+                return candidate;
+            }
+            if candidate.is_some() && self.node_writes_identifier(stmt_idx, &local_name) {
+                return None;
+            }
+            let Some(initializer) =
+                self.local_variable_initializer_for_name_in_statement(stmt_idx, &local_name)
+            else {
+                continue;
+            };
+            let Some(type_text) = self
+                .source_indexed_access_return_type_text(initializer)
+                .or_else(|| self.source_indexed_access_call_return_type_text(initializer))
+            else {
+                continue;
+            };
+            if candidate.replace(type_text).is_some() {
+                return None;
+            }
+        }
+        candidate
+    }
+
+    fn lexical_function_source_indexed_call_return_type_text(
+        &self,
+        call: &CallExprData,
+    ) -> Option<String> {
+        let callee_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(call.expression);
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let callee_name = self.get_identifier_text(callee_idx)?;
+        let mut candidate = None;
+        for node in &self.arena.nodes {
+            if node.kind != syntax_kind_ext::FUNCTION_DECLARATION || node.pos > callee_node.pos {
+                continue;
+            }
+            let Some(func) = self.arena.get_function(node) else {
+                continue;
+            };
+            if self.get_identifier_text(func.name).as_deref() != Some(callee_name.as_str()) {
+                continue;
+            }
+            let Some(type_text) =
+                self.callable_source_indexed_access_return_type_text(self.arena, func)
+            else {
+                continue;
+            };
+            let Some(type_text) =
+                self.substitute_indexed_call_type_parameters(self.arena, func, call, type_text)
+            else {
+                continue;
+            };
+            if candidate.replace(type_text).is_some() {
+                return None;
+            }
+        }
+        candidate
+    }
+
+    fn local_variable_initializer_for_name_in_statement(
+        &self,
+        node_idx: NodeIndex,
+        local_name: &str,
+    ) -> Option<NodeIndex> {
+        let node = self.arena.get(node_idx)?;
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || node.kind == syntax_kind_ext::ARROW_FUNCTION
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+            || node.kind == syntax_kind_ext::METHOD_DECLARATION
+        {
+            return None;
+        }
+        if let Some(var_decl) = self.arena.get_variable_declaration(node)
+            && var_decl.initializer.is_some()
+            && self.get_identifier_text(var_decl.name).as_deref() == Some(local_name)
+        {
+            return Some(var_decl.initializer);
+        }
+        let mut candidate = None;
+        for child_idx in self.arena.get_children(node_idx) {
+            if let Some(initializer) =
+                self.local_variable_initializer_for_name_in_statement(child_idx, local_name)
+            {
+                if candidate.replace(initializer).is_some() {
+                    return None;
+                }
+            }
+        }
+        candidate
+    }
+
+    fn statement_ancestor_in_block(&self, from_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = from_idx;
+        for _ in 0..64 {
+            let parent_idx = self.arena.parent_of(current)?;
+            let parent_node = self.arena.get(parent_idx)?;
+            if parent_node.kind == syntax_kind_ext::BLOCK {
+                return Some(current);
+            }
+            current = parent_idx;
+        }
+        None
+    }
+
+    fn node_writes_identifier(&self, node_idx: NodeIndex, name: &str) -> bool {
+        let Some(node) = self.arena.get(node_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::BINARY_EXPRESSION
+            && let Some(binary) = self.arena.get_binary_expr(node)
+            && binary.operator_token >= SyntaxKind::EqualsToken as u16
+            && binary.operator_token <= SyntaxKind::CaretEqualsToken as u16
+        {
+            return self.node_contains_identifier(binary.left, name);
+        }
+        if (node.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+            || node.kind == syntax_kind_ext::POSTFIX_UNARY_EXPRESSION)
+            && let Some(unary) = self.arena.get_unary_expr(node)
+            && (unary.operator == SyntaxKind::PlusPlusToken as u16
+                || unary.operator == SyntaxKind::MinusMinusToken as u16)
+        {
+            return self.node_contains_identifier(unary.operand, name);
+        }
+        self.arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.node_writes_identifier(child_idx, name))
+    }
+
+    fn node_contains_identifier(&self, node_idx: NodeIndex, name: &str) -> bool {
+        let Some(node) = self.arena.get(node_idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::Identifier as u16
+            && self.get_identifier_text(node_idx).as_deref() == Some(name)
+        {
+            return true;
+        }
+        self.arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.node_contains_identifier(child_idx, name))
+    }
+
+    fn callable_source_indexed_access_return_type_text(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+    ) -> Option<String> {
+        if func.type_annotation.is_some() {
+            let type_idx =
+                source_arena.skip_parenthesized_and_assertions_and_comma(func.type_annotation);
+            let type_node = source_arena.get(type_idx)?;
+            if type_node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
+                return self
+                    .source_slice_from_arena(source_arena, func.type_annotation)
+                    .map(|text| text.trim().to_string());
+            }
+        }
+
+        if func.body.is_some() {
+            if std::ptr::eq(source_arena, self.arena) {
+                return self.function_body_source_indexed_access_return_type_text(func.body);
+            }
+            let scratch = DeclarationEmitter::new(source_arena);
+            return scratch.function_body_source_indexed_access_return_type_text(func.body);
+        }
+
+        None
+    }
+
+    fn this_method_source_indexed_call_return_type_text(
+        &self,
+        call: &CallExprData,
+    ) -> Option<String> {
+        let callee_node = self.arena.get(call.expression)?;
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(callee_node)?;
+        let receiver_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(access.expression);
+        if self
+            .arena
+            .get(receiver_idx)
+            .is_none_or(|node| node.kind != SyntaxKind::ThisKeyword as u16)
+        {
+            return None;
+        }
+        let method_name = self.get_identifier_text(access.name_or_argument)?;
+        let class_idx = self.enclosing_class_declaration_index(call.expression)?;
+        let class = self.arena.get_class_at(class_idx)?;
+        self.class_method_source_indexed_call_return_type_text(
+            self.arena,
+            class,
+            &method_name,
+            call,
+            0,
+        )
+    }
+
+    fn class_method_source_indexed_call_return_type_text(
+        &self,
+        source_arena: &NodeArena,
+        class: &ClassData,
+        method_name: &str,
+        call: &CallExprData,
+        depth: usize,
+    ) -> Option<String> {
+        if depth > 8 {
+            return None;
+        }
+
+        let mut saw_named_member = false;
+        let mut candidate = None;
+        for &member_idx in &class.members.nodes {
+            let Some(member_node) = source_arena.get(member_idx) else {
+                continue;
+            };
+            let member_name = source_arena
+                .get_method_decl(member_node)
+                .and_then(|method| self.property_name_text_from_arena(source_arena, method.name));
+            if member_name.as_deref() != Some(method_name) {
+                continue;
+            }
+            saw_named_member = true;
+            let Some(method) = source_arena.get_method_decl(member_node) else {
+                continue;
+            };
+            let Some(type_text) =
+                self.method_source_indexed_access_return_type_text(source_arena, method)
+            else {
+                continue;
+            };
+            let type_text = self.substitute_indexed_callable_type_parameters(
+                source_arena,
+                method.type_parameters.as_ref(),
+                &method.parameters,
+                call,
+                type_text,
+            )?;
+            if candidate.replace(type_text).is_some() {
+                return None;
+            }
+        }
+        if candidate.is_some() || saw_named_member {
+            return candidate;
+        }
+
+        let heritage_clauses = class.heritage_clauses.as_ref()?;
+        for &heritage_idx in &heritage_clauses.nodes {
+            let Some(heritage) = source_arena.get_heritage_clause_at(heritage_idx) else {
+                continue;
+            };
+            if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                continue;
+            }
+            for &base_idx in &heritage.types.nodes {
+                let base_expr = source_arena
+                    .get_expr_type_args_at(base_idx)
+                    .map_or(base_idx, |expr| expr.expression);
+                let Some(base_sym_id) =
+                    self.declaration_type_symbol_from_type_node(source_arena, base_expr)
+                else {
+                    continue;
+                };
+                if let Some(type_text) =
+                    self.with_symbol_declarations(base_sym_id, |base_arena, decl_idx| {
+                        let base_node = base_arena.get(decl_idx)?;
+                        let base_class = base_arena.get_class(base_node)?;
+                        self.class_method_source_indexed_call_return_type_text(
+                            base_arena,
+                            base_class,
+                            method_name,
+                            call,
+                            depth + 1,
+                        )
+                    })
+                {
+                    return Some(type_text);
+                }
+            }
+        }
+        None
+    }
+
+    fn method_source_indexed_access_return_type_text(
+        &self,
+        source_arena: &NodeArena,
+        method: &MethodDeclData,
+    ) -> Option<String> {
+        if method.type_annotation.is_some() {
+            let type_idx =
+                source_arena.skip_parenthesized_and_assertions_and_comma(method.type_annotation);
+            let type_node = source_arena.get(type_idx)?;
+            if type_node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
+                return self
+                    .source_slice_from_arena(source_arena, method.type_annotation)
+                    .map(|text| text.trim().to_string());
+            }
+        }
+
+        if method.body.is_some() {
+            if std::ptr::eq(source_arena, self.arena) {
+                return self.function_body_source_indexed_access_return_type_text(method.body);
+            }
+            let scratch = DeclarationEmitter::new(source_arena);
+            return scratch.function_body_source_indexed_access_return_type_text(method.body);
+        }
+
+        None
+    }
+
+    fn substitute_indexed_call_type_parameters(
+        &self,
+        source_arena: &NodeArena,
+        func: &tsz_parser::parser::node::FunctionData,
+        call: &tsz_parser::parser::node::CallExprData,
+        type_text: String,
+    ) -> Option<String> {
+        self.substitute_indexed_callable_type_parameters(
+            source_arena,
+            func.type_parameters.as_ref(),
+            &func.parameters,
+            call,
+            type_text,
+        )
+    }
+
+    fn substitute_indexed_callable_type_parameters(
+        &self,
+        source_arena: &NodeArena,
+        type_parameters: Option<&NodeList>,
+        parameters: &NodeList,
+        call: &CallExprData,
+        type_text: String,
+    ) -> Option<String> {
+        let Some(type_params) = type_parameters else {
+            return Some(type_text);
+        };
+        if type_params.nodes.is_empty() {
+            return Some(type_text);
+        }
+
+        let type_param_names = self.collect_type_param_names_from_arena(source_arena, type_params);
+        if type_param_names.is_empty() {
+            return Some(type_text);
+        }
+
+        let mut substitutions = Vec::new();
+        if call.type_arguments.is_some() {
+            let explicit_type_args =
+                self.type_argument_list_source_text(call.type_arguments.as_ref());
+            for (name, value) in type_param_names.iter().zip(explicit_type_args.iter()) {
+                substitutions.push((name.clone(), value.clone()));
+            }
+        } else if let Some(args) = call.arguments.as_ref() {
+            for (&param_idx, &arg_idx) in parameters.nodes.iter().zip(args.nodes.iter()) {
+                let Some(param_node) = source_arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = source_arena.get_parameter(param_node) else {
+                    continue;
+                };
+                let Some(param_type_text) = self
+                    .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                    .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))
+                    .map(|text| text.trim().to_string())
+                else {
+                    continue;
+                };
+                if !type_param_names
+                    .iter()
+                    .any(|name| name.as_str() == param_type_text)
+                    || substitutions
+                        .iter()
+                        .any(|(name, _)| name.as_str() == param_type_text)
+                {
+                    continue;
+                }
+                let Some(arg_text) = self.indexed_call_argument_type_text(arg_idx) else {
+                    continue;
+                };
+                substitutions.push((param_type_text, arg_text));
+            }
+        }
+
+        let type_text = Self::replace_whole_words_in_text(&type_text, &substitutions);
+        if type_param_names.iter().any(|name| {
+            Self::contains_whole_word_in_text(&type_text, name)
+                && !substitutions
+                    .iter()
+                    .any(|(substituted_name, _)| substituted_name == name)
+        }) {
+            return None;
+        }
+        Some(type_text)
+    }
+
+    fn enclosing_class_declaration_index(&self, from_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = from_idx;
+        for _ in 0..64 {
+            let parent_idx = self.arena.parent_of(current)?;
+            let parent_node = self.arena.get(parent_idx)?;
+            if parent_node.kind == syntax_kind_ext::CLASS_DECLARATION
+                || parent_node.kind == syntax_kind_ext::CLASS_EXPRESSION
+            {
+                return Some(parent_idx);
+            }
+            current = parent_idx;
+        }
+        None
+    }
+
+    fn collect_type_param_names_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        type_params: &NodeList,
+    ) -> Vec<String> {
+        type_params
+            .nodes
+            .iter()
+            .filter_map(|&param_idx| {
+                let param_node = source_arena.get(param_idx)?;
+                let param = source_arena.get_type_parameter(param_node)?;
+                self.identifier_text_from_arena(source_arena, param.name)
+            })
+            .collect()
+    }
+
+    fn indexed_call_argument_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        let arg_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(arg_idx);
+        let arg_node = self.arena.get(arg_idx)?;
+        if arg_node.kind == SyntaxKind::ThisKeyword as u16 {
+            return Some("this".to_string());
+        }
+        if arg_node.kind == SyntaxKind::StringLiteral as u16
+            || arg_node.kind == SyntaxKind::NumericLiteral as u16
+            || arg_node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        {
+            return self
+                .get_source_slice(arg_node.pos, arg_node.end)
+                .map(|text| text.trim().to_string());
+        }
+        if arg_node.kind == SyntaxKind::Identifier as u16 {
+            return self
+                .enclosing_parameter_source_type_annotation_text_for_identifier(arg_idx)
+                .or_else(|| self.reference_declared_type_annotation_text(arg_idx))
+                .filter(|text| !text.trim().is_empty() && text != "any");
+        }
+        None
+    }
+
+    fn indexed_access_receiver_type_text(&self, receiver_idx: NodeIndex) -> Option<String> {
+        let receiver_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(receiver_idx);
+        let receiver_node = self.arena.get(receiver_idx)?;
+        if receiver_node.kind == SyntaxKind::ThisKeyword as u16 {
+            return Some("this".to_string());
+        }
+        if receiver_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            return self.source_indexed_access_return_type_text(receiver_idx);
+        }
+        if receiver_node.kind == SyntaxKind::Identifier as u16 {
+            return self
+                .enclosing_parameter_source_type_annotation_text_for_identifier(receiver_idx)
+                .or_else(|| self.reference_declared_type_annotation_text(receiver_idx))
+                .filter(|text| !text.trim().is_empty() && text != "any");
+        }
+        None
+    }
+
+    fn indexed_access_key_type_text(&self, key_idx: NodeIndex) -> Option<String> {
+        let key_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(key_idx);
+        let key_node = self.arena.get(key_idx)?;
+        if key_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(key_node)?;
+            let receiver_text = self.indexed_access_receiver_type_text(access.expression)?;
+            return Self::array_element_type_text(&receiver_text);
+        }
+        if key_node.kind == SyntaxKind::Identifier as u16 {
+            return self
+                .enclosing_parameter_source_type_annotation_text_for_identifier(key_idx)
+                .or_else(|| self.reference_declared_type_annotation_text(key_idx))
+                .filter(|text| !text.trim().is_empty() && text != "any");
+        }
+        if key_node.kind == SyntaxKind::StringLiteral as u16
+            || key_node.kind == SyntaxKind::NumericLiteral as u16
+        {
+            return self
+                .get_source_slice(key_node.pos, key_node.end)
+                .map(|text| text.trim().to_string());
+        }
+        None
+    }
+
+    fn enclosing_parameter_source_type_annotation_text_for_identifier(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let name = self.get_identifier_text(expr_idx)?;
+        let mut current = expr_idx;
+        for _ in 0..32 {
+            let parent_idx = self.arena.parent_of(current)?;
+            let parent_node = self.arena.get(parent_idx)?;
+            if let Some(func) = self.arena.get_function(parent_node) {
+                for &param_idx in &func.parameters.nodes {
+                    let param_node = self.arena.get(param_idx)?;
+                    let param = self.arena.get_parameter(param_node)?;
+                    if self.get_identifier_text(param.name).as_deref() == Some(name.as_str()) {
+                        return self
+                            .source_slice_from_arena(self.arena, param.type_annotation)
+                            .or_else(|| {
+                                self.type_annotation_text_from_arena_node(
+                                    self.arena,
+                                    param.type_annotation,
+                                )
+                            })
+                            .map(|text| text.trim().to_string());
+                    }
+                }
+                return None;
+            }
+            current = parent_idx;
+        }
+        None
+    }
+
+    fn array_element_type_text(type_text: &str) -> Option<String> {
+        let trimmed = type_text.trim();
+        if let Some(element) = trimmed.strip_suffix("[]") {
+            let element = element.trim();
+            if !element.is_empty() {
+                return Some(element.to_string());
+            }
+        }
+        for prefix in ["Array<", "ReadonlyArray<"] {
+            if let Some(inner) = trimmed
+                .strip_prefix(prefix)
+                .and_then(|text| text.strip_suffix('>'))
+            {
+                let inner = inner.trim();
+                if !inner.is_empty() {
+                    return Some(inner.to_string());
+                }
+            }
+        }
+        None
     }
 
     /// Returns `true` when `func_body` is a block whose sole non-trivial

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -508,6 +508,16 @@ impl<'a> DeclarationEmitter<'a> {
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
                 && let Some(type_text) =
+                    self.generic_call_constrained_mapped_return_type_text(initializer)
+            {
+                self.write(": ");
+                self.write(&type_text);
+            } else if has_initializer
+                && self
+                    .arena
+                    .get(initializer)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                && let Some(type_text) =
                     self.call_expression_reused_type_text(initializer)
                         .filter(|text| {
                             text.contains("=>")

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -151,6 +151,177 @@ fn test_inferred_return_preserves_mapped_parameter_annotation() {
     );
 }
 
+#[test]
+fn generic_call_returned_function_object_widens_callback_literals() {
+    let output = emit_dts_with_binding(
+        r#"
+type Func<Value> = (...args: any[]) => Value;
+type Spec<Shape> = {
+    [Field in keyof Shape]: Func<Shape[Field]> | Spec<Shape[Field]>;
+};
+declare function applySpec<Shape>(obj: Spec<Shape>): (...args: any[]) => Shape;
+
+export var g1 = applySpec({
+    sum: (a: any) => 3,
+    nested: {
+        mul: (b: any) => "n"
+    }
+});
+
+type Rule<Result> = {
+    [Name in keyof Result]: (() => Result[Name]) | Rule<Result[Name]>;
+};
+declare function makeRuleResult<Result>(rule: Rule<Result>): () => Result;
+
+export var g2 = makeRuleResult({
+    flag: () => true,
+    child: {
+        text: () => "ok"
+    }
+});
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "export declare var g1: (...args: any[]) => {\n    sum: number;\n    nested: {\n        mul: string;\n    };\n};"
+        ),
+        "Expected callback literal returns to widen inside returned function object: {output}"
+    );
+    assert!(
+        output.contains(
+            "export declare var g2: () => {\n    flag: boolean;\n    child: {\n        text: string;\n    };\n};"
+        ),
+        "Expected renamed generic/mapped callback spec to use the same source-call rule: {output}"
+    );
+}
+
+#[test]
+fn generic_call_returned_function_object_requires_callback_leaves() {
+    let output = emit_dts(
+        r#"
+type Spec<Shape> = {
+    [Field in keyof Shape]: (() => Shape[Field]) | Spec<Shape[Field]>;
+};
+declare function applySpec<Shape>(obj: Spec<Shape>): () => Shape;
+
+export var g = applySpec({
+    value: 3
+});
+"#,
+    );
+
+    assert!(
+        !output.contains("export declare var g: () => {\n    value: number;\n};"),
+        "Non-callback leaves should fall back to the normal inferred call surface: {output}"
+    );
+}
+
+#[test]
+fn generic_call_pick_mapped_arguments_preserve_public_inference_surface() {
+    let output = emit_dts_with_binding(
+        r#"
+type Pick<T, K extends keyof T> = {
+    [P in K]: T[P];
+};
+type Box<T> = {
+    value: T;
+};
+type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
+
+let x0 = f20({ foo: 42, bar: "hello" });
+let x1 = f21({ foo: 42, bar: "hello" });
+let x2 = f22({ foo: { value: 42 }, bar: { value: "hello" } });
+let x4 = f24({ foo: 42, bar: "hello" });
+
+function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+    return {} as any;
+}
+const myAny: any = {};
+const o1 = getProps(myAny, ["foo", "bar"]);
+"#,
+    );
+
+    assert!(
+        output.contains("declare let x0: {\n    foo: number;\n    bar: string;\n};"),
+        "Expected Pick<T, K> object argument to infer the returned object surface: {output}"
+    );
+    assert!(
+        output.contains("declare let x1: \"foo\" | \"bar\";"),
+        "Expected Pick<T, K> object keys to infer K as a literal-key union: {output}"
+    );
+    assert!(
+        output.contains("declare let x2: {\n    foo: number;\n    bar: string;\n};"),
+        "Expected mapped wrapper over Pick<T, K> to unwrap one-property member values: {output}"
+    );
+    assert!(
+        output.contains(
+            "declare let x4: {\n    foo: number;\n    bar: string;\n} & {\n    foo: number;\n    bar: string;\n};"
+        ),
+        "Expected Pick<T & U, K> to preserve the intersection return surface: {output}"
+    );
+    assert!(
+        output.contains("declare const o1: Pick<any, \"foo\" | \"bar\">;"),
+        "Expected K[] literal argument to preserve Pick<any, literal-key-union>: {output}"
+    );
+}
+
+#[test]
+fn generic_call_constrained_mapped_return_uses_concrete_constraint_surface() {
+    let output = emit_dts_with_binding(
+        r#"
+declare function f1<T1>(): { [P in keyof T1]: void };
+declare function f2<T1 extends string>(): { [P in keyof T1]: void };
+declare function f3<T1 extends number>(): { [P in keyof T1]: void };
+interface Number {
+    toString(): string;
+    toFixed(): string;
+    toExponential(): string;
+    toPrecision(): string;
+    valueOf(): number;
+    toLocaleString(): string;
+}
+declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
+interface WrappedValue {
+    alpha(): string;
+    beta: number;
+}
+declare function f5<Value extends WrappedValue>(): { [Key in keyof Value]: boolean };
+
+let x1 = f1();
+let x2 = f2();
+let x3 = f3();
+let x4 = f4();
+let x5 = f5();
+"#,
+    );
+
+    assert!(
+        output.contains("declare let x2: string;"),
+        "Expected string-constrained mapped call result to expand to string: {output}"
+    );
+    assert!(
+        output.contains("declare let x3: number;"),
+        "Expected number-constrained mapped call result to expand to number: {output}"
+    );
+    assert!(
+        output.contains(
+            "declare let x4: {\n    toString: void;\n    toFixed: void;\n    toExponential: void;\n    toPrecision: void;\n    valueOf: void;\n    toLocaleString: void;\n};"
+        ),
+        "Expected object-wrapper mapped call result to expand public members: {output}"
+    );
+    assert!(
+        output.contains("declare let x5: {\n    alpha: boolean;\n    beta: boolean;\n};"),
+        "Expected renamed wrapper mapped call result to expand declared public members: {output}"
+    );
+}
+
 // =============================================================================
 // 7. Ambient / Declare Declarations
 // =============================================================================
@@ -451,6 +622,120 @@ fn emit_dts_with_index_access_return(source: &str, method_name_str: &str) -> Str
     emitter.emit(root)
 }
 
+fn emit_dts_with_method_node_return_type(
+    source: &str,
+    method_name_str: &str,
+    return_type_id: TypeId,
+) -> String {
+    use tsz_parser::parser::syntax_kind_ext;
+
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let method_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            if node.kind != syntax_kind_ext::METHOD_DECLARATION {
+                return None;
+            }
+            let nidx = NodeIndex(idx as u32);
+            let decl = parser.arena.get_method_decl(parser.arena.get(nidx)?)?;
+            (parser.arena.get_identifier_text(decl.name)? == method_name_str).then_some(nidx)
+        })
+        .expect("method not found");
+
+    let mut node_types = FxHashMap::default();
+    node_types.insert(method_idx.0, return_type_id);
+
+    let type_cache = crate::type_cache_view::TypeCacheView {
+        node_types,
+        ..Default::default()
+    };
+
+    let mut emitter =
+        DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    emitter.emit(root)
+}
+
+fn emit_dts_with_function_return_type(
+    source: &str,
+    function_name_str: &str,
+    return_type_id: TypeId,
+) -> String {
+    use tsz_parser::parser::syntax_kind_ext;
+
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let func_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            if node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                return None;
+            }
+            let nidx = NodeIndex(idx as u32);
+            let func = parser.arena.get_function(parser.arena.get(nidx)?)?;
+            (parser.arena.get_identifier_text(func.name)? == function_name_str).then_some(nidx)
+        })
+        .expect("function not found");
+
+    let func_type = interner.function(FunctionShape::new(Vec::new(), return_type_id));
+    let mut node_types = FxHashMap::default();
+    node_types.insert(func_idx.0, func_type);
+
+    let type_cache = crate::type_cache_view::TypeCacheView {
+        node_types,
+        ..Default::default()
+    };
+
+    let mut emitter =
+        DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    emitter.emit(root)
+}
+
+fn preferred_function_body_return_text(source: &str, function_name_str: &str) -> Option<String> {
+    use tsz_parser::parser::syntax_kind_ext;
+
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+
+    let function_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            if node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                return None;
+            }
+            let nidx = NodeIndex(idx as u32);
+            let func = parser.arena.get_function(parser.arena.get(nidx)?)?;
+            (parser.arena.get_identifier_text(func.name)? == function_name_str).then_some(nidx)
+        })?;
+    let func = parser
+        .arena
+        .get(function_idx)
+        .and_then(|node| parser.arena.get_function(node))?;
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    emitter.function_body_preferred_return_type_text(func.body)
+}
+
 #[test]
 fn test_generic_class_method_indexed_access_return_class_param() {
     // Method returns PropType[K] where PropType is the class type param and K is the method's.
@@ -506,5 +791,214 @@ export class Plain {
     assert!(
         output.contains("get(key: string): string"),
         "Non-generic class method should still emit correctly: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_method_indexed_access_return_preserves_declared_receiver_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+class Shape {
+    name: string;
+    width: number;
+    height: number;
+}
+export class Reader {
+    readShape<K extends keyof Shape>(shape: Shape, key: K) {
+        return shape[key];
+    }
+}
+"#,
+        "readShape",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("readShape<K extends keyof Shape>(shape: Shape, key: K): Shape[K]"),
+        "Expected indexed-access return surface from declared receiver: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_method_indexed_access_return_preserves_renamed_key_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+type Store = {
+    title: string;
+    count: number;
+};
+export class Reader {
+    readStore<TKey extends keyof Store>(store: Store, key: TKey) {
+        return store[key];
+    }
+}
+"#,
+        "readStore",
+        TypeId::STRING,
+    );
+    assert!(
+        output
+            .contains("readStore<TKey extends keyof Store>(store: Store, key: TKey): Store[TKey]"),
+        "Expected indexed-access return surface with renamed key type: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_this_indexed_access_return_preserves_this_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+export class Bag {
+    value: number;
+    get<TKey extends keyof this>(key: TKey) {
+        return this[key];
+    }
+}
+"#,
+        "get",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("get<TKey extends keyof this>(key: TKey): this[TKey]"),
+        "Expected this-indexed return surface: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_indexed_access_return_preserves_array_element_key_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+type Store<K extends string> = { [P in K]: 0 | 1 };
+export class Reader {
+    read<K extends string>(store: Store<K>, keys: K[]) {
+        return store[keys[0]];
+    }
+}
+"#,
+        "read",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("read<K extends string>(store: Store<K>, keys: K[]): Store<K>[K]"),
+        "Expected indexed-access return surface from array element key: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_function_indexed_access_return_preserves_array_element_key_surface() {
+    let output = emit_dts_with_function_return_type(
+        r#"
+type Store<K extends string> = { [P in K]: 0 | 1 };
+export function read<K extends string>(store: Store<K>, keys: K[]) {
+    return store[keys[0]];
+}
+"#,
+        "read",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("read<K extends string>(store: Store<K>, keys: K[]): Store<K>[K]"),
+        "Expected top-level indexed-access return surface from array element key: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_function_returning_local_indexed_helper_call_preserves_surface() {
+    let source = r#"
+interface Shape {
+    name: string;
+    width: number;
+    height: number;
+    visible: boolean;
+}
+function getProperty<T, K extends keyof T>(obj: T, key: K) {
+    return obj[key];
+}
+export function read<S extends Shape, K extends keyof S>(shape: S, key: K) {
+    let prop = getProperty(shape, key);
+    return prop;
+}
+"#;
+    assert_eq!(
+        preferred_function_body_return_text(source, "read").as_deref(),
+        Some("S[K]")
+    );
+    let output = emit_dts_with_function_return_type(source, "read", TypeId::NUMBER);
+    assert!(
+        output.contains("read<S extends Shape, K extends keyof S>(shape: S, key: K): S[K]"),
+        "Expected local helper-call indexed-access surface: {output}"
+    );
+}
+
+#[test]
+fn test_explicit_type_argument_indexed_member_call_result_uses_member_type() {
+    let output = emit_dts_with_binding(
+        r#"
+type MethodDescriptor = {
+    name: string;
+    args: any[];
+    returnValue: any;
+};
+declare function dispatchMethod<M extends MethodDescriptor>(
+    name: M["name"],
+    args: M["args"]
+): M["returnValue"];
+type StringMethodDescriptor = {
+    name: "stringMethod";
+    args: [string, number];
+    returnValue: string[];
+};
+let result = dispatchMethod<StringMethodDescriptor>("stringMethod", ["hello", 35]);
+"#,
+    );
+    assert!(
+        output.contains("declare let result: string[]"),
+        "Expected explicit type argument indexed member return to evaluate to member type: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_method_returning_indexed_helper_call_preserves_this_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+function read<TObj, TKey extends keyof TObj>(obj: TObj, key: TKey) {
+    return obj[key];
+}
+export class Person {
+    parts: number;
+    getParts() {
+        return read(this, "parts");
+    }
+}
+"#,
+        "getParts",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("getParts(): this[\"parts\"]"),
+        "Expected helper call indexed-access surface: {output}"
+    );
+}
+
+#[test]
+fn test_unannotated_method_returning_inherited_this_indexed_method_call_preserves_surface() {
+    let output = emit_dts_with_method_node_return_type(
+        r#"
+export class Base {
+    get<TKey extends keyof this>(key: TKey) {
+        return this[key];
+    }
+}
+export class Person extends Base {
+    parts: number;
+    getParts() {
+        return this.get("parts");
+    }
+}
+"#,
+        "getParts",
+        TypeId::NUMBER,
+    );
+    assert!(
+        output.contains("getParts(): this[\"parts\"]"),
+        "Expected inherited this-indexed method call surface: {output}"
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
@@ -1169,6 +1169,32 @@ function f2(item: A | B | undefined) {
 }
 
 #[test]
+fn function_returning_mapped_parameter_preserves_source_surface() {
+    let output = emit_dts(
+        r#"
+export function makeRecord<Value, Key extends string>(obj: { [Field in Key]: Value }) {
+    return obj;
+}
+
+export function makeDictionary<Value>(obj: { [name: string]: Value }) {
+    return obj;
+}
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "export declare function makeRecord<Value, Key extends string>(obj: {\n    [Field in Key]: Value;\n}): { [Field in Key]: Value; };"
+        ),
+        "Expected returned mapped parameter to keep its public source surface: {output}"
+    );
+    assert!(
+        !output.contains("makeDictionary<Value>(obj: {\n    [name: string]: Value;\n}): { [name: string]: Value })"),
+        "Non-mapped index signatures should not use the mapped-parameter source fast path: {output}"
+    );
+}
+
+#[test]
 fn test_nested_mapped_type_as_clause_formats_multiline() {
     let output = emit_dts(
         r#"

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1657,6 +1657,58 @@ fn test_mapped_type_in_declaration() {
 }
 
 #[test]
+fn type_parameter_constraint_mapped_type_stays_inline() {
+    let output = emit_dts(
+        r#"
+export const cf = <T extends { [P in K]: string; } & { cool: string }, K extends keyof T>(t: T, k: K) => {};
+"#,
+    );
+    assert!(
+        output.contains("cf: <T extends { [P in K]: string; } & {\n    cool: string;"),
+        "Mapped type in a type-parameter constraint should stay inline: {output}"
+    );
+}
+
+#[test]
+fn type_parameter_constraint_mapped_type_stays_inline_with_renamed_key() {
+    let output = emit_dts(
+        r#"
+export const pick = <Shape extends { [Key in Field | "extra"]: number; }, Field extends keyof Shape>(shape: Shape, field: Field) => {};
+"#,
+    );
+    assert!(
+        output.contains(
+            "pick: <Shape extends { [Key in Field | \"extra\"]: number; }, Field extends keyof Shape>"
+        ),
+        "Mapped type constraint formatting must not depend on iteration variable names: {output}"
+    );
+}
+
+#[test]
+fn object_valued_type_parameter_constraint_mapped_type_stays_multiline() {
+    let output = emit_dts(
+        r#"
+export type Example<T extends { [Key in keyof T]: { prop: any; } }> = {
+    [Key in keyof T]: T[Key]["prop"];
+};
+"#,
+    );
+    assert!(
+        output.contains("T extends {\n    [Key in keyof T]: {\n        prop: any;\n    };\n}"),
+        "Object-valued mapped type constraints should keep structured multiline formatting: {output}"
+    );
+}
+
+#[test]
+fn top_level_mapped_type_alias_stays_multiline() {
+    let output = emit_dts("export type Names<K extends string> = { [Key in K]: string; };");
+    assert!(
+        output.contains("{\n    [Key in K]: string;\n}"),
+        "Top-level mapped type aliases should keep structured multiline formatting: {output}"
+    );
+}
+
+#[test]
 fn test_indexed_access_type() {
     let output = emit_dts("export type Name = Person['name'];");
     assert!(

--- a/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/type_emission.rs
@@ -577,6 +577,13 @@ impl<'a> DeclarationEmitter<'a> {
                 }
 
                 if let Some(mapped_type) = self.arena.get_mapped_type(type_node) {
+                    if self.current_output_is_type_parameter_constraint()
+                        && self.mapped_type_body_can_emit_inline(mapped_type)
+                    {
+                        self.emit_mapped_type_inline(mapped_type);
+                        return;
+                    }
+
                     self.write("{");
                     self.write_line();
                     self.increase_indent();
@@ -1396,6 +1403,78 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         self.emit_type(type_idx);
+    }
+
+    fn current_output_is_type_parameter_constraint(&self) -> bool {
+        let output = self.writer.get_output();
+        let mut balance = 0i32;
+        let mut candidate_start = None;
+        for (idx, ch) in output.char_indices().rev() {
+            match ch {
+                '>' => balance += 1,
+                '<' if balance == 0 => {
+                    candidate_start = Some(idx);
+                    break;
+                }
+                '<' => balance -= 1,
+                _ => {}
+            }
+        }
+
+        let Some(start) = candidate_start else {
+            return false;
+        };
+        let tail = &output[start..];
+        tail.contains(" extends ") && !tail.contains('\n')
+    }
+
+    fn emit_mapped_type_inline(&mut self, mapped_type: &tsz_parser::parser::node::MappedTypeData) {
+        self.write("{ ");
+
+        if let Some(readonly_node) = self.arena.get(mapped_type.readonly_token) {
+            match readonly_node.kind {
+                k if k == SyntaxKind::PlusToken as u16 => self.write("+readonly "),
+                k if k == SyntaxKind::MinusToken as u16 => self.write("-readonly "),
+                _ => self.write("readonly "),
+            }
+        }
+
+        self.write("[");
+        if let Some(type_param_node) = self.arena.get(mapped_type.type_parameter)
+            && let Some(type_param) = self.arena.get_type_parameter(type_param_node)
+        {
+            self.emit_node(type_param.name);
+            self.write(" in ");
+            if type_param.constraint.is_some() {
+                self.emit_mapped_type_constraint(type_param.constraint);
+            }
+        }
+
+        if mapped_type.name_type.is_some() {
+            self.emit_mapped_type_as_clause(mapped_type.name_type);
+        }
+
+        self.write("]");
+        if let Some(question_node) = self.arena.get(mapped_type.question_token) {
+            match question_node.kind {
+                k if k == SyntaxKind::PlusToken as u16 => self.write("+?"),
+                k if k == SyntaxKind::MinusToken as u16 => self.write("-?"),
+                _ => self.write("?"),
+            }
+        }
+
+        self.write(": ");
+        self.emit_mapped_type_value_type(mapped_type.type_node);
+        self.write("; }");
+    }
+
+    fn mapped_type_body_can_emit_inline(
+        &self,
+        mapped_type: &tsz_parser::parser::node::MappedTypeData,
+    ) -> bool {
+        self.arena.get(mapped_type.type_node).is_none_or(|node| {
+            node.kind != syntax_kind_ext::TYPE_LITERAL && node.kind != syntax_kind_ext::MAPPED_TYPE
+        })
     }
 
     fn expand_mapped_type_to_portable_properties(&self, type_idx: NodeIndex) -> Option<String> {


### PR DESCRIPTION
## Agent
AgentName: Studio-D

Bundling coordinator: Studio-F.
Bundled owner lane: Studio-D (`agent:Studio-D` label retained).

## Track
Track 9 declaration emit parity. PR type: emit/DTS parity bundle for indexed-access and mapped generic public surfaces.

## Invariant
When an unannotated public declaration exposes source-backed indexed-access returns or isomorphic/constrained mapped generic call surfaces, `tsc` preserves the public declaration surface instead of eagerly printing evaluated implementation types. This bundle makes tsz select those source/public surfaces through declaration emitter helpers before DTS printing, without changing checker diagnostics, solver relation behavior, or output-string rewrites.

## Owner Layer
- Owner: declaration emitter return/call normalization and public API surface helpers.
- Source-backed indexed access returns preserve receiver/key public text for functions, methods, helper calls, same-block locals, inherited `this.<method>(literal)` calls, and explicit type-argument indexed member calls.
- Mapped generic call summaries preserve returned mapped-parameter surfaces, callback-result object surfaces, `Pick<T, K>`-family surfaces, and constrained mapped no-argument call surfaces.
- Type-parameter mapped constraints keep the tsc-compatible inline/multiline formatting split in the type-printer path.
- Non-owner layers: checker diagnostics, solver relations, generic inference semantics, and narrowing are unchanged.

## Scope
- Bundle #10326 and #10339 into one carrier PR rebuilt from current `origin/main`.
- Treat #10331 (`fix(dts): infer constructor option type arguments`) as already merged; its branch head is patch-equivalent to current `origin/main` and was not reintroduced as new work.
- Preserve indexed-access return surfaces for top-level functions, methods, `this[K]`, array-element key expressions, helper-call returns, same-block local helper returns, inherited method calls, and explicit type-argument indexed member results.
- Preserve mapped/isomorphic generic public surfaces for returned mapped parameters, recursive callback specs, `Pick<T, K>` and mapped-wrapper call arguments, constrained mapped returns, and structurally-derived object/interface constraint members.
- Keep simple mapped constraints inline while preserving multiline formatting for object-valued/top-level mapped types.
- Add/retain focused emitter coverage in `generics_and_ambient` and `type_formatting`.

## Bundled / Superseded PRs
- Carrier successor: #10326 `fix(dts): preserve indexed return surfaces` -> branch `codex/studio-d-dts-indexed-return-surfaces-20260526`.
- Included: #10326 original head `63d426e4af3621b919b3dd8643a045d890fcf22d`.
- Included and superseded: #10339 `fix(dts): preserve isomorphic mapped inference surfaces`, original head `c4029294319dd199c933be6c64ec68f2f62b3d15`.
- Already merged prerequisite: #10331 `fix(dts): infer constructor option type arguments`; branch head `9af462fdfe641399025a5b72129076efaa14976a` is patch-equivalent to current `origin/main` and was skipped during replay.
- Rebuilt base: `origin/main` at `0c8d8106fab9816168c612792f7fc635aa188304`.
- Bundle head: `30d803243bb609c5c8d579ac19ea7c44137d7aaa`.

## Project Corpus Impact
- Row: `keyofAndIndexedAccess` DTS emit; `isomorphicMappedTypeInference` DTS emit; `mappedTypes1` DTS emit.
- Bug family: declaration emit indexed-access return surfaces, mapped/indexed generic call public surfaces, explicit indexed member call result surfaces, and mapped type-parameter constraint formatting.
- Evidence: focused DTS filters pass on bundle head `30d803243bb609c5c8d579ac19ea7c44137d7aaa`: `keyofAndIndexedAccess` 1/1, `mappedTypes1` 1/1, and `isomorphicMappedTypeInference` 1/1.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-emitter generics_and_ambient` (33 passed)
- `cargo nextest run -p tsz-emitter type_formatting` (66 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=keyofAndIndexedAccess --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-f-keyofAndIndexedAccess-bundle-b.json` (1 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypes1 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-f-mappedTypes1-bundle-b.json` (1 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=isomorphicMappedTypeInference --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-f-isomorphicMappedTypeInference-bundle-b.json` (1 passed)

## Coordination Notes
- Bundling coordinator: Studio-F
- Same-owner check: #10326 and #10339 carry `agent:Studio-D` and body `AgentName: Studio-D`; the carrier keeps the Studio-D label.
- Rebuilt the carrier branch from current `origin/main`, cherry-picked only the still-open Studio-D PR commits with `--no-commit`, resolved expected helper/test placement conflicts, committed one combined commit, and pushed with `--force-with-lease` from `63d426e4af3621b919b3dd8643a045d890fcf22d` to `30d803243bb609c5c8d579ac19ea7c44137d7aaa`.
- Base was moved to `main` because the former root branch/PR #10331 is already merged and patch-equivalent to current main.
- #10339 can be closed as superseded after this body update because all six unique child commits plus the #10326 carrier commits are carried forward in the combined successor commit.
- Auto-merge remains off; do not treat this push as a merge/landing action.
- No roadmap update: this is routine DTS parity bundling under the existing declaration emit direction.

