### PR TITLE
fix(checker): report TS2339 for union-key indexed access in any position

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1286,6 +1286,10 @@ name = "union_index_access_function_application_param_tests"
 path = "tests/union_index_access_function_application_param_tests.rs"
 
 [[test]]
+name = "union_index_annotation_missing_key_tests"
+path = "tests/union_index_annotation_missing_key_tests.rs"
+
+[[test]]
 name = "indexed_access_resolved_union_property_tests"
 path = "tests/indexed_access_resolved_union_property_tests.rs"
 

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1409,6 +1409,7 @@ impl<'a> CheckerContext<'a> {
             || code == 18048
             || code == 18049
             || code == 2322
+            || code == 2339
             || code == 2374
             || code == 2411
             || code == 2413

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -459,25 +459,20 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     /// so union-key access (`I["x" | "y"]`) is validated the same way as a single
     /// literal regardless of where the indexed access appears syntactically.
     fn literal_index_keys(&self, index_type: TypeId, index_node: NodeIndex) -> Vec<String> {
-        if let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, index_type)
-        {
-            return members
-                .iter()
-                .filter_map(|&member| {
-                    crate::query_boundaries::common::string_literal_value(self.ctx.types, member)
-                })
-                .map(|atom| self.ctx.types.resolve_atom(atom))
-                .collect();
+        use crate::query_boundaries::common::{string_literal_value, union_members};
+        let members = union_members(self.ctx.types, index_type).unwrap_or_else(|| vec![index_type]);
+        let keys: Vec<String> = members
+            .iter()
+            .filter_map(|&member| string_literal_value(self.ctx.types, member))
+            .map(|atom| self.ctx.types.resolve_atom(atom))
+            .collect();
+        if keys.is_empty() {
+            get_string_literal_from_type_index(self.ctx.arena, index_node)
+                .into_iter()
+                .collect()
+        } else {
+            keys
         }
-        if let Some(atom) =
-            crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)
-        {
-            return vec![self.ctx.types.resolve_atom(atom)];
-        }
-        get_string_literal_from_type_index(self.ctx.arena, index_node)
-            .into_iter()
-            .collect()
     }
 
     /// Emit TS2339 when `key` is not a property of the indexed object and no
@@ -491,7 +486,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         property_object: TypeId,
         index_node: NodeIndex,
     ) {
-        use crate::query_boundaries::common::PropertyAccessResult;
+        use crate::query_boundaries::common::{
+            PropertyAccessResult, enum_def_id, lazy_def_id, object_shape_for_type,
+        };
         let prop_result = crate::query_boundaries::property_access::resolve_property_access(
             self.ctx.types,
             property_object,
@@ -501,11 +498,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             return;
         }
         let has_index_sig =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, resolved_object)
-                .is_some_and(|shape| {
-                    shape.string_index.is_some()
-                        || (shape.number_index.is_some() && key.parse::<f64>().is_ok())
-                });
+            object_shape_for_type(self.ctx.types, resolved_object).is_some_and(|shape| {
+                shape.string_index.is_some()
+                    || (shape.number_index.is_some() && key.parse::<f64>().is_ok())
+            });
         if has_index_sig {
             return;
         }
@@ -513,16 +509,13 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // (e.g. `type C1 = Color`), tsc displays the underlying enum's nominal
         // name in TS2339 messages. The default formatter would follow the
         // Lazy(DefId) to the alias name, producing `'C1'` instead of `'Color'`.
-        let alias_enum_name =
-            crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)
-                .and_then(|def_id| self.ctx.definition_store.get(def_id))
-                .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
-                .and_then(|_| {
-                    crate::query_boundaries::common::enum_def_id(self.ctx.types, resolved_object)
-                })
-                .and_then(|enum_def_id| self.ctx.def_to_symbol_id(enum_def_id))
-                .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                .map(|symbol| symbol.escaped_name.to_string());
+        let alias_enum_name = lazy_def_id(self.ctx.types, object_type)
+            .and_then(|def_id| self.ctx.definition_store.get(def_id))
+            .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
+            .and_then(|_| enum_def_id(self.ctx.types, resolved_object))
+            .and_then(|enum_def_id| self.ctx.def_to_symbol_id(enum_def_id))
+            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+            .map(|symbol| symbol.escaped_name.to_string());
         let type_str = alias_enum_name.unwrap_or_else(|| {
             let mut formatter = self.ctx.create_type_formatter();
             formatter.format(object_type).into_owned()

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -291,11 +291,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 }
             }
 
-            // TS2339: Check if the property exists on the object type for string literal index access
-            // This handles cases like `Color["Red"]` where "Red" is not a property of the Color type
-            if let Some(key) =
-                get_string_literal_from_type_index(self.ctx.arena, indexed_access.index_type)
-            {
+            // TS2339: Check whether each string-literal index key exists on the
+            // object type. The index may be a single literal (`Color["Red"]`) or
+            // a union of literals (`I["x" | "y"]`); tsc reports one TS2339 per
+            // missing key, anchored at the index node, in any syntactic position.
+            let index_keys = self.literal_index_keys(index_type, indexed_access.index_type);
+            if !index_keys.is_empty() {
                 // Skip for type parameters, generic types, and deferred types - let the
                 // property access validation at the actual access site handle those cases
                 let resolved_object = self.resolve_object_for_tuple_check(object_type);
@@ -411,64 +412,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             object_is_type_query_node,
                         )
                         .unwrap_or_else(|| self.evaluate_type_for_property_check(resolved_object));
-                    let prop_result =
-                        crate::query_boundaries::property_access::resolve_property_access(
-                            self.ctx.types,
-                            property_object,
-                            &key,
-                        );
-
-                    // If property not found and no index signature exists, emit TS2339
-                    use crate::query_boundaries::common::PropertyAccessResult;
-                    if matches!(prop_result, PropertyAccessResult::PropertyNotFound { .. }) {
-                        // Check if there's an index signature that allows this key
-                        let has_index_sig = crate::query_boundaries::common::object_shape_for_type(
-                            self.ctx.types,
+                    for key in &index_keys {
+                        self.report_missing_indexed_access_key(
+                            key,
+                            object_type,
                             resolved_object,
-                        )
-                        .is_some_and(|shape| {
-                            shape.string_index.is_some()
-                                || (shape.number_index.is_some() && key.parse::<f64>().is_ok())
-                        });
-
-                        if !has_index_sig
-                            && let Some(idx_node) = self.ctx.arena.get(indexed_access.index_type)
-                        {
-                            // When the receiver is a type alias whose body resolves
-                            // to an Enum (e.g. `type C1 = Color`), tsc displays the
-                            // underlying enum's nominal name in TS2339 messages.
-                            // The default formatter would follow the Lazy(DefId) to
-                            // the alias name, producing `'C1'` instead of `'Color'`.
-                            let alias_enum_name = crate::query_boundaries::common::lazy_def_id(
-                                self.ctx.types,
-                                object_type,
-                            )
-                            .and_then(|def_id| self.ctx.definition_store.get(def_id))
-                            .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
-                            .and_then(|_| {
-                                crate::query_boundaries::common::enum_def_id(
-                                    self.ctx.types,
-                                    resolved_object,
-                                )
-                            })
-                            .and_then(|enum_def_id| self.ctx.def_to_symbol_id(enum_def_id))
-                            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                            .map(|symbol| symbol.escaped_name.to_string());
-                            let type_str = alias_enum_name.unwrap_or_else(|| {
-                                let mut formatter = self.ctx.create_type_formatter();
-                                formatter.format(object_type).into_owned()
-                            });
-                            let message = crate::diagnostics::format_message(
-                                crate::diagnostics::diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
-                                &[&key, &type_str],
-                            );
-                            self.ctx.error(
-                                idx_node.pos,
-                                idx_node.end - idx_node.pos,
-                                message,
-                                crate::diagnostics::diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
-                            );
-                        }
+                            property_object,
+                            indexed_access.index_type,
+                        );
                     }
                 }
             }
@@ -501,6 +452,94 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         } else {
             TypeId::ERROR
         }
+    }
+
+    /// Collect the string-literal keys named by an indexed-access index type.
+    /// Returns one entry per string-literal union member (or the single literal),
+    /// so union-key access (`I["x" | "y"]`) is validated the same way as a single
+    /// literal regardless of where the indexed access appears syntactically.
+    fn literal_index_keys(&self, index_type: TypeId, index_node: NodeIndex) -> Vec<String> {
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, index_type)
+        {
+            return members
+                .iter()
+                .filter_map(|&member| {
+                    crate::query_boundaries::common::string_literal_value(self.ctx.types, member)
+                })
+                .map(|atom| self.ctx.types.resolve_atom(atom))
+                .collect();
+        }
+        if let Some(atom) =
+            crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)
+        {
+            return vec![self.ctx.types.resolve_atom(atom)];
+        }
+        get_string_literal_from_type_index(self.ctx.arena, index_node)
+            .into_iter()
+            .collect()
+    }
+
+    /// Emit TS2339 when `key` is not a property of the indexed object and no
+    /// index signature accepts it. Anchored at the index node so every union
+    /// member reports at the same span, matching tsc.
+    fn report_missing_indexed_access_key(
+        &mut self,
+        key: &str,
+        object_type: TypeId,
+        resolved_object: TypeId,
+        property_object: TypeId,
+        index_node: NodeIndex,
+    ) {
+        use crate::query_boundaries::common::PropertyAccessResult;
+        let prop_result = crate::query_boundaries::property_access::resolve_property_access(
+            self.ctx.types,
+            property_object,
+            key,
+        );
+        if !matches!(prop_result, PropertyAccessResult::PropertyNotFound { .. }) {
+            return;
+        }
+        let has_index_sig =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, resolved_object)
+                .is_some_and(|shape| {
+                    shape.string_index.is_some()
+                        || (shape.number_index.is_some() && key.parse::<f64>().is_ok())
+                });
+        if has_index_sig {
+            return;
+        }
+        // When the receiver is a type alias whose body resolves to an Enum
+        // (e.g. `type C1 = Color`), tsc displays the underlying enum's nominal
+        // name in TS2339 messages. The default formatter would follow the
+        // Lazy(DefId) to the alias name, producing `'C1'` instead of `'Color'`.
+        let alias_enum_name =
+            crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)
+                .and_then(|def_id| self.ctx.definition_store.get(def_id))
+                .filter(|def| def.kind == tsz_solver::def::DefKind::TypeAlias)
+                .and_then(|_| {
+                    crate::query_boundaries::common::enum_def_id(self.ctx.types, resolved_object)
+                })
+                .and_then(|enum_def_id| self.ctx.def_to_symbol_id(enum_def_id))
+                .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+                .map(|symbol| symbol.escaped_name.to_string());
+        let type_str = alias_enum_name.unwrap_or_else(|| {
+            let mut formatter = self.ctx.create_type_formatter();
+            formatter.format(object_type).into_owned()
+        });
+        let Some(idx_node) = self.ctx.arena.get(index_node) else {
+            return;
+        };
+        let message = crate::diagnostics::format_message(
+            crate::diagnostics::diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+            &[key, &type_str],
+        );
+        self.ctx.error(
+            idx_node.pos,
+            idx_node.end - idx_node.pos,
+            message,
+            crate::diagnostics::diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE,
+        );
     }
 
     /// Check if a type is a union containing Application (generic instantiation) members.

--- a/crates/tsz-checker/tests/union_index_annotation_missing_key_tests.rs
+++ b/crates/tsz-checker/tests/union_index_annotation_missing_key_tests.rs
@@ -1,0 +1,178 @@
+//! TS2339 must fire for every invalid member of a union-key indexed access
+//! (`I["a" | "z"]`) regardless of syntactic position — in particular in a
+//! variable type-annotation position, not only in a `type` alias position.
+//!
+//! Structural rule: when an indexed-access index type resolves to a union of
+//! string-literal keys and the object type is concrete (non-generic, non-
+//! deferred), tsc reports one TS2339 per union member that is not a property
+//! of the object (and is not accepted by an index signature), anchored at the
+//! index node. This test pins that behavior across renamed keys, source types,
+//! `typeof` receivers, and both alias and annotation positions.
+
+use tsz_common::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source_diagnostics(source)
+}
+
+fn missing_keys(diags: &[Diagnostic]) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Reported repro: a single missing member inside a union index in annotation
+/// position must report, with the valid member suppressed.
+#[test]
+fn union_index_annotation_reports_single_missing_member() {
+    let diags = check(
+        r#"
+interface I { a: number; b: string }
+let x: I["z" | "a"];
+"#,
+    );
+    let msgs = missing_keys(&diags);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("'z'") && m.contains("type 'I'")),
+        "expected TS2339 for missing 'z', got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("'a'")),
+        "valid member 'a' must not report, got: {msgs:?}"
+    );
+}
+
+/// Both members missing must yield two TS2339, both anchored at the index node
+/// (same position, distinct messages) — exercising message-aware dedup.
+#[test]
+fn union_index_annotation_reports_both_missing_members() {
+    let diags = check(
+        r#"
+interface I { a: number; b: string }
+let z: I["z" | "w"];
+"#,
+    );
+    let msgs = missing_keys(&diags);
+    assert!(
+        msgs.iter().any(|m| m.contains("'z'")),
+        "expected TS2339 for 'z', got: {msgs:?}"
+    );
+    assert!(
+        msgs.iter().any(|m| m.contains("'w'")),
+        "expected TS2339 for 'w', got: {msgs:?}"
+    );
+}
+
+/// Renamed keys and a renamed source type prove the rule is structural, not
+/// keyed to the spelling in the reported repro.
+#[test]
+fn union_index_annotation_is_structural_not_name_based() {
+    let diags = check(
+        r#"
+interface J { x: number; y: string }
+let a: J["x" | "nope"];
+"#,
+    );
+    let msgs = missing_keys(&diags);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("'nope'") && m.contains("type 'J'")),
+        "expected TS2339 for 'nope', got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("'x'")),
+        "valid member 'x' must not report, got: {msgs:?}"
+    );
+}
+
+/// `typeof obj` receiver in annotation position must report missing keys too.
+#[test]
+fn union_index_annotation_typeof_receiver_reports_missing() {
+    let diags = check(
+        r#"
+const o = { p: 1, q: 2 };
+let m: (typeof o)["p" | "nope"];
+"#,
+    );
+    let msgs = missing_keys(&diags);
+    assert!(
+        msgs.iter().any(|m| m.contains("'nope'")),
+        "expected TS2339 for 'nope' on typeof receiver, got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("'p'")),
+        "valid member 'p' must not report, got: {msgs:?}"
+    );
+}
+
+/// Negative control: the same union in alias position must still report (no
+/// regression of the previously-working path).
+#[test]
+fn union_index_alias_position_still_reports() {
+    let diags = check(
+        r#"
+interface I { a: number; b: string }
+type T = I["a" | "z"];
+"#,
+    );
+    let msgs = missing_keys(&diags);
+    assert!(
+        msgs.iter().any(|m| m.contains("'z'")),
+        "expected TS2339 for 'z' in alias position, got: {msgs:?}"
+    );
+}
+
+/// Negative control: an all-valid union must stay clean in annotation position.
+#[test]
+fn union_index_annotation_all_valid_is_clean() {
+    let diags = check(
+        r#"
+interface I { a: number; b: string }
+let d: I["a" | "b"];
+"#,
+    );
+    assert!(
+        missing_keys(&diags).is_empty(),
+        "all-valid union must not report TS2339, got: {:?}",
+        missing_keys(&diags)
+    );
+}
+
+/// Negative control: a string index signature accepts any string key, so a
+/// union of arbitrary string literals must not report.
+#[test]
+fn union_index_annotation_index_signature_is_clean() {
+    let diags = check(
+        r#"
+interface Dict { [k: string]: number }
+let c: Dict["anything" | "else"];
+"#,
+    );
+    assert!(
+        missing_keys(&diags).is_empty(),
+        "string index signature must accept union keys, got: {:?}",
+        missing_keys(&diags)
+    );
+}
+
+/// Negative control: a generic/deferred index must not eagerly report; the
+/// access site validates it once instantiated.
+#[test]
+fn generic_union_index_does_not_report() {
+    let diags = check(
+        r#"
+function f<T, K extends keyof T>(t: T, k: K) {
+  type R = T[K];
+  return t[k];
+}
+"#,
+    );
+    assert!(
+        missing_keys(&diags).is_empty(),
+        "generic deferred index must not report TS2339, got: {:?}",
+        missing_keys(&diags)
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Conformance — checker diagnostics (TS2339 false-negative).

## Invariant
When an indexed-access index type resolves to a union of string-literal keys and the object type is concrete (non-generic, non-deferred), `tsc` reports one `TS2339` per union member that is not a property of the object (and is not accepted by an index signature), anchored at the index node, in **any** syntactic position; this PR makes tsz do the same through the checker type-resolution path (`get_type_from_indexed_access_type`) plus a message-aware dedup for `TS2339`.

## Scope
- Fixes #9670.
- `crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs`: generalize the resolution-path `TS2339` property-existence check to iterate every string-literal union member (`literal_index_keys` + `report_missing_indexed_access_key`), reusing the existing suppression guards and enum-name display.
- `crates/tsz-checker/src/context/core.rs`: add `2339` to the message-hashed dedup key set (alongside its index-error siblings `2536`/`2537`/`2538`) so two distinct missing-key messages anchored at the same index node both survive.
- New regression test file `union_index_annotation_missing_key_tests.rs`.

### Root cause
The resolution path only extracted a **single** string-literal index key (`get_string_literal_from_type_index`), so a union index returned `None` and the entire `TS2339` block was skipped. The comprehensive union handling only ran from `check_indexed_access_type`, which is reached for `type` aliases but **not** for variable annotations — producing the position-specific divergence in the issue.

## Project Corpus Impact
- Row: n/a (no project-corpus row; checker diagnostic false-negative fix)
- Bug family: indexed-access union-key `TS2339` false-negative
- Evidence: minimized repro from #9670 now matches `tsc` 6.0.2 byte-for-byte (see Verification); CI conformance/emit/fourslash gates will confirm no regression.

## Verification
- `tsz --noEmit --strict` on the issue's full matrix is now **identical** to `tsc 6.0.2` (single missing, missing-first/last, both-missing with two errors at the same column, alias control, single-key control, all-valid control, `typeof` receiver).
- New test (8 cases, all pass): single/both missing in annotation position, renamed keys + renamed source type (structural, not name-based), `typeof` receiver, alias-position control, all-valid control, string-index-signature control, generic/deferred index negative control.
- Related existing suites pass locally: `indexed_access_resolved_union_property_tests`, `element_access_structural_codes_tests`, `homomorphic_indexed_access_tests`, `window_indexed_access_callback_contextual_typing_tests`, `union_index_access_function_application_param_tests`.
- `cargo clippy -p tsz-checker` clean.

## Coordination Notes
- M1-A coordination note: canonicalized ownership to `agent:M1-B`; the original runner identity `opus47-web` remains contributor context, not an ownership lane.
- Picked up the stale `agent:M1-B` lane on #9670 (no open PR referenced it). Signed pickup comment posted on the issue.
- Known orthogonal nuance: for multiple missing keys at the same index node, tsz emits in solver union-member order, which can differ from tsc's literal-type order in rare cases (e.g. enum literal keys). The **set** of diagnostics and their spans match tsc; only emission order may differ. That is a pre-existing union-ordering divergence, not part of this false-negative fix.

https://claude.ai/code/session_01SkygPqC65KrQfRptGqBioL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkygPqC65KrQfRptGqBioL)_