### PR TITLE
fix(dts): preserve this-type accessor value maps

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -736,9 +736,6 @@ impl<'a> DeclarationEmitter<'a> {
             if !param.type_annotation.is_some() {
                 continue;
             }
-            let param_type_text = self
-                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
-                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation));
             self.infer_object_argument_substitutions_from_type_node(
                 source_arena,
                 param.type_annotation,
@@ -748,21 +745,6 @@ impl<'a> DeclarationEmitter<'a> {
                 &mut substitutions,
                 0,
             );
-            if let Some(param_type_text) = param_type_text
-                && let Some((type_param_name, value_text)) = self
-                    .infer_object_map_substitution_from_annotation_text(
-                        &param_type_text,
-                        arg_idx,
-                        type_param_names,
-                        &[],
-                        &substitutions,
-                    )
-                && !substitutions
-                    .iter()
-                    .any(|(existing, _)| existing == &type_param_name)
-            {
-                substitutions.push((type_param_name, value_text));
-            }
         }
 
         substitutions

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -726,6 +726,45 @@ impl<'a> DeclarationEmitter<'a> {
             );
         }
 
+        for (&param_idx, &arg_idx) in parameters.nodes.iter().zip(args.nodes.iter()) {
+            let Some(param_node) = source_arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = source_arena.get_parameter(param_node) else {
+                continue;
+            };
+            if !param.type_annotation.is_some() {
+                continue;
+            }
+            let param_type_text = self
+                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation));
+            self.infer_object_argument_substitutions_from_type_node(
+                source_arena,
+                param.type_annotation,
+                arg_idx,
+                type_param_names,
+                &[],
+                &mut substitutions,
+                0,
+            );
+            if let Some(param_type_text) = param_type_text
+                && let Some((type_param_name, value_text)) = self
+                    .infer_object_map_substitution_from_annotation_text(
+                        &param_type_text,
+                        arg_idx,
+                        type_param_names,
+                        &[],
+                        &substitutions,
+                    )
+                && !substitutions
+                    .iter()
+                    .any(|(existing, _)| existing == &type_param_name)
+            {
+                substitutions.push((type_param_name, value_text));
+            }
+        }
+
         substitutions
     }
 
@@ -886,6 +925,9 @@ impl<'a> DeclarationEmitter<'a> {
         type_param_constraint: Option<&str>,
     ) -> Option<String> {
         if let Some(type_text) = self.referenced_parameter_declared_type_annotation_text(arg_idx) {
+            return Some(type_text);
+        }
+        if let Some(type_text) = self.reference_declared_source_type_annotation_text(arg_idx) {
             return Some(type_text);
         }
         if let Some(type_text) = self.reference_declared_type_annotation_text(arg_idx) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -296,6 +296,7 @@ mod type_inference_return_surface;
 mod type_inference_return_unions;
 mod type_inference_source_call;
 mod type_inference_source_callables;
+mod type_inference_source_object_args;
 mod type_inference_source_text;
 mod type_inference_truncation_expansion;
 mod type_inference_type_annotations;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -426,6 +426,7 @@ impl<'a> DeclarationEmitter<'a> {
                 depth + 1,
                 getter_names.contains(&name),
                 setter_names.contains(&name),
+                Some(object_expr_idx),
             ) {
                 if member_text.trim_start().starts_with(':') {
                     continue;
@@ -595,6 +596,7 @@ impl<'a> DeclarationEmitter<'a> {
         depth: u32,
         getter_exists: bool,
         setter_exists: bool,
+        object_context_idx: Option<NodeIndex>,
     ) -> Option<String> {
         let member_node = self.arena.get(member_idx)?;
 
@@ -636,6 +638,14 @@ impl<'a> DeclarationEmitter<'a> {
                 // Infer return type: explicit annotation > body inference > any
                 let type_text = self
                     .infer_fallback_type_text_at(data.type_annotation, depth)
+                    .or_else(|| {
+                        self.object_literal_this_property_return_type_text(
+                            data.body,
+                            object_context_idx,
+                            Some(member_idx),
+                            depth,
+                        )
+                    })
                     .or_else(|| self.function_body_preferred_return_type_text(data.body))
                     .unwrap_or_else(|| "any".to_string());
                 let readonly = if setter_exists { "" } else { "readonly " };
@@ -665,7 +675,19 @@ impl<'a> DeclarationEmitter<'a> {
                     self.method_function_type_text(member_idx, data, depth)
                         .map(|type_text| format!("{name}: {type_text}"))
                 } else {
-                    self.method_signature_type_text_named_at(member_idx, data, name, depth)
+                    let return_type_override = self.object_literal_this_property_return_type_text(
+                        data.body,
+                        object_context_idx,
+                        Some(member_idx),
+                        depth,
+                    );
+                    self.method_signature_type_text_named_at(
+                        member_idx,
+                        data,
+                        name,
+                        depth,
+                        return_type_override.as_deref(),
+                    )
                 }
             }
             _ => None,
@@ -678,6 +700,7 @@ impl<'a> DeclarationEmitter<'a> {
         method: &tsz_parser::parser::node::MethodDeclData,
         name: &str,
         depth: u32,
+        return_type_override: Option<&str>,
     ) -> Option<String> {
         let mut scratch = self.scratch_declaration_emitter();
         scratch.indent_level = depth;
@@ -708,9 +731,134 @@ impl<'a> DeclarationEmitter<'a> {
         scratch.write("(");
         scratch.emit_parameters_with_body(&method.parameters, method.body);
         scratch.write("): ");
-        scratch.emit_method_function_type_return(method_idx, method);
+        if let Some(return_type) = return_type_override {
+            scratch.write(return_type);
+        } else {
+            scratch.emit_method_function_type_return(method_idx, method);
+        }
         let type_text = scratch.writer.take_output();
         (!type_text.trim().is_empty()).then_some(type_text)
+    }
+
+    fn object_literal_this_property_return_type_text(
+        &self,
+        body_idx: NodeIndex,
+        object_context_idx: Option<NodeIndex>,
+        current_member_idx: Option<NodeIndex>,
+        depth: u32,
+    ) -> Option<String> {
+        if body_idx.is_none() {
+            return None;
+        }
+        let return_expr = self.function_body_single_return_expression(body_idx)?;
+        let return_node = self.arena.get(return_expr)?;
+        if return_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(return_node)?;
+        if self
+            .arena
+            .get(access.expression)
+            .is_none_or(|node| node.kind != SyntaxKind::ThisKeyword as u16)
+        {
+            return None;
+        }
+
+        let object_idx = object_context_idx?;
+        let property_name = self.get_identifier_text(access.name_or_argument)?;
+        let member_idx =
+            self.object_literal_member_by_name_for_inference(object_idx, &property_name)?;
+        if Some(member_idx) == current_member_idx {
+            return None;
+        }
+        self.object_literal_member_value_type_for_this_lookup(
+            member_idx,
+            object_context_idx,
+            current_member_idx,
+            depth + 1,
+        )
+    }
+
+    fn object_literal_member_value_type_for_this_lookup(
+        &self,
+        member_idx: NodeIndex,
+        object_context_idx: Option<NodeIndex>,
+        current_member_idx: Option<NodeIndex>,
+        depth: u32,
+    ) -> Option<String> {
+        let member_node = self.arena.get(member_idx)?;
+        match member_node.kind {
+            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                let data = self.arena.get_property_assignment(member_node)?;
+                self.preferred_object_member_initializer_type_text(data.initializer, depth)
+            }
+            k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                let data = self.arena.get_shorthand_property(member_node)?;
+                let initializer = if data.object_assignment_initializer == NodeIndex::NONE {
+                    data.name
+                } else {
+                    data.object_assignment_initializer
+                };
+                self.preferred_object_member_initializer_type_text(initializer, depth)
+            }
+            k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                let data = self.arena.get_method_decl(member_node)?;
+                self.infer_fallback_type_text_at(data.type_annotation, depth)
+                    .or_else(|| {
+                        self.object_literal_this_property_return_type_text(
+                            data.body,
+                            object_context_idx,
+                            current_member_idx,
+                            depth,
+                        )
+                    })
+                    .or_else(|| self.function_body_preferred_return_type_text(data.body))
+            }
+            k if k == syntax_kind_ext::GET_ACCESSOR => {
+                let data = self.arena.get_accessor(member_node)?;
+                self.infer_fallback_type_text_at(data.type_annotation, depth)
+                    .or_else(|| {
+                        self.object_literal_this_property_return_type_text(
+                            data.body,
+                            object_context_idx,
+                            current_member_idx,
+                            depth,
+                        )
+                    })
+                    .or_else(|| self.function_body_preferred_return_type_text(data.body))
+            }
+            k if k == syntax_kind_ext::SET_ACCESSOR => {
+                let data = self.arena.get_accessor(member_node)?;
+                data.parameters
+                    .nodes
+                    .first()
+                    .and_then(|&p_idx| self.arena.get(p_idx))
+                    .and_then(|p_node| self.arena.get_parameter(p_node))
+                    .and_then(|param| {
+                        self.infer_fallback_type_text_at(param.type_annotation, depth)
+                    })
+            }
+            _ => None,
+        }
+    }
+
+    fn object_literal_member_by_name_for_inference(
+        &self,
+        object_idx: NodeIndex,
+        property_name: &str,
+    ) -> Option<NodeIndex> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        let object = self.arena.get_literal_expr(object_node)?;
+        object.elements.nodes.iter().copied().find(|member_idx| {
+            let Some(member_node) = self.arena.get(*member_idx) else {
+                return false;
+            };
+            self.object_literal_member_name_idx(member_node)
+                .and_then(|name_idx| self.object_literal_member_name_text(name_idx))
+                .as_deref()
+                == Some(property_name)
+        })
     }
 
     fn object_literal_method_uses_property_syntax(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -135,6 +135,7 @@ impl<'a> DeclarationEmitter<'a> {
                                 self.indent_level + 1,
                                 false,
                                 false,
+                                None,
                             );
                     }
                 }
@@ -158,6 +159,7 @@ impl<'a> DeclarationEmitter<'a> {
                 self.indent_level + 1,
                 getter_names.contains(&name_text),
                 setter_names.contains(&name_text),
+                None,
             ) else {
                 continue;
             };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -15,6 +15,10 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         expr_idx: NodeIndex,
     ) -> Option<String> {
+        if let Some(type_text) = self.source_construct_return_new_expression_type_text(expr_idx) {
+            return Some(type_text);
+        }
+
         let expr_node = self.arena.get(expr_idx)?;
         if expr_node.kind != syntax_kind_ext::NEW_EXPRESSION {
             return None;
@@ -36,6 +40,315 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         Some(self.rewrite_exported_import_equals_type_text(type_text))
+    }
+
+    fn source_construct_return_new_expression_type_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != syntax_kind_ext::NEW_EXPRESSION {
+            return None;
+        }
+        let new_expr = self.arena.get_call_expr(expr_node)?;
+        if new_expr.type_arguments.is_some() {
+            return None;
+        }
+
+        if let Some(type_text) = self
+            .reference_declared_source_type_annotation_text(new_expr.expression)
+            .and_then(|construct_text| {
+                self.source_construct_return_from_type_text(&construct_text, new_expr)
+            })
+        {
+            return Some(type_text);
+        }
+
+        if let Some(type_text) = self.source_construct_return_for_local_value(new_expr) {
+            return Some(type_text);
+        }
+
+        let raw_sym_id = self.new_expression_target_symbol(new_expr.expression)?;
+        let binder = self.binder?;
+        let sym_id = self
+            .resolve_portability_import_alias(raw_sym_id, binder)
+            .unwrap_or(raw_sym_id);
+        let symbol = binder.symbols.get(sym_id)?;
+        for decl_idx in symbol.declarations.iter().copied() {
+            let decl_node = self.arena.get(decl_idx)?;
+            let Some(var_decl) = self.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            let Some(type_node) = self.arena.get(var_decl.type_annotation) else {
+                continue;
+            };
+            if type_node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE {
+                continue;
+            }
+            let Some(ctor_type) = self.arena.get_function_type(type_node) else {
+                continue;
+            };
+            let Some(return_type_text) = self.source_type_annotation_text_for_declaration_reuse(
+                self.arena,
+                ctor_type.type_annotation,
+            ) else {
+                continue;
+            };
+            let Some(type_text) = self.substitute_source_construct_type_parameters(
+                ctor_type,
+                new_expr,
+                return_type_text,
+            ) else {
+                continue;
+            };
+            if !type_text.contains("unknown") && !type_text.contains("any") {
+                return Some(type_text);
+            }
+        }
+        None
+    }
+
+    fn source_construct_return_from_type_text(
+        &self,
+        construct_text: &str,
+        new_expr: &tsz_parser::parser::node::CallExprData,
+    ) -> Option<String> {
+        let (type_param_names, parameter_type_texts, return_type_text) =
+            Self::parse_construct_signature_type_text(construct_text)?;
+        let args = new_expr.arguments.as_ref()?;
+        let mut substitutions = Vec::new();
+        for (param_type_text, &arg_idx) in parameter_type_texts.iter().zip(args.nodes.iter()) {
+            self.infer_call_type_param_substitutions_from_type_text_argument(
+                self.arena,
+                param_type_text,
+                arg_idx,
+                &type_param_names,
+                &mut substitutions,
+            );
+        }
+        if substitutions.is_empty() {
+            return None;
+        }
+        let type_text = Self::replace_whole_words_in_text(&return_type_text, &substitutions);
+        if type_param_names
+            .iter()
+            .any(|name| Self::contains_whole_word_in_text(&type_text, name))
+            || type_text.contains("unknown")
+            || type_text.contains("any")
+        {
+            return None;
+        }
+        Some(type_text)
+    }
+
+    fn parse_construct_signature_type_text(
+        construct_text: &str,
+    ) -> Option<(Vec<String>, Vec<String>, String)> {
+        let mut text = construct_text.trim().trim_end_matches(';').trim();
+        text = text.strip_prefix("new ")?;
+
+        let mut type_param_names = Vec::new();
+        if text.starts_with('<') {
+            let type_params_end = Self::matching_angle_end(text, 0)?;
+            let type_params = text.get(1..type_params_end)?.trim();
+            type_param_names = Self::split_top_level_commas(type_params)
+                .into_iter()
+                .filter_map(|part| {
+                    part.split(|ch: char| ch.is_whitespace() || ch == '=' || ch == ',')
+                        .next()
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                        .map(str::to_string)
+                })
+                .collect();
+            text = text.get(type_params_end + 1..)?.trim();
+        }
+
+        let params_end = Self::matching_paren_end(text, 0)?;
+        let params_text = text.get(1..params_end)?.trim();
+        let after_params = text.get(params_end + 1..)?.trim();
+        let return_type = after_params
+            .strip_prefix("=>")?
+            .trim()
+            .trim_end_matches(';')
+            .trim()
+            .to_string();
+        for part in return_type.split(" & ") {
+            let name = part.trim();
+            if !name.is_empty()
+                && name
+                    .chars()
+                    .all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+                && !type_param_names.iter().any(|existing| existing == name)
+            {
+                type_param_names.push(name.to_string());
+            }
+        }
+        let parameter_type_texts = if params_text.is_empty() {
+            Vec::new()
+        } else {
+            Self::split_top_level_commas(params_text)
+                .into_iter()
+                .filter_map(|param| {
+                    let colon = Self::find_top_level_byte(param, b':')?;
+                    param.get(colon + 1..).map(str::trim).map(str::to_string)
+                })
+                .collect()
+        };
+        (!type_param_names.is_empty() && !return_type.is_empty()).then_some((
+            type_param_names,
+            parameter_type_texts,
+            return_type,
+        ))
+    }
+
+    fn matching_angle_end(text: &str, start: usize) -> Option<usize> {
+        Self::matching_delimiter_end(text, start, b'<', b'>')
+    }
+
+    fn matching_paren_end(text: &str, start: usize) -> Option<usize> {
+        Self::matching_delimiter_end(text, start, b'(', b')')
+    }
+
+    fn matching_delimiter_end(text: &str, start: usize, open: u8, close: u8) -> Option<usize> {
+        let bytes = text.as_bytes();
+        if bytes.get(start).copied()? != open {
+            return None;
+        }
+        let mut depth = 0usize;
+        for (idx, byte) in bytes.iter().copied().enumerate().skip(start) {
+            if byte == open {
+                depth += 1;
+            } else if byte == close {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(idx);
+                }
+            }
+        }
+        None
+    }
+
+    fn source_construct_return_for_local_value(
+        &self,
+        new_expr: &tsz_parser::parser::node::CallExprData,
+    ) -> Option<String> {
+        let ident = self.get_identifier_text(new_expr.expression)?;
+        for decl_node in &self.arena.nodes {
+            let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            if self.get_identifier_text(decl.name).as_deref() != Some(ident.as_str()) {
+                continue;
+            }
+            let Some(type_node) = self.arena.get(decl.type_annotation) else {
+                continue;
+            };
+            if type_node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE {
+                continue;
+            }
+            let Some(ctor_type) = self.arena.get_function_type(type_node) else {
+                continue;
+            };
+            let Some(return_type_text) = self.source_type_annotation_text_for_declaration_reuse(
+                self.arena,
+                ctor_type.type_annotation,
+            ) else {
+                continue;
+            };
+            let Some(type_text) = self.substitute_source_construct_type_parameters(
+                ctor_type,
+                new_expr,
+                return_type_text,
+            ) else {
+                continue;
+            };
+            if !type_text.contains("unknown") && !type_text.contains("any") {
+                return Some(type_text);
+            }
+        }
+        None
+    }
+
+    fn substitute_source_construct_type_parameters(
+        &self,
+        ctor_type: &tsz_parser::parser::node::FunctionTypeData,
+        call: &tsz_parser::parser::node::CallExprData,
+        mut type_text: String,
+    ) -> Option<String> {
+        let Some(type_params) = ctor_type.type_parameters.as_ref() else {
+            return Some(type_text);
+        };
+        if type_params.nodes.is_empty() {
+            return Some(type_text);
+        }
+
+        let mut type_param_names = Vec::new();
+        let mut type_param_constraints = Vec::new();
+        let mut type_param_defaults = Vec::new();
+        for &param_idx in &type_params.nodes {
+            let Some(param_node) = self.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.arena.get_type_parameter(param_node) else {
+                continue;
+            };
+            let Some(name_text) = self.get_identifier_text(param.name) else {
+                continue;
+            };
+            if param.constraint.is_some()
+                && let Some(constraint) = self
+                    .emit_type_node_text(param.constraint)
+                    .or_else(|| self.source_slice_from_arena(self.arena, param.constraint))
+            {
+                type_param_constraints.push((name_text.clone(), constraint));
+            }
+            if param.default.is_some()
+                && let Some(default_text) = self
+                    .emit_type_node_text(param.default)
+                    .or_else(|| self.source_slice_from_arena(self.arena, param.default))
+            {
+                type_param_defaults.push((name_text.clone(), default_text));
+            }
+            type_param_names.push(name_text);
+        }
+
+        if !type_param_names
+            .iter()
+            .any(|name| Self::contains_whole_word_in_text(&type_text, name))
+        {
+            return Some(type_text);
+        }
+
+        let mut substitutions = self.infer_call_type_param_substitutions_from_arguments(
+            self.arena,
+            &ctor_type.parameters,
+            call,
+            &type_param_names,
+            &type_param_constraints,
+        );
+        for (name_text, default_text) in type_param_defaults {
+            if substitutions
+                .iter()
+                .any(|(substituted, _)| substituted == &name_text)
+                || !Self::contains_whole_word_in_text(&type_text, &name_text)
+            {
+                continue;
+            }
+            let default_text = Self::replace_whole_words_in_text(&default_text, &substitutions);
+            substitutions.push((name_text, default_text));
+        }
+        if substitutions.is_empty() {
+            return None;
+        }
+        type_text = Self::replace_whole_words_in_text(&type_text, &substitutions);
+        if type_param_names
+            .iter()
+            .any(|name| Self::contains_whole_word_in_text(&type_text, name))
+        {
+            return None;
+        }
+        Some(type_text)
     }
 
     pub(in crate::declaration_emitter) fn call_expression_source_return_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -658,41 +658,6 @@ impl<'a> DeclarationEmitter<'a> {
         })
     }
 
-    pub(in crate::declaration_emitter) fn infer_object_map_substitution_from_annotation_text(
-        &self,
-        annotation_text: &str,
-        arg_idx: NodeIndex,
-        type_param_names: &[String],
-        aliases: &[(String, String)],
-        existing_substitutions: &[(String, String)],
-    ) -> Option<(String, String)> {
-        if !annotation_text.contains('<') {
-            return None;
-        }
-        let mentioned = type_param_names
-            .iter()
-            .filter(|name| {
-                !existing_substitutions
-                    .iter()
-                    .any(|(existing, _)| existing == *name)
-                    && (Self::contains_whole_word_in_text(annotation_text, name)
-                        || aliases.iter().any(|(alias, mapped)| {
-                            mapped == *name
-                                && Self::contains_whole_word_in_text(annotation_text, alias)
-                        }))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        let [type_param_name] = mentioned.as_slice() else {
-            return None;
-        };
-        let object_text = self.object_literal_property_value_map_type_text_with_context(
-            arg_idx,
-            existing_substitutions,
-        )?;
-        Some((type_param_name.clone(), object_text))
-    }
-
     fn object_literal_property_value_map_type_text_with_context(
         &self,
         arg_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -1,0 +1,1063 @@
+//! Source object-argument inference helpers for declaration emit.
+
+use super::super::DeclarationEmitter;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> DeclarationEmitter<'a> {
+    pub(in crate::declaration_emitter) fn infer_call_type_param_substitutions_from_type_text_argument(
+        &self,
+        source_arena: &NodeArena,
+        param_type_text: &str,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        substitutions: &mut Vec<(String, String)>,
+    ) {
+        let Some((alias_name, type_args)) = Self::type_reference_application_parts(param_type_text)
+        else {
+            return;
+        };
+        let Some(alias_type_node) =
+            self.find_type_alias_type_node_in_arena(source_arena, alias_name)
+        else {
+            return;
+        };
+        let Some(alias_decl_idx) = self.find_type_alias_decl_in_arena(source_arena, alias_name)
+        else {
+            return;
+        };
+        let Some(alias_decl_node) = source_arena.get(alias_decl_idx) else {
+            return;
+        };
+        let Some(alias_decl) = source_arena.get_type_alias(alias_decl_node) else {
+            return;
+        };
+        let Some(alias_type_params) = alias_decl.type_parameters.as_ref() else {
+            return;
+        };
+        let mut aliases = Vec::new();
+        for (&param_idx, type_arg) in alias_type_params.nodes.iter().zip(type_args.iter()) {
+            let Some(param_node) = source_arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = source_arena.get_type_parameter(param_node) else {
+                continue;
+            };
+            let Some(alias_param) = identifier_text(source_arena, param.name) else {
+                continue;
+            };
+            if let Some(type_param_name) =
+                Self::mapped_type_param_name(type_arg, type_param_names, &[])
+            {
+                aliases.push((alias_param, type_param_name));
+            }
+        }
+        self.infer_object_argument_substitutions_from_type_node(
+            source_arena,
+            alias_type_node,
+            arg_idx,
+            type_param_names,
+            &aliases,
+            substitutions,
+            0,
+        );
+    }
+
+    pub(in crate::declaration_emitter) fn infer_object_argument_substitutions_from_type_node(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        substitutions: &mut Vec<(String, String)>,
+        depth: u8,
+    ) {
+        if depth > 16 {
+            return;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return;
+        };
+        match type_node.kind {
+            k if k == SyntaxKind::Identifier as u16 => {
+                if let Some(name) = identifier_text(source_arena, type_idx)
+                    && let Some(type_param_name) =
+                        Self::mapped_type_param_name(&name, type_param_names, aliases)
+                    && !substitutions
+                        .iter()
+                        .any(|(existing, _)| existing == &type_param_name)
+                    && let Some(type_text) = self.call_argument_public_type_text(arg_idx)
+                {
+                    substitutions.push((type_param_name, type_text));
+                }
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
+                if let Some(wrapped) = source_arena.get_wrapped_type(type_node) {
+                    self.infer_object_argument_substitutions_from_type_node(
+                        source_arena,
+                        wrapped.type_node,
+                        arg_idx,
+                        type_param_names,
+                        aliases,
+                        substitutions,
+                        depth + 1,
+                    );
+                }
+            }
+            k if k == syntax_kind_ext::INTERSECTION_TYPE || k == syntax_kind_ext::UNION_TYPE => {
+                if let Some(composite) = source_arena.get_composite_type(type_node) {
+                    for part_idx in composite.types.nodes.iter().copied() {
+                        self.infer_object_argument_substitutions_from_type_node(
+                            source_arena,
+                            part_idx,
+                            arg_idx,
+                            type_param_names,
+                            aliases,
+                            substitutions,
+                            depth + 1,
+                        );
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                self.infer_object_argument_substitutions_from_type_literal(
+                    source_arena,
+                    type_idx,
+                    arg_idx,
+                    type_param_names,
+                    aliases,
+                    substitutions,
+                    depth + 1,
+                );
+            }
+            k if k == syntax_kind_ext::MAPPED_TYPE => {
+                self.infer_object_argument_substitution_from_mapped_type(
+                    source_arena,
+                    type_idx,
+                    arg_idx,
+                    type_param_names,
+                    aliases,
+                    substitutions,
+                );
+            }
+            k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                let Some(type_ref) = source_arena.get_type_ref(type_node) else {
+                    return;
+                };
+                if let Some(name) = identifier_text(source_arena, type_ref.type_name)
+                    && let Some(type_param_name) =
+                        Self::mapped_type_param_name(&name, type_param_names, aliases)
+                    && !substitutions
+                        .iter()
+                        .any(|(existing, _)| existing == &type_param_name)
+                    && let Some(type_text) = self.call_argument_public_type_text(arg_idx)
+                {
+                    substitutions.push((type_param_name, type_text));
+                    return;
+                }
+
+                if let Some((type_param_name, value_text)) = self
+                    .infer_mapped_alias_argument_substitution(
+                        source_arena,
+                        type_idx,
+                        arg_idx,
+                        type_param_names,
+                        aliases,
+                    )
+                    && !substitutions
+                        .iter()
+                        .any(|(existing, _)| existing == &type_param_name)
+                {
+                    substitutions.push((type_param_name, value_text));
+                    return;
+                }
+
+                if let Some((type_param_name, value_text)) = self
+                    .infer_descriptor_argument_substitution(
+                        source_arena,
+                        type_idx,
+                        arg_idx,
+                        type_param_names,
+                        aliases,
+                    )
+                    && !substitutions
+                        .iter()
+                        .any(|(existing, _)| existing == &type_param_name)
+                {
+                    substitutions.push((type_param_name, value_text));
+                    return;
+                }
+
+                let Some(alias_sym_id) =
+                    self.declaration_type_symbol_from_type_node(source_arena, type_idx)
+                else {
+                    return;
+                };
+                self.with_symbol_declarations(alias_sym_id, |alias_arena, decl_idx| {
+                    let decl_node = alias_arena.get(decl_idx)?;
+                    let alias = alias_arena.get_type_alias(decl_node)?;
+                    let alias_type_params = alias.type_parameters.as_ref()?;
+                    let alias_args = type_ref.type_arguments.as_ref()?;
+                    let mut next_aliases = aliases.to_vec();
+                    for (&param_idx, &arg_idx) in
+                        alias_type_params.nodes.iter().zip(alias_args.nodes.iter())
+                    {
+                        let param_node = alias_arena.get(param_idx)?;
+                        let param = alias_arena.get_type_parameter(param_node)?;
+                        let alias_param = identifier_text(alias_arena, param.name)?;
+                        let arg_text =
+                            self.emit_type_node_text_from_arena(source_arena, arg_idx)
+                                .or_else(|| self.source_slice_from_arena(source_arena, arg_idx))?;
+                        if let Some(type_param_name) =
+                            Self::mapped_type_param_name(&arg_text, type_param_names, aliases)
+                        {
+                            next_aliases.push((alias_param, type_param_name));
+                        }
+                    }
+                    self.infer_object_argument_substitutions_from_type_node(
+                        alias_arena,
+                        alias.type_node,
+                        arg_idx,
+                        type_param_names,
+                        &next_aliases,
+                        substitutions,
+                        depth + 1,
+                    );
+                    Some(())
+                });
+            }
+            _ => {}
+        }
+    }
+
+    fn infer_mapped_alias_argument_substitution(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+    ) -> Option<(String, String)> {
+        let type_node = source_arena.get(type_idx)?;
+        let type_ref = source_arena.get_type_ref(type_node)?;
+        let type_args = type_ref.type_arguments.as_ref()?;
+        let [type_arg_idx] = type_args.nodes.as_slice() else {
+            return None;
+        };
+        let type_arg_text = self
+            .source_slice_from_arena(source_arena, *type_arg_idx)
+            .or_else(|| self.emit_type_node_text_from_arena(source_arena, *type_arg_idx))?;
+        let type_param_name =
+            Self::mapped_type_param_name(type_arg_text.trim(), type_param_names, aliases)?;
+        let symbol_alias_is_mapped = self
+            .declaration_type_symbol_from_type_node(source_arena, type_idx)
+            .and_then(|alias_sym_id| {
+                self.with_symbol_declarations(alias_sym_id, |alias_arena, decl_idx| {
+                    let decl_node = alias_arena.get(decl_idx)?;
+                    let alias = alias_arena.get_type_alias(decl_node)?;
+                    let alias_type_node = alias_arena.get(alias.type_node)?;
+                    (alias_type_node.kind == syntax_kind_ext::MAPPED_TYPE).then_some(())
+                })
+            })
+            .is_some();
+        let local_alias_is_mapped = identifier_text(source_arena, type_ref.type_name)
+            .and_then(|name| self.find_type_alias_type_node_in_arena(source_arena, &name))
+            .and_then(|alias_type_idx| source_arena.get(alias_type_idx))
+            .is_some_and(|alias_type_node| alias_type_node.kind == syntax_kind_ext::MAPPED_TYPE);
+        if !symbol_alias_is_mapped && !local_alias_is_mapped {
+            return None;
+        }
+        let value_text = self.object_literal_property_value_map_type_text(arg_idx)?;
+        Some((type_param_name, value_text))
+    }
+
+    fn infer_object_argument_substitutions_from_type_literal(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        substitutions: &mut Vec<(String, String)>,
+        depth: u8,
+    ) {
+        let Some(arg_idx) = self.skip_parenthesized_expression(arg_idx) else {
+            return;
+        };
+        let Some(arg_node) = self.arena.get(arg_idx) else {
+            return;
+        };
+        if arg_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return;
+        };
+        let Some(type_literal) = source_arena.get_type_literal(type_node) else {
+            return;
+        };
+
+        for member_idx in type_literal.members.nodes.iter().copied() {
+            let Some(member_node) = source_arena.get(member_idx) else {
+                continue;
+            };
+            let Some(signature) = source_arena.get_signature(member_node) else {
+                continue;
+            };
+            let Some(property_name) = identifier_text(source_arena, signature.name) else {
+                continue;
+            };
+            let Some(arg_member_idx) = self.object_literal_member_by_name(arg_idx, &property_name)
+            else {
+                continue;
+            };
+
+            if let Some((type_param_name, value_text)) = self
+                .infer_descriptor_argument_substitution(
+                    source_arena,
+                    signature.type_annotation,
+                    arg_member_idx,
+                    type_param_names,
+                    aliases,
+                )
+                && !substitutions
+                    .iter()
+                    .any(|(existing, _)| existing == &type_param_name)
+            {
+                substitutions.push((type_param_name, value_text));
+                continue;
+            }
+
+            let raw_member_type_text = self
+                .source_slice_from_arena(source_arena, signature.type_annotation)
+                .or_else(|| {
+                    self.emit_type_node_text_from_arena(source_arena, signature.type_annotation)
+                });
+            let Some(member_type_text) = self
+                .emit_type_node_text_from_arena(source_arena, signature.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, signature.type_annotation))
+            else {
+                continue;
+            };
+            let searchable = Self::type_text_without_this_type_markers(&member_type_text);
+            if let Some(raw_member_type_text) = raw_member_type_text.as_deref()
+                && let Some((type_param_name, value_text)) = self
+                    .infer_object_map_substitution_from_annotation_text(
+                        raw_member_type_text,
+                        arg_member_idx,
+                        type_param_names,
+                        aliases,
+                        &[],
+                    )
+            {
+                Self::replace_or_push_substitution(substitutions, type_param_name, value_text);
+                continue;
+            }
+            if let Some((type_param_name, value_text)) = self
+                .infer_object_map_substitution_from_annotation_text(
+                    &searchable,
+                    arg_member_idx,
+                    type_param_names,
+                    aliases,
+                    &[],
+                )
+            {
+                Self::replace_or_push_substitution(substitutions, type_param_name, value_text);
+                continue;
+            }
+            for type_param_name in type_param_names {
+                let mentions_param =
+                    Self::contains_whole_word_in_text(&searchable, type_param_name)
+                        || aliases.iter().any(|(alias, mapped)| {
+                            mapped == type_param_name
+                                && Self::contains_whole_word_in_text(&searchable, alias)
+                        });
+                if !mentions_param
+                    || substitutions
+                        .iter()
+                        .any(|(existing, _)| existing == type_param_name)
+                {
+                    continue;
+                }
+                if let Some(value_text) =
+                    self.object_member_public_type_text_for_annotation(arg_member_idx, &searchable)
+                {
+                    substitutions.push((type_param_name.clone(), value_text));
+                    break;
+                }
+            }
+
+            self.infer_object_argument_substitutions_from_type_node(
+                source_arena,
+                signature.type_annotation,
+                arg_member_idx,
+                type_param_names,
+                aliases,
+                substitutions,
+                depth + 1,
+            );
+        }
+    }
+
+    fn infer_object_argument_substitution_from_mapped_type(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        substitutions: &mut Vec<(String, String)>,
+    ) {
+        let Some(arg_idx) = self.skip_parenthesized_expression(arg_idx) else {
+            return;
+        };
+        let Some(arg_node) = self.arena.get(arg_idx) else {
+            return;
+        };
+        if arg_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return;
+        }
+        let Some(mapped_node) = source_arena.get(type_idx) else {
+            return;
+        };
+        let Some(mapped) = source_arena.get_mapped_type(mapped_node) else {
+            return;
+        };
+        let Some(type_param_node) = source_arena.get(mapped.type_parameter) else {
+            return;
+        };
+        let Some(type_param) = source_arena.get_type_parameter(type_param_node) else {
+            return;
+        };
+        let Some(constraint_text) = self
+            .emit_type_node_text_from_arena(source_arena, type_param.constraint)
+            .or_else(|| self.source_slice_from_arena(source_arena, type_param.constraint))
+        else {
+            return;
+        };
+        let Some(indexed_param) = constraint_text.trim().strip_prefix("keyof ").map(str::trim)
+        else {
+            return;
+        };
+        let Some(type_param_name) =
+            Self::mapped_type_param_name(indexed_param, type_param_names, aliases)
+        else {
+            return;
+        };
+        if substitutions
+            .iter()
+            .any(|(existing, _)| existing == &type_param_name)
+        {
+            return;
+        }
+        let Some(object) = self.arena.get_literal_expr(arg_node) else {
+            return;
+        };
+
+        let mut lines = Vec::new();
+        for member_idx in object.elements.nodes.iter().copied() {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            let Some(name_idx) = self.object_literal_member_name_idx(member_node) else {
+                continue;
+            };
+            let Some(name_text) = self.object_literal_member_name_text(name_idx) else {
+                continue;
+            };
+            if !Self::is_simple_identifier_text(&name_text) {
+                continue;
+            }
+            let value_text = self
+                .object_literal_member_initializer(member_node)
+                .and_then(|initializer| {
+                    self.infer_descriptor_value_type_from_annotation(
+                        source_arena,
+                        mapped.type_node,
+                        initializer,
+                    )
+                })
+                .or_else(|| self.object_member_public_type_text(member_idx));
+            let Some(value_text) = value_text else {
+                continue;
+            };
+            lines.push(format!("    {name_text}: {value_text};"));
+        }
+        if !lines.is_empty() {
+            substitutions.push((type_param_name, format!("{{\n{}\n}}", lines.join("\n"))));
+        }
+    }
+
+    fn infer_descriptor_argument_substitution(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+    ) -> Option<(String, String)> {
+        let type_node = source_arena.get(type_idx)?;
+        if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = source_arena.get_type_ref(type_node)?;
+        let type_args = type_ref.type_arguments.as_ref()?;
+        let [type_arg_idx] = type_args.nodes.as_slice() else {
+            return None;
+        };
+        let type_arg_text = self
+            .emit_type_node_text_from_arena(source_arena, *type_arg_idx)
+            .or_else(|| self.source_slice_from_arena(source_arena, *type_arg_idx))?;
+        let type_param_name =
+            Self::mapped_type_param_name(type_arg_text.trim(), type_param_names, aliases)?;
+        let value_text =
+            self.infer_descriptor_value_type_from_annotation(source_arena, type_idx, arg_idx)?;
+        Some((type_param_name, value_text))
+    }
+
+    fn infer_descriptor_value_type_from_annotation(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        arg_idx: NodeIndex,
+    ) -> Option<String> {
+        let type_node = source_arena.get(type_idx)?;
+        if type_node.kind == syntax_kind_ext::UNION_TYPE {
+            let union = source_arena.get_composite_type(type_node)?;
+            return union.types.nodes.iter().copied().find_map(|part_idx| {
+                self.infer_descriptor_value_type_from_annotation(source_arena, part_idx, arg_idx)
+            });
+        }
+        if type_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            let wrapped = source_arena.get_wrapped_type(type_node)?;
+            return self.infer_descriptor_value_type_from_annotation(
+                source_arena,
+                wrapped.type_node,
+                arg_idx,
+            );
+        }
+        if type_node.kind == syntax_kind_ext::FUNCTION_TYPE {
+            return self.object_member_public_type_text(arg_idx);
+        }
+        if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let alias_sym_id = self.declaration_type_symbol_from_type_node(source_arena, type_idx)?;
+        self.with_symbol_declarations(alias_sym_id, |alias_arena, decl_idx| {
+            let decl_node = alias_arena.get(decl_idx)?;
+            let alias = alias_arena.get_type_alias(decl_node)?;
+            let alias_type_node = alias_arena.get(alias.type_node)?;
+            if alias_type_node.kind != syntax_kind_ext::TYPE_LITERAL {
+                return None;
+            }
+            let type_literal = alias_arena.get_type_literal(alias_type_node)?;
+            for member_idx in type_literal.members.nodes.iter().copied() {
+                let member_node = alias_arena.get(member_idx)?;
+                let signature = alias_arena.get_signature(member_node)?;
+                let member_name = identifier_text(alias_arena, signature.name)?;
+                if member_name == "value" {
+                    if let Some(value_member_idx) =
+                        self.object_literal_member_by_name(arg_idx, "value")
+                        && let Some(type_text) =
+                            self.object_member_public_type_text(value_member_idx)
+                    {
+                        return Some(type_text);
+                    }
+                } else if member_name == "get"
+                    && let Some(get_member_idx) = self.object_literal_member_by_name(arg_idx, "get")
+                    && let Some(type_text) = self.object_member_public_type_text(get_member_idx)
+                {
+                    return Some(type_text);
+                } else if member_name == "set"
+                    && let Some(set_member_idx) = self.object_literal_member_by_name(arg_idx, "set")
+                    && let Some(type_text) = self.setter_first_parameter_type_text(set_member_idx)
+                {
+                    return Some(type_text);
+                }
+            }
+            None
+        })
+    }
+
+    fn object_literal_member_by_name(
+        &self,
+        object_idx: NodeIndex,
+        property_name: &str,
+    ) -> Option<NodeIndex> {
+        let object_idx = self.skip_parenthesized_expression(object_idx)?;
+        let object_node = self.arena.get(object_idx)?;
+        let object = self.arena.get_literal_expr(object_node)?;
+        object.elements.nodes.iter().copied().find(|member_idx| {
+            let Some(member_node) = self.arena.get(*member_idx) else {
+                return false;
+            };
+            self.object_literal_member_name_idx(member_node)
+                .and_then(|name_idx| self.object_literal_member_name_text(name_idx))
+                .as_deref()
+                == Some(property_name)
+        })
+    }
+
+    pub(in crate::declaration_emitter) fn infer_object_map_substitution_from_annotation_text(
+        &self,
+        annotation_text: &str,
+        arg_idx: NodeIndex,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        existing_substitutions: &[(String, String)],
+    ) -> Option<(String, String)> {
+        if !annotation_text.contains('<') {
+            return None;
+        }
+        let mentioned = type_param_names
+            .iter()
+            .filter(|name| {
+                !existing_substitutions
+                    .iter()
+                    .any(|(existing, _)| existing == *name)
+                    && (Self::contains_whole_word_in_text(annotation_text, name)
+                        || aliases.iter().any(|(alias, mapped)| {
+                            mapped == *name
+                                && Self::contains_whole_word_in_text(annotation_text, alias)
+                        }))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let [type_param_name] = mentioned.as_slice() else {
+            return None;
+        };
+        let object_text = self.object_literal_property_value_map_type_text(arg_idx)?;
+        Some((type_param_name.clone(), object_text))
+    }
+
+    fn object_literal_property_value_map_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
+        let arg_node = self.arena.get(arg_idx)?;
+        let arg_idx = if arg_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            arg_idx
+        } else {
+            self.object_literal_member_initializer(arg_node)?
+        };
+        let arg_node = self.arena.get(arg_idx)?;
+        let object = self.arena.get_literal_expr(arg_node)?;
+        let mut lines = Vec::new();
+        for member_idx in object.elements.nodes.iter().copied() {
+            let member_node = self.arena.get(member_idx)?;
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name_text = self.object_literal_member_name_text(name_idx)?;
+            if !Self::is_simple_identifier_text(&name_text) {
+                return None;
+            }
+            let value_text = self
+                .descriptor_like_object_member_value_type_text(member_idx)
+                .or_else(|| self.object_member_public_type_text(member_idx))?;
+            lines.push(format!("    {name_text}: {value_text};"));
+        }
+        (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
+    }
+
+    fn descriptor_like_object_member_value_type_text(
+        &self,
+        member_idx: NodeIndex,
+    ) -> Option<String> {
+        let member_node = self.arena.get(member_idx)?;
+        let initializer = self.object_literal_member_initializer(member_node)?;
+        self.object_literal_member_by_name(initializer, "value")
+            .and_then(|value_member| self.object_member_public_type_text(value_member))
+            .or_else(|| {
+                self.object_literal_member_by_name(initializer, "get")
+                    .and_then(|get_member| self.object_member_public_type_text(get_member))
+            })
+            .or_else(|| {
+                self.object_literal_member_by_name(initializer, "set")
+                    .and_then(|set_member| self.setter_first_parameter_type_text(set_member))
+            })
+    }
+
+    fn setter_first_parameter_type_text(&self, member_idx: NodeIndex) -> Option<String> {
+        let member_node = self.arena.get(member_idx)?;
+        let method = self.arena.get_method_decl(member_node)?;
+        let param_idx = method.parameters.nodes.first().copied()?;
+        let param_node = self.arena.get(param_idx)?;
+        let param = self.arena.get_parameter(param_node)?;
+        self.emit_type_node_text(param.type_annotation)
+            .or_else(|| self.source_slice_from_arena(self.arena, param.type_annotation))
+    }
+
+    fn object_member_public_type_text(&self, member_idx: NodeIndex) -> Option<String> {
+        let member_node = self.arena.get(member_idx)?;
+        if let Some(initializer) = self.object_literal_member_initializer(member_node) {
+            return self.call_argument_public_type_text(initializer);
+        }
+        if let Some(method) = self.arena.get_method_decl(member_node) {
+            return self
+                .emit_type_node_text(method.type_annotation)
+                .or_else(|| self.function_body_preferred_return_type_text(method.body))
+                .or_else(|| self.infer_fallback_type_text_at(method.body, 0))
+                .map(|text| Self::widen_public_literal_type_text(&text));
+        }
+        if let Some(accessor) = self.arena.get_accessor(member_node)
+            && accessor.body.is_some()
+        {
+            return self
+                .emit_type_node_text(accessor.type_annotation)
+                .or_else(|| self.function_body_preferred_return_type_text(accessor.body))
+                .or_else(|| self.infer_fallback_type_text_at(accessor.body, 0))
+                .map(|text| Self::widen_public_literal_type_text(&text));
+        }
+        None
+    }
+
+    fn object_member_public_type_text_for_annotation(
+        &self,
+        member_idx: NodeIndex,
+        annotation_text: &str,
+    ) -> Option<String> {
+        let member_node = self.arena.get(member_idx)?;
+        if annotation_text.contains("=>")
+            && let Some(initializer) = self.object_literal_member_initializer(member_node)
+            && let Some(type_text) = self.function_expression_public_return_type_text(initializer)
+        {
+            return Some(type_text);
+        }
+        self.object_member_public_type_text(member_idx)
+    }
+
+    fn call_argument_public_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        self.primitive_literal_argument_widened_type_text(arg_idx)
+            .or_else(|| self.object_literal_public_type_text(arg_idx))
+            .or_else(|| self.function_expression_public_return_type_text(arg_idx))
+            .or_else(|| self.call_argument_type_text_for_substitution(arg_idx, None))
+    }
+
+    fn function_expression_public_return_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
+        let arg_node = self.arena.get(arg_idx)?;
+        if arg_node.kind != syntax_kind_ext::ARROW_FUNCTION
+            && arg_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+        {
+            return None;
+        }
+        let func = self.arena.get_function(arg_node)?;
+        let return_expr = if self
+            .arena
+            .get(func.body)
+            .is_some_and(|node| node.kind == syntax_kind_ext::BLOCK)
+        {
+            self.function_body_single_return_expression(func.body)?
+        } else {
+            func.body
+        };
+        self.call_argument_public_type_text(return_expr)
+            .map(|text| Self::widen_public_literal_type_text(&text))
+    }
+
+    fn object_literal_public_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
+        let arg_node = self.arena.get(arg_idx)?;
+        if arg_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let object = self.arena.get_literal_expr(arg_node)?;
+        let mut lines = Vec::new();
+        for member_idx in object.elements.nodes.iter().copied() {
+            let member_node = self.arena.get(member_idx)?;
+            if let Some(method_text) = self.object_method_public_signature_text(member_node) {
+                lines.push(method_text);
+                continue;
+            }
+            let name_idx = self.object_literal_member_name_idx(member_node)?;
+            let name_text = self.object_literal_member_name_text(name_idx)?;
+            if !Self::is_simple_identifier_text(&name_text) {
+                return None;
+            }
+            let value_text = self.object_member_public_type_text(member_idx)?;
+            lines.push(format!("    {name_text}: {value_text};"));
+        }
+        (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
+    }
+
+    fn object_method_public_signature_text(
+        &self,
+        member_node: &tsz_parser::parser::node::Node,
+    ) -> Option<String> {
+        let method = self.arena.get_method_decl(member_node)?;
+        let name = self.object_literal_member_name_text(method.name)?;
+        if !Self::is_simple_identifier_text(&name) {
+            return None;
+        }
+        let params = method
+            .parameters
+            .nodes
+            .iter()
+            .copied()
+            .map(|param_idx| {
+                let param_node = self.arena.get(param_idx)?;
+                let param = self.arena.get_parameter(param_node)?;
+                let name = self.get_identifier_text(param.name)?;
+                let type_text = self
+                    .emit_type_node_text(param.type_annotation)
+                    .unwrap_or_else(|| "any".to_string());
+                Some(format!("{name}: {type_text}"))
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let return_text = self
+            .emit_type_node_text(method.type_annotation)
+            .or_else(|| self.function_body_preferred_return_type_text(method.body))
+            .or_else(|| self.infer_fallback_type_text_at(method.body, 0))
+            .map(|text| Self::widen_public_literal_type_text(&text))
+            .unwrap_or_else(|| "void".to_string());
+        Some(format!("    {name}({}): {return_text};", params.join(", ")))
+    }
+
+    fn primitive_literal_argument_widened_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
+        let arg_node = self.arena.get(arg_idx)?;
+        match arg_node.kind {
+            k if k == SyntaxKind::StringLiteral as u16
+                || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16 =>
+            {
+                Some("string".to_string())
+            }
+            k if k == SyntaxKind::NumericLiteral as u16 => Some("number".to_string()),
+            k if k == SyntaxKind::TrueKeyword as u16 || k == SyntaxKind::FalseKeyword as u16 => {
+                Some("boolean".to_string())
+            }
+            k if k == SyntaxKind::BigIntLiteral as u16 => Some("bigint".to_string()),
+            _ => None,
+        }
+    }
+
+    fn widen_public_literal_type_text(type_text: &str) -> String {
+        let trimmed = type_text.trim();
+        if trimmed.starts_with('{') && trimmed.ends_with('}') {
+            return Self::widen_public_object_literal_type_text(trimmed);
+        }
+        if trimmed.parse::<f64>().is_ok() {
+            return "number".to_string();
+        }
+        if trimmed == "true" || trimmed == "false" {
+            return "boolean".to_string();
+        }
+        if trimmed.len() >= 2
+            && ((trimmed.starts_with('"') && trimmed.ends_with('"'))
+                || (trimmed.starts_with('\'') && trimmed.ends_with('\'')))
+        {
+            return "string".to_string();
+        }
+        trimmed.to_string()
+    }
+
+    fn widen_public_object_literal_type_text(type_text: &str) -> String {
+        let mut output = String::with_capacity(type_text.len());
+        for line in type_text.lines() {
+            let trimmed = line.trim();
+            if let Some((name, rest)) = trimmed.split_once(':') {
+                let value = rest.trim().trim_end_matches(';').trim();
+                let widened = Self::widen_public_literal_type_text(value);
+                if widened != value {
+                    let indent = line
+                        .get(..line.len().saturating_sub(line.trim_start().len()))
+                        .unwrap_or("");
+                    output.push_str(indent);
+                    output.push_str(name.trim());
+                    output.push_str(": ");
+                    output.push_str(&widened);
+                    output.push(';');
+                    output.push('\n');
+                    continue;
+                }
+            }
+            output.push_str(line);
+            output.push('\n');
+        }
+        output.trim_end().to_string()
+    }
+
+    fn mapped_type_param_name(
+        name: &str,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+    ) -> Option<String> {
+        let trimmed = name.trim();
+        if type_param_names.iter().any(|param| param == trimmed) {
+            return Some(trimmed.to_string());
+        }
+        aliases
+            .iter()
+            .find_map(|(alias, mapped)| (alias == trimmed).then(|| mapped.clone()))
+    }
+
+    fn replace_or_push_substitution(
+        substitutions: &mut Vec<(String, String)>,
+        type_param_name: String,
+        value_text: String,
+    ) {
+        if let Some((_, existing_value)) = substitutions
+            .iter_mut()
+            .find(|(existing, _)| existing == &type_param_name)
+        {
+            *existing_value = value_text;
+        } else {
+            substitutions.push((type_param_name, value_text));
+        }
+    }
+
+    fn type_reference_application_parts(type_text: &str) -> Option<(&str, Vec<String>)> {
+        let trimmed = type_text.trim();
+        let open = trimmed.find('<')?;
+        let name = trimmed.get(..open)?.trim();
+        let inner = trimmed.get(open + 1..)?.trim().strip_suffix('>')?.trim();
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|ch| ch == '_' || ch == '$' || ch == '.' || ch.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+        Some((
+            name,
+            Self::split_top_level_commas(inner)
+                .into_iter()
+                .map(str::trim)
+                .map(str::to_string)
+                .collect(),
+        ))
+    }
+
+    fn find_type_alias_decl_in_arena(&self, arena: &NodeArena, name: &str) -> Option<NodeIndex> {
+        let source_file = self.arena_source_file(arena)?;
+        for &stmt_idx in &source_file.statements.nodes {
+            let stmt_node = arena.get(stmt_idx)?;
+            let Some(alias) = arena.get_type_alias(stmt_node) else {
+                continue;
+            };
+            if self
+                .identifier_text_from_arena(arena, alias.name)
+                .as_deref()
+                == Some(name)
+            {
+                return Some(stmt_idx);
+            }
+        }
+        None
+    }
+
+    fn type_text_without_this_type_markers(type_text: &str) -> String {
+        let mut text = type_text.to_string();
+        while let Some(start) = text.find("ThisType<") {
+            let mut depth = 0usize;
+            let mut end = None;
+            for (offset, ch) in text[start + "ThisType".len()..].char_indices() {
+                match ch {
+                    '<' => depth += 1,
+                    '>' => {
+                        depth = depth.saturating_sub(1);
+                        if depth == 0 {
+                            end = Some(start + "ThisType".len() + offset + ch.len_utf8());
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let Some(end) = end else {
+                break;
+            };
+            text.replace_range(start..end, "");
+        }
+        text
+    }
+}
+
+fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    source_arena
+        .get(idx)
+        .and_then(|node| source_arena.get_identifier(node))
+        .map(|ident| ident.escaped_text.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_parser::parser::ParserState;
+
+    #[test]
+    fn mapped_accessor_object_argument_infers_public_value_map() {
+        let mut parser = ParserState::new(
+            "accessor-map.ts".to_string(),
+            r#"
+type Accessor<V> = {
+    get?(): V;
+    set?(value: V): void;
+};
+type AccessorBag<S> = { [Key in keyof S]: (() => S[Key]) | Accessor<S[Key]> };
+type Options<S> = {
+    computed?: AccessorBag<S>;
+};
+let arg = {
+    computed: {
+        total(): number {
+            return 1;
+        },
+        label: {
+            get() {
+                return "ready";
+            },
+            set(value: string) {
+            }
+        }
+    }
+};
+"#
+            .to_string(),
+        );
+        parser.parse_source_file();
+        let arena = parser.get_arena();
+        let emitter = DeclarationEmitter::new(arena);
+        let options_type = emitter
+            .find_type_alias_type_node_in_arena(arena, "Options")
+            .expect("options alias type");
+        let arg_idx = arena
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                let node_idx = NodeIndex(idx as u32);
+                (node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                    && emitter
+                        .object_literal_member_by_name(node_idx, "computed")
+                        .is_some())
+                .then_some(node_idx)
+            })
+            .expect("argument object literal");
+        let computed_member_idx = emitter
+            .object_literal_member_by_name(arg_idx, "computed")
+            .expect("computed member");
+        assert_eq!(
+            emitter.object_literal_property_value_map_type_text(computed_member_idx),
+            Some("{\n    total: number;\n    label: string;\n}".to_string())
+        );
+        let mut substitutions = Vec::new();
+        emitter.infer_object_argument_substitutions_from_type_node(
+            arena,
+            options_type,
+            arg_idx,
+            &["S".to_string()],
+            &[],
+            &mut substitutions,
+            0,
+        );
+
+        assert_eq!(
+            substitutions,
+            vec![(
+                "S".to_string(),
+                "{\n    total: number;\n    label: string;\n}".to_string()
+            )]
+        );
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -166,6 +166,7 @@ impl<'a> DeclarationEmitter<'a> {
                         arg_idx,
                         type_param_names,
                         aliases,
+                        &[],
                     )
                     && !substitutions
                         .iter()
@@ -240,6 +241,7 @@ impl<'a> DeclarationEmitter<'a> {
         arg_idx: NodeIndex,
         type_param_names: &[String],
         aliases: &[(String, String)],
+        this_contexts: &[(String, String)],
     ) -> Option<(String, String)> {
         let type_node = source_arena.get(type_idx)?;
         let type_ref = source_arena.get_type_ref(type_node)?;
@@ -270,7 +272,8 @@ impl<'a> DeclarationEmitter<'a> {
         if !symbol_alias_is_mapped && !local_alias_is_mapped {
             return None;
         }
-        let value_text = self.object_literal_property_value_map_type_text(arg_idx)?;
+        let value_text =
+            self.object_literal_property_value_map_type_text_with_context(arg_idx, this_contexts)?;
         Some((type_param_name, value_text))
     }
 
@@ -331,11 +334,6 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
 
-            let raw_member_type_text = self
-                .source_slice_from_arena(source_arena, signature.type_annotation)
-                .or_else(|| {
-                    self.emit_type_node_text_from_arena(source_arena, signature.type_annotation)
-                });
             let Some(member_type_text) = self
                 .emit_type_node_text_from_arena(source_arena, signature.type_annotation)
                 .or_else(|| self.source_slice_from_arena(source_arena, signature.type_annotation))
@@ -343,32 +341,17 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             };
             let searchable = Self::type_text_without_this_type_markers(&member_type_text);
-            if let Some(raw_member_type_text) = raw_member_type_text.as_deref()
-                && let Some((type_param_name, value_text)) = self
-                    .infer_object_map_substitution_from_annotation_text(
-                        raw_member_type_text,
-                        arg_member_idx,
-                        type_param_names,
-                        aliases,
-                        &[],
-                    )
-            {
-                Self::replace_or_push_substitution(substitutions, type_param_name, value_text);
-                continue;
-            }
-            if let Some((type_param_name, value_text)) = self
-                .infer_object_map_substitution_from_annotation_text(
-                    &searchable,
-                    arg_member_idx,
+            for type_param_name in type_param_names {
+                if !Self::type_node_exposes_direct_type_param(
+                    source_arena,
+                    signature.type_annotation,
+                    type_param_name,
                     type_param_names,
                     aliases,
-                    &[],
-                )
-            {
-                Self::replace_or_push_substitution(substitutions, type_param_name, value_text);
-                continue;
-            }
-            for type_param_name in type_param_names {
+                    0,
+                ) {
+                    continue;
+                }
                 let mentions_param =
                     Self::contains_whole_word_in_text(&searchable, type_param_name)
                         || aliases.iter().any(|(alias, mapped)| {
@@ -382,9 +365,12 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     continue;
                 }
-                if let Some(value_text) =
-                    self.object_member_public_type_text_for_annotation(arg_member_idx, &searchable)
-                {
+                if let Some(value_text) = self.object_member_public_type_text_for_annotation(
+                    arg_member_idx,
+                    &searchable,
+                    Some(arg_idx),
+                    substitutions,
+                ) {
                     substitutions.push((type_param_name.clone(), value_text));
                     break;
                 }
@@ -399,6 +385,71 @@ impl<'a> DeclarationEmitter<'a> {
                 substitutions,
                 depth + 1,
             );
+        }
+    }
+
+    fn type_node_exposes_direct_type_param(
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        type_param_name: &str,
+        type_param_names: &[String],
+        aliases: &[(String, String)],
+        depth: u8,
+    ) -> bool {
+        if depth > 16 {
+            return false;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        match type_node.kind {
+            k if k == SyntaxKind::Identifier as u16 => {
+                identifier_text(source_arena, type_idx)
+                    .and_then(|name| Self::mapped_type_param_name(&name, type_param_names, aliases))
+                    .as_deref()
+                    == Some(type_param_name)
+            }
+            k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                let Some(type_ref) = source_arena.get_type_ref(type_node) else {
+                    return false;
+                };
+                if let Some(name) = identifier_text(source_arena, type_ref.type_name)
+                    && Self::mapped_type_param_name(&name, type_param_names, aliases).as_deref()
+                        == Some(type_param_name)
+                {
+                    return true;
+                }
+                false
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => source_arena
+                .get_wrapped_type(type_node)
+                .is_some_and(|wrapped| {
+                    Self::type_node_exposes_direct_type_param(
+                        source_arena,
+                        wrapped.type_node,
+                        type_param_name,
+                        type_param_names,
+                        aliases,
+                        depth + 1,
+                    )
+                }),
+            k if k == syntax_kind_ext::INTERSECTION_TYPE || k == syntax_kind_ext::UNION_TYPE => {
+                source_arena
+                    .get_composite_type(type_node)
+                    .is_some_and(|composite| {
+                        composite.types.nodes.iter().copied().any(|part_idx| {
+                            Self::type_node_exposes_direct_type_param(
+                                source_arena,
+                                part_idx,
+                                type_param_name,
+                                type_param_names,
+                                aliases,
+                                depth + 1,
+                            )
+                        })
+                    })
+            }
+            _ => false,
         }
     }
 
@@ -480,7 +531,13 @@ impl<'a> DeclarationEmitter<'a> {
                         initializer,
                     )
                 })
-                .or_else(|| self.object_member_public_type_text(member_idx));
+                .or_else(|| {
+                    self.object_member_public_type_text_with_context(
+                        member_idx,
+                        Some(arg_idx),
+                        substitutions,
+                    )
+                });
             let Some(value_text) = value_text else {
                 continue;
             };
@@ -629,11 +686,18 @@ impl<'a> DeclarationEmitter<'a> {
         let [type_param_name] = mentioned.as_slice() else {
             return None;
         };
-        let object_text = self.object_literal_property_value_map_type_text(arg_idx)?;
+        let object_text = self.object_literal_property_value_map_type_text_with_context(
+            arg_idx,
+            existing_substitutions,
+        )?;
         Some((type_param_name.clone(), object_text))
     }
 
-    fn object_literal_property_value_map_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+    fn object_literal_property_value_map_type_text_with_context(
+        &self,
+        arg_idx: NodeIndex,
+        this_contexts: &[(String, String)],
+    ) -> Option<String> {
         let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
         let arg_node = self.arena.get(arg_idx)?;
         let arg_idx = if arg_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
@@ -652,24 +716,46 @@ impl<'a> DeclarationEmitter<'a> {
                 return None;
             }
             let value_text = self
-                .descriptor_like_object_member_value_type_text(member_idx)
-                .or_else(|| self.object_member_public_type_text(member_idx))?;
+                .descriptor_like_object_member_value_type_text_with_context(
+                    member_idx,
+                    this_contexts,
+                )
+                .or_else(|| {
+                    self.object_member_public_type_text_with_context(
+                        member_idx,
+                        Some(arg_idx),
+                        this_contexts,
+                    )
+                })?;
             lines.push(format!("    {name_text}: {value_text};"));
         }
         (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
     }
 
-    fn descriptor_like_object_member_value_type_text(
+    fn descriptor_like_object_member_value_type_text_with_context(
         &self,
         member_idx: NodeIndex,
+        this_contexts: &[(String, String)],
     ) -> Option<String> {
         let member_node = self.arena.get(member_idx)?;
         let initializer = self.object_literal_member_initializer(member_node)?;
         self.object_literal_member_by_name(initializer, "value")
-            .and_then(|value_member| self.object_member_public_type_text(value_member))
+            .and_then(|value_member| {
+                self.object_member_public_type_text_with_context(
+                    value_member,
+                    Some(initializer),
+                    this_contexts,
+                )
+            })
             .or_else(|| {
                 self.object_literal_member_by_name(initializer, "get")
-                    .and_then(|get_member| self.object_member_public_type_text(get_member))
+                    .and_then(|get_member| {
+                        self.object_member_public_type_text_with_context(
+                            get_member,
+                            Some(initializer),
+                            this_contexts,
+                        )
+                    })
             })
             .or_else(|| {
                 self.object_literal_member_by_name(initializer, "set")
@@ -688,13 +774,34 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     fn object_member_public_type_text(&self, member_idx: NodeIndex) -> Option<String> {
+        self.object_member_public_type_text_with_context(member_idx, None, &[])
+    }
+
+    fn object_member_public_type_text_with_context(
+        &self,
+        member_idx: NodeIndex,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
+    ) -> Option<String> {
         let member_node = self.arena.get(member_idx)?;
         if let Some(initializer) = self.object_literal_member_initializer(member_node) {
-            return self.call_argument_public_type_text(initializer);
+            return self.call_argument_public_type_text_with_context(
+                initializer,
+                None,
+                this_contexts,
+            );
         }
         if let Some(method) = self.arena.get_method_decl(member_node) {
             return self
                 .emit_type_node_text(method.type_annotation)
+                .or_else(|| {
+                    self.function_body_this_property_type_text(
+                        method.body,
+                        this_object_idx,
+                        this_contexts,
+                        Some(member_idx),
+                    )
+                })
                 .or_else(|| self.function_body_preferred_return_type_text(method.body))
                 .or_else(|| self.infer_fallback_type_text_at(method.body, 0))
                 .map(|text| Self::widen_public_literal_type_text(&text));
@@ -704,6 +811,14 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return self
                 .emit_type_node_text(accessor.type_annotation)
+                .or_else(|| {
+                    self.function_body_this_property_type_text(
+                        accessor.body,
+                        this_object_idx,
+                        this_contexts,
+                        Some(member_idx),
+                    )
+                })
                 .or_else(|| self.function_body_preferred_return_type_text(accessor.body))
                 .or_else(|| self.infer_fallback_type_text_at(accessor.body, 0))
                 .map(|text| Self::widen_public_literal_type_text(&text));
@@ -715,6 +830,8 @@ impl<'a> DeclarationEmitter<'a> {
         &self,
         member_idx: NodeIndex,
         annotation_text: &str,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
     ) -> Option<String> {
         let member_node = self.arena.get(member_idx)?;
         if annotation_text.contains("=>")
@@ -723,12 +840,27 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return Some(type_text);
         }
-        self.object_member_public_type_text(member_idx)
+        self.object_member_public_type_text_with_context(member_idx, this_object_idx, this_contexts)
     }
 
     fn call_argument_public_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+        self.call_argument_public_type_text_with_context(arg_idx, None, &[])
+    }
+
+    fn call_argument_public_type_text_with_context(
+        &self,
+        arg_idx: NodeIndex,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
+    ) -> Option<String> {
         self.primitive_literal_argument_widened_type_text(arg_idx)
-            .or_else(|| self.object_literal_public_type_text(arg_idx))
+            .or_else(|| {
+                self.object_literal_public_type_text_with_context(
+                    arg_idx,
+                    this_object_idx,
+                    this_contexts,
+                )
+            })
             .or_else(|| self.function_expression_public_return_type_text(arg_idx))
             .or_else(|| self.call_argument_type_text_for_substitution(arg_idx, None))
     }
@@ -755,17 +887,28 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|text| Self::widen_public_literal_type_text(&text))
     }
 
-    fn object_literal_public_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
+    fn object_literal_public_type_text_with_context(
+        &self,
+        arg_idx: NodeIndex,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
+    ) -> Option<String> {
         let arg_idx = self.skip_parenthesized_expression(arg_idx)?;
         let arg_node = self.arena.get(arg_idx)?;
         if arg_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
             return None;
         }
+        let this_object_idx = this_object_idx.or(Some(arg_idx));
         let object = self.arena.get_literal_expr(arg_node)?;
         let mut lines = Vec::new();
         for member_idx in object.elements.nodes.iter().copied() {
             let member_node = self.arena.get(member_idx)?;
-            if let Some(method_text) = self.object_method_public_signature_text(member_node) {
+            if let Some(method_text) = self.object_method_public_signature_text_with_context(
+                Some(member_idx),
+                member_node,
+                this_object_idx,
+                this_contexts,
+            ) {
                 lines.push(method_text);
                 continue;
             }
@@ -774,15 +917,22 @@ impl<'a> DeclarationEmitter<'a> {
             if !Self::is_simple_identifier_text(&name_text) {
                 return None;
             }
-            let value_text = self.object_member_public_type_text(member_idx)?;
+            let value_text = self.object_member_public_type_text_with_context(
+                member_idx,
+                this_object_idx,
+                this_contexts,
+            )?;
             lines.push(format!("    {name_text}: {value_text};"));
         }
         (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
     }
 
-    fn object_method_public_signature_text(
+    fn object_method_public_signature_text_with_context(
         &self,
+        member_idx: Option<NodeIndex>,
         member_node: &tsz_parser::parser::node::Node,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
     ) -> Option<String> {
         let method = self.arena.get_method_decl(member_node)?;
         let name = self.object_literal_member_name_text(method.name)?;
@@ -806,11 +956,73 @@ impl<'a> DeclarationEmitter<'a> {
             .collect::<Option<Vec<_>>>()?;
         let return_text = self
             .emit_type_node_text(method.type_annotation)
+            .or_else(|| {
+                self.function_body_this_property_type_text(
+                    method.body,
+                    this_object_idx,
+                    this_contexts,
+                    member_idx,
+                )
+            })
             .or_else(|| self.function_body_preferred_return_type_text(method.body))
             .or_else(|| self.infer_fallback_type_text_at(method.body, 0))
             .map(|text| Self::widen_public_literal_type_text(&text))
             .unwrap_or_else(|| "void".to_string());
         Some(format!("    {name}({}): {return_text};", params.join(", ")))
+    }
+
+    fn function_body_this_property_type_text(
+        &self,
+        body_idx: NodeIndex,
+        this_object_idx: Option<NodeIndex>,
+        this_contexts: &[(String, String)],
+        current_member_idx: Option<NodeIndex>,
+    ) -> Option<String> {
+        if body_idx.is_none() {
+            return None;
+        }
+        let return_expr = self.function_body_single_return_expression(body_idx)?;
+        let return_node = self.arena.get(return_expr)?;
+        if return_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(return_node)?;
+        if self
+            .arena
+            .get(access.expression)
+            .is_none_or(|node| node.kind != SyntaxKind::ThisKeyword as u16)
+        {
+            return None;
+        }
+
+        let property_name = self.get_identifier_text(access.name_or_argument)?;
+        if let Some(object_idx) = this_object_idx
+            && let Some(member_idx) = self.object_literal_member_by_name(object_idx, &property_name)
+            && Some(member_idx) != current_member_idx
+            && let Some(type_text) = self.object_member_public_type_text_with_context(
+                member_idx,
+                Some(object_idx),
+                this_contexts,
+            )
+        {
+            return Some(type_text);
+        }
+
+        this_contexts.iter().find_map(|(_, context_text)| {
+            Self::object_property_type_from_public_summary(context_text, &property_name)
+                .map(Self::widen_public_literal_type_text)
+        })
+    }
+
+    fn object_property_type_from_public_summary<'b>(
+        summary_text: &'b str,
+        property_name: &str,
+    ) -> Option<&'b str> {
+        summary_text.lines().find_map(|line| {
+            (Self::object_type_property_name_from_line(line).as_deref() == Some(property_name))
+                .then(|| Self::object_literal_property_value_type(line))
+                .flatten()
+        })
     }
 
     fn primitive_literal_argument_widened_type_text(&self, arg_idx: NodeIndex) -> Option<String> {
@@ -889,21 +1101,6 @@ impl<'a> DeclarationEmitter<'a> {
         aliases
             .iter()
             .find_map(|(alias, mapped)| (alias == trimmed).then(|| mapped.clone()))
-    }
-
-    fn replace_or_push_substitution(
-        substitutions: &mut Vec<(String, String)>,
-        type_param_name: String,
-        value_text: String,
-    ) {
-        if let Some((_, existing_value)) = substitutions
-            .iter_mut()
-            .find(|(existing, _)| existing == &type_param_name)
-        {
-            *existing_value = value_text;
-        } else {
-            substitutions.push((type_param_name, value_text));
-        }
     }
 
     fn type_reference_application_parts(type_text: &str) -> Option<(&str, Vec<String>)> {
@@ -1038,7 +1235,8 @@ let arg = {
             .object_literal_member_by_name(arg_idx, "computed")
             .expect("computed member");
         assert_eq!(
-            emitter.object_literal_property_value_map_type_text(computed_member_idx),
+            emitter
+                .object_literal_property_value_map_type_text_with_context(computed_member_idx, &[]),
             Some("{\n    total: number;\n    label: string;\n}".to_string())
         );
         let mut substitutions = Vec::new();
@@ -1058,6 +1256,111 @@ let arg = {
                 "S".to_string(),
                 "{\n    total: number;\n    label: string;\n}".to_string()
             )]
+        );
+    }
+
+    #[test]
+    fn object_literal_method_and_accessor_this_property_returns_use_sibling_public_types() {
+        let mut parser = ParserState::new(
+            "this-property-public-type.ts".to_string(),
+            r#"
+let arg = {
+    a: 1,
+    b: "ready",
+    f() {
+        return this.a;
+    },
+    get d() {
+        return this.a;
+    },
+    get e() {
+        return this.b;
+    }
+};
+"#
+            .to_string(),
+        );
+        parser.parse_source_file();
+        let arena = parser.get_arena();
+        let emitter = DeclarationEmitter::new(arena);
+        let arg_idx = arena
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                let node_idx = NodeIndex(idx as u32);
+                (node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                    && emitter
+                        .object_literal_member_by_name(node_idx, "f")
+                        .is_some())
+                .then_some(node_idx)
+            })
+            .expect("argument object literal");
+
+        assert_eq!(
+            emitter.object_literal_public_type_text_with_context(arg_idx, None, &[]),
+            Some(
+                "{\n    a: number;\n    b: string;\n    f(): number;\n    d: number;\n    e: string;\n}"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn non_mapped_generic_member_alias_does_not_infer_object_value_map() {
+        let mut parser = ParserState::new(
+            "non-mapped-wrapper.ts".to_string(),
+            r#"
+type Wrapper<V> = { value: V };
+type Options<S> = { computed?: Wrapper<S> };
+let arg = {
+    computed: {
+        total(): number {
+            return 1;
+        },
+        label: {
+            get() {
+                return "ready";
+            }
+        }
+    }
+};
+"#
+            .to_string(),
+        );
+        parser.parse_source_file();
+        let arena = parser.get_arena();
+        let emitter = DeclarationEmitter::new(arena);
+        let options_type = emitter
+            .find_type_alias_type_node_in_arena(arena, "Options")
+            .expect("options alias type");
+        let arg_idx = arena
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                let node_idx = NodeIndex(idx as u32);
+                (node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                    && emitter
+                        .object_literal_member_by_name(node_idx, "computed")
+                        .is_some())
+                .then_some(node_idx)
+            })
+            .expect("argument object literal");
+        let mut substitutions = Vec::new();
+        emitter.infer_object_argument_substitutions_from_type_node(
+            arena,
+            options_type,
+            arg_idx,
+            &["S".to_string()],
+            &[],
+            &mut substitutions,
+            0,
+        );
+
+        assert!(
+            substitutions.is_empty(),
+            "non-mapped wrappers must not infer object value maps: {substitutions:?}"
         );
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -109,6 +109,55 @@ let machine = new Machine({
 }
 
 #[test]
+fn test_generic_call_this_type_descriptor_intersections_preserve_source_surfaces() {
+    let output = emit_dts_with_binding(
+        r#"
+type Point = {
+    x: number;
+    y: number;
+    moveBy(dx: number, dy: number): void;
+};
+
+type ObjectDescriptor<D, M> = {
+    data?: D;
+    methods?: M & ThisType<D & M>;
+};
+
+declare function makeObject<D, M>(desc: ObjectDescriptor<D, M>): D & M;
+
+let x = makeObject({
+    data: { x: 0, y: 0 },
+    methods: {
+        moveBy(dx: number, dy: number) {}
+    }
+});
+
+type PropDesc<T> = {
+    value?: T;
+    get?(): T;
+    set?(value: T): void;
+};
+
+declare function defineProp<T, K extends string, U>(obj: T, name: K, desc: PropDesc<U> & ThisType<T>): T & Record<K, U>;
+
+declare const point: Point;
+let p = defineProp(point, "foo", { value: 42 });
+"#,
+    );
+
+    assert!(
+        output.contains(
+            "declare let x: {\n    x: number;\n    y: number;\n} & {\n    moveBy(dx: number, dy: number): void;\n};"
+        ),
+        "Expected source object descriptor call to preserve `D & M`: {output}"
+    );
+    assert!(
+        output.contains("declare let p: Point & Record<\"foo\", number>;"),
+        "Expected descriptor intersection call to preserve alias and `Record`: {output}"
+    );
+}
+
+#[test]
 fn test_multiple_type_parameters() {
     let output = emit_dts(
         "export function map<T, U>(arr: T[], fn: (x: T) => U): U[] { return arr.map(fn); }",

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -322,6 +322,72 @@ const o1 = getProps(myAny, ["foo", "bar"]);
 }
 
 #[test]
+fn generic_call_non_mapped_wrapper_argument_does_not_infer_object_value_map() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Wrapper<V> = { value: V };
+type Options<S> = { computed?: Wrapper<S> };
+declare function make<S>(options: Options<S>): S;
+
+const result = make({
+    computed: {
+        total(): number {
+            return 1;
+        },
+        label: {
+            get() {
+                return "ready";
+            }
+        }
+    }
+});
+"#,
+    );
+
+    assert!(
+        output.contains("declare const result:"),
+        "Expected the call result declaration to be emitted: {output}"
+    );
+    assert!(
+        !output.contains("declare const result: {\n    total: number;\n    label: string;\n};"),
+        "Non-mapped wrapper aliases must not infer object value maps from argument shape: {output}"
+    );
+}
+
+#[test]
+fn construct_signature_non_mapped_wrapper_argument_does_not_infer_object_value_map() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+type Wrapper<V> = { value: V };
+type Options<S> = { computed?: Wrapper<S> };
+declare const Ctor: new <S>(options: Options<S>) => S;
+
+const result = new Ctor({
+    computed: {
+        total(): number {
+            return 1;
+        },
+        label: {
+            get() {
+                return "ready";
+            }
+        }
+    }
+});
+"#,
+    );
+
+    assert!(
+        output.contains("declare const result:"),
+        "Expected the construct result declaration to be emitted: {output}"
+    );
+    assert!(
+        !output.contains("declare const result: {\n    total: number;\n    label: string;\n};"),
+        "Construct signatures must not infer object value maps through non-mapped wrapper aliases: {output}"
+    );
+}
+
+#[test]
 fn generic_call_constrained_mapped_return_uses_concrete_constraint_surface() {
     let output = emit_dts_with_binding(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / DTS object-argument public API summaries.

## Invariant
When object-literal public summaries contain methods or accessors that return a direct `this.<property>` reference, declaration emit should resolve that property from the same public object summary or from previously inferred `ThisType` object contexts. Generic object-option members may infer a public value map only after parsed type/declaration shape proves a mapped type or mapped descriptor/accessor alias; non-mapped wrapper aliases must not take that path.

## Scope
- Adds source object-argument substitution helpers for declaration emit.
- Uses those helpers when substituting generic call and construct return type parameters.
- Preserves mapped accessor/value descriptor surfaces such as `{ [K in keyof T]: (() => T[K]) | Descriptor<T[K]> }` as `{ key: valueType }` in emitted DTS.
- Removes the broad annotation-text object-map fallback from the shared call/construct substitution path in `correlated_union.rs` and deletes the unreferenced text fallback helper from `type_inference_source_object_args.rs`.
- Resolves ordinary object-literal method/getter `return this.<property>` summaries from sibling members, covering `obj1` in `thisTypeInObjectLiterals2`.
- Adds focused unit coverage for descriptor intersections, mapped accessor value maps, sibling `this` property returns, a helper-level non-mapped wrapper negative, and full call/construct non-mapped wrapper negatives.

## Project Corpus Impact
- Row: `thisTypeInObjectLiterals2`
- Bug family: DTS generic object option inference / `ThisType` mapped accessor public value summaries
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=thisTypeInObjectLiterals2 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-10402-thisTypeInObjectLiterals2-d98bee36-20260527.json` passes 2/2 at head `d98bee36cfa42435b42902f66facfae076270d13`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo nextest run -p tsz-emitter -E 'test(non_mapped_generic_member_alias_does_not_infer_object_value_map) or test(generic_call_non_mapped_wrapper_argument_does_not_infer_object_value_map) or test(construct_signature_non_mapped_wrapper_argument_does_not_infer_object_value_map)'` (3 passed)
- `cargo check -p tsz-emitter`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=thisTypeInObjectLiterals2 --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-10402-thisTypeInObjectLiterals2-d98bee36-20260527.json` (2 passed)
- Prior branch verification retained before the review follow-up: `cargo nextest run -p tsz-emitter mapped_accessor_object_argument_infers_public_value_map object_literal_method_and_accessor_this_property_returns_use_sibling_public_types non_mapped_generic_member_alias_does_not_infer_object_value_map test_generic_call_this_type_descriptor_intersections_preserve_source_surfaces` (4 passed); `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`.

## Coordination Notes
- AgentName: Studio-D
- 2026-05-27: Rebased draft branch onto `origin/main` `7503f23a6bc3dfc2b7d4bd9249288a7077ff6859`; pushed head `632c4f6be69083229b4bd62108b512bf2f525a39` with focused verification after re-syncing in the existing worktree.
- 2026-05-27: Reviewer/ReviewHelper blocker addressed at head `d98bee36cfa42435b42902f66facfae076270d13`: removed the remaining broad annotation-text object-map fallback from the shared call/construct substitution path and added full-path call plus construct negatives for non-mapped wrapper aliases.
- The construct-signature text parser remains only for construct-source return reuse; object value-map inference now stays behind parsed mapped-type / mapped-alias / descriptor-alias proof.
- Open Studio-D PRs were inspected before refreshing; this PR targets a separate `thisTypeInObjectLiterals2` DTS row and does not overlap the remapped array mapped or object literal union slices.
- No roadmap update: this is a routine DTS parity fix through declaration/public source-summary boundaries.
- Marked ready for review on 2026-05-27 after exact-head draft-light CI passed for `d98bee36cfa42435b42902f66facfae076270d13`; not queued and auto-merge remains off until ready-run heavy CI completes.

