### PR TITLE
test(checker): cover inline conditional false branches

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -674,6 +674,10 @@ name = "inline_conditional_infer_return_tests"
 path = "tests/inline_conditional_infer_return_tests.rs"
 
 [[test]]
+name = "inline_conditional_generic_ref_infer_false_branch_tests"
+path = "tests/inline_conditional_generic_ref_infer_false_branch_tests.rs"
+
+[[test]]
 name = "recursive_conditional_mapped_infer_tests"
 path = "tests/recursive_conditional_mapped_infer_tests.rs"
 

--- a/crates/tsz-checker/tests/inline_conditional_generic_ref_infer_false_branch_tests.rs
+++ b/crates/tsz-checker/tests/inline_conditional_generic_ref_infer_false_branch_tests.rs
@@ -1,0 +1,92 @@
+//! Regression tests for #9696.
+//!
+//! Structural rule: when an inline conditional return type checks an inferred
+//! type parameter against a generic type reference containing `infer` and the
+//! relation is false, the false branch must substitute the inferred parameter.
+
+use tsz_checker::test_utils::check_source_strict;
+
+fn assert_ts2322(source: &str, label: &str) {
+    let diagnostics = check_source_strict(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect();
+    assert!(
+        !ts2322.is_empty(),
+        "[{label}] expected TS2322 from the false branch result, got diagnostics: {diagnostics:#?}"
+    );
+}
+
+fn assert_ts2322_with_default_libs(source: &str, label: &str) {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    );
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect();
+    assert!(
+        !ts2322.is_empty(),
+        "[{label}] expected TS2322 from the false branch result, got diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn inline_promise_infer_false_branch_preserves_inferred_argument() {
+    let source = r#"
+declare function unwrap<Input>(value: Input): Input extends Promise<infer Value> ? Value : Input;
+
+const result = unwrap(42);
+const bad: string = result;
+"#;
+
+    assert_ts2322_with_default_libs(source, "Promise<infer Value> false branch");
+}
+
+#[test]
+fn inline_generic_ref_infer_false_branch_preserves_inferred_argument() {
+    let source = r#"
+interface Holder<Item> { value: Item; }
+declare function unwrap<Input>(value: Input): Input extends Holder<infer Value> ? Value : Input;
+
+const result = unwrap("hello");
+const bad: number = result;
+"#;
+
+    assert_ts2322(source, "Holder<infer Value> false branch");
+}
+
+#[test]
+fn inline_multi_arg_generic_ref_infer_false_branch_preserves_inferred_argument() {
+    let source = r#"
+interface Pair<Left, Right> { left: Left; right: Right; }
+declare function choose<Candidate>(value: Candidate): Candidate extends Pair<string, infer Picked> ? Picked : Candidate;
+
+const result = choose(99);
+const bad: string = result;
+"#;
+
+    assert_ts2322(source, "Pair<string, infer Picked> false branch");
+}
+
+#[test]
+fn named_alias_form_still_preserves_false_branch() {
+    let source = r#"
+interface Wrapper<Element> { element: Element; }
+type Unwrap<Subject> = Subject extends Wrapper<infer Inner> ? Inner : Subject;
+declare function convert<Given>(value: Given): Unwrap<Given>;
+
+const result = convert(true);
+const bad: string = result;
+"#;
+
+    assert_ts2322(source, "named alias false branch");
+}


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Semantic campaign test coverage for inline conditional/infer evaluation (#9696).

## Invariant
When an inline conditional return type checks an inferred type parameter against a generic type reference containing `infer` and the relation is false, `tsc` substitutes the inferred parameter into the false branch. This PR records that behavior through checker integration tests; it does not change solver or checker behavior because current `origin/main` already passes the repro.

## Scope
- Adds `inline_conditional_generic_ref_infer_false_branch_tests`.
- Registers the new explicit integration-test target in `crates/tsz-checker/Cargo.toml`.

## Project Corpus Impact
- Row: n/a
- Bug family: inline conditional generic-reference `infer` false branch
- Evidence: test-only coverage; no project corpus row is changed by this branch. Current `origin/main` already reports TS2322 for the #9696 repro matrix.

## Verification
- Rebased onto `origin/main` at `fee8384559d5eba4014e23a9a28ed5e33973f905`; current head `26ee51095a2483f264a082ab07ea4459b6cbba09`.
- `cargo fmt --all --check`
- `scripts/safe-run.sh --limit 50% -- cargo nextest run -p tsz-checker --test inline_conditional_generic_ref_infer_false_branch_tests` (4/4 passed)
- `git diff --check origin/main...HEAD`
- Line counts: `crates/tsz-checker/Cargo.toml` 1721 lines; new test file 92 lines.

## Coordination Notes
- Refs #9696.
- The reported behavior appears already resolved on current `origin/main`, likely by `d2f0bff47a fix(checker): evaluate inline conditional infer returns (#10292)`.
- Reviewer found no blocker on the prior head; the prior CI red was inherited from the shared #8225/#10388 lint blocker, now resolved on `main`.
- This is a test-only closure path and does not overlap #10383, which is the reverse-mapped solver slice for #8707.
