### PR TITLE
chore(agents): warn on branch-local goal drift

### DIFF
--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -116,7 +116,10 @@ scripts/agents/show-goal.sh M1-A
 When reviewing or developing a branch that edits a lane goal file, use
 `scripts/agents/show-goal.sh <AgentName> --local` to preview the branch-local
 file. The default command still prefers `origin/main` so launch sessions can be
-redirected without first merging the in-progress branch.
+redirected without first merging the in-progress branch. If the branch-local
+file differs from the printed `origin/main` goal, `show-goal.sh` warns on
+stderr; treat that as a cue to inspect `--local` before acting on branch-local
+coordination.
 
 Then run the remaining commands listed in that lane's `Start Every Cycle`
 section.

--- a/docs/plan/agents/Studio-F.md
+++ b/docs/plan/agents/Studio-F.md
@@ -34,18 +34,15 @@ python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surge
 - Architecture cleanup metric: every cleanup PR must ratchet a named guard
   down, remove an allowlist entry, split a file over a documented ceiling, or
   make a release-gate artifact harder to misread.
-- Current active PR: #10373 follows up after #10308 merged. It keeps the
-  defineProperty JSDoc output-surgery cleanup and refreshes the
-  `query_boundaries::common` guard cap to the current merged count so
-  `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json`
-  and
-  `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
-  both pass on the PR head.
+- Current active PR: #10396 follows up after #10373 merged. It keeps
+  `scripts/agents/show-goal.sh` stdout stable while warning on stderr when a
+  branch-local lane goal differs from the printed `origin/main` goal, and it
+  documents that warning in `docs/plan/agents/README.md`.
 - First live command: run the start-cycle commands and inspect guard failures
   before choosing cleanup work.
-- Next concrete step: keep #10373 current while draft CI/queueing settles, then
-  pick the next measurable guardrail or launch-script gap and keep it
-  behavior-preserving unless it directly fixes a release blocker.
+- Next concrete step: keep #10396 current now that it is retargeted to `main`;
+  once refreshed draft CI is green, decide whether to mark it ready or pick the
+  next measurable guardrail or launch-script gap.
 
 ## Existing Work To Inspect First
 

--- a/scripts/agents/show-goal.sh
+++ b/scripts/agents/show-goal.sh
@@ -63,6 +63,9 @@ fi
 
 if [[ "$LOCAL_ONLY" == false ]] \
   && git -C "$ROOT" show "origin/main:${GOAL_PATH}" >"$REMOTE_GOAL" 2>/dev/null; then
+  if [[ -f "$ROOT/$GOAL_PATH" ]] && ! cmp -s "$REMOTE_GOAL" "$ROOT/$GOAL_PATH"; then
+    echo "warning: printed origin/main:${GOAL_PATH}; branch-local ${GOAL_PATH} differs. Use --local to inspect it." >&2
+  fi
   cat "$REMOTE_GOAL"
   exit 0
 fi

--- a/scripts/agents/test_show_goal.py
+++ b/scripts/agents/test_show_goal.py
@@ -80,19 +80,33 @@ class ShowGoalTests(unittest.TestCase):
             )
             temp_files = sorted(path.name for path in temp_root.glob("tsz-agent-goal.*"))
             calls = calls_log.read_text(encoding="utf-8").splitlines()
-            return result.stdout, calls, temp_files
+            return result.stdout, result.stderr, calls, temp_files
 
     def test_remote_goal_temp_file_is_cleaned_up(self):
-        output, calls, temp_files = self.run_show_goal(["Studio-F", "--no-fetch"])
+        output, stderr, calls, temp_files = self.run_show_goal(["Studio-F", "--no-fetch"])
 
         self.assertEqual(output, "# remote goal\n")
+        self.assertIn("branch-local docs/plan/agents/Studio-F.md differs", stderr)
+        self.assertIn("-C", calls[1])
+        self.assertEqual(temp_files, [])
+
+    def test_matching_remote_goal_does_not_warn(self):
+        output, stderr, calls, temp_files = self.run_show_goal(
+            ["Studio-F", "--no-fetch"],
+            local_goal="# same goal\n",
+            remote_goal="# same goal\n",
+        )
+
+        self.assertEqual(output, "# same goal\n")
+        self.assertEqual(stderr, "")
         self.assertIn("-C", calls[1])
         self.assertEqual(temp_files, [])
 
     def test_local_mode_skips_remote_goal_lookup(self):
-        output, calls, temp_files = self.run_show_goal(["Studio-F", "--local"])
+        output, stderr, calls, temp_files = self.run_show_goal(["Studio-F", "--local"])
 
         self.assertEqual(output, "# local goal\n")
+        self.assertEqual(stderr, "")
         self.assertEqual(calls, ["rev-parse --show-toplevel"])
         self.assertEqual(temp_files, [])
 


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / cheap evidence plumbing.

## Invariant
When `scripts/agents/show-goal.sh` prints the repo-owned `origin/main` lane goal while a branch-local lane goal exists and differs, the command should keep stdout machine-stable but surface the mismatch on stderr so launch sessions do not silently misread branch-local coordination state.

## Scope
- `scripts/agents/show-goal.sh`
- `scripts/agents/test_show_goal.py`
- `docs/plan/agents/README.md`
- `docs/plan/agents/Studio-F.md`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script/docs-only; no compiler, checker, solver, emit, or benchmark behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_show_goal`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
- `git diff --check`
- Previous draft CI on head `ecdf6ee4d51227e8689d1a17d3f633f5e5c629c9`: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed.
- Current-head draft CI on `65ee0556777e8800f537d4967ef8a5a61f3bffc3`: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`, and `GitGuardian Security Checks` passed.

## Coordination Notes
- #10373 merged; this PR is now retargeted to `main`.
- Refreshed draft CI is green for current head `65ee0556777e8800f537d4967ef8a5a61f3bffc3`; ready handoff is appropriate.
- Mark ready after final local sanity checks; leave queue decisions to the manager/queue owner.
- Does not add `merge-queue`; no queue action requested for this follow-up.


