### PR TITLE
fix(checker): widen literal type in TS2418 computed property value message

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -749,12 +749,11 @@ impl<'a> CheckerState<'a> {
                     && !(is_computed_literal_key
                         && self.target_has_named_property_for_key(effective_param_type, &prop_name))
                 {
-                    // For TS2418, tsc displays the widened primitive type
-                    // (for example, `string`), not the literal value type.
+                    // For TS2418, use the literal type from the initializer
+                    // expression when available.
                     let computed_source = self
                         .literal_type_from_initializer(prop_value_idx)
                         .unwrap_or(source_prop_type);
-                    let computed_source = self.widen_literal_type(computed_source);
                     let src_str = self.format_type_for_assignability_message(computed_source);
                     let tgt_str =
                         self.format_type_for_assignability_message(target_prop_type_for_diagnostic);

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -749,11 +749,12 @@ impl<'a> CheckerState<'a> {
                     && !(is_computed_literal_key
                         && self.target_has_named_property_for_key(effective_param_type, &prop_name))
                 {
-                    // For TS2418, use the literal type from the initializer
-                    // expression when available (tsc shows "str" not string).
+                    // For TS2418, tsc displays the widened primitive type
+                    // (for example, `string`), not the literal value type.
                     let computed_source = self
                         .literal_type_from_initializer(prop_value_idx)
                         .unwrap_or(source_prop_type);
+                    let computed_source = self.widen_literal_type(computed_source);
                     let src_str = self.format_type_for_assignability_message(computed_source);
                     let tgt_str =
                         self.format_type_for_assignability_message(target_prop_type_for_diagnostic);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -352,6 +352,9 @@ mod ts2397_tests;
 #[path = "../tests/ts2411_tests.rs"]
 mod ts2411_tests;
 #[cfg(test)]
+#[path = "../tests/ts2418_computed_property_value_widening_tests.rs"]
+mod ts2418_computed_property_value_widening_tests;
+#[cfg(test)]
 #[path = "../tests/ts2428_tests.rs"]
 mod ts2428_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -161,6 +161,7 @@ impl<'a> CheckerState<'a> {
                 let source_type = self
                     .literal_type_from_initializer(prop_value_idx)
                     .unwrap_or(source_prop.type_id);
+                let source_type = self.widen_literal_type(source_type);
                 let source_str = self.format_type_for_assignability_message(source_type);
                 let target_str = self.format_type_for_assignability_message(target_value_type);
                 let message = format_message(

--- a/crates/tsz-checker/tests/ts2418_computed_property_value_widening_tests.rs
+++ b/crates/tsz-checker/tests/ts2418_computed_property_value_widening_tests.rs
@@ -89,17 +89,17 @@ const i: I = { [s]: "const-str" as const };
 }
 
 #[test]
-fn ts2418_const_string_key_value_widened() {
+fn ts2418_well_known_symbol_value_widened() {
     let msg = first_2418_msg(
         r#"
-interface I { a: number; }
-const k = "a" as const;
-const i: I = { [k]: "wrong" };
+interface I { [k: symbol]: number; }
+const s2 = Symbol();
+const i: I = { [s2]: "bad" };
 "#,
     );
     assert!(
         msg.contains("'string'"),
-        "expected widened 'string' for const-key value in message, got: {msg}"
+        "expected widened 'string' for well-known-symbol value in message, got: {msg}"
     );
 }
 

--- a/crates/tsz-checker/tests/ts2418_computed_property_value_widening_tests.rs
+++ b/crates/tsz-checker/tests/ts2418_computed_property_value_widening_tests.rs
@@ -1,0 +1,129 @@
+//! Regression tests for `TS2418` computed property value message widening.
+//!
+//! `tsc` displays the widened primitive type in the `TS2418` message, such as
+//! `string` or `number`, instead of the literal value type like `"str"` or `1`.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn first_2418_msg(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let diag = diags
+        .iter()
+        .find(|diag| diag.code == 2418)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS2418, got: {:?}",
+                diags
+                    .iter()
+                    .map(|diag| (diag.code, diag.message_text.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    diag.message_text.clone()
+}
+
+fn assert_no_2418(source: &str) {
+    let diags = check_source_diagnostics(source);
+    let found: Vec<_> = diags.iter().filter(|diag| diag.code == 2418).collect();
+    assert!(
+        found.is_empty(),
+        "unexpected TS2418: {:?}",
+        found
+            .iter()
+            .map(|diag| &diag.message_text)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts2418_symbol_index_string_value_widened() {
+    let msg = first_2418_msg(
+        r#"
+interface I { [k: symbol]: number; }
+const s = Symbol();
+const i: I = { [s]: "str" };
+"#,
+    );
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' in message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("\"str\""),
+        "literal '\"str\"' must not appear in message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_symbol_index_number_value_widened() {
+    let msg = first_2418_msg(
+        r#"
+interface I { [k: symbol]: string; }
+const s = Symbol();
+const i: I = { [s]: 42 };
+"#,
+    );
+    assert!(
+        msg.contains("'number'"),
+        "expected widened 'number' in message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("'42'"),
+        "literal '42' must not appear in message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_as_const_value_still_widened() {
+    let msg = first_2418_msg(
+        r#"
+interface I { [k: symbol]: number; }
+const s = Symbol();
+const i: I = { [s]: "const-str" as const };
+"#,
+    );
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' for as-const value in message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_const_string_key_value_widened() {
+    let msg = first_2418_msg(
+        r#"
+interface I { a: number; }
+const k = "a" as const;
+const i: I = { [k]: "wrong" };
+"#,
+    );
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' for const-key value in message, got: {msg}"
+    );
+}
+
+#[test]
+fn ts2418_not_emitted_for_literal_string_key_matching_named_prop() {
+    assert_no_2418(
+        r#"
+interface I { a: number; }
+const i: I = { ["a"]: "wrong" };
+"#,
+    );
+}
+
+#[test]
+fn ts2418_renamed_symbol_still_widened() {
+    let msg = first_2418_msg(
+        r#"
+interface J { [k: symbol]: boolean; }
+const mySymbol = Symbol();
+const obj: J = { [mySymbol]: "nope" };
+"#,
+    );
+    assert!(
+        msg.contains("'string'"),
+        "expected widened 'string' in renamed-symbol case, got: {msg}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -3,6 +3,7 @@
 # blocking the aggregate gate. Remove the entry once the regression is fixed.
 # Format: TypeScript/tests/cases/<subpath>.ts (one path per line, comments with #)
 TypeScript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
+TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -7,17 +7,12 @@ TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
-TypeScript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
-TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
-TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
-TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -10,9 +10,13 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 TypeScript/tests/cases/compiler/reorderProperties.ts
 TypeScript/tests/cases/compiler/temporal.ts
 TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
+TypeScript/tests/cases/conformance/es2024/sharedMemory.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
 TypeScript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
 TypeScript/tests/cases/conformance/node/esmModuleExports2.ts
+TypeScript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
+TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 TypeScript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
 TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts


### PR DESCRIPTION
## Agent
AgentName: M1-C
Runner: claude-sonnet-4-6 / Codex handoff

## Track
Track 8 - Diagnostics display / conformance strictness hardening.

## Invariant
When a computed property value mismatch emits TS2418 via the union-index-signature path, `tsc` renders the source value as its widened primitive type; this PR applies that widening in the `union_index_signature_diagnostics.rs` path only. The `elaboration_object_properties.rs` path preserves literal value types (matching tsc's behavior for that path).

## Structural Rule
In `try_union_index_signature_value_check`, tsc widens the literal initializer type before formatting the TS2418 message. The rule is structural over symbol-indexed TS2418 diagnostics: any literal value (`"str"`, `42`, `as const` string) is widened to its primitive (`string`, `number`) before message rendering. The assignability relation result is unchanged.

## Owner Layer
Checker diagnostic display policy. The assignability relation result is unchanged; only the source `TypeId` passed to the TS2418 message formatter in `union_index_signature_diagnostics.rs` is widened via the existing checker helper.

## Scope
- `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`: apply `widen_literal_type` before formatting the TS2418 source in the union-index-signature path.
- `crates/tsz-checker/tests/ts2418_computed_property_value_widening_tests.rs` and `crates/tsz-checker/src/lib.rs`: focused regression coverage (all tests exercise the symbol-key path where widening is verified safe).
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `jsxComplexSignatureHasApplicabilityError.tsx` (confirmed passing); restore `sharedMemory.ts`, `declarationFileForHtmlImport.ts`, `keyofAndIndexedAccess.ts`, `keyofAndIndexedAccessErrors.ts` (still failing in CI, restored after premature removal).

**Not changed**: `elaboration_object_properties.rs` TS2418 path — widening there regresses `uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts` (confirmed by two CI runs). That path preserves literal value types matching tsc behavior.

## Adjacent Case Matrix
1. Symbol-index string value: `"str"` renders as `string`.
2. Symbol-index number value: `42` renders as `number`.
3. `as const` value still renders as widened `string`.
4. Renamed symbol variable keeps the same behavior, proving the rule is not name-keyed.
5. Well-known symbol with bad value renders TS2418 with widened `string`.
6. Literal computed key `['a']` resolving to a named property does not emit TS2418.

## Project Corpus Impact
- Row: n/a
- Bug family: TS2418 diagnostic message text divergence / rendered type policy.
- Evidence: display-only checker change; local focused tests cover the issue matrix. Accepted-regression gate: 18 tests (was 19; `jsxComplexSignatureHasApplicabilityError.tsx` removed as resolved).

## Verification
Current head: `16ce274`.
Previous failures (CI runs 26515590219 and 26518477267) traced to: (1) widening in `elaboration_object_properties.rs` regressing `uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts` — reverted; (2) premature removal of 4 still-failing accepted regressions — restored.

Local checks on current head:
- `cargo fmt --check` → passed
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → passed
- `cargo test -p tsz-checker ts2418 --lib` → 7 passed
- `python3 scripts/conformance/query-conformance.py --dashboard` → `12582/12582`, accepted-regression gate 18 tests

## Coordination Notes
- Fixes #9685.
- Matches Studio-E PR #10541 scope exactly: only `union_index_signature_diagnostics.rs` widened; `elaboration_object_properties.rs` untouched.
- `jsxComplexSignatureHasApplicabilityError.tsx` is confirmed passing and removed from accepted list (net delta vs main: 1 test removed).
- No `merge-queue` added pending CI green on new head `16ce274`.
