### PR TITLE
refactor(checker): route class namespace static relation

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -1332,7 +1332,9 @@ impl<'a> CheckerState<'a> {
                         && derived_ctor_type != TypeId::ERROR
                         && base_ctor_type != TypeId::UNKNOWN
                         && base_ctor_type != TypeId::ERROR
-                        && !self.is_assignable_to(derived_ctor_type, base_ctor_type)
+                        && !self
+                            .assign_relation_outcome(derived_ctor_type, base_ctor_type)
+                            .related
                     {
                         self.error_at_node(
                                 class_data.name,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -112,6 +112,9 @@ mod circular_accessor_annotation_tests;
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]
+#[path = "tests/class_namespace_static_relation_routing_arch_tests.rs"]
+mod class_namespace_static_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/class_property_typed_const_initializer_tests.rs"]
 mod class_property_typed_const_initializer_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_namespace_static_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_namespace_static_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+fn namespace_static_side_block(source: &str) -> &str {
+    let start = source
+        .find("let derived_sym = self.ctx.binder.get_node_symbol(class_idx);")
+        .expect("expected namespace static-side branch");
+    let rest = &source[start..];
+    let end = rest
+        .find("self.pop_type_parameters(derived_type_param_updates);")
+        .expect("expected branch end");
+    &rest[..end]
+}
+
+#[test]
+fn class_namespace_static_side_diagnostic_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/classes/class_checker.rs")
+        .expect("failed to read class checker source");
+    let branch = namespace_static_side_block(&source);
+
+    assert!(
+        branch.contains("assign_relation_outcome(derived_ctor_type, base_ctor_type)"),
+        "namespace-merged class static-side TS2417 check should route through relation outcome boundary"
+    );
+    assert!(
+        !branch.contains("!self.is_assignable_to(derived_ctor_type, base_ctor_type)"),
+        "namespace-merged class static-side TS2417 check should not use a raw boolean assignability gate"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a namespace-merged derived class exports a name that overlaps the base static side, `tsc` reports the existing checker-owned TS2417 diagnostic at the class name when the derived constructor side is not assignable to the base constructor side; this PR keeps that overlap precondition, anchor, and message while routing the relation decision through the shared assignability outcome boundary.

## Scope
- Route the namespace-merged class static-side TS2417 relation gate in `classes/class_checker.rs` through `assign_relation_outcome(...).related`.
- Keep the existing namespace/base static name-overlap precondition, unknown/error skips, TS2417 message, and class-name anchor unchanged.
- Add a focused architecture test guarding this branch against regressing to a raw boolean relation guard.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / class static-side TS2417 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib class_namespace_static_side_diagnostic_uses_relation_outcome_boundary`

## Coordination Notes
- Supports #8227 by moving another diagnostic-bearing assignability pre-gate onto the canonical relation outcome path.
- Disjoint from #10270 object-literal/property diagnostics, #10319 enum object-member diagnostics, #10320 destructuring element diagnostics, #10323 class static-side helper diagnostics, #10327 decorator-return diagnostics, #10328 computed enum diagnostics, #10329 dynamic-import diagnostics, #10330 import-attribute diagnostics, and #10332 `in`-operator diagnostics.
- Based on current `origin/main`; head is `106fb484567dc72a55a499bda8a78339b93f647a`.
- No solver policy, variance, any-propagation, relation cache-key behavior, class static-side name-overlap policy, or diagnostic display-string decision changed.