### PR TITLE
refactor(checker): route jsx React alias relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
@@ -234,8 +234,12 @@ impl<'a> CheckerState<'a> {
         }
         let alias_evaluated = self.evaluate_type_with_env(alias);
         if alias_evaluated != TypeId::ERROR
-            && self.diagnostic_relation_boolean_guard(alias_evaluated, props_type)
-            && self.diagnostic_relation_boolean_guard(props_type, alias_evaluated)
+            && self
+                .assign_relation_outcome(alias_evaluated, props_type)
+                .related
+            && self
+                .assign_relation_outcome(props_type, alias_evaluated)
+                .related
         {
             self.ctx.types.store_display_alias(props_type, alias);
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -658,6 +658,9 @@ mod jsx_element_type_constraint_tests;
 #[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
 mod jsx_excess_attr_with_spread_display_tests;
 #[cfg(test)]
+#[path = "tests/jsx_react_alias_relation_routing_arch_tests.rs"]
+mod jsx_react_alias_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_react_props_alias_storage_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/extraction_react_alias.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX React alias source");
+
+    let function_start = source
+        .find("fn store_jsx_props_display_alias_if_matching")
+        .expect("find JSX props display alias helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("fn jsx_type_contains_callable_surface")
+            .expect("find next JSX React alias helper");
+    let function = &source[function_start..function_end];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "JSX props display-alias storage should route both compatibility decisions through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX props display-alias storage should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics and query-boundary routing.

## Invariant
When JSX props display-alias storage checks that a React props alias and the resolved props shape are mutually compatible, tsz should use the shared relation outcome boundary for both compatibility decisions while keeping JSX alias storage and diagnostic display ownership in the checker.

## Scope
- `crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs`
- `crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project-row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_react_props_alias_storage_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Non-overlap checked against open M1-B JSX relation PRs; this slice is limited to JSX React props display-alias relation decisions.
- Branch was fetched and confirmed one commit ahead / zero behind `origin/main` before push.
- Heavy conformance, emit, fourslash, and WASM suites are CI-only per repo policy and are intentionally not run locally.
