### PR TITLE
refactor(checker): route jsx spread assignability relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -109,7 +109,9 @@ impl<'a> CheckerState<'a> {
         // normalized JSX spread path below so we can classify TS2322 vs TS2741 from
         // the apparent/object shape first.
         if !spread_has_type_params
-            && self.diagnostic_relation_boolean_guard(spread_type, props_type)
+            && self
+                .assign_relation_outcome(spread_type, props_type)
+                .related
         {
             return false;
         }
@@ -195,7 +197,10 @@ impl<'a> CheckerState<'a> {
                 // so the spread's type issues are masked.
                 return false;
             }
-            if self.diagnostic_relation_boolean_guard(spread_type, props_type) {
+            if self
+                .assign_relation_outcome(spread_type, props_type)
+                .related
+            {
                 return false;
             }
             let spread_name = self.format_type(spread_source_type);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -661,6 +661,9 @@ mod jsx_excess_attr_with_spread_display_tests;
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
 #[cfg(test)]
+#[path = "tests/jsx_spread_assignability_relation_routing_arch_tests.rs"]
+mod jsx_spread_assignability_relation_routing_arch_tests;
+#[cfg(test)]
 #[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
 mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
@@ -1,0 +1,28 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn jsx_spread_whole_type_assignability_uses_relation_outcome_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let source_path = Path::new(manifest_dir).join("src/checkers/jsx/spread.rs");
+    let source = fs::read_to_string(source_path).expect("read JSX spread source");
+
+    let function_start = source
+        .find("fn check_spread_property_types")
+        .expect("find JSX spread property checker");
+    let shape_branch_end = function_start
+        + source[function_start..]
+            .find("// When there are multiple spreads")
+            .expect("find JSX spread shape branch end");
+    let prefix = &source[function_start..shape_branch_end];
+
+    assert_eq!(
+        prefix.matches("assign_relation_outcome").count(),
+        2,
+        "early JSX spread whole-type compatibility decisions should route through relation outcomes"
+    );
+    assert!(
+        !prefix.contains("diagnostic_relation_boolean_guard"),
+        "early JSX spread whole-type compatibility should not regress to raw boolean relation guards"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Refactor only: checker relation diagnostics and query-boundary routing.

## Invariant
When JSX spread diagnostics use whole-spread assignability as an early suppression gate before reporting spread incompatibility, tsz should use the shared relation outcome boundary for compatibility while keeping spread diagnostic orchestration in the checker.

## Scope
- `crates/tsz-checker/src/checkers/jsx/spread.rs`
- `crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs`
- `crates/tsz-checker/src/lib.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker boundary refactor; no project-row behavior change intended.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-checker --lib jsx_spread_whole_type_assignability_uses_relation_outcome_boundary`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings`
- `git diff --check origin/main..HEAD`

## Coordination Notes
- Non-overlap checked against open M1-B JSX relation PRs; this slice is limited to the early whole-spread assignability suppression path.
- Branch was fetched and confirmed one commit ahead / zero behind `origin/main` before push.
- Heavy conformance, emit, fourslash, and WASM suites are CI-only per repo policy and are intentionally not run locally.
