### PR TITLE
refactor(checker): route initializer relation outcome

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -589,6 +589,9 @@ mod in_narrow_bare_type_param_chained_tests;
 #[path = "tests/in_operator_relation_routing_arch_tests.rs"]
 mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/initializer_relation_routing_arch_tests.rs"]
+mod initializer_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -551,13 +551,13 @@ impl<'a> CheckerState<'a> {
                             let elaborated_obj =
                                 self.initializer_reaches_object_literal_through_wrappers(
                                     facts.initializer,
-                                ) && !self.diagnostic_relation_boolean_guard(
-                                    checked_init_type,
-                                    declared_type,
-                                ) && self.try_elaborate_object_literal_properties_for_var_init(
-                                    facts.initializer,
-                                    declared_type,
-                                );
+                                ) && !self
+                                    .assign_relation_outcome(checked_init_type, declared_type)
+                                    .related
+                                    && self.try_elaborate_object_literal_properties_for_var_init(
+                                        facts.initializer,
+                                        declared_type,
+                                    );
                             if !elaborated_obj {
                                 let skip_generic_outer_error = self
                                     .ctx
@@ -611,10 +611,9 @@ impl<'a> CheckerState<'a> {
                                         declared_type,
                                     )))
                                 && !(initializer_is_function
-                                    && !self.diagnostic_relation_boolean_guard(
-                                        checked_init_type,
-                                        declared_type,
-                                    )
+                                    && !self
+                                        .assign_relation_outcome(checked_init_type, declared_type)
+                                        .related
                                     && self.try_elaborate_assignment_source_error(
                                         facts.initializer,
                                         declared_type,
@@ -673,14 +672,14 @@ impl<'a> CheckerState<'a> {
                                     // contextual-typing decisions (`callsOnComplexSignatures`).
                                     if !(self.initializer_reaches_object_literal_through_wrappers(
                                         facts.initializer,
-                                    ) && !self.diagnostic_relation_boolean_guard(
-                                        checked_init_type,
-                                        declared_type,
-                                    ) && self
-                                        .try_elaborate_object_literal_properties_for_var_init(
-                                            facts.initializer,
-                                            declared_type,
-                                        ))
+                                    ) && !self
+                                        .assign_relation_outcome(checked_init_type, declared_type)
+                                        .related
+                                        && self
+                                            .try_elaborate_object_literal_properties_for_var_init(
+                                                facts.initializer,
+                                                declared_type,
+                                            ))
                                     {
                                         // Disable callable-with-type-params suppression
                                         // for variable declarations. The suppression is
@@ -691,10 +690,12 @@ impl<'a> CheckerState<'a> {
                                         // (e.g., (cb: (x: string, ...rest: T) => void) => void
                                         //   vs (cb: (...args: never) => void) => void)
                                         if jsdoc_new_expression_relation
-                                            && !self.diagnostic_relation_boolean_guard(
-                                                checked_init_type,
-                                                declared_type,
-                                            )
+                                            && !self
+                                                .assign_relation_outcome(
+                                                    checked_init_type,
+                                                    declared_type,
+                                                )
+                                                .related
                                         {
                                             self.error_type_not_assignable_generic_at(
                                                 checked_init_type,

--- a/crates/tsz-checker/src/tests/initializer_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/initializer_relation_routing_arch_tests.rs
@@ -1,0 +1,19 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn variable_initializer_diagnostics_use_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/state/variable_checking/initializer_policy.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+
+    assert_eq!(
+        source.matches("assign_relation_outcome").count(),
+        4,
+        "variable initializer diagnostic probes should route through assign_relation_outcome"
+    );
+    assert!(
+        !source.contains("diagnostic_relation_boolean_guard("),
+        "variable initializer diagnostics should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics/query-boundary routing.

## Invariant
When variable-initializer diagnostics need an assignability yes/no result, the checker should preserve the same source/target relation while routing through the shared `assign_relation_outcome` boundary instead of the legacy raw boolean guard.

## Scope
- `crates/tsz-checker/src/state/variable_checking/initializer_policy.rs`
- `crates/tsz-checker/src/tests/initializer_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project corpus row semantics changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib variable_initializer_diagnostics_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-033810`.
- Non-overlap checked against open M1-B relation-routing drafts; avoids active call-result, property-key, enum fallback, contextual-new, rest-parameter, index-property, decorator, and return relation slices.
- Draft PR intentionally relies on light CI; full conformance/emit/fourslash remain CI-only when promoted.
