### PR TITLE
refactor(checker): route decorator Function callee relation

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -147,7 +147,8 @@ impl<'a> CheckerState<'a> {
         let Some(function_type) = self.global_function_type_id() else {
             return false;
         };
-        self.diagnostic_relation_boolean_guard(decorator_type, function_type)
+        self.assign_relation_outcome(decorator_type, function_type)
+            .related
     }
 
     fn global_function_type_id(&mut self) -> Option<TypeId> {

--- a/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs
@@ -25,4 +25,22 @@ fn decorator_return_diagnostics_use_relation_outcome_boundary() {
         !source.contains("diagnostic_relation_boolean_guard(return_type, TypeId::VOID)"),
         "void-or-any decorator return diagnostics should not pre-gate with a raw boolean relation"
     );
+
+    let callee_probe_start = source
+        .find("fn decorator_callee_is_untyped_function")
+        .expect("find decorator callee Function probe");
+    let callee_probe_end = callee_probe_start
+        + source[callee_probe_start..]
+            .find("fn global_function_type_id")
+            .expect("find end of decorator callee Function probe");
+    let callee_probe = &source[callee_probe_start..callee_probe_end];
+
+    assert!(
+        callee_probe.contains("assign_relation_outcome(decorator_type, function_type)"),
+        "decorator Function fallback should route relation probing through assign_relation_outcome"
+    );
+    assert!(
+        !callee_probe.contains("diagnostic_relation_boolean_guard(decorator_type, function_type)"),
+        "decorator Function fallback should not use a raw boolean relation guard"
+    );
 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics/query-boundary routing.

## Invariant
When a decorator callee has no call signatures, no construct signatures, is not a union, and is assignable to the global `Function` type, `tsc` treats the callee as an untyped function call and skips the decorator-signature diagnostic; this PR keeps that checker orchestration but routes the assignability probe through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs`
- `crates/tsz-checker/src/tests/decorator_return_relation_routing_arch_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary routing; no intended diagnostic behavior change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib decorator_return_diagnostics_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Base: `main` at `55595ab16d` after #10386 merged.
- Non-overlap: independent of the return-relation stack in #10404/#10406/#10408; this uses the existing `assign_relation_outcome` helper and does not touch solver policy/cache-key semantics.
- Draft while light CI starts; ready handoff can happen after PR-head checks are clean and current.
