### PR TITLE
fix(checker): gate generator yield context by lib identity

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -1526,21 +1526,23 @@ impl<'a> CheckerState<'a> {
     /// Iterator, `AsyncIterator`, `IterableIterator`, `AsyncIterableIterator`,
     /// Iterable, `AsyncIterable`).
     fn is_generator_like_base_type(&mut self, type_id: TypeId) -> bool {
-        // Fast path: Check for Lazy types to known Generator-like types
+        if let Some(def_id) = query::lazy_def_id(self.ctx.types, type_id)
+            && let Some(sym_id) = self.ctx.def_to_symbol_id(def_id)
+            && let Some(symbol) = self.get_symbol_globally(sym_id)
         {
-            if let Some(def_id) = query::lazy_def_id(self.ctx.types, type_id) {
-                // Use def_to_symbol_id to find the symbol
-                if let Some(sym_id) = self.ctx.def_to_symbol_id(def_id)
-                    && let Some(symbol) = self.get_symbol_globally(sym_id)
-                    && Self::is_generator_like_name(&symbol.escaped_name)
-                {
-                    return true;
-                }
+            let name = symbol.escaped_name.as_str();
+            if Self::is_generator_like_name(name)
+                && (!self.ctx.has_lib_loaded()
+                    || self
+                        .ctx
+                        .sym_id_is_actual_or_cloned_lib_global_type_named(sym_id, name))
+            {
+                return true;
             }
         }
 
-        // Robust check: Resolve the global types and compare TypeIds
-        // This handles cases where the type is structural (Object/Callable) rather than a Lazy
+        // Resolve the global protocol types and compare TypeIds. A module-local
+        // alias named `Generator` is not the lib/global generator protocol.
         for name in &[
             "Generator",
             "AsyncGenerator",

--- a/crates/tsz-checker/src/context/lib_queries.rs
+++ b/crates/tsz-checker/src/context/lib_queries.rs
@@ -454,4 +454,26 @@ impl<'a> CheckerContext<'a> {
 
         self.get_file_idx_for_arena(symbol_arena.as_ref()).is_none()
     }
+
+    /// True when `sym_id` is the actual or cloned standard-library global type
+    /// symbol for `name`.
+    pub fn sym_id_is_actual_or_cloned_lib_global_type_named(
+        &self,
+        sym_id: SymbolId,
+        name: &str,
+    ) -> bool {
+        if name.contains('.') {
+            return false;
+        }
+
+        if self.actual_lib_global_type_symbol_id(name) == Some(sym_id) {
+            return true;
+        }
+
+        self.binder.lib_symbol_ids.contains(&sym_id)
+            && self
+                .binder
+                .get_symbol(sym_id)
+                .is_some_and(|symbol| symbol.escaped_name.as_str() == name)
+    }
 }

--- a/crates/tsz-checker/src/dispatch_yield.rs
+++ b/crates/tsz-checker/src/dispatch_yield.rs
@@ -30,10 +30,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         // This preserves `TYield` exactly as written (e.g. `IterableIterator<number>`
         // => `number`) even if semantic base resolution currently widens it.
         let declared_return_node = self.checker.ctx.arena.get(declared_return_type_node)?;
+        let declared_return_type = self
+            .checker
+            .get_type_from_type_node(declared_return_type_node);
         if declared_return_node.kind != syntax_kind_ext::TYPE_REFERENCE {
-            let declared_return_type = self
-                .checker
-                .get_type_from_type_node(declared_return_type_node);
             return self
                 .checker
                 .get_generator_yield_type_argument(declared_return_type);
@@ -46,7 +46,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             .arena
             .get_identifier(type_name_node)
             .map(|ident| ident.escaped_text.as_str())?;
-        if !matches!(
+        let syntactic_generator_name = matches!(
             type_name,
             "Generator"
                 | "AsyncGenerator"
@@ -54,13 +54,12 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 | "AsyncIterator"
                 | "IterableIterator"
                 | "AsyncIterableIterator"
-        ) {
-            let declared_return_type = self
-                .checker
-                .get_type_from_type_node(declared_return_type_node);
-            return self
-                .checker
-                .get_generator_yield_type_argument(declared_return_type);
+        );
+        let semantic_yield_type = self
+            .checker
+            .get_generator_yield_type_argument(declared_return_type);
+        if !syntactic_generator_name || semantic_yield_type.is_none() {
+            return semantic_yield_type;
         }
         if let Some(first_arg) = type_ref
             .type_arguments
@@ -69,11 +68,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         {
             return Some(self.checker.get_type_from_type_node(first_arg));
         }
-        let declared_return_type = self
-            .checker
-            .get_type_from_type_node(declared_return_type_node);
-        self.checker
-            .get_generator_yield_type_argument(declared_return_type)
+        semantic_yield_type
     }
 
     fn type_node_includes_undefined(&self, idx: NodeIndex) -> bool {
@@ -117,6 +112,9 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         if declared_return_node.kind != syntax_kind_ext::TYPE_REFERENCE {
             return None;
         }
+        let declared_return_type = self
+            .checker
+            .get_type_from_type_node(declared_return_type_node);
         let type_ref = self.checker.ctx.arena.get_type_ref(declared_return_node)?;
         let type_name_node = self.checker.ctx.arena.get(type_ref.type_name)?;
         let type_name = self
@@ -136,6 +134,8 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         ) {
             return None;
         }
+        self.checker
+            .get_generator_yield_type_argument(declared_return_type)?;
 
         let first_arg = type_ref.type_arguments.as_ref()?.nodes.first().copied()?;
         Some(self.type_node_includes_undefined(first_arg))

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -157,6 +157,9 @@ mod function_type_return_node_tests;
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]
+#[path = "tests/generator_yield_identity_tests.rs"]
+mod generator_yield_identity_tests;
+#[cfg(test)]
 #[path = "tests/generic_default_application_arg_preservation_tests.rs"]
 mod generic_default_application_arg_preservation_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
@@ -1,0 +1,76 @@
+//! Regression tests for generator-yield contextual typing over stable lib identity.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes_with_libs(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+#[test]
+fn local_generator_alias_does_not_contextually_type_yield_operand() {
+    let codes = strict_codes_with_libs(
+        r#"
+export {};
+
+type Generator<Y, R, N> = { fake: Y };
+
+function* gen(): Generator<(x: string) => void, void, unknown> {
+    yield x => x.toUpperCase();
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&7006),
+        "module-local Generator alias must not provide the yield contextual type; got: {codes:?}"
+    );
+}
+
+#[test]
+fn local_iterator_alias_does_not_contextually_type_yield_operand() {
+    let codes = strict_codes_with_libs(
+        r#"
+export {};
+
+type Iterator<Y, R, N> = { fake: Y };
+
+function* gen(): Iterator<(x: string) => void, void, unknown> {
+    yield x => x.toUpperCase();
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&7006),
+        "module-local Iterator alias must not provide the yield contextual type; got: {codes:?}"
+    );
+}
+
+#[test]
+fn lib_generator_identity_still_contextually_types_yield_operand() {
+    let codes = strict_codes_with_libs(
+        r#"
+function* gen(): Generator<(x: string) => void, void, unknown> {
+    yield x => x.toUpperCase();
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&7006),
+        "lib Generator identity should contextually type the yield operand; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / checker generator-yield contextual typing.

## Invariant
When a generator return annotation provides `TYield` contextual typing, tsz must use global/lib generator and iterator protocol identity. Module-local aliases with the same names must not provide lib protocol facts.

## Scope
- Gate `dispatch_yield` syntactic `TYield` extraction through semantic generator-like extraction.
- Replace the generator-like lazy-base name shortcut with symbol-provenance identity for actual/cloned lib globals, while keeping the no-lib unit-test stub path.
- Add focused regression coverage for local `Generator`/`Iterator` aliases plus positive lib `Generator` behavior.
- Sync the branch with `origin/main` at merge head `523b1ae570c2e5f07912e0658a1117030e8a3275`.

## Project Corpus Impact
- Row: n/a
- Bug family: name-only generator/iterator protocol identity shortcut
- Evidence: checker-only contextual typing regression; no project corpus row identified.

## Verification
- RED before fix: focused local repro missed `TS7006` when a module-local `Generator` alias shadowed the lib global identity.
- Original focused verification passed on the preceding semantic-adjacent base `cd7763979d`: `cargo nextest run -p tsz-checker --lib -E 'test(generator_yield_identity_tests) or test(yield_contextual_typing_flows_through_request_path)'`, `cargo check -p tsz-checker`.
- Exact-head post-`origin/main` sync on `523b1ae570c2e5f07912e0658a1117030e8a3275`: `cargo nextest run -p tsz-checker --lib -E 'test(generator_yield_identity_tests) or test(yield_contextual_typing_flows_through_request_path)'` passed: 4 tests run, 4 passed, 5207 skipped.
- Exact-head checker check on `523b1ae570c2e5f07912e0658a1117030e8a3275`: `cargo check -p tsz-checker` passed.
- Exact-head hygiene on `523b1ae570c2e5f07912e0658a1117030e8a3275`: `git diff --check` and `cargo fmt --check` passed.
- Exact-head architecture guard on `523b1ae570c2e5f07912e0658a1117030e8a3275`: `python3 scripts/arch/arch_guard.py --json` passed with `status: passed`, `total_hits: 0`.

## Coordination Notes
- AgentName: M4-D
- Fresh worktree: `/Users/mohsen/code/tsz-m4d-generator-yield-identity-20260526`, branch `codex/m4-d-generator-yield-identity-20260526`.
- This is independent of #10394, #10392, #10389, and #10377; it handles generator/iterator contextual typing identity only.
- Exact-head ready-review PR-head checks are green on `523b1ae570c2e5f07912e0658a1117030e8a3275`, including `CI Summary` and `GitGuardian Security Checks`. Enqueued with `merge-queue`; queue owns `Queue Tested` and landing.


