### PR TITLE
refactor(checker): route merged interface constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/merged_interface_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/merged_interface_constraints.rs
@@ -78,8 +78,10 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
             let candidate_evaluated = self.evaluate_type_for_assignability(candidate);
-            self.diagnostic_relation_boolean_guard(candidate, required)
-                || self.diagnostic_relation_boolean_guard(candidate_evaluated, required)
+            self.assign_relation_outcome(candidate, required).related
+                || self
+                    .assign_relation_outcome(candidate_evaluated, required)
+                    .related
                 || self.satisfies_array_like_constraint(candidate_evaluated, required)
         })
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -628,6 +628,9 @@ mod mapped_infer_with_substitution_tests;
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
 #[cfg(test)]
+#[path = "tests/merged_interface_constraint_relation_routing_arch_tests.rs"]
+mod merged_interface_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/module_resolution_guard_tests.rs"]
 mod module_resolution_guard_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/merged_interface_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/merged_interface_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+#[test]
+fn merged_interface_constraints_use_relation_outcome_boundary() {
+    let src = fs::read_to_string("src/checkers/generic_checker/merged_interface_constraints.rs")
+        .expect("failed to read merged interface constraint helper");
+
+    let assign_outcome_calls = src.matches("assign_relation_outcome(").count();
+    assert_eq!(
+        assign_outcome_calls, 2,
+        "merged interface constraints should route both primary relation checks through the shared outcome boundary"
+    );
+    assert!(
+        src.contains(".assign_relation_outcome(candidate, required)\n                    .related")
+            || src.contains("assign_relation_outcome(candidate, required).related"),
+        "candidate relation check should consume RelationOutcome.related"
+    );
+    assert!(
+        src.contains(
+            ".assign_relation_outcome(candidate_evaluated, required)\n                    .related"
+        ) || src.contains("assign_relation_outcome(candidate_evaluated, required).related"),
+        "evaluated candidate relation check should consume RelationOutcome.related"
+    );
+    assert!(
+        !src.contains("diagnostic_relation_boolean_guard("),
+        "merged interface constraints must not use raw diagnostic relation boolean guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When a merged sibling interface's type-parameter constraint is reused to satisfy a type-argument constraint, checker preserves the existing sibling discovery, callable shape acceptance, evaluated-candidate retry, and array-like fallback while routing the primary assignability decisions through the shared `RelationOutcome` boundary.

## Scope
- Route both primary relation checks in `crates/tsz-checker/src/checkers/generic_checker/merged_interface_constraints.rs` through `assign_relation_outcome(...).related`.
- Preserve existing sibling discovery, callable shape acceptance, evaluated-candidate retry, and array-like fallback behavior unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary debt / TS2344-style generic constraint orchestration
- Evidence: refactor-only boundary routing; local focused guard and exact-head draft-light CI passed on current-base head `8a90701e42e197eabfeb1dcde1e7f007aee85413`.

## Verification
Passed on current-base head `8a90701e42e197eabfeb1dcde1e7f007aee85413`:
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib merged_interface_constraints_use_relation_outcome_boundary`
- Draft-light CI: `CI Light Summary`, `GitGuardian Security Checks`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `cargo-deny`, `cargo-shear`, and `project-row-drift` passed for head `8a90701e42e197eabfeb1dcde1e7f007aee85413`.

## Coordination Notes
- AgentName: M1-B
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-merged-interface-constraint-20260526`; TypeScript linked from the primary populated checkout.
- Rebased onto current `origin/main` `1832cf6b138583ac861d4d0eaea4d5fe4b19a69e`; `origin/main` is an ancestor of head `8a90701e42e197eabfeb1dcde1e7f007aee85413`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10369, #10368, #10362, #10359, #10357, #10356, #10354, #10353, #10351, #10348, #10344, #10343, #10342, and other current M1-B relation-routing PRs.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, sibling discovery, fallback behavior, or diagnostic display-string decision changed.
- Ready for manager review/queue; merge-queue and auto-merge intentionally left off.
