### PR TITLE
refactor(checker): route dynamic import relation outcomes

### DIFF
--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -45,7 +45,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if the specifier type is assignable to `string`
-        if !self.diagnostic_relation_boolean_guard(arg_type, TypeId::STRING) {
+        if !self
+            .assign_relation_outcome(arg_type, TypeId::STRING)
+            .related
+        {
             let type_str = self.format_type(arg_type);
             let message = format_message(
                 diagnostic_messages::DYNAMIC_IMPORTS_SPECIFIER_MUST_BE_OF_TYPE_STRING_BUT_HERE_HAS_TYPE,
@@ -172,7 +175,10 @@ impl<'a> CheckerState<'a> {
         // For import attribute options (`with` / `assert`), prefer a top-level
         // TS2322 anchored at the options object, matching tsc fingerprints.
         if self.import_options_has_attribute_property(options_idx) {
-            if !self.diagnostic_relation_boolean_guard(options_type, import_call_options_type) {
+            if !self
+                .assign_relation_outcome(options_type, import_call_options_type)
+                .related
+            {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
                 let source_str = self.format_type(options_type);
                 let message = format_message(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -484,6 +484,9 @@ mod dispatch_tests;
 #[path = "tests/do_while_exit_narrowing_tests.rs"]
 mod do_while_exit_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
+mod dynamic_import_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/dynamic_import_ts2307_per_callsite_tests.rs"]
 mod dynamic_import_ts2307_per_callsite_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/dynamic_import_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/dynamic_import_relation_routing_arch_tests.rs
@@ -1,0 +1,30 @@
+use std::fs;
+
+/// Dynamic-import specifier and options diagnostics own their checker anchors
+/// and messages, but the relation decision should use the shared relation
+/// outcome boundary rather than a raw boolean relation guard.
+#[test]
+fn dynamic_import_diagnostics_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/declarations/dynamic_import_checker.rs")
+        .expect("failed to read dynamic_import_checker.rs");
+    let compact_source: String = source.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_source.contains("assign_relation_outcome(arg_type,TypeId::STRING).related"),
+        "dynamic import specifier diagnostics must use relation outcome"
+    );
+    assert!(
+        compact_source
+            .contains("assign_relation_outcome(options_type,import_call_options_type).related"),
+        "dynamic import options diagnostics must use relation outcome"
+    );
+    assert!(
+        !compact_source.contains("diagnostic_relation_boolean_guard(arg_type,TypeId::STRING)"),
+        "dynamic import specifier diagnostics must not use a raw relation guard"
+    );
+    assert!(
+        !compact_source
+            .contains("diagnostic_relation_boolean_guard(options_type,import_call_options_type)"),
+        "dynamic import options diagnostics must not use a raw relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When dynamic import specifiers and import-attribute options require relation checks, `tsc` reports the existing checker-owned TS7036/TS2322 diagnostics at the specifier/options anchors; this PR keeps those anchors and messages while routing the relation decisions through the shared assignability outcome boundary.

## Scope
- Route the dynamic import specifier-to-string relation gate in `declarations/dynamic_import_checker.rs` through `assign_relation_outcome(...).related`.
- Route the dynamic import attribute-options relation gate through `assign_relation_outcome(...).related`.
- Leave the existing weak-type fallback and generic assignability helper paths unchanged.
- Add a focused architecture test guarding the dynamic import diagnostics against regressing to raw boolean relation guards.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / dynamic import relation routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib dynamic_import_diagnostics_use_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving two dynamic-import diagnostic-bearing relation pre-gates onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, #10323 static-side diagnostics, #10327 decorator-return diagnostics, and #10328 computed enum diagnostics.
- Based on current `origin/main` after rebasing; head is `bd34a0c71e10d6fb3734c6bddf618e1d5a464d8d`.
- No solver policy, variance, any-propagation, relation cache-key behavior, weak-type fallback, or diagnostic display-string decision changed.