### PR TITLE
fix(solver): honor skipped weak checks in subtype fallback

### DIFF
--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1643,11 +1643,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.subtype.exact_optional_property_types = self.exact_optional_property_types;
         self.subtype.strict_null_checks = self.strict_null_checks;
         self.subtype.no_unchecked_indexed_access = self.no_unchecked_indexed_access;
-        // Propagate weak type enforcement into nested structural comparisons.
-        // This ensures TS2559 is detected not just at the top-level assignment,
-        // but also when comparing nested property types (e.g., { a: { y: string } }
-        // assigned to { a: { x?: number } }).
-        self.subtype.enforce_weak_types = true;
+        // Propagate weak type enforcement into nested structural comparisons
+        // only when this relation policy enables TS2559-style weak checks.
+        // `isTypeAssignableTo`-style callers set `skip_weak_type_checks`, and
+        // that policy must also suppress the structural fallback.
+        self.subtype.enforce_weak_types = !self.skip_weak_type_checks;
         // Any propagation is controlled by the Lawyer's allow_any_suppression flag
         // Standard TypeScript allows any to propagate through arrays/objects regardless
         // of strictFunctionTypes - it only affects function parameter variance

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -204,6 +204,86 @@ fn skip_weak_type_checks_partitions_cache_entries() {
 }
 
 #[test]
+fn assignability_cache_skip_weak_type_policy_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let optional = interner.intern_string("optional");
+    let unrelated = interner.intern_string("unrelated");
+    let source = interner.object(vec![PropertyInfo::new(unrelated, TypeId::BOOLEAN)]);
+    let target = interner.object(vec![PropertyInfo::opt(optional, TypeId::NUMBER)]);
+
+    let enforced = RelationPolicy::default().with_skip_weak_type_checks(false);
+    let skipped = RelationPolicy::default().with_skip_weak_type_checks(true);
+    let enforced_key = RelationCacheKey::for_assignability(source, target, enforced.cache_config());
+    let skipped_key = RelationCacheKey::for_assignability(source, target, skipped.cache_config());
+
+    assert_ne!(
+        enforced_key, skipped_key,
+        "weak-type enforcement and skipped-weak policies must occupy distinct cache slots",
+    );
+
+    let uncached_enforced = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        enforced,
+        RelationContext::default(),
+    )
+    .is_related();
+    let uncached_skipped = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        skipped,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !uncached_enforced,
+        "weak-type enforcement should reject an unrelated object source",
+    );
+    assert!(
+        uncached_skipped,
+        "skipping weak-type checks should leave the ordinary optional-property relation assignable",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, enforced),
+        uncached_enforced,
+        "cached weak-type-enforced policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(enforced_key),
+        Some(uncached_enforced),
+        "weak-type-enforced result must be stored in the enforced slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(skipped_key),
+        None,
+        "skipped-weak lookup must not hit the enforced slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, skipped),
+        uncached_skipped,
+        "cached skipped-weak policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(skipped_key),
+        Some(uncached_skipped),
+        "skipped-weak result must be stored in the skipped slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(enforced_key),
+        Some(uncached_enforced),
+        "weak-type-enforced slot must remain intact after the skipped lookup",
+    );
+}
+
+#[test]
 fn erase_generics_partitions_cache_entries() {
     assert_subtype_partitions(
         "erase_generics",


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
M4-B relation policy/cache-key contract (#8207 under #8203). Behavior fix for weak-type compatibility policy propagation.

## Structural Rule
When a relation policy skips weak-type checks, tsc-style assignability should suppress TS2559-style weak-type rejection in both the top-level compat check and nested structural fallback; tsz should enforce that through the solver relation policy (`CompatChecker` -> `SubtypeChecker`), not through checker diagnostics or cache-only key partitioning.

## Owner Layer
Solver. `skip_weak_type_checks` is a semantic relation policy bit used by `query_relation` and cached assignability entrypoints. The checker should only choose the policy; the solver must make cached and uncached relation answers agree for that policy.

## Invariant
`skip_weak_type_checks` is a real relation-policy dimension. When it is enabled, both top-level compat handling and the nested structural fallback must suppress TS2559-style weak type rejection, and the assignability cache must store/read answers under policy-shaped keys.

## Scope
- `crates/tsz-solver/src/relations/compat.rs`: propagate weak-type enforcement into `SubtypeChecker` only when the active compat policy does not skip weak checks.
- `crates/tsz-solver/tests/relation_cache_config_tests.rs`: add a red/green cache-policy test proving skipped-vs-enforced weak checks produce distinct cached answers matching uncached `query_relation`.

## Adjacent-Case Matrix
- Enforced weak-type policy: unrelated object source `{ unrelated: boolean }` remains rejected against all-optional target `{ optional?: number }`.
- Skipped weak-type policy: the same source/target pair remains ordinarily structurally assignable once TS2559-style weak checks are disabled.
- Cache agreement: cached assignability results match uncached `query_relation` for both policies and occupy distinct cache slots.
- Existing weak-type coverage: `relations::lawyer::tests::test_compat_checker_weak_type_detection` still covers the ordinary compatibility path that should enforce weak checks.

## Known Unsupported Shapes / Fallback
No new special-case shape is introduced. Unsupported or unrelated relation forms continue through the existing `CompatChecker`/`SubtypeChecker` structural fallback; this PR only changes whether that fallback receives weak-type enforcement when the active policy explicitly skips it.

## Project Corpus Impact
- Row: n/a
- Bug family: relation policy/cache agreement for weak-type compatibility checks
- Evidence: solver-only targeted regression; no project-corpus row was identified for this policy propagation bug.

## Verification
- Red before fix: `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(=relation_cache_config_tests::assignability_cache_skip_weak_type_policy_matches_uncached_relation_query)'` failed because skipped weak checks still rejected the unrelated object source.
- Green after rebase: `cargo fmt --check`
- Green after rebase: `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(/^relation_cache_config_tests::/) or test(=relations::lawyer::tests::test_compat_checker_weak_type_detection)'` (32 passed, 6248 skipped)
- Green after rebase: `git diff --check origin/main..HEAD`
- Green: `scripts/agents/ensure-agent-labels.sh --audit`
- Draft light CI at head `e36dd9f943149623f4ea6c1a33e4a5cece53a1b8`: `CI Light Summary`, lint, dist-binaries, unit, unit-cloudbuild, cargo-deny, cargo-shear, gate, project-row-drift, and queue-one-pr passed.

## Coordination Notes
- Marked ready after draft-light CI passed on head `e36dd9f943149623f4ea6c1a33e4a5cece53a1b8`; ready CI will run the heavy suites.
- This does not overlap the strict-null (#10269), strict-any (#10315), optional parameter (#10282), or checker boundary (#10290) slices beyond the shared cache-policy test theme.
- #10277 has merged, so readonly conditional array test coverage is no longer an active branch conflict.
- Auto-merge is intentionally off; queue/merge decisions remain with the manager/queue owner.
