### PR TITLE
fix(checker): accept React HOC props spreads

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -1538,9 +1538,34 @@ impl<'a> CheckerState<'a> {
         // Checking a synthesized object (which loses the type parameter identity)
         // against the type parameter would produce a false TS2322.
         let spread_satisfies_type_param = props_is_type_param
-            && spread_entries.iter().any(|&(spread_type, _, _, _)| {
-                self.diagnostic_relation_boolean_guard(spread_type, props_type)
-            });
+            && spread_entries
+                .iter()
+                .any(|&(spread_type, display_spread_type, _, _)| {
+                    self.diagnostic_relation_boolean_guard(spread_type, props_type)
+                        || crate::query_boundaries::checkers::jsx::spread_source_covers_readonly_wrapped_type_parameter(
+                            self.ctx.types,
+                            &self.ctx.definition_store,
+                            spread_type,
+                            props_type,
+                        )
+                        || crate::query_boundaries::checkers::jsx::spread_source_covers_readonly_wrapped_type_parameter(
+                            self.ctx.types,
+                            &self.ctx.definition_store,
+                            display_spread_type,
+                            props_type,
+                        )
+                });
+        let react_alias_spread_only_contributes_children = props_is_type_param
+            && !has_explicit_jsx_attrs
+            && !spread_entries.is_empty()
+            && !provided_attrs.is_empty()
+            && provided_attrs.iter().all(|(name, _)| name == "children")
+            && special_attr_component_type
+                .or(component_type)
+                .is_some_and(|component| {
+                    self.is_react_jsx_component_alias_application(component)
+                        || self.is_react_jsx_component_alias_union(component)
+                });
         let reported_type_param_assignability = if !reported_custom_children_assignability
             && !reported_special_attr_assignability
             && !reported_class_missing_props_assignability
@@ -1551,6 +1576,7 @@ impl<'a> CheckerState<'a> {
             && props_is_type_param
             && !self.jsx_props_type_is_library_managed_attributes_application(raw_props_type)
             && !spread_satisfies_type_param
+            && !react_alias_spread_only_contributes_children
         {
             let attrs_type = self.build_jsx_provided_attrs_object_type(&provided_attrs);
             if !self.diagnostic_relation_boolean_guard(attrs_type, props_type) {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -604,6 +604,9 @@ mod jsx_element_type_constraint_tests;
 #[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
 mod jsx_excess_attr_with_spread_display_tests;
 #[cfg(test)]
+#[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
+mod jsx_react_hoc_spread_props_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -234,6 +234,92 @@ pub(crate) fn class_props_is_readonly_wrapper_intersection(
     })
 }
 
+/// Return true when a JSX spread source carries a target props type parameter
+/// through a readonly wrapper such as `Readonly<P & Extra>`.
+///
+/// `React` class `.props` surfaces commonly look like
+/// `Readonly<{ children?: ReactNode }> & Readonly<P>`. When such a value is
+/// spread into a component whose props target is the bare `P`, the synthesized
+/// JSX attrs object can lose the `P` identity and collapse to only enumerable
+/// wrapper props such as `children`. This query keeps the type-parameter
+/// containment decision structural instead of deriving it from rendered text.
+pub(crate) fn spread_source_covers_readonly_wrapped_type_parameter(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    spread_source: TypeId,
+    target: TypeId,
+) -> bool {
+    if !crate::query_boundaries::common::is_type_parameter_like(db, target) {
+        return false;
+    }
+    spread_source_covers_readonly_wrapped_type_parameter_inner(
+        db,
+        def_store,
+        spread_source,
+        target,
+        &mut Vec::new(),
+    )
+}
+
+fn spread_source_covers_readonly_wrapped_type_parameter_inner(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    spread_source: TypeId,
+    target: TypeId,
+    visited: &mut Vec<TypeId>,
+) -> bool {
+    if spread_source.is_intrinsic() || visited.contains(&spread_source) {
+        return false;
+    }
+    visited.push(spread_source);
+
+    if let Some(members) = crate::query_boundaries::common::intersection_members(db, spread_source)
+    {
+        return members.iter().any(|&member| {
+            spread_source_covers_readonly_wrapped_type_parameter_inner(
+                db, def_store, member, target, visited,
+            )
+        });
+    }
+
+    let Some(app) = crate::query_boundaries::common::type_application(db, spread_source) else {
+        return false;
+    };
+    if app.args.len() != 1 || !type_has_declaration_name(db, def_store, spread_source, "Readonly") {
+        return false;
+    }
+
+    type_is_target_or_direct_intersection_member(db, def_store, app.args[0], target)
+}
+
+fn type_is_target_or_direct_intersection_member(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    target: TypeId,
+) -> bool {
+    type_parameter_identity_matches(def_store, type_id, target)
+        || crate::query_boundaries::common::intersection_members(db, type_id).is_some_and(
+            |members| {
+                members
+                    .iter()
+                    .any(|&member| type_parameter_identity_matches(def_store, member, target))
+            },
+        )
+}
+
+fn type_parameter_identity_matches(
+    def_store: &DefinitionStore,
+    candidate: TypeId,
+    target: TypeId,
+) -> bool {
+    candidate == target
+        || def_store
+            .find_def_for_type(candidate)
+            .zip(def_store.find_def_for_type(target))
+            .is_some_and(|(candidate_def, target_def)| candidate_def == target_def)
+}
+
 fn contains_anonymous_object_surface_inner(
     db: &dyn TypeDatabase,
     def_store: &DefinitionStore,

--- a/crates/tsz-checker/tests/jsx_react_hoc_spread_props_tests.rs
+++ b/crates/tsz-checker/tests/jsx_react_hoc_spread_props_tests.rs
@@ -1,0 +1,153 @@
+//! JSX spread checks for `React` higher-order component props surfaces.
+//!
+//! Structural rule: when a JSX spread source is a `React` class `.props` surface
+//! that carries the target component props parameter through a readonly wrapper
+//! (`Readonly<P & Extra>`), the spread already satisfies bare `P`. The
+//! synthesized JSX attrs object must not drop that `P` identity and report
+//! `TS2322` against only wrapper-owned props such as `children`.
+
+use tsz_common::checker_options::{CheckerOptions, JsxMode};
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn jsx_opts() -> CheckerOptions {
+    CheckerOptions {
+        jsx_mode: JsxMode::React,
+        strict: true,
+        strict_null_checks: true,
+        no_implicit_any: true,
+        strict_function_types: true,
+        strict_bind_call_apply: true,
+        strict_property_initialization: true,
+        no_implicit_this: true,
+        always_strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn jsx_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source(source, "test.tsx", jsx_opts())
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn has_code(diags: &[(u32, String)], code: u32) -> bool {
+    diags.iter().any(|(diag_code, _)| *diag_code == code)
+}
+
+fn load_typescript_fixture(rel_path: &str) -> Option<String> {
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let candidates = [
+        manifest_dir.join("../../").join(rel_path),
+        manifest_dir.join("../../../").join(rel_path),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.exists())
+        .and_then(|candidate| std::fs::read_to_string(candidate).ok())
+}
+
+const REACT_PREAMBLE: &str = r#"
+declare namespace JSX {
+    interface Element {}
+    interface ElementClass { render(): React.ReactNode; }
+    interface ElementAttributesProperty { props: {}; }
+    interface IntrinsicElements { div: {}; }
+}
+
+declare namespace React {
+    interface ReactElement<P = any> {}
+    type ReactNode = ReactElement<any> | string | number | boolean | null | undefined;
+
+    class Component<P = {}, S = {}> {
+        constructor(props: Readonly<P>);
+        constructor(props: P, context?: any);
+        readonly props: Readonly<{ children?: ReactNode }> & Readonly<P>;
+        readonly state: Readonly<S>;
+        render(): ReactNode;
+    }
+
+    interface ComponentClass<P = {}, S = {}> {
+        new(props: P, context?: any): Component<P, S>;
+    }
+
+    interface StatelessComponent<P = {}> {
+        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+    }
+}
+"#;
+
+#[test]
+fn react_component_alias_union_accepts_readonly_wrapped_props_spread() {
+    let source = format!(
+        r#"
+{REACT_PREAMBLE}
+
+function wrap<P>(App: React.ComponentClass<P> | React.StatelessComponent<P>): void {{
+    class Wrapper extends React.Component<P & {{ x: number }}> {{
+        render() {{
+            return <App {{...this.props}} />;
+        }}
+    }}
+}}
+"#
+    );
+
+    let diags = jsx_diagnostics(&source);
+    assert!(
+        !has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "readonly wrapped `P & Extra` props spread should satisfy bare `P`, got: {diags:?}"
+    );
+}
+
+#[test]
+fn react_hoc_spreadprops_react16_fixture_has_no_ts2322() {
+    let Some(react_types) = load_typescript_fixture("TypeScript/tests/lib/react16.d.ts") else {
+        return;
+    };
+    let Some(source) =
+        load_typescript_fixture("TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx")
+    else {
+        return;
+    };
+    let source = source.replace("/// <reference path=\"/.lib/react16.d.ts\" />", "");
+    let libs = tsz_checker::test_utils::load_compiled_lib_files(&["lib.es5.d.ts"]);
+    let diags = tsz_checker::test_utils::check_multi_file_with_libs(
+        &[("react.d.ts", &react_types), ("test.tsx", &source)],
+        "test.tsx",
+        jsx_opts(),
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect::<Vec<_>>();
+
+    assert!(
+        !has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "real react16 `reactHOCSpreadprops.tsx` fixture should not emit TS2322, got: {diags:?}"
+    );
+}
+
+#[test]
+fn react_component_class_accepts_renamed_readonly_wrapped_props_spread() {
+    let source = format!(
+        r#"
+{REACT_PREAMBLE}
+
+function decorate<Q>(Widget: React.ComponentClass<Q>): void {{
+    class Decorated extends React.Component<Q & {{ label: string }}> {{
+        render() {{
+            return <Widget {{...this.props}} />;
+        }}
+    }}
+}}
+"#
+    );
+
+    let diags = jsx_diagnostics(&source);
+    assert!(
+        !has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "renamed props parameter should be recognized structurally, got: {diags:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -12,7 +12,6 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
-TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/relationComplexityError.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Track 1 conformance strictness / semantic diagnostic fix.

## Invariant
When a JSX spread source is a `React` class `.props` surface that carries the target component props parameter through a readonly wrapper such as `Readonly<P & Extra>`, `tsc` treats the spread as satisfying bare `P`; this PR keeps tsz from synthesizing a children-only attrs object and reporting `TS2322` against that bare type parameter.

## Scope
- Add a JSX query-boundary classifier for readonly-wrapped props parameter coverage.
- Use that classifier in the bare type-parameter JSX spread-satisfies gate.
- Add focused checker tests, including the real `reactHOCSpreadprops.tsx` + `react16.d.ts` fixture.
- Remove `TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx` from accepted regressions.

## Project Corpus Impact
- Row: n/a
- Bug family: React HOC JSX generic spread false-positive diagnostics
- Evidence: conformance-only accepted-regression burn-down; no project corpus row was targeted.

## Verification
- `cargo fmt`
- `cargo nextest run -p tsz-checker --lib jsx_react_hoc_spread_props_tests`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter reactHOCSpreadprops --verbose`
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12582/12582`, accepted-regression gate `29 listed tests`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check HEAD~1..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Based on `origin/main` at `dfbe2b8db9` after rebase.
- Narrows aggregate accepted-regression tracker #10306 by one path.
- Draft PR intentionally opened for light CI; no auto-merge requested.
