### PR TITLE
chore(agents): link label audit PR rows

### DIFF
--- a/scripts/agents/ensure-agent-labels.sh
+++ b/scripts/agents/ensure-agent-labels.sh
@@ -57,7 +57,7 @@ is_canonical_agent_label() {
 existing="$(gh label list --limit 300 --json name --jq '.[].name')"
 
 if [[ "$AUDIT" == true ]]; then
-  prs_json="$(gh pr list --state open --limit 500 --json number,title,labels,body)"
+  prs_json="$(gh pr list --state open --limit 500 --json number,title,labels,body,url)"
   agents_json="$(
     printf '%s\n' "${AGENTS[@]}" | node -e '
       const fs = require("fs");
@@ -120,21 +120,23 @@ console.log(`open_prs_noncanonical_agent_label=${noncanonicalPrs.length}`);
 
 printRows("Missing Canonical Labels", missingCanonicalLabels, (label) => `- ${label}`);
 printRows("Noncanonical Agent Labels", noncanonicalLabels, (label) => `- ${label}`);
-printRows("Open PRs Missing Agent Label", missingPrs, (pr) => `- #${pr.number} ${pr.title}`);
+const prRow = (pr) => `- #${pr.number} ${pr.title}${pr.url ? ` ${pr.url}` : ""}`;
+
+printRows("Open PRs Missing Agent Label", missingPrs, prRow);
 printRows(
   "Open PRs Intentionally Unassigned",
   intentionallyUnassignedPrs,
-  (pr) => `- #${pr.number} ${pr.title}`,
+  prRow,
 );
 printRows(
   "Open PRs With Multiple Agent Labels",
   multiplePrs,
-  (pr) => `- #${pr.number} ${pr.agentLabels.join(", ")} ${pr.title}`,
+  (pr) => `- #${pr.number} ${pr.agentLabels.join(", ")} ${pr.title}${pr.url ? ` ${pr.url}` : ""}`,
 );
 printRows(
   "Open PRs With Noncanonical Agent Labels",
   noncanonicalPrs,
-  (pr) => `- #${pr.number} ${pr.agentLabels.join(", ")} ${pr.title}`,
+  (pr) => `- #${pr.number} ${pr.agentLabels.join(", ")} ${pr.title}${pr.url ? ` ${pr.url}` : ""}`,
 );
 NODE
   exit 0

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -46,6 +46,10 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     fi
 
                     if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+                      if [[ "$*" != *"--json number,title,labels,body,url"* ]]; then
+                        echo "expected PR audit to request url field: $*" >&2
+                        exit 98
+                      fi
                       printf '%s\n' "${FAKE_GH_PRS}"
                       exit 0
                     fi

--- a/scripts/agents/test_ensure_agent_labels.py
+++ b/scripts/agents/test_ensure_agent_labels.py
@@ -83,12 +83,14 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     "title": "chore: intentionally unassigned",
                     "labels": [],
                     "body": "Coordination Notes\n- No canonical agent lane was assigned.",
+                    "url": "https://github.com/mohsen1/tsz/pull/1",
                 },
                 {
                     "number": 2,
                     "title": "fix: owned",
                     "labels": [{"name": "agent:Studio-F"}],
                     "body": "AgentName: Studio-F",
+                    "url": "https://github.com/mohsen1/tsz/pull/2",
                 },
             ]
         )
@@ -96,7 +98,10 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
         self.assertIn("open_prs_missing_agent_label=0", output)
         self.assertIn("open_prs_intentionally_unassigned=1", output)
         self.assertIn("Open PRs Intentionally Unassigned", output)
-        self.assertIn("#1 chore: intentionally unassigned", output)
+        self.assertIn(
+            "#1 chore: intentionally unassigned https://github.com/mohsen1/tsz/pull/1",
+            output,
+        )
 
     def test_audit_still_flags_unexplained_missing_labels(self):
         output = self.run_audit_with_prs(
@@ -106,13 +111,17 @@ class EnsureAgentLabelsAuditTests(unittest.TestCase):
                     "title": "fix: missing label",
                     "labels": [],
                     "body": "AgentName: Studio-F",
+                    "url": "https://github.com/mohsen1/tsz/pull/3",
                 }
             ]
         )
 
         self.assertIn("open_prs_missing_agent_label=1", output)
         self.assertIn("open_prs_intentionally_unassigned=0", output)
-        self.assertIn("#3 fix: missing label", output)
+        self.assertIn(
+            "#3 fix: missing label https://github.com/mohsen1/tsz/pull/3",
+            output,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Launch infrastructure / cheap evidence plumbing

## Invariant
When the agent-label audit reports an open PR that needs ownership follow-up, the report should include enough information to act immediately; this PR adds the PR URL to each flagged audit row and tests that the audit requests URL data from GitHub.

## Scope
- `scripts/agents/ensure-agent-labels.sh`: request PR URLs from `gh pr list` and print them in missing, unassigned, multiple-label, and noncanonical-label rows.
- `scripts/agents/test_ensure_agent_labels.py`: cover URL-bearing audit output and require the fake `gh pr list` call to request the URL field.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script-only change; no compiler, emit, checker, solver, LSP, WASM, or project corpus behavior changed.

## Verification
- `python3 -m unittest scripts.agents.test_ensure_agent_labels`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `git diff --check`
- Draft/light CI on head `61b3031ef7b4a748d7d0c92e796c185de30208fb`: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and GitGuardian passed.

## Coordination Notes
- Marked ready after local verification and green draft/light CI for the exact head.
- Does not change ownership labels or merge queue state.
- Queue labeling is intentionally left to the manager/queue owner.
- Auto-merge intentionally off.
