### PR TITLE
refactor(checker): route index property relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -589,6 +589,9 @@ mod in_narrow_bare_type_param_chained_tests;
 #[path = "tests/in_operator_relation_routing_arch_tests.rs"]
 mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/index_signature_property_relation_routing_arch_tests.rs"]
+mod index_signature_property_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -16,12 +16,14 @@ impl<'a> CheckerState<'a> {
             self.resolve_lazy_type(prop_type),
         ) {
             let members: Vec<TypeId> = self.ctx.types.type_list(list_id).to_vec();
-            return members
-                .into_iter()
-                .all(|member| self.diagnostic_relation_boolean_guard(member, index_value_type));
+            return members.into_iter().all(|member| {
+                self.assign_relation_outcome(member, index_value_type)
+                    .related
+            });
         }
 
-        self.diagnostic_relation_boolean_guard(prop_type, index_value_type)
+        self.assign_relation_outcome(prop_type, index_value_type)
+            .related
     }
 
     pub(crate) fn format_ts2411_type(&mut self, type_id: TypeId) -> String {

--- a/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn index_signature_property_checks_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/state/state_checking_members/index_signature_key_helpers.rs"),
+    )
+    .expect("failed to read index_signature_key_helpers.rs");
+
+    let function_start = source
+        .find("fn property_type_assignable_to_index_type")
+        .expect("find property/index compatibility helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("pub(crate) fn format_ts2411_type")
+            .expect("find end of property/index compatibility helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper.contains("assign_relation_outcome(member,index_value_type).related"),
+        "union property members should route index-signature value checks through relation outcome"
+    );
+    assert!(
+        compact_helper.contains("assign_relation_outcome(prop_type,index_value_type).related"),
+        "property/index value checks should route through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "property/index value checks should not use raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics/query-boundary routing.

## Invariant
When a property type is checked against an index-signature value type for TS2411-style diagnostics, including each member of a union property type, the checker owns the diagnostic location and message while the compatibility decision flows through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs`
- `crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary routing; no intended diagnostic behavior change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib index_signature_property_checks_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Base: `main` at `55595ab16d` after #10386 merged.
- Non-overlap: independent of the return-relation stack in #10404/#10406/#10408 and the decorator Function callee slice in #10410; this uses the existing `assign_relation_outcome` helper and does not touch solver policy/cache-key semantics.
- Draft while light CI starts; ready handoff can happen after PR-head checks are clean and current.
