### PR TITLE
refactor(checker): route callback parameter relation outcome

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -476,7 +476,9 @@ impl<'a> CheckerState<'a> {
                         .expect("expected_params should not be empty")
                 });
                 // Parameter types conflict if the actual is NOT assignable to expected.
-                !self.diagnostic_relation_boolean_guard(actual_param_type, expected_param_type)
+                !self
+                    .assign_relation_outcome(actual_param_type, expected_param_type)
+                    .related
             })
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -427,6 +427,9 @@ mod builtin_iterator_implements_tests;
 #[path = "tests/call_architecture_tests.rs"]
 mod call_architecture_tests;
 #[cfg(test)]
+#[path = "tests/call_context_relation_routing_arch_tests.rs"]
+mod call_context_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/call_context_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_context_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn explicit_callback_param_conflict_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/checkers/call_context.rs").expect("failed to read call_context.rs");
+    let start = source
+        .find("pub(crate) fn callback_has_explicit_param_type_conflict")
+        .expect("missing callback_has_explicit_param_type_conflict helper");
+    let end = start
+        + source[start..]
+            .find("pub(crate) fn suppress_generic_return_context_for_arg")
+            .expect("missing suppress_generic_return_context_for_arg helper");
+    let helper = &source[start..end];
+
+    assert_eq!(
+        helper.matches("assign_relation_outcome").count(),
+        1,
+        "explicit callback parameter conflict should route through assign_relation_outcome"
+    );
+    assert!(
+        helper.contains(".related"),
+        "explicit callback parameter conflict should use the relation outcome decision"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "explicit callback parameter conflict should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When checker decides whether an explicitly annotated callback parameter conflicts with its contextual parameter type for call-site diagnostic orchestration, checker keeps the existing callback discovery, contextual function parameter extraction, explicit-annotation filter, fallback-to-last-expected-parameter behavior, and diagnostic suppression ownership while routing the parameter type relation decision through the shared assignability outcome boundary.

## Scope
- Route `callback_has_explicit_param_type_conflict` through `assign_relation_outcome(...).related` in `crates/tsz-checker/src/checkers/call_context.rs`.
- Preserve existing contextual type resolution, actual callback type extraction, explicit annotation filtering, and parameter index fallback unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / callback contextual parameter routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard and exact-head draft-light CI passed on current-base head `ab70e9c062a6474be43ad807d518f4a9d655965b`.

## Verification
Passed on current-base head `ab70e9c062a6474be43ad807d518f4a9d655965b`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib explicit_callback_param_conflict_uses_relation_outcome_boundary`
- Draft-light CI: `CI Light Summary`, `GitGuardian Security Checks`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, and `project-row-drift` passed for head `ab70e9c062a6474be43ad807d518f4a9d655965b`.

## Coordination Notes
- AgentName: M1-B
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-call-context-param-relation-20260526`; TypeScript linked from the primary populated checkout.
- Rebased onto current `origin/main` `1832cf6b138583ac861d4d0eaea4d5fe4b19a69e`; `origin/main` is an ancestor of head `ab70e9c062a6474be43ad807d518f4a9d655965b`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10369, #10368, #10364, #10362, #10357, #10356, #10354, #10353, #10351, #10348, #10344, #10343, #10342, and other current M1-B relation-routing PRs.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, contextual callback discovery, parameter extraction, fallback behavior, or diagnostic display-string decision changed.
- Ready for manager review/queue; merge-queue and auto-merge intentionally left off.
