### PR TITLE
refactor(checker): route overload parameter relation

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -733,6 +733,9 @@ mod optional_key_extraction_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_param_relation_routing_arch_tests.rs"]
+mod overload_param_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/partial_pick_indexed_access_write_tests.rs"]
 mod partial_pick_indexed_access_write_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -901,7 +901,8 @@ impl<'a> CheckerState<'a> {
                     self.replace_return_type(impl_stripped, tsz_solver::TypeId::ANY);
                 let overload_with_any_ret =
                     self.replace_return_type(overload_stripped, tsz_solver::TypeId::ANY);
-                self.diagnostic_relation_boolean_guard(impl_with_any_ret, overload_with_any_ret)
+                self.assign_relation_outcome(impl_with_any_ret, overload_with_any_ret)
+                    .related
             }
             _ => {
                 // If we can't get return types, fall back to bivariant assignability

--- a/crates/tsz-checker/src/tests/overload_param_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_param_relation_routing_arch_tests.rs
@@ -1,0 +1,20 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn overload_parameter_signature_check_uses_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src/state/state_checking_members/overload_compatibility.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+
+    assert!(
+        source.contains("assign_relation_outcome(impl_with_any_ret, overload_with_any_ret)"),
+        "overload parameter-only compatibility should use the shared relation outcome boundary"
+    );
+    assert!(
+        !source.contains(
+            "diagnostic_relation_boolean_guard(impl_with_any_ret, overload_with_any_ret)"
+        ),
+        "overload parameter-only compatibility should not use the legacy boolean guard"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker relation diagnostics/query-boundary routing.

## Invariant
When overload implementation compatibility has already accepted return compatibility, the remaining parameter-only strict assignability check should preserve its erased-signature source/target inputs while routing through the shared `assign_relation_outcome` boundary.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs`
- `crates/tsz-checker/src/tests/overload_param_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project corpus row semantics changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib overload_parameter_signature_check_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Fresh branch from current `origin/main` in `/Users/mohsen/code/tsz-m1b-fresh-origin-main-20260527-033810`; rebased onto `origin/main` commit `8ed94739b7` before push.
- Non-overlap checked against open M1-B relation-routing drafts; avoids active initializer, enum fallback, property-key, call-result, contextual-new, rest-parameter, index-property, decorator, and return relation slices.
- Bivariant return/fallback overload checks are intentionally unchanged; this PR only routes the strict parameter-only assignability probe.
- Draft PR intentionally relies on light CI; full conformance/emit/fourslash remain CI-only when promoted.
