### PR TITLE
refactor(checker): route conditional branch constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -44,8 +44,10 @@ impl<'a> CheckerState<'a> {
             }
             let branch = self.resolve_lazy_type(branch);
             let branch_evaluated = self.evaluate_type_for_assignability(branch);
-            self.diagnostic_relation_boolean_guard(branch, constraint)
-                || self.diagnostic_relation_boolean_guard(branch_evaluated, constraint)
+            self.assign_relation_outcome(branch, constraint).related
+                || self
+                    .assign_relation_outcome(branch_evaluated, constraint)
+                    .related
         })
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -484,6 +484,9 @@ mod conditional_alias_unreduced_keeps_alias_display_tests;
 #[path = "tests/conditional_break_narrowing_tests.rs"]
 mod conditional_break_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/conditional_constraint_relation_routing_arch_tests.rs"]
+mod conditional_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/conditional_keyof_test.rs"]
 mod conditional_keyof_test;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn conditional_result_branches_use_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/conditional_constraint_helpers.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read conditional constraint helper source");
+
+    let function_start = source
+        .find("pub(crate) fn conditional_result_branches_satisfy_constraint")
+        .expect("find conditional branch constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn type_alias_application_conditional_components")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "conditional branch relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "the raw and evaluated branch relations should both route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When conditional result constraint validation compares evaluated or resolved branch types against a constraint, checker preserves the existing branch evaluation and fallback flow while routing direct branch relation decisions through the shared assignability outcome boundary.

## Scope
- Route conditional branch constraint relation decisions in `crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs` through `assign_relation_outcome(...).related`.
- Preserve existing evaluated/resolved branch fallback behavior and constraint recursion unchanged.
- Add a focused source-level architecture test guarding this helper against regressing to `diagnostic_relation_boolean_guard`.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / conditional branch constraint routing
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `450a6b51de548e4173da181badf23a91af67e4d5`.

## Verification
Passed locally on stacked head `450a6b51de548e4173da181badf23a91af67e4d5`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib conditional_result_branches_use_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `36ef25f136a385979e44c3ca2edb780b34ce2bb9`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib conditional_result_branches_use_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-9242`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- Supports #8227 by moving another diagnostic-bearing relation gate onto the canonical relation outcome path.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, conditional branch semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
