### PR TITLE
refactor(checker): route jsdoc import constraint relation

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs
@@ -80,7 +80,7 @@ impl<'a> CheckerState<'a> {
                     arg_search_offset += arg_str.len() + 1;
                     continue;
                 }
-                if self.diagnostic_relation_boolean_guard(type_arg, constraint) {
+                if self.assign_relation_outcome(type_arg, constraint).related {
                     arg_search_offset += arg_str.len() + 1;
                     continue;
                 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -166,6 +166,9 @@ mod isolated_declarations_unannotated_param_tests;
 #[path = "../tests/js_property_write_self_declaration_tests.rs"]
 mod js_property_write_self_declaration_tests;
 #[cfg(test)]
+#[path = "tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs"]
+mod jsdoc_import_type_constraints_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_postfix_nullable_type_tests.rs"]
 mod jsdoc_postfix_nullable_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn jsdoc_import_type_constraints_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/jsdoc/diagnostics_import_type_constraints.rs"))
+            .expect("read JSDoc import type constraint diagnostics source");
+
+    let helper = source
+        .split("pub(super) fn report_jsdoc_import_type_constraint_error")
+        .nth(1)
+        .expect("find JSDoc import type constraint diagnostic helper")
+        .split("for (name, previous) in scope_updates")
+        .next()
+        .expect("slice helper body before scope restoration");
+
+    assert!(
+        helper.contains("assign_relation_outcome(type_arg, constraint)")
+            && helper.contains(".related"),
+        "JSDoc import type constraint diagnostics should use the shared relation outcome boundary"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "JSDoc import type constraint diagnostics should not regress to a raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When JSDoc import type arguments are checked against template constraints for TS2344 diagnostic orchestration, checker keeps the existing type-parameter scope setup, error-type suppression, source-span search, widening, and diagnostic rendering behavior while routing the type-argument-vs-constraint relation decision through the shared assignability outcome boundary.

## Scope
- Route `report_jsdoc_import_type_constraint_error` in `crates/tsz-checker/src/jsdoc/diagnostics_import_type_constraints.rs` through `assign_relation_outcome(...).related`.
- Preserve existing argument offset accounting, scope restoration, and TS2344 message construction unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / JSDoc import type constraint routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard and draft-light CI passed on head `4e8f18fa53d264e8372e0fc47e15bd160a912111`.

## Verification
Passed locally on head `4e8f18fa53d264e8372e0fc47e15bd160a912111`:
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib jsdoc_import_type_constraints_use_relation_outcome_boundary`

Passed in draft-light CI for head `4e8f18fa53d264e8372e0fc47e15bd160a912111`:
- `CI Light Summary`
- `lint`
- `dist-binaries`
- `unit`
- `unit-cloudbuild`
- `cargo-deny`
- `cargo-shear`
- `project-row-drift`
- `gate`
- `GitGuardian Security Checks`

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-jsdoc-import-constraint-20260526`; created from `origin/main` `dfbe2b8db9cf984e9bdae06af3122c4935736c25`; TypeScript linked from the primary populated checkout.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from open JSDoc work: #10296 and #10284 cover JSDoc typedef behavior/tests, while this PR is a relation-routing-only guard in import type constraint diagnostics.
- Disjoint from current M1-B relation-routing PRs #10351, #10344, #10343, #10342, #10340, #10338, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, JSDoc type resolution, source-span search, or diagnostic display-string decision changed.
- Ready for manager review/queue; auto-merge intentionally left off.