### PR TITLE
chore(emit): clarify output surgery audit counts

### DIFF
--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -23,6 +23,12 @@ SOURCE_ROOT = ROOT / "crates" / "tsz-emitter" / "src"
 ALLOWLIST_PATH = ROOT / "scripts" / "emit" / "output-surgery-allowlist.txt"
 
 REPLACE_CALL_RE = re.compile(r"(?:\.\s*)?(replace|replacen|replace_range)\s*\(")
+UNALLOWLISTED_FAILURE_RE = re.compile(
+    r": (?P<count>\d+) unallowlisted output-surgery call\(s\)"
+)
+OVER_ALLOWLIST_FAILURE_RE = re.compile(
+    r": (?P<count>\d+) output-surgery call\(s\), allowlist max is (?P<max_count>\d+)"
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -42,9 +48,16 @@ class AllowEntry:
 
 @dataclasses.dataclass(frozen=True)
 class FailureSummary:
+    # Backward-compatible top-level counters:
+    # - unallowlisted counts calls, matching the guardrail debt metric.
+    # - over_allowlist and stale_allowlist count affected allowlist rows.
     unallowlisted: int = 0
     over_allowlist: int = 0
     stale_allowlist: int = 0
+    unallowlisted_files: int = 0
+    over_allowlist_files: int = 0
+    over_allowlist_excess_calls: int = 0
+    stale_allowlist_files: int = 0
 
 
 def iter_rust_files(base: pathlib.Path = SOURCE_ROOT):
@@ -158,12 +171,29 @@ def audit(findings: list[Finding], allowlist: dict[str, AllowEntry]) -> list[str
 def summarize_failures(failures: list[str]) -> FailureSummary:
     summary = FailureSummary()
     for failure in failures:
-        if "unallowlisted output-surgery call(s)" in failure:
-            summary = dataclasses.replace(summary, unallowlisted=summary.unallowlisted + 1)
+        if unallowlisted_match := UNALLOWLISTED_FAILURE_RE.search(failure):
+            summary = dataclasses.replace(
+                summary,
+                unallowlisted=summary.unallowlisted
+                + int(unallowlisted_match.group("count")),
+                unallowlisted_files=summary.unallowlisted_files + 1,
+            )
         elif "allowlist entry is stale" in failure:
-            summary = dataclasses.replace(summary, stale_allowlist=summary.stale_allowlist + 1)
-        elif "allowlist max is" in failure:
-            summary = dataclasses.replace(summary, over_allowlist=summary.over_allowlist + 1)
+            summary = dataclasses.replace(
+                summary,
+                stale_allowlist=summary.stale_allowlist + 1,
+                stale_allowlist_files=summary.stale_allowlist_files + 1,
+            )
+        elif over_allowlist_match := OVER_ALLOWLIST_FAILURE_RE.search(failure):
+            count = int(over_allowlist_match.group("count"))
+            max_count = int(over_allowlist_match.group("max_count"))
+            summary = dataclasses.replace(
+                summary,
+                over_allowlist=summary.over_allowlist + 1,
+                over_allowlist_files=summary.over_allowlist_files + 1,
+                over_allowlist_excess_calls=summary.over_allowlist_excess_calls
+                + max(0, count - max_count),
+            )
     return summary
 
 
@@ -272,9 +302,11 @@ def main(argv: list[str] | None = None) -> int:
         summary = summarize_failures(failures)
         print(
             "\nOutput-surgery audit summary: "
-            f"unallowlisted={summary.unallowlisted}, "
-            f"over_allowlist={summary.over_allowlist}, "
-            f"stale_allowlist={summary.stale_allowlist}",
+            f"unallowlisted_calls={summary.unallowlisted}, "
+            f"unallowlisted_files={summary.unallowlisted_files}, "
+            f"over_allowlist_files={summary.over_allowlist_files}, "
+            f"over_allowlist_excess_calls={summary.over_allowlist_excess_calls}, "
+            f"stale_allowlist_files={summary.stale_allowlist_files}",
             file=sys.stderr,
         )
         print("\nOutput-surgery audit failed:", file=sys.stderr)

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -50,17 +50,21 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         )
         self.assertEqual(failures, ["a.rs: 2 output-surgery call(s), allowlist max is 1"])
 
-    def test_failure_summary_counts_failure_classes(self):
+    def test_failure_summary_preserves_call_counts(self):
         summary = self.audit.summarize_failures(
             [
-                "a.rs: 1 unallowlisted output-surgery call(s)",
+                "a.rs: 3 unallowlisted output-surgery call(s)",
                 "b.rs: 3 output-surgery call(s), allowlist max is 2",
                 "c.rs: allowlist entry is stale; no matching calls remain",
             ]
         )
-        self.assertEqual(summary.unallowlisted, 1)
+        self.assertEqual(summary.unallowlisted, 3)
+        self.assertEqual(summary.unallowlisted_files, 1)
         self.assertEqual(summary.over_allowlist, 1)
+        self.assertEqual(summary.over_allowlist_files, 1)
+        self.assertEqual(summary.over_allowlist_excess_calls, 1)
         self.assertEqual(summary.stale_allowlist, 1)
+        self.assertEqual(summary.stale_allowlist_files, 1)
 
     def test_json_report_includes_summary_and_categories(self):
         findings = [


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / output-surgery evidence plumbing

## Invariant
When the output-surgery guard reports multiple calls in one failure row, the summary and JSON preserve the actual call count and separate it from file/allowlist-row counts.

## Scope
- `scripts/emit/audit-output-surgery.py`
- `scripts/emit/test_output_surgery_audit.py`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: guardrail-script-only; no compiler, checker, solver, parser, emitter output, benchmark fixture, or project corpus behavior changes.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `git diff --check origin/main...HEAD`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-summary.json` exits 1 as expected on current debt and now reports `unallowlisted_calls=2`, `unallowlisted_files=2`, `over_allowlist_files=0`, `over_allowlist_excess_calls=0`, `stale_allowlist_files=0`.
- `scripts/agents/ensure-agent-labels.sh --audit`
- Draft/light CI on exact head `14fa53f15f7000ba649f18540e5cb7a035e8b5cb`: `CI Light Summary`, `GitGuardian Security Checks`, `cargo-deny`, `cargo-shear`, `dist-binaries`, `gate`, `lint`, `project-row-drift`, `unit`, and `unit-cloudbuild` passed.

## Coordination Notes
- AgentName: Studio-F
- This does not touch the two unallowlisted DTS output-surgery sites; it only makes the audit artifact harder to misread while Studio-C/D emit work burns those down structurally.
- Based on current `origin/main` at commit `14fa53f15f7000ba649f18540e5cb7a035e8b5cb`.
- Marked ready after exact-head local verification and draft/light CI passed; no `merge-queue`, auto-merge, or active workflow state was changed by this branch.
