### PR TITLE
refactor(checker): route call result relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -447,6 +447,7 @@ mod call_architecture_tests;
 #[cfg(test)]
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/call_result_relation_routing_arch_tests.rs"]
 mod call_result_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -447,6 +447,8 @@ mod call_architecture_tests;
 #[cfg(test)]
 #[path = "tests/call_context_relation_routing_arch_tests.rs"]
 mod call_context_relation_routing_arch_tests;
+#[path = "tests/call_result_relation_routing_arch_tests.rs"]
+mod call_result_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/call_spread_constructor_parameters_tests.rs"]
 mod call_spread_constructor_parameters_tests;

--- a/crates/tsz-checker/src/tests/call_result_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_result_relation_routing_arch_tests.rs
@@ -1,0 +1,43 @@
+use std::fs;
+
+#[test]
+fn call_result_recovery_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/types/computation/call_result.rs")
+        .expect("failed to read call_result.rs");
+
+    let recovery_start = source
+        .find("fn correlated_union_call_recovery_return")
+        .expect("missing correlated_union_call_recovery_return helper");
+    let recovery_end = recovery_start
+        + source[recovery_start..]
+            .find("fn finalize_call_return_like_success")
+            .expect("missing finalize_call_return_like_success helper");
+    let recovery_helper = &source[recovery_start..recovery_end];
+
+    assert!(
+        recovery_helper.contains("assign_relation_outcome(actual, param_union).related"),
+        "correlated union call recovery should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !recovery_helper.contains("diagnostic_relation_boolean_guard"),
+        "correlated union call recovery should not regress to the raw boolean relation guard"
+    );
+
+    let argument_start = source
+        .find("fn report_polymorphic_this_indexed_conditional_arg")
+        .expect("missing report_polymorphic_this_indexed_conditional_arg helper");
+    let argument_end = argument_start
+        + source[argument_start..]
+            .find("fn error_argument_not_assignable_preserving_param_display")
+            .expect("missing error_argument_not_assignable_preserving_param_display helper");
+    let argument_helper = &source[argument_start..argument_end];
+
+    assert!(
+        argument_helper.contains("assign_relation_outcome(arg_types[2], target).related"),
+        "polymorphic-this argument diagnostics should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !argument_helper.contains("diagnostic_relation_boolean_guard"),
+        "polymorphic-this argument diagnostics should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -57,7 +57,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let param_union = self.ctx.types.factory().union(param_types);
-        if !self.diagnostic_relation_boolean_guard(actual, param_union) {
+        if !self.assign_relation_outcome(actual, param_union).related {
             return None;
         }
 
@@ -220,7 +220,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        if self.diagnostic_relation_boolean_guard(arg_types[2], target) {
+        if self.assign_relation_outcome(arg_types[2], target).related {
             return false;
         }
         self.error_argument_not_assignable_preserving_param_display(arg_types[2], target, args[2]);


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic/query-boundary routing for the M1-B lane.

## Invariant
When call-result recovery or polymorphic-this argument diagnostic gating needs an assignability yes/no answer, checker should consume RelationOutcome.related through the shared assignability boundary. This PR changes checker orchestration only; solver policy and relation semantics are unchanged.

## Scope
- Route two call-result relation probes in crates/tsz-checker/src/types/computation/call_result.rs through assign_relation_outcome(...).related.
- Add a focused architecture regression test in crates/tsz-checker/src/tests/call_result_relation_routing_arch_tests.rs.
- Wire the new test module in crates/tsz-checker/src/lib.rs behind cfg(test).

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor only; no project corpus semantics changed.

## Verification
- cargo fmt --check
- git diff --check
- cargo nextest run -p tsz-checker --lib call_result_recovery_uses_relation_outcome_boundary
- cargo clippy -p tsz-checker --lib --all-features -- -D warnings
- scripts/arch/check-checker-boundaries.sh
- python3 scripts/arch/arch_guard.py
- git diff --check origin/main..HEAD

## Coordination Notes
- Fresh branch from origin/main at 929041f62c.
- Non-overlap: avoids active M1-B decorator, index property, rest parameter, contextual new, property-key, and stacked return-relation PRs.
- Fixed lint failure from the initial test module missing cfg(test); pushed 5ae54d92f9.
- Draft while light CI starts; no full conformance run locally per TSZ policy.