### PR TITLE
refactor(checker): route enum fallback relation outcome

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs
@@ -212,8 +212,12 @@ impl<'a> CheckerState<'a> {
             // assignable to number or string, tsc's evaluator would likely succeed
             // (the import resolves to a const with a literal value).
             if eval_result.is_none()
-                && (self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)
-                    || self.diagnostic_relation_boolean_guard(init_type, TypeId::STRING))
+                && (self
+                    .assign_relation_outcome(init_type, TypeId::NUMBER)
+                    .related
+                    || self
+                        .assign_relation_outcome(init_type, TypeId::STRING)
+                        .related)
             {
                 continue;
             }

--- a/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs
@@ -14,7 +14,11 @@ fn computed_enum_member_ts18033_uses_relation_outcome_boundary() {
         "computed enum-member TS18033 diagnostics should route the final relation through assign_relation_outcome"
     );
     assert!(
-        !source.contains("if !self.diagnostic_relation_boolean_guard(init_type, TypeId::NUMBER)"),
-        "computed enum-member TS18033 diagnostics should not pre-gate final emission with a raw boolean relation"
+        source.contains("assign_relation_outcome(init_type, TypeId::STRING)"),
+        "computed enum-member import fallback should route string assignability through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard"),
+        "computed enum-member diagnostics should not regress to raw boolean relation guards"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor-only checker relation diagnostic/query-boundary routing for the M1-B lane.

## Invariant
When computed enum-member diagnostics use the unknown-evaluation fallback to ask whether an initializer type is assignable to number or string, checker should consume RelationOutcome.related through the shared assignability boundary. This PR changes checker orchestration only; solver policy and relation semantics are unchanged.

## Scope
- Route computed enum fallback number/string relation probes in crates/tsz-checker/src/state/state_checking_members/statement_helpers.rs through assign_relation_outcome(...).related.
- Tighten the existing architecture regression test in crates/tsz-checker/src/tests/enum_computed_relation_routing_arch_tests.rs.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor only; no project corpus semantics changed.

## Verification
- cargo fmt --check
- git diff --check
- cargo nextest run -p tsz-checker --lib computed_enum_member_ts18033_uses_relation_outcome_boundary
- scripts/arch/check-checker-boundaries.sh
- python3 scripts/arch/arch_guard.py
- git diff --check origin/main..HEAD

## Coordination Notes
- Fresh branch from origin/main at 929041f62c.
- Non-overlap: avoids active M1-B decorator, index property, rest parameter, contextual new, call-result, property-key, and stacked return-relation PRs.
- Draft while light CI starts; no full conformance run locally per TSZ policy.