### PR TITLE
refactor(checker): route computed enum relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -127,6 +127,9 @@ mod definite_assignment_tests;
 #[path = "../tests/dynamic_import_defer_tests.rs"]
 mod dynamic_import_defer_tests;
 #[cfg(test)]
+#[path = "tests/enum_computed_relation_routing_arch_tests.rs"]
+mod enum_computed_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/enum_member_cache_tests.rs"]
 mod enum_member_cache_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -220,7 +220,10 @@ impl<'a> CheckerState<'a> {
 
             // Evaluation would fail (or unknown with non-number/string type).
             // Emit TS18033 if the type is not assignable to number.
-            if !self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER) {
+            if !self
+                .assign_relation_outcome(init_type, TypeId::NUMBER)
+                .related
+            {
                 // tsc displays widened types in TS18033: 'string' not '"bar"'
                 let widened =
                     crate::query_boundaries::common::widen_literal_type(self.ctx.types, init_type);

--- a/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn computed_enum_member_ts18033_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/state_checking_members/statement_helpers.rs"),
+    )
+    .expect("failed to read statement_helpers.rs");
+
+    assert!(
+        source.contains("assign_relation_outcome(init_type, TypeId::NUMBER)"),
+        "computed enum-member TS18033 diagnostics should route the final relation through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("if !self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)"),
+        "computed enum-member TS18033 diagnostics should not pre-gate final emission with a raw boolean relation"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a computed enum member initializer cannot be evaluated and its initializer type is not assignable to `number`, `tsc` reports TS18033 at the initializer; this PR keeps the checker-owned enum diagnostic and display policy while routing the final diagnostic relation decision through the shared assignability outcome boundary.

## Scope
- Route the final computed enum-member TS18033 relation gate in `state_checking_members/statement_helpers.rs` through `assign_relation_outcome(...).related`.
- Leave the separate import/evaluation heuristic for `number` or `string` types unchanged because that answers whether the enum evaluator would likely succeed, not whether to emit the final diagnostic.
- Add a focused architecture test guarding the final TS18033 diagnostic gate against regressing to a raw boolean relation call.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / computed enum TS18033 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib computed_enum_member_ts18033_uses_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing assignability pre-gate onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, #10323 static-side diagnostics, and #10327 decorator-return diagnostics.
- Based on `origin/main` at `53619806decfd5c9b95b732ba4000ce440461530`; head is `fe023a839f534c635a75c97d97786cbcaf678c29`.
- No solver policy, variance, any-propagation, relation cache-key behavior, enum evaluation heuristic, or diagnostic display-string decision changed.
