### PR TITLE
refactor(checker): route mapped true base constraint relation

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs
@@ -123,8 +123,12 @@ impl<'a> CheckerState<'a> {
         let true_base_evaluated = self.evaluate_type_for_assignability(true_base_resolved);
         let constraint_evaluated = self.evaluate_type_for_assignability(constraint_resolved);
         true_base_evaluated == constraint_evaluated
-            || self.diagnostic_relation_boolean_guard(true_base_evaluated, constraint_evaluated)
-            || self.diagnostic_relation_boolean_guard(true_base_resolved, constraint_resolved)
+            || self
+                .assign_relation_outcome(true_base_evaluated, constraint_evaluated)
+                .related
+            || self
+                .assign_relation_outcome(true_base_resolved, constraint_resolved)
+                .related
     }
 
     pub(super) fn constraint_check_base_type(&mut self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -682,6 +682,9 @@ mod mapped_indexed_access_diagnostic_tests;
 #[path = "tests/mapped_infer_with_substitution_tests.rs"]
 mod mapped_infer_with_substitution_tests;
 #[cfg(test)]
+#[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
+mod mapped_true_base_constraint_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/mapped_true_base_constraint_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn mapped_true_base_constraint_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/mapped_constraint_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read mapped constraint helper source");
+
+    let function_start = source
+        .find("pub(super) fn conditional_true_type_parameter_base_satisfies_constraint")
+        .expect("find conditional true base constraint helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn constraint_check_base_type")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "conditional true-base constraint relation decisions must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "evaluated and resolved true-base constraint relations should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When mapped-type checking validates the true base constraint relation, checker preserves the existing relation outcome and diagnostic behavior while routing the decision through the relation outcome boundary instead of a direct/broad relation path.

## Scope
- Route mapped true-base constraint checking in `crates/tsz-checker/src/checkers/generic_checker/mapped_constraint_helpers.rs` through the relation outcome boundary.
- Add a focused source-level architecture test guarding this helper against broad query-boundary/common relation calls.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / query-boundary routing ratchet
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `423fed2ea4e70da35847ce5e39d844ee99512a04`.

## Verification
Passed locally on stacked head `423fed2ea4e70da35847ce5e39d844ee99512a04`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib mapped_true_base_constraint_uses_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `e1e733d17aab213fcf387546c000cdd4772259c9`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib mapped_true_base_constraint_uses_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-mapped-true-base-constraint-20260527`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, mapped-type constraint semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
