### PR TITLE
fix(solver): honor method bivariance policy in compat checks

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -448,6 +448,9 @@ mod query_cache_statistics_tests;
 #[path = "../tests/relation_cache_config_tests.rs"]
 mod relation_cache_config_tests;
 #[cfg(test)]
+#[path = "../tests/relation_policy_cache_agreement_tests.rs"]
+mod relation_policy_cache_agreement_tests;
+#[cfg(test)]
 #[path = "tests/solver_file_size_ceiling_tests.rs"]
 mod solver_file_size_ceiling_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -236,6 +236,8 @@ pub struct CompatChecker<'a, R: TypeResolver = NoopResolver> {
     exact_optional_property_types: bool,
     /// When true, enables additional strict subtype checking rules for lib.d.ts
     strict_subtype_checking: bool,
+    /// When true, disables TypeScript's method parameter bivariance exception.
+    disable_method_bivariance: bool,
     /// When true, skip weak type checks (TS2559) during assignability.
     /// This matches tsc's `isTypeAssignableTo` behavior which does not
     /// include the weak type check. The weak type check is only applied
@@ -280,6 +282,7 @@ impl<'a> CompatChecker<'a, NoopResolver> {
             no_unchecked_indexed_access: false,
             exact_optional_property_types: false,
             strict_subtype_checking: false,
+            disable_method_bivariance: false,
             skip_weak_type_checks: false,
             cache: FxHashMap::default(),
         }
@@ -650,6 +653,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             no_unchecked_indexed_access: false,
             exact_optional_property_types: false,
             strict_subtype_checking: false,
+            disable_method_bivariance: false,
             skip_weak_type_checks: false,
             cache: FxHashMap::default(),
         }
@@ -714,6 +718,13 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     pub fn set_strict_subtype_checking(&mut self, strict: bool) {
         if self.strict_subtype_checking != strict {
             self.strict_subtype_checking = strict;
+            self.cache.clear();
+        }
+    }
+
+    pub fn set_disable_method_bivariance(&mut self, disable: bool) {
+        if self.disable_method_bivariance != disable {
+            self.disable_method_bivariance = disable;
             self.cache.clear();
         }
     }
@@ -1652,8 +1663,10 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // Standard TypeScript allows any to propagate through arrays/objects regardless
         // of strictFunctionTypes - it only affects function parameter variance
         self.subtype.any_propagation = self.lawyer.any_propagation_mode();
-        // In strict mode, disable method bivariance for soundness
-        self.subtype.disable_method_bivariance = self.strict_subtype_checking;
+        // In strict mode, or when the policy asks explicitly, disable method
+        // bivariance for soundness.
+        self.subtype.disable_method_bivariance =
+            self.strict_subtype_checking || self.disable_method_bivariance;
     }
 
     /// Whether any recursion limit (depth or iteration count) was exceeded.

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -565,6 +565,7 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     checker.subtype.strict_function_types = policy.strict_function_types();
     checker.subtype.exact_optional_property_types = policy.exact_optional_property_types();
     checker.subtype.no_unchecked_indexed_access = policy.no_unchecked_indexed_access();
+    checker.set_disable_method_bivariance(policy.disable_method_bivariance());
     checker.subtype.disable_method_bivariance = policy.disable_method_bivariance();
     checker.subtype.allow_void_return = policy.allow_void_return();
     checker.subtype.allow_bivariant_rest = policy.allow_bivariant_rest();

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -293,7 +293,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: TypeId,
         allow_bivariant: bool,
     ) -> Option<SubtypeFailureReason> {
-        if allow_bivariant {
+        if allow_bivariant && !self.identity_cycle_check && !self.disable_method_bivariance {
             let prev = self.strict_function_types;
             self.strict_function_types = false;
             let result = self.explain_failure(source, target);

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -271,7 +271,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // In identity mode (TS2403), never use method bivariance.
         // tsc's isTypeIdenticalTo uses the identity relation which is strictly
         // bidirectional structural equality without any bivariance.
-        if allow_bivariant && !self.identity_cycle_check {
+        if allow_bivariant && !self.identity_cycle_check && !self.disable_method_bivariance {
             // Method bivariance: temporarily disable strict_function_types
             // so check_parameter_compatibility uses bivariant parameter checks.
             // This only affects parameter variance, NOT return type variance.

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -1,0 +1,97 @@
+//! Cache-enabled/cache-disabled agreement tests for behavior-changing relation
+//! policies.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::relations::subtype::AnyPropagationMode;
+use crate::types::{PropertyInfo, TypeId};
+
+#[test]
+fn subtype_cache_any_propagation_mode_matches_uncached_nested_any() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let value = interner.intern_string("value");
+
+    let source = interner.object(vec![PropertyInfo::new(value, TypeId::ANY)]);
+    let target = interner.object(vec![PropertyInfo::new(value, TypeId::OBJECT)]);
+    let all_policy = RelationPolicy::default().with_any_propagation_mode(AnyPropagationMode::All);
+    let top_level_only_policy =
+        RelationPolicy::default().with_any_propagation_mode(AnyPropagationMode::TopLevelOnly);
+
+    let all_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        all_policy,
+        RelationContext::default(),
+    );
+    let top_level_only_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        top_level_only_policy,
+        RelationContext::default(),
+    );
+
+    let all_cached = db.is_subtype_of_with_policy(source, target, all_policy);
+    let top_level_only_cached = db.is_subtype_of_with_policy(source, target, top_level_only_policy);
+    let top_level_only_cached_again =
+        db.is_subtype_of_with_policy(source, target, top_level_only_policy);
+    let top_level_uncached = query_relation(
+        &interner,
+        TypeId::ANY,
+        TypeId::OBJECT,
+        RelationKind::Subtype,
+        top_level_only_policy,
+        RelationContext::default(),
+    );
+    let top_level_cached =
+        db.is_subtype_of_with_policy(TypeId::ANY, TypeId::OBJECT, top_level_only_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        all_cached,
+        all_uncached.is_related(),
+        "cached subtype must match uncached all-depth any propagation",
+    );
+    assert_eq!(
+        top_level_only_cached,
+        top_level_only_uncached.is_related(),
+        "cached subtype must match uncached top-level-only any propagation",
+    );
+    assert_eq!(
+        top_level_only_cached_again, top_level_only_cached,
+        "second top-level-only lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        all_cached,
+        "`AnyPropagationMode::All` should allow nested `any` to satisfy `object`",
+    );
+    assert!(
+        !top_level_only_cached,
+        "top-level-only any propagation should not allow nested `any` to satisfy `object`",
+    );
+    assert_eq!(
+        top_level_cached,
+        top_level_uncached.is_related(),
+        "cached subtype must match uncached top-level `any` comparison",
+    );
+    assert!(
+        top_level_cached,
+        "top-level-only any propagation should still allow top-level `any` to satisfy `object`",
+    );
+    assert!(
+        stats.subtype_hits >= 1,
+        "second top-level-only lookup should hit the subtype cache",
+    );
+    assert!(
+        stats.subtype_misses >= 2,
+        "all-depth and top-level-only policies should miss in separate cache slots",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -175,3 +175,67 @@ fn assignability_cache_strict_function_types_matches_uncached_function_variance(
         "strict and loose variance policies should miss in separate cache slots",
     );
 }
+
+#[test]
+fn subtype_cache_allow_void_return_matches_uncached_function_return_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source = interner.function(FunctionShape::new(vec![], TypeId::STRING));
+    let target = interner.function(FunctionShape::new(vec![], TypeId::VOID));
+
+    let strict_policy = RelationPolicy::from_flags(0);
+    let allow_void_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_ALLOW_VOID_RETURN);
+
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        strict_policy,
+        RelationContext::default(),
+    );
+    let allow_void_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        allow_void_policy,
+        RelationContext::default(),
+    );
+
+    let strict_cached = db.is_subtype_of_with_policy(source, target, strict_policy);
+    let allow_void_cached = db.is_subtype_of_with_policy(source, target, allow_void_policy);
+    let strict_cached_again = db.is_subtype_of_with_policy(source, target, strict_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        strict_cached,
+        strict_uncached.is_related(),
+        "cached strict return subtype must match the uncached relation facade",
+    );
+    assert_eq!(
+        allow_void_cached,
+        allow_void_uncached.is_related(),
+        "cached allow-void return subtype must match the uncached relation facade",
+    );
+    assert_eq!(
+        strict_cached_again, strict_cached,
+        "second strict return lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        !strict_cached,
+        "strict return compatibility should reject `() => string` where `() => void` is required",
+    );
+    assert!(
+        allow_void_cached,
+        "allow-void return compatibility should accept ignored source return values",
+    );
+    assert!(
+        stats.subtype_hits >= 1,
+        "second strict return lookup should hit the subtype cache",
+    );
+    assert!(
+        stats.subtype_misses >= 2,
+        "strict and allow-void return policies should miss in separate cache slots",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -239,3 +239,72 @@ fn subtype_cache_allow_void_return_matches_uncached_function_return_policy() {
         "strict and allow-void return policies should miss in separate cache slots",
     );
 }
+
+#[test]
+fn assignability_cache_exact_optional_matches_uncached_property_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+
+    let source = interner.object(vec![PropertyInfo::new(x, TypeId::UNDEFINED)]);
+    let target = interner.object(vec![PropertyInfo::opt(x, TypeId::NUMBER)]);
+
+    let inexact_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
+    let exact_policy = RelationPolicy::from_flags(
+        RelationCacheKey::FLAG_STRICT_NULL_CHECKS
+            | RelationCacheKey::FLAG_EXACT_OPTIONAL_PROPERTY_TYPES,
+    );
+
+    let inexact_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        inexact_policy,
+        RelationContext::default(),
+    );
+    let exact_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        exact_policy,
+        RelationContext::default(),
+    );
+
+    let inexact_cached = db.is_assignable_to_with_policy(source, target, inexact_policy);
+    let exact_cached = db.is_assignable_to_with_policy(source, target, exact_policy);
+    let inexact_cached_again = db.is_assignable_to_with_policy(source, target, inexact_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        inexact_cached,
+        inexact_uncached.is_related(),
+        "cached inexact optional-property assignability must match the uncached relation facade",
+    );
+    assert_eq!(
+        exact_cached,
+        exact_uncached.is_related(),
+        "cached exact optional-property assignability must match the uncached relation facade",
+    );
+    assert_eq!(
+        inexact_cached_again, inexact_cached,
+        "second inexact optional-property lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        inexact_cached,
+        "inexact optional-property mode should allow explicit `undefined` for an optional property",
+    );
+    assert!(
+        !exact_cached,
+        "exact optional-property mode should reject explicit `undefined` for an optional property",
+    );
+    assert!(
+        stats.assignability_hits >= 1,
+        "second inexact optional-property lookup should hit the assignability cache",
+    );
+    assert!(
+        stats.assignability_misses >= 2,
+        "exact and inexact optional-property policies should miss in separate cache slots",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -377,3 +377,89 @@ fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
         "strict and permissive readonly policies should miss in separate cache slots",
     );
 }
+
+#[test]
+fn assignability_cache_disable_method_bivariance_matches_uncached_method_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let run = interner.intern_string("run");
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let dog_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let animal_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+
+    let source = interner.object(vec![PropertyInfo::method(run, dog_method)]);
+    let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
+
+    let bivariant_policy =
+        RelationPolicy::from_flags(RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16);
+    let sound_policy = RelationPolicy::from_flags(
+        (RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::DISABLE_METHOD_BIVARIANCE).bits()
+            as u16,
+    );
+
+    let bivariant_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        bivariant_policy,
+        RelationContext::default(),
+    );
+    let sound_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        sound_policy,
+        RelationContext::default(),
+    );
+
+    let bivariant_cached = db.is_assignable_to_with_policy(source, target, bivariant_policy);
+    let sound_cached = db.is_assignable_to_with_policy(source, target, sound_policy);
+    let bivariant_cached_again = db.is_assignable_to_with_policy(source, target, bivariant_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        bivariant_cached,
+        bivariant_uncached.is_related(),
+        "cached method-bivariant assignability must match the uncached relation facade",
+    );
+    assert_eq!(
+        sound_cached,
+        sound_uncached.is_related(),
+        "cached sound method assignability must match the uncached relation facade",
+    );
+    assert_eq!(
+        bivariant_cached_again, bivariant_cached,
+        "second method-bivariant lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        bivariant_cached,
+        "strict function types should still allow method parameter bivariance by default",
+    );
+    assert!(
+        !sound_cached,
+        "disabling method bivariance should reject `(dog) => void` where `(animal) => void` is required",
+    );
+    assert!(
+        stats.assignability_hits >= 1,
+        "second method-bivariant lookup should hit the assignability cache",
+    );
+    assert!(
+        stats.assignability_misses >= 2,
+        "method-bivariant and sound-method policies should miss in separate cache slots",
+    );
+}

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -8,7 +8,7 @@ use crate::relations::relation_queries::{
     RelationContext, RelationKind, RelationPolicy, query_relation,
 };
 use crate::relations::subtype::AnyPropagationMode;
-use crate::types::{PropertyInfo, TypeId};
+use crate::types::{FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, TypeId};
 
 #[test]
 fn subtype_cache_any_propagation_mode_matches_uncached_nested_any() {
@@ -93,5 +93,85 @@ fn subtype_cache_any_propagation_mode_matches_uncached_nested_any() {
     assert!(
         stats.subtype_misses >= 2,
         "all-depth and top-level-only policies should miss in separate cache slots",
+    );
+}
+
+#[test]
+fn assignability_cache_strict_function_types_matches_uncached_function_variance() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+
+    let handler_dog = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let handler_animal = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+
+    let strict_policy = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES);
+    let loose_policy = RelationPolicy::from_flags(0);
+
+    let strict_uncached = query_relation(
+        &interner,
+        handler_dog,
+        handler_animal,
+        RelationKind::Assignable,
+        strict_policy,
+        RelationContext::default(),
+    );
+    let loose_uncached = query_relation(
+        &interner,
+        handler_dog,
+        handler_animal,
+        RelationKind::Assignable,
+        loose_policy,
+        RelationContext::default(),
+    );
+
+    let strict_cached = db.is_assignable_to_with_policy(handler_dog, handler_animal, strict_policy);
+    let loose_cached = db.is_assignable_to_with_policy(handler_dog, handler_animal, loose_policy);
+    let strict_cached_again =
+        db.is_assignable_to_with_policy(handler_dog, handler_animal, strict_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        strict_cached,
+        strict_uncached.is_related(),
+        "cached strict function variance must match the uncached relation facade",
+    );
+    assert_eq!(
+        loose_cached,
+        loose_uncached.is_related(),
+        "cached loose function variance must match the uncached relation facade",
+    );
+    assert_eq!(
+        strict_cached_again, strict_cached,
+        "second strict function variance lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        !strict_cached,
+        "strict function parameter variance should reject `(dog) => void` where `(animal) => void` is required",
+    );
+    assert!(
+        loose_cached,
+        "loose function parameter variance should accept the bivariant parameter comparison",
+    );
+    assert!(
+        stats.assignability_hits >= 1,
+        "second strict lookup should hit the assignability cache",
+    );
+    assert!(
+        stats.assignability_misses >= 2,
+        "strict and loose variance policies should miss in separate cache slots",
     );
 }

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -8,7 +8,9 @@ use crate::relations::relation_queries::{
     RelationContext, RelationKind, RelationPolicy, query_relation,
 };
 use crate::relations::subtype::AnyPropagationMode;
-use crate::types::{FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, TypeId};
+use crate::types::{
+    FunctionShape, ParamInfo, PropertyInfo, RelationCacheKey, RelationFlags, TypeId,
+};
 
 #[test]
 fn subtype_cache_any_propagation_mode_matches_uncached_nested_any() {
@@ -306,5 +308,72 @@ fn assignability_cache_exact_optional_matches_uncached_property_policy() {
     assert!(
         stats.assignability_misses >= 2,
         "exact and inexact optional-property policies should miss in separate cache slots",
+    );
+}
+
+#[test]
+fn subtype_cache_strict_readonly_identity_matches_uncached_property_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+
+    let source = interner.object(vec![PropertyInfo::readonly(x, TypeId::NUMBER)]);
+    let target = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+
+    let permissive_policy = RelationPolicy::from_flags(0);
+    let strict_policy =
+        RelationPolicy::from_flags(RelationFlags::STRICT_READONLY_IDENTITY.bits() as u16);
+
+    let permissive_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        permissive_policy,
+        RelationContext::default(),
+    );
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        strict_policy,
+        RelationContext::default(),
+    );
+
+    let permissive_cached = db.is_subtype_of_with_policy(source, target, permissive_policy);
+    let strict_cached = db.is_subtype_of_with_policy(source, target, strict_policy);
+    let permissive_cached_again = db.is_subtype_of_with_policy(source, target, permissive_policy);
+    let stats = db.relation_cache_stats();
+
+    assert_eq!(
+        permissive_cached,
+        permissive_uncached.is_related(),
+        "cached permissive readonly subtype must match the uncached relation facade",
+    );
+    assert_eq!(
+        strict_cached,
+        strict_uncached.is_related(),
+        "cached strict readonly subtype must match the uncached relation facade",
+    );
+    assert_eq!(
+        permissive_cached_again, permissive_cached,
+        "second permissive readonly lookup should reuse the policy-shaped answer",
+    );
+    assert!(
+        permissive_cached,
+        "permissive readonly policy should allow a readonly property to satisfy a mutable target",
+    );
+    assert!(
+        !strict_cached,
+        "strict readonly identity should reject readonly-to-mutable property comparison",
+    );
+    assert!(
+        stats.subtype_hits >= 1,
+        "second permissive readonly lookup should hit the subtype cache",
+    );
+    assert!(
+        stats.subtype_misses >= 2,
+        "strict and permissive readonly policies should miss in separate cache slots",
     );
 }

--- a/crates/tsz-solver/tests/typescript_quirks_tests.rs
+++ b/crates/tsz-solver/tests/typescript_quirks_tests.rs
@@ -12,6 +12,7 @@
 //! - Optional property looseness
 
 use super::*;
+use crate::computation::CompatChecker;
 use crate::construction::TypeInterner;
 
 // =============================================================================
@@ -369,6 +370,45 @@ fn test_method_bivariance_disabled() {
     assert!(
         !checker.is_subtype_of(obj_with_cat_method, obj_with_animal_method),
         "With method bivariance disabled, reverse contravariance should be rejected"
+    );
+}
+
+#[test]
+fn test_method_bivariance_disabled_explain_reports_parameter_mismatch() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_strict_function_types(true);
+    checker.set_disable_method_bivariance(true);
+
+    let animal = animal_type(&interner);
+    let cat = cat_type(&interner);
+    let animal_method = method_type(&interner, animal, TypeId::VOID);
+    let cat_method = method_type(&interner, cat, TypeId::VOID);
+    let source = obj_with_method(&interner, "method", cat_method);
+    let target = obj_with_method(&interner, "method", animal_method);
+
+    assert!(
+        !checker.is_assignable(source, target),
+        "disabled method bivariance should reject a method with a narrower parameter",
+    );
+
+    let reason = checker.explain_failure(source, target);
+    let Some(SubtypeFailureReason::PropertyTypeMismatch {
+        nested_reason: Some(nested),
+        ..
+    }) = reason
+    else {
+        panic!(
+            "disabled method bivariance should explain the property mismatch under strict parameter variance: {reason:?}",
+        );
+    };
+
+    assert!(
+        matches!(
+            *nested,
+            SubtypeFailureReason::ParameterTypeMismatch { param_index: 0, .. }
+        ),
+        "method explanation should preserve the strict parameter mismatch, got {nested:?}",
     );
 }
 

--- a/crates/tsz-solver/tests/typescript_quirks_tests.rs
+++ b/crates/tsz-solver/tests/typescript_quirks_tests.rs
@@ -366,19 +366,9 @@ fn test_method_bivariance_disabled() {
         "With method bivariance disabled, methods should be contravariant in strict mode"
     );
 
-    // NOTE: The reverse direction currently also passes due to how method comparison
-    // works (is_method = source.is_method || target.is_method).
-    // This is a known behavior - methods are treated as a group where if either
-    // source or target is a method, both get method handling.
-    // This test documents the current behavior; full contravariance for methods
-    // may require additional solver refinements.
-    //
-    // TODO: Track known limitation - disable_method_bivariance doesn't fully prevent
-    // bivariance because method comparison treats source and target as a group.
-    // Consider tracking as an issue for future solver enhancement.
     assert!(
-        checker.is_subtype_of(obj_with_cat_method, obj_with_animal_method),
-        "Current behavior: reverse also passes (method comparison treats both as methods)"
+        !checker.is_subtype_of(obj_with_cat_method, obj_with_animal_method),
+        "With method bivariance disabled, reverse contravariance should be rejected"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key behavior for #8207.

## Invariant
When a behavior-affecting `RelationPolicy` setting changes a relation answer, typed `QueryCache` relation answers must match uncached `query_relation` answers, and distinct policies must not reuse the same solver cache slot.

Structural rule for the production slice: when `DISABLE_METHOD_BIVARIANCE` is set, method property parameter comparison must follow strict function variance instead of the TypeScript method-bivariance compatibility exception; this is enforced in solver relation policy plumbing.

This PR covers:
- nested `any` propagation for subtype checks
- `strictFunctionTypes` parameter variance for assignability
- `ALLOW_VOID_RETURN` return compatibility for subtype
- `EXACT_OPTIONAL_PROPERTY_TYPES` optional-property assignability
- `STRICT_READONLY_IDENTITY` readonly-property identity sensitivity for subtype checks
- `DISABLE_METHOD_BIVARIANCE` method-property assignability in compat checks

## Scope
- `crates/tsz-solver/src/lib.rs`
- `crates/tsz-solver/src/relations/compat.rs`
- `crates/tsz-solver/src/relations/relation_queries.rs`
- `crates/tsz-solver/src/relations/subtype/rules/unions.rs`
- `crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs`
- `crates/tsz-solver/tests/typescript_quirks_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: solver relation policy/cache-key correctness
- Evidence: solver-only policy behavior and targeted unit coverage; no project-corpus fixture path changed.

## Verification
- RED/GREEN `relation_policy_cache_agreement_tests::subtype_cache_any_propagation_matches_uncached_policy`: first failed on the intentionally inverted cached subtype assertion, then passed after restoring the expected policy split.
- RED/GREEN `relation_policy_cache_agreement_tests::assignability_cache_strict_function_types_matches_uncached_variance_policy`: first failed on the intentionally inverted strict-function-types assertion, then passed after restoring the expected variance split.
- RED/GREEN `relation_policy_cache_agreement_tests::subtype_cache_allow_void_matches_uncached_return_policy`: first failed on the intentionally inverted `ALLOW_VOID_RETURN` assertion, then passed after restoring the expected return-compatibility split.
- RED/GREEN `relation_policy_cache_agreement_tests::assignability_cache_exact_optional_matches_uncached_property_policy`: first failed on the intentionally inverted exact-optional-property assertion, then passed after restoring the expected optional-property split.
- RED/GREEN `relation_policy_cache_agreement_tests::subtype_cache_strict_readonly_identity_matches_uncached_property_policy`: first failed on the intentionally inverted strict-readonly assertion, then passed after restoring the expected readonly-identity split.
- RED/GREEN `relation_policy_cache_agreement_tests::assignability_cache_disable_method_bivariance_matches_uncached_method_policy`: first failed because `DISABLE_METHOD_BIVARIANCE` was ignored by the method-variance helper, then passed after the helper honored `disable_method_bivariance`.
- Ready-review CI passed on previous head `a075e910948453773c14a5132c80e1eafd56132f` before later main refreshes: CI Summary, conformance aggregate, emit, fourslash aggregate, WASM, project compile guard/canary, unit, lint, cargo-deny, cargo-shear, and GitGuardian were green.
- Refreshed onto `origin/main` `eb3ae10691736b2f8b82d85a181bee803cff5e6d`; pushed head `ef64d73ac2e4390f9ca0ddee61154f2b05db3eb7`.
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(/^relation_cache_config_tests::/) | test(/^relation_policy_cache_agreement_tests::/) | test(test_method_bivariance_even_in_strict_mode) | test(test_method_bivariance_disabled) | test(test_method_bivariance_disabled_explain_reports_parameter_mismatch) | test(test_function_property_not_bivariant) | test(test_method_bivariance_even_strict) | test(test_method_bivariance_persists_with_strict_function_types) | test(test_method_bivariance_allows_derived_methods)'` (46 passed, 6253 skipped)
- `CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets -- -D warnings`
- RED/GREEN `typescript_quirks_tests::test_method_bivariance_disabled_explain_reports_parameter_mismatch`: first failed with `nested_reason: None` while relation rejected the method property, then passed after the explain helper honored `disable_method_bivariance`.
- Pushed review-fix head `97b472990ae6a7e173acf8b86831f673a9e0c595`; ready-review CI passed on this head on 2026-05-27: CI Summary, conformance aggregate, fourslash aggregate, emit, WASM, project compile guard/canary, unit, lint, cargo-deny, cargo-shear, and GitGuardian were green. Previous head `ef64d73ac2e4390f9ca0ddee61154f2b05db3eb7` had green heavy CI but is superseded.

## Coordination Notes
- AgentName: M4-B
- Fresh worktree: `/Users/mohsen/code/tsz-m4b-cycle-cache-20260526`.
- Branch: `codex/m4-b-cycle-cache-20260526`.
- Current head is `97b472990ae6a7e173acf8b86831f673a9e0c595`, still based on `origin/main` `eb3ae10691736b2f8b82d85a181bee803cff5e6d`; latest fetched `origin/main` is `902cc1c892533049c8c25a538552b11d7089aa59`.
- Child stacked PR #10407 adds test-only coverage for the adjacent `with_strict_subtype_checking(true)` policy builder path and remains draft until this parent is through review/merge ordering.
- Ready-review CI passed on review-fix head `97b472990ae6a7e173acf8b86831f673a9e0c595`; no `WIP` label and no auto-merge. `merge-queue` label added after exact-head PR-head checks were green; `Queue Tested` is pending for the synthetic merge check.



