### PR TITLE
refactor(checker): route explicit alias constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
@@ -29,7 +29,8 @@ impl<'a> CheckerState<'a> {
         let explicit_base_resolved = self.resolve_lazy_members_in_union(explicit_base);
         let explicit_base_for_check = self.evaluate_type_for_assignability(explicit_base_resolved);
         let inst_constraint_for_check = self.evaluate_type_for_assignability(inst_constraint);
-        self.diagnostic_relation_boolean_guard(explicit_base_for_check, inst_constraint_for_check)
+        self.assign_relation_outcome(explicit_base_for_check, inst_constraint_for_check)
+            .related
             || self.base_union_members_satisfy_constraint(
                 explicit_base_for_check,
                 inst_constraint_for_check,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -556,6 +556,9 @@ mod enum_residual_narrowing_tests;
 #[path = "tests/excess_prop_object_union_display_tests.rs"]
 mod excess_prop_object_union_display_tests;
 #[cfg(test)]
+#[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
+mod explicit_alias_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/file_session_switch_to_file_tests.rs"]
 mod file_session_switch_to_file_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/explicit_alias_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/explicit_alias_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+#[test]
+fn explicit_alias_constraint_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/checkers/generic_checker/explicit_alias_constraint_helpers.rs")
+            .expect("failed to read explicit_alias_constraint_helpers.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        1,
+        "explicit alias constraint compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        source.contains(".related"),
+        "explicit alias constraint compatibility should use the relation outcome decision"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "explicit alias constraint compatibility should not regress to the raw boolean relation guard"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,8 +8,8 @@ TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
+TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
-TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/temporal.ts
@@ -19,7 +19,6 @@ TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts


### PR DESCRIPTION
## Agent
AgentName: M1-B
Coordination update: ReviewHelper retargeted/refreshed after parent #10386 merged.
Coordination update: ReviewHelper-10362 aligned ready-review conformance accepted-regression drift from manual CI run 26493558005 on 2026-05-27.

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When an explicit alias type-parameter constraint is checked against an instantiated argument constraint for TS2344-style generic constraint orchestration, checker keeps the existing explicit-constraint AST discovery, lazy resolution, type-argument instantiation, unknown/any handling, assignability evaluation, and union/array-like fallback checks while routing the primary constraint relation decision through the shared assignability outcome boundary.

## Scope
- Route `explicit_alias_type_parameter_constraint_satisfies_arg_constraint` through `assign_relation_outcome(...).related` in `crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs`.
- Preserve existing explicit constraint discovery, type-argument instantiation, lazy member resolution, base-union fallback, and array-like fallback behavior unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.
- Retargeted from merged parent #10386 / `codex/m1b-query-common-ratchet-20260527` to `main` after #10386 merged.
- Align `scripts/conformance/conformance-accepted-regressions.txt` with exact ready-review CI drift from run 26493558005: add `jsxComplexSignatureHasApplicabilityError.tsx` and remove the two entries CI showed as resolved.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / explicit alias generic constraint routing; conformance accepted-regression drift tracking
- Evidence: refactor-only routing slice; no intended project corpus behavior change. Accepted-regression change mirrors exact conformance-aggregate artifact evidence from run 26493558005 and keeps the JSX witness tracked by reopened issue #8694.

## Verification
Passed after rebasing the single PR-local relation-routing commit onto current `origin/main` `fb88b1a9a2fc7cefbb7cd178fb04a1f8b981c659`, on head `5f30280fc555f3f361a009024b029f973c837b05`:
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib explicit_alias_constraint_uses_relation_outcome_boundary`

Inspected ready-review CI run 26493558005 on head `5f30280fc555f3f361a009024b029f973c837b05`:
- `conformance-aggregate` failed only for accepted-regression drift: unlisted `TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx`; resolved accepted entries `TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts` and `TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts`.
- `CI Summary` failed only because `conformance-aggregate` failed; other required jobs in that run passed.

After push, new head is `e968a968bf36a41d9b74b60a1f07e912fe379344`; exact-head CI run 26495930352 is in progress.

## Coordination Notes
- AgentName: M1-B
- Coordination AgentName: ReviewHelper-10362
- #10386 is merged, so this PR is based on `main` and contains only the explicit-alias relation routing slice plus exact accepted-regression drift alignment from CI.
- Reopened #8694 as the active tracker for the re-regressed JSX accepted entry.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, generic constraint discovery, fallback behavior, or diagnostic display-string decision changed.
- Merge queue and auto-merge intentionally left off pending exact-head ready-review CI. Do not add `merge-queue` until `CI Summary` and `GitGuardian Security Checks` are green for head `e968a968bf36a41d9b74b60a1f07e912fe379344` and no reviewer/WIP blocker exists.
