### PR TITLE
fix(ci): treat unqueued rerun cancellation as skipped

### DIFF
--- a/scripts/ci/check-stale-ci-runs.mjs
+++ b/scripts/ci/check-stale-ci-runs.mjs
@@ -265,6 +265,14 @@ function cancelLabel(result) {
   return `failed: ${result.detail}`;
 }
 
+function cancellationSkipReason(result) {
+  const detail = `${result.stdout || ""}\n${result.stderr || ""}`;
+  if (/Cannot cancel a workflow re-run that has not yet queued/i.test(detail)) {
+    return "workflow re-run has not yet queued";
+  }
+  return null;
+}
+
 export function cancelStaleRuns(findings, repository, runCommand = runGh) {
   if (!repository) {
     throw new Error("REPOSITORY or GITHUB_REPOSITORY is required to cancel stale runs");
@@ -286,6 +294,11 @@ export function cancelStaleRuns(findings, repository, runCommand = runGh) {
 
     if (result.status === 0) {
       return { id: finding.id, status: "requested", detail: "" };
+    }
+
+    const skipReason = cancellationSkipReason(result);
+    if (skipReason) {
+      return { id: finding.id, status: "skipped", detail: skipReason };
     }
 
     return {

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -471,18 +471,18 @@ export function supersededOpenQueueBranchReason(queueBranch, currentBaseOid, que
   return `superseded open PR queue branch for older base (current ${basePrefix || "unknown"})`;
 }
 
-function readPullRequestState(repository, number) {
-  return runGhJson([
-    "api",
-    `repos/${repository}/pulls/${number}`,
-    "--jq",
-    "{number: .number, state: .state, merged: (.merged_at != null), updatedAt: .updated_at}",
-  ]);
+export function normalizePullRequestState(pr) {
+  return {
+    number: pr.number,
+    state: pr.state,
+    merged: pr.merged_at != null,
+    updatedAt: pr.updated_at || "",
+    owner: agentLabel(pr.labels),
+  };
 }
 
-function readPullRequestOwner(repository, number) {
-  const pr = runGhJson(["api", `repos/${repository}/pulls/${number}`]);
-  return agentLabel(pr.labels);
+function readPullRequestState(repository, number) {
+  return normalizePullRequestState(runGhJson(["api", `repos/${repository}/pulls/${number}`]));
 }
 
 function deleteRemoteBranch(branch) {
@@ -747,8 +747,8 @@ function cleanupQueueBranches(repository, options) {
     const { number } = metadata;
 
     const pullRequest = readPullRequestState(repository, number);
+    const owner = pullRequest.owner || "";
     if (String(pullRequest.state || "").toUpperCase() === "OPEN") {
-      const owner = readPullRequestOwner(repository, number);
       const supersededReason = options.cleanupSupersededOpenQueueBranches
         ? supersededOpenQueueBranchReason(queueBranchInfo.branch, currentBaseOid, options.queueBranchPrefix)
         : null;
@@ -796,7 +796,7 @@ function cleanupQueueBranches(repository, options) {
       activeRuns.push({
         branch: queueBranchInfo.branch,
         number,
-        owner: "",
+        owner,
         runId: activeRun.databaseId || null,
         url: activeRun.url || "",
         status: activeRun.status || "",
@@ -805,9 +805,10 @@ function cleanupQueueBranches(repository, options) {
       if (options.verbose) {
         skips.push({
           branch: queueBranchInfo.branch,
-          owner: "",
+          owner,
           reason: `active queue run ${activeRun.databaseId || "(unknown)"}`,
           summaryReason: "active queue run",
+          updatedAt: pullRequest.updatedAt || "",
         });
       }
       continue;

--- a/scripts/ci/test-check-stale-ci-runs.mjs
+++ b/scripts/ci/test-check-stale-ci-runs.mjs
@@ -203,6 +203,26 @@ assert.match(report, /no recent update/);
   assert.match(cancelReport, /failed: HTTP 500: Failed to cancel workflow run/);
 }
 
+{
+  const findings = staleRunFindings([run()], { now: NOW, staleMinutes: 45 });
+  const cancelResults = cancelStaleRuns(findings, "owner/repo", () => ({
+    status: 1,
+    stdout: "",
+    stderr: "gh: Cannot cancel a workflow re-run that has not yet queued. (HTTP 409)",
+  }));
+  assert.deepEqual(cancelResults, [{
+    id: 12345,
+    status: "skipped",
+    detail: "workflow re-run has not yet queued",
+  }]);
+
+  const cancelReport = formatReport(findings, {
+    cancelResults,
+    staleMinutes: 45,
+  });
+  assert.match(cancelReport, /skipped: workflow re-run has not yet queued/);
+}
+
 const advisory = runFixture([run()], ["--stale-minutes", "45"]);
 assert.equal(advisory.status, 0, advisory.stderr);
 assert.match(advisory.stdout, /Found 1 queued or in-progress workflow run/);
@@ -222,13 +242,12 @@ assert.match(clean.stdout, /No queued or in-progress workflow runs are stale/);
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-cancel-"));
   try {
     const fakeGh = path.join(dir, "gh");
-    fs.writeFileSync(fakeGh, `#!/usr/bin/env node
-const endpoint = process.argv.find((arg) => arg.includes("/actions/runs/"));
-if (endpoint) {
-  process.exit(0);
-}
-console.error("unexpected gh args", process.argv.slice(2).join(" "));
-process.exit(1);
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+case "$*" in
+  *"/actions/runs/"*) exit 0 ;;
+esac
+printf 'unexpected gh args %s\\n' "$*" >&2
+exit 1
 `);
     fs.chmodSync(fakeGh, 0o755);
 
@@ -258,9 +277,9 @@ process.exit(1);
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-cancel-fail-"));
   try {
     const fakeGh = path.join(dir, "gh");
-    fs.writeFileSync(fakeGh, `#!/usr/bin/env node
-console.error("HTTP 500: Failed to cancel workflow run");
-process.exit(1);
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+printf '%s\\n' 'HTTP 500: Failed to cancel workflow run' >&2
+exit 1
 `);
     fs.chmodSync(fakeGh, 0o755);
 
@@ -287,24 +306,59 @@ process.exit(1);
 }
 
 {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-cancel-skip-"));
+  try {
+    const fakeGh = path.join(dir, "gh");
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+printf '%s\\n' 'gh: Cannot cancel a workflow re-run that has not yet queued. (HTTP 409)' >&2
+exit 1
+`);
+    fs.chmodSync(fakeGh, 0o755);
+
+    const result = withFixture([run()], (fixture) => spawnSync(process.execPath, [
+      SCRIPT,
+      "--fixture",
+      fixture,
+      "--repository",
+      "owner/repo",
+      "--now",
+      NOW,
+      "--cancel-stale",
+    ], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    }));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /skipped: workflow re-run has not yet queued/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-ci-runs-gh-"));
   try {
     const fakeGh = path.join(dir, "gh");
-    fs.writeFileSync(fakeGh, `#!/usr/bin/env node
-const endpoint = process.argv.find((arg) => arg.includes("/actions/runs?")) || "";
-const status = /[?&]status=([^&]+)/.exec(endpoint)?.[1] || "in_progress";
-const run = {
-  id: status === "queued" ? 22222 : 11111,
-  status,
-  display_title: "large queued payload",
-  head_branch: "codex/large-payload",
-  html_url: "https://github.example/runs/large",
-  created_at: "2026-05-20T11:00:00Z",
-  run_started_at: status === "queued" ? null : "2026-05-20T11:01:00Z",
-  updated_at: "2026-05-20T11:05:00Z",
-  padding: "x".repeat(2 * 1024 * 1024),
-};
-console.log(JSON.stringify({ workflow_runs: [run] }));
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+case "$*" in
+  *"status=queued"*)
+    id=22222
+    status=queued
+    started=null
+    ;;
+  *)
+    id=11111
+    status=in_progress
+    started='"2026-05-20T11:01:00Z"'
+    ;;
+esac
+padding=$(python3 - <<'PY'
+print("x" * (2 * 1024 * 1024))
+PY
+)
+printf '{"workflow_runs":[{"id":%s,"status":"%s","display_title":"large queued payload","head_branch":"codex/large-payload","html_url":"https://github.example/runs/large","created_at":"2026-05-20T11:00:00Z","run_started_at":%s,"updated_at":"2026-05-20T11:05:00Z","padding":"%s"}]}\\n' "$id" "$status" "$started" "$padding"
 `);
     fs.chmodSync(fakeGh, 0o755);
 

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -8,6 +8,7 @@ import {
   forceWithLeaseArgForOid,
   formatResult,
   hasPendingPlaceholderQueueStatus,
+  normalizePullRequestState,
   normalizeRestPullRequest,
   normalizeRestWorkflowRun,
   pendingQueueRun,
@@ -81,6 +82,21 @@ assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123-a56115a-m4c"), 1
 assert.equal(queueBranchPrNumber("automation/merge-queue/pr-123/extra"), null);
 assert.equal(queueBranchPrNumber("automation/merge-queue/not-pr-123"), null);
 assert.equal(queueBranchPrNumber("custom/queue/pr-456", "custom/queue"), 456);
+
+assert.deepEqual(normalizePullRequestState({
+  number: 10271,
+  state: "closed",
+  merged_at: "2026-05-26T20:01:52Z",
+  updated_at: "2026-05-26T20:02:00Z",
+  labels: [{ name: "agent:Studio-E" }],
+}), {
+  number: 10271,
+  state: "closed",
+  merged: true,
+  updatedAt: "2026-05-26T20:02:00Z",
+  owner: "agent:Studio-E",
+});
+
 assert.equal(
   forceWithLeaseArgForOid("automation/merge-queue/pr-123", "a".repeat(40)),
   `--force-with-lease=refs/heads/automation/merge-queue/pr-123:${"a".repeat(40)}`,


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / CI health evidence plumbing

## Invariant
When GitHub refuses to cancel a stale workflow re-run because it has not actually queued yet, the stale-CI helper reports that cancellation as skipped/non-actionable while preserving real cancellation failures as failures. When queue cleanup preserves an active queue run, the queue report keeps the PR owner label attached to the active-run and skip evidence under the label-based merge queue workflow.

## Scope
- `scripts/ci/check-stale-ci-runs.mjs`
- `scripts/ci/test-check-stale-ci-runs.mjs`
- `scripts/ci/poor-mans-merge-queue.mjs`
- `scripts/ci/test-poor-mans-merge-queue.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI-helper-only; no compiler, checker, solver, parser, emitter, benchmark fixture, or project corpus behavior changes.

## Verification
- `node scripts/ci/test-check-stale-ci-runs.mjs`
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check origin/main...HEAD`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --dry-run --cleanup-queue-branches --cleanup-superseded-open-queue-branches --verbose`
- Draft/light CI on exact head `f7ac934b0e3cd69c64ac46a542cd0ad9af6d6f53`: `CI Light Summary`, `GitGuardian Security Checks`, `lint`, `cargo-deny`, `cargo-shear`, `gate`, and `project-row-drift` passed.

## Coordination Notes
- AgentName: Studio-F
- Rebased onto current `origin/main` at head `f7ac934b0e3cd69c64ac46a542cd0ad9af6d6f53` after `main` advanced again.
- Fresh queue dry-run on this head used `Queue label: merge-queue` and `Status: Queue Tested`; it would delete 0 stale queue branches, skipped open PR branches #10259 and #10288, and preserved active queue runs `26474148168` for `automation/merge-queue/pr-10274` and `26475435831` for `automation/merge-queue/pr-10278`.
- Motivated by the live Studio-F stale-CI pass where GitHub returned HTTP 409 for queued workflow re-runs that could not be cancelled yet.
- Real cancellation failures, such as HTTP 500, still report as failed and keep the command failing.
- Marked ready after exact-head local verification and draft/light CI passed; no `merge-queue`, auto-merge, or active workflow state was changed by this branch.
