### PR TITLE
refactor(checker): route rest parameter array relation

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1300,9 +1300,12 @@ impl<'a> CheckerState<'a> {
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
 
-                    if !self.diagnostic_relation_boolean_guard(declared_type, readonly_any_array)
+                    if !self
+                        .assign_relation_outcome(declared_type, readonly_any_array)
+                        .related
                         && !self
-                            .diagnostic_relation_boolean_guard(array_check_type, readonly_any_array)
+                            .assign_relation_outcome(array_check_type, readonly_any_array)
+                            .related
                     {
                         // tsc anchors TS2370 at the parameter (including the
                         // `...` token) rather than at its type annotation or
@@ -1333,7 +1336,10 @@ impl<'a> CheckerState<'a> {
                     let factory = self.ctx.types.factory();
                     let any_array = factory.array(TypeId::ANY);
                     let readonly_any_array = factory.readonly_type(any_array);
-                    if !self.diagnostic_relation_boolean_guard(init_type, readonly_any_array) {
+                    if !self
+                        .assign_relation_outcome(init_type, readonly_any_array)
+                        .related
+                    {
                         self.error_at_node(
                             param_idx,
                             "A rest parameter must be of an array type.",

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -766,6 +766,9 @@ mod relation_flags_boundary_contract_tests;
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]
+#[path = "tests/rest_parameter_relation_routing_arch_tests.rs"]
+mod rest_parameter_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/return_context_promise_identity_tests.rs"]
 mod return_context_promise_identity_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
@@ -1,0 +1,41 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn rest_parameter_array_diagnostics_use_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/checkers/parameter_checker.rs"),
+    )
+    .expect("failed to read parameter_checker.rs");
+
+    let function_start = source
+        .find("fn check_rest_parameter_types")
+        .expect("find rest parameter validation helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find(
+                "// =============================================================================",
+            )
+            .expect("find end of rest parameter validation helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper
+            .contains("assign_relation_outcome(declared_type,readonly_any_array).related"),
+        "rest parameter declared type should route array compatibility through relation outcome"
+    );
+    assert!(
+        compact_helper
+            .contains("assign_relation_outcome(array_check_type,readonly_any_array).related"),
+        "rest parameter resolved type should route array compatibility through relation outcome"
+    );
+    assert!(
+        compact_helper.contains("assign_relation_outcome(init_type,readonly_any_array).related"),
+        "rest parameter initializer type should route array compatibility through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "TS2370 rest parameter array diagnostics should not use raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics/query-boundary routing.

## Invariant
When a rest parameter's declared, resolved, or initializer-derived type is checked for compatibility with a readonly `any[]` target before emitting TS2370, the checker owns the parameter span and message while the compatibility decision flows through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/checkers/parameter_checker.rs`
- `crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary routing; no intended diagnostic behavior change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib rest_parameter_array_diagnostics_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Base: `main` at `55595ab16d` after #10386 merged.
- Non-overlap: independent of the return-relation stack (#10404/#10406/#10408), decorator Function callee slice (#10410), and index property relation slice (#10412); this uses the existing `assign_relation_outcome` helper and does not touch solver policy/cache-key semantics.
- Draft while light CI starts; ready handoff can happen after PR-head checks are clean and current.
