### PR TITLE
refactor(checker): route jsx render fallback relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs
@@ -90,7 +90,7 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::PropertyAccessResult::Success {
                     type_id,
                     ..
-                } if self.diagnostic_relation_boolean_guard(type_id, prop.type_id)
+                } if self.assign_relation_outcome(type_id, prop.type_id).related
             )
         })
     }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -661,6 +661,9 @@ mod jsx_excess_attr_with_spread_display_tests;
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]
+#[path = "tests/jsx_render_fallback_relation_routing_arch_tests.rs"]
+mod jsx_render_fallback_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_render_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_render_fallback_relation_routing_arch_tests.rs
@@ -1,0 +1,25 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_render_fallback_required_props_use_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path =
+        Path::new(manifest_dir).join("src/checkers/jsx/extraction_render_fallback.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX render fallback source");
+
+    let function_start = source
+        .find("fn jsx_construct_return_can_use_render_fallback")
+        .expect("find JSX render fallback helper");
+    let function = &source[function_start..];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        1,
+        "JSX render fallback required-prop compatibility should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX render fallback required-prop compatibility should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics and query-boundary routing.

## Invariant
When JSX construct-return render fallback validates required target properties against properties on the returned source shape, tsz should use the shared relation outcome boundary for the compatibility decision while keeping the JSX checker responsible for fallback orchestration and diagnostic anchors.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction_render_fallback.rs`
- `crates/tsz-checker/src/tests/jsx_render_fallback_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project-row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_render_fallback_required_props_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Non-overlap checked against open M1-B JSX relation PRs; this slice is limited to JSX render fallback required-property compatibility.
- Branch was fetched and confirmed one commit ahead / zero behind `origin/main` before push.
- Heavy conformance, emit, fourslash, and WASM suites are CI-only per repo policy and are intentionally not run locally.
