### PR TITLE
fix(core): preserve lib declaration arenas for shadows

### DIFF
--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -43,6 +43,9 @@ mod driver_tests_ts2307;
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]
+#[path = "../tests/lib_shadow_cli_tests.rs"]
+mod lib_shadow_cli_tests;
+#[cfg(test)]
 #[path = "../tests/reporter_tests.rs"]
 mod reporter_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/lib_shadow_cli_tests.rs
+++ b/crates/tsz-cli/tests/lib_shadow_cli_tests.rs
@@ -1,0 +1,39 @@
+use crate::args::CliArgs;
+use clap::Parser;
+
+#[test]
+fn cli_module_local_symbol_const_shadows_lib_global_value() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join("repro.ts"),
+        r#"
+export {};
+const Symbol = () => 1;
+const key = Symbol();
+type T = { [key]: string };
+declare const t: T;
+t[key].toUpperCase();
+"#,
+    )
+    .expect("write repro");
+
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2020",
+        "repro.ts",
+    ])
+    .expect("parse args");
+
+    let result = crate::driver::compile(&args, dir.path()).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|diag| diag.code).collect();
+
+    assert!(
+        !codes.contains(&2451),
+        "module-local `const Symbol` must shadow the lib global value, got diagnostics: {:#?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
+++ b/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
@@ -991,10 +991,16 @@ impl BindResultReducer {
 
                     // CRITICAL: Populate declaration_arenas for user symbols
                     for &decl_idx in &old_sym.declarations {
-                        self.declaration_arenas
+                        let source_arenas = result.declaration_arenas.get(&(old_id, decl_idx));
+                        let target = self
+                            .declaration_arenas
                             .entry((new_id, decl_idx))
-                            .or_default()
-                            .push(Arc::clone(&result.arena));
+                            .or_default();
+                        if source_arenas.is_some() {
+                            // Exact provenance was copied above; avoid adding the user arena too.
+                            continue;
+                        }
+                        target.push(Arc::clone(&result.arena));
                     }
 
                     let mut nested_merges: Vec<(SymbolId, SymbolId)> = Vec::new();


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / cross-file lib declaration provenance.

## Invariant
When a module-local declaration shadows a lib/global name while preserving the lib's other namespace meaning, merge must keep each preserved lib declaration tied to its original lib arena. A lib declaration `NodeIndex` must not be reinterpreted in the user file arena.

## Scope
- Preserve per-declaration arena provenance in `BindResultReducer` instead of attaching the user arena to declarations that already carry explicit source arenas.
- Add a CLI driver regression for module-local `const Symbol` shadowing the lib global value.
- Sync the branch with `origin/main` at merge head `f290d4361978c8d367a14fda3c318816425742d5`.

## Structural Rule
Shadow symbols may carry declarations from multiple arenas: the user declaration belongs to the source file arena, while preserved lib type/value declarations belong to lib arenas. The program merge reducer must reuse the binder-provided declaration arenas for those entries and only default to the user arena when no explicit declaration provenance exists.

## Owner Layer
`tsz-core` parallel program merge owns the `BindResult` to `MergedProgram` remapping. Binder already records the declaration provenance; checker duplicate diagnostics should consume the merged provenance without adding arena guesses.

## Adjacent-Case Matrix
- Negative: CLI compile of an external module with `const Symbol` shadowing the lib global value must not emit TS2451 against the lib `Symbol` declaration.
- Positive: declarations without explicit arena provenance still receive the user file arena during merge.
- Compatibility: checker/binder lib shadowing behavior is unchanged; this only prevents merge-time provenance pollution.

## Known Unsupported Shapes / Fallback
This PR does not alter duplicate-declaration classification or lib shadowing rules. It only fixes the declaration-arena fallback when a bind result already has exact provenance.

## Project Corpus Impact
- Row: n/a
- Bug family: lib/global shadow declaration provenance in CLI merged-program binding
- Evidence: focused CLI driver regression; no project-corpus row identified for this single-file module shadow case.

## Verification
- RED: `cargo nextest run -p tsz-cli -E 'test(cli_module_local_symbol_const_shadows_lib_global_value)'` failed before the fix with two TS2451 diagnostics on `Symbol`.
- Original focused verification passed on the preceding semantic-adjacent base `cd7763979d`: `cargo nextest run -p tsz-cli -E 'test(cli_module_local_symbol_const_shadows_lib_global_value)'`, `cargo check -p tsz-core -p tsz-cli`, direct `cargo run -q -p tsz-cli --bin tsz -- --ignoreConfig --noEmit --strict --target es2020 <temp repro.ts>`.
- Exact-head post-`origin/main` sync on `f290d4361978c8d367a14fda3c318816425742d5`: `cargo nextest run -p tsz-cli -E 'test(cli_module_local_symbol_const_shadows_lib_global_value)'` passed: 1 test run, 1 passed, 1799 skipped.
- Exact-head core/CLI check on `f290d4361978c8d367a14fda3c318816425742d5`: `cargo check -p tsz-core -p tsz-cli` passed.
- Exact-head hygiene on `f290d4361978c8d367a14fda3c318816425742d5`: `git diff --check` and `cargo fmt --check` passed.
- Exact-head architecture guard on `f290d4361978c8d367a14fda3c318816425742d5`: `python3 scripts/arch/arch_guard.py --json` passed with `status: passed`, `total_hits: 0`.

## Coordination Notes
- AgentName: M4-D
- Fresh worktree: `/Users/mohsen/code/tsz-m4d-symbol-shadow-lib-20260526`, branch `codex/m4-d-symbol-shadow-lib-20260526`.
- Started after checking M4-D owned work and open PR overlap for Symbol/lib/module identity work.
- This is independent of #10394, #10392, #10389, and #10371; it preserves exact lib declaration provenance during program merge.
- Exact-head ready-review PR-head checks are green on `f290d4361978c8d367a14fda3c318816425742d5`, including `CI Summary` and `GitGuardian Security Checks`. Enqueued with `merge-queue`; queue owns `Queue Tested` and landing.


