### PR TITLE
refactor(checker): route union constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/union_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/union_constraint_helpers.rs
@@ -22,7 +22,7 @@ impl<'a> CheckerState<'a> {
                 }
                 let member = self.resolve_lazy_type(member);
                 let member = self.evaluate_type_for_assignability(member);
-                self.diagnostic_relation_boolean_guard(member, constraint)
+                self.assign_relation_outcome(member, constraint).related
                     || self.satisfies_array_like_constraint(member, constraint)
             })
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -757,6 +757,9 @@ mod ts2739_alias_unfold_display_tests;
 #[path = "tests/union_call_resolution_tests.rs"]
 mod union_call_resolution_tests;
 #[cfg(test)]
+#[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
+mod union_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]
 mod union_multi_overload_unified_sig_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/union_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/union_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn base_union_constraint_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/checkers/generic_checker/union_constraint_helpers.rs")
+        .expect("failed to read union_constraint_helpers.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        1,
+        "base union member constraint checks should route the primary relation through assign_relation_outcome"
+    );
+    assert!(
+        source.contains(".related"),
+        "base union member constraint checks should use the relation outcome decision"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "base union member constraint checks should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When checker validates that every member of a union base satisfies an instantiated generic constraint for TS2344-style orchestration, checker keeps the existing per-member resolution, heritage shortcut, evaluated constraint preparation, and array-like fallback while routing the primary member-to-constraint relation decision through the shared assignability outcome boundary.

## Scope
- Route `base_union_members_satisfy_constraint` through `assign_relation_outcome(...).related` in `crates/tsz-checker/src/checkers/generic_checker/union_constraint_helpers.rs`.
- Preserve existing union-member iteration, constraint resolution/evaluation, `member_extends_constraint_heritage`, and `satisfies_array_like_constraint` fallback behavior unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / generic union constraint routing
- Evidence: architecture-only routing slice; no intended project corpus behavior change; local focused guard passed on current-base head `105a9e39350cfac1b7f6c4eed61cf4cb60afc779`.

## Verification
Passed on current-base head `105a9e39350cfac1b7f6c4eed61cf4cb60afc779`:
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib base_union_constraint_uses_relation_outcome_boundary`

Draft-light CI passed for head `105a9e39350cfac1b7f6c4eed61cf4cb60afc779`: CI Light Summary, lint, dist-binaries, unit, unit-cloudbuild, cargo-deny, cargo-shear, project-row-drift, gate, and GitGuardian Security Checks.

## Coordination Notes
- AgentName: M1-B
- Fresh worktree: `/Users/mohsen/code/tsz-m1b-union-constraint-relation-20260526`; TypeScript linked from the primary populated checkout.
- Created from current `origin/main` `1832cf6b138583ac861d4d0eaea4d5fe4b19a69e`; `origin/main` is an ancestor of head `105a9e39350cfac1b7f6c4eed61cf4cb60afc779`.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- Disjoint from #10364, #10362, #10359, #10357, #10356, #10354, #10353, #10351, #10348, #10344, #10343, #10342, and other current M1-B relation-routing PRs.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, union-member discovery, constraint fallback behavior, or diagnostic display-string decision changed.
- Ready for manager review/queue on the current head; exact-head PR checks passed and ReviewHelper may add merge-queue. Auto-merge remains off.