### PR TITLE
refactor(checker): route polymorphic this relation outcome

### DIFF
--- a/crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs
@@ -135,14 +135,13 @@ impl<'a> CheckerState<'a> {
         }
 
         let receiver_type = self.get_type_of_node(access.expression);
-        if receiver_type == target || !self.diagnostic_relation_boolean_guard(receiver_type, target)
-        {
+        if receiver_type == target || !self.assign_relation_outcome(receiver_type, target).related {
             return None;
         }
         if let Some(members) =
             crate::query_boundaries::common::intersection_members(self.ctx.types, receiver_type)
             && let Some(member) = members.into_iter().find(|&member| {
-                member != target && self.diagnostic_relation_boolean_guard(member, target)
+                member != target && self.assign_relation_outcome(member, target).related
             })
         {
             return Some(member);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -667,6 +667,9 @@ mod overload_anchor_at_argument_tests;
 #[path = "tests/partial_pick_indexed_access_write_tests.rs"]
 mod partial_pick_indexed_access_write_tests;
 #[cfg(test)]
+#[path = "tests/polymorphic_this_relation_routing_arch_tests.rs"]
+mod polymorphic_this_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/polymorphic_this_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/polymorphic_this_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn polymorphic_this_receiver_uses_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/assignability/polymorphic_this_diagnostics.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let branch = source
+        .split("let receiver_type = self.get_type_of_node(access.expression);")
+        .nth(1)
+        .expect("missing polymorphic this receiver relation branch")
+        .split("let default_atom = self.ctx.types.intern_string(\"default\");")
+        .next()
+        .expect("missing end of polymorphic this receiver relation branch");
+
+    assert!(
+        branch.contains("self.assign_relation_outcome(receiver_type, target).related"),
+        "receiver relation should use the shared relation outcome boundary"
+    );
+    assert!(
+        branch.contains("self.assign_relation_outcome(member, target).related"),
+        "intersection member relation should use the shared relation outcome boundary"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard"),
+        "polymorphic this receiver branch should not use the legacy boolean guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When checking a polymorphic-this property access receiver against a target and an intersection member against that target, checker keeps the existing method/contains-this/default-export fallback policy while routing relation decisions through the shared assignability outcome boundary.

## Scope
- Route receiver/member relation gates in `crates/tsz-checker/src/assignability/polymorphic_this_diagnostics.rs`.
- Keep the existing property/method/contains-this/default-export fallback behavior unchanged.
- Add a focused architecture test for the polymorphic-this receiver routing slice.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / polymorphic-this receiver routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard passed on head 4d76bf42c3565a264847910e5f459dae1c2f0096.

## Verification
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- python3 scripts/arch/arch_guard.py
- scripts/arch/check-checker-boundaries.sh
- cargo nextest run -p tsz-checker --lib polymorphic_this_receiver_uses_relation_outcome_boundary
- Draft-light CI passed on head 4d76bf42c3565a264847910e5f459dae1c2f0096 before ready handoff.

## Coordination Notes
- Reused inactive worktree /Users/mohsen/code/tsz-m1b-10044 by switching it to a fresh branch from origin/main; the old closed PR branch was clean and preserved in git history.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from current M1-B PRs #10340, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, cache, relation semantics, or diagnostic display-string decision changed.
- Marked ready by AgentName: M1-B after exact-head sync and green draft-light CI; auto-merge intentionally left off.
