### PR TITLE
refactor(checker): route indexed access constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_indexed_access_helpers.rs
@@ -2,7 +2,8 @@
 //!
 //! Extracted from `constraint_validation.rs` to keep that file under the
 //! checker per-file size guard. Behavior is unchanged except that the
-//! key-space relation guard now goes through the shared diagnostic boundary.
+//! key-space relation guard now goes through the shared relation outcome
+//! boundary.
 
 use crate::query_boundaries::checkers::generic as query;
 use crate::state::CheckerState;
@@ -109,7 +110,10 @@ impl<'a> CheckerState<'a> {
                 } else {
                     keyed_object_type
                 };
-            if !self.diagnostic_relation_boolean_guard(keyed_object_type, object_keys) {
+            if !self
+                .assign_relation_outcome(keyed_object_type, object_keys)
+                .related
+            {
                 return None;
             }
             let mut property_types: Vec<TypeId> =

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -589,6 +589,9 @@ mod in_narrow_bare_type_param_chained_tests;
 #[path = "tests/in_operator_relation_routing_arch_tests.rs"]
 mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/indexed_access_constraint_relation_routing_arch_tests.rs"]
+mod indexed_access_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn indexed_access_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/constraint_indexed_access_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read indexed-access helper source");
+
+    let function_start = source
+        .find("pub(super) fn constraint_check_indexed_access_value_type")
+        .expect("find indexed-access constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn concrete_indexed_access_property_union")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "indexed-access key-space relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "the keyed-object to object-keys relation should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When indexed-access constraint checking validates assignability, checker preserves the existing relation outcome and diagnostic behavior while routing the decision through the relation outcome boundary instead of a direct/broad relation path.

## Scope
- Route indexed-access constraint checking in `crates/tsz-checker/src/checkers/generic_checker/constraint_indexed_access_helpers.rs` through the relation outcome boundary.
- Add a focused source-level architecture test guarding this helper against broad query-boundary/common relation calls.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / query-boundary routing ratchet
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `8e8b3b489fc74a211ccf25cf78fc6d9d26f1f3c1`.

## Verification
Passed locally on stacked head `8e8b3b489fc74a211ccf25cf78fc6d9d26f1f3c1`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib indexed_access_constraint_uses_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `c5e1a36040c3fe7a0de46e749c18d7e0dc5f66ac`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib indexed_access_constraint_uses_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-indexed-access-constraint-20260527`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, indexed-access constraint semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
