### PR TITLE
refactor(checker): route interface heritage index relation outcome

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -71,7 +71,10 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         let derived_value = self.evaluate_type_with_env(derived_value);
         let base_value = self.evaluate_type_with_env(base_value);
-        if self.diagnostic_relation_boolean_guard(derived_value, base_value) {
+        if self
+            .assign_relation_outcome(derived_value, base_value)
+            .related
+        {
             return true;
         }
 
@@ -95,7 +98,8 @@ impl<'a> CheckerState<'a> {
         derived_value: TypeId,
         base_value: TypeId,
     ) -> bool {
-        self.diagnostic_relation_boolean_guard(derived_value, base_value)
+        self.assign_relation_outcome(derived_value, base_value)
+            .related
             || self.type_heritage_includes_base(derived_value, base_value)
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -160,6 +160,9 @@ mod imported_generator_iterable_tests;
 #[path = "tests/index_sig_param_intersection_validity_tests.rs"]
 mod index_sig_param_intersection_validity_tests;
 #[cfg(test)]
+#[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
+mod interface_heritage_index_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/interface_heritage_index_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_heritage_index_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+
+#[test]
+fn interface_heritage_index_values_use_relation_outcome_boundary() {
+    let source_path = format!(
+        "{}/src/classes/interface_heritage_index_compat.rs",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let source = fs::read_to_string(source_path)
+        .expect("read interface heritage index compatibility helpers");
+
+    let start = source
+        .find("pub(super) fn index_value_assignable_for_interface_extends")
+        .expect("find interface heritage index value entrypoint");
+    let end = source[start..]
+        .find("fn type_heritage_includes_base")
+        .map(|offset| start + offset)
+        .expect("find end of relation-routing helpers");
+    let helper_source = &source[start..end];
+
+    assert!(
+        helper_source.contains(".assign_relation_outcome(derived_value, base_value)")
+            || helper_source.contains("assign_relation_outcome(derived_value, base_value)"),
+        "interface heritage index value checks must route through assign_relation_outcome"
+    );
+    assert!(
+        helper_source.matches(".related").count() >= 2,
+        "both the direct relation check and member relation check must consume RelationOutcome.related"
+    );
+    assert!(
+        !helper_source.contains("diagnostic_relation_boolean_guard"),
+        "interface heritage index value checks should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When interface heritage index-signature compatibility checks compare a derived index-signature value type, including union members, against a base index-signature value type, checker keeps the existing evaluation, all-members, and heritage-inclusion fallback policy while routing relation decisions through the shared assignability outcome boundary.

## Scope
- Route `index_value_assignable_for_interface_extends` and its member helper in `crates/tsz-checker/src/classes/interface_heritage_index_compat.rs` through `assign_relation_outcome(...).related`.
- Preserve the existing union-member decomposition and `type_heritage_includes_base` fallback.
- Add a focused architecture test guarding this helper against regressing to raw boolean relation guards.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / interface heritage index-signature value routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard and draft-light CI passed on rebased head `d3267baa80d486355b4ab58107b254f9ee5f1b26`.

## Verification
Passed locally on rebased head `d3267baa80d486355b4ab58107b254f9ee5f1b26`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib interface_heritage_index_values_use_relation_outcome_boundary`

Passed in draft-light CI for head `d3267baa80d486355b4ab58107b254f9ee5f1b26`:
- `CI Light Summary`
- `lint`
- `dist-binaries`
- `unit`
- `unit-cloudbuild`
- `cargo-deny`
- `cargo-shear`
- `project-row-drift`
- `gate`
- `GitGuardian Security Checks`

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260526-204617`; TypeScript linked from the primary populated checkout.
- Rebased onto current `origin/main` `dfbe2b8db9cf984e9bdae06af3122c4935736c25` and force-pushed with lease to `d3267baa80d486355b4ab58107b254f9ee5f1b26`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Replaces the older closed stacked slice #10067 with a fresh main-based outcome-boundary version; #10067 was previously closed as superseded by consolidated work.
- Disjoint from current M1-B PRs #10348, #10344, #10342, #10340, #10338, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, union decomposition policy, heritage fallback behavior, or diagnostic display-string decision changed.
- Ready for manager review/queue; auto-merge intentionally left off.