### PR TITLE
refactor(checker): route in operator relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -538,6 +538,9 @@ mod generic_unknown_type_arg_tests;
 #[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
 mod in_narrow_bare_type_param_chained_tests;
 #[cfg(test)]
+#[path = "tests/in_operator_relation_routing_arch_tests.rs"]
+mod in_operator_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/in_operator_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/in_operator_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+fn function_body<'a>(source: &'a str, signature: &str) -> &'a str {
+    let start = source
+        .find(signature)
+        .expect("expected function signature in source");
+    let rest = &source[start..];
+    let end = rest
+        .find("\n    /// Check the `in` operator.")
+        .expect("expected next function boundary");
+    &rest[..end]
+}
+
+#[test]
+fn in_operator_lhs_key_diagnostic_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/types/computation/binary_operator_diagnostics.rs")
+        .expect("failed to read binary operator diagnostics source");
+    let body = function_body(&source, "pub(super) fn check_in_operator_lhs_key_type(");
+
+    assert!(
+        body.contains("self.assign_relation_outcome(key_type, target).related"),
+        "`in` operator TS2322 key check should route through relation outcome boundary"
+    );
+    assert!(
+        !body.contains("self.is_assignable_to(key_type, target)"),
+        "`in` operator TS2322 key check should not use a raw boolean assignability gate"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/binary_operator_diagnostics.rs
+++ b/crates/tsz-checker/src/types/computation/binary_operator_diagnostics.rs
@@ -439,7 +439,7 @@ impl<'a> CheckerState<'a> {
             .ctx
             .types
             .union3(TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL);
-        if self.is_assignable_to(key_type, target) {
+        if self.assign_relation_outcome(key_type, target).related {
             return;
         }
         // Source uses the widened diagnostic form so a fresh literal operand shows its


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When the left operand of an `in` expression is checked against the property-key space, `tsc` reports the existing checker-owned TS2322 diagnostic at the left operand; this PR keeps that anchor and message while routing the relation decision through the shared assignability outcome boundary.

## Scope
- Route `check_in_operator_lhs_key_type` through `assign_relation_outcome(...).related` instead of a raw boolean assignability gate.
- Keep the existing nullish split, widened source display, structural key-union target display, TS2322 code, and left-operand anchor unchanged.
- Add a focused architecture test guarding the `in`-operator diagnostic against regressing to a raw boolean relation guard.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / `in` operator TS2322 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib in_operator_lhs_key_diagnostic_uses_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing assignability pre-gate onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, #10323 static-side diagnostics, #10327 decorator-return diagnostics, #10328 computed enum diagnostics, #10329 dynamic-import diagnostics, and #10330 import-attribute diagnostics.
- Based on current `origin/main`; head is `9cf9a2c56a72f3f7bb61254844008505973283d0`.
- No solver policy, variance, any-propagation, relation cache-key behavior, `in`-operator diagnostic rendering, or display-string decision changed.