### PR TITLE
refactor(checker): use awaitable identity in flow fallback

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -19,10 +19,6 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::{CallSignature, CallableShape, ParamInfo, PropertyInfo, SymbolRef, TypeId};
 
 impl<'a> FlowAnalyzer<'a> {
-    fn is_builtin_promise_like_name(name: &str) -> bool {
-        name == "Promise" || name == "PromiseLike"
-    }
-
     pub(super) fn assigned_type_for_await_rhs(
         &self,
         rhs: NodeIndex,
@@ -699,7 +695,7 @@ impl<'a> FlowAnalyzer<'a> {
                 .and_then(|node| self.arena.get_function(node))
                 .is_some_and(|func| {
                     func.type_annotation.is_some()
-                        && self.type_annotation_looks_like_promise(func.type_annotation)
+                        && self.type_annotation_is_awaitable(func.type_annotation)
                 })
     }
 
@@ -710,27 +706,17 @@ impl<'a> FlowAnalyzer<'a> {
             .is_some_and(|func| func.is_async)
     }
 
-    fn type_annotation_looks_like_promise(&self, type_annotation: NodeIndex) -> bool {
-        let Some(node) = self.arena.get(type_annotation) else {
+    fn type_annotation_is_awaitable(&self, type_annotation: NodeIndex) -> bool {
+        let Some(annotation_type) = self
+            .node_types
+            .and_then(|nt| nt.get(&type_annotation.0).copied())
+            .filter(|&ty| ty != TypeId::ERROR)
+            .or_else(|| self.fallback_type_from_type_node_syntax(type_annotation))
+        else {
             return false;
         };
 
-        let Some(type_ref) = self.arena.get_type_ref(node) else {
-            return false;
-        };
-        let Some(name_node) = self.arena.get(type_ref.type_name) else {
-            return false;
-        };
-
-        if let Some(ident) = self.arena.get_identifier(name_node) {
-            return Self::is_builtin_promise_like_name(ident.escaped_text.as_str());
-        }
-
-        self.arena
-            .get_qualified_name(name_node)
-            .and_then(|qualified| self.arena.get(qualified.right))
-            .and_then(|node| self.arena.get_identifier(node))
-            .is_some_and(|ident| Self::is_builtin_promise_like_name(ident.escaped_text.as_str()))
+        self.awaited_type_from_type(annotation_type).is_some()
     }
 
     fn call_return_type_from_type(&self, ty: TypeId) -> Option<TypeId> {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -154,6 +154,9 @@ mod environment_capabilities_tests;
 #[path = "tests/flow_inferred_predicate_boundary_tests.rs"]
 mod flow_inferred_predicate_boundary_tests;
 #[cfg(test)]
+#[path = "tests/flow_promise_identity_tests.rs"]
+mod flow_promise_identity_tests;
+#[cfg(test)]
 #[path = "tests/function_type_return_node_tests.rs"]
 mod function_type_return_node_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/flow_promise_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_promise_identity_tests.rs
@@ -1,0 +1,58 @@
+use crate::test_utils::check_source_codes;
+use std::fs;
+
+#[test]
+fn await_assignment_flow_does_not_unwrap_local_promise_alias_by_name() {
+    let source = r#"
+type Promise<T> = { value: T };
+declare function getBox(): Promise<string>;
+
+async function f() {
+    let value: Promise<string> | number = 0;
+    value = await getBox();
+    const text: string = value;
+}
+"#;
+
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "local Promise<T> alias must not be treated as lib Promise<T> during await assignment flow; got {codes:?}"
+    );
+}
+
+#[test]
+fn await_assignment_flow_still_unwraps_lib_promise_return() {
+    let source = r#"
+async function getText(): Promise<string> {
+    return "ok";
+}
+
+async function f() {
+    let value: string | number = 0;
+    value = await getText();
+    const text: string = value;
+}
+"#;
+
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&2322),
+        "lib Promise<T> returns should still unwrap during await assignment flow; got {codes:?}"
+    );
+}
+
+#[test]
+fn flow_await_fallback_promise_detection_uses_identity_not_name_allowlist() {
+    let source = fs::read_to_string("src/flow/control_flow/assignment_fallback.rs")
+        .expect("failed to read flow assignment fallback source");
+
+    assert!(
+        !source.contains("is_builtin_promise_like_name"),
+        "flow await fallback must use binder/lib Promise identity, not a raw Promise/PromiseLike name allowlist"
+    );
+    assert!(
+        !source.contains("name == \"Promise\" || name == \"PromiseLike\""),
+        "flow await fallback must not hardcode Promise/PromiseLike spellings for semantic decisions"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-D

## Track
Semantic identity cleanup / flow-control await assignment fallback.

## Invariant
When an `await` assignment fallback inspects a callee return annotation, tsz should decide awaitability from the resolved annotation type through solver-backed flow helpers, not from the user-chosen rightmost type name.

## Structural Rule
When a function return annotation resolves to an awaitable type, flow assignment fallback may unwrap the awaited value; when the annotation is a local non-awaitable alias or namespace member that merely uses a well-known name, flow fallback must preserve that local identity.

## Owner Layer
Checker flow-control owns assignment-flow orchestration. The semantic awaitable decision is delegated through existing flow/query-boundary type helpers (`fallback_type_from_type_node_syntax` plus `awaited_type_from_type`) rather than a checker-local Promise/PromiseLike spelling allowlist.

## Scope
- Remove the raw `Promise`/`PromiseLike` name allowlist from `assignment_fallback.rs`.
- Route return-annotation awaitability through the resolved annotation type and existing awaited-type helper.
- Add focused flow Promise identity tests for local aliases, lib Promise, and source-level no-name-allowlist regression.
- Sync the branch with `origin/main` at merge head `9bcb41114afdf306307365155a061edd1be01e1a`.

## Adjacent-Case Matrix
- Negative: local `type Promise<T> = { value: T }` is not unwrapped by await assignment flow.
- Positive: standard lib `Promise<T>` still unwraps through await assignment flow.
- Architecture guard: flow fallback source must not reintroduce the raw Promise/PromiseLike name helper.

## Known Unsupported Shapes / Fallback
If the annotation type cannot be resolved from cached node types or the syntax fallback, the flow fallback declines to classify it as awaitable and leaves the normal assignment-flow path unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: flow-control Promise/PromiseLike name shortcut cleanup
- Evidence: checker-only identity refactor; no project-corpus row identified for this narrow fallback path.

## Verification
- RED: `cargo nextest run -p tsz-checker --lib flow_await_fallback_promise_detection_uses_identity_not_name_allowlist` failed while `is_builtin_promise_like_name` remained in `assignment_fallback.rs`.
- Original focused exact-head on `ee65dab53304c5fb58482e691f162f9beea0f982`: `cargo nextest run -p tsz-checker --lib -E 'test(flow_promise_identity_tests) or test(return_context_promise_identity_tests) or test(awaited_generic_application_fold_tests)'` passed: 5 tests run, 5 passed, 5206 skipped.
- Exact-head post-`origin/main` sync on `9bcb41114afdf306307365155a061edd1be01e1a`: `cargo nextest run -p tsz-checker --lib -E 'test(flow_promise_identity_tests) or test(return_context_promise_identity_tests) or test(awaited_generic_application_fold_tests)'` passed: 5 tests run, 5 passed, 5206 skipped.
- Exact-head hygiene on `9bcb41114afdf306307365155a061edd1be01e1a`: `git diff --check` and `cargo fmt --check` passed.
- Exact-head architecture guard on `9bcb41114afdf306307365155a061edd1be01e1a`: `python3 scripts/arch/arch_guard.py --json` passed with `status: passed`, `total_hits: 0`.
- File sizes: `lib.rs` 932 lines, `assignment_fallback.rs` 816 lines, `flow_promise_identity_tests.rs` 58 lines.

## Coordination Notes
- AgentName: M4-D
- Fresh/reused worktree: `/Users/mohsen/code/tsz-m4d-9742-ambient-value-export-20260526`; previous branch there was merged as #10360, then this branch was created from `origin/main`.
- Branch: `codex/m4-d-flow-promise-identity-20260527`; head: `9bcb41114afdf306307365155a061edd1be01e1a`.
- Independent of M4-D drafts #10394, #10389, #10377, and #10371; this is a separate flow fallback identity cleanup.
- Exact-head ready-review PR-head checks are green on `9bcb41114afdf306307365155a061edd1be01e1a`, including `CI Summary` and `GitGuardian Security Checks`. Enqueued with `merge-queue`; queue owns `Queue Tested` and landing.


