### PR TITLE
fix(dts): preserve inference return summaries

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -662,6 +662,59 @@ impl<'a> DeclarationEmitter<'a> {
             else {
                 continue;
             };
+            let Some((alias_name, param_inner)) =
+                Self::single_generic_type_argument_text(param_type_text.trim())
+            else {
+                continue;
+            };
+            if !type_param_names
+                .iter()
+                .any(|name| name.as_str() == param_inner)
+                || substitutions
+                    .iter()
+                    .any(|(name, _)| name.as_str() == param_inner)
+            {
+                continue;
+            }
+            let Some(arg_type_text) = self.call_argument_type_text_for_substitution(
+                arg_idx,
+                Self::type_param_constraint_text(type_param_constraints, param_inner),
+            ) else {
+                continue;
+            };
+
+            let inferred = if alias_name == "Partial" {
+                Self::infer_required_from_partial_argument_text(&arg_type_text)
+            } else {
+                self.isomorphic_mapped_alias_value_wrapper(source_arena, alias_name)
+                    .and_then(|wrapper| {
+                        Self::infer_unwrapped_isomorphic_mapped_argument_text(
+                            &arg_type_text,
+                            &wrapper,
+                        )
+                    })
+            };
+            if let Some(value_text) = inferred {
+                substitutions.push((
+                    param_inner.to_string(),
+                    Self::parenthesize_generic_function_type_argument(&value_text),
+                ));
+            }
+        }
+
+        for (&param_idx, &arg_idx) in parameters.nodes.iter().zip(args.nodes.iter()) {
+            let Some(param_node) = source_arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = source_arena.get_parameter(param_node) else {
+                continue;
+            };
+            let Some(param_type_text) = self
+                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
+                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))
+            else {
+                continue;
+            };
             if let Some((param_name, value_text)) = self
                 .infer_single_alias_discriminant_substitution(
                     source_arena,
@@ -727,6 +780,263 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         substitutions
+    }
+
+    fn isomorphic_mapped_alias_value_wrapper(
+        &self,
+        source_arena: &NodeArena,
+        alias_name: &str,
+    ) -> Option<String> {
+        let source_file = self.arena_source_file(source_arena)?;
+        for &stmt_idx in &source_file.statements.nodes {
+            let stmt_node = source_arena.get(stmt_idx)?;
+            let Some(alias) = source_arena.get_type_alias(stmt_node) else {
+                continue;
+            };
+            if self
+                .identifier_text_from_arena(source_arena, alias.name)
+                .as_deref()
+                != Some(alias_name)
+            {
+                continue;
+            }
+            let type_params = alias.type_parameters.as_ref()?;
+            if type_params.nodes.len() != 1 {
+                return None;
+            }
+            let type_param_node = source_arena.get(type_params.nodes[0])?;
+            let type_param = source_arena.get_type_parameter(type_param_node)?;
+            let type_param_name = self.identifier_text_from_arena(source_arena, type_param.name)?;
+            let alias_text = self
+                .source_slice_from_arena(source_arena, alias.type_node)
+                .or_else(|| self.emit_type_node_text_from_arena(source_arena, alias.type_node))?;
+            return Self::isomorphic_mapped_alias_value_wrapper_text(&alias_text, &type_param_name);
+        }
+        None
+    }
+
+    fn isomorphic_mapped_alias_value_wrapper_text(
+        alias_text: &str,
+        type_param_name: &str,
+    ) -> Option<String> {
+        let trimmed = alias_text.trim().trim_end_matches(';').trim();
+        let inner = trimmed.strip_prefix('{')?.strip_suffix('}')?.trim();
+        let mapped = inner.strip_prefix('[')?;
+        let in_marker = format!(" in keyof {type_param_name}");
+        if !mapped.contains(&in_marker) {
+            return None;
+        }
+        let value_text = mapped
+            .split_once("]:")?
+            .1
+            .trim()
+            .trim_end_matches(';')
+            .trim();
+        let lookup = format!("{type_param_name}[");
+        let open = value_text.find('<')?;
+        let wrapper = value_text[..open].trim();
+        if !Self::is_simple_identifier_text(wrapper) || !value_text[open + 1..].contains(&lookup) {
+            return None;
+        }
+        Some(wrapper.to_string())
+    }
+
+    pub(in crate::declaration_emitter) fn infer_unwrapped_isomorphic_mapped_argument_text(
+        arg_type_text: &str,
+        wrapper: &str,
+    ) -> Option<String> {
+        let trimmed = arg_type_text.trim();
+        if let Some(elements) = Self::tuple_type_text_elements_preserving_rest(trimmed) {
+            let mut inferred = Vec::new();
+            for element in elements {
+                inferred.push(Self::unwrap_mapped_tuple_element(&element, wrapper)?);
+            }
+            return Some(format!("[{}]", inferred.join(", ")));
+        }
+
+        if let Some(inner) = Self::strip_array_suffix(trimmed)
+            && let Some(unwrapped) = Self::unwrap_single_wrapper_type(inner, wrapper)
+        {
+            return Some(format!("{unwrapped}[]"));
+        }
+
+        Self::object_type_members(trimmed).and_then(|members| {
+            let mut lines = Vec::new();
+            for member in members {
+                let (name, optional, type_text) = Self::object_member_parts(&member)?;
+                let unwrapped = Self::unwrap_single_wrapper_type(type_text, wrapper)?;
+                let optional = if optional { "?" } else { "" };
+                lines.push(format!("    {name}{optional}: {unwrapped};"));
+            }
+            (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
+        })
+    }
+
+    pub(in crate::declaration_emitter) fn infer_required_from_partial_argument_text(
+        arg_type_text: &str,
+    ) -> Option<String> {
+        let trimmed = arg_type_text.trim();
+        if let Some(elements) = Self::tuple_type_text_elements_preserving_rest(trimmed) {
+            let mut inferred = Vec::new();
+            for element in elements {
+                inferred.push(Self::required_tuple_element_text(&element));
+            }
+            return Some(format!("[{}]", inferred.join(", ")));
+        }
+
+        if let Some(inner) = Self::strip_array_suffix(trimmed) {
+            let inner = Self::remove_undefined_union_member(inner);
+            return Some(format!("{inner}[]"));
+        }
+
+        Self::object_type_members(trimmed).and_then(|members| {
+            let mut lines = Vec::new();
+            for member in members {
+                let (name, _, type_text) = Self::object_member_parts(&member)?;
+                let required = Self::remove_undefined_union_member(type_text);
+                lines.push(format!("    {name}: {required};"));
+            }
+            (!lines.is_empty()).then(|| format!("{{\n{}\n}}", lines.join("\n")))
+        })
+    }
+
+    fn tuple_type_text_elements_preserving_rest(type_text: &str) -> Option<Vec<String>> {
+        let mut text = type_text.trim();
+        if let Some(rest) = text.strip_prefix("readonly ") {
+            text = rest.trim();
+        }
+        if !text.starts_with('[') || !text.ends_with(']') {
+            return None;
+        }
+        let inner = text[1..text.len() - 1].trim();
+        if inner.is_empty() {
+            return Some(Vec::new());
+        }
+        Some(
+            Self::split_top_level_commas(inner)
+                .into_iter()
+                .map(|part| part.trim().to_string())
+                .collect(),
+        )
+    }
+
+    fn unwrap_mapped_tuple_element(element: &str, wrapper: &str) -> Option<String> {
+        let trimmed = element.trim();
+        if let Some(rest) = trimmed.strip_prefix("...") {
+            let rest = rest.trim();
+            let array_inner = Self::strip_array_suffix(rest).unwrap_or(rest);
+            let unwrapped = Self::unwrap_single_wrapper_type(array_inner, wrapper)?;
+            return Some(format!("...{unwrapped}[]"));
+        }
+        Self::unwrap_single_wrapper_type(trimmed.trim_end_matches('?').trim(), wrapper)
+            .map(str::to_string)
+    }
+
+    fn required_tuple_element_text(element: &str) -> String {
+        let trimmed = element.trim();
+        if let Some(rest) = trimmed.strip_prefix("...") {
+            let rest = rest.trim();
+            let array_inner = Self::strip_array_suffix(rest).unwrap_or(rest);
+            let required = Self::remove_undefined_union_member(array_inner);
+            return format!("...{required}[]");
+        }
+        Self::remove_undefined_union_member(trimmed.trim_end_matches('?').trim())
+    }
+
+    fn strip_array_suffix(type_text: &str) -> Option<&str> {
+        let trimmed = type_text.trim();
+        let inner = trimmed.strip_suffix("[]")?.trim();
+        Some(
+            inner
+                .strip_prefix('(')
+                .and_then(|text| text.strip_suffix(')'))
+                .unwrap_or(inner)
+                .trim(),
+        )
+    }
+
+    fn unwrap_single_wrapper_type<'b>(type_text: &'b str, wrapper: &str) -> Option<&'b str> {
+        let trimmed = type_text.trim();
+        let inner = trimmed.strip_prefix(wrapper)?.trim_start();
+        let inner = inner.strip_prefix('<')?.strip_suffix('>')?.trim();
+        (!inner.is_empty()).then_some(inner)
+    }
+
+    fn object_type_members(type_text: &str) -> Option<Vec<String>> {
+        let inner = type_text
+            .trim()
+            .strip_prefix('{')?
+            .strip_suffix('}')?
+            .trim();
+        if inner.is_empty() {
+            return Some(Vec::new());
+        }
+        Some(
+            Self::split_top_level_semicolon_members(inner)
+                .into_iter()
+                .map(|member| member.trim().to_string())
+                .filter(|member| !member.is_empty())
+                .collect(),
+        )
+    }
+
+    fn split_top_level_semicolon_members(text: &str) -> Vec<&str> {
+        let mut parts = Vec::new();
+        let mut start = 0usize;
+        let mut angle_depth = 0usize;
+        let mut brace_depth = 0usize;
+        let mut bracket_depth = 0usize;
+        let mut paren_depth = 0usize;
+        for (idx, ch) in text.char_indices() {
+            match ch {
+                '<' => angle_depth += 1,
+                '>' => angle_depth = angle_depth.saturating_sub(1),
+                '{' => brace_depth += 1,
+                '}' => brace_depth = brace_depth.saturating_sub(1),
+                '[' => bracket_depth += 1,
+                ']' => bracket_depth = bracket_depth.saturating_sub(1),
+                '(' => paren_depth += 1,
+                ')' => paren_depth = paren_depth.saturating_sub(1),
+                ';' if angle_depth == 0
+                    && brace_depth == 0
+                    && bracket_depth == 0
+                    && paren_depth == 0 =>
+                {
+                    parts.push(&text[start..idx]);
+                    start = idx + 1;
+                }
+                _ => {}
+            }
+        }
+        parts.push(&text[start..]);
+        parts
+    }
+
+    fn object_member_parts(member: &str) -> Option<(&str, bool, &str)> {
+        let colon = Self::find_top_level_byte(member, b':')?;
+        let name = member[..colon].trim();
+        let type_text = member[colon + 1..].trim();
+        if name.is_empty() || type_text.is_empty() {
+            return None;
+        }
+        let (name, optional) = name
+            .strip_suffix('?')
+            .map(|name| (name.trim_end(), true))
+            .unwrap_or((name, false));
+        Some((name, optional, type_text))
+    }
+
+    fn remove_undefined_union_member(type_text: &str) -> String {
+        let parts = Self::split_top_level_union_type_parts(type_text)
+            .into_iter()
+            .map(|part| part.trim().to_string())
+            .filter(|part| part != "undefined")
+            .collect::<Vec<_>>();
+        if parts.is_empty() {
+            "undefined".to_string()
+        } else {
+            parts.join(" | ")
+        }
     }
 
     pub(super) fn infer_constrained_identity_callback_substitution(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -1,7 +1,7 @@
 //! Correlated union and generic call substitution helpers for DTS emit.
 
 use super::super::DeclarationEmitter;
-use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::node::{MappedTypeData, NodeArena, TypeAliasData};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
@@ -14,6 +14,11 @@ struct CorrelatedAliasShape {
     callback_map_type_name: String,
     callback_return_type_text: String,
     member_indices: Vec<NodeIndex>,
+}
+
+enum MappedArgumentInference {
+    PartialRequired,
+    IsomorphicWrapper(String),
 }
 
 impl<'a> DeclarationEmitter<'a> {
@@ -656,47 +661,38 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(param) = source_arena.get_parameter(param_node) else {
                 continue;
             };
-            let Some(param_type_text) = self
-                .emit_type_node_text_from_arena(source_arena, param.type_annotation)
-                .or_else(|| self.source_slice_from_arena(source_arena, param.type_annotation))
-            else {
-                continue;
-            };
-            let Some((alias_name, param_inner)) =
-                Self::single_generic_type_argument_text(param_type_text.trim())
+            let Some((param_inner, inference)) =
+                self.mapped_argument_inference_from_param_type(source_arena, param.type_annotation)
             else {
                 continue;
             };
             if !type_param_names
                 .iter()
-                .any(|name| name.as_str() == param_inner)
+                .any(|name| name.as_str() == param_inner.as_str())
                 || substitutions
                     .iter()
-                    .any(|(name, _)| name.as_str() == param_inner)
+                    .any(|(name, _)| name.as_str() == param_inner.as_str())
             {
                 continue;
             }
             let Some(arg_type_text) = self.call_argument_type_text_for_substitution(
                 arg_idx,
-                Self::type_param_constraint_text(type_param_constraints, param_inner),
+                Self::type_param_constraint_text(type_param_constraints, &param_inner),
             ) else {
                 continue;
             };
 
-            let inferred = if alias_name == "Partial" {
-                Self::infer_required_from_partial_argument_text(&arg_type_text)
-            } else {
-                self.isomorphic_mapped_alias_value_wrapper(source_arena, alias_name)
-                    .and_then(|wrapper| {
-                        Self::infer_unwrapped_isomorphic_mapped_argument_text(
-                            &arg_type_text,
-                            &wrapper,
-                        )
-                    })
+            let inferred = match inference {
+                MappedArgumentInference::PartialRequired => {
+                    Self::infer_required_from_partial_argument_text(&arg_type_text)
+                }
+                MappedArgumentInference::IsomorphicWrapper(wrapper) => {
+                    Self::infer_unwrapped_isomorphic_mapped_argument_text(&arg_type_text, &wrapper)
+                }
             };
             if let Some(value_text) = inferred {
                 substitutions.push((
-                    param_inner.to_string(),
+                    param_inner,
                     Self::parenthesize_generic_function_type_argument(&value_text),
                 ));
             }
@@ -782,63 +778,170 @@ impl<'a> DeclarationEmitter<'a> {
         substitutions
     }
 
-    fn isomorphic_mapped_alias_value_wrapper(
+    fn mapped_argument_inference_from_param_type(
         &self,
         source_arena: &NodeArena,
-        alias_name: &str,
-    ) -> Option<String> {
-        let source_file = self.arena_source_file(source_arena)?;
-        for &stmt_idx in &source_file.statements.nodes {
-            let stmt_node = source_arena.get(stmt_idx)?;
-            let Some(alias) = source_arena.get_type_alias(stmt_node) else {
-                continue;
-            };
-            if self
-                .identifier_text_from_arena(source_arena, alias.name)
-                .as_deref()
-                != Some(alias_name)
-            {
-                continue;
-            }
-            let type_params = alias.type_parameters.as_ref()?;
-            if type_params.nodes.len() != 1 {
+        param_type_idx: NodeIndex,
+    ) -> Option<(String, MappedArgumentInference)> {
+        let param_type_idx = source_arena.skip_parenthesized(param_type_idx);
+        let param_type_node = source_arena.get(param_type_idx)?;
+        if param_type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let param_type = source_arena.get_type_ref(param_type_node)?;
+        let type_args = param_type.type_arguments.as_ref()?;
+        let [type_arg_idx] = type_args.nodes.as_slice() else {
+            return None;
+        };
+        let param_inner = self.simple_type_node_name_from_arena(source_arena, *type_arg_idx)?;
+        let sym_id = self
+            .declaration_type_symbol_from_type_node(source_arena, param_type_idx)
+            .or_else(|| {
+                let name = self.simple_type_node_name_from_arena(source_arena, param_type_idx)?;
+                self.binder?.get_global_type(&name)
+            })?;
+        let inference = self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
+            let alias_node = alias_arena.get(decl_idx)?;
+            let alias = alias_arena.get_type_alias(alias_node)?;
+            self.mapped_argument_inference_from_alias(alias_arena, alias)
+        })?;
+        Some((param_inner, inference))
+    }
+
+    fn mapped_argument_inference_from_alias(
+        &self,
+        alias_arena: &NodeArena,
+        alias: &TypeAliasData,
+    ) -> Option<MappedArgumentInference> {
+        let type_params = alias.type_parameters.as_ref()?;
+        let [type_param_idx] = type_params.nodes.as_slice() else {
+            return None;
+        };
+        let type_param = alias_arena
+            .get(*type_param_idx)
+            .and_then(|node| alias_arena.get_type_parameter(node))?;
+        let type_param_name = self.identifier_text_from_arena(alias_arena, type_param.name)?;
+        let mapped = Self::mapped_type_from_type_node(alias_arena, alias.type_node)?;
+        let (mapped_param_name, source_type_name) =
+            self.mapped_keyof_source_type_name(alias_arena, mapped)?;
+        if source_type_name != type_param_name {
+            return None;
+        }
+        if mapped.name_type.is_some()
+            || mapped.members.as_ref().is_some_and(|m| !m.nodes.is_empty())
+        {
+            return None;
+        }
+        if mapped.question_token.is_some()
+            && self.mapped_value_is_indexed_access(
+                alias_arena,
+                mapped.type_node,
+                &type_param_name,
+                &mapped_param_name,
+            )
+        {
+            return Some(MappedArgumentInference::PartialRequired);
+        }
+        self.mapped_value_isomorphic_wrapper(
+            alias_arena,
+            mapped.type_node,
+            &type_param_name,
+            &mapped_param_name,
+        )
+        .map(MappedArgumentInference::IsomorphicWrapper)
+    }
+
+    fn mapped_type_from_type_node(
+        arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<&MappedTypeData> {
+        let type_idx = arena.skip_parenthesized(type_idx);
+        let type_node = arena.get(type_idx)?;
+        if type_node.kind == syntax_kind_ext::MAPPED_TYPE {
+            return arena.get_mapped_type(type_node);
+        }
+        if type_node.kind == syntax_kind_ext::TYPE_LITERAL {
+            let literal = arena.get_type_literal(type_node)?;
+            let [member_idx] = literal.members.nodes.as_slice() else {
                 return None;
+            };
+            let member_node = arena.get(*member_idx)?;
+            if member_node.kind == syntax_kind_ext::MAPPED_TYPE {
+                return arena.get_mapped_type(member_node);
             }
-            let type_param_node = source_arena.get(type_params.nodes[0])?;
-            let type_param = source_arena.get_type_parameter(type_param_node)?;
-            let type_param_name = self.identifier_text_from_arena(source_arena, type_param.name)?;
-            let alias_text = self
-                .source_slice_from_arena(source_arena, alias.type_node)
-                .or_else(|| self.emit_type_node_text_from_arena(source_arena, alias.type_node))?;
-            return Self::isomorphic_mapped_alias_value_wrapper_text(&alias_text, &type_param_name);
         }
         None
     }
 
-    fn isomorphic_mapped_alias_value_wrapper_text(
-        alias_text: &str,
-        type_param_name: &str,
+    fn mapped_keyof_source_type_name(
+        &self,
+        arena: &NodeArena,
+        mapped: &MappedTypeData,
+    ) -> Option<(String, String)> {
+        let mapped_param = arena
+            .get(mapped.type_parameter)
+            .and_then(|node| arena.get_type_parameter(node))?;
+        let mapped_param_name = self.identifier_text_from_arena(arena, mapped_param.name)?;
+        let constraint_idx = arena.skip_parenthesized(mapped_param.constraint.into_option()?);
+        let constraint_node = arena.get(constraint_idx)?;
+        let type_op = arena.get_type_operator(constraint_node)?;
+        if type_op.operator != SyntaxKind::KeyOfKeyword as u16 {
+            return None;
+        }
+        let source_type_name = self.simple_type_node_name_from_arena(arena, type_op.type_node)?;
+        Some((mapped_param_name, source_type_name))
+    }
+
+    fn mapped_value_is_indexed_access(
+        &self,
+        arena: &NodeArena,
+        value_idx: NodeIndex,
+        object_name: &str,
+        index_name: &str,
+    ) -> bool {
+        self.indexed_access_names(arena, value_idx)
+            .is_some_and(|(object, index)| object == object_name && index == index_name)
+    }
+
+    fn mapped_value_isomorphic_wrapper(
+        &self,
+        arena: &NodeArena,
+        value_idx: NodeIndex,
+        object_name: &str,
+        index_name: &str,
     ) -> Option<String> {
-        let trimmed = alias_text.trim().trim_end_matches(';').trim();
-        let inner = trimmed.strip_prefix('{')?.strip_suffix('}')?.trim();
-        let mapped = inner.strip_prefix('[')?;
-        let in_marker = format!(" in keyof {type_param_name}");
-        if !mapped.contains(&in_marker) {
+        let value_idx = arena.skip_parenthesized(value_idx);
+        let value_node = arena.get(value_idx)?;
+        if value_node.kind != syntax_kind_ext::TYPE_REFERENCE {
             return None;
         }
-        let value_text = mapped
-            .split_once("]:")?
-            .1
-            .trim()
-            .trim_end_matches(';')
-            .trim();
-        let lookup = format!("{type_param_name}[");
-        let open = value_text.find('<')?;
-        let wrapper = value_text[..open].trim();
-        if !Self::is_simple_identifier_text(wrapper) || !value_text[open + 1..].contains(&lookup) {
+        let value_type = arena.get_type_ref(value_node)?;
+        let wrapper = self.simple_type_node_name_from_arena(arena, value_idx)?;
+        if !Self::is_simple_identifier_text(&wrapper) {
             return None;
         }
-        Some(wrapper.to_string())
+        let type_args = value_type.type_arguments.as_ref()?;
+        let [inner_idx] = type_args.nodes.as_slice() else {
+            return None;
+        };
+        self.mapped_value_is_indexed_access(arena, *inner_idx, object_name, index_name)
+            .then_some(wrapper)
+    }
+
+    fn indexed_access_names(
+        &self,
+        arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<(String, String)> {
+        let type_idx = arena.skip_parenthesized(type_idx);
+        let type_node = arena.get(type_idx)?;
+        if type_node.kind != syntax_kind_ext::INDEXED_ACCESS_TYPE {
+            return None;
+        }
+        let indexed = arena.get_indexed_access_type(type_node)?;
+        let object_name = self.simple_type_node_name_from_arena(arena, indexed.object_type)?;
+        let index_name = self.simple_type_node_name_from_arena(arena, indexed.index_type)?;
+        Some((object_name, index_name))
     }
 
     pub(in crate::declaration_emitter) fn infer_unwrapped_isomorphic_mapped_argument_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -650,3 +650,65 @@ let y10 = unboxify(x10);
         Some("[number, string, ...boolean[]]".to_string())
     );
 }
+
+#[test]
+fn declared_call_return_inverts_structural_partial_like_mapped_alias() {
+    let source = r#"
+type OptionalShape<T> = { [Key in keyof T]?: T[Key] };
+declare function complete<T>(x: OptionalShape<T>): T;
+declare let value: { a?: number; b: string | undefined };
+let y = complete(value);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert_eq!(
+        emitter.call_expression_declared_return_type_text(call_idx),
+        Some("{\n    a: number;\n    b: string;\n}".to_string())
+    );
+}
+
+#[test]
+fn declared_call_return_does_not_treat_shadowed_partial_name_as_builtin() {
+    let source = r#"
+type Partial<T> = T;
+declare function complete<T>(x: Partial<T>): T;
+declare let value: { a?: number };
+let y = complete(value);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert_eq!(
+        emitter.call_expression_declared_return_type_text(call_idx),
+        None
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -1,6 +1,7 @@
 use super::DeclarationEmitter;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tsz_binder::BinderState;
+use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::ParserState;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::construction::TypeInterner;
@@ -571,5 +572,81 @@ fn tuple_item_lookup_mapped_type_expands_compact_string_key() {
             "{\n    a: {\n        readonly name: \"a\";\n    };\n    b: {\n        readonly name: \"b\";\n    };\n}"
                 .to_string()
         )
+    );
+}
+
+#[test]
+fn isomorphic_mapped_argument_unwraps_tuple_and_array_wrappers() {
+    assert_eq!(
+        DeclarationEmitter::infer_unwrapped_isomorphic_mapped_argument_text(
+            "[Box<number>, Box<string>, ...Box<boolean>[]]",
+            "Box",
+        ),
+        Some("[number, string, ...boolean[]]".to_string())
+    );
+    assert_eq!(
+        DeclarationEmitter::infer_unwrapped_isomorphic_mapped_argument_text(
+            "[Box<number>, Box<string>, ...Box<boolean>]",
+            "Box",
+        ),
+        Some("[number, string, ...boolean[]]".to_string())
+    );
+    assert_eq!(
+        DeclarationEmitter::infer_unwrapped_isomorphic_mapped_argument_text("Box<number>[]", "Box"),
+        Some("number[]".to_string())
+    );
+}
+
+#[test]
+fn partial_argument_inference_restores_required_public_surface() {
+    assert_eq!(
+        DeclarationEmitter::infer_required_from_partial_argument_text(
+            "[number | undefined, string?, ...boolean[]]",
+        ),
+        Some("[number, string, ...boolean[]]".to_string())
+    );
+    assert_eq!(
+        DeclarationEmitter::infer_required_from_partial_argument_text(
+            "[number | undefined, string?, ...boolean]",
+        ),
+        Some("[number, string, ...boolean[]]".to_string())
+    );
+    assert_eq!(
+        DeclarationEmitter::infer_required_from_partial_argument_text(
+            "{ a: number | undefined; b?: string[]; }",
+        ),
+        Some("{\n    a: number;\n    b: string[];\n}".to_string())
+    );
+}
+
+#[test]
+fn declared_call_return_inverts_isomorphic_mapped_tuple_argument() {
+    let source = r#"
+type Box<T> = { value: T };
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+declare function unboxify<T>(x: Boxified<T>): T;
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+let y10 = unboxify(x10);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert_eq!(
+        emitter.call_expression_declared_return_type_text(call_idx),
+        Some("[number, string, ...boolean[]]".to_string())
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -34,12 +34,15 @@ impl<'a> DeclarationEmitter<'a> {
                     Self::type_text_starts_with_string_intrinsic(raw_type_text)
                 });
             match printed {
-                Some(printed) if printed != "any" && raw_string_intrinsic_type_text.is_some() => {
+                Some(printed)
+                    if !matches!(printed.as_str(), "any" | "unknown")
+                        && raw_string_intrinsic_type_text.is_some() =>
+                {
                     raw_string_intrinsic_type_text
                         .expect("string intrinsic type text was checked above")
                 }
                 Some(printed)
-                    if printed != "any"
+                    if !matches!(printed.as_str(), "any" | "unknown")
                         && (!printed.contains("any") || type_text.contains("any"))
                         && printed.contains("typeof ")
                         && !type_text.contains("typeof ") =>
@@ -47,7 +50,7 @@ impl<'a> DeclarationEmitter<'a> {
                     printed.replace("typeof ", "")
                 }
                 Some(printed)
-                    if printed != "any"
+                    if !matches!(printed.as_str(), "any" | "unknown")
                         && (!printed.contains("any") || type_text.contains("any")) =>
                 {
                     printed
@@ -63,7 +66,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .unwrap_or(rewritten);
             match printed {
                 Some(ref printed)
-                    if printed != "any"
+                    if !matches!(printed.as_str(), "any" | "unknown")
                         && !printed.contains("any")
                         && !expands_mapped_object
                         && (!Self::type_text_contains_import_type(&rewritten)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_inference_features.rs
@@ -95,6 +95,24 @@ function rawr(dino: RexOrRaptor) {
 }
 
 #[test]
+fn isomorphic_mapped_call_infers_variadic_tuple_return_from_argument() {
+    let output = emit_dts_with_binding(
+        r#"
+type Box<T> = { value: T };
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+declare function unboxify<T>(x: Boxified<T>): T;
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+let y10 = unboxify(x10);
+"#,
+    );
+
+    assert!(
+        output.contains("declare let y10: [number, string, ...boolean[]];"),
+        "Expected mapped tuple call to recover the public tuple return: {output}"
+    );
+}
+
+#[test]
 fn test_mutable_array_literal_binding_widens_homogeneous_literals() {
     let source = r#"
 let [hello, brave] = ["Hello", "Brave"];


### PR DESCRIPTION
## Agent
AgentName: Studio-D

## Track
Declaration emit parity / mapped tuple and array inverse return summaries. PR type: emit/DTS parity.

## Invariant
When a public declaration return can be recovered from a source-level generic mapped inference pattern, `tsc` emits the recovered public surface rather than a broader fallback type. This PR makes tsz recover mapped/Partial-like tuple, array, and object inverse inference through declaration-emitter summary helpers.

## Owner Layer
- Declaration emitter source-call inference helpers.
- No checker or solver relation behavior changes.
- Unsupported shapes fall back to the existing declaration return/type annotation path rather than guessing.

## Scope
- Infer tuple, array, and object public returns from isomorphic mapped aliases such as `{ [P in keyof T]: Box<T[P]> }`.
- Restore required public surfaces from structurally Partial-like mapped aliases, including renamed aliases and mapped variables.
- Resolve the mapped alias declaration through binder/global symbol identity and inspect AST shape; no raw `Partial` spelling shortcut and no rendered mapped-type text parser.
- Keep `unknown` solver fallback prints from replacing better source annotation text in the affected annotation path.
- Tests cover tuple/array wrappers, Partial-like structural inference, shadowed `type Partial<T> = T`, and variadic tuple call inference.

## Project Corpus Impact
- Row: `mappedTypesArraysTuples`
- Bug family: mapped tuple/array inverse call return summaries
- Evidence: `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypesArraysTuples --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-10421-mappedTypesArraysTuples-rebased2-20260527.json` passes 1/1 at head `9fcd6e945ae2225fbb8cb4d3dbaf75cb36a25439`.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-emitter -E 'test(isomorphic_mapped_argument_unwraps_tuple_and_array_wrappers) | test(partial_argument_inference_restores_required_public_surface) | test(declared_call_return_inverts_isomorphic_mapped_tuple_argument) | test(isomorphic_mapped_call_infers_variadic_tuple_return_from_argument) | test(declared_call_return_inverts_structural_partial_like_mapped_alias) | test(declared_call_return_does_not_treat_shadowed_partial_name_as_builtin)'` (6 passed)
- `scripts/safe-run.sh scripts/emit/run.sh --filter=mappedTypesArraysTuples --dts-only --verbose --concurrency=1 --timeout=60000 --json-out=/tmp/studio-d-10421-mappedTypesArraysTuples-rebased2-20260527.json` (1 passed)
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- No full conformance, full emit, or fourslash suite run locally.

## Coordination Notes
- AgentName: Studio-D
- 2026-05-27: Rebased the draft branch onto current `origin/main` `fc7e22dc4127dddf9a181cd19cf0ea4bb210ef09`; pushed current head `9fcd6e945ae2225fbb8cb4d3dbaf75cb36a25439` with fresh focused local verification.
- Review blocker addressed: the mapped/Partial inference trigger is structural over the alias declaration AST and symbol identity, with a negative test for a local shadowed `Partial` alias. Reviewer found no static blocker on the prior structural head.
- Files changed: `helpers/correlated_union.rs`, `helpers/type_inference_tests.rs`, `helpers/type_inference_type_annotations.rs`, and `tests/misc_inference_features.rs`.
- Kept this PR draft until fresh PR-head light CI completes for head `9fcd6e945ae2225fbb8cb4d3dbaf75cb36a25439`; ready handoff should happen only after exact-head checks are green.
- No roadmap update: this is a routine DTS parity fix through declaration/public source-summary boundaries.
