### PR TITLE
fix(checker): preserve esm module.exports default new targets

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -803,6 +803,36 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    fn import_equals_exported_namespace_receiver_display(
+        &mut self,
+        receiver: NodeIndex,
+    ) -> Option<String> {
+        let receiver = self.ctx.arena.skip_parenthesized_and_assertions(receiver);
+        let receiver_node = self.ctx.arena.get(receiver)?;
+        if receiver_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+
+        let sym_id = self.resolve_identifier_symbol(receiver)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        let decl_idx = symbol.value_declaration.into_option()?;
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        if decl_node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return None;
+        }
+
+        let import_decl = self.ctx.arena.get_import_decl(decl_node)?;
+        let module_name = self.get_require_module_specifier(import_decl.module_specifier)?;
+        let declaring_file_idx = self.ctx.resolve_symbol_file_index(sym_id);
+        let exports_table =
+            self.resolve_effective_module_exports_from_file(&module_name, declaring_file_idx)?;
+        let display_module_name =
+            self.resolve_namespace_display_module_name(&exports_table, &module_name);
+        let fallback_module_name = self.imported_namespace_display_module_name(&module_name);
+        (display_module_name != fallback_module_name)
+            .then(|| format!("typeof import(\"{display_module_name}\")"))
+    }
+
     fn property_receiver_display_for_node(&mut self, type_id: TypeId, idx: NodeIndex) -> String {
         let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
         if let Some(name) = self.js_constructor_receiver_display_for_node(idx) {
@@ -829,6 +859,11 @@ impl<'a> CheckerState<'a> {
             } else {
                 class_name
             };
+        }
+        if let Some(receiver) = self.access_receiver_for_diagnostic_node(idx)
+            && let Some(display) = self.import_equals_exported_namespace_receiver_display(receiver)
+        {
+            return display;
         }
         // When the receiver has a declared type annotation, prefer the source-text
         // annotation for the property-receiver display in cases where tsz's

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -399,8 +399,8 @@ impl<'a> CheckerState<'a> {
                     .get_identifier(expr_node)
                     .map(|ident| ident.escaped_text.as_str())
                     .unwrap_or_default();
-                if let Some(module_name) = self
-                    .source_file_default_import_module_named(new_expr.expression, identifier_text)
+                if let Some(module_name) =
+                    self.default_import_module_for_new_target(new_expr.expression, identifier_text)
                     && let Some(ty) =
                         self.module_exports_interop_new_type(&module_name, new_expr.expression)
                 {

--- a/crates/tsz-checker/src/types/computation/complex_new_target.rs
+++ b/crates/tsz-checker/src/types/computation/complex_new_target.rs
@@ -13,6 +13,24 @@ use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    pub(crate) fn default_import_module_for_new_target(
+        &self,
+        expr_idx: NodeIndex,
+        fallback_name: &str,
+    ) -> Option<String> {
+        self.resolve_identifier_symbol(expr_idx)
+            .and_then(|sym_id| {
+                self.get_cross_file_symbol(sym_id)
+                    .or_else(|| self.ctx.binder.get_symbol(sym_id))
+                    .and_then(|symbol| {
+                        (symbol.import_name.as_deref() == Some("default"))
+                            .then(|| symbol.import_module.clone())
+                            .flatten()
+                    })
+            })
+            .or_else(|| self.source_file_default_import_module_named(expr_idx, fallback_name))
+    }
+
     pub(crate) fn type_node_contains_abstract_constructor(
         &self,
         type_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -64,6 +64,19 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    fn typeof_global_this_indexed_key_is_missing(&self, key: &str) -> bool {
+        if key == "globalThis" {
+            return false;
+        }
+        let Some(sym_id) = self.ctx.binder.file_locals.get(key) else {
+            return true;
+        };
+        self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
+            symbol.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
+                && !symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE)
+        })
+    }
+
     pub(crate) fn is_keyof_for_current_object(
         &mut self,
         ty: TypeId,
@@ -486,6 +499,19 @@ impl<'a> CheckerState<'a> {
         let object_type = self.get_type_from_type_node(data.object_type);
         let index_type = self.get_type_from_type_node(data.index_type);
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        if crate::types_domain::type_node_helpers::is_typeof_global_this_type_node(
+            self.ctx.arena,
+            data.object_type,
+        ) && let Some(key) =
+            crate::types_domain::type_node_helpers::get_string_literal_from_type_index(
+                self.ctx.arena,
+                data.index_type,
+            )
+            && self.typeof_global_this_indexed_key_is_missing(&key)
+        {
+            return;
+        }
 
         if indexed_access_object_alias_application_exceeds_depth(self, data.object_type) {
             self.error_at_node(

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -248,9 +248,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             //     are NOT properties of typeof globalThis;
             //   - a name not bound in the file's global locals at all (e.g.
             //     the key is a quoted ambient-module name like `"mod"`).
-            if object_type == TypeId::ANY
-                && is_typeof_global_this_type_node(self.ctx.arena, indexed_access.object_type)
-            {
+            if is_typeof_global_this_type_node(self.ctx.arena, indexed_access.object_type) {
                 // In type position, the index is a LiteralType wrapping a string literal
                 if let Some(key) =
                     get_string_literal_from_type_index(self.ctx.arena, indexed_access.index_type)

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -11,7 +11,7 @@ use super::type_node::{TypeLiteralSignatureScopeUpdates, TypeNodeChecker};
 
 /// Extract the string literal text from a type-level index (e.g., `'y'` from `T['y']`).
 /// In type position, the index is a `LiteralType` node wrapping a string literal.
-pub(super) fn get_string_literal_from_type_index(
+pub(crate) fn get_string_literal_from_type_index(
     arena: &tsz_parser::parser::NodeArena,
     idx: NodeIndex,
 ) -> Option<String> {
@@ -31,7 +31,7 @@ pub(super) fn get_string_literal_from_type_index(
 
 /// Check if a type node is `typeof globalThis`, possibly wrapped in parentheses.
 /// Used to detect `(typeof globalThis)['key']` patterns in indexed access types.
-pub(super) fn is_typeof_global_this_type_node(
+pub(crate) fn is_typeof_global_this_type_node(
     arena: &tsz_parser::parser::NodeArena,
     mut node_idx: NodeIndex,
 ) -> bool {

--- a/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs
@@ -988,6 +988,60 @@ types.A;
 }
 
 #[test]
+fn test_import_equals_export_equals_type_only_namespace_display() {
+    let files = [
+        (
+            "/a.ts",
+            r#"
+class A {}
+export type { A };
+"#,
+        ),
+        (
+            "/b.ts",
+            r#"
+import * as a from "./a";
+export = a;
+"#,
+        ),
+        (
+            "/c.ts",
+            r#"
+import a = require("./b");
+new a.A();
+"#,
+        ),
+    ];
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &files,
+        "/c.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            module: ModuleKind::CommonJS,
+            es_module_interop: true,
+            no_lib: true,
+            ..Default::default()
+        },
+    );
+    let relevant: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code != 2318)
+        .collect();
+    let ts2339: Vec<_> = relevant.iter().filter(|(code, _)| *code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "Expected one TS2339 for value access to type-only export through import-equals/export-equals namespace. Got: {relevant:#?}"
+    );
+    assert!(
+        ts2339[0]
+            .1
+            .contains("Property 'A' does not exist on type 'typeof import(\"a\")'"),
+        "Expected TS2339 receiver to preserve the original namespace import module, got: {ts2339:#?}"
+    );
+}
+
+#[test]
 fn test_named_import_from_export_equals_ambient_module_preserves_ts2454() {
     let ambient_source = r#"
 declare namespace Express {

--- a/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
@@ -85,6 +85,48 @@ const bad = g.definitelyMissingOnGlobalThis;
     );
 }
 
+#[test]
+fn typeof_globalthis_indexed_access_missing_key_reports_ts2339_only() {
+    let source = r#"
+type Missing = (typeof globalThis)["\"ambientModule\""];
+"#;
+    let diags = check_with_no_implicit_any(source);
+    let ts2339: Vec<_> = diags.iter().filter(|diag| diag.code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "missing typeof globalThis indexed key should emit one TS2339; got: {diags:#?}"
+    );
+    assert!(
+        ts2339[0]
+            .message_text
+            .contains("Property '\"ambientModule\"' does not exist on type 'typeof globalThis'"),
+        "TS2339 must keep the canonical typeof globalThis receiver; got: {}",
+        ts2339[0].message_text
+    );
+    assert_eq!(
+        count(&diags, 2536),
+        0,
+        "TS2536 should not cascade after the missing globalThis property; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn typeof_globalthis_indexed_access_keeps_declared_namespace_keys_valid() {
+    let source = r#"
+namespace renamedValue { export var val = 1; }
+namespace renamedNamespace { export type typ = 1; }
+type ValueOk = (typeof globalThis)["renamedValue"];
+type NamespaceOk = globalThis.renamedNamespace.typ;
+"#;
+    let diags = check_with_no_implicit_any(source);
+    assert_eq!(
+        count(&diags, 2339) + count(&diags, 2536),
+        0,
+        "declared global namespace/value keys should not regress; got: {diags:#?}"
+    );
+}
+
 /// Element access `globalThis['unknown']` under `--noImplicitAny` must emit
 /// TS7053. Same rationale as TS7017 above.
 #[test]

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -9,12 +9,9 @@ TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElabora
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
-TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C
Owner lane: M1-C (`agent:M1-C`)
Bundling coordinator: Studio-F

## Track
Conformance strictness / accepted-regression burn-down for the M1-C module identity and diagnostic display family.

## Invariant
When module identity facts flow into checker diagnostics, tsz should preserve the same user-facing receiver or constructability surface that `tsc` reports without changing solver relation behavior:

- `typeof globalThis` indexed-access types with missing global keys report the canonical TS2339 `typeof globalThis` property path and do not cascade into TS2536 for the same missing literal key.
- CommonJS `import = require(...)` receivers that resolve through an `export =` namespace alias preserve the import-equals namespace receiver display in TS2339.
- Node20/NodeNext CommonJS-mode default imports from ESM modules with a `"module.exports"` export resolve the `new` target through that value and report TS2351 when it is not constructable.

## Scope
- `crates/tsz-checker/src/error_reporter/properties.rs`
- `crates/tsz-checker/src/types/computation/complex.rs`
- `crates/tsz-checker/src/types/computation/complex_new_target.rs`
- `crates/tsz-checker/src/types/type_checking/indexed_access.rs`
- `crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs`
- `crates/tsz-checker/src/types/type_node_helpers.rs`
- `crates/tsz-checker/tests/conformance_issues/modules/package_resolution.rs`
- `crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs`
- `scripts/conformance/conformance-accepted-regressions.txt`

## Owner Layer
Checker diagnostic rendering and checker new-target orchestration. The bundled changes reuse binder/checker symbol and module facts, keep relation and constructability decisions on existing shared helper paths, and do not introduce solver relation behavior changes.

## Bundled PRs
- #10384 `fix(checker): preserve esm module.exports default new targets`, original head `d30499872827732ed3226888b731e01c575cc146`.
- #10370 `fix(checker): canonicalize globalThis indexed access diagnostics`, original head `e69f64d4f4fd714049466d828049abbf102e70c4`.
- #10379 `fix(checker): preserve import-equals namespace display`, original head `987d1f0306bea3aa11845074867339b09b842fa0`.

## Adjacent-Case Matrix
- `(typeof globalThis)["\"ambientModule\""]` emits one TS2339 with receiver `typeof globalThis`; declared global value/namespace keys remain valid.
- `import a = require("./b")` with an `export =` namespace alias preserves `typeof import("...")` receiver display when the effective exported namespace differs from the fallback display.
- `import Foo from "./exporter.mjs"; new Foo();` uses symbol-backed default-import module facts before falling back to source-file import scanning.
- Existing require-style alias, namespace import, ordinary indexed-access, and non-import-equals receiver paths continue through the previous fallback behavior.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic conformance accepted-regression / module identity display and Node ESM `"module.exports"` constructability diagnostics.
- Evidence: conformance-only checker diagnostic changes; focused checker tests and focused conformance filters for `globalThisAmbientModules`, `importEquals2`, and `esmModuleExports2` passed locally on refreshed head `382e5bd1fc4452b6f927877281f8d9085ae28614`. The accepted-regression list removes those three retained paths.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/conformance/query-conformance.py --dashboard` (12582/12582, accepted-regression gate: 15 listed tests)
- `cargo nextest run -p tsz-checker --test global_this_property_access_diagnostics_tests typeof_globalthis` (4 passed)
- `cargo nextest run -p tsz-checker --test conformance_issues_modules test_import_equals_export_equals_type_only_namespace_display` (1 passed)
- `cargo nextest run -p tsz-checker --test conformance_issues_features test_esm_module_exports_default_import_uses_module_exports_value` (1 passed)
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter globalThisAmbientModules --verbose` (1/1 passed, fingerprint-only 0)
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter importEquals2 --verbose` (1/1 passed, fingerprint-only 0)
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter esmModuleExports2 --verbose` (1/1 passed, fingerprint-only 0)
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

## Coordination Notes
- AgentName: M1-C
- Bundling coordinator: Studio-F.
- Refreshed from stale conflicting head `cf000e548842ebecdcae66ab3d7617187d6263dc` to current `origin/main` and force-pushed head `382e5bd1fc4452b6f927877281f8d9085ae28614`.
- The rebase conflict was limited to `scripts/conformance/conformance-accepted-regressions.txt`; the resolution preserved current `main` and removed only `globalThisAmbientModules.ts`, `importEquals2.ts`, and `esmModuleExports2.ts`.
- Kept this PR as draft after the refresh so draft light CI can validate the rewritten head before it is marked ready for heavy CI.
- No merge-queue requested.

