### PR TITLE
refactor(checker): use Promise identity in return context

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/return_context.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/return_context.rs
@@ -89,7 +89,7 @@ impl<'a> CheckerState<'a> {
         if let Some((base, args)) =
             crate::query_boundaries::common::application_info(self.ctx.types, existing)
             && args.len() == 1
-            && self.return_context_application_base_has_name(base, &["Promise", "PromiseLike"])
+            && self.return_context_application_base_is_lib_promise_like(base)
             && let Some(refined_arg) = self.return_context_refinement_for_arg_inference_inner(
                 args[0],
                 contextual,

--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -801,7 +801,7 @@ impl<'a> CheckerState<'a> {
         if let Some((base, args)) = common::application_info(self.ctx.types, source)
             && args.len() == 1
             && common::application_info(self.ctx.types, target).is_none()
-            && self.return_context_application_base_has_name(base, &["Promise", "PromiseLike"])
+            && self.return_context_application_base_is_lib_promise_like(base)
         {
             return self.contextual_return_type_specializes_wrapped_params(
                 args[0],
@@ -815,7 +815,7 @@ impl<'a> CheckerState<'a> {
             && let Some((base, args)) = common::application_info(self.ctx.types, source_evaluated)
             && args.len() == 1
             && common::application_info(self.ctx.types, target).is_none()
-            && self.return_context_application_base_has_name(base, &["Promise", "PromiseLike"])
+            && self.return_context_application_base_is_lib_promise_like(base)
         {
             return self.contextual_return_type_specializes_wrapped_params(
                 args[0],
@@ -948,6 +948,10 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    pub(crate) fn return_context_application_base_is_lib_promise_like(&self, base: TypeId) -> bool {
+        self.is_promise_type(base)
     }
 
     pub(crate) fn return_context_application_base_has_name(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -694,6 +694,9 @@ mod recursive_path_default_type_param_tests;
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]
+#[path = "tests/return_context_promise_identity_tests.rs"]
+mod return_context_promise_identity_tests;
+#[cfg(test)]
 #[path = "../tests/reverse_mapped_inference_tests.rs"]
 mod reverse_mapped_inference_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/return_context_promise_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/return_context_promise_identity_tests.rs
@@ -1,0 +1,45 @@
+use crate::test_utils::check_source_diagnostics;
+
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn return_context_does_not_treat_user_promise_alias_as_lib_promise() {
+    let source = r#"
+type Promise<T> = { value: T };
+declare function make<T>(callback: () => Promise<T>): T;
+
+const n: number = make(() => ({ value: "text" }));
+"#;
+
+    let codes = diagnostic_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "user-defined Promise<T> should not be unwrapped as the lib Promise<T>; got {codes:?}"
+    );
+}
+
+#[test]
+fn return_context_promise_wrapper_detection_uses_lib_identity_helper() {
+    let sources = [
+        include_str!("../checkers/call_context.rs"),
+        include_str!("../checkers/call_checker/overload_resolution/return_context.rs"),
+        include_str!("../types/utilities/return_type.rs"),
+    ];
+    assert!(
+        sources.iter().all(|source| !source.contains(
+            "return_context_application_base_has_name(base, &[\"Promise\", \"PromiseLike\"])"
+        )),
+        "return-context Promise wrapper detection must use lib/global identity, not a name allowlist"
+    );
+    assert!(
+        sources
+            .iter()
+            .any(|source| source.contains("return_context_application_base_is_lib_promise_like")),
+        "expected the call-context path to route Promise wrapper checks through the identity helper"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -86,7 +86,7 @@ impl<'a> CheckerState<'a> {
             if let Some((base, args)) =
                 return_type_queries::application_info(self.ctx.types, member)
                 && args.len() == 1
-                && self.return_context_application_base_has_name(base, &["Promise", "PromiseLike"])
+                && self.return_context_application_base_is_lib_promise_like(base)
                 && return_type_queries::array_element_type(self.ctx.types, args[0]).is_some()
             {
                 saw_promise_wrapped_array = true;


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker return-context refactor.

## Invariant
When checker return-context logic treats `Promise<T>` or `PromiseLike<T>` as a transparent wrapper, the wrapper base must resolve through lib/global Promise identity rather than a raw symbol-name allowlist.

## Scope
- Route return-context Promise wrapper checks through `return_context_application_base_is_lib_promise_like`.
- Reuse the existing strict `is_promise_type` identity path for Promise/PromiseLike bases.
- Leave transparent wrapper spellings such as `Readonly`, `NoInfer`, and `Awaited` untouched.
- Add focused behavior and source-level architecture coverage for the return-context Promise identity invariant.

## Project Corpus Impact
- Row: n/a
- Bug family: name-only Promise/PromiseLike identity shortcut in checker return-context logic
- Evidence: behavior-preserving architecture cleanup; no project-corpus row identified for this narrow checker refactor.

## Verification
Original patch verification on head `8badc456fd` rebased onto `origin/main` `5787824581`:
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib -E 'test(return_context_promise_identity_tests) or test(test_promise_then_return_context_preserves_literal)'`
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests generic_call_with_promise_return_context`
- `cargo nextest run -p tsz-checker --test nonnull_contextual_type_arg_inference_tests contextual_return_checks_promise_awaited_conflicting_literal`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo check -p tsz-checker`
- `scripts/agents/ensure-agent-labels.sh --audit`

Post-main-sync verification on head `2d8c6c858e` rebased onto `origin/main` `a9cbcc5ac2`:
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- Draft-light CI run `26474933657` reached green for `unit`, `lint`, and other light jobs but was superseded before `dist-binaries` completed because `origin/main` advanced.

Latest sync verification on head `853307a6b4` rebased onto current `origin/main` `1832cf6b13`:
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- Draft-light CI run `26475465253` passed for exact head `853307a6b4`.

## Coordination Notes
- Fresh/reused worktree: `/Users/mohsen/code/tsz-m4d-9742-ambient-value-export-20260526`, branch `codex/m4-d-return-context-promise-identity-20260526`.
- Started after closing stale M4-D issue #8695 as already resolved on current main; this PR is a separate small identity-debt ratchet and does not claim #8695.
- Overlap check found #10295 already addressed by M1-D PR #10309, so this slice avoids imported predicate narrowing and only touches return-context Promise wrapper identity.
- Rebased onto current `origin/main` and force-pushed with lease after main advanced under the previous draft-light CI run.
- Ready for manager review/queue on exact head `853307a6b4`. Auto-merge and merge-queue intentionally left off.