### PR TITLE
refactor(checker): route jsdoc heritage constraint relation

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -246,7 +246,10 @@ impl<'a> CheckerState<'a> {
             };
             let arg_eval = self.evaluate_type_for_assignability(arg_prop.type_id);
             let constraint_eval = self.evaluate_type_for_assignability(constraint_prop.type_id);
-            if !self.diagnostic_relation_boolean_guard(arg_eval, constraint_eval) {
+            if !self
+                .assign_relation_outcome(arg_eval, constraint_eval)
+                .related
+            {
                 return true;
             }
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -439,6 +439,9 @@ mod class_duplicate_extends_skip_resolution_tests;
 #[path = "tests/class_feature_target_gates_tests.rs"]
 mod class_feature_target_gates_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_jsdoc_heritage_relation_routing_arch_tests.rs"]
+mod class_implements_jsdoc_heritage_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/class_index_signature_compat_tests.rs"]
 mod class_index_signature_compat_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_implements_jsdoc_heritage_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_jsdoc_heritage_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn jsdoc_extends_object_constraints_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/classes/class_implements_checker/jsdoc_heritage.rs")
+        .expect("failed to read jsdoc_heritage.rs");
+    let start = source
+        .find("fn jsdoc_extends_object_violates_constraint")
+        .expect("missing jsdoc_extends_object_violates_constraint helper");
+    let end = start
+        + source[start..]
+            .find("fn split_jsdoc_type_arguments_with_offsets")
+            .expect("missing split_jsdoc_type_arguments_with_offsets helper");
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome").count(),
+        1,
+        "JSDoc heritage object constraint compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "JSDoc heritage object constraint compatibility should use the relation outcome decision"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "JSDoc heritage object constraint compatibility should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When JSDoc `@extends` object-shape type arguments are checked against `@template` object constraints for TS2344 diagnostic orchestration, checker keeps the existing JSDoc heritage parsing, constraint lookup, object-shape property discovery, missing-required-property decision, and diagnostic rendering while routing the property type compatibility decision through the shared assignability outcome boundary.

## Scope
- Route the property type compatibility check inside `jsdoc_extends_object_violates_constraint` through `assign_relation_outcome(...).related`.
- Preserve existing object-shape discovery, property matching, missing required property handling, type evaluation, and TS2344 diagnostic construction unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / JSDoc heritage constraint routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard passed and draft-light CI passed on exact head `c218d0bfa3b9cc8047daa4b2cd94a4e1c0841468`.

## Verification
Passed on rebased head `c218d0bfa3b9cc8047daa4b2cd94a4e1c0841468`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib jsdoc_extends_object_constraints_use_relation_outcome_boundary`

Draft-light CI passed on exact head `c218d0bfa3b9cc8047daa4b2cd94a4e1c0841468`:
- `cargo-shear`: SUCCESS
- `unit-cloudbuild`: SUCCESS
- `cargo-deny`: SUCCESS
- `lint`: SUCCESS
- `project-row-drift`: SUCCESS
- `unit`: SUCCESS
- `dist-binaries`: SUCCESS
- `gate`: SUCCESS
- `queue-one-pr`: SUCCESS
- `GitGuardian Security Checks`: SUCCESS
- `CI Light Summary`: SUCCESS

## Coordination Notes
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-jsdoc-heritage-constraint-20260526`; created from `origin/main`, then rebased onto current `origin/main` `3ec4d965a703b0db1bb755ba300a2f652b43fd0e`; TypeScript linked from the primary populated checkout.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10357: that PR routes callable-to-union compatibility in `assignability/callable_union_relation.rs`.
- Disjoint from #10354: that PR routes class extends index-signature checks in `class_checker_compat.rs`; this PR routes JSDoc heritage object constraint property compatibility in `class_implements_checker/jsdoc_heritage.rs`.
- Disjoint from #10353: that PR routes class implements index-signature checks in `class_implements_checker/core.rs`.
- Disjoint from #10351 and #10348: those PRs route JSDoc lookup/import constraint checks in `jsdoc/lookup.rs` and `jsdoc/diagnostics_import_type_constraints.rs`.
- Disjoint from current M1-B relation-routing PRs #10344, #10343, #10342, #10340, #10338, #10337, #10336, #10335, #10334, #10332, #10330, #10329, #10328, #10327, #10323, #10320, #10319, and #10270.
- No solver policy, variance, any-propagation, relation cache-key behavior, JSDoc parsing, object-shape discovery, missing-property handling, or diagnostic display-string decision changed.
- Promoted from draft after draft-light CI passed on exact head `c218d0bfa3b9cc8047daa4b2cd94a4e1c0841468`; ready-for-review CI owns conformance, emit, fourslash, WASM, and snapshot gates.
- Auto-merge intentionally left off.