### PR TITLE
fix(checker): preserve import-equals namespace display

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -801,6 +801,36 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    fn import_equals_exported_namespace_receiver_display(
+        &mut self,
+        receiver: NodeIndex,
+    ) -> Option<String> {
+        let receiver = self.ctx.arena.skip_parenthesized_and_assertions(receiver);
+        let receiver_node = self.ctx.arena.get(receiver)?;
+        if receiver_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(receiver)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        let decl_idx = symbol.value_declaration.into_option()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        if decl_node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return None;
+        }
+
+        let import_decl = self.ctx.arena.get_import_decl(decl_node)?;
+        let module_name = self.get_require_module_specifier(import_decl.module_specifier)?;
+        let declaring_file_idx = self.ctx.resolve_symbol_file_index(sym_id);
+        let exports_table =
+            self.resolve_effective_module_exports_from_file(&module_name, declaring_file_idx)?;
+        let display_module_name =
+            self.resolve_namespace_display_module_name(&exports_table, &module_name);
+        let fallback_module_name = self.imported_namespace_display_module_name(&module_name);
+        (display_module_name != fallback_module_name)
+            .then(|| format!("typeof import(\"{display_module_name}\")"))
+    }
+
     fn property_receiver_display_for_node(&mut self, type_id: TypeId, idx: NodeIndex) -> String {
         let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
         if let Some(name) = self.js_constructor_receiver_display_for_node(idx) {
@@ -827,6 +857,11 @@ impl<'a> CheckerState<'a> {
             } else {
                 class_name
             };
+        }
+        if let Some(receiver) = self.access_receiver_for_diagnostic_node(idx)
+            && let Some(display) = self.import_equals_exported_namespace_receiver_display(receiver)
+        {
+            return display;
         }
         // When the receiver has a declared type annotation, prefer the source-text
         // annotation for the property-receiver display in cases where tsz's

--- a/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
@@ -988,6 +988,60 @@ types.A;
 }
 
 #[test]
+fn test_import_equals_export_equals_type_only_namespace_display() {
+    let files = [
+        (
+            "/a.ts",
+            r#"
+class A {}
+export type { A };
+"#,
+        ),
+        (
+            "/b.ts",
+            r#"
+import * as a from "./a";
+export = a;
+"#,
+        ),
+        (
+            "/c.ts",
+            r#"
+import a = require("./b");
+new a.A();
+"#,
+        ),
+    ];
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &files,
+        "/c.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            module: ModuleKind::CommonJS,
+            es_module_interop: true,
+            no_lib: true,
+            ..Default::default()
+        },
+    );
+    let relevant: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code != 2318)
+        .collect();
+    let ts2339: Vec<_> = relevant.iter().filter(|(code, _)| *code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected one TS2339 for value access to type-only export through import-equals/export-equals namespace. Got: {relevant:#?}"
+    );
+    assert!(
+        ts2339[0]
+            .1
+            .contains("Property 'A' does not exist on type 'typeof import(\"a\")'"),
+        "Expected TS2339 receiver to preserve the original namespace import module, got: {ts2339:#?}"
+    );
+}
+
+#[test]
 fn test_named_import_from_export_equals_ambient_module_preserves_ts2454() {
     let ambient_source = r#"
 declare namespace Express {

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -22,7 +22,6 @@ TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
 TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsTypedefAndLatebound.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Conformance strictness / accepted-regression burn-down.

## Invariant
When a CommonJS import-equals namespace resolves through an `export =` alias of a namespace import whose value surface excludes type-only exports, `tsc` preserves the import-equals namespace receiver text in the TS2339 diagnostic; this PR makes tsz do the same through checker diagnostic rendering without changing solver relation behavior.

## Scope
- Preserve the original namespace module display for `import a = require("./b")` when the required module is an `export =` alias of a namespace import whose value surface excludes type-only exports.
- Add a focused checker regression covering the `importEquals2` type-only namespace export shape.
- Retire `TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts` from accepted regressions.

## Owner Layer
Checker diagnostic rendering; no solver relation behavior changes.

## Adjacent-Case Matrix
- `importEquals2`: now passes the focused conformance filter.
- Type-only namespace export: covered by `test_import_equals_export_equals_type_only_namespace_display`.
- Non-import-equals receiver display: unchanged; the helper only applies to structurally recognized import-equals require/export-equals namespace receivers.

## Fallback Behavior
If the structural lookup cannot prove a distinct exported namespace receiver display, existing property receiver display logic remains the fallback.

## Project Corpus Impact
- Row: n/a
- Bug family: TS2339 rendered/source-text diagnostic display for import-equals namespace receivers.
- Evidence: conformance-only strictness burn-down; `importEquals2` removed from accepted regressions after focused conformance passed 1/1.

## Verification
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main...HEAD`
- `python3 scripts/conformance/query-conformance.py --dashboard` (12582/12582, accepted-regression gate 29)
- `cargo nextest run -p tsz-checker --test conformance_issues_modules test_import_equals_export_equals_type_only_namespace_display`
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter importEquals2 --verbose` (1/1 passed)
- Ready-review CI was triggered after light CI passed; this body update fixes the stricter `project-corpus-pr-body` section format.

## Coordination Notes
- AgentName: M1-C.
- Fresh worktree: `/Users/mohsen/code/tsz-m1c-import-equals-display-20260526`.
- Related tracking: #10350 and #10306. `esmModuleExports2` is owned separately by draft PR #10384.
- This PR is ready for heavy CI; do not add `merge-queue` until PR-head required checks are green for head `987d1f0306bea3aa11845074867339b09b842fa0`.
