### PR TITLE
refactor(checker): route jsx union props relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -190,7 +190,7 @@ impl<'a> CheckerState<'a> {
                         if *attr_type == TypeId::ANY || *attr_type == TypeId::ERROR {
                             return true;
                         }
-                        self.diagnostic_relation_boolean_guard(*attr_type, expected)
+                        self.assign_relation_outcome(*attr_type, expected).related
                     }
                     _ => true,
                 }
@@ -262,7 +262,7 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         let attrs_type = self.ctx.types.factory().object(properties);
-        if self.diagnostic_relation_boolean_guard(attrs_type, props_type) {
+        if self.assign_relation_outcome(attrs_type, props_type).related {
             return;
         }
         self.report_jsx_synthesized_props_assignability_error(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -664,6 +664,9 @@ mod jsx_react_hoc_spread_props_tests;
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]
+#[path = "tests/jsx_union_props_relation_routing_arch_tests.rs"]
+mod jsx_union_props_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "../tests/keyof_function_type_is_never_tests.rs"]
 mod keyof_function_type_is_never_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_union_props_diagnostics_use_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/union_props.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX union props source");
+
+    let function_start = source
+        .find("fn check_jsx_union_props")
+        .expect("find JSX union props helper");
+    let function_end = function_start
+        + source[function_start..]
+            .find("fn jsx_props_type_is_library_managed_attributes_application")
+            .expect("find next JSX union props helper");
+    let function = &source[function_start..function_end];
+
+    assert_eq!(
+        function.matches("assign_relation_outcome").count(),
+        2,
+        "JSX union props compatibility decisions should route through relation outcomes"
+    );
+    assert!(
+        !function.contains("diagnostic_relation_boolean_guard"),
+        "JSX union props diagnostics should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics and query-boundary routing.

## Invariant
When JSX union-props diagnostics check provided attributes against a candidate union member or check the synthesized attributes object against the props union before reporting, tsz should use the shared relation outcome boundary for compatibility while keeping JSX diagnostic orchestration in the checker.

## Scope
- `crates/tsz-checker/src/checkers/jsx/props/union_props.rs`
- `crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project-row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_union_props_diagnostics_use_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Non-overlap checked against open M1-B JSX/object-literal relation PRs; this slice is limited to JSX union props compatibility decisions.
- Branch was rebased after `origin/main` advanced and confirmed one commit ahead / zero behind before push.
- Heavy conformance, emit, fourslash, and WASM suites are CI-only per repo policy and are intentionally not run locally.
