### PR TITLE
refactor(checker): route jsx single child relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -121,7 +121,8 @@ impl<'a> CheckerState<'a> {
             && !children_type_is_originally_compound
             && !self.type_requires_multiple_children(children_type)
             && !self
-                .diagnostic_relation_boolean_guard(synthesized_children_type, precise_children_type)
+                .assign_relation_outcome(synthesized_children_type, precise_children_type)
+                .related
         {
             children_type = precise_children_type;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -661,6 +661,9 @@ mod jsx_excess_attr_with_spread_display_tests;
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]
+#[path = "tests/jsx_single_child_precise_relation_routing_arch_tests.rs"]
+mod jsx_single_child_precise_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_single_child_precise_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_single_child_precise_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_single_child_precise_type_uses_relation_outcome_boundary() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/jsx/children.rs");
+    let source = fs::read_to_string(&source_path).expect("read JSX children source");
+
+    let function_start = source
+        .find("pub(super) fn check_jsx_children_shape")
+        .expect("find JSX children shape helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    pub(super) fn jsx_children_shape_diagnostic_takes_precedence")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+    let precise_branch_start = function
+        .find("if child_count == 1")
+        .expect("find single-child precise type branch");
+    let precise_branch_end = function[precise_branch_start..]
+        .find("match child_count")
+        .expect("find child count match");
+    let precise_branch = &function[precise_branch_start..precise_branch_start + precise_branch_end];
+
+    assert!(
+        !precise_branch.contains("diagnostic_relation_boolean_guard"),
+        "single JSX child precise-type fallback must use the shared relation outcome boundary"
+    );
+    assert_eq!(
+        precise_branch.matches("assign_relation_outcome").count(),
+        1,
+        "the synthesized-child to precise-children relation should route through RelationOutcome"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / checker relation diagnostics boundary cleanup.

## Invariant
When JSX single-child contextual checking needs the precise child type, checker preserves the existing relation outcome and diagnostic behavior while routing the relation decision through the assignability query-boundary helper instead of a broad checker-local relation path.

## Scope
- Route JSX single-child precise-type relation checking in `crates/tsz-checker/src/checkers/jsx/children.rs` through the relation outcome boundary.
- Add a focused source-level architecture test guarding the JSX helper against broad query-boundary/common relation calls.
- Restack this PR on #10386 (`codex/m1b-query-common-ratchet-20260527`) after #10386 moved to head `9432b438d496bd7278612e6c24640efd4950afd4`.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostics / query-boundary routing ratchet
- Evidence: refactor-only routing slice; no intended project corpus behavior change; local architecture guards and focused checker guard passed on stacked head `5b120057167de8767cfe35c043d1b6acf640a2a1`.

## Verification
Passed locally on stacked head `5b120057167de8767cfe35c043d1b6acf640a2a1`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib jsx_single_child_precise_type_uses_relation_outcome_boundary`

Previously passed after rebasing onto old #10386 head `904e1a31f9725dcec7f323a57abc7089339a9948`, on head `5510a2424b33435695557af7a3c9d1d362e5290c`:
- `cargo fmt --check`
- `git diff --check origin/codex/m1b-query-common-ratchet-20260527..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo nextest run -p tsz-checker --lib jsx_single_child_precise_type_uses_relation_outcome_boundary`

## Coordination Notes
- AgentName: M1-B
- Existing worktree: `/Users/mohsen/code/tsz-m1b-9922`; TypeScript linked from the primary populated checkout.
- Stacked on #10386 (`codex/m1b-query-common-ratchet-20260527`) so the base branch can land first.
- No solver policy, variance mode, any-propagation, relation cache-key behavior, JSX child semantics, or diagnostic display-string decision changed.
- Draft for light CI only; merge queue and auto-merge intentionally left off.
