### PR TITLE
fix(checker): preserve recursive mapped redeclaration identity

### DIFF
--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -345,6 +345,10 @@ impl<'a> CheckerState<'a> {
         let prev_type = self.array_application_to_array_for_redeclaration(prev_type);
         let current_type = self.array_application_to_array_for_redeclaration(current_type);
 
+        if self.recursive_mapped_alias_applications_have_distinct_args(prev_type, current_type) {
+            return false;
+        }
+
         // Nominal identity check: when both types come from different named type
         // references (Application with different bases, or Lazy with different DefIds),
         // tsc's isTypeIdenticalTo rejects them even if structurally equivalent.
@@ -457,6 +461,35 @@ impl<'a> CheckerState<'a> {
         }
 
         result
+    }
+
+    fn recursive_mapped_alias_applications_have_distinct_args(
+        &self,
+        prev_type: TypeId,
+        current_type: TypeId,
+    ) -> bool {
+        let Some(prev_app) =
+            crate::query_boundaries::common::type_application(self.ctx.types, prev_type)
+        else {
+            return false;
+        };
+        let Some(current_app) =
+            crate::query_boundaries::common::type_application(self.ctx.types, current_type)
+        else {
+            return false;
+        };
+        if prev_app.base != current_app.base || prev_app.args == current_app.args {
+            return false;
+        }
+        let Some(def_id) =
+            crate::query_boundaries::common::lazy_def_id(self.ctx.types, prev_app.base)
+        else {
+            return false;
+        };
+        let Some(sym_id) = self.ctx.def_to_symbol_id(def_id) else {
+            return false;
+        };
+        self.symbol_declares_recursive_mapped_alias(sym_id)
     }
 
     fn array_application_to_array_for_redeclaration(&self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -562,6 +562,12 @@ impl<'a> CheckerState<'a> {
             return fallback_type;
         };
 
+        if let Some(raw_application) =
+            self.recursive_mapped_alias_application_ts2403_type(annotation_idx)
+        {
+            return raw_application;
+        }
+
         if ann_node.kind == syntax_kind_ext::TYPE_REFERENCE
             && let Some(type_ref) = self.ctx.arena.get_type_ref(ann_node)
             && let Some(name_node) = self.ctx.arena.get(type_ref.type_name)
@@ -616,6 +622,92 @@ impl<'a> CheckerState<'a> {
         }
 
         fallback_type
+    }
+
+    fn recursive_mapped_alias_application_ts2403_type(
+        &mut self,
+        annotation_idx: NodeIndex,
+    ) -> Option<TypeId> {
+        let ann_node = self.ctx.arena.get(annotation_idx)?;
+        if ann_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = self.ctx.arena.get_type_ref(ann_node)?;
+        let args = type_ref.type_arguments.as_ref()?;
+        if args.nodes.is_empty() {
+            return None;
+        }
+        let crate::symbol_resolver::TypeSymbolResolution::Type(sym_id) =
+            self.resolve_identifier_symbol_in_type_position_without_tracking(type_ref.type_name)
+        else {
+            return None;
+        };
+        if !self.symbol_declares_recursive_mapped_alias(sym_id) {
+            return None;
+        }
+
+        let type_args = args
+            .nodes
+            .iter()
+            .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+            .collect();
+        let def_id = self.ctx.get_or_create_def_id(sym_id);
+        let base = self.ctx.types.lazy(def_id);
+        Some(self.ctx.types.application(base, type_args))
+    }
+
+    pub(crate) fn symbol_declares_recursive_mapped_alias(&self, sym_id: SymbolId) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
+            return false;
+        }
+        symbol.declarations.iter().any(|&decl_idx| {
+            let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                return false;
+            };
+            if decl_node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                return false;
+            }
+            let Some(alias) = self.ctx.arena.get_type_alias(decl_node) else {
+                return false;
+            };
+            self.ctx
+                .arena
+                .get(alias.type_node)
+                .is_some_and(|body| body.kind == syntax_kind_ext::MAPPED_TYPE)
+                && self.type_node_contains_type_reference_to_symbol(alias.type_node, sym_id)
+        })
+    }
+
+    fn type_node_contains_type_reference_to_symbol(
+        &self,
+        node_idx: NodeIndex,
+        sym_id: SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+            && matches!(
+                self.resolve_identifier_symbol_in_type_position_without_tracking(
+                    type_ref.type_name
+                ),
+                crate::symbol_resolver::TypeSymbolResolution::Type(resolved)
+                    if resolved == sym_id
+            )
+        {
+            return true;
+        }
+
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.type_node_contains_type_reference_to_symbol(child_idx, sym_id))
     }
 
     /// For TS2403: resolve a property access expression (like `m3.Color` or `M3.Color`)

--- a/crates/tsz-checker/tests/deeply_nested_conditional_mapped_recursion_tests.rs
+++ b/crates/tsz-checker/tests/deeply_nested_conditional_mapped_recursion_tests.rs
@@ -343,6 +343,55 @@ declare var x: FindConditions<Entity>;
     );
 }
 
+/// Exact shape from `noExcessiveStackDepthError.ts`: two function-local `var`
+/// declarations inside a generic function, with a recursive mapped alias whose
+/// property value also includes a wrapper application.
+#[test]
+fn function_local_find_conditions_wrapper_triggers_ts2403_on_redeclaration() {
+    let source = r#"
+interface FindOperator<T> {
+    foo: T;
+}
+
+type FindConditions<T> = {
+    [P in keyof T]?: FindConditions<T[P]> | FindOperator<FindConditions<T[P]>>;
+};
+
+function foo<Entity>() {
+    var x: FindConditions<any>;
+    var x: FindConditions<Entity>;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2403),
+        "Function-local FindConditions redeclaration must produce TS2403. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn function_local_recursive_mapped_wrapper_with_renamed_binders_triggers_ts2403() {
+    let source = r#"
+interface CriteriaWrapper<Value> {
+    value: Value;
+}
+
+type SearchCriteria<Item> = {
+    [Key in keyof Item]?: SearchCriteria<Item[Key]> | CriteriaWrapper<SearchCriteria<Item[Key]>>;
+};
+
+function search<Row>() {
+    var criteria: SearchCriteria<any>;
+    var criteria: SearchCriteria<Row>;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2403),
+        "Renamed recursive mapped wrapper redeclaration must produce TS2403. Got: {codes:?}"
+    );
+}
+
 /// Same `FindConditions` pattern with renamed type parameters to confirm the
 /// fix is not keyed on specific identifier names.
 #[test]

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -10,7 +10,6 @@ TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
-TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts
 TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 TypeScript/tests/cases/compiler/reactHOCSpreadprops.tsx
 TypeScript/tests/cases/compiler/relationComplexityError.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Semantic campaign: conformance accepted-regression burn-down for recursive mapped redeclaration diagnostics.

## Invariant
When two `var` declarations compare instantiations of the same recursive mapped alias with different type arguments, `tsc` preserves the raw alias applications for TS2403 redeclaration identity instead of letting mapped-type expansion collapse the comparison to `any`. This PR makes tsz preserve that TS2403 fact through checker redeclaration bookkeeping before relation evaluation erases the alias arguments.

## Owner Layer
Owner layer: checker TS2403 declaration bookkeeping plus the existing redeclaration identity boundary.

The semantic rule is redeclaration type identity for recursive mapped alias applications. The checker already owns TS2403 source ordering, declaration caching, and diagnostic rendering; this PR keeps the raw recursive mapped alias application only for that redeclaration path and asks the existing identity gate to reject distinct arguments before assignability-style evaluation expands the alias.

## Scope
- Preserve generic recursive mapped alias applications as raw TS2403 declared types.
- Treat same-base recursive mapped alias applications with different arguments as non-identical before application evaluation.
- Add function-local generic `var` redeclaration tests for the `noExcessiveStackDepthError.ts` shape and a renamed-binder companion.
- Remove `TypeScript/tests/cases/compiler/noExcessiveStackDepthError.ts` from accepted regressions.

## Adjacent-Case Matrix
- Reported shape: `FindConditions<any>` vs `FindConditions<Entity>` inside a generic function now reports TS2403.
- Renamed shape: `SearchCriteria<any>` vs `SearchCriteria<Row>` with renamed mapped keys and wrapper type also reports TS2403.
- Existing conditional mapped redeclaration tests still pass.
- Existing non-conditional mapped alias identity tests still pass.

## Fallback Behavior
The new raw-application preservation only applies to explicit type-reference annotations whose target symbol is a recursive mapped type alias. Other annotations continue through the existing `annotation_ts2403_type` path, including array shorthand canonicalization, `typeof Enum` handling, and ordinary evaluated alias comparison.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic conformance accepted-regression / TS2403 redeclaration identity for recursive mapped aliases
- Evidence: compiler conformance-only change; focused `noExcessiveStackDepthError` conformance filter passes 1/1 on head `351a1802780dd9cf53fb0b0c8a759471a180953e`, and the dashboard accepted-regression strictness drops from 30 to 29 in this PR worktree.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test deeply_nested_conditional_mapped_recursion_tests function_local`
- `cargo nextest run -p tsz-checker --test deeply_nested_conditional_mapped_recursion_tests`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter noExcessiveStackDepthError --verbose`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: M1-C
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-no-excessive-stack-depth-20260526`, branch `codex/m1-c-no-excessive-stack-depth-20260526`, based on current `origin/main`.
- Tracks one path from #10349 and the aggregate accepted-regression tracker #10306.
- Marked ready after draft light CI completed green on head `351a1802780dd9cf53fb0b0c8a759471a180953e`; ready-review CI owns heavy conformance/emit/fourslash/WASM/snapshot gates. Auto-merge remains off.



