### PR TITLE
refactor(checker): route jsx generic spread relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -63,7 +63,9 @@ impl<'a> CheckerState<'a> {
             let Some(expected_type) = expected_type else {
                 return false;
             };
-            !self.diagnostic_relation_boolean_guard(*actual_type, expected_type)
+            !self
+                .assign_relation_outcome(*actual_type, expected_type)
+                .related
         });
 
         let has_alias_string_prop_mismatch = provided_attrs.iter().any(|(name, actual_type)| {
@@ -79,7 +81,7 @@ impl<'a> CheckerState<'a> {
 
         if !has_explicit_prop_mismatch
             && !has_alias_string_prop_mismatch
-            && self.diagnostic_relation_boolean_guard(attrs_type, props_type)
+            && self.assign_relation_outcome(attrs_type, props_type).related
         {
             return false;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -658,6 +658,9 @@ mod jsx_element_type_constraint_tests;
 #[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
 mod jsx_excess_attr_with_spread_display_tests;
 #[cfg(test)]
+#[path = "tests/jsx_generic_spread_relation_routing_arch_tests.rs"]
+mod jsx_generic_spread_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_generic_spread_assignability_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/generic_spread.rs");
+    let source = fs::read_to_string(source_path).expect("read jsx generic_spread.rs");
+
+    let function_start = source
+        .find("fn report_invalid_generic_jsx_spread_assignability")
+        .expect("find generic JSX spread assignability reporter");
+    let function = &source[function_start..];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "generic JSX spread assignability decisions should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "generic JSX spread assignability should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics and query-boundary routing.

## Invariant
When JSX generic spread fallback diagnostics decide whether explicit attributes or synthesized spread attributes already fit the props target, tsz should use the shared relation outcome boundary for the relation decision and keep the JSX checker responsible only for diagnostic routing and anchors.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs`
- `crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project-row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_generic_spread_assignability_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Non-overlap checked against open M1-B JSX/object-literal routing PRs; this slice is limited to JSX generic spread props diagnostics.
- Heavy conformance, emit, fourslash, and WASM suites are CI-only per repo policy and are intentionally not run locally.
