### PR TITLE
refactor(checker): route callable union relation outcomes

### DIFF
--- a/crates/tsz-checker/src/assignability/callable_union_relation.rs
+++ b/crates/tsz-checker/src/assignability/callable_union_relation.rs
@@ -36,7 +36,8 @@ impl<'a> CheckerState<'a> {
                     .any(|(target_params, target_return)| {
                         self.callable_relation_params_compatible(source_params, target_params)
                             && self
-                                .diagnostic_relation_boolean_guard(*source_return, *target_return)
+                                .assign_relation_outcome(*source_return, *target_return)
+                                .related
                     })
             })
     }
@@ -111,7 +112,8 @@ impl<'a> CheckerState<'a> {
             .iter()
             .zip(target_params.iter())
             .all(|(source_param, target_param)| {
-                self.diagnostic_relation_boolean_guard(target_param.type_id, source_param.type_id)
+                self.assign_relation_outcome(target_param.type_id, source_param.type_id)
+                    .related
             })
     }
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -433,6 +433,9 @@ mod call_spread_constructor_parameters_tests;
 #[path = "tests/callable_interface_assignment_tests.rs"]
 mod callable_interface_assignment_tests;
 #[cfg(test)]
+#[path = "tests/callable_union_relation_routing_arch_tests.rs"]
+mod callable_union_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/class_duplicate_extends_skip_resolution_tests.rs"]
 mod class_duplicate_extends_skip_resolution_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/callable_union_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/callable_union_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn callable_union_compatibility_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/assignability/callable_union_relation.rs")
+        .expect("failed to read callable_union_relation.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        2,
+        "callable-to-union parameter and return compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        source.contains(".related"),
+        "callable-to-union compatibility should use the relation outcome decision"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "callable-to-union compatibility should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a callable source is checked against callable arms of a target union for assignability diagnostic compatibility, checker keeps the existing signature discovery, alias/evaluation/lazy traversal, plain-callable filtering, required/rest arity checks, and source/target parameter variance order while routing parameter and return type relation decisions through the shared assignability outcome boundary.

## Scope
- Route callable-to-union return compatibility through `assign_relation_outcome(...).related` in `crates/tsz-checker/src/assignability/callable_union_relation.rs`.
- Route callable-to-union parameter compatibility through `assign_relation_outcome(...).related` while preserving the existing target-parameter-to-source-parameter comparison order.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / callable union relation routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard passed on current-base head `915be2934c1ca9b2b83f66bf625a1a71019f2075`.

## Verification
Passed on current-base head `915be2934c1ca9b2b83f66bf625a1a71019f2075`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib callable_union_compatibility_uses_relation_outcome_boundary`

Draft-light CI passed for refreshed head `915be2934c1ca9b2b83f66bf625a1a71019f2075`: CI Light Summary, lint, dist-binaries, unit, unit-cloudbuild, cargo-deny, cargo-shear, project-row-drift, gate, and GitGuardian Security Checks.

## Coordination Notes
- AgentName: M1-B
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-callable-union-relation-20260526`; TypeScript linked from the primary populated checkout.
- Rebased onto current `origin/main` `1832cf6b138583ac861d4d0eaea4d5fe4b19a69e`; `origin/main` is an ancestor of head `915be2934c1ca9b2b83f66bf625a1a71019f2075`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10364, #10362, #10359, #10356, #10354, #10353, #10351, #10348, #10344, #10343, #10342, and other current M1-B relation-routing PRs.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, callable signature discovery, arity filtering, or diagnostic display-string decision changed.
- Ready for manager review/queue on the current head; exact-head PR checks passed and ReviewHelper may add merge-queue. Auto-merge remains off.