### PR TITLE
refactor(checker): route decorator return relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -121,6 +121,9 @@ mod control_flow_tests;
 #[path = "../tests/control_flow_type_guard_tests.rs"]
 mod control_flow_type_guard_tests;
 #[cfg(test)]
+#[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
+mod decorator_return_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/definite_assignment_tests.rs"]
 mod definite_assignment_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -514,7 +514,10 @@ impl<'a> CheckerState<'a> {
         else {
             return;
         };
-        if !self.diagnostic_relation_boolean_guard(return_type, expected_return) {
+        if !self
+            .assign_relation_outcome(return_type, expected_return)
+            .related
+        {
             let return_str = self.format_type_diagnostic(return_type);
             let expected_str = self.format_type_diagnostic(expected_return);
             let message = format_message(
@@ -654,7 +657,10 @@ impl<'a> CheckerState<'a> {
         if matches!(return_type, TypeId::ERROR | TypeId::ANY) {
             return;
         }
-        if !self.diagnostic_relation_boolean_guard(return_type, TypeId::VOID) {
+        if !self
+            .assign_relation_outcome(return_type, TypeId::VOID)
+            .related
+        {
             let return_str = self.format_type_diagnostic(return_type);
             let message = format_message(
                 diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_BUT_IS_EXPECTED_TO_BE_VOID_OR_ANY,

--- a/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn decorator_return_diagnostics_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/state_checking_members/decorator_signature_checks.rs"),
+    )
+    .expect("failed to read decorator_signature_checks.rs");
+
+    assert!(
+        source.contains("assign_relation_outcome(return_type, expected_return)"),
+        "method/accessor decorator return diagnostics should route through assign_relation_outcome"
+    );
+    assert!(
+        source.contains("assign_relation_outcome(return_type, TypeId::VOID)"),
+        "void-or-any decorator return diagnostics should route through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard(return_type, expected_return)"),
+        "method/accessor decorator return diagnostics should not pre-gate with a raw boolean relation"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard(return_type, TypeId::VOID)"),
+        "void-or-any decorator return diagnostics should not pre-gate with a raw boolean relation"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When decorator function return types are compared with the expected method/accessor decorator return type or the legacy void-or-any decorator return rule, `tsc` reports the existing decorator diagnostic at the decorator node when the return type is not assignable; this PR keeps the checker-owned anchors/messages while routing those relation decisions through the shared assignability outcome boundary.

## Scope
- Route method/accessor decorator return mismatch checks in `state_checking_members/decorator_signature_checks.rs` through `assign_relation_outcome(...).related`.
- Route the void-or-any decorator return rule through `assign_relation_outcome(...).related`.
- Add a focused architecture test guarding both decorator return diagnostic pre-gates against regressing to raw boolean relation calls.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / decorator return routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib decorator_return_diagnostics_use_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving two decorator-return diagnostic-bearing assignability pre-gates onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, and #10323 static-side diagnostics.
- Based on `origin/main` at `06a7d7d214e7450de9d8f8756e0fd3a811e967f6`; head is `b9e7c4e8565d14e2b488ef83137e1a36dbdf5e6e`.
- No solver policy, variance, any-propagation, relation cache-key behavior, or diagnostic display-string decision changed.
