### PR TITLE
refactor(checker): route type parameter default relations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -751,6 +751,9 @@ mod ts2590_array_literal_identity_skip_tests;
 #[path = "tests/ts2739_alias_unfold_display_tests.rs"]
 mod ts2739_alias_unfold_display_tests;
 #[cfg(test)]
+#[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
+mod type_param_default_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/union_call_resolution_tests.rs"]
 mod union_call_resolution_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
+++ b/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
@@ -50,8 +50,9 @@ impl<'a> CheckerState<'a> {
             if self.type_parameter_default_syntactically_satisfies_constraint(param_idx) {
                 continue;
             }
-            let mut default_satisfies =
-                self.diagnostic_relation_boolean_guard(default_type, constraint_type);
+            let mut default_satisfies = self
+                .assign_relation_outcome(default_type, constraint_type)
+                .related;
             if !default_satisfies {
                 self.ensure_refs_resolved(default_type);
                 self.ensure_refs_resolved(constraint_type);
@@ -64,7 +65,8 @@ impl<'a> CheckerState<'a> {
                     )
                 {
                     default_satisfies = self
-                        .diagnostic_relation_boolean_guard(evaluated_default, evaluated_constraint)
+                        .assign_relation_outcome(evaluated_default, evaluated_constraint)
+                        .related
                         || self.satisfies_array_like_constraint(
                             evaluated_default,
                             evaluated_constraint,
@@ -88,7 +90,8 @@ impl<'a> CheckerState<'a> {
                     let evaluated_default =
                         self.evaluate_type_for_assignability(instantiated_default);
                     default_satisfies = self
-                        .diagnostic_relation_boolean_guard(evaluated_default, constraint_type)
+                        .assign_relation_outcome(evaluated_default, constraint_type)
+                        .related
                         || self.satisfies_array_like_constraint(evaluated_default, constraint_type)
                         || self.conditional_result_branches_satisfy_constraint(
                             evaluated_default,

--- a/crates/tsz-checker/src/tests/type_param_default_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/type_param_default_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn type_param_defaults_use_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path =
+        Path::new(manifest_dir).join("src/state/type_analysis/type_param_defaults.rs");
+    let source = fs::read_to_string(source_path).expect("read type_param_defaults.rs");
+
+    let function_start = source
+        .find("fn validate_type_parameter_defaults_against_constraints")
+        .expect("find type parameter default validation function");
+    let diagnostic_start = source[function_start..]
+        .find("self.error_at_node_msg(")
+        .expect("find default constraint diagnostic emission");
+    let branch = &source[function_start..function_start + diagnostic_start];
+
+    assert!(
+        branch.contains(".assign_relation_outcome(default_type, constraint_type)")
+            && branch.contains(".assign_relation_outcome(evaluated_default, evaluated_constraint)")
+            && branch.contains(".assign_relation_outcome(evaluated_default, constraint_type)"),
+        "type-parameter default relation decisions should use relation outcomes"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard"),
+        "type-parameter default validation should not fall back to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When validating a type-parameter default against its declared constraint, checker keeps the existing syntactic, evaluated, array-like, and conditional-branch fallback policy while routing the default-vs-constraint relation decisions through the shared assignability outcome boundary.

## Scope
- Route the three default/constraint relation gates in `crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs` through `assign_relation_outcome(...).related`.
- Keep the existing self-reference, optional mapped constraint, syntactic union branch, array-like, conditional branch, and diagnostic emission behavior unchanged.
- Add a focused architecture test guarding this helper against regressing to raw boolean relation guards.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / type-parameter default constraint routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard and draft-light CI passed on rebased head `e86ee4bc3fa5dfd292422592a4c8f436cb7f1876`.

## Verification
Passed locally on rebased head `e86ee4bc3fa5dfd292422592a4c8f436cb7f1876`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib type_param_defaults_use_relation_outcome_boundary`

Draft-light CI passed on head `e86ee4bc3fa5dfd292422592a4c8f436cb7f1876`:
- `CI Light Summary`
- `lint`
- `unit`
- `unit-cloudbuild`
- `dist-binaries`
- `cargo-deny`
- `cargo-shear`
- `project-row-drift`
- `queue-one-pr`
- `GitGuardian Security Checks`

## Coordination Notes
- Reused inactive worktree `/Users/mohsen/code/tsz-m1b-10051`; TypeScript was linked from the primary populated checkout.
- Rebased from old pushed head `0dc6a9ceba47ae212e3cdf36ac3c9a20eecd7f1b` onto current `origin/main` (`bc3c40a7b71237487a069bd103bb41bb6ca20f44`) and force-pushed with lease to `e86ee4bc3fa5dfd292422592a4c8f436cb7f1876`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from current M1-B PRs #10343, #10342, #10338, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, or diagnostic display-string decision changed.
- Broader exploratory `cargo nextest run -p tsz-checker --lib type_param` hit `state_domain::state_checking::property_access::tests::type_param_property_access_with_mapped_constraint`; the same single test fails on clean `origin/main` head `ea0e5aa3d87d` in `/Users/mohsen/code/tsz-m1b-10047`, so it is not claimed as this PR's verification.
- Ready for heavy CI; auto-merge intentionally left off for manager/queue-owner handling.
