### PR TITLE
test(agents): cover disk preflight evidence

### DIFF
--- a/scripts/agents/test_disk_preflight.py
+++ b/scripts/agents/test_disk_preflight.py
@@ -1,0 +1,113 @@
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agents" / "disk-preflight.sh"
+GUARD = ROOT / "scripts" / "setup" / "disk-worktree-guard.sh"
+
+
+class DiskPreflightTests(unittest.TestCase):
+    def run_git(self, args, cwd):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def make_fake_repo(self, temp_root):
+        fake_repo = temp_root / "tsz"
+        fake_repo.mkdir()
+
+        agents_dir = fake_repo / "scripts" / "agents"
+        setup_dir = fake_repo / "scripts" / "setup"
+        agents_dir.mkdir(parents=True)
+        setup_dir.mkdir(parents=True)
+        fake_script = agents_dir / "disk-preflight.sh"
+        fake_guard = setup_dir / "disk-worktree-guard.sh"
+        fake_script.symlink_to(SCRIPT)
+        fake_guard.symlink_to(GUARD)
+
+        self.run_git(["init"], fake_repo)
+        self.run_git(["config", "user.email", "studio-f@example.invalid"], fake_repo)
+        self.run_git(["config", "user.name", "Studio F"], fake_repo)
+        (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
+        self.run_git(["add", "README.md", "scripts"], fake_repo)
+        self.run_git(["commit", "-m", "initial"], fake_repo)
+
+        return fake_repo, fake_script
+
+    def run_preflight(self, fake_repo, fake_script):
+        env = {
+            **os.environ,
+            "TSZ_WORKTREE_INACTIVE_HOURS": "1",
+        }
+        return subprocess.run(
+            ["bash", str(fake_script), "Studio-F"],
+            cwd=fake_repo,
+            env=env,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def test_reports_populated_typescript_and_cache_state(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            (fake_repo / "TypeScript" / "tests" / "cases").mkdir(parents=True)
+            (fake_repo / "target").mkdir()
+
+            result = self.run_preflight(fake_repo, fake_script)
+
+            self.assertIn("agent=Studio-F", result.stdout)
+            self.assertIn("typescript=populated-local-submodule", result.stdout)
+            self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
+            self.assertIn("target=present", result.stdout)
+
+    def test_worktree_without_typescript_points_to_link_helper(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            (fake_repo / "TypeScript" / "tests" / "cases").mkdir(parents=True)
+
+            linked_worktree = temp_root / "tsz-linked"
+            self.run_git(
+                ["worktree", "add", "--detach", str(linked_worktree), "HEAD"],
+                fake_repo,
+            )
+            linked_script = linked_worktree / "scripts" / "agents" / "disk-preflight.sh"
+
+            result = self.run_preflight(linked_worktree, linked_script)
+
+            self.assertIn("typescript=missing", result.stdout)
+            self.assertIn(f"primary={fake_repo} ts-populated", result.stdout)
+            self.assertIn("hint=run scripts/setup/link-ts-submodule.sh", result.stdout)
+
+    def test_unknown_agent_fails_before_preflight(self):
+        with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+
+            result = subprocess.run(
+                ["bash", str(fake_script), "Dreamy-F"],
+                cwd=fake_repo,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("unknown AgentName: Dreamy-F", result.stderr)
+            self.assertEqual("", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -392,6 +392,10 @@ run_lint() {
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?
   node scripts/ci/test-type-challenges-solutions-manifest.mjs || return $?
+  for test_file in scripts/agents/test_*.py scripts/setup/test_*.py; do
+    [[ -f "$test_file" ]] || continue
+    python3 "$test_file" || return $?
+  done
   python3 scripts/ci/test_ci_resources.py || return $?
   python3 scripts/ci/test_gcp_full_ci_conformance_artifacts.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?


### PR DESCRIPTION
## Agent
AgentName: Studio-F

## Track
Track 10 launch infrastructure / cheap evidence plumbing.

## Invariant
When agent launch sessions run `scripts/agents/disk-preflight.sh`, the script should provide compact, trustworthy evidence about TypeScript reuse and cache state; this PR adds focused tests for those evidence paths without changing runtime behavior.

## Scope
- `scripts/agents/test_disk_preflight.py`
- `scripts/ci/gcp-full-ci.sh`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-script test-only; no compiler, checker, solver, emit, or benchmark behavior changes.

## Verification
- `python3 -m unittest scripts.agents.test_disk_preflight`
- `python3 -m unittest scripts.setup.test_disk_worktree_guard`
- `python3 -m unittest scripts.agents.test_disk_preflight scripts.setup.test_disk_worktree_guard scripts.agents.test_ensure_agent_labels scripts.agents.test_show_goal`
- `for test_file in scripts/agents/test_*.py scripts/setup/test_*.py; do python3 "$test_file" || exit $?; done`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json`
- `git diff --check`

## Coordination Notes
- Follow-up after #10396 was marked ready; this branch starts from `origin/main` and does not stack on #10396.
- No overlap with checker/solver/emit behavior PRs; this is launch evidence coverage for Studio-F's required start-cycle disk preflight.
- Wires the cheap agent/setup Python helper tests into the lint suite so the new disk-preflight evidence coverage is enforced by CI.
- Draft light CI passed on head `8ece8305bf4b661f520f35cfb377dcba478e2aff`; marking ready for review after local verification. No `merge-queue` requested.


