### PR TITLE
fix(checker): retire index signature diagnostic drift

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -451,7 +451,9 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
         idx: NodeIndex,
     ) -> (u32, String) {
-        let prop_display = tsz_solver::format_excess_property_name(prop_name);
+        let prop_display = self
+            .excess_property_name_display_for_site(idx, self.ctx.types.intern_string(prop_name))
+            .unwrap_or_else(|| tsz_solver::format_excess_property_name(prop_name).into_owned());
         let type_str = self.excess_property_target_display_for_site(target, idx);
         let suggestion_target = self.strip_non_object_union_members_for_excess_display(target);
         if !self.has_syntax_parse_errors()
@@ -2442,8 +2444,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let mut formatter = self.ctx.create_type_formatter();
-        let index_str = formatter.format(index_type);
+        let index_str = self.format_type_for_assignability_message(index_type);
         // For type parameters, tsc displays the constraint type name in the
         // diagnostic (e.g., "can't be used to index type 'Item'" not "'T'").
         let display_object_type =

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -569,6 +569,53 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    pub(crate) fn excess_property_name_display_for_site(
+        &self,
+        idx: NodeIndex,
+        property_name: tsz_common::interner::Atom,
+    ) -> Option<String> {
+        use tsz_parser::parser::syntax_kind_ext;
+        const MAX_DEPTH: u32 = 8;
+        let mut stack: Vec<(NodeIndex, u32)> = vec![(idx, 0)];
+        while let Some((current, depth)) = stack.pop() {
+            if depth > MAX_DEPTH {
+                continue;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+                if let Some(display) =
+                    self.excess_property_name_display_in_literal(current, property_name)
+                {
+                    return Some(display);
+                }
+                continue;
+            }
+            if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                && let Some(paren) = self.ctx.arena.get_parenthesized(node)
+            {
+                stack.push((paren.expression, depth + 1));
+                continue;
+            }
+            if node.kind == syntax_kind_ext::BINARY_EXPRESSION
+                && let Some(bin) = self.ctx.arena.get_binary_expr(node)
+            {
+                stack.push((bin.right, depth + 1));
+                stack.push((bin.left, depth + 1));
+                continue;
+            }
+            if node.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION
+                && let Some(cond) = self.ctx.arena.get_conditional_expr(node)
+            {
+                stack.push((cond.when_false, depth + 1));
+                stack.push((cond.when_true, depth + 1));
+                continue;
+            }
+        }
+        None
+    }
+
     pub(super) fn excess_property_name_span_in_literal(
         &self,
         literal_idx: NodeIndex,
@@ -601,6 +648,58 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    fn excess_property_name_display_in_literal(
+        &self,
+        literal_idx: NodeIndex,
+        property_name: tsz_common::interner::Atom,
+    ) -> Option<String> {
+        use tsz_parser::parser::syntax_kind_ext;
+        let node = self.ctx.arena.get(literal_idx)?;
+        let literal = self.ctx.arena.get_literal_expr(node)?;
+        for &elem in &literal.elements.nodes {
+            let elem_node = self.ctx.arena.get(elem)?;
+            let maybe_name_idx = if elem_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                self.ctx
+                    .arena
+                    .get_property_assignment(elem_node)
+                    .map(|prop| prop.name)
+            } else if elem_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+                self.ctx
+                    .arena
+                    .get_shorthand_property(elem_node)
+                    .map(|prop| prop.name)
+            } else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                self.ctx
+                    .arena
+                    .get_method_decl(elem_node)
+                    .map(|method| method.name)
+            } else {
+                None
+            };
+            let Some(name_idx) = maybe_name_idx else {
+                continue;
+            };
+
+            let Some(name_node) = self.ctx.arena.get(name_idx) else {
+                continue;
+            };
+            if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                && self.property_name_matches_atom(name_idx, property_name)
+            {
+                let display = self
+                    .get_source_text_for_node(name_idx)
+                    .trim()
+                    .trim_end_matches(':')
+                    .trim_end()
+                    .to_string();
+                if !display.is_empty() {
+                    return Some(display);
+                }
+            }
+        }
+        None
+    }
+
     pub(super) fn property_name_matches_atom(
         &self,
         name_idx: NodeIndex,
@@ -616,6 +715,25 @@ impl<'a> CheckerState<'a> {
         }
         if let Some(literal) = self.ctx.arena.get_literal(name_node) {
             return literal.text.as_str() == target_str;
+        }
+        if name_node.kind == tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME
+            && let Some(computed) = self.ctx.arena.get_computed_property(name_node)
+        {
+            if let Some(suffix) = target_str.strip_prefix("__unique_")
+                && let Ok(target_symbol_id) = suffix.parse::<u32>()
+                && let Some(local_symbol_id) = self.resolve_identifier_symbol(computed.expression)
+            {
+                let symbol_id = self
+                    .ctx
+                    .resolve_import_alias_and_register(local_symbol_id)
+                    .unwrap_or(local_symbol_id);
+                if symbol_id.0 == target_symbol_id {
+                    return true;
+                }
+            }
+            return self
+                .computed_property_expression_name_atom(computed.expression)
+                .is_some_and(|resolved| resolved == target);
         }
         false
     }

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -383,6 +383,64 @@ const dst: { [k: symbol]: string } = src;
     );
 }
 
+#[test]
+fn ts2353_computed_symbol_excess_property_displays_source_name() {
+    let diagnostics = check_source_code_messages(
+        r#"
+const sym = Symbol();
+const obj: { [key: number]: string } = { [sym]: "hello" };
+"#,
+    );
+    let ts2353 = diagnostics
+        .iter()
+        .find(|(code, _)| *code == diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE);
+    let Some((_, msg)) = ts2353 else {
+        panic!(
+            "expected TS2353 for symbol key against number index signature, got: {diagnostics:?}"
+        );
+    };
+    assert!(
+        msg.contains("'[sym]'"),
+        "computed symbol excess-property diagnostics should display the source key, got: {msg:?}",
+    );
+    assert!(
+        !msg.contains("__unique_"),
+        "computed symbol excess-property diagnostics must not leak synthetic symbol keys, got: {msg:?}",
+    );
+}
+
+#[test]
+fn ts7053_branded_string_union_index_display_omits_alias_parentheses() {
+    let diagnostics = check_source_code_messages(
+        r#"
+type Tag1 = { __tag1__: void };
+type Tag2 = { __tag2__: void };
+type TaggedString1 = string & Tag1;
+type TaggedString2 = string & Tag2;
+
+declare let key: TaggedString1 | TaggedString2;
+interface Box { [key: TaggedString1]: string }
+declare let boxy: Box;
+boxy[key];
+"#,
+    );
+    let ts7053 = diagnostics.iter().find(|(code, _)| {
+        *code
+            == diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN
+    });
+    let Some((_, msg)) = ts7053 else {
+        panic!("expected TS7053 for incompatible branded-string union key, got: {diagnostics:?}");
+    };
+    assert!(
+        msg.contains("expression of type 'TaggedString1 | TaggedString2'"),
+        "TS7053 should preserve the union of branded aliases without member parentheses, got: {msg:?}",
+    );
+    assert!(
+        !msg.contains("(TaggedString1) | (TaggedString2)"),
+        "TS7053 should not parenthesize branded alias union members, got: {msg:?}",
+    );
+}
+
 // Same structural rule with different param names to prove the fix is not
 // keyed on identifier spelling ("k", "sym", etc.).
 #[test]

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -1236,7 +1236,10 @@ impl<'a> TypeFormatter<'a> {
 
         let formatted = self.format(id);
         let needs_parens = match self.interner.lookup(id) {
-            Some(TypeData::Intersection(_)) => !formatted.starts_with("NonNullable<"),
+            Some(TypeData::Intersection(_)) => {
+                !formatted.starts_with("NonNullable<")
+                    && contains_top_level_intersection_separator(&formatted)
+            }
             Some(TypeData::Function(_)) => true,
             Some(TypeData::Callable(_)) => {
                 formatted.starts_with('(')

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -30,5 +30,4 @@ TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/literal/stringMappingOverPatternLiterals.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
-TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 5: Key-Space, Indexed Access, And Property Semantics. Accepted-regression burn-down for `indexSignatures1` diagnostic fingerprint drift.

## Invariant
When an excess-property diagnostic is reported for a computed symbol key, tsz should render the source computed property name after matching the semantic key, not leak the internal `__unique_N` atom. When TS7053 displays a union of branded alias keys, alias surfaces should not be parenthesized merely because their underlying type is an intersection.

## Scope
- `crates/tsz-checker/src/error_reporter/properties.rs`
- `crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs`
- `crates/tsz-solver/src/diagnostics/format/compound.rs`
- `crates/tsz-checker/tests/symbol_index_signature_tests.rs`
- `scripts/conformance/conformance-accepted-regressions.txt`

## Owner Layer
- Checker diagnostic rendering owns mapping a computed-property diagnostic back to a source-facing property key after semantic matching.
- Solver diagnostic formatting owns when a branded-alias union member needs intersection parentheses in display.
- The accepted-regression list edit is artifact strictness only and is backed by focused conformance evidence.
- No new decision is driven by source text snippets, conformance test names, or rendered diagnostic strings.

## Adjacent-Case Matrix
- Reported witness: `indexSignatures1` focused conformance now passes and the accepted-regression entry is removed.
- Computed-key display case: TS2353 for a computed symbol key renders the source property name instead of an internal unique-symbol atom.
- Branded-alias union case: TS7053 display keeps alias surfaces unparenthesized when the alias itself is the display boundary.
- Negative/fallback case: the known `imported_symbol_typed_computed_member_access_uses_export_binding` failure already exists on current `origin/main` and is not changed by this PR.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression diagnostic fingerprint drift for `indexSignatures1`
- Evidence: conformance-only diagnostic/display slice; no project-corpus row is targeted. Focused conformance now passes for `TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts`.

## Verification
- `cargo nextest run -p tsz-checker --test symbol_index_signature_tests -E 'test(ts2353_computed_symbol_excess_property_displays_source_name) | test(ts7053_branded_string_union_index_display_omits_alias_parentheses)'`
- `cargo nextest run -p tsz-solver -E 'test(diagnostics::format::tests::format_union_of_intersections_display_order_independent_of_alloc_order) | test(diagnostics::format::tests::format_union_of_intersections_does_not_factor_different_common_parts) | test(diagnostics::format::tests::format_union_of_intersections_factors_common_type_parameter) | test(diagnostics::core::tests::test_format_union_of_intersections_parenthesized)'`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter indexSignatures1 --verbose`
- `python3 scripts/conformance/query-conformance.py --dashboard` reports accepted-regression gate: 29 listed tests
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`
- Post-rebase on head `75ca4510db`: `git diff --check HEAD~1..HEAD`, dashboard `12582/12582` with accepted-regression gate 29, and `python3 scripts/arch/arch_guard.py`
- Draft light CI on head `75ca4510db`: `CI Light Summary`, `gate`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `lint`, `unit`, `dist-binaries`, and GitGuardian passed in https://github.com/mohsen1/tsz/actions/runs/26467766150.

## Coordination Notes
- Fixes #10149.
- Rebased onto current `origin/main` and force-pushed with lease; current head is `75ca4510db`.
- Overlap checked against open indexed-access/index-signature PRs. This PR is limited to diagnostic rendering/key display and removal of one accepted-regression entry after a focused green witness.
- Marked ready after exact-head draft light CI passed. Auto-merge remains off; heavy CI and queue/merge decisions are left to the manager.
- Note: `imported_symbol_typed_computed_member_access_uses_export_binding` in `symbol_index_signature_tests` is already failing on current `origin/main` (`e1fbeec696`) with `[7053, 2322]`; this PR does not change that path.
