### PR TITLE
fix(dts): preserve nullish guarded generic returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -1048,6 +1048,20 @@ impl<'a> DeclarationEmitter<'a> {
                     } else if let Some(type_text) = func_body
                         .is_some()
                         .then(|| {
+                            self.function_body_nullish_guarded_parameter_return_type_text(
+                                func, func_body,
+                            )
+                        })
+                        .flatten()
+                    {
+                        self.write(": ");
+                        self.write(&type_text);
+                        let _ = self.emit_non_portable_function_return_diagnostics(
+                            &type_text, func_body, func_name,
+                        );
+                    } else if let Some(type_text) = func_body
+                        .is_some()
+                        .then(|| {
                             self.evaluated_literal_return_type_text_for_returned_identifier(
                                 func,
                                 func_body,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -10,6 +10,23 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
+#[derive(Clone, Copy, Default)]
+struct NullishReturnExclusions {
+    null: bool,
+    undefined: bool,
+}
+
+impl NullishReturnExclusions {
+    const fn any(self) -> bool {
+        self.null || self.undefined
+    }
+
+    const fn add(&mut self, other: Self) {
+        self.null |= other.null;
+        self.undefined |= other.undefined;
+    }
+}
+
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn function_body_preferred_return_type_text(
         &self,
@@ -46,6 +63,306 @@ impl<'a> DeclarationEmitter<'a> {
             .single_line_mapped_type_annotation_text(type_annotation)
             .or_else(|| self.function_parameter_type_text(func, returned_identifier))?;
         (!type_text.trim().is_empty()).then_some(type_text)
+    }
+
+    pub(in crate::declaration_emitter) fn function_body_nullish_guarded_parameter_return_type_text(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        body_idx: NodeIndex,
+    ) -> Option<String> {
+        let (param_idx, exclusions) =
+            self.function_body_nullish_guarded_return_source(func, body_idx, 0)?;
+        if !exclusions.any() {
+            return None;
+        }
+        let type_text = self.function_parameter_type_text(func, param_idx)?;
+        if !self.function_parameter_type_is_own_type_param(func, param_idx) {
+            return None;
+        }
+        Some(Self::format_nullish_guarded_parameter_type(
+            &type_text, exclusions,
+        ))
+    }
+
+    fn function_body_nullish_guarded_return_source(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        body_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<(NodeIndex, NullishReturnExclusions)> {
+        if depth > 8 {
+            return None;
+        }
+        let body_node = self.arena.get(body_idx)?;
+        let block = self.arena.get_block(body_node)?;
+        let mut exclusions = NullishReturnExclusions::default();
+        let mut returned_expr = None;
+
+        for stmt_idx in block.statements.nodes.iter().copied() {
+            if returned_expr.is_some() {
+                return None;
+            }
+
+            if let Some(param_idx) = self.nullish_guarded_return_parameter(func, stmt_idx)
+                && let Some(guard_exclusions) =
+                    self.nullish_terminal_guard_exclusions(stmt_idx, param_idx)
+            {
+                exclusions.add(guard_exclusions);
+                continue;
+            }
+
+            let stmt_node = self.arena.get(stmt_idx)?;
+            if stmt_node.kind == syntax_kind_ext::RETURN_STATEMENT {
+                let ret = self.arena.get_return_statement(stmt_node)?;
+                if ret.expression.is_none() {
+                    return None;
+                }
+                returned_expr = Some(ret.expression);
+                continue;
+            }
+
+            return None;
+        }
+
+        let returned_expr = returned_expr?;
+        let (param_idx, returned_exclusions) =
+            self.nullish_return_expression_source(func, returned_expr, depth + 1)?;
+        exclusions.add(returned_exclusions);
+        Some((param_idx, exclusions))
+    }
+
+    fn nullish_return_expression_source(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<(NodeIndex, NullishReturnExclusions)> {
+        let expr_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(expr_idx);
+        if self.function_parameter_type_is_own_type_param(func, expr_idx) {
+            return Some((expr_idx, NullishReturnExclusions::default()));
+        }
+
+        if depth > 8 {
+            return None;
+        }
+        let expr_node = self.arena.get(expr_idx)?;
+        let call = self.arena.get_call_expr(expr_node)?;
+        let args = call.arguments.as_ref()?;
+        if args.nodes.len() != 1 {
+            return None;
+        }
+        let (param_idx, mut exclusions) =
+            self.nullish_return_expression_source(func, args.nodes[0], depth + 1)?;
+        let callee_exclusions =
+            self.nullish_guard_function_exclusions(call.expression, depth + 1)?;
+        exclusions.add(callee_exclusions);
+        Some((param_idx, exclusions))
+    }
+
+    fn nullish_guard_function_exclusions(
+        &self,
+        callee_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<NullishReturnExclusions> {
+        if depth > 8 {
+            return None;
+        }
+        let callee_idx = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(callee_idx);
+        let callee_node = self.arena.get(callee_idx)?;
+        if callee_node.kind != SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.value_reference_symbol(callee_idx)?;
+        let binder = self.binder?;
+        let symbol = binder.symbols.get(sym_id)?;
+
+        for decl_idx in symbol.declarations.iter().copied() {
+            let decl_node = self.arena.get(decl_idx)?;
+            let Some(func) = self.arena.get_function(decl_node) else {
+                continue;
+            };
+            if func.parameters.nodes.len() != 1 {
+                continue;
+            }
+            let (param_idx, exclusions) =
+                self.function_body_nullish_guarded_return_source(func, func.body, depth + 1)?;
+            let only_param = func.parameters.nodes[0];
+            let param_node = self.arena.get(only_param)?;
+            let param = self.arena.get_parameter(param_node)?;
+            if self
+                .get_identifier_text(param.name)
+                .zip(self.get_identifier_text(param_idx))
+                .is_some_and(|(expected, actual)| expected == actual)
+                && exclusions.any()
+            {
+                return Some(exclusions);
+            }
+        }
+
+        None
+    }
+
+    fn nullish_guarded_return_parameter(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        stmt_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let stmt_node = self.arena.get(stmt_idx)?;
+        let if_data = self.arena.get_if_statement(stmt_node)?;
+        if if_data.else_statement.is_some()
+            || !self.statement_is_terminal_exit(if_data.then_statement)
+        {
+            return None;
+        }
+        let condition = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(if_data.expression);
+        let condition_node = self.arena.get(condition)?;
+        let binary = self.arena.get_binary_expr(condition_node)?;
+        let left = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.left);
+        let right = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.right);
+
+        if self.function_parameter_type_is_own_type_param(func, left)
+            && Self::nullish_literal_exclusion(self.arena, right, binary.operator_token).is_some()
+        {
+            return Some(left);
+        }
+        if self.function_parameter_type_is_own_type_param(func, right)
+            && Self::nullish_literal_exclusion(self.arena, left, binary.operator_token).is_some()
+        {
+            return Some(right);
+        }
+        None
+    }
+
+    fn nullish_terminal_guard_exclusions(
+        &self,
+        stmt_idx: NodeIndex,
+        param_idx: NodeIndex,
+    ) -> Option<NullishReturnExclusions> {
+        let stmt_node = self.arena.get(stmt_idx)?;
+        let if_data = self.arena.get_if_statement(stmt_node)?;
+        if if_data.else_statement.is_some()
+            || !self.statement_is_terminal_exit(if_data.then_statement)
+        {
+            return None;
+        }
+        let condition = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(if_data.expression);
+        let condition_node = self.arena.get(condition)?;
+        let binary = self.arena.get_binary_expr(condition_node)?;
+        let left = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.left);
+        let right = self
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(binary.right);
+
+        if self.same_identifier_text(left, param_idx) {
+            return Self::nullish_literal_exclusion(self.arena, right, binary.operator_token);
+        }
+        if self.same_identifier_text(right, param_idx) {
+            return Self::nullish_literal_exclusion(self.arena, left, binary.operator_token);
+        }
+        None
+    }
+
+    fn function_parameter_type_is_own_type_param(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+        identifier_idx: NodeIndex,
+    ) -> bool {
+        let Some(type_text) = self.function_parameter_type_text(func, identifier_idx) else {
+            return false;
+        };
+        let Some(type_params) = func.type_parameters.as_ref() else {
+            return false;
+        };
+        let trimmed = type_text.trim();
+        self.collect_type_param_names(type_params)
+            .iter()
+            .any(|name| name == trimmed)
+    }
+
+    fn same_identifier_text(&self, left: NodeIndex, right: NodeIndex) -> bool {
+        self.get_identifier_text(left)
+            .zip(self.get_identifier_text(right))
+            .is_some_and(|(left, right)| left == right)
+    }
+
+    fn statement_is_terminal_exit(&self, stmt_idx: NodeIndex) -> bool {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return false;
+        };
+        match stmt_node.kind {
+            k if k == syntax_kind_ext::RETURN_STATEMENT
+                || k == syntax_kind_ext::THROW_STATEMENT =>
+            {
+                true
+            }
+            k if k == syntax_kind_ext::BLOCK => {
+                self.arena.get_block(stmt_node).is_some_and(|block| {
+                    block
+                        .statements
+                        .nodes
+                        .iter()
+                        .copied()
+                        .any(|stmt| self.statement_is_terminal_exit(stmt))
+                })
+            }
+            _ => false,
+        }
+    }
+
+    fn nullish_literal_exclusion(
+        arena: &NodeArena,
+        expr_idx: NodeIndex,
+        operator_token: u16,
+    ) -> Option<NullishReturnExclusions> {
+        let expr_node = arena.get(expr_idx)?;
+        let is_null = expr_node.kind == SyntaxKind::NullKeyword as u16;
+        let is_undefined = expr_node.kind == SyntaxKind::UndefinedKeyword as u16
+            || arena
+                .get_identifier(expr_node)
+                .is_some_and(|ident| ident.escaped_text == "undefined");
+        if !is_null && !is_undefined {
+            return None;
+        }
+
+        match operator_token {
+            op if op == SyntaxKind::EqualsEqualsEqualsToken as u16 => {
+                Some(NullishReturnExclusions {
+                    null: is_null,
+                    undefined: is_undefined,
+                })
+            }
+            op if op == SyntaxKind::EqualsEqualsToken as u16 => Some(NullishReturnExclusions {
+                null: true,
+                undefined: true,
+            }),
+            _ => None,
+        }
+    }
+
+    fn format_nullish_guarded_parameter_type(
+        type_text: &str,
+        exclusions: NullishReturnExclusions,
+    ) -> String {
+        match (exclusions.null, exclusions.undefined) {
+            (true, true) => format!("{type_text} & {{}}"),
+            (true, false) => format!("{type_text} & ({{}} | undefined)"),
+            (false, true) => format!("{type_text} & ({{}} | null)"),
+            (false, false) => type_text.to_string(),
+        }
     }
 
     fn function_parameter_type_annotation(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
@@ -963,3 +963,99 @@ export { t };
         "Expected export specifier to remain: {output}"
     );
 }
+
+#[test]
+fn nullish_guarded_generic_parameter_returns_preserve_flow_summary() {
+    let source = r#"
+function rejectNull<T>(value: T) {
+    if (value === null) throw Error();
+    return value;
+}
+
+function rejectUndefined<K>(input: K) {
+    if (undefined === input) {
+        throw Error();
+    }
+    return input;
+}
+
+function rejectNullish<U>(item: U) {
+    if (item == null) throw Error();
+    return item;
+}
+
+function keepPlain<V>(value: V) {
+    return value;
+}
+"#;
+
+    for (name, expected) in [
+        ("rejectNull", Some("T & ({} | undefined)")),
+        ("rejectUndefined", Some("K & ({} | null)")),
+        ("rejectNullish", Some("U & {}")),
+        ("keepPlain", None),
+    ] {
+        let actual = nullish_return_summary_for_function(source, name);
+        assert!(
+            actual.as_deref() == expected,
+            "expected nullish-guarded return summary for `{name}` to be {expected:?}, got {actual:?}"
+        );
+    }
+}
+
+#[test]
+fn nested_nullish_guard_helpers_compose_return_summary() {
+    let source = r#"
+function rejectNull<T>(value: T) {
+    if (value === null) throw Error();
+    return value;
+}
+
+function rejectUndefined<K>(input: K) {
+    if (input === undefined) throw Error();
+    return input;
+}
+
+function rejectBoth<Item>(item: Item) {
+    return rejectUndefined(rejectNull(item));
+}
+"#;
+
+    let actual = nullish_return_summary_for_function(source, "rejectBoth");
+    assert_eq!(
+        actual.as_deref(),
+        Some("Item & {}"),
+        "expected composed nullish guard helpers to preserve the narrowed return"
+    );
+}
+
+fn nullish_return_summary_for_function(source: &str, name: &str) -> Option<String> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+
+    let root_node = parser.arena.get(root)?;
+    let source_file = parser.arena.get_source_file(root_node)?;
+    for stmt_idx in source_file.statements.nodes.iter().copied() {
+        let stmt_node = parser.arena.get(stmt_idx)?;
+        let Some(func) = parser.arena.get_function(stmt_node) else {
+            continue;
+        };
+        let func_name = parser
+            .arena
+            .get(func.name)
+            .and_then(|node| parser.arena.get_identifier(node))
+            .map(|ident| ident.escaped_text.as_str());
+        if func_name == Some(name) {
+            return emitter
+                .function_body_nullish_guarded_parameter_return_type_text(func, func.body);
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / DTS flow-narrowed generic return summaries

## Invariant
When a generic function returns one of its own generic parameters after terminal guards exclude `null`, `undefined`, or both, `tsc` emits the flow-narrowed public return type; this PR makes tsz emit that summary through the declaration return-summary helper.

## Scope
- Add a declaration-summary helper for generic parameter returns narrowed by terminal nullish guards.
- Compose summaries through nested local single-argument guard helper calls.
- Wire the summary into function declaration return emission before falling back to the broader solver return type.
- Add focused tests for null, undefined, loose nullish, renamed type parameters, unchanged plain returns, and nested guard composition.

## Project Corpus Impact
- Row: `unknownControlFlow`
- Bug family: DTS flow-narrowed generic return summaries / nullish guard public API surfaces
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=unknownControlFlow --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-unknown-control-flow-after2.json` passes 1/1.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `wc -l crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs`
- `cargo nextest run -p tsz-emitter nullish_guarded_generic_parameter_returns_preserve_flow_summary nested_nullish_guard_helpers_compose_return_summary`
- `scripts/safe-run.sh scripts/emit/run.sh --filter=unknownControlFlow --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-unknown-control-flow-after2.json`
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`

## Coordination Notes
- AgentName: Studio-D
- Draft PR for light CI; no WIP label requested.
- No roadmap update: focused DTS parity fix, not a durable sequencing or architecture-direction change.
- Checker diagnostics are unaffected; the change is limited to declaration emit return summaries and tests.
- No overlap found with active Studio-D mapped/indexed/object-literal/string-literal declaration PRs or current open PR titles.
- Known fallback: unsupported control-flow shapes fall back to the existing solver/declaration return path rather than guessing.