### PR TITLE
refactor(checker): route array-like constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/array_like_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/array_like_constraint_helpers.rs
@@ -88,7 +88,9 @@ impl<'a> CheckerState<'a> {
 
         let source_elem = self.get_element_access_type(source, TypeId::NUMBER, Some(0));
         source_elem != TypeId::ERROR
-            && (self.diagnostic_relation_boolean_guard(source_elem, target_elem)
+            && (self
+                .assign_relation_outcome(source_elem, target_elem)
+                .related
                 || ((source_elem != source || target_elem != target)
                     && self.satisfies_array_like_constraint(source_elem, target_elem)))
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -427,6 +427,9 @@ mod architecture_contract_tests_src;
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/array_like_constraint_relation_routing_arch_tests.rs"]
+mod array_like_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/array_literal_spread_inference_widening_tests.rs"]
 mod array_literal_spread_inference_widening_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/array_like_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/array_like_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn array_like_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/array_like_constraint_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read array-like helper source");
+
+    let function_start = source
+        .find("pub(crate) fn satisfies_array_like_constraint")
+        .expect("find array-like constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn tuple_constraint_accepts_array_like_source")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "array-like element relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "the direct source-element to target-element relation should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When array-like constraint checking validates assignability, checker preserves the existing relation outcome and diagnostic behavior while routing the decision through the relation outcome boundary instead of a direct/broad relation path.

## Scope
- Route array-like constraint checking in `crates/tsz-checker/src/checkers/generic_checker/array_like_constraint_helpers.rs` through the relation outcome boundary.
- Add a focused source-level architecture test guarding this helper against broad query-boundary/common relation calls.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / query-boundary routing ratchet
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `3085482924e5dff8134a8e9f5439abeb6ee9a2ce`.

## Verification
Passed locally on stacked head `3085482924e5dff8134a8e9f5439abeb6ee9a2ce`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib array_like_constraint_uses_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `7ba77ddd31ba0bc026499b680eb6f2c3cfac5853`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib array_like_constraint_uses_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-9245`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, array-like constraint semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
