### PR TITLE
refactor(checker): bundle generic constraint relation routing

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/array_like_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/array_like_constraint_helpers.rs
@@ -88,7 +88,9 @@ impl<'a> CheckerState<'a> {
 
         let source_elem = self.get_element_access_type(source, TypeId::NUMBER, Some(0));
         source_elem != TypeId::ERROR
-            && (self.diagnostic_relation_boolean_guard(source_elem, target_elem)
+            && (self
+                .assign_relation_outcome(source_elem, target_elem)
+                .related
                 || ((source_elem != source || target_elem != target)
                     && self.satisfies_array_like_constraint(source_elem, target_elem)))
     }

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -44,8 +44,10 @@ impl<'a> CheckerState<'a> {
             }
             let branch = self.resolve_lazy_type(branch);
             let branch_evaluated = self.evaluate_type_for_assignability(branch);
-            self.diagnostic_relation_boolean_guard(branch, constraint)
-                || self.diagnostic_relation_boolean_guard(branch_evaluated, constraint)
+            self.assign_relation_outcome(branch, constraint).related
+                || self
+                    .assign_relation_outcome(branch_evaluated, constraint)
+                    .related
         })
     }
 

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_indexed_access_helpers.rs
@@ -2,7 +2,8 @@
 //!
 //! Extracted from `constraint_validation.rs` to keep that file under the
 //! checker per-file size guard. Behavior is unchanged except that the
-//! key-space relation guard now goes through the shared diagnostic boundary.
+//! key-space relation guard now goes through the shared relation outcome
+//! boundary.
 
 use crate::query_boundaries::checkers::generic as query;
 use crate::state::CheckerState;
@@ -109,7 +110,10 @@ impl<'a> CheckerState<'a> {
                 } else {
                     keyed_object_type
                 };
-            if !self.diagnostic_relation_boolean_guard(keyed_object_type, object_keys) {
+            if !self
+                .assign_relation_outcome(keyed_object_type, object_keys)
+                .related
+            {
                 return None;
             }
             let mut property_types: Vec<TypeId> =

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
@@ -71,13 +71,13 @@ impl<'a> CheckerState<'a> {
             let db = self.ctx.types.as_type_database();
             return query::is_callable_type(db, syntax_instantiated_type_arg)
                 || query::callable_shape_for_type(db, syntax_instantiated_type_arg).is_some()
-                || self.diagnostic_relation_boolean_guard(
-                    syntax_instantiated_type_arg,
-                    inst_constraint,
-                );
+                || self
+                    .assign_relation_outcome(syntax_instantiated_type_arg, inst_constraint)
+                    .related;
         }
 
-        self.diagnostic_relation_boolean_guard(syntax_instantiated_type_arg, inst_constraint)
+        self.assign_relation_outcome(syntax_instantiated_type_arg, inst_constraint)
+            .related
             || self.base_union_members_satisfy_constraint(
                 syntax_instantiated_type_arg,
                 inst_constraint,

--- a/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/explicit_alias_constraint_helpers.rs
@@ -29,7 +29,8 @@ impl<'a> CheckerState<'a> {
         let explicit_base_resolved = self.resolve_lazy_members_in_union(explicit_base);
         let explicit_base_for_check = self.evaluate_type_for_assignability(explicit_base_resolved);
         let inst_constraint_for_check = self.evaluate_type_for_assignability(inst_constraint);
-        self.diagnostic_relation_boolean_guard(explicit_base_for_check, inst_constraint_for_check)
+        self.assign_relation_outcome(explicit_base_for_check, inst_constraint_for_check)
+            .related
             || self.base_union_members_satisfy_constraint(
                 explicit_base_for_check,
                 inst_constraint_for_check,

--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
@@ -63,8 +63,11 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
-            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
+        self.assign_relation_outcome(restricted_evaluated, inst_constraint)
+            .related
+            || self
+                .assign_relation_outcome(restricted, inst_constraint)
+                .related
     }
 
     fn infer_result_satisfies_via_mapped_key_subset(

--- a/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
@@ -123,8 +123,12 @@ impl<'a> CheckerState<'a> {
         let true_base_evaluated = self.evaluate_type_for_assignability(true_base_resolved);
         let constraint_evaluated = self.evaluate_type_for_assignability(constraint_resolved);
         true_base_evaluated == constraint_evaluated
-            || self.diagnostic_relation_boolean_guard(true_base_evaluated, constraint_evaluated)
-            || self.diagnostic_relation_boolean_guard(true_base_resolved, constraint_resolved)
+            || self
+                .assign_relation_outcome(true_base_evaluated, constraint_evaluated)
+                .related
+            || self
+                .assign_relation_outcome(true_base_resolved, constraint_resolved)
+                .related
     }
 
     pub(super) fn constraint_check_base_type(&mut self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -121,7 +121,8 @@ impl<'a> CheckerState<'a> {
             && !children_type_is_originally_compound
             && !self.type_requires_multiple_children(children_type)
             && !self
-                .diagnostic_relation_boolean_guard(synthesized_children_type, precise_children_type)
+                .assign_relation_outcome(synthesized_children_type, precise_children_type)
+                .related
         {
             children_type = precise_children_type;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -442,6 +442,9 @@ mod architecture_contract_tests_src;
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/array_like_constraint_relation_routing_arch_tests.rs"]
+mod array_like_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/array_literal_spread_inference_widening_tests.rs"]
 mod array_literal_spread_inference_widening_tests;
 #[cfg(test)]
@@ -502,6 +505,9 @@ mod conditional_alias_unreduced_keeps_alias_display_tests;
 #[path = "tests/conditional_break_narrowing_tests.rs"]
 mod conditional_break_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/conditional_constraint_relation_routing_arch_tests.rs"]
+mod conditional_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/conditional_keyof_test.rs"]
 mod conditional_keyof_test;
 #[cfg(test)]
@@ -559,6 +565,9 @@ mod enum_residual_narrowing_tests;
 #[path = "tests/excess_prop_object_union_display_tests.rs"]
 mod excess_prop_object_union_display_tests;
 #[cfg(test)]
+#[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
+mod explicit_alias_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/file_session_switch_to_file_tests.rs"]
 mod file_session_switch_to_file_tests;
 #[cfg(test)]
@@ -609,6 +618,12 @@ mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/index_signature_value_relation_routing_arch_tests.rs"]
 mod index_signature_value_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/indexed_access_constraint_relation_routing_arch_tests.rs"]
+mod indexed_access_constraint_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/infer_conditional_relation_routing_arch_tests.rs"]
+mod infer_conditional_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
@@ -685,6 +700,9 @@ mod jsx_excess_attr_with_spread_display_tests;
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]
+#[path = "tests/jsx_single_child_precise_relation_routing_arch_tests.rs"]
+mod jsx_single_child_precise_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]
@@ -705,6 +723,9 @@ mod mapped_indexed_access_diagnostic_tests;
 #[cfg(test)]
 #[path = "tests/mapped_infer_with_substitution_tests.rs"]
 mod mapped_infer_with_substitution_tests;
+#[cfg(test)]
+#[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
+mod mapped_true_base_constraint_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
@@ -816,6 +837,9 @@ mod string_literal_union_display_order_tests;
 #[cfg(test)]
 #[path = "../tests/symbol_index_signature_tests.rs"]
 mod symbol_index_signature_tests;
+#[cfg(test)]
+#[path = "tests/syntax_constraint_relation_routing_arch_tests.rs"]
+mod syntax_constraint_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/synthetic_unique_atom_union_display_tests.rs"]
 mod synthetic_unique_atom_union_display_tests;

--- a/crates/tsz-checker/src/tests/array_like_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/array_like_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn array_like_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/array_like_constraint_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read array-like helper source");
+
+    let function_start = source
+        .find("pub(crate) fn satisfies_array_like_constraint")
+        .expect("find array-like constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn tuple_constraint_accepts_array_like_source")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "array-like element relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "the direct source-element to target-element relation should route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn conditional_result_branches_use_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/conditional_constraint_helpers.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(crate) fn conditional_result_branches_satisfy_constraint")
+        .expect("find conditional branch constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn type_alias_application_conditional_components")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "conditional branch relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "the raw and evaluated branch relations should both route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/explicit_alias_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/explicit_alias_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+#[test]
+fn explicit_alias_constraint_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/checkers/generic_checker/explicit_alias_constraint_helpers.rs")
+            .expect("failed to read explicit_alias_constraint_helpers.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        1,
+        "explicit alias constraint compatibility should route through assign_relation_outcome"
+    );
+    assert!(
+        source.contains(".related"),
+        "explicit alias constraint compatibility should use the relation outcome decision"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "explicit alias constraint compatibility should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn indexed_access_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/constraint_indexed_access_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read indexed-access helper source");
+
+    let function_start = source
+        .find("pub(super) fn constraint_check_indexed_access_value_type")
+        .expect("find indexed-access constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn concrete_indexed_access_property_union")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "indexed-access key-space relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "the keyed-object to object-keys relation should route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn infer_result_check_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/infer_conditional_constraints.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read infer conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn infer_result_satisfies_via_check_constraint")
+        .expect("find infer-result check-constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn infer_result_satisfies_via_mapped_key_subset")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "infer-result check-constraint relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "the evaluated and raw restricted relations should both route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_single_child_precise_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_single_child_precise_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_single_child_precise_type_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/jsx/children.rs");
+    let source = fs::read_to_string(&source_path).expect("read JSX children source");
+
+    let function_start = source
+        .find("pub(super) fn check_jsx_children_shape")
+        .expect("find JSX children shape helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn jsx_children_shape_diagnostic_takes_precedence")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+    let precise_branch_start = function
+        .find("if child_count == 1")
+        .expect("find single-child precise type branch");
+    let precise_branch_end = function[precise_branch_start..]
+        .find("match child_count")
+        .expect("find child count match");
+    let precise_branch = &function[precise_branch_start..precise_branch_start + precise_branch_end];
+
+    assert!(
+        !precise_branch.contains("diagnostic_relation_boolean_guard"),
+        "single JSX child precise-type fallback must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        precise_branch.matches("assign_relation_outcome").count(),
+        1,
+        "the synthesized-child to precise-children relation should route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn mapped_true_base_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/mapped_constraint_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read mapped constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn conditional_true_type_parameter_base_satisfies_constraint")
+        .expect("find conditional true base constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn constraint_check_base_type")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "conditional true-base constraint relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "evaluated and resolved true-base constraint relations should route through RelationOutcome"
+    );
+}

--- a/crates/tsz-checker/src/tests/syntax_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/syntax_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+#[test]
+fn syntax_instantiated_constraint_uses_relation_outcome_boundary() {
+    let source =
+        fs::read_to_string("src/checkers/generic_checker/constraint_syntax_instantiation.rs")
+            .expect("failed to read constraint_syntax_instantiation.rs");
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        2,
+        "syntax-instantiated constraint checks should route primary relations through assign_relation_outcome"
+    );
+    assert!(
+        source.contains(".related"),
+        "syntax-instantiated constraint checks should use the relation outcome decision"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "syntax-instantiated constraint checks should not regress to the raw boolean relation guard"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -8,8 +8,8 @@ TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
+TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
-TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/temporal.ts
@@ -19,7 +19,6 @@ TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only / semantic campaign support for checker relation diagnostics boundary cleanup.

## Invariant
When generic constraint helpers or the JSX single-child precise-type branch make relation decisions, checker preserves the existing discovery, instantiation, fallback, and diagnostic behavior while routing the primary relation decision through the shared `assign_relation_outcome(...).related` query-boundary path.

## Scope
- Bundle the M1-B generic constraint/query-common routing slices into one successor PR on `main`.
- Route syntax-instantiated, infer conditional, conditional branch, array-like, indexed access, mapped true-base, explicit alias, and JSX single-child precise relation decisions through `assign_relation_outcome`.
- Add focused source-level architecture tests for each bundled helper.
- Carry forward the accepted-regression drift alignment from #10362 in `scripts/conformance/conformance-accepted-regressions.txt`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / generic constraint query-boundary routing
- Evidence: refactor-only routing bundle; no intended project corpus behavior change. #10362's accepted-regression file change is carried forward exactly so the ready-review drift evidence is not lost.

## Verification
Passed locally on bundle head `dbada0df1b219941d55e9d93bb89330a48a56956` from `/Users/mohsen/code/tsz-bundle-m1b-query-common`:
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo nextest run -p tsz-checker --lib relation_routing_arch_tests` (34 passed, 5201 skipped)

## Coordination Notes
- AgentName: M1-B
- Ownership lane: `agent:M1-B`.
- Successor PR for bundled work: #10369.
- Bundled/superseded PRs: #10372, #10375, #10380, #10381, #10382, #10385, and #10362.
- #10362 was included because its explicit-alias constraint routing is the same generic-constraint/query-boundary family and cherry-picked safely, including its accepted-regression drift update.
- Hidden base `codex/m1b-query-common-ratchet-20260527` / `9432b438d496bd7278612e6c24640efd4950afd4` was not cherry-picked as a raw commit because current `origin/main` already contains the needed query-common boundary work via merged #10386; raw cherry-pick conflicted add/add in the already-present `assignability_relation.rs` helper, so the bundle uses `main`'s merged version.
- Resolved only safe `crates/tsz-checker/src/lib.rs` architecture-test registration overlaps while composing the bundle.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, fallback behavior, or diagnostic display-string decision changed.
- Draft status retained for light CI after the branch rewrite; auto-merge remains off.