### PR TITLE
test(solver): cover no-unchecked indexed cache agreement

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -448,6 +448,9 @@ mod query_cache_statistics_tests;
 #[path = "../tests/relation_cache_config_tests.rs"]
 mod relation_cache_config_tests;
 #[cfg(test)]
+#[path = "../tests/relation_no_unchecked_indexed_cache_tests.rs"]
+mod relation_no_unchecked_indexed_cache_tests;
+#[cfg(test)]
 #[path = "../tests/relation_policy_cache_agreement_tests.rs"]
 mod relation_policy_cache_agreement_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs
+++ b/crates/tsz-solver/tests/relation_no_unchecked_indexed_cache_tests.rs
@@ -1,0 +1,93 @@
+//! Cache agreement tests for `NO_UNCHECKED_INDEXED_ACCESS` relation policy.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::intern::TypeInterner;
+use crate::relations::relation_queries::{
+    RelationContext, RelationKind, RelationPolicy, query_relation,
+};
+use crate::types::{RelationCacheKey, TypeData, TypeId};
+
+#[test]
+fn subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let string_array = interner.array(TypeId::STRING);
+    let indexed_string = interner.intern(TypeData::IndexAccess(string_array, TypeId::NUMBER));
+
+    let ordinary = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_NULL_CHECKS);
+    let no_unchecked = RelationPolicy::from_flags(
+        RelationCacheKey::FLAG_STRICT_NULL_CHECKS
+            | RelationCacheKey::FLAG_NO_UNCHECKED_INDEXED_ACCESS,
+    );
+    let ordinary_key =
+        RelationCacheKey::for_subtype(indexed_string, TypeId::STRING, ordinary.cache_config());
+    let no_unchecked_key =
+        RelationCacheKey::for_subtype(indexed_string, TypeId::STRING, no_unchecked.cache_config());
+
+    assert_ne!(
+        ordinary_key, no_unchecked_key,
+        "ordinary and no-unchecked-indexed-access policies must occupy distinct subtype cache slots",
+    );
+
+    let uncached_ordinary = query_relation(
+        &interner,
+        indexed_string,
+        TypeId::STRING,
+        RelationKind::Subtype,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let uncached_no_unchecked = query_relation(
+        &interner,
+        indexed_string,
+        TypeId::STRING,
+        RelationKind::Subtype,
+        no_unchecked,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        uncached_ordinary,
+        "ordinary indexed access should resolve `string[][number]` to `string`",
+    );
+    assert!(
+        !uncached_no_unchecked,
+        "no-unchecked-indexed-access should add `undefined` and reject subtype-of `string`",
+    );
+
+    assert_eq!(
+        db.is_subtype_of_with_policy(indexed_string, TypeId::STRING, ordinary),
+        uncached_ordinary,
+        "cached ordinary policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(ordinary_key),
+        Some(uncached_ordinary),
+        "ordinary result must be stored in the ordinary subtype slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(no_unchecked_key),
+        None,
+        "no-unchecked lookup must not hit the ordinary subtype slot",
+    );
+
+    assert_eq!(
+        db.is_subtype_of_with_policy(indexed_string, TypeId::STRING, no_unchecked),
+        uncached_no_unchecked,
+        "cached no-unchecked policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(no_unchecked_key),
+        Some(uncached_no_unchecked),
+        "no-unchecked result must be stored in the no-unchecked subtype slot",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(ordinary_key),
+        Some(uncached_ordinary),
+        "ordinary subtype slot must remain intact after the no-unchecked lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key contracts (#8207).

## Invariant
When NO_UNCHECKED_INDEXED_ACCESS changes an index-access subtype answer under strict null checks, the typed QueryCache subtype path must match uncached query_relation for the same RelationPolicy and must not reuse the opposite policy cache slot.

## Scope
- Adds a focused solver cache-agreement test for STRICT_NULL_CHECKS plus NO_UNCHECKED_INDEXED_ACCESS.
- Registers the standalone test module from tsz-solver lib.rs.
- No production relation semantics changed.

## Project Corpus Impact
- Row: n/a
- Bug family: relation-cache policy contract
- Evidence: test-only solver relation-cache coverage; no compiler, emit, parser, checker, LSP, WASM, or project-corpus runtime behavior changed.

## Verification
- Refreshed onto origin/main 156b7e754f197aa7be5b9089a6319f7752403793; later refreshed onto current origin/main 0c8d8106fab9816168c612792f7fc635aa188304; force-pushed head 54a3b6451817b8d68eae2628c2abb500399c911b.
- cargo fmt --check
- git diff --check origin/main..HEAD
- CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E test(subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_query) -- 1 passed, 6301 skipped.
- REBASE GREEN on head 54a3b6451817b8d68eae2628c2abb500399c911b: cargo fmt --check.
- REBASE GREEN on head 54a3b6451817b8d68eae2628c2abb500399c911b: git diff --check origin/main..HEAD.
- REBASE GREEN on head 54a3b6451817b8d68eae2628c2abb500399c911b: CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(subtype_cache_no_unchecked_indexed_access_policy_matches_uncached_relation_query)' (1 passed, 6304 skipped).
- Draft-light CI passed for head de0c130c780e14644cc4e06a41cb2394f2fa9b76: https://github.com/mohsen1/tsz/actions/runs/26491977893
- Draft-light CI restarted for rebased head 54a3b6451817b8d68eae2628c2abb500399c911b: https://github.com/mohsen1/tsz/actions/runs/26495392004; latest inspection had light jobs queued or pending, with `gate` and `GitGuardian Security Checks` passing.

## Coordination Notes
- AgentName: M4-B
- Draft/off queue; no WIP, auto-merge, or merge-queue labels added.
- This is independent of M4-B draft PRs #10397, #10398, #10399, and #10407; those cover cycle, readonly identity, bivariant-rest, and strict-subtype cache agreement respectively.
- The only rebase conflict was the tsz-solver test module registry; both the existing relation_policy_cache_agreement_tests module and this PR relation_no_unchecked_indexed_cache_tests module are preserved.
- Prior checker boundary lint debt was resolved by #10386; this PR remains a narrow test-only relation-cache proof.
