### PR TITLE
fix(checker): preserve merged lib generic defaults

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1060,15 +1060,40 @@ impl<'a> CheckerContext<'a> {
     /// let params = vec![TypeParamInfo { name: "T", ... }];
     /// ctx.insert_def_type_params(def_id, params);
     /// ```
-    pub fn insert_def_type_params(&self, def_id: DefId, params: Vec<tsz_solver::TypeParamInfo>) {
-        if !params.is_empty() {
-            // Sync type params into the DefinitionStore so the TypeFormatter
-            // can display generic types with their type parameter names
-            // (e.g., `MyClass<T>` instead of just `MyClass`).
-            self.definition_store
-                .set_type_params(def_id, params.clone());
-            self.def_type_params.borrow_mut().insert(def_id, params);
+    pub fn insert_def_type_params(
+        &self,
+        def_id: DefId,
+        mut params: Vec<tsz_solver::TypeParamInfo>,
+    ) {
+        if params.is_empty() {
+            return;
         }
+
+        let existing = self
+            .def_type_params
+            .borrow()
+            .get(&def_id)
+            .cloned()
+            .or_else(|| self.definition_store.get_type_params(def_id));
+        if let Some(existing) = existing
+            && existing.len() == params.len()
+        {
+            for (param, existing_param) in params.iter_mut().zip(existing) {
+                if param.constraint.is_none() {
+                    param.constraint = existing_param.constraint;
+                }
+                if param.default.is_none() {
+                    param.default = existing_param.default;
+                }
+            }
+        }
+
+        // Sync type params into the DefinitionStore so the TypeFormatter
+        // can display generic types with their type parameter names
+        // (e.g., `MyClass<T>` instead of just `MyClass`).
+        self.definition_store
+            .set_type_params(def_id, params.clone());
+        self.def_type_params.borrow_mut().insert(def_id, params);
     }
 
     /// Get type parameters for a `DefId`.

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part2.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part2.rs
@@ -13,6 +13,109 @@
         }
         resolved
     }
+
+    fn resolved_options_for_esnext_sharedmemory_strict_test() -> ResolvedCompilerOptions {
+        let mut args = default_cli_args_for_test();
+        args.ignore_config = true;
+        args.strict = true;
+        args.no_emit = true;
+        args.target = Some(crate::args::Target::EsNext);
+        args.lib = Some(vec!["es2023".to_string(), "es2024.sharedmemory".to_string()]);
+
+        let mut resolved = crate::config::resolve_compiler_options(None)
+            .expect("resolve default compiler options");
+        crate::driver::apply_cli_overrides(&mut resolved, &args).expect("apply cli overrides");
+        if matches!(resolved.printer.module, ModuleKind::None) {
+            resolved.printer.module = ModuleKind::ESNext;
+            resolved.checker.module = ModuleKind::ESNext;
+        }
+        resolved
+    }
+
+    #[test]
+    fn test_compile_inner_program_accepts_atomics_wait_async_bigint_sharedarraybuffer() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file_path = dir.path().join("main.ts");
+        std::fs::write(
+            &file_path,
+            r#"
+const sab64 = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT * 1024);
+const int64 = new BigInt64Array(sab64);
+const { async: async64, value: value64 } = Atomics.waitAsync(int64, 0, BigInt(0));
+
+async function main() {
+    if (async64) {
+        await value64;
+    }
+}
+"#,
+        )
+        .expect("write source");
+
+        let resolved = resolved_options_for_esnext_sharedmemory_strict_test();
+        let file_paths = vec![file_path];
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            module_resolutions: _,
+            type_reference_errors,
+            resolution_mode_errors,
+            ..
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        let diagnostics = collect_diagnostics(
+            &CollectDiagnosticsInput {
+                program: &program,
+                options: &resolved,
+                base_dir: dir.path(),
+                checker_libs: &checker_libs,
+                typescript_dom_replacement_globals: (false, false, false),
+                has_deprecation_diagnostics: false,
+                collect_compile_stats: false,
+            },
+            None,
+            &type_cache_output,
+        )
+        .diagnostics;
+
+        assert!(
+            diagnostics.iter().all(|diag| diag.code != 2769),
+            "Did not expect TS2769 for Atomics.waitAsync with BigInt64Array<SharedArrayBuffer>, got: {diagnostics:?}"
+        );
+    }
+
     #[test]
     fn test_compile_inner_program_build_promise_is_assignable_to_promise_like() {
         let dir = tempfile::TempDir::new().expect("temp dir");

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -12,6 +12,20 @@ use tsz_solver::types::{
 };
 
 impl<'a> TypeLowering<'a> {
+    fn lower_lazy_def_reference(&self, def_id: tsz_solver::def::DefId) -> TypeId {
+        let lazy = self.interner.lazy(def_id);
+        if let Some(resolve_params) = self.lazy_type_params_resolver
+            && let Some(type_params) = resolve_params(def_id)
+            && !type_params.is_empty()
+            && type_params.iter().all(|param| param.default.is_some())
+            && let Some(default_args) =
+                tsz_solver::computation::fill_application_defaults(self.interner, &[], &type_params)
+        {
+            return self.interner.application(lazy, default_args);
+        }
+        lazy
+    }
+
     /// Lower a conditional type (T extends U ? X : Y)
     pub(super) fn lower_conditional_type(&self, node_idx: NodeIndex) -> TypeId {
         let node = match self.arena.get(node_idx) {
@@ -569,6 +583,13 @@ impl<'a> TypeLowering<'a> {
                     args.nodes.iter().map(|&idx| self.lower_type(idx)).collect();
                 let type_symbol = self.resolve_type_symbol(data.type_name);
                 let value_symbol = self.resolve_value_symbol(data.type_name);
+                let base_type = if let Some(tsz_solver::TypeData::Application(app_id)) =
+                    self.interner.lookup(base_type)
+                {
+                    self.interner.type_application(app_id).base
+                } else {
+                    base_type
+                };
                 let base_type = if type_symbol.is_some() && base_type != TypeId::ERROR {
                     base_type
                 } else if base_type == TypeId::ERROR {
@@ -756,7 +777,7 @@ impl<'a> TypeLowering<'a> {
             if self.preferred_self_name.as_deref() == Some(name.as_ref())
                 && let Some(def_id) = self.preferred_self_def_id
             {
-                return self.interner.lazy(def_id);
+                return self.lower_lazy_def_reference(def_id);
             }
 
             // Must resolve to DefId.
@@ -769,25 +790,25 @@ impl<'a> TypeLowering<'a> {
                 if let Some(scoped_name) = self.scoped_identifier_name_text(node_idx)
                     && let Some(def_id) = self.resolve_def_id_by_name(&scoped_name)
                 {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
                 if let Some(def_id) = self.resolve_def_id_by_name(name) {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
                 if let Some(def_id) = self.resolve_def_id(node_idx) {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
             } else {
                 if let Some(def_id) = self.resolve_def_id(node_idx) {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
                 if let Some(scoped_name) = self.scoped_identifier_name_text(node_idx)
                     && let Some(def_id) = self.resolve_def_id_by_name(&scoped_name)
                 {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
                 if let Some(def_id) = self.resolve_def_id_by_name(name) {
-                    return self.interner.lazy(def_id);
+                    return self.lower_lazy_def_reference(def_id);
                 }
             }
 

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -9,7 +9,6 @@ TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElabora
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
-TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C

## Track
Semantic campaign: accepted-regression burn-down / lib generic default metadata.

## Invariant
When a generic declaration is merged across declaration shards and a later shard omits metadata that an earlier shard supplied, tsz preserves the complete merged type-parameter metadata; bare references to all-default generic declarations lower as defaulted applications through the lowering layer.

## Scope
- Preserve existing type-parameter defaults/constraints when registering metadata for an already-known `DefId`.
- Lower bare lazy generic references with all-default parameters as defaulted applications.
- Add a driver repro for `Atomics.waitAsync` with `BigInt64Array` under `--lib es2023,es2024.sharedmemory`.
- Remove `TypeScript/tests/cases/conformance/es2024/sharedMemory.ts` from accepted regressions.

## Owner Layer
- Metadata preservation belongs in checker context `DefId` bookkeeping because the stale state is registered before relation checks run.
- Bare-reference default application belongs in lowering because the syntactic type reference has no explicit type arguments and should enter solver relations already carrying declaration defaults.
- Relation/compat fallback code is intentionally untouched.

## Adjacent-Case Matrix
- Later lib declaration omits a default already supplied by an earlier declaration: preserved by merge-on-register rather than overwrite.
- Later declaration omits a constraint already supplied by an earlier declaration: same merge rule preserves the constraint.
- Explicit type arguments on a generic reference: lowering unwraps defaulted bare applications back to the base before applying explicit args, so explicit args remain authoritative.
- Non-generic or partially defaulted declarations: fall back to the existing lazy reference path; no synthetic args are introduced.

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression / merged lib generic defaults
- Evidence: focused conformance filter `sharedMemory` passes on refreshed head `2c7d939e92ae16a10917a4c9ec839af74fbd2be5`; no project-corpus row touched.

## Verification
Exact refreshed head: `2c7d939e92ae16a10917a4c9ec839af74fbd2be5`.
Base: `origin/main` at `1d43c855784b1dca3b9be686c3f399866371638e`.

Local checks on exact head:
- `cargo fmt --check` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python3 scripts/arch/arch_guard.py` -> passed
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12582/12582`, accepted-regression gate `14 listed tests`
- `cargo nextest run -p tsz-cli --lib test_compile_inner_program_accepts_atomics_wait_async_bigint_sharedarraybuffer` -> 1 passed
- `scripts/safe-run.sh --limit 50% -- ./scripts/conformance/conformance.sh run --filter sharedMemory --verbose` -> `FINAL RESULTS: 1/1 passed (100.0%)`, fingerprint-only 0
- `scripts/safe-run.sh --limit 50% -- cargo clippy --profile ci-lint -p tsz-checker -p tsz-lowering --all-targets -- -D warnings` -> passed

## Coordination Notes
- AgentName: M1-C
- Worktree: `/Users/mohsen/code/tsz-m1c-shared-memory-20260527`.
- Coordinates with #10306 by retiring the `sharedMemory.ts` accepted-regression path.
- Refreshed from stale conflicting head `709f6a4df2843852e06abe1a37862c358ae7ca3d` onto current `origin/main` and force-pushed head `2c7d939e92ae16a10917a4c9ec839af74fbd2be5`.
- The accepted-list conflict was resolved by preserving current `main` and removing only `TypeScript/tests/cases/conformance/es2024/sharedMemory.ts`.
- The PR diff against `main` remains the intended four files only.
- This PR intentionally avoids relation fallback changes and does not overlap M1-B relation-boundary refactor PRs.
- Ready for PR-head CI and manager queue review once exact-head checks are green.
