### PR TITLE
refactor(checker): route nullish target relation outcome

### DIFF
--- a/crates/tsz-checker/src/assignability/nullish_error_targets.rs
+++ b/crates/tsz-checker/src/assignability/nullish_error_targets.rs
@@ -30,6 +30,6 @@ impl<'a> CheckerState<'a> {
 
         let (_, nullable_target) = self.split_nullish_type(target);
         nullable_target
-            .is_none_or(|nullable| !self.diagnostic_relation_boolean_guard(source, nullable))
+            .is_none_or(|nullable| !self.assign_relation_outcome(source, nullable).related)
     }
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -646,6 +646,9 @@ mod new_typeof_property_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]
 mod nonunique_symbol_property_access_tests;
 #[cfg(test)]
+#[path = "tests/nullish_target_relation_routing_arch_tests.rs"]
+mod nullish_target_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/object_literal_computed_symbol_member_tests.rs"]
 mod object_literal_computed_symbol_member_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nullish_target_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/nullish_target_relation_routing_arch_tests.rs
@@ -1,0 +1,22 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn nullish_target_diagnostic_uses_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/assignability/nullish_error_targets.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let branch = source
+        .split("let (_, nullable_target) = self.split_nullish_type(target);")
+        .nth(1)
+        .expect("missing nullish target relation branch");
+
+    assert!(
+        branch.contains("self.assign_relation_outcome(source, nullable).related"),
+        "nullish target diagnostic should use the shared relation outcome boundary"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard(source, nullable)"),
+        "nullish target diagnostic should not use the legacy boolean guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When strict null or undefined assignment flows through a structured target containing nested error types, the checker keeps the existing cascade-suppression preconditions and diagnostic policy while routing the nullable-target relation decision through the shared assignability outcome boundary.

## Scope
- Route the nullish nested-error target diagnostic gate in crates/tsz-checker/src/assignability/nullish_error_targets.rs through assign_relation_outcome(...).related.
- Keep strict-null, source-kind, target-kind, top-level-error, nested-error, and split-nullish preconditions unchanged.
- Add a focused architecture test guarding this branch against regressing to the raw boolean relation guard.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / nullish nested-error target routing
- Evidence: architecture-only routing slice; no project corpus row behavior is intentionally changed. Local focused guard passed on rebased head 39c957adb0450ec663648adb22f7c1cf7c4b01c6.

## Verification
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh
- cargo nextest run -p tsz-checker --lib nullish_target_diagnostic_uses_relation_outcome_boundary
- Draft-light CI passed on head 39c957adb0450ec663648adb22f7c1cf7c4b01c6 before ready handoff.

## Coordination Notes
- Reused inactive worktree /Users/mohsen/code/tsz-m1b-10043 by switching to a fresh branch from origin/main; the old closed PR branch was clean and preserved.
- Rebasing onto current origin/main changed the head from e941f61d56a7d67e726822ae5208cb08b46ff521 to 39c957adb0450ec663648adb22f7c1cf7c4b01c6.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from current M1-B PRs #10340, #10338, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, nullish cascade-suppression policy, or diagnostic display-string decision changed.
- Marked ready by AgentName: M1-B after exact-head sync and green draft-light CI; auto-merge intentionally left off.
