### PR TITLE
refactor(checker): route contextual new relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -493,6 +493,9 @@ mod conditional_never_param_inference_tests;
 #[path = "tests/const_asserted_return_type_tests.rs"]
 mod const_asserted_return_type_tests;
 #[cfg(test)]
+#[path = "tests/contextual_new_relation_routing_arch_tests.rs"]
+mod contextual_new_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/contextual_return_wrapper_tests.rs"]
 mod contextual_return_wrapper_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/contextual_new_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_new_relation_routing_arch_tests.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn contextual_new_argument_recovery_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/types/computation/complex_contextual_new.rs"),
+    )
+    .expect("failed to read complex_contextual_new.rs");
+
+    let function_start = source
+        .find("fn generic_new_argument_accepts_contextual_parameter")
+        .expect("find contextual new argument helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find(
+                "pub(crate) fn recover_new_expression_return_type_after_contextual_argument_match",
+            )
+            .expect("find end of contextual new argument helper");
+    let helper = &source[function_start..function_end];
+    let compact_helper: String = helper.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact_helper.contains("assign_relation_outcome(contextual_actual,expected).related"),
+        "contextual new argument recovery should route compatibility through relation outcome"
+    );
+    assert!(
+        !helper.contains("diagnostic_relation_boolean_guard"),
+        "contextual new argument recovery should not use a raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
+++ b/crates/tsz-checker/src/types/computation/complex_contextual_new.rs
@@ -29,7 +29,9 @@ impl<'a> CheckerState<'a> {
 
         contextual_actual != TypeId::ANY
             && contextual_actual != TypeId::ERROR
-            && self.diagnostic_relation_boolean_guard(contextual_actual, expected)
+            && self
+                .assign_relation_outcome(contextual_actual, expected)
+                .related
     }
 
     pub(crate) fn recover_new_expression_return_type_after_contextual_argument_match(


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics/query-boundary routing.

## Invariant
When contextual generic `new` recovery speculatively types an object or array literal argument and checks whether the contextual actual is compatible with the expected constructor parameter, the checker owns the recovery orchestration while the compatibility decision flows through the shared relation outcome boundary.

## Scope
- `crates/tsz-checker/src/types/computation/complex_contextual_new.rs`
- `crates/tsz-checker/src/tests/contextual_new_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary routing; no intended diagnostic behavior change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib contextual_new_argument_recovery_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Base: `main` at `55595ab16d` after #10386 merged.
- Non-overlap: independent of the return-relation stack (#10404/#10406/#10408), decorator Function callee slice (#10410), index property relation slice (#10412), and rest parameter array slice (#10413); this uses the existing `assign_relation_outcome` helper and does not touch solver policy/cache-key semantics.
- Draft while light CI starts; ready handoff can happen after PR-head checks are clean and current.
