### PR TITLE
fix(solver): preserve reverse mapped dependent defaults

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -364,7 +364,6 @@ const checked_ = checkType_<{x: number, y: string}>()({
 }
 
 #[test]
-#[ignore = "const-generic TS2353 display requires literal TConfig inference, not upper-bound substitution — tracked as known gap"]
 fn reverse_mapped_const_generic_ts2353_omits_outer_readonly_in_target_display() {
     // `const` type-parameter inference records readonly flags on the captured
     // object literal, but tsc's TS2353 target display omits those flags at the

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -872,7 +872,11 @@ impl<'a> InferenceContext<'a> {
         let highest_priority = filtered_no_never.first().map(|c| c.priority);
         let is_contextual_inference = matches!(
             highest_priority,
-            Some(InferencePriority::ReturnType | InferencePriority::LowPriority)
+            Some(
+                InferencePriority::ReturnType
+                    | InferencePriority::LowPriority
+                    | InferencePriority::HomomorphicMappedType
+            )
         );
         let resolved = if !preserve_literals && !is_contextual_inference && !resolved.is_intrinsic()
         {

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -286,6 +286,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         &mut self,
         ctx: &mut InferenceContext,
         var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
+        source_type: TypeId,
         source_obj: &ObjectShape,
         mapped: &crate::types::MappedType,
         target_placeholder: TypeId,
@@ -301,8 +302,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
 
         let mut reverse_properties = Vec::with_capacity(source_obj.properties.len());
         let mut any_reversed = false;
+        // Fresh object literals keep their as-written literal property types in
+        // display provenance even when the canonical checking type is widened.
+        // Reverse-mapped inference needs that source surface so dependent
+        // defaults like `T["entry"]` can observe the captured literal.
+        let display_properties = self.interner.get_display_properties(source_type);
 
         for prop in &source_obj.properties {
+            let source_prop_type = display_properties
+                .as_ref()
+                .and_then(|properties| properties.iter().find(|display| display.name == prop.name))
+                .map_or(prop.type_id, |display| display.type_id);
             // Substitute the iteration parameter K with the property-key literal.
             // Bare numeric names (`{ 1: ... }`) substitute as `Number(1)`, not `"1"`.
             let key_literal = crate::utils::literal_key_for_property_name(
@@ -311,11 +321,31 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 prop.is_string_named,
             );
             let subst = TypeSubstitution::single(iter_param_name, key_literal);
-            let instantiated_template = instantiate_type(self.interner, template, &subst);
+            let mut instantiated_template = instantiate_type(self.interner, template, &subst);
+            if let Some(TypeData::IndexAccess(obj, idx)) =
+                self.interner.lookup(instantiated_template)
+                && !self.is_placeholder_match(obj, target_placeholder)
+            {
+                // Instantiated mapped constraints can resolve `T[K]` through
+                // `T`'s upper bound (`Constraint[K]`) while the inference target
+                // remains the placeholder. Rebind that upper-bound access to the
+                // placeholder so template reversal still reconstructs `T`.
+                if var_map
+                    .get(&target_placeholder)
+                    .and_then(|&var| ctx.get_constraints(var))
+                    .is_some_and(|constraints| constraints.upper_bounds.contains(&obj))
+                {
+                    instantiated_template = self.interner.index_access(target_placeholder, idx);
+                } else if let Some(TypeData::TypeParameter(info)) = self.interner.lookup(obj) {
+                    let target_subst = TypeSubstitution::single(info.name, target_placeholder);
+                    instantiated_template =
+                        instantiate_type(self.interner, instantiated_template, &target_subst);
+                }
+            }
 
             // Reverse-infer through the template: find what T[K] should be.
             let mut reversed_value = match self.reverse_infer_through_template(
-                prop.type_id,
+                source_prop_type,
                 instantiated_template,
                 target_placeholder,
             ) {
@@ -342,7 +372,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // assignability check reject `null` against `Deep<any>` so the
                     // expected TS2345 still fires (e.g. mappedTypeRecursiveInference).
                     any_reversed = true;
-                    if prop_source_has_nullish_union(self.interner, prop.type_id) {
+                    if prop_source_has_nullish_union(self.interner, source_prop_type) {
                         TypeId::ANY
                     } else {
                         TypeId::UNKNOWN

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -566,6 +566,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             && self.constrain_reverse_mapped_type(
                                 ctx,
                                 var_map,
+                                source,
                                 &source_obj,
                                 &mapped,
                                 keyof_target,

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -555,7 +555,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         // This handles homomorphic mapped types like Boxified<T> =
                         // { [P in keyof T]: Box<T[P]> }. For each source property,
                         // we reverse through the template to reconstruct T.
-                        //
                         // Following tsc's inferToMappedType, we decompose Union and
                         // Intersection constraints to find a `keyof T` member.
                         // E.g., `{ [K in keyof T & keyof Constraint]: T[K] }` has

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -7,6 +7,17 @@ use crate::types::{FunctionShape, ObjectFlags, ParamInfo, TypeData, TypeId, Type
 use rustc_hash::{FxHashMap, FxHashSet};
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
+    pub(super) fn eval_type_param_default(
+        &mut self,
+        default: TypeId,
+        subst: &TypeSubstitution,
+        actual_this_type: Option<TypeId>,
+    ) -> TypeId {
+        let instantiated =
+            super::instantiate_call_type(self.interner, default, subst, actual_this_type);
+        self.checker.evaluate_type(instantiated)
+    }
+
     pub(super) fn resolve_direct_parameter_inference_type(
         &mut self,
         lower_bounds: &[TypeId],

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -76,16 +76,6 @@ use super::{
 };
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
-    fn instantiate_and_evaluate_type_param_default(
-        &mut self,
-        default: TypeId,
-        subst: &TypeSubstitution,
-        actual_this_type: Option<TypeId>,
-    ) -> TypeId {
-        let instantiated = instantiate_call_type(self.interner, default, subst, actual_this_type);
-        self.checker.evaluate_type(instantiated)
-    }
-
     fn duplicate_single_arg_application_value_shape(&self, arg_type: TypeId) -> Option<TypeId> {
         let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
             self.interner.lookup(arg_type)
@@ -2160,7 +2150,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             {
                                 upper
                             } else if let Some(default) = tp.default {
-                                self.instantiate_and_evaluate_type_param_default(
+                                self.eval_type_param_default(
                                     default,
                                     &final_subst,
                                     actual_this_type,
@@ -2321,11 +2311,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
                 }
             } else if let Some(default) = tp.default {
-                let ty = self.instantiate_and_evaluate_type_param_default(
-                    default,
-                    &final_subst,
-                    actual_this_type,
-                );
+                let ty = self.eval_type_param_default(default, &final_subst, actual_this_type);
                 trace!(resolved_type = ?ty, "Using default type");
                 // Track that this type parameter fell back to its default.
                 // We should NOT check argument assignability against the default

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -76,6 +76,16 @@ use super::{
 };
 
 impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
+    fn instantiate_and_evaluate_type_param_default(
+        &mut self,
+        default: TypeId,
+        subst: &TypeSubstitution,
+        actual_this_type: Option<TypeId>,
+    ) -> TypeId {
+        let instantiated = instantiate_call_type(self.interner, default, subst, actual_this_type);
+        self.checker.evaluate_type(instantiated)
+    }
+
     fn duplicate_single_arg_application_value_shape(&self, arg_type: TypeId) -> Option<TypeId> {
         let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
             self.interner.lookup(arg_type)
@@ -2150,8 +2160,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             {
                                 upper
                             } else if let Some(default) = tp.default {
-                                instantiate_call_type(
-                                    self.interner,
+                                self.instantiate_and_evaluate_type_param_default(
                                     default,
                                     &final_subst,
                                     actual_this_type,
@@ -2312,8 +2321,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     }
                 }
             } else if let Some(default) = tp.default {
-                let ty =
-                    instantiate_call_type(self.interner, default, &final_subst, actual_this_type);
+                let ty = self.instantiate_and_evaluate_type_param_default(
+                    default,
+                    &final_subst,
+                    actual_this_type,
+                );
                 trace!(resolved_type = ?ty, "Using default type");
                 // Track that this type parameter fell back to its default.
                 // We should NOT check argument assignability against the default

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -11,7 +11,6 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts
 TypeScript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 TypeScript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign: reverse-mapped inference, dependent type-parameter defaults, accepted-regression strictness.

## Invariant
When a reverse-mapped target uses a property-dependent template and a later type-parameter default references an earlier inferred parameter, `tsc` keeps the source property shape and evaluates the default after earlier inference. This PR makes tsz do that through solver-owned reverse-mapped constraint matching and generic-call default evaluation.

## Scope
- `crates/tsz-solver/src/operations/constraints/reverse_mapped.rs`
- `crates/tsz-solver/src/operations/constraints/walker.rs`
- `crates/tsz-solver/src/operations/generic_call/{resolve.rs,inference_helpers.rs}`
- `crates/tsz-solver/src/inference/infer_resolve.rs`
- `crates/tsz-checker/tests/reverse_mapped_inference_tests.rs`
- `scripts/conformance/conformance-accepted-regressions.txt`

## Project Corpus Impact
- Row: n/a
- Bug family: reverse-mapped inference + dependent generic-call defaults
- Evidence: focused conformance `reverseMappedTypeIntersectionConstraint` passes and remains removed from accepted regressions; no benchmark/project row was run locally for this solver slice.

## Verification
- Rebased onto `origin/main` at `fee8384559d5eba4014e23a9a28ed5e33973f905`; current head `151e8218382e715894d22031e8367926ce1a9d01`.
- `cargo fmt --all --check`
- `python3 scripts/arch/arch_guard.py` (passed)
- `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-checker --lib reverse_mapped_dependent_default_uses_inferred_literal_not_constraint reverse_mapped_excess_property_display_matches_nested_and_asserted_branches` (2/2 passed)
- `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-checker --test reverse_mapped_inference_tests` (24/24 passed)
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter reverseMappedTypeIntersectionConstraint --verbose` (1/1 passed, fingerprint-only 0)
- `python3 scripts/conformance/query-conformance.py --dashboard` (`12582/12582`, accepted-regression gate 24)
- `git diff --check origin/main...HEAD`
- Line counts: `constraints/walker.rs` 2230, `generic_call/resolve.rs` 3378, `generic_call/inference_helpers.rs` 1894, `inference/infer_resolve.rs` 1928.

## Coordination Notes
- Refs #8707.
- Previous reviewer file-size blocker remains addressed: new helper code lives in `generic_call/inference_helpers.rs`, `walker.rs` stays flat, and `resolve.rs` is below the prior over-cap ratchet.
- The prior shared #8225/#10388 lint blocker has landed on `main`; local `arch_guard.py` now passes on this head.
- Keep draft until refreshed exact-head light CI completes green, then promote for heavy CI/manager queue review.
- No overlap with #10390; that PR is test-only coverage for #9696.
