### PR TITLE
fix(ci): rely on queue branch push CI

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -930,7 +930,6 @@ function prepareSyntheticMerge(repository, pr, baseOid, options) {
   const mergeOid = git(["rev-parse", "HEAD"]).trim();
   if (!options.dryRun) {
     git(["push", forceWithLeaseArg(branch), "origin", `${mergeOid}:refs/heads/${branch}`], { stdio: "inherit" });
-    runGh(["workflow", "run", "ci.yml", "--repo", repository, "--ref", branch]);
   }
   return { branch, mergeOid };
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 9 / CI merge-queue tooling

## Invariant
A queue branch push must produce one authoritative synthetic `CI Summary` for the queue branch. The queue script must not enqueue a second CI run on the same ref that can cancel or supersede the push-triggered run before the required summary is written.

## Scope
- Remove the manual `gh workflow run ci.yml --ref <queue-branch>` dispatch after pushing a synthetic queue branch.
- Keep the push-triggered CI run as the single synthetic check source.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI tooling only; no compiler, checker, solver, emitter, benchmark fixture, or corpus behavior changes.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`

## Coordination Notes
- Live queue run for #10269 showed the manual dispatch and the queue-branch push competing in the same CI concurrency group. The dispatch cancelled/superseded the fast push run before `CI Summary` could become authoritative.
- This PR keeps queue semantics serial and status-based while removing the duplicate CI trigger.