### PR TITLE
refactor(checker): route property index key relation

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -748,6 +748,9 @@ mod promise_like_infer_tests;
 #[path = "tests/property_alias_display_tests.rs"]
 mod property_alias_display_tests;
 #[cfg(test)]
+#[path = "tests/property_index_key_relation_routing_arch_tests.rs"]
+mod property_index_key_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
 
         let prop_literal =
             crate::query_boundaries::common::create_string_literal_type(self.ctx.types, prop_name);
-        self.diagnostic_relation_boolean_guard(prop_literal, key_type)
+        self.assign_relation_outcome(prop_literal, key_type).related
     }
 
     pub(super) fn index_value_type_is_deferred(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/tests/property_index_key_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/property_index_key_relation_routing_arch_tests.rs
@@ -1,0 +1,16 @@
+use std::fs;
+
+#[test]
+fn property_index_key_acceptance_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/state/state_checking/property_index_key_helpers.rs")
+        .expect("failed to read property_index_key_helpers.rs");
+
+    assert!(
+        source.contains("assign_relation_outcome(prop_literal, key_type).related"),
+        "string index key acceptance should route assignability through RelationOutcome.related"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "string index key acceptance should not regress to the raw boolean relation guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic/query-boundary routing for the M1-B lane.

## Invariant
When excess-property diagnostics check whether a concrete string property name is accepted by a non-broad index key type, checker should consume RelationOutcome.related through the shared assignability boundary. This PR changes checker orchestration only; solver policy and relation semantics are unchanged.

## Scope
- Route string_index_key_accepts_property_name in crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs through assign_relation_outcome(...).related.
- Add a focused architecture regression test in crates/tsz-checker/src/tests/property_index_key_relation_routing_arch_tests.rs.
- Wire the new test module in crates/tsz-checker/src/lib.rs.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor only; no project corpus semantics changed.

## Verification
- cargo fmt --check
- git diff --check
- cargo nextest run -p tsz-checker --lib property_index_key_acceptance_uses_relation_outcome_boundary
- scripts/arch/check-checker-boundaries.sh
- python3 scripts/arch/arch_guard.py
- git diff --check origin/main..HEAD

## Coordination Notes
- Fresh branch from origin/main at 929041f62c.
- Non-overlap: avoids active M1-B decorator, index property, rest parameter, contextual new, call-result, and stacked return-relation PRs.
- Draft while light CI starts; no full conformance run locally per TSZ policy.