### PR TITLE
docs(agents): adopt merge queue workflow

### DIFF
--- a/.agents/skills/tsz-ci-pr/SKILL.md
+++ b/.agents/skills/tsz-ci-pr/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: tsz-ci-pr
-description: Drive TSZ GitHub PRs through review, CI, and merge. Use when checking PR status, debugging failing GitHub Actions, deciding whether a PR is WIP, marking draft PRs ready, enabling or verifying auto-merge, landing a PR, or interpreting TSZ CI gates.
+description: Drive TSZ GitHub PRs through review, CI, and the merge queue. Use when checking PR status, debugging failing GitHub Actions, deciding whether a PR is WIP, marking draft PRs ready, enqueueing or verifying the queue, landing a PR, or interpreting TSZ CI gates.
 ---
 
 # TSZ CI And PR
 
 Use this skill for TSZ PR operations. The repository uses draft PRs for
-coordination and heavy CI only after ready-for-review. A queued merge is not a
-landed merge; always verify the final PR state.
+coordination and heavy CI only after ready-for-review. TSZ's required
+`Queue Tested` status is produced by the repo-local merge queue after a ready
+PR is labeled `merge-queue`. A queued merge is not a landed merge; always
+verify the final PR state.
 
 ## Ground Rules
 
@@ -18,7 +20,9 @@ landed merge; always verify the final PR state.
 - Do not add `[codex]` to PR titles.
 - Draft PRs run light CI. Ready PRs run conformance, emit, fourslash, WASM, and
   snapshot gates.
-- If the user asks to land a PR, do not stop at enabled auto-merge. Verify
+- `Queue Tested` is queue-owned. It may be missing or pending before enqueue;
+  do not wait for it before labeling an otherwise ready PR `merge-queue`.
+- If the user asks to land a PR, do not stop at an armed queue. Verify
   `state: MERGED` or keep working.
 
 ## Status Commands
@@ -54,25 +58,33 @@ gh run view <run-id> --job <job-id> --log
    gh pr ready <pr>
    ```
 
-5. Use squash merge or squash auto-merge according to branch protection:
+5. Once PR-head checks such as `CI Summary` and `GitGuardian Security Checks`
+   pass for the exact head, enqueue the PR with the durable queue label:
 
    ```bash
-   gh pr merge <pr> --squash --auto
+   gh pr edit <pr> --add-label merge-queue
    ```
 
-6. After checks pass, verify the merge actually happened:
+6. Watch `Queue Tested` only as queue evidence, not as a PR-head prerequisite.
+   The `Poor Man's Merge Queue` workflow synthetic-tests one latest-`main`
+   merge branch and posts `Queue Tested` to the PR head before merging.
+7. After the queue runs, verify the merge actually happened:
 
    ```bash
    gh pr view <pr> --json state,mergedAt,mergedBy,url
    ```
 
-If auto-merge is enabled but the PR remains open after green checks, inspect
-branch protection and merge queue status, then run a direct squash merge when
-allowed.
+If a `merge-queue` labeled PR remains open after green PR-head checks, inspect
+`Queue Tested`, the `Poor Man's Merge Queue` workflow, and any synthetic
+`automation/merge-queue/pr-<n>` CI run. Do not direct-merge around the queue
+unless the user explicitly asks for an emergency admin bypass.
 
 ## CI Failure Triage
 
-- `CI Summary` is the required umbrella status; inspect its prerequisites.
+- `CI Summary` is the required umbrella PR-head status; inspect its
+  prerequisites.
+- `Queue Tested` is the required queue status; inspect the queue workflow and
+  synthetic merge branch when it fails or stays pending.
 - `conformance-aggregate` can fail even when shards pass if accepted-regression
   drift exists. Compare unlisted vs resolved accepted paths.
 - `unit-cloudbuild` often exposes memory, linking, or architecture-contract

--- a/.agents/skills/tsz-pr-coordination/SKILL.md
+++ b/.agents/skills/tsz-pr-coordination/SKILL.md
@@ -7,7 +7,7 @@ description: Create, refresh, and publish TSZ pull requests with correct coordin
 
 Use this skill for TSZ PR state, especially before pushing a branch or changing
 draft/WIP/ready status. It complements `tsz-ci-pr`: use this skill for the
-coordination contract and `tsz-ci-pr` for check triage. Merge and auto-merge
+coordination contract and `tsz-ci-pr` for check triage. Merge and queue-label
 coordination belongs to an explicit manager or queue-owner agent, not every
 implementation agent.
 
@@ -29,17 +29,18 @@ Individual implementation agents own only their own PRs. They should:
 - mark their own PR ready only when implementation and verification are done and
   the lane permits it,
 - leave a signed readiness or blocker note for the manager agent,
-- avoid queue sweeps, merge decisions, or auto-merge changes on unrelated PRs.
+- avoid queue sweeps, merge decisions, or queue changes on unrelated PRs.
 
 Manager or queue-owner agents handle cross-PR coordination. They may:
 
 - inspect the full PR queue and ownership state,
 - decide merge order and dependency handoffs,
-- enable or disable auto-merge when policy and exact-head checks allow it,
-- merge ready PRs or leave signed blocker comments.
+- add or remove `merge-queue` when policy and exact-head PR-head checks allow
+  it,
+- verify queued PRs landed or leave signed blocker comments.
 
-If you are not acting as the manager/queue owner, do not merge PRs or use
-auto-merge as part of routine implementation work.
+If you are not acting as the manager/queue owner, do not merge PRs or add
+`merge-queue` as part of routine implementation work.
 
 ## Before Publishing
 
@@ -103,8 +104,8 @@ gh pr view <number> --json body
 ## WIP And Draft State
 
 Treat a PR as WIP if it is draft, has a `WIP` label, starts with `[WIP]`, or
-declares a blocker in the body. Do not mark ready or enable auto-merge until the
-current head is genuinely ready.
+declares a blocker in the body. Do not mark ready or add `merge-queue` until
+the current head is genuinely ready.
 
 Whenever adding `WIP`, adding `[WIP]`, or converting a PR back to draft because
 it is blocked, immediately leave a signed PR comment with:
@@ -125,9 +126,11 @@ Before marking your own PR ready or handing it to the manager:
 4. Comment with remaining risks, dependencies, or a clear "ready for manager
    review/queue" note.
 
-Do not use auto-merge as a CI watcher. Unless you are the manager/queue owner,
-leave merge and auto-merge decisions to the manager after exact-head checks are
-complete.
+Do not use auto-merge as a CI watcher or queue signal. Unless you are the
+manager/queue owner, leave merge-queue decisions to the manager after
+exact-head PR-head checks are complete. `Queue Tested` is produced by the merge
+queue after `merge-queue` is added; it does not need to be present before a
+ready handoff.
 
 ## Review Responses
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,21 +44,28 @@
   supersedes it and links back to the preserved branch/commits and findings.
   Before closing for duplicate/superseded reasons, leave a signed comment with
   the evidence, the successor link, and what useful work was carried forward.
-- Do not enable or re-enable auto-merge unless you own the PR and the current
-  head SHA is genuinely ready to land: the PR is not draft, WIP, or blocked;
-  every required check for that exact head has completed successfully; no
-  required check is pending, queued, unexpectedly skipped, missing, or failing;
-  and you have intentionally reviewed the latest pushed changes. Old green
-  checks on a previous head are not evidence.
-- Do not use auto-merge as a CI watcher. If checks are pending, missing, or
-  failing, leave auto-merge off, keep or restore the PR's draft/WIP/blocked
-  state as appropriate, and post a signed status comment naming the blocker,
-  the affected check or rule, and the next owner/action.
-- Never re-promote a PR from draft/WIP or re-arm auto-merge after another agent
-  disabled it, converted it to draft, or marked it blocked unless you have fixed
-  the blocker on a new head and re-verified a clean, complete check picture.
-  Repeated auto-merge re-arming is stop-the-line coordination debt; link the
-  blocking issue or PR comment instead of fighting the cleanup agent.
+- TSZ's merge gate is the repo-local merge queue. Ready PRs are enqueued with
+  the `merge-queue` label; the queue then tests a synthetic latest-`main`
+  merge, posts the required `Queue Tested` status to the PR head, and lands one
+  PR at a time. Do not bypass it with direct/admin merge unless the user
+  explicitly asks for an emergency bypass.
+- Do not add or re-add `merge-queue` unless you own the PR and the current head
+  SHA is genuinely ready to land: the PR is not draft, WIP, or blocked; PR-head
+  checks such as `CI Summary` and `GitGuardian Security Checks` have completed
+  successfully for that exact head; and you have intentionally reviewed the
+  latest pushed changes. `Queue Tested` is owned by the merge queue and may be
+  missing or pending before enqueue. Old green checks on a previous head are
+  not evidence.
+- Do not use auto-merge as a queue signal or CI watcher. If PR-head checks are
+  pending, missing, or failing, leave `merge-queue` off, keep or restore the
+  PR's draft/WIP/blocked state as appropriate, and post a signed status comment
+  naming the blocker, the affected check or rule, and the next owner/action.
+- Never re-promote a PR from draft/WIP or re-add `merge-queue` after another
+  agent removed it, converted the PR to draft, or marked it blocked unless you
+  have fixed the blocker on a new head and re-verified a clean, complete
+  PR-head check picture. Repeated queue re-arming is stop-the-line coordination
+  debt; link the blocking issue or PR comment instead of fighting the cleanup
+  agent.
 - Draft PRs intentionally run only light CI: lint, dist-fast build, and unit
   tests. Marking a PR ready for review triggers the heavy suites: conformance,
   emit, fourslash, and WASM. See §19.5 for the rules around local vs. CI work.
@@ -223,6 +230,9 @@ For each change ask:
 - Open a draft PR early. Draft CI runs lint, dist-fast build, and unit tests.
   When the PR is marked ready for review, CI runs conformance, emit, fourslash,
   WASM, and snapshot gates.
+- After exact-head PR-head gates pass on a ready PR, the merge manager adds the
+  `merge-queue` label. The required `Queue Tested` status is produced by the
+  queue's synthetic latest-`main` run and is not a pre-enqueue prerequisite.
 - **Never sit waiting for CI.** Push the draft PR, note the run URL if useful,
   then switch to non-overlapping work. Come back later to inspect status.
 - **Use `cargo nextest run` instead of `cargo test`** for unit/integration runs.
@@ -304,7 +314,7 @@ matches their description:
 - `tsz-project-bench`: benchmark/project-corpus rows, fixture metadata, PGO, and
   benchmark dashboard work.
 - `tsz-pr-coordination`: PR body, AgentName, WIP/draft/ready, labels, review
-  response, and auto-merge coordination.
+  response, and merge-queue coordination.
 - `tsz-tracing`: tracing-driven debugging of checker/solver/binder behavior.
 - `tsz-worktree-intake`: safe task start, stale branch recovery, disk/cache
   preflight, dirty workspace triage, and worktree reuse.
@@ -328,8 +338,8 @@ them as TSZ repo skills.
   apply labels such as `agent:claude-sonnet-*`, `agent:dreamy-*`, other
   generated runner aliases, or typo labels such as `agnet:*`. If you inherit a
   PR with a noncanonical owner label, replace it with the correct canonical
-  lane before marking the PR ready or enabling auto-merge, and leave a signed
-  comment if the ownership handoff is not obvious from the PR body.
+  lane before marking the PR ready or adding `merge-queue`, and leave a
+  signed comment if the ownership handoff is not obvious from the PR body.
 - **Sign your work.** Every PR body and GitHub issue you create or comment on
   must include your AgentName so humans (and other agents) can tell who did it.
 - **PR bodies are mandatory coordination state, not paperwork.** Never open or

--- a/.github/workflows/poor-mans-merge-queue.yml
+++ b/.github/workflows/poor-mans-merge-queue.yml
@@ -1,5 +1,8 @@
 name: Poor Man's Merge Queue
 
+# Official TSZ merge queue for this user-owned repository. It uses the
+# required `Queue Tested` status as the final latest-main merge gate.
+
 on:
   push:
     branches: [main]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,6 +14,12 @@ Open a draft PR to run the light CI suite: lint, dist-fast build, and unit
 tests. Mark the PR ready for review when it should run the heavy suites:
 WASM, conformance, emit, fourslash, and snapshot gates.
 
+When a ready PR's exact head has passed the PR-head gates (`CI Summary`,
+`GitGuardian Security Checks`, and any review/body checks), the merge manager
+adds the `merge-queue` label. The queue owns the required `Queue Tested`
+status: it synthetic-tests the PR against latest `main`, posts `Queue Tested`,
+and merges one PR at a time.
+
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for the full development guide.
 
 ## How tsz Works
@@ -60,6 +66,9 @@ python3 scripts/conformance/query-conformance.py --dashboard
 6. **Verify narrowly** — run only targeted local checks needed for debugging
 7. **Push updates to the draft PR** — let CI run build, lint, and unit tests; do not wait idle
 8. **Mark ready for review** — triggers conformance, emit, fourslash, WASM, and snapshot gates
+9. **Hand off to the merge queue** — after exact-head PR-head gates pass,
+   the manager adds `merge-queue`; do not treat missing `Queue Tested` as a
+   blocker before enqueue
 
 Include your stable `AgentName` in every PR body and substantive PR comment.
 Use the draft PR body for scope, invariants, findings, verification, and

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -153,7 +153,7 @@ GitHub is the coordination surface.
    Address other agents by `AgentName` when coordination matters.
 8. Use only canonical ownership labels from `docs/plan/agents/README.md`.
    Replace generated runner labels or `agnet:*` typos with the correct lane
-   before marking a PR ready or enabling auto-merge.
+   before marking a PR ready or adding `merge-queue`.
 9. Never merge work that is still draft, labeled `WIP`, titled with `[WIP]`, or
    described as not ready.
 10. Treat `ready` plus a `WIP` label as WIP. Remove the label before merge.

--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -123,8 +123,8 @@ section.
 ## GitHub Actions Outages
 
 When GitHub Actions is unavailable or checkout/action-download failures are
-clearly infrastructure-wide, do not rerun jobs as a watcher and do not enable
-auto-merge. Keep the lane moving with local, cheap evidence:
+clearly infrastructure-wide, do not rerun jobs as a watcher and do not add
+`merge-queue`. Keep the lane moving with local, cheap evidence:
 
 1. Confirm the branch is clean and synced with `origin/main`.
 2. Run the lane's local guardrail commands and any narrow script tests that
@@ -133,7 +133,9 @@ auto-merge. Keep the lane moving with local, cheap evidence:
    the local verification, and the next action after Actions recovers.
 
 Resume CI only after the external outage clears, and re-check the exact head
-before changing draft/ready state or auto-merge.
+before changing draft/ready state or adding `merge-queue`. `Queue Tested` is
+produced after the label is added, so it is not evidence to wait on before
+enqueue.
 
 ## Worktree And Cache Policy
 

--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -5,6 +5,7 @@ import { readyStateFailures } from "./check-pr-ready-state.mjs";
 const DEFAULT_BASE = "main";
 const DEFAULT_MAX_PRS = 200;
 const DEFAULT_QUEUE_BRANCH_PREFIX = "automation/merge-queue";
+const DEFAULT_QUEUE_LABEL = "merge-queue";
 const DEFAULT_STATUS_CONTEXT = "Queue Tested";
 const DEFAULT_PR_REQUIRED_CHECKS = ["CI Summary", "GitGuardian Security Checks"];
 const DEFAULT_MERGE_REQUIRED_CHECKS = ["CI Summary"];
@@ -18,13 +19,14 @@ function usage() {
   return [
     "usage: poor-mans-merge-queue.mjs --repository owner/repo [options]",
     "",
-    "Serially tests one auto-merge PR on a synthetic latest-main merge branch,",
+    "Serially tests one labeled PR on a synthetic latest-main merge branch,",
     "posts a required status to the PR head, and merges only if main/head did not move.",
     "",
     "Options:",
     "  --base <branch>                 Base branch (default: main)",
     "  --max-prs <n>                   Max open PRs to inspect",
     "  --status-context <name>         Required status context to post",
+    "  --queue-label <name>            Label that marks a PR ready for the queue",
     "  --queue-branch-prefix <prefix>  Temporary branch namespace",
     "  --agent-name <name>             AgentName for queue failure comments",
     "  --pr-required-check <name>      PR-head check required before queueing",
@@ -61,6 +63,7 @@ export function parseArgs(argv) {
     maxPrs: DEFAULT_MAX_PRS,
     mergeRequiredChecks: [...DEFAULT_MERGE_REQUIRED_CHECKS],
     prRequiredChecks: [...DEFAULT_PR_REQUIRED_CHECKS],
+    queueLabel: process.env.QUEUE_LABEL || DEFAULT_QUEUE_LABEL,
     queueBranchPrefix: DEFAULT_QUEUE_BRANCH_PREFIX,
     repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
     statusContext: DEFAULT_STATUS_CONTEXT,
@@ -82,6 +85,9 @@ export function parseArgs(argv) {
     } else if (arg === "--status-context") {
       options.statusContext = argv[++index];
       if (!options.statusContext) throw new Error("--status-context requires a name");
+    } else if (arg === "--queue-label") {
+      options.queueLabel = argv[++index];
+      if (!options.queueLabel) throw new Error("--queue-label requires a label name");
     } else if (arg === "--queue-branch-prefix") {
       options.queueBranchPrefix = argv[++index];
       if (!options.queueBranchPrefix) throw new Error("--queue-branch-prefix requires a branch prefix");
@@ -193,6 +199,10 @@ function labelNames(labels) {
 
 function agentLabel(labels) {
   return labelNames(labels).find((label) => label.startsWith("agent:")) || "";
+}
+
+function hasQueueLabel(labels, queueLabel = DEFAULT_QUEUE_LABEL) {
+  return labelNames(labels).includes(queueLabel);
 }
 
 function normalize(value) {
@@ -329,11 +339,10 @@ function activePendingQueueRun(repository, pr, options) {
   };
 }
 
-export function queueSkipReason(pr, requiredState, base) {
+export function queueSkipReason(pr, requiredState, base, queueLabel = DEFAULT_QUEUE_LABEL) {
   if (pr.baseRefName !== base) return `base is ${pr.baseRefName || "(unknown)"}, not ${base}`;
   if (pr.isDraft) return "draft PR";
   if (pr.isCrossRepository) return "cross-repository PR";
-  if (!pr.autoMergeRequest) return "auto-merge is not armed";
   const readinessFailures = readyStateFailures({
     number: pr.number,
     title: pr.title,
@@ -342,6 +351,7 @@ export function queueSkipReason(pr, requiredState, base) {
     labels: labelNames(pr.labels),
   });
   if (readinessFailures.length) return `ready-state WIP marker: ${readinessFailures.join(", ")}`;
+  if (!hasQueueLabel(pr.labels, queueLabel)) return `missing ${queueLabel} label`;
   if (requiredState.kind !== "passed") return requiredState.reason;
   return null;
 }
@@ -840,11 +850,11 @@ function readQueueCandidates(repository, options) {
   return readPullRequests(repository, options.base, options.maxPrs)
     .sort((a, b) => a.number - b.number)
     .map((pr) => {
-      const skipReason = queueSkipReason(pr, { kind: "passed" }, options.base);
+      const skipReason = queueSkipReason(pr, { kind: "passed" }, options.base, options.queueLabel);
       if (skipReason) return { pr, skipReason };
       const detailed = readPullRequest(repository, pr.number);
       const requiredState = requiredCheckState(detailed.statusCheckRollup, options.prRequiredChecks);
-      const detailedSkipReason = queueSkipReason(detailed, requiredState, options.base);
+      const detailedSkipReason = queueSkipReason(detailed, requiredState, options.base, options.queueLabel);
       if (detailedSkipReason) return { pr: detailed, skipReason: detailedSkipReason };
       const activeRun = activePendingQueueRun(repository, detailed, options);
       if (activeRun) {
@@ -1032,6 +1042,7 @@ export function formatResult(result, options) {
     "",
     `Mode: ${options.dryRun ? "dry run" : "apply"}`,
     `Base: \`${options.base}\``,
+    `Queue label: \`${options.queueLabel}\``,
     `Status: \`${options.statusContext}\``,
     "",
   ];
@@ -1090,7 +1101,7 @@ export function formatResult(result, options) {
       pushCleanupSkipRows(lines, result.skips);
     }
   } else if (!result.selected) {
-    lines.push("No queue-ready auto-merge PR found.");
+    lines.push("No queue-ready PR found.");
   } else if (result.dryRun) {
     lines.push(`Would synthetic-test and merge #${result.selected.number} at \`${result.selected.headRefOid.slice(0, 12)}\`.`);
   } else if (result.merged) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -41,7 +41,7 @@ function pr(overrides = {}) {
     headRefOid: "a".repeat(40),
     isCrossRepository: false,
     isDraft: false,
-    labels: [],
+    labels: ["merge-queue"],
     number: 42,
     statusCheckRollup: [check(), check({ name: "GitGuardian Security Checks" })],
     title: "fix(ci): sample",
@@ -60,6 +60,7 @@ if (originalAgentName === undefined) {
   process.env.AGENT_NAME = originalAgentName;
 }
 assert.equal(parseArgs(["--repository", "owner/repo", "--agent-name", "M4-B"]).agentName, "M4-B");
+assert.equal(parseArgs(["--repository", "owner/repo", "--queue-label", "ready-to-merge"]).queueLabel, "ready-to-merge");
 assert.equal(parseArgs(["--repository", "owner/repo", "--cleanup-queue-branches"]).cleanupQueueBranches, true);
 assert.equal(
   parseArgs(["--repository", "owner/repo", "--cleanup-superseded-open-queue-branches"]).cleanupSupersededOpenQueueBranches,
@@ -196,7 +197,8 @@ assert.equal(
 );
 
 assert.equal(queueSkipReason(pr({ isDraft: true }), { kind: "passed" }, "main"), "draft PR");
-assert.equal(queueSkipReason(pr({ autoMergeRequest: null }), { kind: "passed" }, "main"), "auto-merge is not armed");
+assert.equal(queueSkipReason(pr({ labels: [] }), { kind: "passed" }, "main"), "missing merge-queue label");
+assert.equal(queueSkipReason(pr({ labels: ["ready-to-merge"] }), { kind: "passed" }, "main", "ready-to-merge"), null);
 assert.equal(queueSkipReason(pr({ labels: ["WIP"] }), { kind: "passed" }, "main"), "ready-state WIP marker: WIP label");
 assert.equal(queueSkipReason(pr(), { kind: "pending", reason: "pending checks" }, "main"), "pending checks");
 assert.equal(queueSkipReason(pr(), { kind: "passed" }, "main"), null);
@@ -262,12 +264,12 @@ assert.deepEqual(
 assert.deepEqual(
   skipReasonCounts([
     { number: 1, reason: "draft PR" },
-    { number: 2, reason: "auto-merge is not armed" },
+    { number: 2, reason: "missing merge-queue label" },
     { number: 3, reason: "draft PR" },
   ]),
   [
     { reason: "draft PR", count: 2 },
-    { reason: "auto-merge is not armed", count: 1 },
+    { reason: "missing merge-queue label", count: 1 },
   ],
 );
 assert.deepEqual(
@@ -284,8 +286,8 @@ assert.deepEqual(
 assert.deepEqual(
   skipOwnerCounts([
     { owner: "agent:M4-A", reason: "draft PR" },
-    { owner: "agent:M4-B", reason: "auto-merge is not armed" },
-    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-B", reason: "missing merge-queue label" },
+    { owner: "agent:M4-A", reason: "missing merge-queue label" },
   ]),
   [
     { owner: "agent:M4-A", count: 2 },
@@ -295,15 +297,15 @@ assert.deepEqual(
 assert.deepEqual(
   skipOwnerReasonCounts([
     { owner: "agent:M4-A", reason: "draft PR" },
-    { owner: "agent:M4-B", reason: "auto-merge is not armed" },
-    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
-    { owner: "agent:M4-A", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-B", reason: "missing merge-queue label" },
+    { owner: "agent:M4-A", reason: "missing merge-queue label" },
+    { owner: "agent:M4-A", reason: "missing merge-queue label" },
     { owner: "agent:M4-B", reason: "PR #10084 is open", summaryReason: "open PR branch" },
   ]),
   [
-    { owner: "agent:M4-A", reason: "auto-merge is not armed", count: 2 },
+    { owner: "agent:M4-A", reason: "missing merge-queue label", count: 2 },
     { owner: "agent:M4-A", reason: "draft PR", count: 1 },
-    { owner: "agent:M4-B", reason: "auto-merge is not armed", count: 1 },
+    { owner: "agent:M4-B", reason: "missing merge-queue label", count: 1 },
     { owner: "agent:M4-B", reason: "open PR branch", count: 1 },
   ],
 );
@@ -323,8 +325,8 @@ assert.deepEqual(
 assert.deepEqual(
   skipOwnerCounts([
     { owner: "agent:M4-A", updatedAt: "2026-05-25T10:00:00Z", reason: "draft PR" },
-    { owner: "agent:M4-B", updatedAt: "2026-05-24T09:00:00Z", reason: "auto-merge is not armed" },
-    { owner: "agent:M4-A", updatedAt: "2026-05-23T08:00:00Z", reason: "auto-merge is not armed" },
+    { owner: "agent:M4-B", updatedAt: "2026-05-24T09:00:00Z", reason: "missing merge-queue label" },
+    { owner: "agent:M4-A", updatedAt: "2026-05-23T08:00:00Z", reason: "missing merge-queue label" },
   ]),
   [
     { owner: "agent:M4-A", count: 2, oldestUpdatedAt: "2026-05-23T08:00:00Z" },
@@ -494,17 +496,17 @@ const queueSkipFormat = formatResult({
   skips: Array.from({ length: 27 }, (_, index) => ({
     number: index + 1,
     owner: index % 2 === 0 ? "agent:M1-A" : "agent:M4-B",
-    reason: index % 3 === 0 ? "draft PR" : "auto-merge is not armed",
+    reason: index % 3 === 0 ? "draft PR" : "missing merge-queue label",
   })),
 }, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
 assert.match(queueSkipFormat, /### Skip Reason Counts/);
-assert.match(queueSkipFormat, /\| 18 \| auto-merge is not armed \|/);
+assert.match(queueSkipFormat, /\| 18 \| missing merge-queue label \|/);
 assert.match(queueSkipFormat, /\| 9 \| draft PR \|/);
 assert.match(queueSkipFormat, /### Skip Owner Counts/);
 assert.match(queueSkipFormat, /\| 14 \| agent:M1-A \|/);
 assert.match(queueSkipFormat, /\| 13 \| agent:M4-B \|/);
 assert.match(queueSkipFormat, /### Skip Owner Reason Counts/);
-assert.match(queueSkipFormat, /\| 9 \| agent:M4-B \| auto-merge is not armed \|/);
+assert.match(queueSkipFormat, /\| 9 \| agent:M4-B \| missing merge-queue label \|/);
 assert.match(queueSkipFormat, /\| 5 \| agent:M1-A \| draft PR \|/);
 assert.match(queueSkipFormat, /\| PR \| Owner \| Reason \|/);
 assert.match(queueSkipFormat, /\| #1 \| agent:M1-A \| draft PR \|/);
@@ -515,15 +517,15 @@ const queueSkipOwnerDateFormat = formatResult({
   selected: null,
   skips: [
     { number: 1, owner: "agent:M1-A", reason: "draft PR", updatedAt: "2026-05-25T10:00:00Z" },
-    { number: 2, owner: "agent:M1-A", reason: "auto-merge is not armed", updatedAt: "2026-05-23T08:00:00Z" },
-    { number: 3, owner: "agent:M4-B", reason: "auto-merge is not armed", updatedAt: "2026-05-24T09:00:00Z" },
+    { number: 2, owner: "agent:M1-A", reason: "missing merge-queue label", updatedAt: "2026-05-23T08:00:00Z" },
+    { number: 3, owner: "agent:M4-B", reason: "missing merge-queue label", updatedAt: "2026-05-24T09:00:00Z" },
   ],
 }, parseArgs(["--repository", "owner/repo", "--dry-run", "--verbose"]));
 assert.match(queueSkipOwnerDateFormat, /\| Count \| Owner \| Oldest updated \| Oldest age \|/);
 assert.match(queueSkipOwnerDateFormat, /\| 2 \| agent:M1-A \| 2026-05-23 \| 3d 3h \|/);
 assert.match(queueSkipOwnerDateFormat, /\| 1 \| agent:M4-B \| 2026-05-24 \| 2d 2h \|/);
 assert.match(queueSkipOwnerDateFormat, /\| PR \| Owner \| Updated \| Reason \|/);
-assert.match(queueSkipOwnerDateFormat, /\| #2 \| agent:M1-A \| 2026-05-23 \| auto-merge is not armed \|/);
+assert.match(queueSkipOwnerDateFormat, /\| #2 \| agent:M1-A \| 2026-05-23 \| missing merge-queue label \|/);
 
 assert.match(
   formatResult({


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
CI/PR coordination, merge queue adoption.

## Invariant
When a ready PR's exact head has passed PR-head gates, agents should enqueue TSZ PRs with the durable `merge-queue` label. `Queue Tested` is queue-owned and is produced after the label is added.

## Scope
- Update `.claude/CLAUDE.md` / `AGENTS.md` prompt text for label-based queue enqueueing and emergency bypass policy.
- Update TSZ PR/CI and PR coordination skills with queue-specific landing instructions.
- Update contributor and agent coordination docs to explain `Queue Tested` ownership.
- Mark the `Poor Man's Merge Queue` workflow as the official TSZ merge queue for this user-owned repository.
- Update `scripts/ci/poor-mans-merge-queue.mjs` and its tests so the queue uses the durable `merge-queue` label instead of GitHub auto-merge state.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI/tooling and docs/prompt only; no compiler, checker, solver, parser, emitter, LSP, WASM, or benchmark behavior changes.

## Verification
- `git diff --check`
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `gh workflow enable poor-mans-merge-queue.yml`
- `gh workflow disable refresh-green-prs.yml`
- `gh label create merge-queue --color 0E8A16 --description "Ready for TSZ repo-local merge queue" 2>/dev/null || gh label edit merge-queue --color 0E8A16 --description "Ready for TSZ repo-local merge queue"`
- `gh api repos/:owner/:repo/branches/main/protection --jq '{required_status_checks:.required_status_checks, enforce_admins:.enforce_admins.enabled}'`
- `gh api repos/:owner/:repo/rulesets/15287170 --jq '{name,enforcement,rules:[.rules[].type]}'`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --dry-run --verbose --max-prs 100` (before label migration, showed auto-merge was not a viable durable queue signal)

## Coordination Notes
- Studio-F adopted this PR because merge-queue workflow and agent coordination docs are in the Studio-F launch-infrastructure lane. Original runner identity from the initial body: `m5-pro-48g-gpt5`.
- Evaluated native GitHub merge queue first because it is the cleanest no-frills option, but `gh api -X PUT repos/:owner/:repo/rulesets/15287170` with a `merge_queue` rule returned HTTP 422 `Invalid rule 'merge_queue'` for this user-owned public repository.
- Keeping and hardening the existing repo-local queue as the adoptable path: branch protection already requires `Queue Tested`, squash merge is enabled, and the `Poor Man's Merge Queue` workflow is active.
- Live testing showed GitHub auto-merge is dropped when `Queue Tested` is invalidated after a main push, so auto-merge cannot be the durable queue signal. This PR switches the queue signal to the `merge-queue` label and disables the old `Refresh Green PRs` workflow that armed auto-merge.
