### PR TITLE
test(solver): cover bivariant rest cache agreement

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -445,6 +445,9 @@ mod property_helpers_tests;
 #[path = "caches/query_cache_statistics_test.rs"]
 mod query_cache_statistics_tests;
 #[cfg(test)]
+#[path = "../tests/relation_bivariant_rest_cache_tests.rs"]
+mod relation_bivariant_rest_cache_tests;
+#[cfg(test)]
 #[path = "../tests/relation_cache_config_tests.rs"]
 mod relation_cache_config_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/tests/relation_bivariant_rest_cache_tests.rs
+++ b/crates/tsz-solver/tests/relation_bivariant_rest_cache_tests.rs
@@ -1,0 +1,106 @@
+//! Cache agreement tests for bivariant rest-parameter relation policy.
+
+use super::*;
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::types::{FunctionShape, ParamInfo, RelationCacheKey, RelationFlags};
+
+fn void_function(params: Vec<ParamInfo>) -> FunctionShape {
+    FunctionShape {
+        params,
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    }
+}
+
+#[test]
+fn subtype_cache_bivariant_rest_policy_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let rest = interner.intern_string("args");
+    let source = interner.function(void_function(vec![ParamInfo::unnamed(TypeId::STRING)]));
+    let target = interner.function(void_function(vec![ParamInfo::rest(
+        rest,
+        interner.array(TypeId::UNKNOWN),
+    )]));
+
+    let strict = RelationPolicy::from_flags(RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16);
+    let bivariant = RelationPolicy::from_flags(
+        (RelationFlags::STRICT_FUNCTION_TYPES | RelationFlags::ALLOW_BIVARIANT_REST).bits() as u16,
+    );
+    let strict_key = RelationCacheKey::for_subtype(source, target, strict.cache_config());
+    let bivariant_key = RelationCacheKey::for_subtype(source, target, bivariant.cache_config());
+
+    assert_ne!(
+        strict_key, bivariant_key,
+        "strict and bivariant rest policies must occupy distinct cache slots",
+    );
+
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        strict,
+        RelationContext::default(),
+    )
+    .is_related();
+    let bivariant_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Subtype,
+        bivariant,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        !strict_uncached,
+        "strict rest policy should reject fixed string param against unknown rest target",
+    );
+    assert!(
+        bivariant_uncached,
+        "bivariant rest policy should treat unknown rest target as top-like",
+    );
+
+    assert_eq!(
+        db.is_subtype_of_with_policy(source, target, strict),
+        strict_uncached,
+        "cached strict rest policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(strict_key),
+        Some(strict_uncached),
+        "strict rest result must be stored in the strict slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(bivariant_key),
+        None,
+        "bivariant rest lookup must not hit the strict slot",
+    );
+
+    assert_eq!(
+        db.is_subtype_of_with_policy(source, target, bivariant),
+        bivariant_uncached,
+        "cached bivariant rest policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(bivariant_key),
+        Some(bivariant_uncached),
+        "bivariant rest result must be stored in the bivariant slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(strict_key),
+        Some(strict_uncached),
+        "strict rest slot must remain intact after the bivariant lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-contract proof for #8207.

## Invariant
When ALLOW_BIVARIANT_REST is enabled alongside STRICT_FUNCTION_TYPES, a fixed-parameter function can satisfy an unknown[] rest target that strict function-parameter checking rejects; the shared subtype cache must store strict and bivariant-rest answers in distinct policy-shaped slots. This PR changes only solver tests.

## Scope
- crates/tsz-solver/tests/relation_bivariant_rest_cache_tests.rs
- crates/tsz-solver/src/lib.rs

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache policy contract
- Evidence: solver test-only coverage for cache-enabled/cache-disabled agreement; no checker, emitter, project corpus, or conformance snapshot behavior changed.

## Verification
- Refreshed onto origin/main 86d6f3f9dce7da494c494b16674f9cb6fbeaa6f0; later refreshed onto current origin/main 0c8d8106fab9816168c612792f7fc635aa188304; force-pushed head e8997ee04dcf1458fa49a4c98f5650008abbe604.
- cargo fmt --check
- git diff --check origin/main..HEAD
- CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E test(subtype_cache_bivariant_rest_policy_matches_uncached_relation_query) -- 1 passed, 6301 skipped.
- REBASE GREEN on head e8997ee04dcf1458fa49a4c98f5650008abbe604: cargo fmt --check.
- REBASE GREEN on head e8997ee04dcf1458fa49a4c98f5650008abbe604: git diff --check origin/main..HEAD.
- REBASE GREEN on head e8997ee04dcf1458fa49a4c98f5650008abbe604: CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(subtype_cache_bivariant_rest_policy_matches_uncached_relation_query)' (1 passed, 6304 skipped).
- Draft-light CI passed for head f55bbbc08bd56f8e3c94c5e2b0eeb07db1a8333b: https://github.com/mohsen1/tsz/actions/runs/26492195797
- Draft-light CI restarted for rebased head e8997ee04dcf1458fa49a4c98f5650008abbe604: https://github.com/mohsen1/tsz/actions/runs/26495472144; latest inspection had `gate` in progress and `GitGuardian Security Checks` passing.

## Coordination Notes
- AgentName: M4-B
- Non-overlap: new solver test module; avoids editing relation_cache_config_tests.rs, which is touched by other M4-B drafts.
- Complements M4-B drafts #10387, #10397, #10398, #10401, and #10407 without touching checker relation routing or production solver policy.
- Draft/off queue after refreshed light CI passed; no WIP, auto-merge, or merge-queue labels added.
- Draft/off queue after rebased head e8997ee04dcf1458fa49a4c98f5650008abbe604; no WIP, auto-merge, or merge-queue labels added.
