### PR TITLE
fix(ci): include paginated queue check runs

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -183,6 +183,26 @@ function readPaginatedArray(path, { limit = Number.POSITIVE_INFINITY, perPage = 
   return items.slice(0, limit);
 }
 
+export function readPaginatedObjectArray(
+  path,
+  key,
+  { limit = Number.POSITIVE_INFINITY, perPage = 100, readJson = (url) => runGhJson(["api", url]) } = {},
+) {
+  const items = [];
+  for (let page = 1; items.length < limit; page += 1) {
+    const pageSize = Math.min(perPage, limit - items.length);
+    const separator = path.includes("?") ? "&" : "?";
+    const response = readJson(`${path}${separator}per_page=${pageSize}&page=${page}`);
+    const chunk = response?.[key];
+    if (!Array.isArray(chunk)) {
+      throw new Error(`expected GitHub API object array ${key} from ${path}`);
+    }
+    items.push(...chunk);
+    if (chunk.length < pageSize) break;
+  }
+  return items.slice(0, limit);
+}
+
 function git(args, options = {}) {
   return run("git", args, options);
 }
@@ -209,12 +229,36 @@ function normalize(value) {
   return String(value || "").toUpperCase();
 }
 
+function checkTimestampMs(check) {
+  const timestamp = check.completedAt
+    || check.completed_at
+    || check.startedAt
+    || check.started_at
+    || check.createdAt
+    || check.created_at
+    || "";
+  const ms = Date.parse(timestamp);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function shouldReplaceCheck(current, candidate) {
+  const currentMs = checkTimestampMs(current);
+  const candidateMs = checkTimestampMs(candidate);
+  if (currentMs !== null && candidateMs !== null) return candidateMs >= currentMs;
+  if (candidateMs !== null) return true;
+  if (currentMs !== null) return false;
+  return true;
+}
+
 export function requiredCheckState(checks, requiredNames) {
   const byName = new Map();
   for (const check of checks || []) {
     const name = check.name || check.context;
     if (!name) continue;
-    byName.set(name, check);
+    const current = byName.get(name);
+    if (!current || shouldReplaceCheck(current, check)) {
+      byName.set(name, check);
+    }
   }
 
   const missing = [];
@@ -898,25 +942,28 @@ function commitStatusRollup(repository, sha) {
     "--jq",
     "{statuses: .statuses}",
   ]);
-  const checks = runGhJson([
-    "api",
-    `repos/${repository}/commits/${sha}/check-runs?per_page=100`,
-    "--jq",
-    "{check_runs: .check_runs}",
-  ]);
+  const checks = readPaginatedObjectArray(
+    `repos/${repository}/commits/${sha}/check-runs`,
+    "check_runs",
+    { perPage: 100 },
+  );
   return [
     ...(status.statuses || []).map((item) => ({
       __typename: "StatusContext",
       context: item.context,
       state: item.state,
       targetUrl: item.target_url || "",
+      createdAt: item.created_at || "",
     })),
-    ...(checks.check_runs || []).map((item) => ({
+    ...checks.map((item) => ({
       __typename: "CheckRun",
       name: item.name,
       status: item.status,
       conclusion: item.conclusion,
       detailsUrl: item.html_url || item.details_url || "",
+      completedAt: item.completed_at || "",
+      startedAt: item.started_at || "",
+      createdAt: item.created_at || "",
     })),
   ];
 }

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -16,6 +16,7 @@ import {
   queueBranchPrNumber,
   queueRunIsActive,
   queueSkipReason,
+  readPaginatedObjectArray,
   requiredCheckState,
   skipOwnerCounts,
   skipOwnerReasonCounts,
@@ -107,12 +108,44 @@ assert.equal(
   null,
 );
 
+const paginatedObjectArrayUrls = [];
+assert.deepEqual(
+  readPaginatedObjectArray("repos/owner/repo/commits/abc/check-runs", "check_runs", {
+    perPage: 2,
+    readJson: (url) => {
+      paginatedObjectArrayUrls.push(url);
+      if (url.endsWith("page=1")) return { check_runs: [{ name: "CI Summary" }, { name: "lint" }] };
+      if (url.endsWith("page=2")) return { check_runs: [{ name: "GitGuardian Security Checks" }] };
+      return { check_runs: [] };
+    },
+  }).map((item) => item.name),
+  ["CI Summary", "lint", "GitGuardian Security Checks"],
+);
+assert.deepEqual(paginatedObjectArrayUrls, [
+  "repos/owner/repo/commits/abc/check-runs?per_page=2&page=1",
+  "repos/owner/repo/commits/abc/check-runs?per_page=2&page=2",
+]);
+assert.throws(
+  () => readPaginatedObjectArray("repos/owner/repo/commits/abc/check-runs", "check_runs", {
+    readJson: () => ({ not_check_runs: [] }),
+  }),
+  /expected GitHub API object array check_runs/,
+);
+
 assert.equal(requiredCheckState([check()], ["CI Summary"]).kind, "passed");
 assert.equal(requiredCheckState([check({ status: "IN_PROGRESS", conclusion: "" })], ["CI Summary"]).kind, "pending");
 assert.equal(requiredCheckState([check({ conclusion: "FAILURE" })], ["CI Summary"]).kind, "failed");
 assert.equal(requiredCheckState([], ["CI Summary"]).kind, "missing");
 assert.equal(requiredCheckState([{ context: "Queue Tested", state: "SUCCESS" }], ["Queue Tested"]).kind, "passed");
 assert.equal(requiredCheckState([{ context: "Queue Tested", state: "PENDING" }], ["Queue Tested"]).kind, "pending");
+assert.equal(requiredCheckState([
+  check({ conclusion: "SUCCESS", completedAt: "2026-05-26T12:00:00Z" }),
+  check({ conclusion: "FAILURE", completedAt: "2026-05-26T11:00:00Z" }),
+], ["CI Summary"]).kind, "passed");
+assert.equal(requiredCheckState([
+  { context: "Queue Tested", state: "SUCCESS", createdAt: "2026-05-26T11:00:00Z" },
+  { context: "Queue Tested", state: "PENDING", createdAt: "2026-05-26T12:00:00Z" },
+], ["Queue Tested"]).kind, "pending");
 assert.deepEqual(
   pendingQueueRun(pr({
     statusCheckRollup: [


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 9 / CI merge-queue tooling

## Invariant
When a queued PR has more than one page of commit check runs and duplicate historical contexts on the same head SHA, the merge queue evaluates the latest visible PR-head checks. This PR changes queue tooling only.

## Scope
- Paginate commit check-run reads in `scripts/ci/poor-mans-merge-queue.mjs`.
- Keep the newest check/status per required context before deciding queue eligibility.
- Add coverage for duplicate required contexts and paginated object-array reads in `scripts/ci/test-poor-mans-merge-queue.mjs`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI tooling only; no compiler, checker, solver, emitter, benchmark fixture, or corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `wc -l scripts/ci/poor-mans-merge-queue.mjs scripts/ci/test-poor-mans-merge-queue.mjs` -> 1208 / 596
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --dry-run` -> selects `#10257` for synthetic test/merge at `44c0ac5ccb95` before this PR is marked ready.
- Draft/light CI on head `dd9f1f19fa5ab5c0b1cf00265bfacaed59bd0957`: `CI Light Summary`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `queue-one-pr`, and `GitGuardian Security Checks` passed.
- Ready-review PR-head CI on head `dd9f1f19fa5ab5c0b1cf00265bfacaed59bd0957`: `CI Summary`, `lint`, `cargo-shear`, `cargo-deny`, `project-corpus-pr-body`, `project-row-drift`, `gate`, `queue-one-pr`, and `GitGuardian Security Checks` passed.
- Rebased/force-pushed to current `origin/main` on head `c8c761e1f5e9aadf35d143188180a6bf8b703fc0`; new exact-head PR checks are in progress. Current observed passes: `gate`, `project-corpus-pr-body`, `project-row-drift`, and `GitGuardian Security Checks`; `lint`, `cargo-shear`, and `cargo-deny` are still queued.

## Coordination Notes
- Root cause found while managing M1-A queue PR `#10257`: current `main` queue runs reported no queue-ready PR because the script missed later check-run pages and then collapsed duplicate `CI Summary` contexts by insertion order.
- Live evidence on `#10257` head `44c0ac5ccb95ea177dfa6a5c5ee6ce31c1a0f362`: GitHub reports 162 check runs, and `GitGuardian Security Checks` appears on check-runs page 2.
- At root-cause time, `#10257` was the only `merge-queue` labeled PR. Current live queue also includes other lanes; this PR intentionally does not change labels on PRs owned by other agents.
- This PR was queued on exact head `dd9f1f19fa5ab5c0b1cf00265bfacaed59bd0957`, then rebased/force-pushed to exact head `c8c761e1f5e9aadf35d143188180a6bf8b703fc0` after `origin/main` advanced. Because the exact head changed, `merge-queue` is off and auto-merge is disabled.
- Next owner/action: wait for the new exact-head PR checks on `c8c761e1f5e9` to complete successfully, then M1-A can re-add `merge-queue` for #10366 before releasing the wider queue holds.