### PR TITLE
chore(agents): surface owned PR queue state

### DIFF
--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -97,6 +97,7 @@ Useful live checks:
 ```bash
 scripts/agents/ensure-agent-labels.sh --audit
 scripts/agents/list-owned-work.sh --all
+scripts/agents/list-owned-work.sh --pr-state Studio-F
 node scripts/ci/pr-ownership-report.mjs
 gh issue list --repo mohsen1/tsz --state open --limit 200 --json number,title,labels,updatedAt,url
 ```

--- a/scripts/agents/list-owned-work.sh
+++ b/scripts/agents/list-owned-work.sh
@@ -13,11 +13,12 @@ AGENTS=(
 
 usage() {
   cat <<'USAGE'
-usage: scripts/agents/list-owned-work.sh [AgentName|--all]
+usage: scripts/agents/list-owned-work.sh [--pr-state] [AgentName|--all]
 
 Examples:
   scripts/agents/list-owned-work.sh M1-A
   scripts/agents/list-owned-work.sh --all
+  scripts/agents/list-owned-work.sh --pr-state Studio-F
 USAGE
 }
 
@@ -26,15 +27,38 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if [[ $# -gt 1 ]]; then
-  echo "Unknown option: $2 (try --help)" >&2
+WITH_PR_STATE=false
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr-state|--with-pr-state)
+      WITH_PR_STATE=true
+      shift
+      ;;
+    --all)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1 (try --help)" >&2
+      exit 2
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -gt 1 ]]; then
+  echo "Unknown option: ${POSITIONAL[1]} (try --help)" >&2
   exit 2
 fi
 
-if [[ $# -eq 0 || "${1:-}" == "--all" ]]; then
+if [[ ${#POSITIONAL[@]} -eq 0 || "${POSITIONAL[0]:-}" == "--all" ]]; then
   SELECTED=("${AGENTS[@]}")
 else
-  SELECTED=("$1")
+  SELECTED=("${POSITIONAL[0]}")
 fi
 
 REPOSITORY="${GITHUB_REPOSITORY:-mohsen1/tsz}"
@@ -83,12 +107,37 @@ for agent in "${SELECTED[@]}"; do
   echo "## $label"
   echo ""
   echo "PRs:"
-  prs="$(
-    gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url \
-      --jq '.[] | "#\(.number) " + (if .isDraft then "draft" else "ready" end) + " " + .title + " " + .url' \
-      2>/dev/null ||
-      list_owned_items_rest "$label" pr
-  )"
+  if [[ "$WITH_PR_STATE" == true ]]; then
+    prs="$(
+      gh pr list --state open --limit 100 --label "$label" \
+        --json number,title,isDraft,url,mergeStateStatus,mergeable,autoMergeRequest,statusCheckRollup \
+        --jq '
+          def queue_state:
+            ([.statusCheckRollup[]? | select((.__typename == "StatusContext" and .context == "Queue Tested") or .name == "Queue Tested")] | first) as $queue |
+            if $queue == null then "queue=none"
+            elif $queue.__typename == "StatusContext" then "queue=\(($queue.state // "unknown") | ascii_downcase)"
+            else "queue=\((($queue.conclusion // $queue.status // "unknown")) | ascii_downcase)"
+            end;
+          .[] |
+            "#\(.number) " +
+            (if .isDraft then "draft" else "ready" end) +
+            " merge=\(.mergeStateStatus // "UNKNOWN")" +
+            " mergeable=\(.mergeable // "UNKNOWN")" +
+            " autoMerge=" + (if .autoMergeRequest then "on" else "off" end) +
+            " " + queue_state +
+            " " + .title + " " + .url
+        ' \
+        2>/dev/null ||
+        list_owned_items_rest "$label" pr
+    )"
+  else
+    prs="$(
+      gh pr list --state open --limit 100 --label "$label" --json number,title,isDraft,url \
+        --jq '.[] | "#\(.number) " + (if .isDraft then "draft" else "ready" end) + " " + .title + " " + .url' \
+        2>/dev/null ||
+        list_owned_items_rest "$label" pr
+    )"
+  fi
   if [[ -n "$prs" ]]; then
     printf '%s\n' "$prs"
   else


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing

## Invariant
When a lane has ready PRs blocked by queue or merge-policy state, agents should be able to inspect that state from the owned-work helper without changing PRs, queue status, branches, or caches.

## Scope
- Add an opt-in `--pr-state` / `--with-pr-state` mode to `scripts/agents/list-owned-work.sh`.
- Keep default `list-owned-work` output unchanged for existing Start Every Cycle commands.
- Document the new live-check command in `docs/plan/agents/README.md`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: launch-script-only; no compiler, checker, solver, parser, emitter, benchmark fixture, or project corpus behavior changes.

## Verification
- `bash -n scripts/agents/list-owned-work.sh`
- `scripts/agents/list-owned-work.sh --help`
- `scripts/agents/list-owned-work.sh Studio-F`
- `scripts/agents/list-owned-work.sh --pr-state Studio-F`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-pr-state.json`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Exact-head draft CI for `b047b8efe4d701e3775e33a851377a2a512debfe`: `CI Light Summary`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, `gate`, `queue-one-pr`, and GitGuardian successful; compiler-heavy jobs intentionally skipped for this launch-script/docs path.

## Coordination Notes
- The current Studio-F PR runway remains blocked by merge/queue policy rather than failing head checks; this helper makes that state visible without rearming auto-merge or rebasing ready PRs.
- This does not overlap Studio-A metric refresh work in #10259 or the existing Studio-F ready PRs.
- Ready for manager/queue-owner review. Auto-merge remains off; `Queue Tested` is pending because the queue is not armed for this PR.
