### PR TITLE
test(solver): cover strict subtype cache agreement

### DIFF
--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
@@ -463,3 +463,100 @@ fn assignability_cache_disable_method_bivariance_matches_uncached_method_policy(
         "method-bivariant and sound-method policies should miss in separate cache slots",
     );
 }
+
+#[test]
+fn assignability_cache_strict_subtype_checking_matches_uncached_method_policy() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let run = interner.intern_string("run");
+    let name = interner.intern_string("name");
+    let breed = interner.intern_string("breed");
+
+    let animal = interner.object(vec![PropertyInfo::new(name, TypeId::STRING)]);
+    let dog = interner.object(vec![
+        PropertyInfo::new(name, TypeId::STRING),
+        PropertyInfo::new(breed, TypeId::STRING),
+    ]);
+    let dog_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(dog)],
+        TypeId::VOID,
+    ));
+    let animal_method = interner.function(FunctionShape::new(
+        vec![ParamInfo::unnamed(animal)],
+        TypeId::VOID,
+    ));
+    let source = interner.object(vec![PropertyInfo::method(run, dog_method)]);
+    let target = interner.object(vec![PropertyInfo::method(run, animal_method)]);
+
+    let ordinary = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES)
+        .with_strict_subtype_checking(false);
+    let strict = RelationPolicy::from_flags(RelationCacheKey::FLAG_STRICT_FUNCTION_TYPES)
+        .with_strict_subtype_checking(true);
+    let ordinary_key = RelationCacheKey::for_assignability(source, target, ordinary.cache_config());
+    let strict_key = RelationCacheKey::for_assignability(source, target, strict.cache_config());
+
+    assert_ne!(
+        ordinary_key, strict_key,
+        "ordinary and strict-subtype policies must occupy distinct assignability cache slots",
+    );
+
+    let ordinary_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        ordinary,
+        RelationContext::default(),
+    )
+    .is_related();
+    let strict_uncached = query_relation(
+        &interner,
+        source,
+        target,
+        RelationKind::Assignable,
+        strict,
+        RelationContext::default(),
+    )
+    .is_related();
+
+    assert!(
+        ordinary_uncached,
+        "ordinary strict-function assignability should keep method parameters bivariant",
+    );
+    assert!(
+        !strict_uncached,
+        "strict subtype checking should disable method bivariance for assignability",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, ordinary),
+        ordinary_uncached,
+        "cached ordinary policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary result must be stored in the ordinary assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        None,
+        "strict-subtype lookup must not hit the ordinary slot",
+    );
+
+    assert_eq!(
+        db.is_assignable_to_with_policy(source, target, strict),
+        strict_uncached,
+        "cached strict-subtype policy must match direct query_relation",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(strict_key),
+        Some(strict_uncached),
+        "strict-subtype result must be stored in the strict assignability slot",
+    );
+    assert_eq!(
+        db.lookup_assignability_cache(ordinary_key),
+        Some(ordinary_uncached),
+        "ordinary assignability slot must remain intact after the strict lookup",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Solver relation policy/cache-key contract (#8207), strict-subtype agreement test slice.

## Invariant
When the typed relation-policy builder enables strict-subtype checking, cached assignability must match the uncached query_relation answer for the same structural method-property comparison, and the opposite builder policy must not reuse that cache slot.

## Scope
- crates/tsz-solver/tests/relation_policy_cache_agreement_tests.rs
- Test-only strict-subtype policy/cache agreement coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: solver relation policy/cache-key contract
- Evidence: test-only solver cache agreement coverage; no compiler, emit, parser, checker, LSP, WASM, or project-corpus runtime behavior changed.

## Verification
- Retargeted from merged parent #10376 to main, refreshed onto origin/main 21b0002bb3d333981f3ae1b8030eb43622cf7ddb, refreshed again onto origin/main fee8384559d5eba4014e23a9a28ed5e33973f905, then refreshed again onto current origin/main 0c8d8106fab9816168c612792f7fc635aa188304; force-pushed head 24747ac253bfc211ed57659f72ee9c7405ab3de6.
- cargo fmt --check
- git diff --check origin/main..HEAD
- CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E test(assignability_cache_strict_subtype_checking_matches_uncached_method_policy) passed on prior head: 1 passed, 6303 skipped.
- REBASE GREEN on head 24747ac253bfc211ed57659f72ee9c7405ab3de6: cargo fmt --check.
- REBASE GREEN on head 24747ac253bfc211ed57659f72ee9c7405ab3de6: git diff --check origin/main..HEAD.
- REBASE GREEN on head 24747ac253bfc211ed57659f72ee9c7405ab3de6: CARGO_TARGET_DIR=/Users/mohsen/code/tsz/target cargo nextest run -p tsz-solver -E 'test(assignability_cache_strict_subtype_checking_matches_uncached_method_policy)' (1 passed, 6304 skipped).
- Draft-light CI passed for prior head 13546ad710c353cef21acf5de30b8be8c8a3931e: https://github.com/mohsen1/tsz/actions/runs/26492958071
- Draft-light CI passed for rebased head a6edf7add245586818d17b3aa349c30d8494d03a: https://github.com/mohsen1/tsz/actions/runs/26494790095
- Draft-light CI restarted for rebased head 24747ac253bfc211ed57659f72ee9c7405ab3de6: https://github.com/mohsen1/tsz/actions/runs/26495285775; latest inspection had `dist-binaries`, `unit-cloudbuild`, `cargo-deny`, `unit`, `lint`, `cargo-shear`, and `project-row-drift` pending, with `gate` and `GitGuardian Security Checks` passing.

## Coordination Notes
- AgentName: M4-B
- Draft/off queue after rebased head 24747ac253bfc211ed57659f72ee9c7405ab3de6; no WIP label, no auto-merge, and no merge-queue label.
- Parent #10376 merged at cee7d3d64b2b6656ce241320116c3760c6473bd8; this PR is now based directly on main.
- Keep draft until exact-head light CI completes and the lane owner decides the cache-agreement test slices are ready for heavy CI/queue sequencing.

