### PR TITLE
refactor(checker): bundle jsx relation routing

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -1168,7 +1168,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if `string` is assignable to the children type.
-        if self.diagnostic_relation_boolean_guard(TypeId::STRING, children_type) {
+        if self
+            .assign_relation_outcome(TypeId::STRING, children_type)
+            .related
+        {
             return;
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
@@ -234,8 +234,12 @@ impl<'a> CheckerState<'a> {
         }
         let alias_evaluated = self.evaluate_type_with_env(alias);
         if alias_evaluated != TypeId::ERROR
-            && self.diagnostic_relation_boolean_guard(alias_evaluated, props_type)
-            && self.diagnostic_relation_boolean_guard(props_type, alias_evaluated)
+            && self
+                .assign_relation_outcome(alias_evaluated, props_type)
+                .related
+            && self
+                .assign_relation_outcome(props_type, alias_evaluated)
+                .related
         {
             self.ctx.types.store_display_alias(props_type, alias);
         }

--- a/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
@@ -90,7 +90,7 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::PropertyAccessResult::Success {
                     type_id,
                     ..
-                } if self.diagnostic_relation_boolean_guard(type_id, prop.type_id)
+                } if self.assign_relation_outcome(type_id, prop.type_id).related
             )
         })
     }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -693,7 +693,7 @@ impl<'a> CheckerState<'a> {
                 if !crate::query_boundaries::common::is_template_literal_type(
                     self.ctx.types,
                     key_type,
-                ) || !self.diagnostic_relation_boolean_guard(tag_literal, key_type)
+                ) || !self.assign_relation_outcome(tag_literal, key_type).related
                 {
                     continue;
                 }
@@ -715,16 +715,22 @@ impl<'a> CheckerState<'a> {
             while i < best_matches.len() {
                 let (best_key, _) = best_matches[i];
                 let candidate_more_specific = self
-                    .diagnostic_relation_boolean_guard(candidate_key, best_key)
-                    && !self.diagnostic_relation_boolean_guard(best_key, candidate_key);
+                    .assign_relation_outcome(candidate_key, best_key)
+                    .related
+                    && !self
+                        .assign_relation_outcome(best_key, candidate_key)
+                        .related;
                 if candidate_more_specific {
                     best_matches.swap_remove(i);
                     continue;
                 }
 
                 let best_more_specific = self
-                    .diagnostic_relation_boolean_guard(best_key, candidate_key)
-                    && !self.diagnostic_relation_boolean_guard(candidate_key, best_key);
+                    .assign_relation_outcome(best_key, candidate_key)
+                    .related
+                    && !self
+                        .assign_relation_outcome(candidate_key, best_key)
+                        .related;
                 if best_more_specific {
                     candidate_is_best = false;
                     break;
@@ -897,7 +903,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
         let tag_type = self.ctx.types.literal_string(tag);
-        if self.diagnostic_relation_boolean_guard(tag_type, evaluated) {
+        if self.assign_relation_outcome(tag_type, evaluated).related {
             return;
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -456,7 +456,7 @@ impl<'a> CheckerState<'a> {
             // is not assignable to type parameters like `P`, so we can't just assume
             // empty attrs match when the shape can't be resolved.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
+            return self.assign_relation_outcome(attrs_type, props_type).related;
         };
 
         let has_string_index = shape.string_index.is_some();
@@ -535,7 +535,7 @@ impl<'a> CheckerState<'a> {
             // and explicit-excess checks have already passed, defer to the
             // canonical assignability gate before rejecting the overload.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self.diagnostic_relation_boolean_guard(attrs_type, props_type);
+            return self.assign_relation_outcome(attrs_type, props_type).related;
         }
 
         true
@@ -646,7 +646,7 @@ impl<'a> CheckerState<'a> {
     /// keeps overload matching aligned with the canonical generic-constraint
     /// path without naming any particular helper alias.
     fn jsx_attr_assignable_to_expected(&mut self, attr_type: TypeId, expected: TypeId) -> bool {
-        self.diagnostic_relation_boolean_guard(attr_type, expected)
+        self.assign_relation_outcome(attr_type, expected).related
             || self.jsx_attr_assignable_after_referenced_constraints(attr_type, expected)
     }
 
@@ -692,8 +692,9 @@ impl<'a> CheckerState<'a> {
         }
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.diagnostic_relation_boolean_guard(restricted_evaluated, expected)
-            || self.diagnostic_relation_boolean_guard(restricted, expected)
+        self.assign_relation_outcome(restricted_evaluated, expected)
+            .related
+            || self.assign_relation_outcome(restricted, expected).related
     }
 
     /// Build an object type from collected JSX attribute info.

--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -63,7 +63,9 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
-            !self.diagnostic_relation_boolean_guard(*actual_type, expected_type)
+            !self
+                .assign_relation_outcome(*actual_type, expected_type)
+                .related
         });
 
         let has_alias_string_prop_mismatch = provided_attrs.iter().any(|(name, actual_type)| {
@@ -79,7 +81,7 @@ impl<'a> CheckerState<'a> {
 
         if !has_explicit_prop_mismatch
             && !has_alias_string_prop_mismatch
-            && self.diagnostic_relation_boolean_guard(attrs_type, props_type)
+            && self.assign_relation_outcome(attrs_type, props_type).related
         {
             return false;
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -190,7 +190,7 @@ impl<'a> CheckerState<'a> {
                         if *attr_type == TypeId::ANY || *attr_type == TypeId::ERROR {
                             return true;
                         }
-                        self.diagnostic_relation_boolean_guard(*attr_type, expected)
+                        self.assign_relation_outcome(*attr_type, expected).related
                     }
                     _ => true,
                 }
@@ -262,7 +262,7 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         let attrs_type = self.ctx.types.factory().object(properties);
-        if self.diagnostic_relation_boolean_guard(attrs_type, props_type) {
+        if self.assign_relation_outcome(attrs_type, props_type).related {
             return;
         }
         self.report_jsx_synthesized_props_assignability_error(

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -109,7 +109,9 @@ impl<'a> CheckerState<'a> {
         // normalized JSX spread path below so we can classify TS2322 vs TS2741 from
         // the apparent/object shape first.
         if !spread_has_type_params
-            && self.diagnostic_relation_boolean_guard(spread_type, props_type)
+            && self
+                .assign_relation_outcome(spread_type, props_type)
+                .related
         {
             return false;
         }
@@ -195,7 +197,10 @@ impl<'a> CheckerState<'a> {
                 // so the spread's type issues are masked.
                 return false;
             }
-            if self.diagnostic_relation_boolean_guard(spread_type, props_type) {
+            if self
+                .assign_relation_outcome(spread_type, props_type)
+                .related
+            {
                 return false;
             }
             let spread_name = self.format_type(spread_source_type);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -214,6 +214,12 @@ mod jsdoc_this_arrow_tests;
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
+#[path = "tests/jsx_component_props_relation_routing_arch_tests.rs"]
+mod jsx_component_props_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/jsx_overload_relation_routing_arch_tests.rs"]
+mod jsx_overload_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/lib_abstract_member_ts2515_tests.rs"]
 mod lib_abstract_member_ts2515_tests;
 #[cfg(test)]
@@ -682,11 +688,29 @@ mod jsx_element_type_constraint_tests;
 #[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
 mod jsx_excess_attr_with_spread_display_tests;
 #[cfg(test)]
+#[path = "tests/jsx_generic_spread_relation_routing_arch_tests.rs"]
+mod jsx_generic_spread_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/jsx_react_alias_relation_routing_arch_tests.rs"]
+mod jsx_react_alias_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]
+#[path = "tests/jsx_render_fallback_relation_routing_arch_tests.rs"]
+mod jsx_render_fallback_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/jsx_spread_assignability_relation_routing_arch_tests.rs"]
+mod jsx_spread_assignability_relation_routing_arch_tests;
+#[cfg(test)]
+#[path = "tests/jsx_text_child_relation_routing_arch_tests.rs"]
+mod jsx_text_child_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
+#[cfg(test)]
+#[path = "tests/jsx_union_props_relation_routing_arch_tests.rs"]
+mod jsx_union_props_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/keyof_function_type_is_never_tests.rs"]
 mod keyof_function_type_is_never_tests;

--- a/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn jsx_component_props_tag_relations_use_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/checkers/jsx/orchestration/component_props.rs")
+        .expect("failed to read JSX component props orchestration source");
+    let start = source
+        .find("pub(in crate::checkers_domain::jsx) fn get_jsx_intrinsic_props_from_template_literal_index_signatures")
+        .expect("missing template literal intrinsic props helper");
+    let end = source[start..]
+        .find("fn jsx_element_type_for_validation")
+        .expect("missing JSX element type validation helper")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        6,
+        "JSX component prop tag relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "JSX component prop tag relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "JSX component prop tag relation checks should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_generic_spread_assignability_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/generic_spread.rs");
+    let source = fs::read_to_string(source_path).expect("read jsx generic_spread.rs");
+
+    let function_start = source
+        .find("fn report_invalid_generic_jsx_spread_assignability")
+        .expect("find generic JSX spread assignability reporter");
+    let function = &source[function_start..];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "generic JSX spread assignability decisions should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "generic JSX spread assignability should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn jsx_overload_matching_uses_relation_outcome_boundary() {
+    let source = fs::read_to_string("src/checkers/jsx/overloads.rs")
+        .expect("failed to read JSX overload source");
+    let start = source
+        .find("fn jsx_attrs_match_overload")
+        .expect("missing JSX attrs overload matcher");
+    let end = source[start..]
+        .find("/// Build an object type from collected JSX attribute info.")
+        .expect("missing attrs object builder")
+        + start;
+    let helpers = &source[start..end];
+
+    assert_eq!(
+        helpers.matches("assign_relation_outcome").count(),
+        5,
+        "JSX overload relation checks should route through assign_relation_outcome"
+    );
+    assert!(
+        helpers.contains(".related"),
+        "JSX overload relation checks should use the relation outcome decision"
+    );
+    assert!(
+        !helpers.contains("diagnostic_relation_boolean_guard"),
+        "JSX overload matching should not regress to the raw boolean relation guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_react_props_alias_storage_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/extraction_react_alias.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX React alias source");
+
+    let function_start = source
+        .find("fn store_jsx_props_display_alias_if_matching")
+        .expect("find JSX props display alias helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("fn jsx_type_contains_callable_surface")
+            .expect("find next JSX React alias helper");
+    let function = &source[function_start..function_end];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "JSX props display-alias storage should route both compatibility decisions through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX props display-alias storage should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_render_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_render_fallback_relation_routing_arch_tests.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_render_fallback_required_props_use_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path =
+        Path::new(manifest_dir).join("src/checkers/jsx/extraction_render_fallback.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX render fallback source");
+
+    let function_start = source
+        .find("fn jsx_construct_return_can_use_render_fallback")
+        .expect("find JSX render fallback helper");
+    let function = &source[function_start..];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "JSX render fallback required-prop compatibility should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX render fallback required-prop compatibility should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_spread_whole_type_assignability_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/spread.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX spread source");
+
+    let function_start = source
+        .find("fn check_spread_property_types")
+        .expect("find JSX spread property checker");
+    let shape_branch_end = function_start
+        + source[function_start..]
+            .find("// When there are multiple spreads")
+            .expect("find JSX spread shape branch end");
+    let prefix = &source[function_start..shape_branch_end];
+
+    assert_eq!(
+        prefix.matches("assign_relation_outcome").count(),
+        2,
+        "early JSX spread whole-type compatibility decisions should route through relation outcomes"
+    );
+    assert!(
+        !prefix.contains("diagnostic_relation_boolean_guard"),
+        "early JSX spread whole-type compatibility should not regress to raw boolean relation guards"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_text_child_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_text_child_relation_routing_arch_tests.rs
@@ -1,0 +1,24 @@
+use std::{fs, path::PathBuf};
+
+#[test]
+fn jsx_text_child_diagnostic_uses_relation_outcome_boundary() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/checkers/jsx/diagnostics.rs");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let branch = source
+        .split("pub(crate) fn check_jsx_text_children_accepted")
+        .nth(1)
+        .expect("missing JSX text child diagnostic helper")
+        .split("// Get component name for the diagnostic message.")
+        .next()
+        .expect("missing JSX text child diagnostic relation branch");
+
+    assert!(
+        branch.contains("assign_relation_outcome(TypeId::STRING, children_type)"),
+        "JSX text-child diagnostics should use the shared relation outcome boundary"
+    );
+    assert!(
+        !branch.contains("diagnostic_relation_boolean_guard(TypeId::STRING, children_type)"),
+        "JSX text-child diagnostics should not use the legacy boolean guard"
+    );
+}

--- a/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_union_props_diagnostics_use_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/union_props.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX union props source");
+
+    let function_start = source
+        .find("fn check_jsx_union_props")
+        .expect("find JSX union props helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("fn jsx_props_type_is_library_managed_attributes_application")
+            .expect("find next JSX union props helper");
+    let function = &source[function_start..function_end];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "JSX union props compatibility decisions should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX union props diagnostics should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

Coordination AgentName: Studio-F

## Track
Refactor only: checker JSX relation diagnostics/query-boundary routing.

## Invariant
When JSX checker paths compare JSX-derived source and target types, tsz should preserve the existing assignability decisions while routing relation outcome checks through the shared `assign_relation_outcome`/query-boundary path instead of direct ad-hoc checker relation calls.

## Scope
- Bundle of same-owner `agent:M1-B` JSX relation-routing draft PRs into this successor PR.
- `crates/tsz-checker/src/checkers/jsx/diagnostics.rs`
- `crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs`
- `crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs`
- `crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs`
- `crates/tsz-checker/src/checkers/jsx/overloads.rs`
- `crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs`
- `crates/tsz-checker/src/checkers/jsx/props/union_props.rs`
- `crates/tsz-checker/src/checkers/jsx/spread.rs`
- `crates/tsz-checker/src/lib.rs`
- Focused architecture tests under `crates/tsz-checker/src/tests/jsx_*relation*_routing_arch_tests.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project corpus row semantics changed.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo nextest run -p tsz-checker --lib relation_outcome_boundary` (32 passed, including all eight bundled JSX tests)
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Successor PR for bundled same-owner `agent:M1-B` drafts:
  - #10425 `refactor(checker): route jsx text child relation`, previous head `7b8160b92ce013d83589ea14bff9cfcc3f900cf9`
  - #10426 `refactor(checker): route jsx generic spread relation`, head `59f3850ea6be096d807bb5f4360ff1b03799cf6a`
  - #10427 `refactor(checker): route jsx render fallback relation`, head `5bb6294df5bbe822edf0b2db959f086080a0764a`
  - #10428 `refactor(checker): route jsx React alias relation`, head `cbcfc22d2d9ccbca4b28343a2fc97a17705912fc`
  - #10429 `refactor(checker): route jsx union props relation`, head `2416602ac52bef1ab96a8e2b07d0dc6689da95ca`
  - #10431 `refactor(checker): route jsx spread assignability relation`, head `25d38448870d1be9f34063dfc38d8725351bb422`
  - #10432 `refactor(checker): route jsx component prop relations`, head `ba5e84bdeeea7a7d0f1f0341a382640217c503dc`
  - #10434 `refactor(checker): route jsx overload relations`, head `5be9761ec9698d8c8dfd22305ebbc1e93989bcf8`
- Carrier branch `codex/m1b-jsx-text-child-relation-outcome-20260527` was updated to combined head `e1cc4d9d6041af6ac4834783f862c183b468e92c`.
- Conflict resolution was limited to `crates/tsz-checker/src/lib.rs` test-module registrations; all bundled test modules were preserved.
- #10385 was inspected and intentionally skipped because it is stacked on `codex/m1b-query-common-ratchet-20260527`, not `main`.
- Draft state is intentional while this bundle is reviewed; full conformance/emit/fourslash remain CI-only when promoted.
