### PR TITLE
fix(checker): canonicalize globalThis indexed access diagnostics

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -64,6 +64,19 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn typeof_global_this_indexed_key_is_missing(&self, key: &str) -> bool {
+        if key == "globalThis" {
+            return false;
+        }
+        let Some(sym_id) = self.ctx.binder.file_locals.get(key) else {
+            return true;
+        };
+        self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
+            symbol.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
+                && !symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE)
+        })
+    }
+
     pub(crate) fn is_keyof_for_current_object(
         &mut self,
         ty: TypeId,
@@ -486,6 +499,19 @@ impl<'a> CheckerState<'a> {
         let object_type = self.get_type_from_type_node(data.object_type);
         let index_type = self.get_type_from_type_node(data.index_type);
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        if crate::types_domain::type_node_helpers::is_typeof_global_this_type_node(
+            self.ctx.arena,
+            data.object_type,
+        ) && let Some(key) =
+            crate::types_domain::type_node_helpers::get_string_literal_from_type_index(
+                self.ctx.arena,
+                data.index_type,
+            )
+            && self.typeof_global_this_indexed_key_is_missing(&key)
+        {
+            return;
+        }
 
         if indexed_access_object_alias_application_exceeds_depth(self, data.object_type) {
             self.error_at_node(

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -248,9 +248,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             //     are NOT properties of typeof globalThis;
             //   - a name not bound in the file's global locals at all (e.g.
             //     the key is a quoted ambient-module name like `"mod"`).
-            if object_type == TypeId::ANY
-                && is_typeof_global_this_type_node(self.ctx.arena, indexed_access.object_type)
-            {
+            if is_typeof_global_this_type_node(self.ctx.arena, indexed_access.object_type) {
                 // In type position, the index is a LiteralType wrapping a string literal
                 if let Some(key) =
                     get_string_literal_from_type_index(self.ctx.arena, indexed_access.index_type)

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -11,7 +11,7 @@ use super::type_node::{TypeLiteralSignatureScopeUpdates, TypeNodeChecker};
 
 /// Extract the string literal text from a type-level index (e.g., `'y'` from `T['y']`).
 /// In type position, the index is a `LiteralType` node wrapping a string literal.
-pub(super) fn get_string_literal_from_type_index(
+pub(crate) fn get_string_literal_from_type_index(
     arena: &tsz_parser::parser::NodeArena,
     idx: NodeIndex,
 ) -> Option<String> {
@@ -31,7 +31,7 @@ pub(super) fn get_string_literal_from_type_index(
 
 /// Check if a type node is `typeof globalThis`, possibly wrapped in parentheses.
 /// Used to detect `(typeof globalThis)['key']` patterns in indexed access types.
-pub(super) fn is_typeof_global_this_type_node(
+pub(crate) fn is_typeof_global_this_type_node(
     arena: &tsz_parser::parser::NodeArena,
     mut node_idx: NodeIndex,
 ) -> bool {

--- a/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
@@ -85,6 +85,48 @@ const bad = g.definitelyMissingOnGlobalThis;
     );
 }
 
+#[test]
+fn typeof_globalthis_indexed_access_missing_key_reports_ts2339_only() {
+    let source = r#"
+type Missing = (typeof globalThis)["\"ambientModule\""];
+"#;
+    let diags = check_with_no_implicit_any(source);
+    let ts2339: Vec<_> = diags.iter().filter(|diag| diag.code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "missing typeof globalThis indexed key should emit one TS2339; got: {diags:#?}"
+    );
+    assert!(
+        ts2339[0]
+            .message_text
+            .contains("Property '\"ambientModule\"' does not exist on type 'typeof globalThis'"),
+        "TS2339 must keep the canonical typeof globalThis receiver; got: {}",
+        ts2339[0].message_text
+    );
+    assert_eq!(
+        count(&diags, 2536),
+        0,
+        "TS2536 should not cascade after the missing globalThis property; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn typeof_globalthis_indexed_access_keeps_declared_namespace_keys_valid() {
+    let source = r#"
+namespace renamedValue { export var val = 1; }
+namespace renamedNamespace { export type typ = 1; }
+type ValueOk = (typeof globalThis)["renamedValue"];
+type NamespaceOk = globalThis.renamedNamespace.typ;
+"#;
+    let diags = check_with_no_implicit_any(source);
+    assert_eq!(
+        count(&diags, 2339) + count(&diags, 2536),
+        0,
+        "declared global namespace/value keys should not regress; got: {diags:#?}"
+    );
+}
+
 /// Element access `globalThis['unknown']` under `--noImplicitAny` must emit
 /// TS7053. Same rationale as TS7017 above.
 #[test]

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -19,7 +19,6 @@ TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
-TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Conformance accepted-regression burn-down for module/global identity diagnostics.

## Invariant
`typeof globalThis` indexed-access types should report missing globally-visible keys through the canonical TS2339 globalThis property path. When the key is not a real global value/type/namespace property, the checker should keep the receiver display as `typeof globalThis` and avoid cascading into TS2536 for the same indexed-access type.

## Owner Layer
Owner layer: checker type-node diagnostics and indexed-access validation.

The structural fact is the AST/type-node target `typeof globalThis` plus a literal index key that is not a valid globalThis surface key. The fix reuses the existing `typeof globalThis` type-node gate, broadens it beyond the old `ANY`-only lowering case, and makes the later indexed-access checker return once that same missing-key fact has already been diagnosed.

## Scope
- Broaden the existing `typeof globalThis` indexed-access diagnostic path so synthesized global object types still render TS2339 as `typeof globalThis`.
- Prevent the follow-on indexed-access validator from emitting TS2536 for the same missing globalThis literal key.
- Add renamed positive and quoted ambient-module negative tests for `typeof globalThis` indexed-access types.
- Remove `TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts` from accepted regressions.

## Adjacent-Case Matrix
- Reported shape: `(typeof globalThis)["\"ambientModule\""]` now emits one TS2339 with receiver `typeof globalThis` and no TS2536 cascade.
- Renamed positive shape: declared `renamedValue`/`renamedNamespace` global namespace/value keys remain valid.
- Existing `globalThis` member/element access diagnostic tests still pass.
- Remaining #10350 paths were checked separately and left accepted: `importEquals2` still renders `{}` instead of `typeof import("a")`, and `esmModuleExports2` still has a TS2351 fingerprint mismatch.

## Fallback Behavior
Only literal indexed-access type nodes whose object type node is structurally `typeof globalThis` use the new early return. Other indexed-access type validation, including ordinary object types, generic key-space errors, and mapped/indexed TS2536 paths, continues through the existing checker logic.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic conformance accepted-regression / globalThis module identity TS2339 display and cascade suppression
- Evidence: conformance-only checker diagnostic change; focused `globalThisAmbientModules` conformance filter passes 1/1 on head `e69f64d4f4`, and the dashboard accepted-regression strictness drops from 30 to 29 in this PR worktree.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-checker --test global_this_property_access_diagnostics_tests typeof_globalthis`
- `cargo nextest run -p tsz-checker --test global_this_property_access_diagnostics_tests`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter globalThisAmbientModules --verbose`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- Investigation only, not removed: `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter importEquals2 --verbose` still fingerprint-fails on receiver display.
- Investigation only, not removed: `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter esmModuleExports2 --verbose` still fingerprint-fails on TS2351.

## Coordination Notes
- AgentName: M1-C
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-module-identity-20260526`, branch `codex/m1-c-module-identity-regression-20260526`, based on current `origin/main`.
- Tracks #10350 and aggregate accepted-regression tracker #10306.
- Opened as draft while light CI runs; do not auto-merge from this implementation lane.
