### PR TITLE
refactor(checker): route import attribute relation outcome

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration.rs
@@ -696,10 +696,10 @@ impl<'a> CheckerState<'a> {
         {
             return;
         }
-
-        // Emit top-level TS2322 at the attributes object (matching tsc fingerprint
-        // parity for import attribute shape mismatches).
-        if !self.diagnostic_relation_boolean_guard(source_type, import_attributes_type) {
+        let related = self
+            .assign_relation_outcome(source_type, import_attributes_type)
+            .related;
+        if !related {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
             let source_str = self.format_type(source_type);
             let message = format_message(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -535,6 +535,9 @@ mod generic_tests;
 #[path = "tests/generic_unknown_type_arg_tests.rs"]
 mod generic_unknown_type_arg_tests;
 #[cfg(test)]
+#[path = "tests/import_attributes_relation_routing_arch_tests.rs"]
+mod import_attributes_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
 mod in_narrow_bare_type_param_chained_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/import_attributes_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/import_attributes_relation_routing_arch_tests.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+/// Import-attribute shape diagnostics own their checker anchor and TS2322
+/// message, but the relation decision should use the shared relation outcome
+/// boundary rather than a raw boolean relation guard.
+#[test]
+fn import_attributes_diagnostics_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/declarations/import/declaration.rs")
+        .expect("failed to read declarations/import/declaration.rs");
+    let compact_source: String = source.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_source
+            .contains("assign_relation_outcome(source_type,import_attributes_type).related"),
+        "import attribute diagnostics must use relation outcome"
+    );
+    assert!(
+        !compact_source
+            .contains("diagnostic_relation_boolean_guard(source_type,import_attributes_type)"),
+        "import attribute diagnostics must not use a raw relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When an import declaration attribute object is compared against `ImportAttributes`, `tsc` reports the existing checker-owned TS2322 diagnostic at the attributes object; this PR keeps that anchor and message while routing the relation decision through the shared assignability outcome boundary.

## Scope
- Route the import declaration attribute-object relation gate in `declarations/import/declaration.rs` through `assign_relation_outcome(...).related`.
- Keep the existing manually built source type, `ImportAttributes` target lookup, TS2322 message, and attributes-object anchor unchanged.
- Add a focused architecture test guarding the import attribute diagnostic against regressing to a raw boolean relation guard.
- Keep the oversized production file line-neutral; the guard lives in a separate small test file.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / import attribute TS2322 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib import_attributes_diagnostics_use_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing assignability pre-gate onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, #10323 static-side diagnostics, #10327 decorator-return diagnostics, #10328 computed enum diagnostics, and #10329 dynamic-import diagnostics.
- Based on current `origin/main`; head is `ccdbc76fda678efce020f6442b707c45572d9312`.
- No solver policy, variance, any-propagation, relation cache-key behavior, attribute type construction, or diagnostic display-string decision changed.