### PR TITLE
refactor(checker): route infer conditional constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
@@ -63,8 +63,11 @@ impl<'a> CheckerState<'a> {
         );
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, inst_constraint)
-            || self.diagnostic_relation_boolean_guard(restricted, inst_constraint)
+        self.assign_relation_outcome(restricted_evaluated, inst_constraint)
+            .related
+            || self
+                .assign_relation_outcome(restricted, inst_constraint)
+                .related
     }
 
     fn infer_result_satisfies_via_mapped_key_subset(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -589,6 +589,9 @@ mod in_narrow_bare_type_param_chained_tests;
 #[path = "tests/in_operator_relation_routing_arch_tests.rs"]
 mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/infer_conditional_relation_routing_arch_tests.rs"]
+mod infer_conditional_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/infer_conditional_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn infer_result_check_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/infer_conditional_constraints.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read infer conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn infer_result_satisfies_via_check_constraint")
+        .expect("find infer-result check-constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn infer_result_satisfies_via_mapped_key_subset")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "infer-result check-constraint relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "the evaluated and raw restricted relations should both route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When infer-result constraint validation compares an inferred candidate with its instantiated constraint, checker preserves the existing infer-base and evaluated-type-argument fallback flow while routing direct relation decisions through the shared assignability outcome boundary.

## Scope
- Route infer conditional constraint relation decisions in `crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs` through `assign_relation_outcome(...).related`.
- Preserve existing infer-base, instantiated-constraint, and evaluated type-argument fallback behavior unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / infer conditional constraint routing
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `1b5e5e0ca0131085ffca9405f209aaf8498bb9e2`.

## Verification
Passed locally on stacked head `1b5e5e0ca0131085ffca9405f209aaf8498bb9e2`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib infer_result_check_constraint_uses_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `73ce86710f5b9027eff44661b84e62b4d3621dbd`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib infer_result_check_constraint_uses_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-9238`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, infer constraint semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
