### PR TITLE
refactor(checker): route for-in lhs relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -505,6 +505,9 @@ mod file_session_switch_to_file_tests;
 #[path = "../tests/flow_boundary_contract_tests.rs"]
 mod flow_boundary_contract_tests;
 #[cfg(test)]
+#[path = "tests/for_in_lhs_relation_routing_arch_tests.rs"]
+mod for_in_lhs_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/for_in_narrowing_tests.rs"]
 mod for_in_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -599,7 +599,7 @@ impl<'a> CheckerState<'a> {
             if var_type != TypeId::STRING
                 && var_type != TypeId::ANY
                 && var_type != TypeId::UNKNOWN
-                && !self.diagnostic_relation_boolean_guard(element_type, var_type)
+                && !self.assign_relation_outcome(element_type, var_type).related
             {
                 self.error_at_node(
                     initializer,

--- a/crates/tsz-checker/src/tests/for_in_lhs_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/for_in_lhs_relation_routing_arch_tests.rs
@@ -1,0 +1,25 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn for_in_lhs_diagnostic_uses_relation_outcome_boundary() {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/state/variable_checking/for_loop.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let branch = source
+        .split("// TS2405: For for-in, also check that the LHS type is string or any.")
+        .nth(1)
+        .expect("missing for-in LHS diagnostic branch")
+        .split("// Get the type of the initializer expression")
+        .next()
+        .expect("missing end of for-in LHS diagnostic branch");
+
+    assert!(
+        branch.contains("self.assign_relation_outcome(element_type, var_type).related"),
+        "for-in LHS diagnostic should use the shared relation outcome boundary"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard(element_type, var_type)"),
+        "for-in LHS diagnostic should not use the legacy boolean guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a for-in assignment target is checked against the source key type, the checker keeps the existing TS2404 diagnostic message, anchor, and target filters while routing the relation decision through the shared assignability outcome boundary.

## Scope
- Route the for-in LHS TS2404 relation gate in crates/tsz-checker/src/state/variable_checking/for_loop.rs through assign_relation_outcome(...).related.
- Keep the existing identifier/property/element target filter, optional-chain skip, any/unknown/string skips, message, and initializer anchor unchanged.
- Add a focused architecture test guarding this branch against regressing to the raw boolean relation guard.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / for-in LHS TS2404 routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed. Local focused guard passed on head c8c2a7c8a6ace585c98fa8824a9490b580afe3e7.

## Verification
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh
- cargo nextest run -p tsz-checker --lib for_in_lhs_diagnostic_uses_relation_outcome_boundary

## Coordination Notes
- Fresh worktree off origin/main: /Users/mohsen/code/tsz-m1b-for-in-lhs-relation-20260526.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from current M1-B PRs #10336, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, for-in LHS filtering, or diagnostic display-string decision changed.
- Ready for manager review/queue after local verification and green draft-light CI; no auto-merge enabled by this lane.