### PR TITLE
refactor(checker): route class decorator return relation

### DIFF
--- a/crates/tsz-checker/src/assignability/mod.rs
+++ b/crates/tsz-checker/src/assignability/mod.rs
@@ -18,4 +18,5 @@ mod index_access_normalization;
 mod nullish_error_targets;
 mod polymorphic_this_diagnostics;
 mod readonly_tuple_diagnostics;
+mod relation_outcome_helpers;
 pub mod subtype_identity_checker;

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -1,0 +1,17 @@
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Execute a diagnostic-bearing return-statement relation for raw checker
+    /// types, preserving the canonical return relation request shape.
+    pub(crate) fn return_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::return_stmt(source, target);
+        self.execute_relation_request(&request)
+    }
+}

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -244,6 +244,9 @@ mod rest_parameter_tests;
 #[path = "../tests/rest_tuple_contextual_typing_tests.rs"]
 mod rest_tuple_contextual_typing_tests;
 #[cfg(test)]
+#[path = "tests/return_relation_routing_arch_tests.rs"]
+mod return_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/spread_rest_diagnostics_tests.rs"]
 mod spread_rest_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -1797,7 +1797,10 @@ impl<'a> CheckerState<'a> {
             .types
             .factory()
             .union2(TypeId::VOID, class_constructor_type);
-        if !self.diagnostic_relation_boolean_guard(return_type, expected_return) {
+        if !self
+            .return_relation_outcome(return_type, expected_return)
+            .related
+        {
             let return_str = self.format_type_diagnostic(return_type);
             let expected_str = self.format_type_diagnostic(expected_return);
             let message = format_message(

--- a/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
@@ -8,6 +8,14 @@ fn decorator_return_diagnostics_use_relation_outcome_boundary() {
             .join("src/state/state_checking_members/decorator_signature_checks.rs"),
     )
     .expect("failed to read decorator_signature_checks.rs");
+    let class_source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/state/state_checking/class.rs"),
+    )
+    .expect("failed to read state_checking/class.rs");
+    let compact_class_source: String = class_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
 
     assert!(
         source.contains("assign_relation_outcome(return_type, expected_return)"),
@@ -24,5 +32,15 @@ fn decorator_return_diagnostics_use_relation_outcome_boundary() {
     assert!(
         !source.contains("diagnostic_relation_boolean_guard(return_type, TypeId::VOID)"),
         "void-or-any decorator return diagnostics should not pre-gate with a raw boolean relation"
+    );
+    assert!(
+        compact_class_source
+            .contains("return_relation_outcome(return_type,expected_return).related"),
+        "class decorator return diagnostics should route through return_relation_outcome"
+    );
+    assert!(
+        !compact_class_source
+            .contains("diagnostic_relation_boolean_guard(return_type,expected_return)"),
+        "class decorator return diagnostics should not pre-gate with a raw boolean relation"
     );
 }

--- a/crates/tsz-checker/src/tests/return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/return_relation_routing_arch_tests.rs
@@ -1,0 +1,40 @@
+use std::fs;
+
+#[test]
+fn return_statement_diagnostics_use_return_relation_outcome_boundary() {
+    let helper_source = fs::read_to_string("src/assignability/relation_outcome_helpers.rs")
+        .expect("failed to read relation_outcome_helpers.rs");
+    let return_source = fs::read_to_string("src/types/type_checking/core_statement_checks.rs")
+        .expect("failed to read core_statement_checks.rs");
+    let compact_return_source: String = return_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        helper_source.contains("fn return_relation_outcome("),
+        "return diagnostics should expose a named relation outcome helper"
+    );
+    assert!(
+        helper_source.contains("RelationRequest::return_stmt("),
+        "return diagnostics should build a return-shaped RelationRequest"
+    );
+    assert!(
+        compact_return_source
+            .contains("return_relation_outcome(return_type,expected_type).related"),
+        "return statement compatibility checks should use the return relation outcome"
+    );
+    assert!(
+        compact_return_source.contains("return_relation_outcome(return_type,member)"),
+        "contextual callable-union return deferral should use the return relation outcome"
+    );
+    assert!(
+        !compact_return_source
+            .contains("diagnostic_relation_boolean_guard(return_type,expected_type)"),
+        "return statement diagnostics should not pre-gate with a raw boolean relation"
+    );
+    assert!(
+        !compact_return_source.contains("assign_relation_outcome(return_type,member)"),
+        "return statement callable-union deferral should not use the generic assignment relation"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -226,7 +226,9 @@ impl<'a> CheckerState<'a> {
                 && request.contextual_type.is_some()
                 && self
                     .async_contextual_return_call_has_only_fixed_arguments(return_data.expression)
-                && !self.diagnostic_relation_boolean_guard(return_type, expected_type)
+                && !self
+                    .return_relation_outcome(return_type, expected_type)
+                    .related
             {
                 self.invalidate_expression_for_contextual_retry(return_data.expression);
                 let mut raw_return_type = self
@@ -330,7 +332,9 @@ impl<'a> CheckerState<'a> {
             && (!expected_contains_error_nested || allow_check_through_nested_error)
         {
             if is_conditional_expr
-                && !self.diagnostic_relation_boolean_guard(return_type, expected_type)
+                && !self
+                    .return_relation_outcome(return_type, expected_type)
+                    .related
             {
                 // Per-branch error elaboration for conditional expressions.
                 // Instead of "Type '1 | 2' is not assignable to type '3'" at `return`,
@@ -405,7 +409,7 @@ impl<'a> CheckerState<'a> {
                                 );
                             }
                             callable_members.into_iter().any(|member| {
-                                let outcome = self.assign_relation_outcome(return_type, member);
+                                let outcome = self.return_relation_outcome(return_type, member);
                                 outcome.related
                                     || crate::query_boundaries::assignability::contextual_callable_member_failure_is_generic_parameter_drift(
                                         self.ctx.types,


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics / refactor-only query-boundary routing for #8225 and #8227.

## Invariant
When a class decorator call return type is compared with `void | <class constructor type>`, tsz should execute a return-shaped `RelationRequest` through the checker query boundary before emitting the class-decorator-specific diagnostic; this PR routes that decision through `return_relation_outcome` without changing solver policy or diagnostic text.

## Scope
- Stack on #10404, which introduces `return_relation_outcome`.
- Route class decorator return compatibility in `state_checking/class.rs` through the return relation outcome.
- Extend the decorator return architecture test to prevent this path from regressing to a raw boolean relation guard.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostic routing
- Evidence: refactor-only boundary routing; no solver policy, project fixture, or project-row behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check codex/m1b-return-relation-outcome-20260527..HEAD`
- `cargo nextest run -p tsz-checker --lib decorator_return_diagnostics_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Stacked on #10404 / `codex/m1b-return-relation-outcome-20260527`; land after that PR.
- Sibling of #10406; this branch does not depend on #10406.
- Does not touch solver relation policy/cache keys; M4-B solver-policy work remains non-overlapping.
- `crates/tsz-checker/src/state/state_checking/class.rs` remains under the 2000-line ceiling at 1976 lines after this slice, but is close and should not absorb broad follow-up work.
- Draft while dependency and draft-light CI settle.