### PR TITLE
refactor(checker): route class implements index relations

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -39,7 +39,8 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
             if !self
-                .diagnostic_relation_boolean_guard(source_index.value_type, target_index.value_type)
+                .assign_relation_outcome(source_index.value_type, target_index.value_type)
+                .related
             {
                 return false;
             }
@@ -50,7 +51,8 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
             if !self
-                .diagnostic_relation_boolean_guard(source_index.value_type, target_index.value_type)
+                .assign_relation_outcome(source_index.value_type, target_index.value_type)
+                .related
             {
                 return false;
             }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -109,6 +109,9 @@ mod async_imported_promise_tests;
 #[path = "../tests/circular_accessor_annotation_tests.rs"]
 mod circular_accessor_annotation_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
+mod class_implements_index_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_implements_index_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_index_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn class_implements_index_signatures_use_relation_outcome_boundary() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source =
+        fs::read_to_string(manifest_dir.join("src/classes/class_implements_checker/core.rs"))
+            .expect("read class implements checker source");
+
+    let helper = source
+        .split("fn class_index_signatures_satisfy_interface")
+        .nth(1)
+        .expect("find class implements index-signature helper")
+        .split("fn class_member_name_is_computed")
+        .next()
+        .expect("slice helper body before next helper");
+
+    assert_eq!(
+        helper
+            .matches("assign_relation_outcome(source_index.value_type, target_index.value_type)")
+            .count(),
+        2,
+        "class implements string and number index signature checks should use relation outcomes"
+    );
+    assert!(
+        helper.contains(".related"),
+        "class implements index signature checks should inspect the relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "class implements index signature checks should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a class implementation is checked against an interface's string or number index signatures for TS2420/TS2720 diagnostic orchestration, checker keeps the existing source/target index-signature discovery and boolean fallback behavior while routing the index value-type relation decisions through the shared assignability outcome boundary.

## Scope
- Route the string and number index-signature value checks in `class_index_signatures_satisfy_interface` through `assign_relation_outcome(...).related`.
- Preserve existing missing-index behavior, checked-index return behavior, and whole-type diagnostic suppression orchestration unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / class implements index-signature routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard passed and draft-light CI passed on exact head `199d18b1cff3c737d074d2d69019fcf82e95ec60`.

## Verification
Passed on rebased head `199d18b1cff3c737d074d2d69019fcf82e95ec60`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib class_implements_index_signatures_use_relation_outcome_boundary`

Draft-light CI passed on exact head `199d18b1cff3c737d074d2d69019fcf82e95ec60`:
- `cargo-shear`: SUCCESS
- `unit-cloudbuild`: SUCCESS
- `cargo-deny`: SUCCESS
- `lint`: SUCCESS
- `project-row-drift`: SUCCESS
- `unit`: SUCCESS
- `dist-binaries`: SUCCESS
- `gate`: SUCCESS
- `queue-one-pr`: SUCCESS
- `GitGuardian Security Checks`: SUCCESS
- `CI Light Summary`: SUCCESS

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-class-implements-index-20260526`; created from `origin/main`, then rebased onto current `origin/main` `6a534b57ac636177d0a3d58aea6711f6b69c62ba`; TypeScript linked from the primary populated checkout.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10342: that PR routes state-checking member/index value helpers in `state_checking_members/index_signature_key_helpers.rs`; this PR routes class implements index-signature value checks in `class_implements_checker/core.rs`.
- Disjoint from current M1-B relation-routing PRs #10354, #10351, #10348, #10344, #10343, #10342, #10340, #10338, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, index-signature discovery, whole-type diagnostic suppression, or diagnostic display-string decision changed.
- Promoted from draft after draft-light CI passed on exact head `199d18b1cff3c737d074d2d69019fcf82e95ec60`; ready-for-review CI owns conformance, emit, fourslash, WASM, and snapshot gates.
- Auto-merge intentionally left off.